### PR TITLE
Add Computer Use forensic evidence runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WORKSPACE := osaurus.xcworkspace
 DERIVED := build/DerivedData
 XCODEBUILD_FLAGS ?=
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
+.PHONY: help cli app install-cli serve status test ci-test computer-use-evidence clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
 
 help:
 	@echo "Targets:"
@@ -38,6 +38,7 @@ help:
 	@echo "  evals-compat        Fold reports/community/* into the COMPATIBILITY.md leaderboard (COMPAT_DIR=)"
 	@echo "  test           Run OsaurusCore package tests via 'swift test'"
 	@echo "  ci-test        Reproduce the CI test-core job locally (xcodebuild + xcbeautify)"
+	@echo "  computer-use-evidence Run local Computer Use proof lane into build/computer-use-evidence/"
 	@echo "  clean          Remove DerivedData build output"
 
 cli:
@@ -101,6 +102,10 @@ ci-test:
 		| xcbeautify --renderer terminal
 	@echo ""
 	@echo "Done. Inspect failures with: open build/Tests.xcresult"
+
+computer-use-evidence:
+	@OUT_DIR="$(OUT_DIR)" RUN_EVALS="$(RUN_EVALS)" MODEL="$(MODEL)" STRICT="$(STRICT)" \
+		bash scripts/evals/computer-use-evidence.sh
 
 ## ── LOCOMO Benchmark ──────────────────────────────────────────────
 

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -144,8 +144,8 @@ final class ComputerUseEvidencePackTests: XCTestCase {
         let pid: Int32 = 5150
         // MockMacDriver advances one snapshot per capture: initial observe,
         // one post-action verify per acting verb, then one final assertion read.
-        // Keep the submit button visible through snapshot 5 so resolution tests
-        // the pre-submit tree, then expose the submitted state on snapshots 6-7.
+        // Keep status as Draft through snapshot 5 so the submit click resolves
+        // against the pre-submit tree, then expose the submitted state on 6-7.
         let snapshots = [
             browserFormSnapshot(snapshotId: 1, pid: pid),
             browserFormSnapshot(snapshotId: 2, pid: pid, team: "Synthetic Platform Team"),

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -140,6 +140,141 @@ final class ComputerUseEvidencePackTests: XCTestCase {
         XCTAssertFalse(result.metrics.cloudVisionUsed)
     }
 
+    func testBrowserFormLoopFillsFieldsAndSubmitsDeterministically() async {
+        let pid: Int32 = 5150
+        // MockMacDriver advances one snapshot per capture: initial observe,
+        // one post-action verify per acting verb, then one final assertion read.
+        // Keep the submit button visible through snapshot 5 so resolution tests
+        // the pre-submit tree, then expose the submitted state on snapshots 6-7.
+        let snapshots = [
+            browserFormSnapshot(snapshotId: 1, pid: pid),
+            browserFormSnapshot(snapshotId: 2, pid: pid, team: "Synthetic Platform Team"),
+            browserFormSnapshot(
+                snapshotId: 3,
+                pid: pid,
+                team: "Synthetic Platform Team",
+                email: "ops@example.com"
+            ),
+            browserFormSnapshot(
+                snapshotId: 4,
+                pid: pid,
+                team: "Synthetic Platform Team",
+                email: "ops@example.com",
+                justification: "Automate a repetitive access request."
+            ),
+            browserFormSnapshot(
+                snapshotId: 5,
+                pid: pid,
+                team: "Synthetic Platform Team",
+                email: "ops@example.com",
+                justification: "Automate a repetitive access request.",
+                termsAccepted: true
+            ),
+            browserFormSnapshot(
+                snapshotId: 6,
+                pid: pid,
+                team: "Synthetic Platform Team",
+                email: "ops@example.com",
+                justification: "Automate a repetitive access request.",
+                termsAccepted: true,
+                status: "Submitted request for Synthetic Platform Team"
+            ),
+            browserFormSnapshot(
+                snapshotId: 7,
+                pid: pid,
+                team: "Synthetic Platform Team",
+                email: "ops@example.com",
+                justification: "Automate a repetitive access request.",
+                termsAccepted: true,
+                status: "Submitted request for Synthetic Platform Team"
+            ),
+        ]
+        let driver = MockMacDriver(
+            activeWindow: CUActiveWindow(
+                pid: pid,
+                app: "Safari",
+                title: "Access request form",
+                x: 0,
+                y: 0,
+                w: 1280,
+                h: 900
+            ),
+            snapshots: [pid: snapshots]
+        )
+        let confirmationRecorder = ConfirmationRecorder()
+
+        let result = await ComputerUseLoop.run(
+            goal: "Fill out and submit the access request web form.",
+            modelId: "scripted-browser-form",
+            driver: driver,
+            gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted)),
+            feed: ComputerUseFeed(toolCallId: "evidence-browser-form", goal: "Fill out the form"),
+            interrupt: InterruptToken(),
+            confirm: { preview in
+                await confirmationRecorder.record(preview)
+                return true
+            },
+            limits: RunLimits(maxSteps: 8, wallClockSeconds: 30),
+            vision: .none,
+            sessionId: "evidence-browser-form",
+            nextAction: ComputerUseLoop.scriptedProvider([
+                AgentAction(
+                    verb: .setValue,
+                    target: AgentTarget(describe: "Team name"),
+                    text: "Synthetic Platform Team"
+                ),
+                AgentAction(
+                    verb: .setValue,
+                    target: AgentTarget(describe: "Email"),
+                    text: "ops@example.com"
+                ),
+                AgentAction(
+                    verb: .setValue,
+                    target: AgentTarget(describe: "Justification"),
+                    text: "Automate a repetitive access request."
+                ),
+                AgentAction(verb: .click, target: AgentTarget(describe: "Agree to terms")),
+                AgentAction(verb: .click, target: AgentTarget(describe: "Submit request")),
+                AgentAction(verb: .done, reason: "The access request form was submitted."),
+            ])
+        )
+
+        XCTAssertTrue(result.outcome.isSuccess, "Expected form completion; got \(result.outcome)")
+        XCTAssertEqual(result.metrics.maxTier, .ax)
+        XCTAssertFalse(result.metrics.cloudVisionUsed)
+        XCTAssertEqual(result.metrics.targetResolveAttempts, 5)
+        XCTAssertEqual(result.metrics.targetResolveSuccesses, 5)
+        XCTAssertEqual(result.metrics.actsAttempted, 5)
+        XCTAssertEqual(result.metrics.verifyChanged, 5)
+        XCTAssertEqual(result.metrics.confirmsRequested, 1)
+        XCTAssertEqual(result.metrics.confirmsApproved, 1)
+
+        let confirmed = await confirmationRecorder.previews()
+        XCTAssertEqual(confirmed.map(\.effect), [.consequential])
+        XCTAssertEqual(confirmed.first?.targetLabel, "button \"Submit request\"")
+
+        let actions = await driver.elementActions
+        XCTAssertEqual(
+            actionTrace(actions),
+            [
+                "setValue:team=Synthetic Platform Team",
+                "setValue:email=ops@example.com",
+                "setValue:justification=Automate a repetitive access request.",
+                "click:terms",
+                "click:submit",
+            ]
+        )
+        let coordinateActions = await driver.coordinateActions
+        XCTAssertTrue(coordinateActions.isEmpty, "Resolved AX form controls should not need coordinate fallback.")
+
+        let finalSnapshot = await driver.capture(pid: pid, tier: .ax)
+        XCTAssertEqual(value(in: finalSnapshot, id: "team"), "Synthetic Platform Team")
+        XCTAssertEqual(value(in: finalSnapshot, id: "email"), "ops@example.com")
+        XCTAssertEqual(value(in: finalSnapshot, id: "justification"), "Automate a repetitive access request.")
+        XCTAssertEqual(value(in: finalSnapshot, id: "terms"), "checked")
+        XCTAssertEqual(value(in: finalSnapshot, id: "status"), "Submitted request for Synthetic Platform Team")
+    }
+
     func testDangerousAppConfirmGuardrailCannotBeBypassedByAutonomousPreset() async {
         let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
         let decision = await gate.evaluate(
@@ -308,5 +443,141 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             width: cg.width,
             height: cg.height
         )
+    }
+
+    private func browserFormSnapshot(
+        snapshotId: Int,
+        pid: Int32,
+        team: String = "",
+        email: String = "",
+        justification: String = "",
+        termsAccepted: Bool = false,
+        status: String = "Draft"
+    ) -> CUSnapshot {
+        let window = CUWindowSummary(
+            id: 1,
+            title: "Access request form",
+            focused: true,
+            x: 0,
+            y: 0,
+            w: 1280,
+            h: 900
+        )
+        let elements = [
+            CUElement(
+                id: "team",
+                role: "textfield",
+                label: "Team name",
+                value: team,
+                windowId: 1,
+                x: 120,
+                y: 120,
+                w: 360,
+                h: 32,
+                actions: ["setValue"]
+            ),
+            CUElement(
+                id: "email",
+                role: "textfield",
+                label: "Email",
+                value: email,
+                windowId: 1,
+                x: 120,
+                y: 180,
+                w: 360,
+                h: 32,
+                actions: ["setValue"]
+            ),
+            CUElement(
+                id: "justification",
+                role: "textview",
+                label: "Justification",
+                value: justification,
+                windowId: 1,
+                x: 120,
+                y: 240,
+                w: 520,
+                h: 120,
+                actions: ["setValue"]
+            ),
+            CUElement(
+                id: "terms",
+                role: "checkbox",
+                label: "Agree to terms",
+                value: termsAccepted ? "checked" : "unchecked",
+                windowId: 1,
+                x: 120,
+                y: 390,
+                w: 220,
+                h: 28,
+                actions: ["press"]
+            ),
+            CUElement(
+                id: "submit",
+                role: "button",
+                label: "Submit request",
+                windowId: 1,
+                x: 120,
+                y: 450,
+                w: 180,
+                h: 36,
+                actions: ["press"]
+            ),
+            CUElement(
+                id: "status",
+                role: "staticText",
+                label: "Status",
+                value: status,
+                windowId: 1,
+                x: 120,
+                y: 520,
+                w: 520,
+                h: 24
+            ),
+        ]
+        return CUSnapshot(
+            snapshotId: snapshotId,
+            pid: pid,
+            app: "Safari",
+            focusedWindow: "Access request form",
+            tier: .ax,
+            truncated: false,
+            windows: [window],
+            elements: elements,
+            image: nil
+        )
+    }
+
+    private func actionTrace(_ actions: [CUElementAction]) -> [String] {
+        actions.map { action in
+            switch action {
+            case .click(let id, _, _):
+                return "click:\(id)"
+            case .setValue(let id, let value):
+                return "setValue:\(id)=\(value)"
+            case .typeText(let id, _, let text, let replace):
+                return "typeText:\(id ?? "pid")=\(text):replace=\(replace)"
+            case .pressKey(_, let key, let modifiers):
+                return "pressKey:\((modifiers + [key]).joined(separator: "+"))"
+            case .clearField(let id):
+                return "clear:\(id)"
+            }
+        }
+    }
+
+    private func value(in snapshot: CUSnapshot, id: String) -> String? {
+        snapshot.elements.first(where: { $0.id == id })?.value
+    }
+}
+
+private actor ConfirmationRecorder {
+    private var stored: [ActionPreview] = []
+
+    func record(_ preview: ActionPreview) {
+        stored.append(preview)
+    }
+
+    func previews() -> [ActionPreview] {
+        stored
     }
 }

--- a/docs/COMPUTER_USE_EVIDENCE.md
+++ b/docs/COMPUTER_USE_EVIDENCE.md
@@ -1,10 +1,40 @@
 # Computer Use Evidence Pack
 
 This pack maps CI-safe evidence for the contract documented in
-`docs/COMPUTER_USE.md`. It is a local evidence map only; it does not create a
-report store.
+`docs/COMPUTER_USE.md`. The canonical local runner writes an ignored evidence
+bundle under `build/computer-use-evidence/`, including command logs,
+`manifest.json`, `summary.md`, git metadata, and timing for each proof step.
+
+## Canonical local runner
+
+```bash
+make computer-use-evidence
+```
+
+The default lane runs:
+
+- `git diff --check`
+- `ComputerUseEvidencePackTests`
+- the full `ComputerUse` Swift test filter
+
+Generated artifacts stay local because `build/` is gitignored. To include the
+model-dependent OsaurusEvals ComputerUse suite:
+
+```bash
+RUN_EVALS=1 MODEL=foundation make computer-use-evidence
+```
+
+Useful overrides:
+
+```bash
+OUT_DIR=build/computer-use-evidence/manual RUN_EVALS=1 make computer-use-evidence
+STRICT=0 make computer-use-evidence
+```
 
 ## Focused commands
+
+The runner above executes the deterministic commands for you. Equivalent manual
+commands are:
 
 ```bash
 swift test --package-path Packages/OsaurusCore --filter ComputerUseEvidencePackTests

--- a/docs/COMPUTER_USE_EVIDENCE.md
+++ b/docs/COMPUTER_USE_EVIDENCE.md
@@ -24,6 +24,10 @@ model-dependent OsaurusEvals ComputerUse suite:
 RUN_EVALS=1 MODEL=foundation make computer-use-evidence
 ```
 
+With `RUN_EVALS=1`, the runner also executes the model-dependent
+`ComputerUseLoop` suite. That suite is where live-model loop quality is scored;
+the default Swift tests keep the CI-safe proof deterministic.
+
 Useful overrides:
 
 ```bash
@@ -43,6 +47,9 @@ swift build --package-path Packages/OsaurusEvals --product osaurus-evals
 Packages/OsaurusEvals/.build/debug/osaurus-evals run \
   --suite Packages/OsaurusEvals/Suites/ComputerUse \
   --model auto
+Packages/OsaurusEvals/.build/debug/osaurus-evals run \
+  --suite Packages/OsaurusEvals/Suites/ComputerUseLoop \
+  --model auto
 git diff --check
 ```
 
@@ -58,12 +65,14 @@ swiftlint lint Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTes
 | --- | --- |
 | Custom-agent opt-in only; Default agent cannot use `computer_use` | `ComputerUseEvidencePackTests.testComputerUseToolIsCustomAgentOptInOnly` |
 | AX-first; no screenshot/cloud path when AX resolves the task | `ComputerUseEvidencePackTests.testAxResolvedRunStaysAxOnlyAndDoesNotUseScreenshots`, `PerceptionTests`, `ComputerUseLoopRunTests` empty-AX escalation cases |
+| Boring web-form loop plumbing in a deterministic mock AX scene: fill fields, accept terms, resolve the submit button, require consequential-action confirmation, and observe the submitted-state snapshot | `ComputerUseEvidencePackTests.testBrowserFormLoopFillsFieldsAndSubmitsDeterministically` |
 | Dangerous-app confirm guardrail | `ComputerUseEvidencePackTests.testDangerousAppConfirmGuardrailCannotBeBypassedByAutonomousPreset`, `GateHardeningTests` |
 | Cloud vision requires consent and a `ScrubbedFrame` | `ComputerUseEvidencePackTests.testCloudVisionRequiresConsentAndScrubbedFrameRoute`, `CloudVisionScrubModeTests`, `PerceptionTests` |
 | Secure-field/raw text containment where feasible | `ScreenContextDistillerTests.testSecureFieldDirectReadNeverSurfacesValue`, `ScreenContextDistillerTests.testSecureFieldTraversalFallbackNeverSurfacesValue` |
 | Stop/cancel resolves pending confirm and cloud-consent prompts | `ComputerUseEvidencePackTests.testStopCancelResolvesPendingConfirmationAndCloudConsentPrompts` |
 | Screen-context privacy path stays on latest user turn, not system prompt | `ComputerUseEvidencePackTests.testScreenContextPrivacyPathInjectsFrozenBlockIntoLatestUserTurnOnly`, `ScreenContextInjectionTests` |
 | Autonomy policy regression matrix | `Packages/OsaurusEvals/Suites/ComputerUse/*.json` through the `computer_use` eval runner |
+| Live-model loop quality, including field typing, async waits, submit keys, recovery, and escalation | `Packages/OsaurusEvals/Suites/ComputerUseLoop/*.json` through the `computer_use` eval runner when `RUN_EVALS=1` |
 
 Screen-context freezing itself is owned by `ChatView` state (`frozenScreenContext`
 and `isScreenContextFrozen`). The Computer Use test pack pins the pure privacy

--- a/docs/COMPUTER_USE_EVIDENCE.md
+++ b/docs/COMPUTER_USE_EVIDENCE.md
@@ -24,9 +24,10 @@ model-dependent OsaurusEvals ComputerUse suite:
 RUN_EVALS=1 MODEL=foundation make computer-use-evidence
 ```
 
-With `RUN_EVALS=1`, the runner also executes the model-dependent
-`ComputerUseLoop` suite. That suite is where live-model loop quality is scored;
-the default Swift tests keep the CI-safe proof deterministic.
+With `RUN_EVALS=1`, the runner builds `osaurus-evals` and executes both
+model-dependent suites: `ComputerUse` and `ComputerUseLoop`. The loop suite is
+where live-model Computer Use quality is scored; the default Swift tests keep
+the CI-safe proof deterministic.
 
 Useful overrides:
 

--- a/scripts/evals/computer-use-evidence.sh
+++ b/scripts/evals/computer-use-evidence.sh
@@ -14,7 +14,8 @@ Usage:
 Environment:
   OUT_DIR=path        Evidence output directory.
                       Default: build/computer-use-evidence/<UTC timestamp>
-  RUN_EVALS=1        Also run the Packages/OsaurusEvals ComputerUse suite.
+  RUN_EVALS=1        Also run the Packages/OsaurusEvals ComputerUse and
+                      ComputerUseLoop suites.
   MODEL=id           Model id passed to osaurus-evals when RUN_EVALS=1.
   STRICT=0           Always exit 0 after writing artifacts. Default exits nonzero
                       when a required command fails.
@@ -101,8 +102,17 @@ if [[ "$RUN_EVALS" == "1" ]]; then
     eval_cmd+=(--model "$MODEL")
   fi
   run_step evals-computer-use "${eval_cmd[@]}"
+  loop_eval_cmd=(
+    swift run --package-path Packages/OsaurusEvals osaurus-evals run
+    --suite Packages/OsaurusEvals/Suites/ComputerUseLoop
+    --out "${OUT_DIR}/evals-computer-use-loop.json"
+  )
+  if [[ -n "${MODEL:-}" ]]; then
+    loop_eval_cmd+=(--model "$MODEL")
+  fi
+  run_step evals-computer-use-loop "${loop_eval_cmd[@]}"
 else
-  echo "RUN_EVALS is not 1; skipping model-dependent ComputerUse eval suite."
+  echo "RUN_EVALS is not 1; skipping model-dependent ComputerUse and ComputerUseLoop eval suites."
 fi
 
 {

--- a/scripts/evals/computer-use-evidence.sh
+++ b/scripts/evals/computer-use-evidence.sh
@@ -20,6 +20,8 @@ Environment:
   STRICT=0           Always exit 0 after writing artifacts. Default exits nonzero
                       when a required command fails.
 
+Requires `python3` for timing, manifest, and summary generation.
+
 The runner writes logs, manifest.json, summary.md, and command-results.tsv under
 OUT_DIR. build/ is gitignored, so generated evidence stays local by default.
 EOF
@@ -39,6 +41,12 @@ RESULTS_TSV="${OUT_DIR}/command-results.tsv"
 STRICT="${STRICT:-1}"
 RUN_EVALS="${RUN_EVALS:-0}"
 OSAURUS_TEST_ROOT="${OSAURUS_TEST_ROOT:-/tmp/osaurus-computer-use-evidence}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "error: ${PYTHON_BIN} is required to write Computer Use evidence artifacts." >&2
+  exit 1
+fi
 
 mkdir -p "$LOG_DIR"
 printf "name\tcommand\tlog\texit_code\tduration_ms\n" > "$RESULTS_TSV"
@@ -55,7 +63,7 @@ quote_cmd() {
 }
 
 now_ms() {
-  python3 -c 'import time; print(int(time.time() * 1000))'
+  "$PYTHON_BIN" -c 'import time; print(int(time.time() * 1000))'
 }
 
 run_step() {
@@ -126,7 +134,7 @@ fi
   if [[ -n "${MODEL:-}" ]]; then echo "model ${MODEL}"; fi
 } > "${OUT_DIR}/environment.txt"
 
-python3 - "$OUT_DIR" "$RESULTS_TSV" "$fail" <<'PY'
+"$PYTHON_BIN" - "$OUT_DIR" "$RESULTS_TSV" "$fail" <<'PY'
 import csv
 import json
 import pathlib

--- a/scripts/evals/computer-use-evidence.sh
+++ b/scripts/evals/computer-use-evidence.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Run local, forensic Computer Use evidence.
+
+Usage:
+  scripts/evals/computer-use-evidence.sh
+
+Environment:
+  OUT_DIR=path        Evidence output directory.
+                      Default: build/computer-use-evidence/<UTC timestamp>
+  RUN_EVALS=1        Also run the Packages/OsaurusEvals ComputerUse suite.
+  MODEL=id           Model id passed to osaurus-evals when RUN_EVALS=1.
+  STRICT=0           Always exit 0 after writing artifacts. Default exits nonzero
+                      when a required command fails.
+
+The runner writes logs, manifest.json, summary.md, and command-results.tsv under
+OUT_DIR. build/ is gitignored, so generated evidence stays local by default.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+cd "$REPO_ROOT"
+
+timestamp="$(date -u +"%Y%m%d-%H%M%S")"
+OUT_DIR="${OUT_DIR:-build/computer-use-evidence/${timestamp}}"
+LOG_DIR="${OUT_DIR}/logs"
+RESULTS_TSV="${OUT_DIR}/command-results.tsv"
+STRICT="${STRICT:-1}"
+RUN_EVALS="${RUN_EVALS:-0}"
+OSAURUS_TEST_ROOT="${OSAURUS_TEST_ROOT:-/tmp/osaurus-computer-use-evidence}"
+
+mkdir -p "$LOG_DIR"
+printf "name\tcommand\tlog\texit_code\tduration_ms\n" > "$RESULTS_TSV"
+
+fail=0
+
+quote_cmd() {
+  local out=""
+  local arg
+  for arg in "$@"; do
+    printf -v out '%s%q ' "$out" "$arg"
+  done
+  printf '%s' "${out% }"
+}
+
+now_ms() {
+  python3 -c 'import time; print(int(time.time() * 1000))'
+}
+
+run_step() {
+  local name="$1"
+  shift
+  local log="${LOG_DIR}/${name}.log"
+  local rel_log="logs/${name}.log"
+  local cmd_display
+  cmd_display="$(quote_cmd "$@")"
+  local start end duration rc
+  start="$(now_ms)"
+  echo "==> ${name}: ${cmd_display}"
+  set +e
+  "$@" >"$log" 2>&1
+  rc=$?
+  set -e
+  end="$(now_ms)"
+  duration=$((end - start))
+  printf "%s\t%s\t%s\t%d\t%d\n" "$name" "$cmd_display" "$rel_log" "$rc" "$duration" >> "$RESULTS_TSV"
+  if [[ "$rc" -eq 0 ]]; then
+    echo "PASS ${name} (${duration}ms)"
+  else
+    echo "FAIL ${name} (${duration}ms); see ${log}" >&2
+    fail=1
+  fi
+}
+
+run_step git-diff-check git diff --check
+run_step computer-use-evidence-pack \
+  env OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT="$OSAURUS_TEST_ROOT" \
+  swift test --package-path Packages/OsaurusCore --quiet --filter ComputerUseEvidencePackTests
+run_step computer-use-suite \
+  env OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT="$OSAURUS_TEST_ROOT" \
+  swift test --package-path Packages/OsaurusCore --quiet --filter ComputerUse
+
+if [[ "$RUN_EVALS" == "1" ]]; then
+  run_step evals-build swift build --package-path Packages/OsaurusEvals --product osaurus-evals
+  eval_cmd=(
+    swift run --package-path Packages/OsaurusEvals osaurus-evals run
+    --suite Packages/OsaurusEvals/Suites/ComputerUse
+    --out "${OUT_DIR}/evals-computer-use.json"
+  )
+  if [[ -n "${MODEL:-}" ]]; then
+    eval_cmd+=(--model "$MODEL")
+  fi
+  run_step evals-computer-use "${eval_cmd[@]}"
+else
+  echo "RUN_EVALS is not 1; skipping model-dependent ComputerUse eval suite."
+fi
+
+{
+  echo "branch $(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  echo "head $(git rev-parse HEAD 2>/dev/null || true)"
+  echo "origin_main $(git rev-parse origin/main 2>/dev/null || true)"
+  echo "dirty_lines $(git status --short | wc -l | tr -d ' ')"
+  echo "swift $(swift --version 2>/dev/null | head -1)"
+  echo "xcodebuild $(xcodebuild -version 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]*$//' || true)"
+  echo "run_evals ${RUN_EVALS}"
+  if [[ -n "${MODEL:-}" ]]; then echo "model ${MODEL}"; fi
+} > "${OUT_DIR}/environment.txt"
+
+python3 - "$OUT_DIR" "$RESULTS_TSV" "$fail" <<'PY'
+import csv
+import json
+import pathlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+out_dir = pathlib.Path(sys.argv[1])
+tsv = pathlib.Path(sys.argv[2])
+failed = sys.argv[3] != "0"
+
+steps = []
+with tsv.open(newline="") as f:
+    for row in csv.DictReader(f, delimiter="\t"):
+        steps.append(
+            {
+                "name": row["name"],
+                "command": row["command"],
+                "log": row["log"],
+                "exit_code": int(row["exit_code"]),
+                "duration_ms": int(row["duration_ms"]),
+            }
+        )
+
+def git(args):
+    try:
+        return subprocess.check_output(["git", *args], text=True).strip()
+    except Exception:
+        return ""
+
+manifest = {
+    "schema": 1,
+    "kind": "computer_use_evidence",
+    "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "head": git(["rev-parse", "HEAD"]),
+    "branch": git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    "origin_main": git(["rev-parse", "origin/main"]),
+    "dirty_status_lines": git(["status", "--short"]).splitlines(),
+    "result": "failed" if failed else "passed",
+    "commands": steps,
+    "artifacts": {
+        "summary": "summary.md",
+        "environment": "environment.txt",
+        "command_results": "command-results.tsv",
+    },
+}
+
+(out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+lines = [
+    "# Computer Use Evidence",
+    "",
+    f"- Result: **{manifest['result']}**",
+    f"- Branch: `{manifest['branch']}`",
+    f"- Head: `{manifest['head']}`",
+    f"- Created: `{manifest['created_at']}`",
+    "",
+    "| Step | Exit | Duration | Log |",
+    "| --- | ---: | ---: | --- |",
+]
+for step in steps:
+    seconds = step["duration_ms"] / 1000.0
+    lines.append(
+        f"| `{step['name']}` | {step['exit_code']} | {seconds:.2f}s | `{step['log']}` |"
+    )
+lines.extend(
+    [
+        "",
+        "Generated by `scripts/evals/computer-use-evidence.sh`.",
+        "Artifacts live under `build/` and are intentionally ignored by git.",
+        "",
+    ]
+)
+(out_dir / "summary.md").write_text("\n".join(lines))
+PY
+
+echo "Wrote Computer Use evidence to ${OUT_DIR}"
+echo "Summary: ${OUT_DIR}/summary.md"
+
+if [[ "$fail" -ne 0 && "$STRICT" != "0" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a local Computer Use evidence runner script and Makefile target.
- Adds deterministic mock-AX proof for a web-form workflow: fill fields, accept terms, resolve submit, require consequential-action confirmation, and observe the submitted-state snapshot.
- Extends optional RUN_EVALS evidence to include both ComputerUse and ComputerUseLoop suites.
- Documents the evidence bundle contract for local harness proof, including the Python dependency used for artifact generation.

## Why
Computer Use needs repeatable proof for the practical workflow tpae called out: using the harness to complete boring web forms. This PR keeps the default lane CI-safe and deterministic, while making the live-model ComputerUseLoop suite part of the opt-in evidence path for deeper local/frontier validation.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-cu-evidence make computer-use-evidence`
- Evidence artifact: `build/computer-use-evidence/20260625-211439/summary.md`
- `swift build --package-path Packages/OsaurusEvals --product osaurus-evals`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-cu-evals swift test --package-path Packages/OsaurusEvals --quiet --filter ComputerUseLoopEvalTests` (10 Swift Testing cases)
- `git diff --check && bash -n scripts/evals/computer-use-evidence.sh`
- Claude follow-up review: no blockers or should-fix items after the amendments.