### PR TITLE
Fix invalid triple-quote delimiter in generated Swift plugin scaffold

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsCreate.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsCreate.swift
@@ -412,7 +412,7 @@ public struct ToolsCreate {
                 }
                 
                 api.get_manifest = { ctxPtr in
-                    let manifest = \\"\\"\\"
+                    let manifest = \"\"\"
                     {
                       "plugin_id": "dev.example.\(name)",
                       "name": "\(displayName)",
@@ -443,7 +443,7 @@ public struct ToolsCreate {
                         ]
                       }
                     }
-                    \\"\\"\\"
+                    \"\"\"
                     return makeCString(manifest)
                 }
                 

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsCreateTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsCreateTests.swift
@@ -89,6 +89,30 @@ final class ToolsCreateTests: XCTestCase {
         XCTAssertTrue(content.contains("api.version = 2"))
     }
 
+    func testSwiftManifestUsesValidTripleQuoteDelimiter() throws {
+        ToolsCreate.scaffoldPlugin(name: "test-plugin", language: "swift", rootDirectory: tempDir)
+
+        let pluginPath =
+            tempDir
+            .appendingPathComponent("test-plugin")
+            .appendingPathComponent("Sources/test_plugin/Plugin.swift")
+        let content = try String(contentsOf: pluginPath, encoding: .utf8)
+
+        // The generated `get_manifest` body opens a Swift multiline string literal.
+        // The template must emit a bare `"""` delimiter, not an escaped-quote triple
+        // (`\"\"\"`), which is a Swift syntax error that makes the scaffold fail to compile.
+        let escapedTriple = "\\\"\\\"\\\""  // \" \" \"
+        let bareTriple = "\"\"\""  // """
+        XCTAssertFalse(
+            content.contains("let manifest = " + escapedTriple),
+            "Generated Plugin.swift must not open the manifest with an escaped-quote triple"
+        )
+        XCTAssertTrue(
+            content.contains("let manifest = " + bareTriple),
+            "Generated Plugin.swift must open the manifest with a bare triple-quote delimiter"
+        )
+    }
+
     func testSwiftManifestContainsPluginId() throws {
         ToolsCreate.scaffoldPlugin(name: "my-tool", language: "swift", rootDirectory: tempDir)
 


### PR DESCRIPTION
## Summary

`osaurus tools create <name>` with the default language (`swift`) scaffolds a `Sources/<module>/Plugin.swift` **that does not compile**.

The scaffold template (`ToolsCreate.createSwiftPlugin`'s `pluginSwift`) is itself a Swift `"""..."""` literal. The `get_manifest` body opens its manifest with the delimiter written as `\\"\\"\\"` (`ToolsCreate.swift:415`, and the matching close at `:446`). Inside the outer multiline literal, `\\` collapses to one backslash and `\"` to one quote, so the **generated** file receives the literal text `\"\"\"`:

```swift
let manifest = \"\"\"
```

That is a stray backslash outside any string literal — a Swift syntax error. Every Swift plugin scaffolded by the CLI fails to build out of the box.

The fix drops one backslash per quote (`\\"\\"\\"` -> `\"\"\"`) at both the opening and closing manifest delimiter, so the generated file gets a valid bare `"""`. The Rust path is unaffected — it uses an `r#"..."#` raw string.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusCLI` (89 tests green, +1 new) + `swift-format lint --strict` clean. The new test (`testSwiftManifestUsesValidTripleQuoteDelimiter`) reads the generated `Plugin.swift` and asserts it opens the manifest with a bare `"""` and not an escaped-quote triple; it fails on the pre-fix template and passes after. No MLX/GUI dependency.