### PR TITLE
Degrade to defaults on a corrupt feature-flags.json instead of throwing

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/CoordinatorFeatureFlags.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/CoordinatorFeatureFlags.swift
@@ -38,7 +38,16 @@ public struct CoordinatorFeatureFlagsStore {
         }
         let data = try Data(contentsOf: paths.featureFlagsFile)
         let decoder = JSONDecoder()
-        return try decoder.decode(CoordinatorFeatureFlags.self, from: data)
+        do {
+            return try decoder.decode(CoordinatorFeatureFlags.self, from: data)
+        } catch is DecodingError {
+            // An undecodable (truncated / hand-edited / partially written) file
+            // degrades to defaults, mirroring the absent-file branch above, so the
+            // read-only `coord status` diagnostic keeps working and `feature-flags
+            // set` can repair the file. Genuine I/O errors from Data(contentsOf:)
+            // still propagate.
+            return CoordinatorFeatureFlags.defaults
+        }
     }
 
     @discardableResult

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/CoordinatorFeatureFlagsTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/CoordinatorFeatureFlagsTests.swift
@@ -20,4 +20,42 @@ final class CoordinatorFeatureFlagsTests: XCTestCase {
 
         XCTAssertEqual(reloaded["heartbeat"], true)
     }
+
+    private func writeCorruptFlags(_ paths: CoordinatorPaths) throws {
+        try FileManager.default.createDirectory(
+            at: paths.stateDirectory,
+            withIntermediateDirectories: true
+        )
+        try Data("{ this is not valid json".utf8).write(to: paths.featureFlagsFile)
+    }
+
+    func testLoadCorruptFlagsReturnsDefaults() throws {
+        let paths = try temporaryPaths()
+        try writeCorruptFlags(paths)
+
+        let store = CoordinatorFeatureFlagsStore(paths: paths)
+        let flags = try store.load()
+
+        XCTAssertEqual(flags, CoordinatorFeatureFlags.defaults)
+        XCTAssertEqual(flags["coordinator"], true)
+    }
+
+    func testSnapshotToleratesCorruptFlags() throws {
+        let paths = try temporaryPaths()
+        try writeCorruptFlags(paths)
+
+        let snapshot = try CoordinatorStatusService(paths: paths).snapshot()
+
+        XCTAssertEqual(snapshot.featureFlags, CoordinatorFeatureFlags.defaults.flags)
+    }
+
+    func testSetRepairsCorruptFlags() throws {
+        let paths = try temporaryPaths()
+        try writeCorruptFlags(paths)
+
+        _ = try CoordinatorFeatureFlagsStore(paths: paths).set("heartbeat", enabled: true)
+        let reloaded = try CoordinatorFeatureFlagsStore(paths: paths).load()
+
+        XCTAssertEqual(reloaded["heartbeat"], true)
+    }
 }


### PR DESCRIPTION
## Problem

`CoordinatorFeatureFlagsStore.load()` already treats an **absent** feature-flags file as a non-error (returns `CoordinatorFeatureFlags.defaults`). But when the file **exists yet is undecodable** (truncated, hand-edited, partially written), `decoder.decode(...)` throws `DecodingError`:

```swift
guard fileManager.fileExists(atPath: paths.featureFlagsFile.path) else {
    return CoordinatorFeatureFlags.defaults   // absent -> defaults
}
let data = try Data(contentsOf: paths.featureFlagsFile)
return try decoder.decode(CoordinatorFeatureFlags.self, from: data)  // corrupt -> throws
```

That throw propagates through `CoordinatorStatusService.snapshot()` (which calls `.load().flags` with no catch), so **`coord status` — a read-only diagnostic — fails entirely** with a raw decode error instead of degrading. It also makes **`coord feature-flags set` throw before it can rewrite the file** (`set` → `load` → `save`), so a corrupt file can't be repaired through the CLI.

This is the same class of defect already fixed for the sibling lock file in #1690 (`CoordinatorLockService.reapExpired` tolerates undecodable lock files), and it contradicts `load()`'s own "absent → defaults" contract — absent and corrupt should both degrade, not diverge.

## Fix

Catch `DecodingError` specifically and return defaults. `coord status` keeps reporting, and `feature-flags set` can repair the file (set → load returns defaults → save overwrites atomically). Real I/O errors from `Data(contentsOf:)` still propagate, so a genuine read failure is not silently masked.

## Tests

Adds three tests to `CoordinatorFeatureFlagsTests`: corrupt file → `load()` returns defaults; `CoordinatorStatusService.snapshot()` tolerates a corrupt file; and `set` repairs a corrupt file. The existing missing-file and round-trip tests stay green.

3-state verified: reverting to the plain `try decoder.decode(...)` makes all three new tests fail with `DecodingError`; the fix makes them pass. `swift-format lint --strict` clean.