### PR TITLE
Surface host-side remote-agent (p2p) activity

### DIFF
--- a/Packages/OsaurusCore/Managers/InsightsService.swift
+++ b/Packages/OsaurusCore/Managers/InsightsService.swift
@@ -156,6 +156,8 @@ final class InsightsService: ObservableObject {
                 if log.source != .httpAPI { return false }
             case .plugin:
                 if log.source != .plugin { return false }
+            case .p2p:
+                if log.source != .p2p { return false }
             }
 
             switch method {
@@ -369,6 +371,7 @@ enum SourceFilter: String, CaseIterable {
     case chatUI = "Chat"
     case httpAPI = "HTTP"
     case plugin = "Plugin"
+    case p2p = "P2P"
 
     var displayName: String {
         switch self {
@@ -376,6 +379,7 @@ enum SourceFilter: String, CaseIterable {
         case .chatUI: return L("Chat")
         case .httpAPI: return "HTTP"
         case .plugin: return L("Plugin")
+        case .p2p: return L("P2P")
         }
     }
 }
@@ -624,6 +628,19 @@ extension InsightsService {
         )
     }
 
+    /// Resolve the Insights source category for an HTTP-logged request.
+    /// In-app chat (`method == "CHAT"`) stays `.chatUI`. Anything that arrived
+    /// over the Secure Channel is another Osaurus peer (remote chat completions
+    /// or a remote agent run) and is surfaced under `.p2p`; all other
+    /// local/LAN HTTP traffic remains `.httpAPI`.
+    nonisolated static func inboundSource(
+        method: String,
+        transport: RequestTransport?
+    ) -> RequestSource {
+        if method == "CHAT" { return .chatUI }
+        return transport == .secureChannel ? .p2p : .httpAPI
+    }
+
     /// Logs HTTP requests with optional inference data
     nonisolated static func logAsync(
         method: String,
@@ -644,7 +661,7 @@ extension InsightsService {
         errorMessage: String? = nil,
         connection: RequestConnectionInfo? = nil
     ) {
-        let source: RequestSource = method == "CHAT" ? .chatUI : .httpAPI
+        let source = Self.inboundSource(method: method, transport: connection?.transport)
 
         logRequest(
             source: source,

--- a/Packages/OsaurusCore/Managers/PeerCallNotifier.swift
+++ b/Packages/OsaurusCore/Managers/PeerCallNotifier.swift
@@ -1,0 +1,58 @@
+//
+//  PeerCallNotifier.swift
+//  osaurus
+//
+//  Debounced host-side notification when a connected peer drives this host
+//  over the Secure Channel (remote agent run / remote chat completion).
+//
+
+import Foundation
+
+/// Shows an in-app toast (via `ToastManager`, consistent with the rest of the
+/// app) when an authenticated remote peer calls the host, debounced per peer
+/// so a multi-turn burst collapses into a single toast instead of a flood.
+@MainActor
+final class PeerCallNotifier {
+    static let shared = PeerCallNotifier()
+
+    /// Per-peer cooldown. Chosen default: long enough to collapse a burst of
+    /// back-to-back calls from one peer into a single toast, short enough that
+    /// a later, separate session still surfaces. Easy to tweak.
+    private let cooldown: TimeInterval = 60
+
+    /// Last toast time keyed by a stable peer identifier.
+    private var lastNotified: [String: Date] = [:]
+
+    private init() {}
+
+    /// Toast that a connected peer is running one of the host's agents.
+    /// - Parameters:
+    ///   - peerKey: Stable peer identifier (access-key id, else scoped audience).
+    ///   - agentName: Display name of the agent being driven.
+    func notifyAgentRun(peerKey: String, agentName: String) {
+        guard shouldNotify(peerKey) else { return }
+        ToastManager.shared.info(
+            L("Agent in use"),
+            message: String(
+                format: L("A connected peer is running \u{201C}%@\u{201D}."),
+                agentName
+            )
+        )
+    }
+
+    /// True at most once per `cooldown` per peer; records the time when it
+    /// returns true.
+    private func shouldNotify(_ peerKey: String) -> Bool {
+        let now = Date()
+        if let last = lastNotified[peerKey], now.timeIntervalSince(last) < cooldown {
+            return false
+        }
+        lastNotified[peerKey] = now
+        // Bound the dict across long uptimes that see many distinct peers.
+        if lastNotified.count > 256 {
+            let cutoff = now.addingTimeInterval(-cooldown)
+            lastNotified = lastNotified.filter { $0.value >= cutoff }
+        }
+        return true
+    }
+}

--- a/Packages/OsaurusCore/Managers/PeerCallNotifier.swift
+++ b/Packages/OsaurusCore/Managers/PeerCallNotifier.swift
@@ -34,7 +34,7 @@ final class PeerCallNotifier {
         ToastManager.shared.info(
             L("Agent in use"),
             message: String(
-                format: L("A connected peer is running \u{201C}%@\u{201D}."),
+                format: L("A connected peer is running “%@”."),
                 agentName
             )
         )

--- a/Packages/OsaurusCore/Models/Chat/RequestLog.swift
+++ b/Packages/OsaurusCore/Models/Chat/RequestLog.swift
@@ -38,12 +38,16 @@ enum RequestSource: String, Sendable, CaseIterable {
     case chatUI = "Chat UI"
     case httpAPI = "HTTP API"
     case plugin = "Plugin"
+    /// Inbound traffic from another Osaurus peer over the Secure Channel
+    /// (remote chat completions and remote agent runs).
+    case p2p = "P2P"
 
     var displayName: String {
         switch self {
         case .chatUI: return L("Chat UI")
         case .httpAPI: return L("HTTP API")
         case .plugin: return L("Plugin")
+        case .p2p: return L("P2P")
         }
     }
 }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4632,6 +4632,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         // loopback caller is unauthenticated under the no-auth-loopback model,
         // so it never receives the host-folder relaxation.
         let isAuthenticatedRemote = !isLoopbackConnection(context)
+        // Stable identity of an authenticated remote caller (for the debounced
+        // host toast in the run task); nil for loopback callers.
+        let peerCallKey: String? = {
+            guard isAuthenticatedRemote else { return nil }
+            let info = inboundConnectionInfo()
+            return info?.accessKeyId ?? info?.audience ?? "peer"
+        }()
 
         hop { writerBound.value.writeHeaders(ctx.value, extraHeaders: cors) }
 
@@ -4649,6 +4656,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         runRequestTask(priority: .userInitiated) {
             defer { admissionToken.release() }
+            // HTTP inference bypasses the in-app "generating" dot; drive it for
+            // the whole run (incl. remote-peer runs). `defer` balances all exits.
+            ServerController.signalGenerationStart()
+            defer { ServerController.signalGenerationEnd() }
             // Resolve model: a Mode 2 caller omits `model` (decoded as empty),
             // and older clients send the "default" sentinel. Both resolve to
             // the agent's effective model server-side.
@@ -4696,6 +4707,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // per-turn `message_sent` is emitted separately by ChatEngine on
             // the first (user) turn only.
             Task { @MainActor in FeatureTelemetry.agentRun(source: "http_api") }
+
+            // Debounced host toast: a connected peer is driving one of its
+            // agents. Loopback callers (`peerCallKey == nil`) never toast.
+            if let peerCallKey {
+                await MainActor.run {
+                    if let agentName = AgentManager.shared.agent(for: agentId)?.name {
+                        PeerCallNotifier.shared.notifyAgentRun(peerKey: peerCallKey, agentName: agentName)
+                    }
+                }
+            }
 
             // Mount the agent's host workspace folder when an authenticated
             // remote caller drives an agent whose owner granted one. Reachable
@@ -4817,6 +4838,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // the post-batch framing can attach it to the assistant
             // tool_calls message (mirrors the historical loop local).
             var responseContent = ""
+
+            // Host-side Insights enrichment: accumulate the full visible answer
+            // and every executed tool so the `/agents/{id}/run` row isn't empty.
+            // The loop invokes its hooks serially, so these plain vars are
+            // race-free — same capture pattern as `responseContent` above.
+            var loggedResponseText = ""
+            var loggedToolCalls: [ToolCallLog] = []
 
             // Set when a successful `complete`/`clarify` intercept ends the
             // run — the post-loop tail streams this text (the parsed summary
@@ -4951,6 +4979,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             if StreamingStatsHint.decode(delta) != nil { continue }
                             if StreamingToolHint.isSentinel(delta) { continue }
                             responseContent += delta
+                            loggedResponseText += delta
                             if let chunk = contentCoalescer.append(delta) {
                                 hop {
                                     writerBound.value.writeContent(
@@ -5135,6 +5164,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             )
                         )
                         toolResultsByCallId.append((outcome.callId, outcome.result))
+                        // Host-only: full tool detail (args + result). The peer
+                        // still sees only the sanitized SSE trace emitted above.
+                        loggedToolCalls.append(
+                            ToolCallLog(
+                                name: outcome.invocation.toolName,
+                                arguments: outcome.invocation.jsonArguments,
+                                result: outcome.result,
+                                isError: outcome.wasError
+                            )
+                        )
                     }
 
                     messages.append(
@@ -5164,6 +5203,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         )
                     }
                     messages.append(ChatMessage(role: "assistant", content: text))
+                    loggedResponseText += text
                 }
             )
 
@@ -5209,8 +5249,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     path: path,
                     userAgent: logUserAgent,
                     requestBody: logRequestBody,
+                    responseBody: loggedResponseText.isEmpty ? nil : loggedResponseText,
                     responseStatus: 200,
                     startTime: logStartTime,
+                    toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls,
                     errorMessage: error.localizedDescription
                 )
                 return
@@ -5235,8 +5277,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     path: path,
                     userAgent: logUserAgent,
                     requestBody: logRequestBody,
+                    responseBody: loggedResponseText.isEmpty ? nil : loggedResponseText,
                     responseStatus: 200,
                     startTime: logStartTime,
+                    toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls,
                     errorMessage: AgentToolLoop.overBudgetMessage
                 )
                 return
@@ -5257,6 +5301,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         context: ctx.value
                     )
                 }
+                loggedResponseText += notice
             }
             // A successful `complete`/`clarify` intercept ended the run:
             // stream the parsed summary/question as the final content so
@@ -5272,6 +5317,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         context: ctx.value
                     )
                 }
+                loggedResponseText += text
             }
             hop {
                 writerBound.value.writeFinish(model, responseId: responseId, created: created, context: ctx.value)
@@ -5282,9 +5328,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 path: path,
                 userAgent: logUserAgent,
                 requestBody: logRequestBody,
+                responseBody: loggedResponseText.isEmpty ? nil : loggedResponseText,
                 responseStatus: 200,
                 startTime: logStartTime,
-                model: model
+                model: model,
+                toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls
             )
         }
     }
@@ -6489,6 +6537,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             runRequestTask(priority: .userInitiated) {
                 defer { keepaliveTask.cancel() }
                 defer { HTTPInferenceAdmission.shared.release() }
+                // Same menu-bar "generating" dot for host-side server inference
+                // (incl. remote Mode-1 chat completions over the Secure Channel).
+                ServerController.signalGenerationStart()
+                defer { ServerController.signalGenerationEnd() }
                 let wasResidentBeforeStream = await ModelRuntime.shared.isResident(name: model)
                 var emittedSemanticDelta = false
                 func markSemanticDeltaIfConnected() {
@@ -6857,6 +6909,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
             runRequestTask(priority: .userInitiated) {
                 defer { HTTPInferenceAdmission.shared.release() }
+                // Same menu-bar "generating" dot (non-streaming path).
+                ServerController.signalGenerationStart()
+                defer { ServerController.signalGenerationEnd() }
                 do {
                     httpTrace.mark("http_task_start")
                     wasResidentBeforeComplete.value = await ModelRuntime.shared.isResident(name: model)

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -7279,6 +7279,40 @@
         }
       }
     },
+    "A connected peer is running “%@”." : {
+      "comment" : "In-app toast message shown on the host when a connected remote peer runs one of its agents. %@ is the agent name.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ein verbundener Peer führt „%@“ aus."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已连接的对等方正在运行“%@”。"
+          }
+        }
+      }
+    },
+    "Agent in use" : {
+      "comment" : "In-app toast title shown on the host when a connected remote peer is driving one of its agents.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agent wird verwendet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "代理使用中"
+          }
+        }
+      }
+    },
     "All" : {
       "localizations" : {
         "de" : {
@@ -59626,6 +59660,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接入一个你已经付费的大脑，或使用 Ollama 在本地运行一个。"
+          }
+        }
+      }
+    },
+    "P2P" : {
+      "comment" : "Insights source category for inbound peer-to-peer traffic over the Osaurus Secure Channel (remote chat completions and remote agent runs).",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P"
           }
         }
       }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -7288,6 +7288,12 @@
             "value" : "Ein verbundener Peer führt „%@“ aus."
           }
         },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "연결된 피어가 “%@”을(를) 실행하고 있습니다."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -7303,6 +7309,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Agent wird verwendet"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "에이전트 사용 중"
           }
         },
         "zh-Hans" : {
@@ -59668,6 +59680,12 @@
       "comment" : "Insights source category for inbound peer-to-peer traffic over the Osaurus Secure Channel (remote chat completions and remote agent runs).",
       "localizations" : {
         "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P"
+          }
+        },
+        "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "P2P"

--- a/Packages/OsaurusCore/Services/FeatureTelemetry.swift
+++ b/Packages/OsaurusCore/Services/FeatureTelemetry.swift
@@ -299,6 +299,7 @@ enum FeatureTelemetry {
         case .chatUI: return "chat_ui"
         case .httpAPI: return "http_api"
         case .plugin: return "plugin"
+        case .p2p: return "p2p"
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Insights/InsightsP2PSourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Insights/InsightsP2PSourceTests.swift
@@ -1,0 +1,102 @@
+//
+//  InsightsP2PSourceTests.swift
+//  osaurusTests
+//
+//  Pins the host-side "p2p" visibility surface added for remote-agent calls:
+//    1. `InsightsService.inboundSource` labels Secure-Channel peer traffic as
+//       `.p2p`, in-app chat as `.chatUI`, and everything else as `.httpAPI`.
+//    2. `RequestSource.p2p` exposes the new category's display/short labels and
+//       is enumerable so the Insights filter pill can render it.
+//    3. A `RequestLog` (the shape `/agents/{id}/run` now logs) retains the
+//       enriched `responseBody` + `toolCalls` so the Insights detail pane can
+//       show the full answer and every executed tool on the host.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Insights p2p source + agent-run enrichment")
+struct InsightsP2PSourceTests {
+
+    // MARK: - Source resolution (the single p2p chokepoint)
+
+    @Test func inboundSource_chatMethodIsChatUI() {
+        #expect(InsightsService.inboundSource(method: "CHAT", transport: nil) == .chatUI)
+        // CHAT (in-app) always wins, even if a transport is attached.
+        #expect(
+            InsightsService.inboundSource(method: "CHAT", transport: .secureChannel) == .chatUI
+        )
+    }
+
+    @Test func inboundSource_secureChannelIsP2P() {
+        // Any inbound peer request over the Secure Channel — remote chat
+        // completions AND remote agent runs — is categorized p2p.
+        #expect(
+            InsightsService.inboundSource(method: "POST", transport: .secureChannel) == .p2p
+        )
+    }
+
+    @Test func inboundSource_directLocalAndNilStayHTTP() {
+        #expect(InsightsService.inboundSource(method: "POST", transport: .direct) == .httpAPI)
+        #expect(InsightsService.inboundSource(method: "POST", transport: .local) == .httpAPI)
+        #expect(InsightsService.inboundSource(method: "POST", transport: nil) == .httpAPI)
+        #expect(InsightsService.inboundSource(method: "GET", transport: nil) == .httpAPI)
+    }
+
+    // MARK: - RequestSource category labels
+
+    @Test func p2pSource_labels() {
+        #expect(RequestSource.p2p.rawValue == "P2P")
+        #expect(RequestSource.p2p.shortName == "P2P")
+        // Acronym: stays "P2P" whether localized or falling back to the key.
+        #expect(RequestSource.p2p.displayName == "P2P")
+        // Enumerable so `FilterPills` (driven by CaseIterable) renders the pill.
+        #expect(RequestSource.allCases.contains(.p2p))
+    }
+
+    @Test func sourceFilter_includesP2P() {
+        #expect(SourceFilter.allCases.contains(.p2p))
+        #expect(SourceFilter.p2p.rawValue == "P2P")
+    }
+
+    // MARK: - Agent-run enrichment shape
+
+    @Test func requestLog_retainsResponseBodyAndToolCalls() {
+        let toolCalls = [
+            ToolCallLog(
+                name: "read_file",
+                arguments: #"{"path":"notes.md"}"#,
+                result: "ok: 3 lines",
+                isError: false
+            ),
+            ToolCallLog(
+                name: "write_file",
+                arguments: #"{"path":"out.md","contents":"hi"}"#,
+                result: "wrote 2 bytes",
+                isError: false
+            ),
+        ]
+        let log = RequestLog(
+            source: .p2p,
+            method: "POST",
+            path: "/agents/0xabc/run",
+            statusCode: 200,
+            durationMs: 1234,
+            responseBody: "Here is the summary you asked for.",
+            model: "peer/model",
+            toolCalls: toolCalls,
+            connection: RequestConnectionInfo(transport: .secureChannel, mode: .remoteAgentRun)
+        )
+
+        #expect(log.source == .p2p)
+        #expect(log.responseBody == "Here is the summary you asked for.")
+        #expect(log.toolCalls?.count == 2)
+        #expect(log.toolCalls?.first?.name == "read_file")
+        #expect(log.toolCalls?.first?.arguments == #"{"path":"notes.md"}"#)
+        #expect(log.toolCalls?.first?.result == "ok: 3 lines")
+        #expect(log.toolCalls?.last?.name == "write_file")
+        #expect(log.connection?.transport == .secureChannel)
+    }
+}

--- a/Packages/OsaurusCore/Views/Insights/InsightsDetailPane.swift
+++ b/Packages/OsaurusCore/Views/Insights/InsightsDetailPane.swift
@@ -242,6 +242,7 @@ struct InsightsDetailPane: View {
         case .chatUI: return "bubble.left.and.bubble.right.fill"
         case .httpAPI: return "network"
         case .plugin: return "puzzlepiece.extension.fill"
+        case .p2p: return "antenna.radiowaves.left.and.right"
         }
     }
 

--- a/Packages/OsaurusCore/Views/Insights/InsightsView.swift
+++ b/Packages/OsaurusCore/Views/Insights/InsightsView.swift
@@ -631,6 +631,7 @@ private struct SourceBadge: View {
         case .chatUI: return .pink
         case .httpAPI: return .blue
         case .plugin: return .teal
+        case .p2p: return .purple
         }
     }
 }
@@ -641,6 +642,7 @@ extension RequestSource {
         case .chatUI: return "Chat"
         case .httpAPI: return "HTTP"
         case .plugin: return "Plugin"
+        case .p2p: return "P2P"
         }
     }
 }


### PR DESCRIPTION
## Summary

Make inbound remote-agent calls fully visible on the **host** — the screenshot that prompted this showed an `/agents/{id}/run` row with no response and no way to tell a peer made the call.

- **`p2p` Insights category** for all inbound Secure-Channel peer traffic (remote chat completions **and** agent runs). Resolved at a single chokepoint (`InsightsService.inboundSource`) and wired through the filter pill, list-row source badge, detail-pane icon, and telemetry token. The client's own rows stay `chatUI`.
- **Enriched agent-run row**: `/agents/{id}/run` now logs the full assistant answer (`responseBody`) and every executed tool (`toolCalls` with args + results), accumulated via the agent loop's `modelStep`/`onBatchComplete` hooks and logged on both success and error paths. The calling peer still only sees the sanitized SSE trace — raw tool args/results never leave the host.
- **Menu-bar "generating" indicator** now lights for host-side server inference (agent runs and both `/chat/completions` paths) via balanced `ServerController.signalGenerationStart/End`, so the dot blinks during remote inference too.
- **Host toast**: a debounced per-peer (60s) `PeerCallNotifier` shows a `ToastManager` toast when an authenticated remote peer drives one of the host's agents — in-app toast for consistency with the rest of the app.
- **Localization + tests**: added `P2P` and toast strings to `Localizable.xcstrings`; `InsightsP2PSourceTests` covers source resolution, category labels, and the enriched `RequestLog` shape.

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore`
- [x] `swift test --filter InsightsP2PSourceTests` (6/6 pass)
- [x] `make app`
- [ ] Live host check: trigger a remote agent run and confirm the Insights row shows tool calls + response under a **P2P** badge, the menu-bar dot blinks during the run, and a toast appears.

Made with [Cursor](https://cursor.com)