### PR TITLE
Substitute embedded and multiple ${env:VAR} tokens in MCPB manifest env values

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManifest.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManifest.swift
@@ -95,13 +95,46 @@ struct MCPBundleManifest: Codable {
         let (_, _, env) = getEntryPoint()
         var resolved: [String: String] = [:]
         for (key, value) in (env ?? [:]) {
-            if value.hasPrefix("${env:"), value.hasSuffix("}") {
-                let envVar = String(value.dropFirst(6).dropLast(1))
-                resolved[key] = ProcessInfo.processInfo.environment[envVar] ?? ""
-            } else {
-                resolved[key] = value
-            }
+            resolved[key] = MCPBundleManifest.substituteEnvTokens(
+                value,
+                environment: ProcessInfo.processInfo.environment
+            )
         }
         return resolved
+    }
+
+    /// Substitute every `${env:NAME}` token found anywhere in `value` with the
+    /// corresponding entry from `environment`. Unset variables resolve to the
+    /// empty string (preserving the prior whole-value behavior). Literal text
+    /// surrounding a token is left intact, so embedded tokens
+    /// (`"https://${env:HOST}/path"`) and multiple tokens (`"${env:A}:${env:B}"`)
+    /// both resolve correctly. A value containing no token is returned unchanged.
+    static func substituteEnvTokens(_ value: String, environment: [String: String]) -> String {
+        guard value.contains("${env:") else { return value }
+        let pattern = #"\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return value }
+
+        let ns = value as NSString
+        let fullRange = NSRange(location: 0, length: ns.length)
+        var result = ""
+        var cursor = 0
+        for match in regex.matches(in: value, range: fullRange) {
+            let tokenRange = match.range
+            let nameRange = match.range(at: 1)
+            // Copy literal text preceding this token.
+            if tokenRange.location > cursor {
+                result += ns.substring(
+                    with: NSRange(location: cursor, length: tokenRange.location - cursor)
+                )
+            }
+            let name = ns.substring(with: nameRange)
+            result += environment[name] ?? ""
+            cursor = tokenRange.location + tokenRange.length
+        }
+        // Copy any trailing literal text after the last token.
+        if cursor < ns.length {
+            result += ns.substring(with: NSRange(location: cursor, length: ns.length - cursor))
+        }
+        return result
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPBundleManifestTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPBundleManifestTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class MCPBundleManifestTests: XCTestCase {
+    /// Decode a minimal manifest whose entry point carries the given env map.
+    private func manifest(env: [String: String]) throws -> MCPBundleManifest {
+        let entries = env.map { "\"\($0.key)\": \"\($0.value)\"" }.joined(separator: ",")
+        let json = """
+            {
+              "mcpVersion": "0.1.0",
+              "name": "test",
+              "version": "1.0.0",
+              "entry": { "command": "node", "args": [], "env": { \(entries) } }
+            }
+            """
+        return try JSONDecoder().decode(MCPBundleManifest.self, from: Data(json.utf8))
+    }
+
+    /// Embedded token: `${env:VAR}` inside a larger string must be substituted.
+    func testResolveEnvironmentSubstitutesEmbeddedToken() throws {
+        setenv("OSAURUS_TEST_HOST", "example.com", 1)
+        defer { unsetenv("OSAURUS_TEST_HOST") }
+
+        let m = try manifest(env: ["URL": "https://${env:OSAURUS_TEST_HOST}/path"])
+        XCTAssertEqual(m.resolveEnvironment()["URL"], "https://example.com/path")
+    }
+
+    /// Multiple tokens in one value must each be substituted.
+    func testResolveEnvironmentSubstitutesMultipleTokens() throws {
+        setenv("OSAURUS_TEST_A", "x", 1)
+        setenv("OSAURUS_TEST_B", "y", 1)
+        defer {
+            unsetenv("OSAURUS_TEST_A")
+            unsetenv("OSAURUS_TEST_B")
+        }
+
+        let m = try manifest(env: ["PAIR": "${env:OSAURUS_TEST_A}:${env:OSAURUS_TEST_B}"])
+        XCTAssertEqual(m.resolveEnvironment()["PAIR"], "x:y")
+    }
+
+    /// Regression guard: a whole-value token still resolves (the path that worked before).
+    func testResolveEnvironmentSubstitutesWholeValueToken() throws {
+        setenv("OSAURUS_TEST_TOKEN", "secret", 1)
+        defer { unsetenv("OSAURUS_TEST_TOKEN") }
+
+        let m = try manifest(env: ["TOKEN": "${env:OSAURUS_TEST_TOKEN}"])
+        XCTAssertEqual(m.resolveEnvironment()["TOKEN"], "secret")
+    }
+
+    /// Regression guard: a literal value with no token is returned unchanged.
+    func testResolveEnvironmentLeavesLiteralUnchanged() throws {
+        let m = try manifest(env: ["PLAIN": "just-a-value"])
+        XCTAssertEqual(m.resolveEnvironment()["PLAIN"], "just-a-value")
+    }
+
+    /// An unset variable resolves to the empty string (documents the missing-var policy).
+    func testResolveEnvironmentMissingVariableResolvesEmpty() throws {
+        unsetenv("OSAURUS_TEST_DEFINITELY_UNSET")
+
+        let m = try manifest(env: ["X": "${env:OSAURUS_TEST_DEFINITELY_UNSET}"])
+        XCTAssertEqual(m.resolveEnvironment()["X"], "")
+    }
+
+    /// The pure helper is directly unit-testable with an injected environment.
+    func testSubstituteEnvTokensPureFunction() {
+        let env = ["A": "x", "B": "y", "HOST": "example.com"]
+        XCTAssertEqual(
+            MCPBundleManifest.substituteEnvTokens("${env:A}:${env:B}", environment: env),
+            "x:y"
+        )
+        XCTAssertEqual(
+            MCPBundleManifest.substituteEnvTokens("https://${env:HOST}/p", environment: env),
+            "https://example.com/p"
+        )
+        XCTAssertEqual(
+            MCPBundleManifest.substituteEnvTokens("plain", environment: env),
+            "plain"
+        )
+        XCTAssertEqual(
+            MCPBundleManifest.substituteEnvTokens("${env:MISSING}", environment: env),
+            ""
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`MCPBundleManifest.resolveEnvironment()` treats each env value as a single *whole-value* variable reference — it gates on `value.hasPrefix("${env:") && value.hasSuffix("}")` and then strips a fixed 6-char prefix / 1-char suffix:

```swift
if value.hasPrefix("${env:"), value.hasSuffix("}") {
    let envVar = String(value.dropFirst(6).dropLast(1))
    resolved[key] = ProcessInfo.processInfo.environment[envVar] ?? ""
} else {
    resolved[key] = value
}
```

This is wrong for two common, realistic manifest shapes:

- **Embedded token** — `"https://${env:HOST}/path"` does not *start* with `${env:`, so it is passed through literally. The launched MCP server receives the raw `${env:HOST}` text instead of the resolved host.
- **Multiple tokens** — `"${env:A}:${env:B}"` *does* satisfy both `hasPrefix` and `hasSuffix`, so `dropFirst(6).dropLast(1)` yields the bogus variable name `"A}:${env:B"`. The lookup misses and the value resolves to `""` (the `?? ""` fallback) — silently dropping a composed/credentialed value to empty with no error.

Because env values commonly carry tokens, paths, and URLs for the proxied server, this silently breaks server launch or drops a credential to empty.

## Fix

Replace the whole-value check with an in-place scan that substitutes **every** `${env:NAME}` occurrence anywhere in the value, leaving surrounding literal text intact. The substitution is extracted into a pure `static func substituteEnvTokens(_:environment:)` so the environment source is injectable for testing.

Behavior preserved:
- missing variable → `""` (unchanged)
- plain value with no token → returned unchanged
- whole-value token → still resolves (the path that already worked)

## Tests

Adds `MCPBundleManifestTests` (OsaurusCLI is a light, MLX-free package — `swift test` runs in milliseconds) covering embedded, multiple, whole-value, literal, and missing-variable cases, plus the pure helper. `resolveEnvironment()` previously had no test coverage.

3-state verified: reverting just `resolveEnvironment()` to the old inline logic makes the embedded test return the literal `https://${env:OSAURUS_TEST_HOST}/path` and the multiple-token test return `""`; the fix makes both pass. `swift-format lint --strict` clean.