### PR TITLE
Fix manifest validate semver check to mirror SemanticVersion.parse

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Manifest/ManifestValidate.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Manifest/ManifestValidate.swift
@@ -268,12 +268,21 @@ public struct ManifestValidate {
         }
     }
 
-    /// Loose semver shape check: at least three dot-separated integer
-    /// components. Mirrors what `SemanticVersion.parse` accepts without
-    /// re-implementing it (the CLI module deliberately doesn't depend
-    /// on `OsaurusRepository`'s parser).
+    /// Loose semver shape check: exactly three dot-separated integer core
+    /// components, after stripping build metadata and prerelease. Mirrors
+    /// what `SemanticVersion.parse` accepts without re-implementing it (the
+    /// CLI module deliberately doesn't depend on `OsaurusRepository`'s
+    /// parser). Build metadata (`+...`) is stripped first, exactly as the
+    /// parser does, so `1.2.3+build` is accepted; and both splits keep empty
+    /// subsequences so a leading `-` or `+` (e.g. `-1.2.3`) yields an empty
+    /// core component and is rejected, matching the parser instead of
+    /// silently passing.
     private static func looksLikeSemver(_ s: String) -> Bool {
-        let core = s.split(separator: "-", maxSplits: 1).first ?? Substring(s)
+        let withoutBuild =
+            s.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false).first ?? Substring(s)
+        let core =
+            withoutBuild.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false).first
+            ?? withoutBuild
         let nums = core.split(separator: ".", omittingEmptySubsequences: false)
         guard nums.count == 3 else { return false }
         return nums.allSatisfy { Int($0) != nil }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ManifestValidateTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ManifestValidateTests.swift
@@ -363,6 +363,37 @@ final class ManifestValidateExtendedCoverageTests: XCTestCase {
         XCTAssertTrue(report.warnings.contains(where: { $0.contains("min_macos") }))
     }
 
+    func testMinOsaurusWithBuildMetadataPasses() {
+        // `SemanticVersion.parse("0.18.0+build7")` succeeds (it strips the
+        // `+build` metadata before checking the numeric core), so the
+        // validator — which claims to "mirror what SemanticVersion.parse
+        // accepts" — must not warn on a valid version carrying build
+        // metadata.
+        let report = validate(
+            #"{ "plugin_id": "com.test", "capabilities": {}, "min_osaurus": "0.18.0+build7" }"#
+        )
+        XCTAssertTrue(report.errors.isEmpty, "build metadata is valid: \(report.errors)")
+        XCTAssertTrue(
+            report.warnings.isEmpty,
+            "valid semver with build metadata must not warn: \(report.warnings)"
+        )
+    }
+
+    func testMalformedMinOsaurusWithLeadingDashWarns() {
+        // `SemanticVersion.parse("-1.2.3")` returns nil (the core before the
+        // first `-` is empty, so the major component fails to parse). The
+        // validator must likewise reject it instead of silently accepting a
+        // version the host will then refuse to parse.
+        let report = validate(
+            #"{ "plugin_id": "com.test", "capabilities": {}, "min_osaurus": "-1.2.3" }"#
+        )
+        XCTAssertTrue(report.errors.isEmpty, "shape mismatch should warn, not error: \(report.errors)")
+        XCTAssertTrue(
+            report.warnings.contains(where: { $0.contains("min_osaurus") && $0.contains("semver") }),
+            "a leading-dash version is not valid semver and must warn: \(report.warnings)"
+        )
+    }
+
     // MARK: - instructions / license / authors
 
     func testInstructionsMustBeString() {


### PR DESCRIPTION
## Summary

`ManifestValidate.looksLikeSemver` claims to "mirror what `SemanticVersion.parse` accepts," but diverged in two ways, producing both a false warning and a false pass on `osaurus manifest validate`:

- It never stripped build metadata, so a valid `min_osaurus` like `1.2.3+build` failed the check and emitted a spurious `expected semver` warning even though the host parser accepts it.
- Its prerelease split used the default `omittingEmptySubsequences: true`, so a leading-dash version like `-1.2.3` — which `SemanticVersion.parse` rejects (the core before the first `-` is empty) — silently passed with no warning.

The fix strips build metadata first and keeps empty subsequences on both splits, matching the parser.

`looksLikeSemver` remains an intentionally loose *shape* check (three integer core components) and deliberately doesn't depend on `OsaurusRepository`'s parser, so it does not enforce the full SemVer §9 empty-identifier rules — the two cases above are the user-visible ones.

## Changes
- [x] Behavior change (validator warnings)
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusCLI` (all green) + `swift-format lint --strict` clean. New tests cover the build-metadata and leading-dash cases (fail before the fix, pass after). No MLX/GUI dependency.
