### PR TITLE
Fix tools rollback to step down from the active version, not the highest

### DIFF
--- a/Packages/OsaurusCLI/Package.swift
+++ b/Packages/OsaurusCLI/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
             dependencies: [
                 "OsaurusCLICore",
                 .product(name: "MCP", package: "swift-sdk"),
+                .product(name: "OsaurusRepository", package: "OsaurusRepository"),
             ]
         ),
     ]

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsRollback.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsRollback.swift
@@ -14,12 +14,10 @@ public struct ToolsRollback {
             fputs("Usage: osaurus tools rollback <plugin_id>\n", stderr)
             exit(EXIT_FAILURE)
         }
-        let versions = InstalledPluginsStore.shared.installedVersions(pluginId: pluginId)
-        guard versions.count >= 2 else {
+        guard let target = previousVersion(pluginId: pluginId) else {
             fputs("No previous version to roll back to for \(pluginId)\n", stderr)
             exit(EXIT_FAILURE)
         }
-        let target = versions[1]  // previous
         do {
             try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: target)
             print("Rolled back \(pluginId) to \(target)")
@@ -28,5 +26,26 @@ public struct ToolsRollback {
             fputs("Rollback failed: \(error)\n", stderr)
             exit(EXIT_FAILURE)
         }
+    }
+
+    /// The version to roll back to: the installed version immediately below the
+    /// currently active one, or nil when the active version is already the
+    /// oldest installed (nothing to roll back to).
+    ///
+    /// `installedVersions` is sorted descending, so the active version is not
+    /// necessarily `versions[0]`: the `current` symlink can point below the
+    /// highest installed version (after a previous rollback, or when a newer
+    /// version was installed without moving `current`). Resolve the active
+    /// version and step to the next-lower one. When the active version is the
+    /// highest, this reduces to the previous `versions[1]` behavior.
+    public static func previousVersion(pluginId: String) -> SemanticVersion? {
+        let versions = InstalledPluginsStore.shared.installedVersions(pluginId: pluginId)
+        guard let active = InstalledPluginsStore.shared.latestInstalledVersion(pluginId: pluginId),
+            let index = versions.firstIndex(of: active),
+            index + 1 < versions.count
+        else {
+            return nil
+        }
+        return versions[index + 1]
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsRollbackTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsRollbackTests.swift
@@ -1,0 +1,85 @@
+//
+//  ToolsRollbackTests.swift
+//  osaurus
+//
+//  `tools rollback` must step down from the *currently active* version (the
+//  `current` symlink), not blindly from the highest installed version.
+//
+
+import Foundation
+import XCTest
+
+import OsaurusRepository
+
+@testable import OsaurusCLICore
+
+final class ToolsRollbackTests: XCTestCase {
+    private let pluginId = "osaurus.example"
+    private var tempRoot: URL!
+    private var previousOverride: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-rollback-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousOverride = ToolsPaths.overrideRoot
+        ToolsPaths.overrideRoot = tempRoot
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func makeVersion(_ version: String) throws {
+        let semver = try XCTUnwrap(SemanticVersion.parse(version))
+        let dir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: semver)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // A .dylib is enough for installedVersions to treat the dir as installed.
+        try Data().write(to: dir.appendingPathComponent("Plugin.dylib", isDirectory: false))
+    }
+
+    private func setCurrent(_ version: String) throws {
+        try PluginInstallManager.updateCurrentSymlink(
+            pluginId: pluginId,
+            version: try XCTUnwrap(SemanticVersion.parse(version))
+        )
+    }
+
+    /// The active version diverges from the highest installed one (e.g. after a
+    /// previous rollback, or a newer version installed without moving `current`).
+    /// Rollback must target the version below the active one, not the active
+    /// version itself.
+    func test_rollsBackBelowActiveVersion_notSecondHighest() throws {
+        try makeVersion("3.0.0")
+        try makeVersion("2.0.0")
+        try makeVersion("1.0.0")
+        try setCurrent("2.0.0")
+
+        XCTAssertEqual(ToolsRollback.previousVersion(pluginId: pluginId), SemanticVersion.parse("1.0.0"))
+    }
+
+    /// Common case: when `current` is the highest version, behavior is unchanged
+    /// (roll back to the second-highest).
+    func test_commonCase_activeIsHighest_rollsBackToSecondHighest() throws {
+        try makeVersion("3.0.0")
+        try makeVersion("2.0.0")
+        try makeVersion("1.0.0")
+        try setCurrent("3.0.0")
+
+        XCTAssertEqual(ToolsRollback.previousVersion(pluginId: pluginId), SemanticVersion.parse("2.0.0"))
+    }
+
+    /// When the active version is already the oldest, there is nothing below it.
+    func test_activeIsOldest_hasNoPreviousVersion() throws {
+        try makeVersion("2.0.0")
+        try makeVersion("1.0.0")
+        try setCurrent("1.0.0")
+
+        XCTAssertNil(ToolsRollback.previousVersion(pluginId: pluginId))
+    }
+}


### PR DESCRIPTION
## Problem

`tools rollback` used `installedVersions(...)[1]` as the rollback target. `installedVersions` is sorted descending, so this assumes the active version is always `versions[0]` (the highest). The active version is whatever the `current` symlink points at, which can diverge from the highest:

- after a previous rollback, `current` sits below the newest version on disk;
- a newer version can be installed without moving `current`.

When they diverge, `versions[1]` is wrong. With `[3.0.0, 2.0.0, 1.0.0]` and `current -> 2.0.0`, rollback "rolls back" to `2.0.0` — the version already active (a silent no-op) — instead of `1.0.0`. A second consecutive rollback is therefore permanently stuck.

## Fix

Resolve the active version via `latestInstalledVersion` (which follows the `current` symlink and falls back to the highest) and step to the next-lower version. When the active version is the highest, this reduces to the previous behavior. The target selection is factored into a testable `previousVersion(pluginId:)`.

## Testing

- New `ToolsRollbackTests` covering the divergent case (`current -> 2.0.0` rolls back to `1.0.0`), the common case (`current` is highest → second-highest), and the oldest-active case (nothing to roll back to → `nil`). It fails on the bug and passes with the fix.
- Full `OsaurusCLI` suite green, `swift-format lint --strict` clean.