### PR TITLE
Fix Shell.which returning "" instead of nil for missing commands

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManager.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManager.swift
@@ -154,10 +154,21 @@ enum Shell {
         process.standardOutput = pipe
         process.standardError = Pipe()
 
-        try? process.run()
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
         process.waitUntilExit()
 
+        // `which` exits non-zero and prints nothing when the command is not
+        // found. Without this guard the empty stdout was returned as `""`,
+        // which the launcher then treated as a resolved path and tried to exec
+        // an empty file instead of falling back to the bare command name.
+        guard process.terminationStatus == 0 else { return nil }
+
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (path?.isEmpty == false) ? path : nil
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ShellWhichTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ShellWhichTests.swift
@@ -1,0 +1,35 @@
+//
+//  ShellWhichTests.swift
+//  osaurus
+//
+//  Covers `Shell.which`, used by the MCP bundle launcher to resolve a server
+//  command to an absolute path (with a fallback to the bare command name).
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ShellWhichTests: XCTestCase {
+
+    /// A command that does not exist must resolve to nil, so the launcher takes
+    /// its `cmdPath = cmdName` fallback instead of trying to exec an empty path.
+    /// Previously `which` returned the empty stdout as `Optional("")`, ignoring
+    /// `/usr/bin/which`'s non-zero exit status.
+    func testWhichReturnsNilForNonexistentCommand() {
+        let bogus = "osaurus-no-such-command-\(UUID().uuidString)"
+        XCTAssertNil(Shell.which(bogus))
+    }
+
+    /// A real command on PATH must resolve to an absolute, executable path.
+    func testWhichResolvesAnExecutableOnPath() throws {
+        let resolved = try XCTUnwrap(Shell.which("ls"))
+        XCTAssertTrue(resolved.hasPrefix("/"), "expected an absolute path, got \(resolved)")
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(atPath: resolved),
+            "expected \(resolved) to be executable"
+        )
+        XCTAssertEqual((resolved as NSString).lastPathComponent, "ls")
+    }
+}


### PR DESCRIPTION
## Problem

`/usr/bin/which` exits non-zero and prints nothing when a command is not on `PATH`. `Shell.which` ignored the exit status and returned the empty stdout as `Optional("")`. The MCP bundle launcher treats any non-nil result as a resolved absolute path:

```swift
if let resolved = Shell.which(cmdName) { cmdPath = resolved } // = "" when not found
else { cmdPath = cmdName }                                     // intended fallback, never reached
...
process.executableURL = URL(fileURLWithPath: cmdPath)          // exec ""
```

So a missing server command made the launcher try to exec an empty path instead of taking its `cmdName` fallback. A launch failure of `process.run()` was also swallowed and surfaced as `""`.

## Fix

Guard on a zero exit status and non-empty output, and return `nil` if the process fails to launch.

## Testing

- New `ShellWhichTests`: a nonexistent command resolves to `nil` (fails on the bug), and a real command on `PATH` resolves to an absolute, executable path.
- Full `OsaurusCLI` suite green, `swift-format lint --strict` clean.