### PR TITLE
Accept an omitted args in desktop-format MCP bundle manifests

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManifest.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManifest.swift
@@ -71,6 +71,22 @@ struct MCPBundleManifest: Codable {
             let command: String
             let args: [String]
             let env: [String: String]?
+
+            enum CodingKeys: String, CodingKey {
+                case command
+                case args
+                case env
+            }
+
+            // Default a missing `args` to `[]`, matching `EntryPoint` above so the
+            // two interchangeable formats behave the same. Without this a valid
+            // desktop manifest whose command takes no arguments fails to decode.
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                command = try container.decode(String.self, forKey: .command)
+                args = try container.decodeIfPresent([String].self, forKey: .args) ?? []
+                env = try container.decodeIfPresent([String: String].self, forKey: .env)
+            }
         }
     }
 

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPBundleManifestDesktopFormatTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPBundleManifestDesktopFormatTests.swift
@@ -1,0 +1,53 @@
+//
+//  MCPBundleManifestDesktopFormatTests.swift
+//  osaurus
+//
+//  The desktop-client integration format (`server.mcp_config`) should accept an
+//  omitted `args`, exactly like the standard MCPB `entry` format does.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class MCPBundleManifestDesktopFormatTests: XCTestCase {
+
+    /// A desktop-format manifest whose server command takes no arguments omits
+    /// `args`. The standard `EntryPoint` defaults a missing `args` to `[]`; the
+    /// desktop-format `MCPConfig` must do the same instead of failing to decode.
+    func testDesktopFormatManifestWithoutArgsDecodes() throws {
+        let json = """
+            {
+              "name": "x",
+              "version": "1.0",
+              "server": { "type": "stdio", "mcp_config": { "command": "my-mcp" } }
+            }
+            """
+        let manifest = try JSONDecoder().decode(MCPBundleManifest.self, from: Data(json.utf8))
+        let entry = manifest.getEntryPoint()
+        XCTAssertEqual(entry.command, "my-mcp")
+        XCTAssertEqual(entry.args, [])
+        XCTAssertNil(entry.env)
+    }
+
+    /// Regression guard: a desktop-format manifest that does provide `args`/`env`
+    /// continues to decode them.
+    func testDesktopFormatManifestWithArgsStillDecodes() throws {
+        let json = """
+            {
+              "name": "x",
+              "version": "1.0",
+              "server": {
+                "type": "stdio",
+                "mcp_config": { "command": "my-mcp", "args": ["--port", "3000"], "env": { "K": "v" } }
+              }
+            }
+            """
+        let manifest = try JSONDecoder().decode(MCPBundleManifest.self, from: Data(json.utf8))
+        let entry = manifest.getEntryPoint()
+        XCTAssertEqual(entry.command, "my-mcp")
+        XCTAssertEqual(entry.args, ["--port", "3000"])
+        XCTAssertEqual(entry.env, ["K": "v"])
+    }
+}


### PR DESCRIPTION
## Problem

`MCPBundleManifest` supports two interchangeable formats. The standard MCPB `EntryPoint` has a custom decoder that defaults a missing `args` to `[]`, but the parallel desktop-client format `ServerConfig.MCPConfig` (`server.mcp_config`) relied on the synthesized `Codable`, which makes `args` a **required** key.

`getEntryPoint()` treats both formats the same, so a structurally valid desktop manifest whose server command takes no arguments (omits `args`) failed to decode with `keyNotFound("args")`, and `bundle load` rejected it as an invalid manifest:

```jsonc
{ "name": "x", "version": "1.0",
  "server": { "type": "stdio", "mcp_config": { "command": "my-mcp" } } }  // rejected
```

## Fix

Give `MCPConfig` the same custom decoder as `EntryPoint` so a missing `args` defaults to `[]`. This only loosens decoding (accepts more inputs); the with-args path is unchanged.

## Testing

- New `MCPBundleManifestDesktopFormatTests`: a desktop manifest without `args` decodes (fails on the bug), and one with `args`/`env` still decodes (regression guard).
- Full `OsaurusCLI` suite green, `swift-format lint --strict` clean.