### PR TITLE
Fix SemVer prerelease precedence for unequal-length identifier sets

### DIFF
--- a/Packages/OsaurusRepository/SemanticVersion.swift
+++ b/Packages/OsaurusRepository/SemanticVersion.swift
@@ -59,10 +59,14 @@ public struct SemanticVersion: Codable, Hashable, Comparable, CustomStringConver
     private static func comparePrerelease(_ l: String, _ r: String) -> Int {
         let lParts = l.split(separator: ".").map(String.init)
         let rParts = r.split(separator: ".").map(String.init)
-        let count = max(lParts.count, rParts.count)
+        // SemVer 2.0.0 §11.4: compare identifiers left to right over the shared
+        // length only. Padding the shorter set with "" inverts the ordering,
+        // because "" reads as non-numeric and loses to any numeric identifier
+        // (e.g. it made "alpha" outrank "alpha.1").
+        let count = min(lParts.count, rParts.count)
         for i in 0 ..< count {
-            let li = i < lParts.count ? lParts[i] : ""
-            let ri = i < rParts.count ? rParts[i] : ""
+            let li = lParts[i]
+            let ri = rParts[i]
             let lIsNum = Int(li) != nil
             let rIsNum = Int(ri) != nil
             if lIsNum && rIsNum {
@@ -76,6 +80,11 @@ public struct SemanticVersion: Codable, Hashable, Comparable, CustomStringConver
             } else if li != ri {
                 return li < ri ? -1 : 1
             }
+        }
+        // §11.4.4: when all preceding identifiers are equal, the larger set of
+        // pre-release fields has the higher precedence.
+        if lParts.count != rParts.count {
+            return lParts.count < rParts.count ? -1 : 1
         }
         return 0
     }

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/SemanticVersionTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/SemanticVersionTests.swift
@@ -1,0 +1,84 @@
+//
+//  SemanticVersionTests.swift
+//  OsaurusRepository
+//
+//  Precedence coverage for SemanticVersion, in particular the prerelease
+//  ordering rules from Semantic Versioning 2.0.0 §11.4.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusRepository
+
+final class SemanticVersionTests: XCTestCase {
+
+    private func sv(_ s: String) -> SemanticVersion {
+        guard let v = SemanticVersion.parse(s) else {
+            XCTFail("could not parse semver \(s)")
+            return SemanticVersion(major: 0, minor: 0, patch: 0)
+        }
+        return v
+    }
+
+    /// Asserts every element is strictly less than every later element (and the
+    /// reverse never holds), i.e. the list is a strict total order.
+    private func assertStrictlyAscending(
+        _ versions: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let parsed = versions.map(sv)
+        for i in parsed.indices {
+            for j in parsed.indices where j > i {
+                XCTAssertTrue(
+                    parsed[i] < parsed[j],
+                    "\(versions[i]) should have lower precedence than \(versions[j])",
+                    file: file,
+                    line: line
+                )
+                XCTAssertFalse(
+                    parsed[j] < parsed[i],
+                    "\(versions[j]) should not have lower precedence than \(versions[i])",
+                    file: file,
+                    line: line
+                )
+            }
+        }
+    }
+
+    /// The canonical precedence chain from SemVer 2.0.0 §11.4.
+    func test_prereleasePrecedenceMatchesSemverSpecExample() {
+        assertStrictlyAscending([
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-alpha.beta",
+            "1.0.0-beta",
+            "1.0.0-beta.2",
+            "1.0.0-beta.11",
+            "1.0.0-rc.1",
+            "1.0.0",
+        ])
+    }
+
+    /// §11.4.4: a larger set of pre-release fields has higher precedence than a
+    /// smaller set, when all preceding identifiers are equal. This is the case
+    /// the old padding-based comparison inverted.
+    func test_largerPrereleaseSetHasHigherPrecedence() {
+        XCTAssertTrue(sv("1.0.0-alpha") < sv("1.0.0-alpha.1"))
+        XCTAssertTrue(sv("1.0.0-beta") < sv("1.0.0-beta.2"))
+        XCTAssertFalse(sv("1.0.0-alpha.1") < sv("1.0.0-alpha"))
+    }
+
+    /// §11.4.1: identifiers consisting of only digits compare numerically.
+    func test_numericIdentifiersCompareNumerically() {
+        XCTAssertTrue(sv("1.0.0-beta.2") < sv("1.0.0-beta.11"))
+    }
+
+    /// §11.3: a version with a prerelease has lower precedence than the same
+    /// version without one.
+    func test_prereleaseHasLowerPrecedenceThanRelease() {
+        XCTAssertTrue(sv("1.0.0-rc.1") < sv("1.0.0"))
+        XCTAssertFalse(sv("1.0.0") < sv("1.0.0-rc.1"))
+    }
+}


### PR DESCRIPTION
## Problem

`SemanticVersion.comparePrerelease` padded the shorter prerelease identifier set with empty strings and iterated over the longer length. An empty pad reads as non-numeric, so when the other side had a numeric identifier the comparison returned the wrong sign:

```
1.0.0-alpha   vs  1.0.0-alpha.1   ->  alpha ranked HIGHER  (wrong)
1.0.0-beta    vs  1.0.0-beta.2    ->  beta  ranked HIGHER  (wrong)
```

This is the opposite of Semantic Versioning 2.0.0 §11.4.4: *"a larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal."* It can make version selection/sorting pick the wrong prerelease.

## Fix

Compare identifiers only over the shared length, then let the larger identifier set win when all preceding identifiers are equal.

## Testing

- New `SemanticVersionTests` covering the canonical §11.4 precedence chain (`alpha < alpha.1 < alpha.beta < beta < beta.2 < beta.11 < rc.1 < 1.0.0`), numeric-vs-lexical identifier comparison (`beta.2 < beta.11`), and prerelease-vs-release ordering. It fails on the bug and passes with the fix.
- Full `OsaurusRepository` suite green, `swift-format lint --strict` clean.