### PR TITLE
Make SemanticVersion SemVer-compliant: total order + reject empty identifiers

### DIFF
--- a/Packages/OsaurusRepository/SemanticVersion.swift
+++ b/Packages/OsaurusRepository/SemanticVersion.swift
@@ -56,6 +56,30 @@ public struct SemanticVersion: Codable, Hashable, Comparable, CustomStringConver
         }
     }
 
+    /// Equality and hashing follow SemVer precedence rather than raw field
+    /// equality. Build metadata is ignored (SemVer §10), and two versions are
+    /// equal exactly when neither orders before the other. Deriving `==` from
+    /// `<` guarantees the `Comparable` total-order contract holds for every
+    /// pair — including build-metadata-only differences (`1.0.0+a` vs
+    /// `1.0.0+b`) and numerically-equal prerelease identifiers (`1.0.0-alpha.1`
+    /// vs `1.0.0-alpha.01`), which the synthesized member-wise `==` reported
+    /// as unequal even though `<` ranked neither below the other (so none of
+    /// `<`, `>`, `==` held).
+    public static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        !(lhs < rhs) && !(rhs < lhs)
+    }
+
+    /// Hashes only the precedence-significant core. Prerelease and build are
+    /// omitted so that values which `==` deems equal (e.g. build-only or
+    /// `1`/`01` prerelease differences) always share a hash, as `Hashable`
+    /// requires. Versions sharing a core but differing in precedence
+    /// (`1.0.0` vs `1.0.0-alpha`) hash-collide, which is permitted.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(major)
+        hasher.combine(minor)
+        hasher.combine(patch)
+    }
+
     private static func comparePrerelease(_ l: String, _ r: String) -> Int {
         let lParts = l.split(separator: ".").map(String.init)
         let rParts = r.split(separator: ".").map(String.init)
@@ -91,6 +115,14 @@ public struct SemanticVersion: Codable, Hashable, Comparable, CustomStringConver
         let core = preSplit.first ?? withoutBuild
         let prerelease = preSplit.count == 2 ? preSplit[1] : nil
 
+        // SemVer §9: a prerelease or build section, once introduced by its
+        // separator, must be a series of non-empty dot-separated identifiers.
+        // The permissive split above keeps empty subsequences, so without this
+        // guard `1.0.0-`, `1.0.0+`, and `1.0.0-a..b` would parse into lossy
+        // values that render as `1.0.0` yet compare unequal to it.
+        if let prerelease, !isValidIdentifierSeries(prerelease) { return nil }
+        if let build, !isValidIdentifierSeries(build) { return nil }
+
         let nums = core.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
         guard nums.count == 3,
             let maj = Int(nums[0]),
@@ -98,5 +130,13 @@ public struct SemanticVersion: Codable, Hashable, Comparable, CustomStringConver
             let pat = Int(nums[2])
         else { return nil }
         return SemanticVersion(major: maj, minor: min, patch: pat, prerelease: prerelease, build: build)
+    }
+
+    /// True when `s` is a non-empty series of non-empty dot-separated
+    /// identifiers — the structural rule SemVer §9 imposes on a prerelease or
+    /// build section.
+    private static func isValidIdentifierSeries(_ s: String) -> Bool {
+        !s.isEmpty
+            && s.split(separator: ".", omittingEmptySubsequences: false).allSatisfy { !$0.isEmpty }
     }
 }

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/SemanticVersionSemVerComplianceTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/SemanticVersionSemVerComplianceTests.swift
@@ -1,0 +1,101 @@
+//
+//  SemanticVersionSemVerComplianceTests.swift
+//  osaurus
+//
+//  Pins two SemVer-spec correctness properties of `SemanticVersion`:
+//    - Comparable total order: build metadata must not break trichotomy
+//      (SemVer §10), and `==` must agree with `<`.
+//    - `parse` must reject empty prerelease / build identifiers (SemVer §9).
+//
+
+import XCTest
+
+@testable import OsaurusRepository
+
+final class SemanticVersionTotalOrderTests: XCTestCase {
+
+    private func v(_ s: String) -> SemanticVersion { SemanticVersion.parse(s)! }
+
+    // SemVer §10: build metadata MUST be ignored when determining precedence,
+    // so two versions differing only in build metadata are equal.
+    func testBuildMetadataDoesNotAffectEquality() {
+        XCTAssertEqual(v("1.0.0+exp.sha.5114f85"), v("1.0.0+21AF26D3"))
+        XCTAssertEqual(v("1.0.0"), v("1.0.0+meta"))
+    }
+
+    // The Comparable contract: for any two values exactly one of a<b, b<a,
+    // a==b holds. With build metadata ignored, build-only differences are
+    // equal — not the "none of the three holds" state the synthesized `==`
+    // produced.
+    func testTotalOrderHoldsForBuildMetadataDifference() {
+        let a = v("1.0.0+exp.sha.5114f85")
+        let b = v("1.0.0+21AF26D3")
+        let trueCount = [a < b, b < a, a == b].filter { $0 }.count
+        XCTAssertEqual(trueCount, 1, "exactly one of <, >, == must hold")
+        XCTAssertTrue(a == b)
+    }
+
+    // `<` already treats numerically-equal prerelease identifiers (1 vs 01)
+    // as equal precedence, so `==` must agree to preserve trichotomy.
+    func testTotalOrderHoldsForNumericallyEqualPrerelease() {
+        let a = v("1.0.0-alpha.1")
+        let b = v("1.0.0-alpha.01")
+        let trueCount = [a < b, b < a, a == b].filter { $0 }.count
+        XCTAssertEqual(trueCount, 1)
+        XCTAssertTrue(a == b)
+    }
+
+    // Equal values must hash equal so Set / Dictionary dedup correctly.
+    func testEqualValuesHashEqualAndDedupInSet() {
+        let set: Set<SemanticVersion> = [v("1.0.0+a"), v("1.0.0+b"), v("1.0.0")]
+        XCTAssertEqual(set.count, 1)
+    }
+
+    // Equality is SemVer-precedence, not field-wise: build metadata is dropped
+    // from `==` but preserved in `description` / Codable, so two equal values
+    // can intentionally still render (and round-trip) to different strings.
+    func testEqualValuesCanRenderDifferently() {
+        let withBuild = v("1.0.0+a")
+        let plain = v("1.0.0")
+        XCTAssertEqual(withBuild, plain)
+        XCTAssertNotEqual(withBuild.description, plain.description)
+    }
+
+    // Genuine ordering and inequality must be unaffected by the fix.
+    func testOrderingAndInequalityUnaffected() {
+        XCTAssertTrue(v("1.0.0") < v("2.0.0"))
+        XCTAssertTrue(v("1.0.0-alpha") < v("1.0.0"))
+        XCTAssertTrue(v("1.0.0-alpha.1") < v("1.0.0-alpha.2"))
+        XCTAssertNotEqual(v("1.0.0"), v("1.0.1"))
+        XCTAssertNotEqual(v("1.0.0-alpha"), v("1.0.0"))
+    }
+}
+
+final class SemanticVersionParseValidationTests: XCTestCase {
+
+    // SemVer §9: a prerelease section, when present, is a series of non-empty
+    // dot-separated identifiers. `1.0.0-` is invalid — but the permissive
+    // split accepted it as `prerelease == ""`, which renders as `1.0.0` yet
+    // is unequal to and sorts below a real `1.0.0`.
+    func testParseRejectsEmptyPrerelease() {
+        XCTAssertNil(SemanticVersion.parse("1.0.0-"))
+    }
+
+    // Likewise `1.0.0+` (empty build) is invalid.
+    func testParseRejectsEmptyBuild() {
+        XCTAssertNil(SemanticVersion.parse("1.0.0+"))
+    }
+
+    // An empty inner identifier (`alpha..1`) is also invalid per §9.
+    func testParseRejectsEmptyInnerPrereleaseIdentifier() {
+        XCTAssertNil(SemanticVersion.parse("1.0.0-alpha..1"))
+    }
+
+    // Valid prerelease / build forms must still parse.
+    func testParseStillAcceptsValidPrereleaseAndBuild() {
+        XCTAssertNotNil(SemanticVersion.parse("1.0.0"))
+        XCTAssertNotNil(SemanticVersion.parse("1.0.0-rc.1"))
+        XCTAssertNotNil(SemanticVersion.parse("1.0.0+sha.abc"))
+        XCTAssertNotNil(SemanticVersion.parse("1.0.0-alpha.1+build.7"))
+    }
+}


### PR DESCRIPTION
## Summary

Two SemVer correctness defects in `SemanticVersion`:

1. **Broken Comparable total order (SemVer §10).** The struct synthesized `==`/`hash` over every stored field including `build`, but `<` never compares `build`. For two versions differing only in build metadata (`1.0.0+exp.sha.5114f85` vs `1.0.0+21AF26D3`), `a < b`, `b < a`, and `a == b` were *all* false — none of the trichotomy relations held. The same gap hit numerically-equal prerelease identifiers (`1.0.0-alpha.1` vs `1.0.0-alpha.01`). Now `==` is derived from `<` and `hash` covers only the precedence-significant core, so equality agrees with ordering and build metadata is ignored per §10.

2. **`parse` accepted empty identifiers.** `1.0.0-` and `1.0.0+` parsed into values with an empty (not nil) prerelease/build: they render as `1.0.0` via `description` yet are unequal to a real `1.0.0`, breaking the Codable round-trip. Now rejected per SemVer §9 (also `1.0.0-a..b`).

**Equality semantics:** `==` is now SemVer-*precedence* equality, not field equality. Build metadata and `01`/`1` prerelease differences are intentionally indistinguishable under `==` / `Set` / `Dictionary` keys, while `description`/Codable still preserve them — so two `==` values can render differently (pinned by a test). No `Set<SemanticVersion>` or `SemanticVersion`-keyed dictionary exists in the tree today, so this is inert for current consumers.

**Coupling:** this touches `SemanticVersion.swift`, which open #1688 also edits (a different region — `comparePrerelease`). They're independently mergeable; whichever lands second is a trivial rebase. Once #1688 lands, `<` — and therefore this `==` — also picks up its prerelease-arity fix automatically.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusRepository` (all green) + `swift-format lint --strict` clean. Tests cover both defects plus regression guards that ordering, genuine inequality, and valid prerelease/build parsing are unaffected. No MLX/GUI dependency.
