### PR TITLE
Fix MCP schema proxy miscasting JSON integers 0 and 1 as booleans

### DIFF
--- a/Packages/OsaurusCLI/Package.swift
+++ b/Packages/OsaurusCLI/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
         ),
         .testTarget(
             name: "OsaurusCLITests",
-            dependencies: ["OsaurusCLICore"]
+            dependencies: [
+                "OsaurusCLICore",
+                .product(name: "MCP", package: "swift-sdk"),
+            ]
         ),
     ]
 )

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift
@@ -281,12 +281,20 @@ public struct MCPCommand: Command {
     }
 
     // Convert loosely-typed JSON (from JSONSerialization) into MCP.Value
-    private static func toMCPValue(from any: Any?) -> MCP.Value {
+    static func toMCPValue(from any: Any?) -> MCP.Value {
         guard let value = any else { return .null }
         if value is NSNull { return .null }
-        if let b = value as? Bool { return .bool(b) }
-        if let i = value as? Int { return .double(Double(i)) }
-        if let d = value as? Double { return .double(d) }
+        // JSONSerialization decodes every JSON number AND boolean as NSNumber, so
+        // this branch must run before any `as? Bool` / `as? Int` cast: in
+        // Foundation's bridging both `NSNumber(value: 0) as? Bool` and
+        // `NSNumber(value: 1) as? Bool` succeed, so a plain JSON integer 0 or 1
+        // would otherwise be miscast to a boolean and corrupt the proxied tool
+        // schema (e.g. {"minimum": 0} -> {"minimum": false}). Use the CFBoolean
+        // type id to tell a real JSON boolean apart from the integers 0/1.
+        if let n = value as? NSNumber {
+            if CFGetTypeID(n) == CFBooleanGetTypeID() { return .bool(n.boolValue) }
+            return .double(n.doubleValue)
+        }
         if let s = value as? String { return .string(s) }
         if let arr = value as? [Any] {
             return .array(arr.map { toMCPValue(from: $0) })
@@ -297,11 +305,6 @@ public struct MCPCommand: Command {
                 mapped[k] = toMCPValue(from: v)
             }
             return .object(mapped)
-        }
-        // NSNumber (covers both ints and doubles when decoded by JSONSerialization)
-        if let n = value as? NSNumber {
-            if CFNumberGetType(n) == .charType { return .bool(n.boolValue) }
-            return .double(n.doubleValue)
         }
         return .null
     }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPCommandSchemaConversionTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPCommandSchemaConversionTests.swift
@@ -1,0 +1,48 @@
+//
+//  MCPCommandSchemaConversionTests.swift
+//  osaurus
+//
+//  Tests the JSON -> MCP.Value conversion the stdio MCP bridge uses when it
+//  proxies a tool's `inputSchema` from the local HTTP server to the client.
+//
+
+import XCTest
+
+import MCP
+
+@testable import OsaurusCLICore
+
+final class MCPCommandSchemaConversionTests: XCTestCase {
+
+    /// Regression: JSON integers 0 and 1 were miscast to booleans.
+    ///
+    /// `JSONSerialization` decodes every JSON number (and boolean) as an
+    /// `NSNumber`, and in Foundation's bridging both `NSNumber(value: 0) as? Bool`
+    /// and `NSNumber(value: 1) as? Bool` succeed. Because the old conversion tried
+    /// the `as? Bool` cast before inspecting the `NSNumber`, a plain JSON integer
+    /// 0 or 1 anywhere in a tool's schema (e.g. `"minimum": 0`, `"default": 1`,
+    /// `"maxItems": 1`, `"exclusiveMinimum": 0`) was emitted to the MCP client as a
+    /// JSON boolean (`false`/`true`), corrupting the advertised schema.
+    func testProxiedSchemaPreservesIntegerZeroAndOne() throws {
+        let raw = """
+            {"minimum": 0, "default": 1, "maxItems": 1, "count": 5,
+             "ratio": 0.5, "flag": true, "off": false}
+            """
+        let object = try JSONSerialization.jsonObject(with: Data(raw.utf8))
+
+        guard case let .object(map) = MCPCommand.toMCPValue(from: object) else {
+            return XCTFail("expected the schema to convert to an object value")
+        }
+
+        // Integers must stay numbers, not booleans.
+        XCTAssertEqual(map["minimum"], .double(0))
+        XCTAssertEqual(map["default"], .double(1))
+        XCTAssertEqual(map["maxItems"], .double(1))
+        XCTAssertEqual(map["count"], .double(5))
+        XCTAssertEqual(map["ratio"], .double(0.5))
+
+        // Genuine JSON booleans must stay booleans.
+        XCTAssertEqual(map["flag"], .bool(true))
+        XCTAssertEqual(map["off"], .bool(false))
+    }
+}


### PR DESCRIPTION
## Problem

When `osaurus mcp` (the stdio bridge) proxies a tool's `inputSchema`, it parses the schema with `JSONSerialization` and converts it to `MCP.Value` via `toMCPValue`. `JSONSerialization` decodes every JSON number **and** boolean as `NSNumber`, and in Foundation's bridging both `NSNumber(value: 0) as? Bool` and `NSNumber(value: 1) as? Bool` succeed.

Because the conversion tried the `as? Bool` cast before inspecting the `NSNumber`, any JSON integer `0` or `1` in a tool's schema was emitted to the MCP client as a JSON **boolean**:

```jsonc
{ "minimum": 0 }      // -> { "minimum": false }
{ "default": 1 }      // -> { "default": true }
{ "maxItems": 1 }     // -> { "maxItems": true }
{ "exclusiveMinimum": 0 }  // -> { "exclusiveMinimum": false }
```

These are extremely common in JSON Schema, so the advertised tool schema is corrupted and clients (Claude Desktop, etc.) can reject it or pass wrong argument types. The function already had a correct `NSNumber`/charType branch, but it was unreachable because the `as? Bool`/`as? Int`/`as? Double` shortcuts consumed the value first.

## Fix

Inspect the `NSNumber` first and use `CFBooleanGetTypeID` to tell a real JSON boolean apart from the integers `0`/`1`. Number→`.double` mapping is preserved (unchanged behavior for every other value).

> Optional follow-up (not done here to keep the change minimal): integers could map to `MCP.Value.int` for fidelity (e.g. so `maxItems: 1` stays `1` rather than `1.0`). Happy to add that if you'd prefer.

## Testing

- New `MCPCommandSchemaConversionTests` builds the schema exactly as the proxy does (through `JSONSerialization`) and asserts integers `0`/`1`/`5`, a double, and real booleans all convert correctly. It fails on the bug and passes with the fix.
- Full `OsaurusCLI` suite green (`swift test`), `swift-format lint --strict` clean.