### PR TITLE
Avoid CLI crash on out-of-Int64-range model_info numbers in `show`

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
@@ -46,8 +46,9 @@ public struct ShowCommand: Command {
         }
     }
 
-    /// Type-erased decodable for heterogeneous JSON values
-    private enum AnyCodableValue: Decodable {
+    /// Type-erased decodable for heterogeneous JSON values.
+    /// Internal (not private) so the numeric coercion can be unit-tested.
+    enum AnyCodableValue: Decodable {
         case string(String)
         case int(Int)
         case double(Double)
@@ -84,7 +85,7 @@ public struct ShowCommand: Command {
         var intValue: Int? {
             switch self {
             case .int(let i): return i
-            case .double(let d): return Int(d)
+            case .double(let d): return Int(exactly: d)
             case .string(let s): return Int(s)
             default: return nil
             }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ShowCommandTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ShowCommandTests.swift
@@ -1,0 +1,39 @@
+//
+//  ShowCommandTests.swift
+//  osaurus
+//
+//  Regression coverage for `ShowCommand.AnyCodableValue.intValue`: a model_info
+//  number outside Int64 range must coerce to nil, not trap.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ShowCommandTests: XCTestCase {
+    private func decodeValue(_ json: String) throws -> ShowCommand.AnyCodableValue {
+        let values = try JSONDecoder().decode(
+            [ShowCommand.AnyCodableValue].self,
+            from: Data(json.utf8)
+        )
+        return values[0]
+    }
+
+    /// `/api/show` `model_info` can carry a JSON number larger than `Int64.max`.
+    /// It decodes as `.double`, and the unguarded `Int(d)` conversion traps —
+    /// aborting the whole CLI. `intValue` must return nil instead.
+    func testIntValueReturnsNilForOutOfRangeDouble() throws {
+        let value = try decodeValue("[99999999999999999999]")
+        XCTAssertNil(
+            value.intValue,
+            "A double outside Int64 range must coerce to nil, not trap the process"
+        )
+    }
+
+    /// In-range integers and doubles still coerce correctly (no over-correction).
+    func testIntValuePreservesInRangeNumbers() throws {
+        XCTAssertEqual(try decodeValue("[4096]").intValue, 4096)
+        XCTAssertEqual(try decodeValue("[100.0]").intValue, 100)
+    }
+}


### PR DESCRIPTION
## Summary

`osaurus show <model>` can crash the entire CLI on a server response it has no control over.

`ShowCommand.AnyCodableValue.intValue` coerces a `.double` with `Int(d)` (`Show.swift:87`), which **traps** for any value outside `Int64` range. The command decodes the `/api/show` `model_info` map into `[String: AnyCodableValue]`; a numeric value larger than `Int64.max` (e.g. a JSON number like `99999999999999999999`) fails `decode(Int.self)` and decodes as `.double`. `printFormattedOutput` then calls `intValue` for every key ending in `.context_length` (`Show.swift:187`) and `.embedding_length` (`Show.swift:196`), so a single out-of-range value aborts the process with:

```
Fatal error: Double value cannot be converted to Int because the result would be greater than Int.max
```

The fix uses `Int(exactly:)` so a non-representable value yields nil and the field is simply skipped, rather than crashing. The enum is made internal (was private) so the numeric coercion can be unit-tested.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusCLI` (90 tests green, +2 new) + `swift-format lint --strict` clean. New tests: an out-of-`Int64`-range double coerces to nil instead of trapping (the pre-fix code aborts the test process with the fatal error above), and in-range integers/doubles still convert correctly. No MLX/GUI dependency.