### PR TITLE
make agent run honor agent temperature

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2857,6 +2857,24 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         )
     }
 
+    /// Resolve the sampling values the `/agents/{id}/run` loop should use.
+    /// The request body wins when present; the agent's configured value
+    /// (`effectiveTemperature` / `effectiveMaxTokens`) is the fallback before
+    /// the model-bundle default, matching the in-app Chat and plugin-host
+    /// surfaces. A `nil` result means "no explicit value" — the engine then
+    /// applies the bundle default.
+    @MainActor
+    static func resolveAgentSampling(
+        request: ChatCompletionRequest,
+        agentId: UUID
+    ) -> (temperature: Float?, maxTokens: Int?) {
+        let manager = AgentManager.shared
+        return (
+            request.temperature ?? manager.effectiveTemperature(for: agentId),
+            request.resolvedMaxTokens ?? manager.effectiveMaxTokens(for: agentId)
+        )
+    }
+
     private static func mergeAgentContextTools(
         _ agentTools: [Tool],
         clientTools: [Tool]?
@@ -4795,10 +4813,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // the model-bundle default. Resolved once here because the loop's
             // `modelStep` samples from `req`, not the enriched request.
             let (effectiveTemperature, effectiveMaxTokens) = await MainActor.run {
-                (
-                    req.temperature ?? AgentManager.shared.effectiveTemperature(for: agentId),
-                    req.resolvedMaxTokens ?? AgentManager.shared.effectiveMaxTokens(for: agentId)
-                )
+                Self.resolveAgentSampling(request: req, agentId: agentId)
             }
 
             let configuredMaxToolAttempts = await MainActor.run {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4788,6 +4788,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let tools = enrichedReq.tools ?? []
             let resolvedToolChoice = enrichedReq.tool_choice
 
+            // Honor the agent's configured sampling when the request omits it,
+            // matching the in-app Chat and plugin-host surfaces (which apply
+            // `effectiveTemperature` / `effectiveMaxTokens`). The request body
+            // still wins when present; the agent config is the fallback before
+            // the model-bundle default. Resolved once here because the loop's
+            // `modelStep` samples from `req`, not the enriched request.
+            let (effectiveTemperature, effectiveMaxTokens) = await MainActor.run {
+                (
+                    req.temperature ?? AgentManager.shared.effectiveTemperature(for: agentId),
+                    req.resolvedMaxTokens ?? AgentManager.shared.effectiveMaxTokens(for: agentId)
+                )
+            }
+
             let configuredMaxToolAttempts = await MainActor.run {
                 ChatConfigurationStore.load().maxToolAttempts ?? 30
             }
@@ -4815,7 +4828,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     contextWindow: contextWindow,
                     systemPromptChars: sysChars,
                     toolTokens: toolTokens,
-                    maxResponseTokens: req.resolvedMaxTokens
+                    maxResponseTokens: effectiveMaxTokens
                 )
             }()
             // Request-scoped sticky compaction: trims stay monotonic across
@@ -4911,8 +4924,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     var iterationReq = ChatCompletionRequest(
                         model: model,
                         messages: msgs,
-                        temperature: req.temperature,
-                        max_tokens: req.resolvedMaxTokens,
+                        temperature: effectiveTemperature,
+                        max_tokens: effectiveMaxTokens,
                         stream: true,
                         top_p: req.top_p,
                         frequency_penalty: req.frequency_penalty,

--- a/Packages/OsaurusCore/Tests/Networking/AgentRunSamplingResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/AgentRunSamplingResolutionTests.swift
@@ -1,0 +1,77 @@
+//
+//  AgentRunSamplingResolutionTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the sampling-resolution contract for the `/agents/{id}/run` endpoint:
+//  an agent's configured temperature / max tokens are honored when the request
+//  omits them, while an explicit request value still wins. Guards against the
+//  HTTP agent-run path reverting to sampling only from the raw request body
+//  (the bug where an agent's `effectiveTemperature` was ignored over HTTP).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct AgentRunSamplingResolutionTests {
+
+    /// Decode a minimal chat-completion request, optionally carrying explicit
+    /// sampling values. Omitted keys decode to `nil` (the real wire behavior).
+    private func makeRequest(temperature: Float?, maxTokens: Int?) -> ChatCompletionRequest {
+        var fields = ["\"model\":\"m\"", "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]"]
+        if let temperature { fields.append("\"temperature\":\(temperature)") }
+        if let maxTokens { fields.append("\"max_tokens\":\(maxTokens)") }
+        let json = "{\(fields.joined(separator: ","))}"
+        return try! JSONDecoder().decode(
+            ChatCompletionRequest.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    @Test
+    func omittedSamplingFallsBackToAgentConfig() async {
+        await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let agent = Agent(
+                name: "Sampling Probe \(UUID().uuidString)",
+                temperature: 0.1,
+                maxTokens: 512
+            )
+            manager.add(agent)
+
+            let resolved = HTTPHandler.resolveAgentSampling(
+                request: self.makeRequest(temperature: nil, maxTokens: nil),
+                agentId: agent.id
+            )
+            #expect(resolved.temperature == 0.1)
+            #expect(resolved.maxTokens == 512)
+
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+
+    @Test
+    func explicitRequestSamplingWinsOverAgentConfig() async {
+        await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let agent = Agent(
+                name: "Sampling Probe \(UUID().uuidString)",
+                temperature: 0.1,
+                maxTokens: 512
+            )
+            manager.add(agent)
+
+            let resolved = HTTPHandler.resolveAgentSampling(
+                request: self.makeRequest(temperature: 0.9, maxTokens: 256),
+                agentId: agent.id
+            )
+            #expect(resolved.temperature == 0.9)
+            #expect(resolved.maxTokens == 256)
+
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

closes #1674 

  - fixed the HTTP agent-run endpoint ignoring the agent's configured temperature so only the request body value or the model-bundle default reached the sampler
  - fell back to the agent's configured temperature and max tokens when the request omits them which matches the in-app chat and plugin-host surfaces
  - kept an explicit request value taking precedence over the agent configuration
  - applied the resolved max tokens to the loop's context budget reservation for parity
  - extracted the sampling resolution into a testable helper and added tests for the omitted and explicit cases

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
