### PR TITLE
Clean up the extraction temp directory when MCPB unzip fails

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManager.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bundle/MCPBundleManager.swift
@@ -112,16 +112,21 @@ class MCPBundleManager {
 
         try FileManager.default.createDirectory(atPath: extractPath, withIntermediateDirectories: true)
 
-        // Use unzip CLI
-        try unzipWithCLI(bundlePath, to: extractPath)
+        do {
+            // Use unzip CLI
+            try unzipWithCLI(bundlePath, to: extractPath)
 
-        let manifestPath = "\(extractPath)/manifest.json"
-        guard FileManager.default.fileExists(atPath: manifestPath) else {
+            let manifestPath = "\(extractPath)/manifest.json"
+            guard FileManager.default.fileExists(atPath: manifestPath) else {
+                throw BundleLoadError.missingManifest
+            }
+
+            return BundleInfo(extractedPath: extractPath, manifestPath: manifestPath, bundleUUID: uuid)
+        } catch {
+            // Any failure after the directory was created must not leak it.
             try? FileManager.default.removeItem(atPath: extractPath)
-            throw BundleLoadError.missingManifest
+            throw error
         }
-
-        return BundleInfo(extractedPath: extractPath, manifestPath: manifestPath, bundleUUID: uuid)
     }
 
     private static func unzipWithCLI(_ zipPath: String, to destination: String) throws {

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPBundleManagerTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPBundleManagerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class MCPBundleManagerTests: XCTestCase {
+    private let bundlesRoot = "/tmp/osaurus-bundles"
+
+    private func snapshot() -> Set<String> {
+        let entries = (try? FileManager.default.contentsOfDirectory(atPath: bundlesRoot)) ?? []
+        return Set(entries)
+    }
+
+    /// A failed extraction must not leave its partially-created temp directory behind.
+    func testExtractCleansUpTempDirectoryOnUnzipFailure() throws {
+        // A non-zip file makes `/usr/bin/unzip` exit non-zero -> extractionFailed.
+        let badBundle = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-not-a-zip-\(UUID().uuidString).mcpb")
+        try Data("this is not a zip archive".utf8).write(to: badBundle)
+        defer { try? FileManager.default.removeItem(at: badBundle) }
+
+        let before = snapshot()
+        XCTAssertThrowsError(try MCPBundleManager.extract(badBundle.path)) { error in
+            guard case BundleLoadError.extractionFailed = error else {
+                return XCTFail("expected extractionFailed, got \(error)")
+            }
+        }
+        let after = snapshot()
+
+        XCTAssertEqual(
+            after.subtracting(before),
+            [],
+            "extract() leaked a temp directory under \(bundlesRoot) on extraction failure"
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`MCPBundleManager.extract()` creates `/tmp/osaurus-bundles/<uuid>` and then calls `unzipWithCLI()`:

```swift
try FileManager.default.createDirectory(atPath: extractPath, withIntermediateDirectories: true)
try unzipWithCLI(bundlePath, to: extractPath)   // <- throwing here leaks extractPath
let manifestPath = "\(extractPath)/manifest.json"
guard FileManager.default.fileExists(atPath: manifestPath) else {
    try? FileManager.default.removeItem(atPath: extractPath)   // cleaned up only here
    throw BundleLoadError.missingManifest
}
```

If `unzipWithCLI` throws (`extractionFailed`), the error propagates **without** removing the directory just created — so every failed or corrupt bundle load orphans a temp directory in `/tmp`. The two failure paths are inconsistent: missing-manifest cleans up, unzip-failure does not. And unlike `BundleLoad.run`'s `defer { bundleInfo.cleanup() }`, no `BundleInfo` exists yet to drive cleanup when extraction itself fails.

## Fix

Wrap the post-`createDirectory` work in a `do`/`catch` that removes `extractPath` on **any** failure and rethrows the original error unchanged. This collapses both failure paths into one cleanup point, so `BundleLoad`'s error `description` strings are unaffected.

## Tests

Adds `MCPBundleManagerTests` (OsaurusCLI is a light, MLX-free package): a non-zip `.mcpb` makes `/usr/bin/unzip` exit non-zero, and the test asserts no new `<uuid>` directory is left under `/tmp/osaurus-bundles` after the throw.

3-state verified: removing the new cleanup line makes the test fail with a leaked `<uuid>` directory; the fix makes it pass. `swift-format lint --strict` clean.