### PR TITLE
Fix #1680: surface (not silently truncate) multi-step tool tasks on a premature-EOS empty turn

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5221,6 +5221,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 emitFallbackText: { text in
                     // Empty-turn recovery exhausted: stream a visible fallback
                     // so the client never receives an empty assistant message.
+                    if text == AgentToolLoop.emptyToolTaskFallback {
+                        messages.append(ChatMessage(role: "assistant", content: text))
+                        loggedResponseText += text
+                        return
+                    }
                     hop {
                         writerBound.value.writeContent(
                             text,
@@ -5310,6 +5315,26 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     startTime: logStartTime,
                     toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls,
                     errorMessage: AgentToolLoop.overBudgetMessage
+                )
+                return
+            }
+
+            if exitState == .emptyResponseExhausted {
+                hop {
+                    writerBound.value.writeError(AgentToolLoop.emptyToolTaskFallback, context: ctx.value)
+                    writerBound.value.writeEnd(ctx.value)
+                }
+                logSelf.logRequest(
+                    method: "POST",
+                    path: path,
+                    userAgent: logUserAgent,
+                    requestBody: logRequestBody,
+                    responseBody: loggedResponseText.isEmpty ? nil : loggedResponseText,
+                    responseStatus: 200,
+                    startTime: logStartTime,
+                    model: model,
+                    toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls,
+                    errorMessage: AgentToolLoop.emptyToolTaskFallback
                 )
                 return
             }
@@ -6621,6 +6646,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     httpTrace.mark("http_stream_chat_ready")
                     if disconnected.value { throw CancellationError() }
                     var accumulatedContent = ""
+                    var accumulatedReasoning = ""
                     var contentCoalescer = Self.StreamDeltaCoalescer(
                         interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
                     )
@@ -6633,6 +6659,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         if let reasoning = StreamingReasoningHint.decode(delta) {
                             httpTrace.markFirstSemanticDelta("reasoning")
                             markSemanticDeltaIfConnected()
+                            accumulatedReasoning += reasoning
                             if let pending = contentCoalescer.flush() {
                                 hop {
                                     writerBound.value.writeContent(
@@ -6703,6 +6730,39 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                                 context: ctx.value
                             )
                         }
+                    }
+                    let terminalMessage = ChatMessage(
+                        role: "assistant",
+                        content: accumulatedContent,
+                        tool_calls: nil,
+                        tool_call_id: nil,
+                        reasoning_content: accumulatedReasoning.isEmpty ? nil : accumulatedReasoning
+                    )
+                    if let error = Self.emptyToolTaskCompletionError(
+                        requestMessages: enrichedReq.messages,
+                        responseMessage: terminalMessage
+                    ) {
+                        let message = error.localizedDescription
+                        hop {
+                            writerBound.value.writeError(message, context: ctx.value)
+                            writerBound.value.writeEnd(ctx.value)
+                        }
+                        httpTrace.mark("http_sse_error_written")
+                        httpTrace.emit(finishReason: "error", responseStatus: 200, errorMessage: message)
+                        logSelf.logRequest(
+                            method: "POST",
+                            path: "/chat/completions",
+                            userAgent: logUserAgent,
+                            requestBody: logRequestBody,
+                            responseStatus: 200,
+                            startTime: logStartTime,
+                            model: logModel,
+                            temperature: logTemperature,
+                            maxTokens: logMaxTokens,
+                            finishReason: .error,
+                            errorMessage: message
+                        )
+                        return
                     }
                     let includeUsage = req.stream_options?.include_usage == true
                     let promptTokens = Self.estimatePromptTokens(enrichedReq.messages)
@@ -6961,6 +7021,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         systemContent: sysContent,
                         tools: enrichedReq.tools ?? []
                     )
+                    if let error = Self.emptyToolTaskCompletionError(
+                        requestMessages: enrichedReq.messages,
+                        responseMessage: resp.choices.first?.message
+                    ) {
+                        throw error
+                    }
                     if persistOnSuccess, let assistantMsg = resp.choices.first?.message {
                         var finalMessages = priorMessages
                         finalMessages.append(assistantMsg)

--- a/Packages/OsaurusCore/Networking/HTTPProtocolErrors.swift
+++ b/Packages/OsaurusCore/Networking/HTTPProtocolErrors.swift
@@ -14,6 +14,10 @@ import NIOHTTP1
 
 extension HTTPHandler {
 
+    static let emptyToolTaskCompletionMessage = AgentToolLoop.emptyToolTaskFallback
+
+    private static let emptyToolTaskCompletionDomain = "OsaurusEmptyToolTaskCompletion"
+
     /// Wire flavor for the JSON error body. Each flavor uses the envelope
     /// shape its protocol's clients expect.
     enum HTTPErrorFlavor {
@@ -49,6 +53,9 @@ extension HTTPHandler {
         if error is CancellationError {
             return HTTPResponseStatus(statusCode: 499, reasonPhrase: "Client Closed Request")
         }
+        if (error as NSError).domain == emptyToolTaskCompletionDomain {
+            return .serviceUnavailable
+        }
         if error is ModelRuntime.LoadRefusedError {
             return .serviceUnavailable
         }
@@ -65,6 +72,9 @@ extension HTTPHandler {
         if error is CancellationError {
             return "request_cancelled"
         }
+        if (error as NSError).domain == emptyToolTaskCompletionDomain {
+            return "server_error"
+        }
         if error is ModelRuntime.LoadRefusedError {
             return "insufficient_resources"
         }
@@ -75,6 +85,35 @@ extension HTTPHandler {
             return "invalid_request_error"
         }
         return "internal_error"
+    }
+
+    static func emptyToolTaskCompletionError(
+        requestMessages: [ChatMessage],
+        responseMessage: ChatMessage?
+    ) -> Error? {
+        guard requestContainsToolTaskHistory(requestMessages),
+            assistantResponseIsEmptyNoTool(responseMessage)
+        else { return nil }
+        return NSError(
+            domain: emptyToolTaskCompletionDomain,
+            code: 503,
+            userInfo: [NSLocalizedDescriptionKey: emptyToolTaskCompletionMessage]
+        )
+    }
+
+    private static func requestContainsToolTaskHistory(_ messages: [ChatMessage]) -> Bool {
+        messages.contains { message in
+            message.role == "tool" || !(message.tool_calls?.isEmpty ?? true)
+        }
+    }
+
+    private static func assistantResponseIsEmptyNoTool(_ message: ChatMessage?) -> Bool {
+        guard let message, message.role == "assistant" else { return false }
+        let contentEmpty = (message.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let reasoningEmpty =
+            (message.reasoning_content ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let toolCallsEmpty = message.tool_calls?.isEmpty ?? true
+        return contentEmpty && reasoningEmpty && toolCallsEmpty
     }
 
     static func anthropicErrorType(for error: Error) -> String {

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -564,6 +564,9 @@ enum AgentToolLoop {
         /// surface emits a distinct "context cannot fit" envelope instead
         /// of sending a doomed request.
         case overBudget
+        /// Empty-turn recovery exhausted after at least one tool result had
+        /// already landed, so the task may be truncated rather than merely blank.
+        case emptyResponseExhausted
     }
 
     struct RunResult: Equatable, Sendable {
@@ -595,6 +598,9 @@ enum AgentToolLoop {
     /// an empty turn never surfaces as a silent "No visible text was produced".
     static let emptyTurnFallback =
         "I wasn't able to generate a response to that. Please try rephrasing your request."
+
+    static let emptyToolTaskFallback =
+        "The model returned empty output after tool execution. The agent task may be incomplete; retry with less context or continue from the latest tool result."
 
     /// The iteration-budget warning staged when the remaining budget
     /// drops to the policy threshold.
@@ -937,6 +943,7 @@ enum AgentToolLoop {
         // the relief yet (staged once per run).
         var dataMovementStepsUsed = 0
         var announcedDataMovementRelief = false
+        var completedToolWork = false
 
         while iteration < policy.maxIterations {
             if await hooks.isCancelled() {
@@ -990,6 +997,10 @@ enum AgentToolLoop {
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue
+                }
+                if completedToolWork {
+                    await hooks.emitFallbackText?(Self.emptyToolTaskFallback)
+                    return RunResult(exit: .emptyResponseExhausted, iterations: iteration)
                 }
                 // Recovery exhausted: guarantee a visible message instead of
                 // a silent dead-end, then end the run.
@@ -1241,6 +1252,9 @@ enum AgentToolLoop {
                 }
 
                 await hooks.onBatchComplete(outcomes)
+                if !outcomes.isEmpty {
+                    completedToolWork = true
+                }
 
                 // Data-movement relief: when an iteration's tool calls
                 // are ALL successful bulk loads (db_import / bulk

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -856,6 +856,7 @@ public enum AgentLoopEvaluator {
         case .iterationCapReached: return "iterationCapReached"
         case .cancelled: return "cancelled"
         case .overBudget: return "overBudget"
+        case .emptyResponseExhausted: return "emptyResponseExhausted"
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1548,6 +1548,14 @@ final class PluginHostContext: @unchecked Sendable {
                     "shared_artifacts": sharedArtifacts,
                 ])
             }
+            if exit == .emptyResponseExhausted {
+                return Self.jsonString([
+                    "error": "empty_tool_task_completion",
+                    "message": AgentToolLoop.emptyToolTaskFallback,
+                    "tool_calls_executed": toolCallsExecuted,
+                    "shared_artifacts": sharedArtifacts,
+                ])
+            }
 
             // A successful `complete`/`clarify` intercept ended the run
             // (`.endedBySurface`): build the matching terminal envelope
@@ -2019,6 +2027,16 @@ final class PluginHostContext: @unchecked Sendable {
                 return Self.jsonString([
                     "error": "context_overflow",
                     "message": AgentToolLoop.overBudgetMessage,
+                    "tool_calls_executed": toolCallsExecuted,
+                    "shared_artifacts": sharedArtifacts,
+                ])
+            }
+            if exit == .emptyResponseExhausted {
+                emit(Self.chunkPayload(id: cid, delta: [:], finishReason: "empty_response"))
+                persistPartial(lastContent)
+                return Self.jsonString([
+                    "error": "empty_tool_task_completion",
+                    "message": AgentToolLoop.emptyToolTaskFallback,
                     "tool_calls_executed": toolCallsExecuted,
                     "shared_artifacts": sharedArtifacts,
                 ])

--- a/Packages/OsaurusCore/Tests/Networking/HTTPChatCompletionsEmptyToolTaskTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPChatCompletionsEmptyToolTaskTests.swift
@@ -1,0 +1,47 @@
+//
+//  HTTPChatCompletionsEmptyToolTaskTests.swift
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+struct HTTPChatCompletionsEmptyToolTaskTests {
+
+    @Test func emptyNoToolResponseAfterToolHistoryIsRejected() {
+        let toolCall = ToolCall(
+            id: "call_read",
+            type: "function",
+            function: ToolCallFunction(name: "file_read", arguments: #"{"path":"notes.md"}"#)
+        )
+        let activeToolTranscript = [
+            ChatMessage(role: "user", content: "Read notes.md and summarize it."),
+            ChatMessage(role: "assistant", content: nil, tool_calls: [toolCall], tool_call_id: nil),
+            ChatMessage(role: "tool", content: "notes", tool_calls: nil, tool_call_id: "call_read"),
+        ]
+
+        let emptyFinal = ChatMessage(role: "assistant", content: " \n ", tool_calls: nil, tool_call_id: nil)
+        #expect(
+            HTTPHandler.emptyToolTaskCompletionError(
+                requestMessages: activeToolTranscript,
+                responseMessage: emptyFinal
+            ) != nil
+        )
+
+        let textFinal = ChatMessage(role: "assistant", content: "Summary: notes")
+        #expect(
+            HTTPHandler.emptyToolTaskCompletionError(
+                requestMessages: activeToolTranscript,
+                responseMessage: textFinal
+            ) == nil
+        )
+
+        let ordinaryEmpty = ChatMessage(role: "assistant", content: "")
+        #expect(
+            HTTPHandler.emptyToolTaskCompletionError(
+                requestMessages: [ChatMessage(role: "user", content: "Hello")],
+                responseMessage: ordinaryEmpty
+            ) == nil
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tools/SandboxReduceTool.swift
+++ b/Packages/OsaurusCore/Tools/SandboxReduceTool.swift
@@ -391,6 +391,13 @@ struct SandboxReduceTool: OsaurusTool, @unchecked Sendable {
                 tool: name,
                 retryable: true
             )
+        case .emptyResponseExhausted:
+            return ToolEnvelope.failure(
+                kind: .executionError,
+                message: AgentToolLoop.emptyToolTaskFallback,
+                tool: name,
+                retryable: true
+            )
         }
     }
 }


### PR DESCRIPTION
## Problem (#1680)

A tool-using agent driving `/v1/chat/completions` silently truncates a multi-step task: with `qwen3.6-35b-a3b-mxfp4-mtp` at large context the model returns an **empty, no-tool-call** completion (premature EOS), and osaurus returns that empty turn as a normal **HTTP 200 success**. An external harness sees "assistant produced no tool call" and ends the task — so the work stops mid-multi-step with no error, no signal, nothing in logs pointing at the cause.

The root cause of the truncation symptom is on the **osaurus serving side**: an empty completion after tool execution is indistinguishable, to the client, from a deliberate "I'm done" turn. The premature EOS itself (the model emitting `<|im_end|>` early under MTP at large context) is a separate model/runtime concern tracked as a follow-up; this PR makes the osaurus-side symptom **non-silent regardless of why the model stopped early**.

## Fix

- **`/v1/chat/completions` (streaming + non-streaming):** an empty/no-tool assistant response that arrives **after tool-task history** (the request contains a `tool` message or a prior assistant `tool_calls`) is now rejected with an OpenAI-style **503 `server_error`** instead of being returned as an empty 200. The truncation becomes a visible error the client can surface or retry on.
  - Gated tightly: a normal text response is never rejected, and an empty plain first-turn (no prior tool history) is never rejected — only the "empty after tool work" case.
- **`AgentToolLoop`:** the empty-turn recovery path, when it exhausts **after tool work has completed**, now returns a distinct `.emptyResponseExhausted` exit with a clearer message ("The model returned empty output after tool execution. The agent task may be incomplete; retry with less context or continue from the latest tool result."). `/agents/{id}/run` emits a distinct SSE error for it.

## Why this shape

The fix distinguishes three cases the old code conflated:
1. empty first turn (no tool history) → unchanged (not an error)
2. normal text/tool response → unchanged
3. **empty + no-tool, after tool history → rejected (was silently 200)**

Only case 3 changes, so existing well-behaved flows are unaffected.

## Tests

Adds `HTTPChatCompletionsEmptyToolTaskTests.emptyNoToolResponseAfterToolHistoryIsRejected` covering all three cases (empty-after-tool → rejected; normal text → not rejected; empty first-turn → not rejected). No existing tests modified or removed.

## Verification

- Release build (`xcodebuild ... -configuration Release`) **SUCCEEDED** with the new exit case and all exhaustive-switch consumers updated.

## Follow-up (out of scope)

The premature EOS under `qwen3.6 *-mtp` at large context is a vmlx/MTP-side concern (early `<|im_end|>` emission). This PR is the serving-side guard so the truncation is never silent; the early-EOS root cause is tracked separately.

Closes #1680.
