### PR TITLE
Reject directory/symlink named *.dylib in dev-mode install detection

### DIFF
--- a/Packages/OsaurusRepository/InstalledPluginsStore.swift
+++ b/Packages/OsaurusRepository/InstalledPluginsStore.swift
@@ -78,6 +78,31 @@ public final class InstalledPluginsStore: @unchecked Sendable {
         return receipt
     }
 
+    /// Returns true if `directory` directly contains a regular (non-symlink) file with a
+    /// `.dylib` extension. Mirrors `PluginInstallManager.isRegularPayloadFile` so a
+    /// directory or symlink merely *named* `*.dylib` is not mistaken for a loadable plugin
+    /// binary by the dev-mode ("no receipt.json") validity check.
+    private func containsLoadableDylib(in directory: URL) -> Bool {
+        let fm = FileManager.default
+        guard
+            let urls = try? fm.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return false
+        }
+        return urls.contains { url in
+            guard url.pathExtension == "dylib",
+                let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            else {
+                return false
+            }
+            return values.isRegularFile == true && values.isSymbolicLink != true
+        }
+    }
+
     /// Returns all installed versions for a plugin by scanning the file system.
     public func installedVersions(pluginId: String) -> [SemanticVersion] {
         let fm = FileManager.default
@@ -109,10 +134,8 @@ public final class InstalledPluginsStore: @unchecked Sendable {
             // Must contain a receipt.json OR a .dylib file (for dev mode)
             let receiptURL = entry.appendingPathComponent("receipt.json", isDirectory: false)
             if !fm.fileExists(atPath: receiptURL.path) {
-                // Check for any .dylib file
-                guard let files = try? fm.contentsOfDirectory(atPath: entry.path),
-                    files.contains(where: { $0.hasSuffix(".dylib") })
-                else {
+                // Check for any real (regular, non-symlink) .dylib file (dev mode)
+                guard containsLoadableDylib(in: entry) else {
                     continue
                 }
             }
@@ -164,8 +187,8 @@ public final class InstalledPluginsStore: @unchecked Sendable {
             let receiptURL = versionDir.appendingPathComponent("receipt.json", isDirectory: false)
 
             var isValid = fm.fileExists(atPath: receiptURL.path)
-            if !isValid, let files = try? fm.contentsOfDirectory(atPath: versionDir.path) {
-                isValid = files.contains(where: { $0.hasSuffix(".dylib") })
+            if !isValid {
+                isValid = containsLoadableDylib(in: versionDir)
             }
 
             if isValid, let version = SemanticVersion.parse(dest) {

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/InstalledPluginsStoreTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/InstalledPluginsStoreTests.swift
@@ -1,0 +1,110 @@
+//
+//  InstalledPluginsStoreTests.swift
+//  OsaurusRepository
+//
+//  Regression coverage for the dev-mode ("no receipt.json, detect a `.dylib`")
+//  validity check: a *directory* or symlink merely named `*.dylib` must not be
+//  mistaken for a loadable plugin binary.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusRepository
+
+final class InstalledPluginsStoreTests: XCTestCase {
+    private var tempRoot: URL!
+    private var previousOverride: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let fm = FileManager.default
+        tempRoot = fm.temporaryDirectory.appendingPathComponent(
+            "osaurus-installed-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousOverride = ToolsPaths.overrideRoot
+        ToolsPaths.overrideRoot = tempRoot
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    /// Creates `<tools>/<pluginId>/<version>/` with no receipt.json and returns the version dir.
+    private func makeReceiptlessVersionDir(pluginId: String, version: String) throws -> URL {
+        let dir = ToolsPaths.toolsRootDirectory()
+            .appendingPathComponent(pluginId, isDirectory: true)
+            .appendingPathComponent(version, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - installedVersions dev-mode detection
+
+    /// A version directory whose only `.dylib`-suffixed entry is itself a DIRECTORY
+    /// (not a loadable binary) must NOT be treated as an installed version.
+    func test_installedVersions_excludesVersionWhoseDylibIsADirectory() throws {
+        let dir = try makeReceiptlessVersionDir(pluginId: "devplug", version: "1.0.0")
+        // A *directory* named like a dylib — string-suffix matching would wrongly accept it.
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("Plugin.dylib", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let versions = InstalledPluginsStore.shared.installedVersions(pluginId: "devplug")
+        XCTAssertTrue(
+            versions.isEmpty,
+            "A directory named *.dylib must not count as a loadable plugin binary"
+        )
+    }
+
+    /// A real (regular, non-symlink) `.dylib` file with no receipt is the legitimate
+    /// "dev mode" install and MUST still be detected (guards against over-correction).
+    func test_installedVersions_includesVersionWithRegularDylib() throws {
+        let dir = try makeReceiptlessVersionDir(pluginId: "realplug", version: "2.0.0")
+        try Data("not a real binary".utf8).write(
+            to: dir.appendingPathComponent("Real.dylib", isDirectory: false)
+        )
+
+        let versions = InstalledPluginsStore.shared.installedVersions(pluginId: "realplug")
+        XCTAssertEqual(
+            versions.map(\.description),
+            ["2.0.0"],
+            "A regular .dylib file is a valid dev-mode install and must be detected"
+        )
+    }
+
+    // MARK: - latestInstalledVersion current-symlink detection
+
+    /// The `current` symlink fast-path must apply the same regular-file check: a
+    /// `current` -> version dir whose only `.dylib` entry is a directory must not
+    /// be accepted as the latest installed version.
+    func test_latestInstalledVersion_currentSymlinkRejectsDirectoryNamedDylib() throws {
+        let dir = try makeReceiptlessVersionDir(pluginId: "devsym", version: "1.0.0")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("Plugin.dylib", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        // current -> 1.0.0
+        let currentLink = ToolsPaths.toolsRootDirectory()
+            .appendingPathComponent("devsym", isDirectory: true)
+            .appendingPathComponent("current", isDirectory: false)
+        try FileManager.default.createSymbolicLink(
+            atPath: currentLink.path,
+            withDestinationPath: "1.0.0"
+        )
+
+        XCTAssertNil(
+            InstalledPluginsStore.shared.latestInstalledVersion(pluginId: "devsym"),
+            "current -> a version dir with no real .dylib must not be reported as latest"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`InstalledPluginsStore` treats a version directory that has no `receipt.json` as a valid "dev mode" install when it contains a `.dylib`. Both detection sites used a bare `contentsOfDirectory(atPath:)` + `hasSuffix(".dylib")` string check with **no file-type test**:

- `installedVersions(pluginId:)` — the receipt-less fallback (`InstalledPluginsStore.swift:111`)
- `latestInstalledVersion(pluginId:)` — the `current`-symlink fast path (`InstalledPluginsStore.swift:167`)

Because the check is pure string matching, a *subdirectory* (or symlink) merely named `Foo.dylib` — with no real loadable binary — is accepted as a valid version. That false positive then flows into `allInstalledPluginIds()`, `latestInstalledVersion()`, and `repairDanglingCurrentSymlinks()`, which can repoint `current` at a binary-less directory.

The real install path already guards the identical decision behind `PluginInstallManager.isRegularPayloadFile` (`.isRegularFileKey` && `!.isSymbolicLinkKey`), whose doc comment warns that symlinked payloads are unsafe. This mirrors it: a private `containsLoadableDylib(in:)` helper that only accepts a regular, non-symlink `*.dylib` file, used at both sites.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusRepository` (27 tests green, +3 new) + `swift-format lint --strict` clean. New regression tests: a directory named `Plugin.dylib` is rejected at both the `installedVersions` and `current`-symlink paths (each fails on the pre-fix logic, passes after), while a regular `.dylib` dev-mode install is still detected (guards against over-correction). No MLX/GUI dependency.