### PR TITLE
Escape "."/".." path components so a lane name cannot escape lanes/

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/CoordinatorPaths.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/CoordinatorPaths.swift
@@ -71,6 +71,13 @@ public struct CoordinatorPaths: Equatable, Sendable {
                 output += String(format: "%%%02X", byte)
             }
         }
+        // A component of only "." or ".." resolves to the current/parent directory,
+        // which would let a name escape its intended container (e.g.
+        // `laneDirectory(named: "..")` resolving above `lanes/`). Percent-encode the
+        // dots so the component stays a literal child name.
+        if output == "." || output == ".." {
+            return output.replacingOccurrences(of: ".", with: "%2E")
+        }
         return output.isEmpty ? "_" : output
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/CoordinatorPathsTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/CoordinatorPathsTests.swift
@@ -25,4 +25,29 @@ final class CoordinatorPathsTests: XCTestCase {
         let paths = try CoordinatorPaths(rootPath: "/tmp/coordinator-test")
         XCTAssertEqual(paths.lockFile(for: "Packages/Foo.swift").lastPathComponent, "Packages%2FFoo.swift.lock.json")
     }
+
+    func testFileComponentEscapesDotSegments() {
+        // "." and ".." would resolve to the current/parent directory and let a
+        // name escape its container; they must be percent-encoded.
+        XCTAssertEqual(CoordinatorPaths.fileComponent(for: ".."), "%2E%2E")
+        XCTAssertEqual(CoordinatorPaths.fileComponent(for: "."), "%2E")
+    }
+
+    func testFileComponentLeavesDotsInsideNamesUntouched() {
+        // A dot that is part of a longer name is safe and must pass through.
+        XCTAssertEqual(CoordinatorPaths.fileComponent(for: "Foo.swift"), "Foo.swift")
+        XCTAssertEqual(CoordinatorPaths.fileComponent(for: "v1.2.3"), "v1.2.3")
+    }
+
+    func testLaneDirectoryCannotEscapeLanesContainer() throws {
+        let paths = try CoordinatorPaths(rootPath: "/tmp/coordinator-test")
+        let lanes = paths.lanesDirectory.standardizedFileURL.path
+        for lane in ["..", "."] {
+            let dir = paths.laneDirectory(named: lane).standardizedFileURL.path
+            XCTAssertTrue(
+                dir.hasPrefix(lanes + "/"),
+                "laneDirectory(named: \"\(lane)\") must stay strictly under lanes/, got \(dir)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`CoordinatorPaths.fileComponent(for:)` exists to neutralize path separators so a resource/lane name stays a single child component (the existing `testLockFileComponentEscapesPathSeparators` enforces `Packages/Foo.swift` -> `Packages%2FFoo.swift`). But it passes `.` (byte 46) through verbatim, so a component of only `.` or `..` survives unescaped, and `laneDirectory(named:)` appends it directly:

- `laneDirectory(named: "..")` -> `<root>/lanes/..` -> standardizes to `<root>` — one level **above** the `lanes/` container
- `laneDirectory(named: ".")` -> `<root>/lanes/.` -> the `lanes/` directory itself

Multi-segment traversal like `../../etc` is already blocked (`/` is escaped to `%2F`); only a bare single-segment `.`/`..` slips through. There is no untrusted caller today (`CoordinatorBootstrap` uses a fixed lane list), so this is a defense-in-depth correctness fix for a public sanitization API, not an exploitable path in current code.

The fix percent-encodes the dots when the whole sanitized component is `.` or `..`. Dots inside longer names (`Foo.swift`, `v1.2.3`) are unaffected, so the existing separator test still passes.

## Changes
- [x] Bug fix
- [x] Tests

## Test Plan
`swift test` in `Packages/OsaurusCLI` (91 tests green, +3 new) + `swift-format lint --strict` clean. New tests: `.`/`..` encode to `%2E`/`%2E%2E` (fail on pre-fix), dots inside names pass through unchanged, and `laneDirectory(named:)` stays strictly under `lanes/` for both `.` and `..`. No MLX/GUI dependency.