### PR TITLE
Tolerate and reap corrupt coordinator lock files

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/CoordinatorLockService.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/CoordinatorLockService.swift
@@ -105,6 +105,7 @@ public struct CoordinatorLockService {
 
     @discardableResult
     public func reapExpired(now: Date = Date()) throws -> [CoordinatorLock] {
+        removeUndecodableLockFiles()
         let locks = try list()
         let expired = locks.filter { $0.isExpired(now: now) }
         for lock in expired {
@@ -113,12 +114,43 @@ public struct CoordinatorLockService {
         return expired
     }
 
+    /// Removes lock files whose contents can no longer be decoded (empty,
+    /// truncated, or otherwise corrupt). `list()` silently skips such files, so
+    /// without this pass a single poison file would linger forever and keep
+    /// tripping the decode for every future scan.
+    private func removeUndecodableLockFiles() {
+        guard fileManager.fileExists(atPath: paths.locksDirectory.path),
+            let urls = try? fileManager.contentsOfDirectory(
+                at: paths.locksDirectory,
+                includingPropertiesForKeys: nil
+            )
+        else { return }
+        for url in urls where url.pathExtension == "json" {
+            // `loadLock` yields a value for a valid file and nil for an
+            // undecodable one; it throws only on a genuine read error, which we
+            // leave alone. (`try?` can't tell a nil return from a throw, so use
+            // do/catch.)
+            let loaded: CoordinatorLock?
+            do {
+                loaded = try loadLock(at: url)
+            } catch {
+                continue
+            }
+            if loaded == nil {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+    }
+
     private func loadLock(at url: URL) throws -> CoordinatorLock? {
         guard fileManager.fileExists(atPath: url.path) else { return nil }
         let data = try Data(contentsOf: url)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(CoordinatorLock.self, from: data)
+        // Treat an undecodable (corrupt/truncated) lock file as absent rather
+        // than letting one bad file abort list()/reapExpired()/status for every
+        // resource.
+        return try? decoder.decode(CoordinatorLock.self, from: data)
     }
 
     private func encoded(_ lock: CoordinatorLock) throws -> Data {

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/CoordinatorLockServiceCorruptFileTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/CoordinatorLockServiceCorruptFileTests.swift
@@ -1,0 +1,41 @@
+//
+//  CoordinatorLockServiceCorruptFileTests.swift
+//  osaurus
+//
+//  A single corrupt/truncated lock file must not break listing, status, and
+//  reaping for every other resource — and must be garbage-collectable.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class CoordinatorLockServiceCorruptFileTests: XCTestCase {
+
+    func testCorruptLockFileIsToleratedAndReapable() throws {
+        let service = CoordinatorLockService(paths: try temporaryPaths())
+
+        // A valid lock so the locks directory exists alongside the bad file.
+        _ = try service.acquire(resource: "good", owner: "worker-a")
+
+        // Plant a corrupt lock file using the real naming scheme.
+        let badURL = service.paths.lockFile(for: "poison")
+        try Data("{ this is not valid json".utf8).write(to: badURL)
+
+        // Before the fix `list()` rethrew the decode error and aborted the whole
+        // scan; it must now skip the corrupt file and return the good lock.
+        XCTAssertEqual(try service.list().map(\.resource), ["good"])
+
+        // `reapExpired()` is the auto-cleanup path; before the fix it threw before
+        // it could remove anything, so the poison file could never be reaped.
+        XCTAssertNoThrow(try service.reapExpired())
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: badURL.path),
+            "the corrupt lock file should be garbage-collected by reapExpired()"
+        )
+
+        // The valid, non-expired lock is untouched.
+        XCTAssertEqual(try service.list().map(\.resource), ["good"])
+    }
+}


### PR DESCRIPTION
## Problem

`CoordinatorLockService.loadLock` decoded each lock file with `try decoder.decode(...)` and let a `DecodingError` propagate. One empty/truncated/corrupt lock file (a process crashing mid-write, a short write, external tampering) therefore broke `list()`, `reapExpired()`, and `coord status` for **every** resource.

Worse, `reapExpired()` calls `list()` first, so it threw before it could delete anything — the poison file could never be cleaned up automatically and required manual filesystem intervention.

## Fix

- `loadLock` now treats an undecodable file as absent (returns `nil`) instead of throwing, so `list()`/status skip it.
- `reapExpired()` garbage-collects undecodable lock files in addition to expired ones, so a poison file is removed rather than lingering forever.

## Testing

- New `CoordinatorLockServiceCorruptFileTests` plants a corrupt lock file next to a valid one and asserts `list()` returns only the good lock, `reapExpired()` does not throw, and the corrupt file is removed. It fails on the bug and passes with the fix.
- Full `OsaurusCLI` suite green, `swift-format lint --strict` clean.