### PR TITLE
Reject out-of-range proxy ports in GlobalProxyConfiguration

### DIFF
--- a/Packages/OsaurusNetworking/Package.swift
+++ b/Packages/OsaurusNetworking/Package.swift
@@ -11,6 +11,10 @@ let package = Package(
         .target(
             name: "OsaurusNetworking",
             path: "Sources"
-        )
+        ),
+        .testTarget(
+            name: "OsaurusNetworkingTests",
+            dependencies: ["OsaurusNetworking"]
+        ),
     ]
 )

--- a/Packages/OsaurusNetworking/Sources/GlobalProxyConfiguration.swift
+++ b/Packages/OsaurusNetworking/Sources/GlobalProxyConfiguration.swift
@@ -28,6 +28,7 @@ public struct GlobalProxyConfiguration: Equatable, Sendable {
         case missingHost
         case unsafeHost(String)
         case missingPort
+        case invalidPort(Int)
         case unsupportedURLComponents
         case credentialsInURL
 
@@ -49,6 +50,8 @@ public struct GlobalProxyConfiguration: Equatable, Sendable {
                 "Proxy host '\(host)' is reserved for local networking."
             case .missingPort:
                 "Proxy URL must include an explicit port."
+            case .invalidPort(let port):
+                "Proxy port \(port) is out of range (must be 1–65535)."
             case .unsupportedURLComponents:
                 "Proxy URL must only contain scheme, host, and port."
             case .credentialsInURL:
@@ -98,6 +101,9 @@ public struct GlobalProxyConfiguration: Equatable, Sendable {
         guard !host.isEmpty else { throw ValidationError.missingHost }
         guard !Self.isLocalOnlyHost(host) else { throw ValidationError.unsafeHost(host) }
         guard let port = components.port else { throw ValidationError.missingPort }
+        // `URLComponents` parses port 0 and values above 65535 verbatim; reject
+        // them so an invalid port can't reach the CFNetwork proxy dictionary.
+        guard (1 ... 65535).contains(port) else { throw ValidationError.invalidPort(port) }
 
         self.scheme = scheme
         self.host = host

--- a/Packages/OsaurusNetworking/Tests/OsaurusNetworkingTests/GlobalProxyConfigurationPortTests.swift
+++ b/Packages/OsaurusNetworking/Tests/OsaurusNetworkingTests/GlobalProxyConfigurationPortTests.swift
@@ -1,0 +1,43 @@
+//
+//  GlobalProxyConfigurationPortTests.swift
+//  OsaurusNetworking
+//
+
+import XCTest
+
+import OsaurusNetworking
+
+final class GlobalProxyConfigurationPortTests: XCTestCase {
+
+    /// `URLComponents` happily parses port 0 and ports above 65535, so without a
+    /// range check the configuration accepted them and injected an invalid port
+    /// into the CFNetwork proxy dictionary.
+    func testRejectsZeroAndOutOfRangePorts() {
+        for (url, expectedPort) in [
+            ("http://proxy.example.com:0", 0),
+            ("http://proxy.example.com:70000", 70000),
+            ("http://proxy.example.com:99999", 99999),
+        ] {
+            XCTAssertThrowsError(try GlobalProxyConfiguration(urlString: url), "expected \(url) to be rejected") {
+                error in
+                XCTAssertEqual(
+                    error as? GlobalProxyConfiguration.ValidationError,
+                    .invalidPort(expectedPort),
+                    "expected .invalidPort(\(expectedPort)) for \(url), got \(error)"
+                )
+            }
+        }
+    }
+
+    /// Valid ports (including the 1 and 65535 boundaries) still construct.
+    func testAcceptsInRangePorts() throws {
+        for (url, expectedPort) in [
+            ("http://proxy.example.com:1", 1),
+            ("http://proxy.example.com:8080", 8080),
+            ("socks://proxy.example.com:65535", 65535),
+        ] {
+            let config = try GlobalProxyConfiguration(urlString: url)
+            XCTAssertEqual(config.port, expectedPort)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`URLComponents` parses port `0` and ports above `65535` verbatim (confirmed: `http://h:0` → `0`, `http://h:99999` → `99999`). `GlobalProxyConfiguration` only guarded `components.port != nil`, so it accepted these and injected an invalid port into the CFNetwork proxy dictionary (e.g. `kCFNetworkProxiesHTTPPort: 0`).

## Fix

Add a `1...65535` range check (new `ValidationError.invalidPort(Int)`) immediately after the existing `missingPort` guard.

## Testing

- Adds the package's first test target (`OsaurusNetworkingTests`) covering zero / out-of-range rejection (`:0`, `:70000`, `:99999`) and the valid boundaries (`:1`, `:8080`, `:65535`).
- `OsaurusNetworking` + consumer `OsaurusRepository` suites green, `swift-format lint --strict` clean.