### PR TITLE
Preflight Computer Use starting context

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -205,6 +205,7 @@ public enum ComputerUseLoop {
         limits: RunLimits = RunLimits(),
         policySummary: String = "",
         vision: VisionContext = .none,
+        contextPreflight: ComputerUseContextPreflight = .disabled,
         sessionId: String,
         nextAction: AgentStepProvider? = nil
     ) async -> ComputerUseRunResult {
@@ -259,6 +260,21 @@ public enum ComputerUseLoop {
         // Cloud-vision consent state for THIS run. Seeded from the snapshot taken
         // at run start; a just-in-time prompt can flip `granted` true mid-run.
         var runConsent = RunCloudVisionConsent(granted: vision.cloudConsent, asked: false)
+        var step = 0
+
+        func terminate(_ outcome: RunOutcome) -> ComputerUseRunResult {
+            metrics.steps = step
+            feed.emit(
+                SubagentActivityEvent(
+                    step: step,
+                    kind: .outcome,
+                    title: outcome.summary,
+                    success: outcome.isSuccess
+                )
+            )
+            feed.finish(success: outcome.isSuccess, summary: outcome.summary)
+            return ComputerUseRunResult(outcome: outcome, metrics: metrics)
+        }
 
         // Initial perception so the model's first turn has something to act on.
         // An empty AX tree (Electron, custom-drawn UI) escalates ax→som→vision
@@ -278,6 +294,62 @@ public enum ComputerUseLoop {
         lastView = initialView.view
         lastSnapshot = initialView.snapshot
         if let app = initialView.snapshot?.app { currentApp = app }
+
+        if contextPreflight.enabled {
+            metrics.contextPreflightChecks += 1
+        }
+        switch contextPreflight.evaluate(
+            goal: goal,
+            appName: currentApp,
+            focusedWindow: initialView.snapshot?.focusedWindow
+        ) {
+        case .allow:
+            break
+        case .reject(let reason):
+            metrics.contextPreflightBlocks += 1
+            metrics.blocked += 1
+            feed.emit(
+                SubagentActivityEvent(
+                    step: 0,
+                    kind: .blocked,
+                    title: "Blocked starting context",
+                    detail: reason,
+                    success: false
+                )
+            )
+            return terminate(.failed(reason: reason))
+        case .confirm(let preview, let reason):
+            metrics.contextPreflightConfirms += 1
+            metrics.confirmsRequested += 1
+            feed.emit(
+                SubagentActivityEvent(
+                    step: 0,
+                    kind: .confirmRequested,
+                    title: "Confirm: \(preview.summary)",
+                    detail: reason
+                )
+            )
+            if await confirm(preview) {
+                metrics.confirmsApproved += 1
+                feed.emit(
+                    SubagentActivityEvent(
+                        step: 0,
+                        kind: .confirmed,
+                        title: "Approved: Start Computer Use"
+                    )
+                )
+            } else {
+                metrics.confirmsDeclined += 1
+                feed.emit(
+                    SubagentActivityEvent(
+                        step: 0,
+                        kind: .denied,
+                        title: "Declined: Start Computer Use"
+                    )
+                )
+                return terminate(.interrupted)
+            }
+        }
 
         messages.append(
             ChatMessage(
@@ -302,27 +374,12 @@ public enum ComputerUseLoop {
             )
         }
 
-        var step = 0
         var consecutiveInvalid = 0
         var consecutiveDeadEnd = 0
         var lastReobserveTargetKey: String? = nil
         var consecutiveReobserve = 0
         var lastActionSignature: String? = nil
         var repeatedActionCount = 0
-
-        func terminate(_ outcome: RunOutcome) -> ComputerUseRunResult {
-            metrics.steps = step
-            feed.emit(
-                SubagentActivityEvent(
-                    step: step,
-                    kind: .outcome,
-                    title: outcome.summary,
-                    success: outcome.isSuccess
-                )
-            )
-            feed.finish(success: outcome.isSuccess, summary: outcome.summary)
-            return ComputerUseRunResult(outcome: outcome, metrics: metrics)
-        }
 
         while true {
             // Interrupt / cancellation / wall-clock boundary.

--- a/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseContextPreflight.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseContextPreflight.swift
@@ -1,0 +1,120 @@
+//
+//  ComputerUseContextPreflight.swift
+//  OsaurusCore -- Computer Use
+//
+//  Run-start contextual-integrity checks. These happen after the local driver
+//  has identified the frontmost app, but before the rendered AX view is added
+//  to the inner model transcript. That gap matters: action-level gates protect
+//  clicks and typing, while this preflight protects the starting context itself.
+//
+
+import Foundation
+
+public enum ComputerUseContextPreflightDecision: Sendable, Equatable {
+    case allow
+    case confirm(ActionPreview, reason: String)
+    case reject(reason: String)
+}
+
+public struct ComputerUseContextPreflight: Sendable, Equatable {
+    public var policy: AutonomyPolicy
+    public var ceiling: AutonomyCeiling?
+    public var modelIsLocal: Bool
+    public var enabled: Bool
+
+    public init(
+        policy: AutonomyPolicy = .defaultPolicy,
+        ceiling: AutonomyCeiling? = nil,
+        modelIsLocal: Bool = true,
+        enabled: Bool = true
+    ) {
+        self.policy = policy
+        self.ceiling = ceiling
+        self.modelIsLocal = modelIsLocal
+        self.enabled = enabled
+    }
+
+    public static let disabled = ComputerUseContextPreflight(enabled: false)
+
+    public func evaluate(
+        goal: String,
+        appName: String?,
+        focusedWindow: String?
+    ) -> ComputerUseContextPreflightDecision {
+        guard enabled else { return .allow }
+        guard let appName = clean(appName) else { return .allow }
+
+        if hasActiveAllowlist, !policy.isAppAllowed(appName) {
+            return .reject(
+                reason:
+                    "\(appName) is not on the Computer Use allowlist. Switch to an allowed app or add it "
+                    + "in Settings before starting, so the starting window is not exposed to the "
+                    + "computer-use model."
+            )
+        }
+
+        if policy.requiresForcedConfirm(app: appName) {
+            return .confirm(
+                preview(appName: appName, focusedWindow: focusedWindow),
+                reason:
+                    "Computer Use is starting in \(appName), which can expose secrets, run code, or "
+                    + "change system state. Confirm that this is the intended context before the inner "
+                    + "model receives the current view."
+            )
+        }
+
+        if !modelIsLocal, Self.isPrivacySensitiveContext(appName) {
+            return .confirm(
+                preview(appName: appName, focusedWindow: focusedWindow),
+                reason:
+                    "Computer Use is starting in \(appName) while the selected model is not local. "
+                    + "The accessibility view can include private on-screen text, so confirm before "
+                    + "that context leaves this Mac."
+            )
+        }
+
+        _ = goal  // Reserved for future task/app intent matching without widening call sites.
+        return .allow
+    }
+
+    public static func isPrivacySensitiveContext(_ appName: String?) -> Bool {
+        guard let appName = clean(appName) else { return false }
+        let normalized = AutonomyPolicy.normalize(appName)
+        return privacySensitiveAppNeedles.contains { normalized.contains($0) }
+    }
+
+    private var hasActiveAllowlist: Bool {
+        guard let allowlist = policy.allowlist else { return false }
+        return !allowlist.isEmpty
+    }
+
+    private func preview(appName: String, focusedWindow: String?) -> ActionPreview {
+        ActionPreview(
+            appName: appName,
+            actionLabel: "Start Computer Use",
+            targetLabel: clean(focusedWindow),
+            effect: .read,
+            note: nil
+        )
+    }
+
+    private static let privacySensitiveAppNeedles: Set<String> = [
+        "mail", "com.apple.mail",
+        "messages", "com.apple.messages", "com.apple.imservice", "com.apple.ichat",
+        "safari", "com.apple.safari",
+        "chrome", "google chrome", "com.google.chrome",
+        "firefox", "org.mozilla.firefox",
+        "edge", "microsoft edge", "com.microsoft.edgemac",
+        "brave", "com.brave.browser",
+        "arc", "company.thebrowser.browser",
+        "calendar", "com.apple.ical",
+        "contacts", "com.apple.addressbook",
+        "slack", "discord", "teams", "zoom",
+    ]
+}
+
+private func clean(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}

--- a/Packages/OsaurusCore/ComputerUse/Telemetry/ComputerUseRunMetrics.swift
+++ b/Packages/OsaurusCore/ComputerUse/Telemetry/ComputerUseRunMetrics.swift
@@ -26,6 +26,12 @@ public struct ComputerUseRunMetrics: Sendable, Equatable {
     public var confirmsDeclined = 0
     /// Gate rejections (allowlist / deny disposition).
     public var blocked = 0
+    /// Run-start contextual-integrity checks. These are separate from action
+    /// gates because they happen before the current view enters the model
+    /// transcript.
+    public var contextPreflightChecks = 0
+    public var contextPreflightConfirms = 0
+    public var contextPreflightBlocks = 0
     /// Dead-end terminations encountered (resolution gave out).
     public var deadEnds = 0
     /// Actions executed and how many the verify step saw land (view changed).

--- a/Packages/OsaurusCore/Services/FeatureTelemetry.swift
+++ b/Packages/OsaurusCore/Services/FeatureTelemetry.swift
@@ -224,6 +224,9 @@ enum FeatureTelemetry {
             "verify_pass": ComputerUseRunMetrics.rateBucket(metrics.verifyPassRate),
             "had_dead_end": metrics.deadEnds > 0,
             "had_block": metrics.blocked > 0,
+            "preflight_checked": metrics.contextPreflightChecks > 0,
+            "preflight_blocked": metrics.contextPreflightBlocks > 0,
+            "preflight_confirmed": metrics.contextPreflightConfirms > 0,
             "cloud_vision_used": metrics.cloudVisionUsed,
         ]
         service.track("computer_use_run", props)

--- a/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
@@ -82,6 +82,7 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
         let policy: AutonomyPolicy
         let vision: VisionContext
         let policySummary: String
+        let contextPreflight: ComputerUseContextPreflight
     }
     private var config: RunConfig?
     /// Residency plan resolved in `resolveModel` (reject-before-evict), run by
@@ -154,6 +155,11 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
             policySummary: ComputerUseTool.policySummary(
                 policy: snapshot.policy,
                 ceiling: snapshot.ceiling
+            ),
+            contextPreflight: ComputerUseContextPreflight(
+                policy: snapshot.policy,
+                ceiling: snapshot.ceiling,
+                modelIsLocal: snapshot.vision.modelIsLocal
             )
         )
         self.residencyPlan = resolved.decision.plan
@@ -237,6 +243,7 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
             limits: limits,
             policySummary: config.policySummary,
             vision: config.vision,
+            contextPreflight: config.contextPreflight,
             sessionId: scope.sessionId
         )
 

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -24,26 +24,37 @@ final class ComputerUseLoopRunTests: XCTestCase {
 
     // MARK: - Fixtures
 
+    private actor StepCounter {
+        private var count = 0
+        func bump() { count += 1 }
+        func value() -> Int { count }
+    }
+
     private func el(_ id: String, _ role: String, _ label: String?, value: String? = nil) -> CUElement {
         CUElement(id: id, role: role, label: label, value: value)
     }
 
     /// A driver with one focused app (so `currentPid` is non-nil from the
     /// start) serving a single steady-state snapshot.
-    private func driver(_ elements: [CUElement], pid: Int32 = 4242) -> MockMacDriver {
+    private func driver(
+        _ elements: [CUElement],
+        pid: Int32 = 4242,
+        app: String = "Demo",
+        windowTitle: String = "Main"
+    ) -> MockMacDriver {
         let snap = CUSnapshot(
             snapshotId: 1,
             pid: pid,
-            app: "Demo",
-            focusedWindow: "Main",
+            app: app,
+            focusedWindow: windowTitle,
             tier: .ax,
             truncated: false,
-            windows: [CUWindowSummary(id: 1, title: "Main", focused: true, x: 0, y: 0, w: 800, h: 600)],
+            windows: [CUWindowSummary(id: 1, title: windowTitle, focused: true, x: 0, y: 0, w: 800, h: 600)],
             elements: elements,
             image: nil
         )
         return MockMacDriver(
-            activeWindow: CUActiveWindow(pid: pid, app: "Demo", title: "Main", x: 0, y: 0, w: 800, h: 600),
+            activeWindow: CUActiveWindow(pid: pid, app: app, title: windowTitle, x: 0, y: 0, w: 800, h: 600),
             snapshots: [pid: [snap]]
         )
     }
@@ -54,7 +65,8 @@ final class ComputerUseLoopRunTests: XCTestCase {
         gate: ComputerUseGating = HardwiredGate(),
         confirm: @escaping @Sendable (ActionPreview) async -> Bool = { _ in true },
         interrupt: InterruptToken = InterruptToken(),
-        limits: RunLimits = RunLimits(wallClockSeconds: 30)
+        limits: RunLimits = RunLimits(wallClockSeconds: 30),
+        contextPreflight: ComputerUseContextPreflight = .disabled
     ) async -> ComputerUseRunResult {
         await ComputerUseLoop.run(
             goal: "test goal",
@@ -65,6 +77,7 @@ final class ComputerUseLoopRunTests: XCTestCase {
             interrupt: interrupt,
             confirm: confirm,
             limits: limits,
+            contextPreflight: contextPreflight,
             sessionId: "cu-test",
             nextAction: provider
         )
@@ -181,6 +194,94 @@ final class ComputerUseLoopRunTests: XCTestCase {
         guard case .interrupted = result.outcome else {
             return XCTFail("Expected interrupted; got \(result.outcome)")
         }
+    }
+
+    // MARK: - Context preflight
+
+    func testContextPreflightRejectsBeforeProviderRuns() async {
+        let d = driver([el("msg", "text", "Inbox")], app: "Mail", windowTitle: "Inbox")
+        let counter = StepCounter()
+        let provider: AgentStepProvider = { _ in
+            await counter.bump()
+            return ModelActionCall(
+                id: "should-not-run",
+                arguments: AgentAction(verb: .done, reason: "unexpected").argumentsJSON()
+            )
+        }
+
+        let result = await run(
+            d,
+            provider: provider,
+            contextPreflight: ComputerUseContextPreflight(
+                policy: AutonomyPolicy(allowlist: ["Notes"]),
+                modelIsLocal: true
+            )
+        )
+
+        guard case .failed(let reason) = result.outcome else {
+            return XCTFail("Expected failed preflight rejection; got \(result.outcome)")
+        }
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("allowlist"))
+        let providerCalls = await counter.value()
+        XCTAssertEqual(providerCalls, 0, "The model/provider must not see an out-of-scope view")
+        XCTAssertEqual(result.metrics.contextPreflightChecks, 1)
+        XCTAssertEqual(result.metrics.contextPreflightBlocks, 1)
+        XCTAssertEqual(result.metrics.blocked, 1)
+    }
+
+    func testContextPreflightConfirmationCanApproveRunStart() async {
+        let d = driver([el("prompt", "text", "Shell")], app: "Terminal.app", windowTitle: "zsh")
+        let result = await run(
+            d,
+            provider: ComputerUseLoop.scriptedProvider([
+                AgentAction(verb: .done, reason: "looked")
+            ]),
+            confirm: { preview in
+                XCTAssertEqual(preview.actionLabel, "Start Computer Use")
+                XCTAssertEqual(preview.appName, "Terminal.app")
+                return true
+            },
+            contextPreflight: ComputerUseContextPreflight(
+                policy: AutonomyPolicy(globalPreset: .autonomous),
+                modelIsLocal: true
+            )
+        )
+
+        XCTAssertTrue(result.outcome.isSuccess, "Approved preflight should continue; got \(result.outcome)")
+        XCTAssertEqual(result.metrics.contextPreflightChecks, 1)
+        XCTAssertEqual(result.metrics.contextPreflightConfirms, 1)
+        XCTAssertEqual(result.metrics.confirmsRequested, 1)
+        XCTAssertEqual(result.metrics.confirmsApproved, 1)
+    }
+
+    func testContextPreflightDeclineStopsBeforeProviderRuns() async {
+        let d = driver([el("prompt", "text", "Shell")], app: "Terminal.app", windowTitle: "zsh")
+        let counter = StepCounter()
+        let provider: AgentStepProvider = { _ in
+            await counter.bump()
+            return ModelActionCall(
+                id: "should-not-run",
+                arguments: AgentAction(verb: .done, reason: "unexpected").argumentsJSON()
+            )
+        }
+
+        let result = await run(
+            d,
+            provider: provider,
+            confirm: { _ in false },
+            contextPreflight: ComputerUseContextPreflight(
+                policy: AutonomyPolicy(globalPreset: .autonomous),
+                modelIsLocal: true
+            )
+        )
+
+        guard case .interrupted = result.outcome else {
+            return XCTFail("Expected interrupted after declined preflight; got \(result.outcome)")
+        }
+        let providerCalls = await counter.value()
+        XCTAssertEqual(providerCalls, 0, "Declining context preflight must stop before model step")
+        XCTAssertEqual(result.metrics.contextPreflightConfirms, 1)
+        XCTAssertEqual(result.metrics.confirmsDeclined, 1)
     }
 
     // MARK: - Gate decline

--- a/Packages/OsaurusCore/Tests/ComputerUse/Policy/ContextPreflightTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Policy/ContextPreflightTests.swift
@@ -1,0 +1,95 @@
+//
+//  ContextPreflightTests.swift
+//  OsaurusCoreTests -- Computer Use
+//
+//  Pure coverage for run-start contextual-integrity checks. These checks
+//  protect the initial rendered view before it enters the inner model
+//  transcript; action-level gates still protect subsequent clicks/typing.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class ComputerUseContextPreflightTests: XCTestCase {
+    func testDisabledPreflightAllowsEverything() {
+        let decision = ComputerUseContextPreflight.disabled.evaluate(
+            goal: "read the inbox",
+            appName: "Mail",
+            focusedWindow: "Inbox"
+        )
+        XCTAssertEqual(decision, .allow)
+    }
+
+    func testRejectsOutOfScopeStartingAppBeforeModelContext() {
+        let preflight = ComputerUseContextPreflight(
+            policy: AutonomyPolicy(allowlist: ["Notes"]),
+            modelIsLocal: true
+        )
+        let decision = preflight.evaluate(
+            goal: "summarize this",
+            appName: "Mail",
+            focusedWindow: "Inbox"
+        )
+
+        guard case .reject(let reason) = decision else {
+            return XCTFail("Expected allowlist preflight rejection; got \(decision)")
+        }
+        XCTAssertTrue(reason.contains("Mail"))
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("allowlist"))
+    }
+
+    func testAllowsMissingStartingAppEvenWithAllowlist() {
+        let preflight = ComputerUseContextPreflight(
+            policy: AutonomyPolicy(allowlist: ["Notes"]),
+            modelIsLocal: true
+        )
+
+        XCTAssertEqual(
+            preflight.evaluate(goal: "open Notes", appName: nil, focusedWindow: nil),
+            .allow
+        )
+    }
+
+    func testDangerousStartingAppRequiresConfirmationEvenForLocalModel() {
+        let preflight = ComputerUseContextPreflight(
+            policy: AutonomyPolicy(globalPreset: .autonomous),
+            modelIsLocal: true
+        )
+        let decision = preflight.evaluate(
+            goal: "check the shell",
+            appName: "Terminal.app",
+            focusedWindow: "zsh"
+        )
+
+        guard case .confirm(let preview, let reason) = decision else {
+            return XCTFail("Expected dangerous app preflight confirmation; got \(decision)")
+        }
+        XCTAssertEqual(preview.appName, "Terminal.app")
+        XCTAssertEqual(preview.actionLabel, "Start Computer Use")
+        XCTAssertEqual(preview.targetLabel, "zsh")
+        XCTAssertEqual(preview.effect, .read)
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("secrets"))
+    }
+
+    func testRemotePrivacySensitiveContextRequiresConfirmation() {
+        let remote = ComputerUseContextPreflight(modelIsLocal: false)
+        let local = ComputerUseContextPreflight(modelIsLocal: true)
+
+        guard case .confirm(let preview, let reason) = remote.evaluate(
+            goal: "summarize the message",
+            appName: "Mail",
+            focusedWindow: "Inbox"
+        ) else {
+            return XCTFail("Remote Mail context should confirm before AX text leaves the Mac")
+        }
+        XCTAssertEqual(preview.appName, "Mail")
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("not local"))
+
+        XCTAssertEqual(
+            local.evaluate(goal: "summarize the message", appName: "Mail", focusedWindow: "Inbox"),
+            .allow
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Telemetry/FeatureTelemetryEventTests.swift
+++ b/Packages/OsaurusCore/Tests/Telemetry/FeatureTelemetryEventTests.swift
@@ -386,6 +386,31 @@ struct FeatureTelemetryEventTests {
         #expect(event.props["is_vlm"] as? Bool == true)
     }
 
+    @Test func computerUseRun_carries_context_preflight_flags() {
+        let (service, rec, cleanup) = makeRecordingService()
+        defer { cleanup() }
+
+        var metrics = ComputerUseRunMetrics()
+        metrics.contextPreflightChecks = 1
+        metrics.contextPreflightConfirms = 1
+        metrics.contextPreflightBlocks = 1
+        metrics.blocked = 1
+
+        FeatureTelemetry.computerUseRun(metrics, outcome: "failed", service: service)
+
+        let event = rec.events[0]
+        #expect(event.name == "computer_use_run")
+        let props = business(event.props)
+        #expect(props["outcome"] as? String == "failed")
+        #expect(props["had_block"] as? Bool == true)
+        #expect(props["preflight_checked"] as? Bool == true)
+        #expect(props["preflight_confirmed"] as? Bool == true)
+        #expect(props["preflight_blocked"] as? Bool == true)
+        #expect(props["cloud_vision_used"] as? Bool == false)
+        #expect(props["goal"] == nil)
+        #expect(props["app"] == nil)
+    }
+
     @Test func providerAdded_events_carry_only_type_and_transport() {
         let (service, rec, cleanup) = makeRecordingService()
         defer { cleanup() }


### PR DESCRIPTION
## Summary
- Adds a starting-context preflight before the Computer Use provider step runs.
- Rejects out-of-allowlist contexts and confirms sensitive/dangerous starts where appropriate.
- Records preflight outcome in Computer Use telemetry and tests the provider is not called on rejection.

## Why
The local sub-agent should receive minimal, hyperfocused context. This preflight keeps the built-in loop from sending irrelevant or sensitive starting context into model execution.

## Validation
- `git diff --check origin/main...HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-computer-use-pr-validation swift test --package-path Packages/OsaurusCore --quiet --filter ComputerUse`