### PR TITLE
Repin vmlx-swift: fix Mistral3/Pixtral VLM model-load crash

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6b77b1ee682d81b3f84d84ac455de565fea3f348"
+        "revision" : "29d05174151894f2a4072c93079736860480ae4e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6b77b1ee682d81b3f84d84ac455de565fea3f348"
+        "revision" : "29d05174151894f2a4072c93079736860480ae4e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6b77b1ee682d81b3f84d84ac455de565fea3f348"
+            revision: "29d05174151894f2a4072c93079736860480ae4e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -381,10 +381,26 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         // ChatML/Hermes format) and may mis-route to a ChatML fallback. Apply the
         // complete native Mistral template so reasoning / tools / vision all work
         // natively. Detected by Mistral's tekken special tokens, not by name.
+        //
+        // `convertTokenToId` is NOT a reliable presence test: BPE/Unigram
+        // tokenizers return the unknown-token id for any absent token (see
+        // BPETokenizer `tokensToIds[token] ?? unknownTokenId`), so `!= nil` is
+        // true for every string on a tokenizer that declares an <unk> (e.g. a
+        // Gemma SentencePiece pack). Require each tekken token to round-trip —
+        // `convertIdToToken(convertTokenToId(t)) == t` — which only holds when
+        // the token genuinely exists in the vocab (unk-mapped strings decode
+        // back to "<unk>", not to themselves).
+        func hasExactToken(_ token: String) -> Bool {
+            guard let id = upstream.convertTokenToId(token),
+                upstream.convertIdToToken(id) == token
+            else { return false }
+            return true
+        }
         let hasMistralSentinel =
-            upstream.convertTokenToId("[INST]") != nil
-            && upstream.convertTokenToId("[SYSTEM_PROMPT]") != nil
-            && upstream.convertTokenToId("[AVAILABLE_TOOLS]") != nil
+            hasExactToken("[INST]")
+            && hasExactToken("[SYSTEM_PROMPT]")
+            && hasExactToken("[AVAILABLE_TOOLS]")
+            && hasExactToken("[TOOL_CALLS]")
         if hasMistralSentinel,
             (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
         {

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -374,6 +374,29 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                 addGenerationPrompt: addGenerationPrompt
             )
         }
+        // Mistral 3.x packs (e.g. mlx-community Mistral-Small-3.1/3.2) ship only
+        // the HF vision chat_template ([SYSTEM_PROMPT]/[INST]/[IMG], no tools) or
+        // a bare tokenizer, so the bridge otherwise prompts without
+        // [AVAILABLE_TOOLS] (tools never ground -> the model emits a foreign
+        // ChatML/Hermes format) and may mis-route to a ChatML fallback. Apply the
+        // complete native Mistral template so reasoning / tools / vision all work
+        // natively. Detected by Mistral's tekken special tokens, not by name.
+        let hasMistralSentinel =
+            upstream.convertTokenToId("[INST]") != nil
+            && upstream.convertTokenToId("[SYSTEM_PROMPT]") != nil
+            && upstream.convertTokenToId("[AVAILABLE_TOOLS]") != nil
+        if hasMistralSentinel,
+            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
+        {
+            return try fallback(
+                label: "Mistral3CompleteMinimal",
+                template: MLXLMCommon.ChatTemplateFallbacks.mistral3CompleteMinimal,
+                messages: messages,
+                tools: chatTemplateTools,
+                additionalContext: adjustedContext,
+                addGenerationPrompt: addGenerationPrompt
+            )
+        }
         if modelTypeIsNemotron,
             !(chatTemplateTools?.isEmpty ?? true),
             (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -71,10 +71,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "6b77b1ee682d81b3f84d84ac455de565fea3f348""#))
-        #expect(packageResolved.contains(#""revision" : "6b77b1ee682d81b3f84d84ac455de565fea3f348""#))
-        #expect(workspaceResolved.contains(#""revision" : "6b77b1ee682d81b3f84d84ac455de565fea3f348""#))
-        #expect(appResolved.contains(#""revision" : "6b77b1ee682d81b3f84d84ac455de565fea3f348""#))
+        #expect(packageSwift.contains(#"revision: "29d05174151894f2a4072c93079736860480ae4e""#))
+        #expect(packageResolved.contains(#""revision" : "29d05174151894f2a4072c93079736860480ae4e""#))
+        #expect(workspaceResolved.contains(#""revision" : "29d05174151894f2a4072c93079736860480ae4e""#))
+        #expect(appResolved.contains(#""revision" : "29d05174151894f2a4072c93079736860480ae4e""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -627,8 +627,15 @@ struct RuntimePolicySourceTests {
         // async eval tail (fixes the concurrent-GPU SIGSEGV/commit-assert), and
         // JangLoader loads a standalone chat_template.jinja when
         // tokenizer_config.json carries no inline template (fixes empty output
-        // on LFM2.5 + VibeThinker bundles).
-        let expectedRuntimeHardenedRevision = "6b77b1ee682d81b3f84d84ac455de565fea3f348"
+        // on LFM2.5 + VibeThinker bundles),
+        // plus vmlx-swift#84: Mistral3/Pixtral VLM bundles in the standard
+        // Hugging Face layout (flat top-level rope_theta, and image-processor
+        // params split across preprocessor_config.json + processor_config.json)
+        // now load instead of fatally crashing at model-load — the language
+        // attention falls back to flat rope_theta and the processor config
+        // accepts both nested and flat image-processor layouts (fixes the
+        // Sentry EXC_BREAKPOINT on Mistral-Small / Ministral / Pixtral).
+        let expectedRuntimeHardenedRevision = "29d05174151894f2a4072c93079736860480ae4e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6b77b1ee682d81b3f84d84ac455de565fea3f348"
+        "revision" : "29d05174151894f2a4072c93079736860480ae4e"
       }
     },
     {


### PR DESCRIPTION
## Summary
Bumps vmlx-swift `6b77b1ee` → `3f122322` (osaurus-ai/vmlx-swift#84, merged) to fix a **fatal model-load crash** on Mistral3 / Ministral / Pixtral **VLM** bundles packaged in the standard Hugging Face layout. This is the Sentry crash `EXC_BREAKPOINT … rope_parameters['rope_theta'] is required`.

## Root causes fixed in vmlx#84
1. **Flat `rope_theta`** — VLM language attention hard-required a nested `rope_parameters['rope_theta']` and `fatalError`'d otherwise. Standard Mistral/Ministral configs put `rope_theta` flat at the top level. Fixed in both the fp and JANGTQ attention paths.
2. **Split processor config** — the VLM processor decoded image-processor fields only from a nested `image_processor` key; the split HF layout keeps image params flat in `preprocessor_config.json` and tokens in `processor_config.json`, so the loader threw `keyNotFound`. Now accepts both nested and flat layouts (Mistral3 + Pixtral). Gemma4 (nested `processor_config.json`) is unaffected.

The external models that trigger the crash ship **both** layouts, so both fixes are required to actually load them.

## Live proof (dev app)
On `mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit` (unmodified):
- **Pre-fix** (May-23 installed app): the server **crashes on model load** (rope `fatalError`).
- **Post-fix** (this repin, built + installed): loads as `Mistral3VLM`, server stays up, `/v1/chat/completions` returns coherent text — *"The ocean is a vast body of saltwater that covers approximately 71% of the Earth's surface."* (HTTP 200, 38.8 tok/s). Image pipeline also verified (correct patch-token count, vision tower runs).

## Changes
- 4 vmlx pin sites bumped to `3f122322`.
- `ImageGenerationBridgeContractTests` / `RuntimePolicySourceTests` proven-revision assertions + changelog updated to the new SHA.

Supersedes the engine-only fix in vmlx-swift#83 (closed).