### PR TITLE
improved plugin discovery for smaller local models

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -926,8 +926,14 @@ enum AgentToolLoop {
     /// (registry dispatch is by name), but the rendered tool-schema block
     /// stays frozen until the next compose so the prompt prefix — and the
     /// paged-KV cache built on it — stays byte-stable mid-run.
+    ///
+    /// The anti-rediscovery clause is load-bearing: small models read "not in
+    /// the tool list yet" as "I can't call it" and loop back into
+    /// `capabilities_discover` / a redundant `capabilities_load` (observed on
+    /// gemma-12B after a `plugin/<id>` group load). Stating outright that the
+    /// tools are ready and must NOT be re-discovered cuts that detour.
     static let deferredSchemaNotice =
-        "\nNote: loaded tools are callable NOW — call them by name with JSON arguments. Their full schemas will appear in the tool list from the next user turn."
+        "\nNote: the tools just loaded are callable NOW — invoke them directly by name with JSON arguments. Do NOT call capabilities_discover or capabilities_load for them again; they are already available. Their schemas are omitted from the tool list until the next user turn, but calling them by name works immediately."
 
     /// Stable call-id assignment: preserve the model-supplied id when
     /// present (OpenAI `call_xxx`), otherwise mint one in the same shape.

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -281,6 +281,15 @@ public struct SystemPromptComposer: Sendable {
                     + "staticPrefixHash=\(manifest.staticPrefixHash(tools: toolset.tools).prefix(16))\n"
                     + manifest.debugDescription
             )
+            // Dump the rendered enabled-capabilities section verbatim so a
+            // single run shows EXACTLY what the model sees (e.g. the tiered
+            // `plugin/<id>` lines) — the token table above can't reveal the
+            // text. Bounded: the manifest itself is capped.
+            if let manifestText = manifest.section("enabledManifest")?.content,
+                !manifestText.isEmpty
+            {
+                PrefillDebugLog.shared.log("---- ENABLED-MANIFEST (rendered)\n\(manifestText)")
+            }
         }
 
         emitToolDiagnostics(
@@ -623,9 +632,10 @@ public struct SystemPromptComposer: Sendable {
         let groups = deriveEnabledManifest(agentId: agentId)
         // `prefersCompactPrompt` already folds the small/tiny-window cases
         // (existing behaviour) and the local-small-model case (large window,
-        // ≤ param ceiling). Compact drops per-capability descriptions + the
-        // worked example — ~14k → <1k tokens here — while keeping every
-        // loadable id, so tool discovery is unaffected.
+        // ≤ param ceiling). Compact tiers the manifest to one `plugin/<id>`
+        // line per plugin (the model loads the id to expand the group) and
+        // drops the worked example — so cold first-turn prefill stays bounded
+        // as installed plugins grow, while every plugin stays visible.
         let compact = ContextSizeResolver.resolve(modelId: snapshot.model).prefersCompactPrompt
         let section = SystemPromptTemplates.enabledCapabilitiesManifest(
             groups: groups,
@@ -1242,6 +1252,7 @@ public struct SystemPromptComposer: Sendable {
         let orderedIds = allGroupIds.sorted()
         var groups = orderedIds.map { groupId in
             SystemPromptTemplates.ManifestPluginGroup(
+                groupId: groupId,
                 pluginDisplay: pluginDisplayName(for: groupId),
                 skills: (skillsByGroup[groupId] ?? []).sorted { $0.name < $1.name },
                 tools: (toolsByGroup[groupId] ?? []).sorted { $0.name < $1.name }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -492,10 +492,10 @@ public enum SystemPromptTemplates {
             intro = """
                 ## Enabled capabilities
 
-                Enabled for this session. To use a plugin, first load its whole \
-                tool group with capabilities_load using the `plugin/<id>` shown \
-                (e.g. `capabilities_load({"ids": ["plugin/calendar"]})`); ids \
-                beginning `tool/` or `skill/` load individually.
+                Enabled for this session. Load a plugin with capabilities_load \
+                using its `plugin/<id>` (e.g. \
+                `capabilities_load({"ids": ["plugin/calendar"]})`); `tool/` and \
+                `skill/` ids load individually.
                 """
         } else {
             intro = """

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -419,14 +419,22 @@ public enum SystemPromptTemplates {
     /// layout. `skills` render before `tools` so the "Skills that govern
     /// tool groups" rule has a visible anchor.
     public struct ManifestPluginGroup: Sendable, Equatable {
+        /// The plugin's tool-group id, used to form the loadable `plugin/<id>`
+        /// in the compact tiered manifest. Empty for synthetic groups that
+        /// have no single loadable group (built-in image tools, the
+        /// standalone-skills bucket); those fall back to listing their
+        /// directly-loadable `tool/`/`skill/` ids inline.
+        public let groupId: String
         public let pluginDisplay: String
         public let skills: [ManifestCapability]
         public let tools: [ManifestCapability]
         public init(
+            groupId: String = "",
             pluginDisplay: String,
             skills: [ManifestCapability],
             tools: [ManifestCapability]
         ) {
+            self.groupId = groupId
             self.pluginDisplay = pluginDisplay
             self.skills = skills
             self.tools = tools
@@ -461,15 +469,91 @@ public enum SystemPromptTemplates {
     ) -> String? {
         guard !groups.isEmpty else { return nil }
 
+        let blocks =
+            compact
+            ? tieredCompactBlocks(groups)
+            : verboseBlocks(groups)
+
+        // The "never deny a listed capability" rule is owned by
+        // `toolGroundingLine` / `groundingDirective` (which co-fire whenever
+        // this section renders), so the intro doesn't restate it. Compact
+        // mode (small-context models) also drops the worked example — the
+        // ids themselves are what stop a small model from denying a
+        // capability, and the example's tokens crowd an 8K window.
+        let intro: String
+        if compact {
+            // Tiered manifest: one `plugin/<id>` line per plugin instead of a
+            // line per tool. A plugin with N tools costs one line, not N, so
+            // the cold first-turn prefill stays bounded as installed plugins
+            // grow — while the model still SEES every plugin (it never has to
+            // guess one exists and `capabilities_discover` for it). Loading
+            // `plugin/<id>` expands the whole group (and runs its governing
+            // skill) in one call.
+            intro = """
+                ## Enabled capabilities
+
+                Enabled for this session. To use a plugin, first load its whole \
+                tool group with capabilities_load using the `plugin/<id>` shown \
+                (e.g. `capabilities_load({"ids": ["plugin/calendar"]})`); ids \
+                beginning `tool/` or `skill/` load individually.
+                """
+        } else {
+            intro = """
+                ## Enabled capabilities
+
+                These capabilities are enabled for this session. Each line begins \
+                with its loadable id; some are already in your tool schema, others \
+                must be loaded first. To load one, call capabilities_load with its \
+                id exactly as shown \
+                (e.g. `capabilities_load({"ids": ["tool/<name>"]})`).
+
+                Worked example — User: "You have a list_messages tool." If \
+                `tool/list_messages` is listed here, confirm it and capabilities_load \
+                it before use.
+                """
+        }
+
+        return intro + "\n\n" + blocks.joined(separator: "\n")
+    }
+
+    /// Compact (small-context model) rendering: one `plugin/<id>` line per
+    /// plugin. The model loads the id to pull in the whole group, so the menu
+    /// stays one line regardless of how many tools a plugin owns. Synthetic
+    /// groups with no loadable group id (built-in image tools, standalone
+    /// skills) keep listing their directly-loadable `tool/`/`skill/` ids
+    /// inline — there is no `plugin/<id>` to expand and they are few.
+    private static func tieredCompactBlocks(
+        _ groups: [ManifestPluginGroup]
+    ) -> [String] {
+        groups.map { group in
+            guard !group.groupId.isEmpty else {
+                var lines = ["<\(group.pluginDisplay)>"]
+                lines.append(contentsOf: group.skills.map { "  skill/\($0.name)" })
+                lines.append(contentsOf: group.tools.map { "  tool/\($0.name)" })
+                return lines.joined(separator: "\n")
+            }
+            // `skill-governed` tells the model to expect tool-ordering
+            // instructions when it loads the group; loading `plugin/<id>`
+            // surfaces them automatically, so it is a hint, not a step.
+            let governed = group.skills.isEmpty ? "" : " — skill-governed"
+            return "plugin/\(group.groupId) — \(group.pluginDisplay)\(governed)"
+        }
+    }
+
+    /// Verbose (large-context model) rendering: a line per tool/skill with
+    /// its one-line description, capped at `enabledManifestToolCap` total
+    /// tool lines before low-priority plugins collapse to a `+N more`
+    /// pointer. Unchanged from the original manifest behavior.
+    private static func verboseBlocks(
+        _ groups: [ManifestPluginGroup]
+    ) -> [String] {
         var blocks: [String] = []
         var renderedToolLines = 0
 
         for group in groups {
             let skillLines = group.skills.map { skill -> String in
                 let desc = skill.description.isEmpty ? "Plugin skill." : skill.description
-                return compact
-                    ? "  skill/\(skill.name)"
-                    : "  skill/\(skill.name) — \(desc)"
+                return "  skill/\(skill.name) — \(desc)"
             }
 
             let remaining = max(enabledManifestToolCap - renderedToolLines, 0)
@@ -491,7 +575,7 @@ public enum SystemPromptTemplates {
 
             let toolLines = toolsToShow.map { tool -> String in
                 let desc = tool.description.isEmpty ? "(no description)" : tool.description
-                return compact ? "  tool/\(tool.name)" : "  tool/\(tool.name) — \(desc)"
+                return "  tool/\(tool.name) — \(desc)"
             }
 
             var lines = ["<plugin: \(group.pluginDisplay)>"]
@@ -504,39 +588,7 @@ public enum SystemPromptTemplates {
             }
             blocks.append(lines.joined(separator: "\n"))
         }
-
-        // The "never deny a listed capability" rule is owned by
-        // `toolGroundingLine` / `groundingDirective` (which co-fire whenever
-        // this section renders), so the intro doesn't restate it. Compact
-        // mode (small-context models) also drops the worked example — the
-        // ids themselves are what stop a small model from denying a
-        // capability, and the example's tokens crowd an 8K window.
-        let intro: String
-        if compact {
-            intro = """
-                ## Enabled capabilities
-
-                Enabled for this session. Each line begins with its loadable \
-                id; load one before use with capabilities_load \
-                (e.g. `capabilities_load({"ids": ["tool/<name>"]})`).
-                """
-        } else {
-            intro = """
-                ## Enabled capabilities
-
-                These capabilities are enabled for this session. Each line begins \
-                with its loadable id; some are already in your tool schema, others \
-                must be loaded first. To load one, call capabilities_load with its \
-                id exactly as shown \
-                (e.g. `capabilities_load({"ids": ["tool/<name>"]})`).
-
-                Worked example — User: "You have a list_messages tool." If \
-                `tool/list_messages` is listed here, confirm it and capabilities_load \
-                it before use.
-                """
-        }
-
-        return intro + "\n\n" + blocks.joined(separator: "\n")
+        return blocks
     }
 
     /// General rule that replaces the per-plugin "Plugin Companions"

--- a/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
@@ -96,28 +96,61 @@ struct EnabledCapabilitiesManifestTests {
         #expect(rendered.contains("  skill/code-review — Catch obvious smells"))
     }
 
-    @Test("compact mode drops per-tool and per-skill descriptions")
-    func compactDropsDescriptions() throws {
+    @Test("compact mode renders one plugin/<id> line per plugin, not per tool")
+    func compactTiersToPluginLines() throws {
+        // A real plugin (groupId set) collapses to a single loadable
+        // `plugin/<id>` line regardless of how many tools it owns — this is
+        // the cold-prefill saving. Per-tool ids must NOT appear.
         let groups = [
             Group(
+                groupId: "osaurus-mail",
                 pluginDisplay: "Osaurus Mail",
                 skills: [Cap(name: "Mail Helper", description: "Email skill")],
-                tools: [Cap(name: "list_messages", description: "List inbox messages")]
+                tools: [
+                    Cap(name: "list_messages", description: "List inbox messages"),
+                    Cap(name: "send_message", description: "Send an email"),
+                ]
             )
         ]
         let rendered = try #require(
             SystemPromptTemplates.enabledCapabilitiesManifest(groups: groups, compact: true)
         )
-        #expect(rendered.contains("  tool/list_messages"))
-        #expect(!rendered.contains("list_messages — List inbox messages"))
-        #expect(rendered.contains("  skill/Mail Helper"))
-        #expect(!rendered.contains("Mail Helper — "))
-        #expect(!rendered.contains("(skill)"))
-        // Compact also shortens the intro: the worked example is for the
-        // full variant; the load-by-id instruction must survive.
-        #expect(!rendered.contains("Worked example"))
+        #expect(rendered.contains("plugin/osaurus-mail — Osaurus Mail"))
+        // Skill-governed plugins are flagged so the model expects the skill.
+        #expect(rendered.contains("skill-governed"))
+        // The whole point: no per-tool / per-skill id enumeration.
+        #expect(!rendered.contains("tool/list_messages"))
+        #expect(!rendered.contains("tool/send_message"))
+        #expect(!rendered.contains("skill/Mail Helper"))
+        // Compact intro teaches plugin loading and drops the worked example.
         #expect(rendered.contains("## Enabled capabilities"))
+        #expect(rendered.contains("plugin/<id>"))
         #expect(rendered.contains("capabilities_load"))
+        #expect(!rendered.contains("Worked example"))
+    }
+
+    @Test("compact mode lists synthetic (no group id) capabilities inline")
+    func compactSyntheticGroupListsIdsInline() throws {
+        // Groups with no loadable group id (built-in image tools, standalone
+        // skills) have no `plugin/<id>` to expand, so their directly-loadable
+        // ids are listed inline even in compact mode — dropping descriptions.
+        let groups = [
+            Group(
+                pluginDisplay: "Image Generation",
+                skills: [],
+                tools: [
+                    Cap(name: "image_generate", description: "Make an image"),
+                    Cap(name: "image_edit", description: "Edit an image"),
+                ]
+            )
+        ]
+        let rendered = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(groups: groups, compact: true)
+        )
+        #expect(rendered.contains("  tool/image_generate"))
+        #expect(rendered.contains("  tool/image_edit"))
+        #expect(!rendered.contains("image_generate — Make an image"))
+        #expect(!rendered.contains("plugin/"))
     }
 
     @Test("token cap collapses overflow plugins to a pointer line")

--- a/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
@@ -150,7 +150,11 @@ struct EnabledCapabilitiesManifestTests {
         #expect(rendered.contains("  tool/image_generate"))
         #expect(rendered.contains("  tool/image_edit"))
         #expect(!rendered.contains("image_generate — Make an image"))
-        #expect(!rendered.contains("plugin/"))
+        // The group has no loadable id, so it must NOT be collapsed into a
+        // `plugin/<id> — Image Generation` tier line. (The intro itself
+        // references `plugin/<id>`/`plugin/calendar`, so a blanket
+        // `!contains("plugin/")` would be wrong — assert on the display name.)
+        #expect(!rendered.contains("— Image Generation"))
     }
 
     @Test("token cap collapses overflow plugins to a pointer line")

--- a/Packages/OsaurusCore/Tests/Chat/TotalPromptBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TotalPromptBudgetTests.swift
@@ -99,23 +99,36 @@ struct TotalPromptBudgetTests {
             maxBytes: SystemPromptComposer.soulSmallMaxBytes
         )
 
-        // Enabled manifest at the 70-tool cap, compact (the `.small` form).
-        let bigTools = (0 ..< SystemPromptTemplates.enabledManifestToolCap).map {
-            SystemPromptTemplates.ManifestCapability(
-                name: "plugin_tool_\($0)",
-                description: "Does a focused thing with the service"
+        // Voluminous install, compact (`.small`) form. Under tiering each
+        // plugin costs ONE manifest line regardless of its tool count, so the
+        // compact manifest now scales with plugin COUNT, not tool count —
+        // model a heavy install (25 plugins, some skill-governed) to bound
+        // that growth.
+        let manyPlugins = (0 ..< 25).map { i in
+            SystemPromptTemplates.ManifestPluginGroup(
+                groupId: "service.plugin_\(i)",
+                pluginDisplay: "Service Plugin \(i)",
+                skills: i % 4 == 0
+                    ? [
+                        SystemPromptTemplates.ManifestCapability(
+                            name: "Guide \(i)",
+                            description: "How to drive the plugin tools"
+                        )
+                    ]
+                    : [],
+                tools: (0 ..< 6).map {
+                    SystemPromptTemplates.ManifestCapability(
+                        name: "tool_\(i)_\($0)",
+                        description: "Does a focused thing with the service"
+                    )
+                }
             )
         }
-        let manifest = makeManifest(
-            pluginDisplay: "Big Plugin",
-            skills: [
-                SystemPromptTemplates.ManifestCapability(
-                    name: "Big Plugin Guide",
-                    description: "How to drive the plugin tools"
-                )
-            ],
-            tools: bigTools
-        )
+        let manifest =
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: manyPlugins,
+                compact: true
+            ) ?? ""
 
         let sections: [String] = [
             SystemPromptTemplates.platformIdentity,
@@ -152,7 +165,10 @@ struct TotalPromptBudgetTests {
     /// The everyday `.small` configuration: modest manifest, no plugin
     /// creation, no SOUL yet, no secrets/packages.
     private func typicalSmallPrompt() -> String {
+        // A real plugin tiers to ONE line under the compact manifest
+        // regardless of its tool count — so 10 tools cost one line, not ten.
         let manifest = makeManifest(
+            groupId: "osaurus.mail",
             pluginDisplay: "Mail",
             skills: [],
             tools: (0 ..< 10).map {
@@ -186,6 +202,7 @@ struct TotalPromptBudgetTests {
     }
 
     private func makeManifest(
+        groupId: String,
         pluginDisplay: String,
         skills: [SystemPromptTemplates.ManifestCapability],
         tools: [SystemPromptTemplates.ManifestCapability]
@@ -193,6 +210,7 @@ struct TotalPromptBudgetTests {
         SystemPromptTemplates.enabledCapabilitiesManifest(
             groups: [
                 SystemPromptTemplates.ManifestPluginGroup(
+                    groupId: groupId,
                     pluginDisplay: pluginDisplay,
                     skills: skills,
                     tools: tools
@@ -211,7 +229,7 @@ struct TotalPromptBudgetTests {
         let total = promptTokens + toolTokens
         let window = ContextSizeResolver.smallCeiling  // 8192
 
-        // The full worst case (70-tool manifest + plugin creator + SOUL
+        // The full worst case (many-plugin manifest + plugin creator + SOUL
         // at cap) must at minimum fit the window with room for one real
         // exchange. The live number is printed in the failure message so
         // reviewers re-anchor deliberately, not silently.

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -326,8 +326,10 @@ struct CapabilitiesLoadToolTests {
         // The issue's repro: a wrong-prefix id is a deterministic invalid_args
         // failure. Capability ids are a closed vocabulary, so re-issuing the
         // identical call cannot succeed — it must NOT be advertised retryable.
+        // `plugin/` is now a real loadable type, so use a genuinely-unknown
+        // prefix to exercise the invalid_args path.
         let tool = CapabilitiesLoadTool()
-        let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"plugin/Scite.AI\"]}")
+        let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"widget/Scite.AI\"]}")
         #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
         #expect(EnvelopeAssertions.failureRetryable(result) == false)
     }

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -488,7 +488,8 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         "Load capabilities into the current session by ID. IDs come from the Enabled capabilities list "
         + "or from `capabilities_discover` results — do not invent IDs. After loading, the named tools are "
         + "callable for the rest of the session; a named skill's instructions are returned in this tool's "
-        + "result for you to follow. Example: `{\"ids\": [\"tool/sandbox_exec\", \"skill/plot-data\"]}`."
+        + "result for you to follow. A `plugin/<id>` id loads that plugin's whole tool group (and any "
+        + "governing skill) in one call. Example: `{\"ids\": [\"plugin/calendar\", \"tool/sandbox_exec\", \"skill/plot-data\"]}`."
 
     let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -498,7 +499,7 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                 "type": .string("array"),
                 "items": .object(["type": .string("string")]),
                 "description": .string(
-                    "IDs from the Enabled capabilities list or capabilities_discover results (e.g. 'method/abc', 'tool/sandbox_exec', 'skill/swift-best-practices')"
+                    "IDs from the Enabled capabilities list or capabilities_discover results (e.g. 'plugin/calendar', 'method/abc', 'tool/sandbox_exec', 'skill/swift-best-practices')"
                 ),
             ])
         ]),
@@ -545,13 +546,15 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                 outcome = await loadTool(rawId)
             case "skill":
                 outcome = await loadSkill(rawId)
+            case "plugin":
+                outcome = await loadPlugin(rawId)
             default:
                 outcome = .failure(
                     LoadFailure(
                         kind: .invalidArgs,
                         message:
                             "Unknown type '\(typePrefix)' in ID '\(id)' "
-                            + "(expected `tool`, `skill`, or `method`)."
+                            + "(expected `tool`, `skill`, `plugin`, or `method`)."
                     )
                 )
             }
@@ -857,38 +860,120 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
 
         // A plugin skill governs its sibling tools, so auto-load the plugin's
         // whole dynamic tool group (agent-scoped) instead of forcing a
-        // separate `capabilities_load` per tool. Sorted for a deterministic,
-        // KV-stable load order and a predictable cap boundary.
+        // separate `capabilities_load` per tool.
         if let pluginId = skill.pluginId, !pluginId.isEmpty {
-            let allowedNames = await grantedToolNamesForCurrentAgent()
-            let groupToolNames = await MainActor.run {
-                ToolRegistry.shared.listDynamicTools()
-                    .filter { ToolRegistry.shared.groupName(for: $0.name) == pluginId }
-                    .map(\.name)
-                    .filter { allowedNames?.contains($0) ?? true }
-            }
-            .sorted()
+            output += await bufferPluginGroup(pluginId: pluginId)
+        }
+        return .success(output)
+    }
 
-            // Size guard: a skill governing a very large plugin would
-            // otherwise dump every sibling tool's schema into the live tool
-            // channel on a single load — unnecessary context the model rarely
-            // needs all of, and a needless bloat of the `<tools>` block. Cap
-            // the auto-load at the same ceiling the enabled-capabilities
-            // manifest uses; the model can pull any remaining tool by id with
-            // `capabilities_load`.
-            let cap = SystemPromptTemplates.enabledManifestToolCap
-            if groupToolNames.count > cap {
-                let loaded = Array(groupToolNames.prefix(cap))
-                let deferred = Array(groupToolNames.dropFirst(cap))
-                output += await bufferToolSpecs(named: loaded)
-                output +=
-                    "\(groupToolNames.count) tools belong to this skill's plugin; "
-                    + "auto-loaded the first \(cap). Load any of the remaining "
-                    + "\(deferred.count) by id with `capabilities_load` "
-                    + "(e.g. `tool/\(deferred.first ?? "")`).\n"
-            } else {
-                output += await bufferToolSpecs(named: groupToolNames)
+    /// Buffer every agent-allowed dynamic tool in `pluginId`'s group, capped
+    /// at `enabledManifestToolCap`, and return the human-facing summary line.
+    /// Sorted for a deterministic, KV-stable load order and a predictable cap
+    /// boundary. Shared by the skill-governed auto-load (`skill/<name>`) and
+    /// the `plugin/<id>` group loader.
+    ///
+    /// Size guard: a very large plugin would otherwise dump every sibling
+    /// tool's schema into the live tool channel on a single load — context the
+    /// model rarely needs all of, and needless `<tools>` bloat. Past the cap,
+    /// the model can pull any remaining tool by id with `capabilities_load`.
+    private func bufferPluginGroup(pluginId: String) async -> String {
+        let allowedNames = await grantedToolNamesForCurrentAgent()
+        let groupToolNames = await MainActor.run {
+            ToolRegistry.shared.listDynamicTools()
+                .filter { ToolRegistry.shared.groupName(for: $0.name) == pluginId }
+                .map(\.name)
+                .filter { allowedNames?.contains($0) ?? true }
+        }
+        .sorted()
+        guard !groupToolNames.isEmpty else { return "" }
+
+        let cap = SystemPromptTemplates.enabledManifestToolCap
+        if groupToolNames.count > cap {
+            let loaded = Array(groupToolNames.prefix(cap))
+            let deferred = Array(groupToolNames.dropFirst(cap))
+            var summary = await bufferToolSpecs(named: loaded)
+            summary +=
+                "\(groupToolNames.count) tools belong to this plugin; "
+                + "auto-loaded the first \(cap). Load any of the remaining "
+                + "\(deferred.count) by id with `capabilities_load` "
+                + "(e.g. `tool/\(deferred.first ?? "")`).\n"
+            return summary
+        }
+        return await bufferToolSpecs(named: groupToolNames)
+    }
+
+    /// Load a whole plugin tool group by its `plugin/<id>` manifest id. This
+    /// is the compact-manifest entry point: the tiered manifest lists one
+    /// `plugin/<id>` per plugin, and loading it pulls in the group's tools
+    /// plus any governing skill's instructions in a single call.
+    private func loadPlugin(_ rawId: String) async -> LoadOutcome {
+        if ChatExecutionContext.currentAgentId == Agent.defaultId {
+            return .failure(
+                LoadFailure(
+                    kind: .rejected,
+                    message:
+                        "Plugin loading is disabled for the configuration agent. "
+                        + "Use `capabilities_discover` to find a configuration tool (osaurus_*_<verb>) "
+                        + "and load it directly."
+                )
+            )
+        }
+
+        // Resolve the manifest id to a concrete tool-group id. The tiered
+        // manifest emits the exact group id, so an exact match is the common
+        // path; the case-insensitive and display-name fallbacks tolerate a
+        // model that copies the friendly name instead.
+        let resolved = await MainActor.run { () -> String? in
+            let groupIds = Set(
+                ToolRegistry.shared.listDynamicTools()
+                    .compactMap { ToolRegistry.shared.groupName(for: $0.name) }
+                    .filter { !$0.isEmpty }
+            )
+            if groupIds.contains(rawId) { return rawId }
+            if let ci = groupIds.first(where: { $0.caseInsensitiveCompare(rawId) == .orderedSame }) {
+                return ci
             }
+            return groupIds.first { gid in
+                guard let display = PluginManager.shared.loadedPlugin(for: gid)?.plugin.manifest.name
+                else { return false }
+                return display.caseInsensitiveCompare(rawId) == .orderedSame
+            }
+        }
+        guard let pluginId = resolved else {
+            return .failure(
+                LoadFailure(
+                    kind: .notFound,
+                    message:
+                        "Plugin '\(rawId)' not found. Use the `plugin/<id>` exactly as shown in "
+                        + "the Enabled capabilities list, or call `capabilities_discover`."
+                )
+            )
+        }
+
+        // Governing skill(s) first — their instructions teach the tool
+        // ordering a name-only manifest can't convey. Mirrors `loadSkill`.
+        var output = ""
+        let governingSkills = await MainActor.run {
+            SkillManager.shared.skills.filter { $0.enabled && $0.pluginId == pluginId }
+        }
+        for skill in governingSkills {
+            output += "## Skill: \(skill.name)\n"
+            if !skill.description.isEmpty {
+                output += "*\(skill.description)*\n\n"
+            }
+            output += skill.instructions
+            output += "\n\n"
+        }
+
+        output += await bufferPluginGroup(pluginId: pluginId)
+        guard !output.isEmpty else {
+            return .failure(
+                LoadFailure(
+                    kind: .notFound,
+                    message: "Plugin '\(pluginId)' has no loadable tools or skills for this agent."
+                )
+            )
         }
         return .success(output)
     }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -645,12 +645,28 @@ final class ToolRegistry: ObservableObject {
             // embedding search, shell, network) so the /tmp log can separate
             // tool-execution latency from model decode between agent-loop steps.
             let toolExecStart = CFAbsoluteTimeGetCurrent()
-            PrefillDebugLog.shared.log("       TOOL-EXEC-BEGIN name=\(name)")
+            if PrefillDebugLog.shared.isEnabled {
+                // Capture the (coerced) call arguments so the log shows WHICH
+                // capability a load targeted — e.g. `plugin/calendar` — since
+                // the tool name alone can't. Single-lined and truncated to
+                // bound log size and avoid dumping large tool payloads (file
+                // contents, shell scripts) verbatim into /tmp.
+                let flat = effectiveArgumentsJSON.replacingOccurrences(of: "\n", with: " ")
+                let argsForLog = flat.count > 200 ? String(flat.prefix(200)) + "…" : flat
+                PrefillDebugLog.shared.log("       TOOL-EXEC-BEGIN name=\(name) args=\(argsForLog)")
+            }
+            // Captured for the END line below: the result of a `capabilities_*`
+            // call (which tools a `plugin/<id>` load expanded to, or what a
+            // discover returned). Scoped to capability tools ONLY — other tool
+            // results (file contents, shell/web output) can be large or
+            // sensitive and have no place in this diagnostic.
+            var resultForLog: String? = nil
             defer {
-                PrefillDebugLog.shared.log(
+                var line =
                     "       TOOL-EXEC-END   name=\(name) "
-                        + "ms=\(Int((CFAbsoluteTimeGetCurrent() - toolExecStart) * 1000))"
-                )
+                    + "ms=\(Int((CFAbsoluteTimeGetCurrent() - toolExecStart) * 1000))"
+                if let resultForLog { line += " result=\(resultForLog)" }
+                PrefillDebugLog.shared.log(line)
             }
             // Run the tool body off MainActor so long-running tools (file
             // I/O, network, shell) don't contend with SwiftUI layout on the
@@ -672,7 +688,7 @@ final class ToolRegistry: ObservableObject {
             // relying on each caller to remember. Inert outside combined
             // mode, leaving plain folder + plain sandbox modes untouched.
             let policy = combinedHostReadPolicy
-            return try await ChatExecutionContext.$hostReadOnlyScope.withValue(policy.scope) {
+            let result = try await ChatExecutionContext.$hostReadOnlyScope.withValue(policy.scope) {
                 try await ChatExecutionContext.$allowHostSecretReads.withValue(policy.allowSecretReads) {
                     try await ChatExecutionContext.$sandboxReadBridge.withValue(combinedSandboxReadBridge) {
                         if tool.bypassRegistryTimeout {
@@ -695,6 +711,11 @@ final class ToolRegistry: ObservableObject {
                     }
                 }
             }
+            if PrefillDebugLog.shared.isEnabled, name.hasPrefix("capabilities_") {
+                let flat = result.replacingOccurrences(of: "\n", with: " ")
+                resultForLog = flat.count > 300 ? String(flat.prefix(300)) + "…" : flat
+            }
+            return result
         }
     }
 


### PR DESCRIPTION
## Summary

**Before:**
- The session prompt listed every enabled plugin tool individually, one line per tool.
- For a typical install the capabilities listing ran to roughly 28 lines, and it grew with every plugin and tool added.
- Because the prompt is paid in full on the first message of a session, this lengthened the initial prefill and the time to first response, scaling with how many plugins a user had installed.

**After:**
- The compact prompt lists one line per plugin instead of one per tool, with skill-governed plugins flagged.
- The model pulls in a plugin's full set of tools on demand and then calls them directly.
- Larger and cloud models were left unchanged and still receive the full per-tool listing.

**Measured metrics (12B local model, same set of plugins):**
- Capabilities listing was cut by about 60%, from 331 to 135 tokens (tokenizer-counted, controlled comparison).
- The full first-message request fell from 1097 to 901 prompt tokens.
- The in-app run corroborated this: the rendered listing measured 132 tokens, with 5 plugins shown as 5 lines.
- On a memory-constrained machine prefilling at about 14 ms per token, the listing's first-turn cost dropped from roughly 4.7 seconds to 1.9 seconds, reclaiming about 3 seconds on the first message. This is a one-time cost per session, served from cache on later turns. On a machine with memory headroom prefill is several times faster, so the wall-clock saving is proportionally smaller while the token reduction stays the same.

**Behavior:**
- Loading a plugin expanded its entire group of tools in a single step.
- The post-load message was made more directive so small models call the freshly loaded tools immediately instead of redundantly searching for them again.
- Added off-by-default diagnostics that capture the rendered capabilities listing along with load arguments and results, for prefill analysis.

**Verification:**
- Confirmed end to end on a 12B local model: the tiered listing rendered as expected, loading a plugin expanded its tools, the model then called a tool and answered, and cross-turn prompt caching stayed intact.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
