### PR TITLE
Clamp pull progress fraction to avoid a negative-count String trap

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Pull.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Pull.swift
@@ -347,18 +347,27 @@ public struct PullCommand: Command {
         total: Int64,
         fraction: Double
     ) {
-        let percent = Int(fraction * 100)
+        let percent = Int(min(max(fraction, 0), 1) * 100)
         let receivedStr = ByteCountFormatter.string(fromByteCount: received, countStyle: .file)
         let totalStr = ByteCountFormatter.string(fromByteCount: total, countStyle: .file)
 
-        // 20-character progress bar
-        let barWidth = 20
-        let filled = Int(Double(barWidth) * fraction)
-        let bar = String(repeating: "=", count: filled) + String(repeating: " ", count: barWidth - filled)
+        let bar = renderProgressBar(fraction: fraction, width: 20)
 
         let line = "\r[\(bar)] \(percent)%  \(receivedStr)/\(totalStr)  \(fileName)"
         fputs(line, stdout)
         fflush(stdout)
+    }
+
+    /// Renders the fixed-width progress-bar body: `filled` `=` characters
+    /// followed by padding spaces to `width`. `fraction` is clamped into
+    /// `0...1` first, so an over-reported fraction (e.g. a download whose
+    /// actual byte count exceeds the precomputed size estimate, giving
+    /// `fraction > 1.0`) can never make `width - filled` negative and trap
+    /// `String(repeating:count:)`, which would abort the whole `pull`.
+    static func renderProgressBar(fraction: Double, width: Int) -> String {
+        let clamped = min(max(fraction, 0), 1)
+        let filled = Int(Double(width) * clamped)
+        return String(repeating: "=", count: filled) + String(repeating: " ", count: width - filled)
     }
 }
 

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/PullProgressBarTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/PullProgressBarTests.swift
@@ -1,0 +1,42 @@
+//
+//  PullProgressBarTests.swift
+//  osaurus
+//
+//  Tests for the `osaurus pull` progress-bar renderer. The reported
+//  fraction is `completedBytes / totalBytes`, where `totalBytes` is a
+//  precomputed estimate; if the actual download exceeds that estimate the
+//  fraction goes above 1.0, which must not crash the renderer.
+//
+
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class PullProgressBarTests: XCTestCase {
+
+    func testProgressBarClampsOverflowFractionToFull() {
+        // fraction > 1.0 (download exceeded the size estimate) previously
+        // made `width - filled` negative and trapped `String(repeating:
+        // count:)`, aborting the whole `pull`. It must clamp to a full bar.
+        let bar = PullCommand.renderProgressBar(fraction: 1.5, width: 20)
+        XCTAssertEqual(bar, String(repeating: "=", count: 20))
+    }
+
+    func testProgressBarClampsNegativeFractionToEmpty() {
+        let bar = PullCommand.renderProgressBar(fraction: -0.5, width: 20)
+        XCTAssertEqual(bar, String(repeating: " ", count: 20))
+    }
+
+    func testProgressBarHalfwayIsHalfFilled() {
+        let bar = PullCommand.renderProgressBar(fraction: 0.5, width: 20)
+        XCTAssertEqual(
+            bar,
+            String(repeating: "=", count: 10) + String(repeating: " ", count: 10)
+        )
+    }
+
+    func testProgressBarExactlyFull() {
+        let bar = PullCommand.renderProgressBar(fraction: 1.0, width: 20)
+        XCTAssertEqual(bar, String(repeating: "=", count: 20))
+    }
+}


### PR DESCRIPTION
## Summary

`Pull.printProgress` rendered the bar as `String(repeating: "=", count: filled) + String(repeating: " ", count: barWidth - filled)` with `filled = Int(20 * fraction)`. The fraction is `completedBytes / totalBytes`, where `totalBytes` is a precomputed size estimate. When the actual download exceeds that estimate the fraction goes above 1.0, `filled` exceeds 20, `barWidth - filled` is negative, and `String(repeating:count:)` traps with "Negative count not allowed" — aborting the entire `osaurus pull`.

This extracts the bar rendering into a testable `renderProgressBar(fraction:width:)` that clamps the fraction into `0...1`, and clamps the percentage display the same way.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusCLI` (all green) + `swift-format lint --strict` clean. New tests cover overflow (fraction > 1 → full bar, no trap), underflow, half, and exact-full; the overflow test traps on the pre-fix logic and passes after. No MLX/GUI dependency.
