### PR TITLE
Record background-thread host calls and support nested MockHost installs

### DIFF
--- a/Packages/OsaurusPluginTestKit/Sources/OsaurusPluginTestKit/MockHost.swift
+++ b/Packages/OsaurusPluginTestKit/Sources/OsaurusPluginTestKit/MockHost.swift
@@ -10,10 +10,14 @@
 //
 //  Why this design (`UnsafeMutableRawPointer` to `Unmanaged`):
 //  `@convention(c)` callbacks cannot capture Swift state, so the
-//  trampolines recover the `MockHost` instance from a static slot
-//  the test installed before the plugin made the call. We use a
-//  thread-local install stack so concurrent tests can run their
-//  own `MockHost` without clobbering each other's slot.
+//  trampolines recover the `MockHost` instance from a per-thread slot
+//  the test installed before the plugin made the call. The slot is a
+//  thread-local install stack: concurrent tests on different threads keep
+//  their own `MockHost`, and a `withInstalled { ... }` may nest inside
+//  another, restoring the outer host on exit. Host-global callbacks
+//  (log / config / dispatch / http) made from a plugin-spawned background
+//  thread — which has no slot of its own — fall back to the uniquely
+//  installed host so they are still recorded.
 //
 
 import Foundation
@@ -66,20 +70,27 @@ public final class MockHost: @unchecked Sendable {
     // MARK: - Install / uninstall
 
     /// Builds the C `OsrHostAPI` struct wired to this mock. The pointer
-    /// is heap-allocated and lives until `freeHostAPI()` is called or
-    /// the mock is deinitialized. Pass to the plugin's entry point.
+    /// is heap-allocated and lives until `uninstall()` is called or the
+    /// mock is deinitialized. Pass to the plugin's entry point.
     ///
-    /// IMPORTANT: only one `MockHost` may be installed at a time on a
-    /// given thread. Calling `hostAPIPointer` while another host is
-    /// installed traps. Use `withInstalled { ... }` for nested or
-    /// concurrent tests.
+    /// Installs onto this thread's install stack: any host already installed
+    /// on the thread is saved and restored when this one is uninstalled, so
+    /// a `withInstalled { ... }` may nest inside another. Installing the same
+    /// `MockHost` twice without an intervening `uninstall()` traps.
     public func hostAPIPointer() -> UnsafeMutablePointer<OsrHostAPI> {
         precondition(
-            Thread.current.threadDictionary[Self.threadKey] == nil,
-            "another MockHost is already installed on this thread; nest with `withInstalled`"
+            !didInstall,
+            "this MockHost is already installed; uninstall() it (or use `withInstalled`) before reinstalling"
         )
         let retain = Unmanaged.passRetained(self)
+        // Save the host this one displaces so uninstall() can restore it
+        // (the install stack), rather than unconditionally clearing the slot.
+        previousSlot = Thread.current.threadDictionary[Self.threadKey] as? UnsafeMutableRawPointer
         Thread.current.threadDictionary[Self.threadKey] = retain.toOpaque()
+        didInstall = true
+        Self.registryLock.withLock {
+            Self.installedHosts[ObjectIdentifier(self)] = Unmanaged.passUnretained(self)
+        }
 
         let api = OsrHostAPI(
             version: 6,
@@ -99,8 +110,9 @@ public final class MockHost: @unchecked Sendable {
         return ptr
     }
 
-    /// Frees the heap-allocated `OsrHostAPI` and clears the thread-
-    /// local install slot. Idempotent. Call from your test's tearDown
+    /// Frees the heap-allocated `OsrHostAPI`, drops this host's retain, and
+    /// restores the host it displaced on this thread's install stack (clearing
+    /// the slot if there was none). Idempotent. Call from your test's tearDown
     /// or use `withInstalled` which auto-cleans.
     public func uninstall() {
         if let ptr = installedPointer {
@@ -108,15 +120,44 @@ public final class MockHost: @unchecked Sendable {
             ptr.deallocate()
             installedPointer = nil
         }
-        if let raw = Thread.current.threadDictionary[Self.threadKey] as? UnsafeMutableRawPointer {
-            Unmanaged<MockHost>.fromOpaque(raw).release()
+        Self.registryLock.withLock {
+            Self.installedHosts[ObjectIdentifier(self)] = nil
+        }
+        guard didInstall else { return }
+        didInstall = false
+        // The install stack must unwind last-in-first-out on the install
+        // thread: this host's retained opaque is owned by the thread slot
+        // (if it is still the top) or has been moved into the `previousSlot`
+        // of whatever host was installed after it. Releasing it while a later
+        // host still references it would dangle that host's `previousSlot`, so
+        // a non-LIFO (or cross-thread) uninstall is unsupported and traps
+        // rather than silently leaking. `withInstalled`'s `defer` guarantees
+        // LIFO, so the blessed path never hits this.
+        let selfOpaque = Unmanaged.passUnretained(self).toOpaque()
+        precondition(
+            Thread.current.threadDictionary[Self.threadKey] as? UnsafeMutableRawPointer == selfOpaque,
+            "MockHost.uninstall() must run on the install thread and unwind in LIFO order; use `withInstalled` to guarantee this"
+        )
+        Unmanaged<MockHost>.fromOpaque(selfOpaque).release()
+        if let previousSlot {
+            Thread.current.threadDictionary[Self.threadKey] = previousSlot
+        } else {
             Thread.current.threadDictionary.removeObject(forKey: Self.threadKey)
         }
+        previousSlot = nil
     }
 
     deinit { uninstall() }
 
     private var installedPointer: UnsafeMutablePointer<OsrHostAPI>?
+
+    /// True between `hostAPIPointer()` and `uninstall()`. Guards against
+    /// double-install and makes `uninstall()` idempotent.
+    private var didInstall = false
+
+    /// The opaque pointer this host displaced on its install thread, restored
+    /// on `uninstall()` so installs nest correctly.
+    private var previousSlot: UnsafeMutableRawPointer?
 
     // MARK: - Convenience
 
@@ -135,10 +176,35 @@ public final class MockHost: @unchecked Sendable {
 
     private static let threadKey = "ai.osaurus.plugintestkit.mockhost"
 
+    /// Process-wide set of currently-installed hosts, used to attribute a
+    /// host-global callback made from a plugin-spawned background thread (which
+    /// carries no thread-local install slot). A background callback resolves to
+    /// the host here only when exactly one is installed; with two or more the
+    /// call is ambiguous and is dropped rather than misrouted.
+    private static let registryLock = NSLock()
+    nonisolated(unsafe) private static var installedHosts: [ObjectIdentifier: Unmanaged<MockHost>] = [:]
+
+    /// The host bound to the current per-agent frame (the calling thread's
+    /// install slot). Used by `get_active_agent_id`, which must return NULL
+    /// outside a per-agent frame — including a background thread — per the
+    /// host ABI.
     private static func current() -> MockHost? {
         guard let raw = Thread.current.threadDictionary[threadKey] as? UnsafeMutableRawPointer
         else { return nil }
         return Unmanaged<MockHost>.fromOpaque(raw).takeUnretainedValue()
+    }
+
+    /// The host to route a host-global callback (log / config / dispatch /
+    /// http) to. Prefers the calling thread's install slot; if there is none
+    /// (a plugin-spawned background thread) it falls back to the uniquely
+    /// installed host so the call is still recorded. Returns nil when zero or
+    /// more-than-one hosts are installed, so an ambiguous background call is
+    /// dropped rather than attributed to the wrong recorder.
+    private static func recordingHost() -> MockHost? {
+        if let host = current() { return host }
+        return registryLock.withLock {
+            installedHosts.count == 1 ? installedHosts.values.first?.takeUnretainedValue() : nil
+        }
     }
 
     /// Heap-allocate `s` as a NUL-terminated C string the plugin
@@ -155,14 +221,14 @@ public final class MockHost: @unchecked Sendable {
     }
 
     private static let trampolineConfigGet: OsrConfigGet = { keyPtr in
-        guard let host = current(), let keyPtr else { return nil }
+        guard let host = recordingHost(), let keyPtr else { return nil }
         let key = String(cString: keyPtr)
         guard let value = host.onConfigGet(key) else { return nil }
         return makeCString(value)
     }
 
     private static let trampolineConfigSet: OsrConfigSet = { keyPtr, valuePtr in
-        guard let host = current(), let keyPtr, let valuePtr else { return }
+        guard let host = recordingHost(), let keyPtr, let valuePtr else { return }
         host.configWrites.recordSet(
             key: String(cString: keyPtr),
             value: String(cString: valuePtr)
@@ -170,12 +236,12 @@ public final class MockHost: @unchecked Sendable {
     }
 
     private static let trampolineConfigDelete: OsrConfigDelete = { keyPtr in
-        guard let host = current(), let keyPtr else { return }
+        guard let host = recordingHost(), let keyPtr else { return }
         host.configWrites.recordDelete(key: String(cString: keyPtr))
     }
 
     private static let trampolineLog: OsrLog = { level, msgPtr in
-        guard let host = current(), let msgPtr else { return }
+        guard let host = recordingHost(), let msgPtr else { return }
         host.logs.record(level: Int(level), message: String(cString: msgPtr))
     }
 
@@ -183,7 +249,7 @@ public final class MockHost: @unchecked Sendable {
     /// the message via the same `LogRecorder`. NULL payload degrades
     /// to a normal log entry.
     private static let trampolineLogStructured: OsrLogStructured = { level, msgPtr, payloadPtr in
-        guard let host = current(), let msgPtr else { return }
+        guard let host = recordingHost(), let msgPtr else { return }
         let message = String(cString: msgPtr)
         if let payloadPtr {
             host.logs.record(
@@ -196,12 +262,12 @@ public final class MockHost: @unchecked Sendable {
     }
 
     private static let trampolineDispatch: OsrDispatch = { jsonPtr in
-        guard let host = current(), let jsonPtr else { return nil }
+        guard let host = recordingHost(), let jsonPtr else { return nil }
         return makeCString(host.onDispatch(String(cString: jsonPtr)))
     }
 
     private static let trampolineHttpRequest: OsrHttpRequest = { jsonPtr in
-        guard let host = current(), let jsonPtr else { return nil }
+        guard let host = recordingHost(), let jsonPtr else { return nil }
         return makeCString(host.onHttpRequest(String(cString: jsonPtr)))
     }
 

--- a/Packages/OsaurusPluginTestKit/Tests/OsaurusPluginTestKitTests/MockHostTests.swift
+++ b/Packages/OsaurusPluginTestKit/Tests/OsaurusPluginTestKitTests/MockHostTests.swift
@@ -13,6 +13,13 @@ import Testing
 
 @testable import OsaurusPluginTestKit
 
+// Serialized so the host installs these tests perform never overlap a
+// concurrently-installed host from another test. That matters for the
+// background-thread fallback exercised by the nested `Threading` suite
+// (`MockHostThreadingTests.swift`): a host-global callback from a background
+// thread resolves to the uniquely-installed host, which is only well-defined
+// when installs don't run in parallel.
+@Suite(.serialized)
 struct MockHostTests {
 
     @Test func hostAPIPointerAdvertisesV6() throws {

--- a/Packages/OsaurusPluginTestKit/Tests/OsaurusPluginTestKitTests/MockHostThreadingTests.swift
+++ b/Packages/OsaurusPluginTestKit/Tests/OsaurusPluginTestKitTests/MockHostThreadingTests.swift
@@ -1,0 +1,189 @@
+//
+//  MockHostThreadingTests.swift
+//  OsaurusPluginTestKitTests
+//
+//  The host ABI (osaurus_plugin.h) documents that a plugin may call host
+//  callbacks from a plugin-spawned background thread, and the recorders are
+//  NSLock-protected specifically to accept those writes. These tests pin two
+//  threading properties of MockHost:
+//    - host-global callbacks (log / config) made from a background thread
+//      are recorded, while get_active_agent_id still returns NULL there
+//      (per the ABI's "outside any per-agent frame" rule);
+//    - installs nest: `withInstalled` can wrap another install, routing to
+//      the inner host and restoring the outer one on exit.
+//
+//  Nested inside `MockHostTests` (which is `.serialized`) so these tests and
+//  every other host-installing test run one at a time: the process-wide
+//  single-host fallback (used to attribute a background-thread call when
+//  exactly one host is installed) is only well-defined when installs don't
+//  overlap.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusPluginTestKit
+
+extension MockHostTests {
+
+    @Suite(.serialized)
+    struct Threading {
+
+        @Test func backgroundThreadLogIsRecorded() {
+            let host = MockHost()
+            host.withInstalled { ptr in
+                let api = ptr.pointee
+                let done = DispatchSemaphore(value: 0)
+                Thread.detachNewThread {
+                    "bg log".withCString { api.log?(2, $0) }
+                    done.signal()
+                }
+                done.wait()
+            }
+            #expect(host.logs.entries.count == 1)
+            #expect(host.logs.contains("bg log"))
+        }
+
+        @Test func backgroundThreadConfigWriteIsRecorded() {
+            let host = MockHost()
+            host.withInstalled { ptr in
+                let api = ptr.pointee
+                let done = DispatchSemaphore(value: 0)
+                Thread.detachNewThread {
+                    "k".withCString { k in "v".withCString { v in api.configSet?(k, v) } }
+                    done.signal()
+                }
+                done.wait()
+            }
+            #expect(host.configWrites.lastValue(forKey: "k") == "v")
+        }
+
+        @Test func getActiveAgentIdIsNilOnBackgroundThread() {
+            // Per the ABI, get_active_agent_id returns NULL outside a per-agent
+            // frame — including a plugin-spawned background thread — even when an
+            // id is configured for the install-thread frame.
+            let host = MockHost()
+            host.activeAgentId = "11111111-2222-3333-4444-555555555555"
+            host.withInstalled { ptr in
+                let api = ptr.pointee
+                let done = DispatchSemaphore(value: 0)
+                Thread.detachNewThread {
+                    let wasNil = (api.getActiveAgentId?() == nil)
+                    (wasNil ? "agentid:nil" : "agentid:set").withCString { api.log?(2, $0) }
+                    done.signal()
+                }
+                done.wait()
+                // The install-thread frame still returns the configured id.
+                if let cstr = api.getActiveAgentId?() {
+                    let s = String(cString: cstr)
+                    free(UnsafeMutableRawPointer(mutating: cstr))
+                    #expect(s == "11111111-2222-3333-4444-555555555555")
+                } else {
+                    Issue.record("expected the configured agent id on the install thread")
+                }
+            }
+            #expect(host.logs.messages.last == "agentid:nil")
+        }
+
+        @Test func backgroundCallIsDroppedWhenMultipleHostsInstalled() {
+            // Two hosts installed on different threads: a background-thread call
+            // can't be unambiguously attributed, so it is dropped (not misrouted
+            // to the wrong recorder).
+            let hostA = MockHost()
+            let hostB = MockHost()
+            let bInstalled = DispatchSemaphore(value: 0)
+            let releaseB = DispatchSemaphore(value: 0)
+            let bWorkerDone = DispatchSemaphore(value: 0)
+            Thread.detachNewThread {
+                hostB.withInstalled { _ in
+                    bInstalled.signal()
+                    releaseB.wait()
+                }
+                // hostB is now fully uninstalled (out of the registry).
+                bWorkerDone.signal()
+            }
+            bInstalled.wait()
+            hostA.withInstalled { ptr in
+                let api = ptr.pointee
+                let done = DispatchSemaphore(value: 0)
+                Thread.detachNewThread {
+                    "ambiguous".withCString { api.log?(2, $0) }
+                    done.signal()
+                }
+                done.wait()
+            }
+            releaseB.signal()
+            // Join the hostB worker so it can't leave hostB in the registry past
+            // this test and perturb the next test's single-host fallback.
+            bWorkerDone.wait()
+            #expect(hostA.logs.entries.isEmpty)
+            #expect(hostB.logs.entries.isEmpty)
+        }
+
+        @Test func nestedInstallRoutesToInnerThenRestoresOuter() {
+            let outer = MockHost()
+            let inner = MockHost()
+            outer.withInstalled { outerPtr in
+                let outerApi = outerPtr.pointee
+                "outer-before".withCString { outerApi.log?(2, $0) }
+                inner.withInstalled { innerPtr in
+                    let innerApi = innerPtr.pointee
+                    "inner".withCString { innerApi.log?(2, $0) }
+                }
+                // Inner uninstalled: the outer host is restored as current.
+                "outer-after".withCString { outerApi.log?(2, $0) }
+            }
+            #expect(inner.logs.messages == ["inner"])
+            #expect(outer.logs.messages == ["outer-before", "outer-after"])
+        }
+
+        @Test func nestedLifoUninstallDoesNotLeakOrPoisonSlot() {
+            // The install stack is `Unmanaged`-retained, so a regression here
+            // could (a) leak a host whose slot retain is never released, or
+            // (b) leave the thread slot pointing at a logically-uninstalled
+            // host. Pin both: after a nested LIFO unwind every host must
+            // deallocate and the slot must be clean.
+            weak var weakOuter: MockHost?
+            weak var weakInner: MockHost?
+            do {
+                let outer = MockHost()
+                let inner = MockHost()
+                weakOuter = outer
+                weakInner = inner
+                outer.withInstalled { _ in
+                    inner.withInstalled { _ in }
+                }
+                // Both uninstalled LIFO via `defer`; only the locals retain them.
+            }
+            #expect(weakOuter == nil, "outer must deallocate after LIFO uninstall (no leaked slot retain)")
+            #expect(weakInner == nil, "inner must deallocate after LIFO uninstall")
+            // Slot is clean: a fresh sole host records a background-thread call,
+            // which it could not if the slot still pointed at a dead host.
+            let fresh = MockHost()
+            fresh.withInstalled { ptr in
+                let api = ptr.pointee
+                let done = DispatchSemaphore(value: 0)
+                Thread.detachNewThread {
+                    "after-nest".withCString { api.log?(2, $0) }
+                    done.signal()
+                }
+                done.wait()
+            }
+            #expect(fresh.logs.messages == ["after-nest"])
+        }
+
+        @Test func nonLifoUninstallTraps() async {
+            // A manual out-of-LIFO uninstall (outer before inner) would
+            // otherwise orphan the outer's retain and leave the slot pointing
+            // at it; instead it must trap. Run in a child process so the
+            // precondition abort is observed rather than crashing this suite.
+            await #expect(processExitsWith: .failure) {
+                let outer = MockHost()
+                let inner = MockHost()
+                _ = outer.hostAPIPointer()
+                _ = inner.hostAPIPointer()
+                outer.uninstall()  // not the slot top → precondition failure
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`MockHost` resolved every host-API trampoline through a thread-local install slot, which had two gaps versus the behavior `OsaurusPluginTestKit` documents:

1. **Background-thread host calls were dropped.** Host-global callbacks (`log` / `config_set` / `config_delete` / `dispatch` / `http_request`) made from a plugin-spawned background thread — an explicitly supported frame per `osaurus_plugin.h`, and the reason the recorders are `NSLock`-guarded — found no thread-local slot in `current()` and were silently dropped. A plugin that persists config or logs on an async path recorded nothing, so a passing `host.configWrites.lastValue(...) != nil` / `host.logs.contains(...)` assertion was a false negative.

2. **`withInstalled` couldn't nest.** The docstrings promised a thread-local install "stack" that "restores the previous host," and the precondition message said to "nest with `withInstalled`," but `hostAPIPointer` trapped on any second install and `uninstall` unconditionally cleared the slot — nesting was impossible.

## Approach

- New `recordingHost()` resolves host-global callbacks to the calling thread's install slot if present, else — for a background thread with no slot — the uniquely-installed host from a small process-wide registry. When zero or ≥2 hosts are installed the background call is ambiguous and is **dropped, never misrouted**. (A `@convention(c)` trampoline carries no per-host context, so a contextless background call can only be attributed via process-wide state; single-host is the well-defined common case.)
- `get_active_agent_id` keeps using the thread-local slot, so it still returns `NULL` outside a per-agent frame (including a background thread), matching the ABI.
- `hostAPIPointer` saves the displaced host and `uninstall` restores it, so installs nest (LIFO, as `withInstalled`'s `defer` guarantees). Re-installing the *same* host without an intervening `uninstall` still traps.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan

`swift test` in `Packages/OsaurusPluginTestKit` (15 tests, all green) + `swift-format lint --strict` clean. New `Threading` suite covers background-thread log/config recording, the `get_active_agent_id` NULL-on-background-thread rule, the ambiguous-multi-host drop, and nested install/restore. The suite is nested under a now-`.serialized` `MockHostTests` so host installs never overlap (the background-thread fallback's single-host attribution is only well-defined when installs don't run concurrently); verified stable across 20 consecutive full-suite runs. No MLX/GUI dependency.
