### PR TITLE
stop wasted iterations on repeated failing capabilities_load calls

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -102,15 +102,17 @@ public final class AgentTaskState {
     /// before failing.
     private static let execLikeTools: Set<String> = ["shell_run", "sandbox_exec"]
 
-    /// Folder tools whose `invalid_args` / `not_found` failures are
-    /// DETERMINISTIC given an unchanged filesystem: re-issuing the identical
-    /// call must return the identical error. Their held errors are replayed
-    /// instead of re-executed (observed live: a model repeating the same
-    /// failing `file_edit` 8× until the iteration cap). `shell_run` and
-    /// `db_*` are deliberately excluded — identical re-runs there are
-    /// legitimate retries that may succeed.
+    /// Tools whose `invalid_args` / `not_found` failures are DETERMINISTIC
+    /// given an unchanged filesystem / capability catalog: re-issuing the
+    /// identical call must return the identical error. Their held errors are
+    /// replayed instead of re-executed (observed live: a model repeating the
+    /// same failing `file_edit` 8× until the iteration cap). `capabilities_load`
+    /// qualifies because capability ids are a closed vocabulary — a bad/unknown
+    /// id fails identically on every retry. `shell_run` and `db_*` are
+    /// deliberately excluded — identical re-runs there are legitimate retries
+    /// that may succeed.
     private static let deterministicErrorTools: Set<String> = [
-        "file_read", "file_search", "file_edit",
+        "file_read", "file_search", "file_edit", "capabilities_load",
     ]
 
     /// Error kinds eligible for held-error replay. Both depend only on the

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -212,6 +212,26 @@ struct AgentTaskStateTests {
         #expect(held == env, "the replay must be the exact prior envelope, not a collapsed form")
     }
 
+    /// `capabilities_load` is a path-less deterministic-error tool: a failing
+    /// `invalid_args` load is held and replayed (with an escalation notice)
+    /// instead of re-executing, so a model can't burn iterations re-issuing
+    /// the same bad capability id.
+    @Test func dedupe_capabilitiesLoadInvalidArgsIsHeld() {
+        let state = AgentTaskState()
+        let args = #"{"ids":["plugin/Scite.AI"]}"#
+        let err = ToolEnvelope.failure(
+            kind: .invalidArgs,
+            message: "Unknown type 'plugin'",
+            tool: "capabilities_load",
+            retryable: false
+        )
+        state.record(name: "capabilities_load", argsJSON: args, result: err)
+        #expect(state.heldResult(name: "capabilities_load", argsJSON: args) == err)
+        #expect(state.lastReplayNotice?.contains("capabilities_load") == true)
+        // A different id set is a different call — not held.
+        #expect(state.heldResult(name: "capabilities_load", argsJSON: #"{"ids":["skill/other"]}"#) == nil)
+    }
+
     // MARK: - Next-step nudge
 
     /// Reactive: a single listing does NOT nudge (a capable model that

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -322,6 +322,27 @@ struct CapabilitiesLoadToolTests {
         #expect(result.contains("Unknown type"))
     }
 
+    @Test func invalidIdIsNonRetryable() async throws {
+        // The issue's repro: a wrong-prefix id is a deterministic invalid_args
+        // failure. Capability ids are a closed vocabulary, so re-issuing the
+        // identical call cannot succeed — it must NOT be advertised retryable.
+        let tool = CapabilitiesLoadTool()
+        let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"plugin/Scite.AI\"]}")
+        #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+        #expect(EnvelopeAssertions.failureRetryable(result) == false)
+    }
+
+    @Test func notFoundIsNonRetryable() async throws {
+        // A not_found capability id is equally deterministic within a turn; the
+        // prior `kind != .rejected` rule wrongly advertised it as retryable.
+        let tool = CapabilitiesLoadTool()
+        let result = try await tool.execute(
+            argumentsJSON: "{\"ids\": [\"skill/zzz_nonexistent_skill\"]}"
+        )
+        #expect(EnvelopeAssertions.failureKind(result) == "not_found")
+        #expect(EnvelopeAssertions.failureRetryable(result) == false)
+    }
+
     @Test func methodNotFoundReturnsError() async throws {
         let tool = CapabilitiesLoadTool()
         let result = try await tool.execute(

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -566,12 +566,18 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         // taught small models to treat misses as wins.
         if sections.isEmpty, let first = failures.first {
             let combined = failures.map(\.message).joined(separator: "\n")
+            // A bad/unknown capability id is deterministic: capability ids are
+            // a closed vocabulary, so re-issuing the identical call cannot
+            // succeed. Mark those (and policy refusals) non-retryable — only a
+            // genuine runtime error is worth retrying as-is. This also keeps
+            // the flag consistent with the deterministic-error replay guard.
+            let deterministicKinds: Set<ToolEnvelope.Kind> = [.rejected, .invalidArgs, .notFound]
             return ToolEnvelope.failure(
                 kind: first.kind,
                 message: combined,
                 field: first.kind == .invalidArgs ? "ids" : nil,
                 tool: name,
-                retryable: first.kind != .rejected
+                retryable: !deterministicKinds.contains(first.kind)
             )
         }
 


### PR DESCRIPTION
## Summary

addresses #1675 

  - marked deterministic capability load failures as non retryable so a malformed or unknown capability id is no longer advertised as worth retrying
  - fixed not found capability loads being reported as retryable to align them with the framework convention
  - added capabilities_load to the deterministic error replay guard so an identical failing call is  replayed with an escalation notice instead of re-executed until the iteration cap
  - kept genuine runtime errors retryable and left successful and partial loads unchanged
  - added tests covering the non-retryable failure cases and the replay guard

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
