### PR TITLE
Add native Slack Agent Channel

### DIFF
--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
@@ -570,6 +570,7 @@ struct AgentChannelCustomHTTPConfiguration: Codable, Equatable, Sendable {
 
 struct AgentChannelConnection: Codable, Equatable, Identifiable, Sendable {
     static let nativeDiscordConnectionId = "discord"
+    static let nativeSlackConnectionId = "slack"
 
     var id: String
     var name: String

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CryptoKit
 
 struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
     var configuredTeamIds: [String]
@@ -14,6 +15,9 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
     var writeEnabled: Bool
     var defaultReadLimit: Int
     var allowBroadcastMentions: Bool
+    var botUserId: String?
+    var botId: String?
+    var apiAppId: String?
 
     init(
         configuredTeamIds: [String] = [],
@@ -21,7 +25,10 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
         writableChannelIds: [String] = [],
         writeEnabled: Bool = false,
         defaultReadLimit: Int = 50,
-        allowBroadcastMentions: Bool = false
+        allowBroadcastMentions: Bool = false,
+        botUserId: String? = nil,
+        botId: String? = nil,
+        apiAppId: String? = nil
     ) {
         self.configuredTeamIds = Self.normalizedIds(configuredTeamIds)
         self.readableChannelIds = Self.normalizedIds(readableChannelIds)
@@ -29,6 +36,9 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
         self.writeEnabled = writeEnabled
         self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
         self.allowBroadcastMentions = allowBroadcastMentions
+        self.botUserId = Self.normalizedOptionalId(botUserId)
+        self.botId = Self.normalizedOptionalId(botId)
+        self.apiAppId = Self.normalizedOptionalId(apiAppId)
     }
 
     var normalized: SlackConnectionConfiguration {
@@ -38,7 +48,10 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
             writableChannelIds: writableChannelIds,
             writeEnabled: writeEnabled,
             defaultReadLimit: defaultReadLimit,
-            allowBroadcastMentions: allowBroadcastMentions
+            allowBroadcastMentions: allowBroadcastMentions,
+            botUserId: botUserId,
+            botId: botId,
+            apiAppId: apiAppId
         )
     }
 
@@ -64,6 +77,11 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
 
     static func normalizedId(_ id: String) -> String {
         id.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func normalizedOptionalId(_ id: String?) -> String? {
+        let normalized = normalizedId(id ?? "")
+        return normalized.isEmpty ? nil : normalized
     }
 
     static func isValidSlackId(_ id: String) -> Bool {
@@ -252,5 +270,45 @@ enum SlackSecurity {
             return text
         }
         return text.replacingOccurrences(of: value, with: replacement)
+    }
+}
+
+enum SlackSignatureVerifier {
+    static func isAuthorized(
+        signingSecret: String,
+        timestamp: String,
+        body: Data,
+        signature: String,
+        now: Date = Date(),
+        tolerance: TimeInterval = 300
+    ) -> Bool {
+        let trimmedSecret = signingSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTimestamp = timestamp.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSignature = signature.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmedSecret.isEmpty,
+              let timestampSeconds = TimeInterval(trimmedTimestamp),
+              abs(now.timeIntervalSince1970 - timestampSeconds) <= tolerance,
+              trimmedSignature.hasPrefix("v0=")
+        else {
+            return false
+        }
+
+        var base = Data("v0:\(trimmedTimestamp):".utf8)
+        base.append(body)
+        let key = SymmetricKey(data: Data(trimmedSecret.utf8))
+        let digest = HMAC<SHA256>.authenticationCode(for: base, using: key)
+        let expected = "v0=" + digest.map { String(format: "%02x", $0) }.joined()
+        return constantTimeEquals(trimmedSignature, expected)
+    }
+
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        guard lhsBytes.count == rhsBytes.count else { return false }
+        var difference: UInt8 = 0
+        for index in lhsBytes.indices {
+            difference |= lhsBytes[index] ^ rhsBytes[index]
+        }
+        return difference == 0
     }
 }

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -1,0 +1,256 @@
+//
+//  SlackConnectionConfiguration.swift
+//  osaurus
+//
+//  Non-secret configuration for the native Slack connection.
+//
+
+import Foundation
+
+struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
+    var configuredTeamIds: [String]
+    var readableChannelIds: [String]
+    var writableChannelIds: [String]
+    var writeEnabled: Bool
+    var defaultReadLimit: Int
+    var allowBroadcastMentions: Bool
+
+    init(
+        configuredTeamIds: [String] = [],
+        readableChannelIds: [String] = [],
+        writableChannelIds: [String] = [],
+        writeEnabled: Bool = false,
+        defaultReadLimit: Int = 50,
+        allowBroadcastMentions: Bool = false
+    ) {
+        self.configuredTeamIds = Self.normalizedIds(configuredTeamIds)
+        self.readableChannelIds = Self.normalizedIds(readableChannelIds)
+        self.writableChannelIds = Self.normalizedIds(writableChannelIds)
+        self.writeEnabled = writeEnabled
+        self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
+        self.allowBroadcastMentions = allowBroadcastMentions
+    }
+
+    var normalized: SlackConnectionConfiguration {
+        SlackConnectionConfiguration(
+            configuredTeamIds: configuredTeamIds,
+            readableChannelIds: readableChannelIds,
+            writableChannelIds: writableChannelIds,
+            writeEnabled: writeEnabled,
+            defaultReadLimit: defaultReadLimit,
+            allowBroadcastMentions: allowBroadcastMentions
+        )
+    }
+
+    func canRead(channelId: String) -> Bool {
+        readableChannelIds.contains(Self.normalizedId(channelId))
+    }
+
+    func canWrite(channelId: String) -> Bool {
+        writeEnabled && writableChannelIds.contains(Self.normalizedId(channelId))
+    }
+
+    func canUseTeam(teamId: String) -> Bool {
+        let normalized = Self.normalizedId(teamId)
+        return configuredTeamIds.isEmpty || configuredTeamIds.contains(normalized)
+    }
+
+    static func normalizedIds(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return ids
+            .map(normalizedId)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    static func normalizedId(_ id: String) -> String {
+        id.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func isValidSlackId(_ id: String) -> Bool {
+        let trimmed = normalizedId(id)
+        guard (2 ... 64).contains(trimmed.count) else { return false }
+        return trimmed.allSatisfy { character in
+            character.isASCII && (character.isLetter || character.isNumber || character == "." || character == "-")
+        }
+    }
+
+    static func clampReadLimit(_ value: Int) -> Int {
+        min(max(value, 1), 100)
+    }
+}
+
+enum SlackConnectionConfigurationStore {
+    nonisolated(unsafe) static var overrideDirectory: URL?
+
+    private static let fileName = "slack.json"
+
+    static func load() -> SlackConnectionConfiguration {
+        let url = configurationFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return SlackConnectionConfiguration()
+        }
+        do {
+            return try JSONDecoder()
+                .decode(SlackConnectionConfiguration.self, from: Data(contentsOf: url))
+                .normalized
+        } catch {
+            NSLog("[Slack] Failed to load Slack configuration: \(error.localizedDescription)")
+            return SlackConnectionConfiguration()
+        }
+    }
+
+    static func save(_ configuration: SlackConnectionConfiguration) throws {
+        let url = configurationFileURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(configuration.normalized).write(to: url, options: [.atomic])
+    }
+
+    static func configurationFileURL() -> URL {
+        if let overrideDirectory {
+            return overrideDirectory.appendingPathComponent(fileName)
+        }
+        return OsaurusPaths.config().appendingPathComponent(fileName)
+    }
+}
+
+enum SlackCredentialStore {
+    static let pluginId = "osaurus.slack"
+    static let botTokenKey = "bot_token"
+    static let signingSecretKey = "signing_secret"
+
+    @discardableResult
+    static func saveBotToken(_ token: String) -> Bool {
+        saveSecret(token, id: botTokenKey)
+    }
+
+    static func botToken() -> String? {
+        secret(id: botTokenKey)
+    }
+
+    static func hasBotToken() -> Bool {
+        hasSecret(id: botTokenKey)
+    }
+
+    @discardableResult
+    static func deleteBotToken() -> Bool {
+        deleteSecret(id: botTokenKey)
+    }
+
+    @discardableResult
+    static func saveSigningSecret(_ secret: String) -> Bool {
+        saveSecret(secret, id: signingSecretKey)
+    }
+
+    static func signingSecret() -> String? {
+        secret(id: signingSecretKey)
+    }
+
+    static func hasSigningSecret() -> Bool {
+        hasSecret(id: signingSecretKey)
+    }
+
+    @discardableResult
+    static func deleteSigningSecret() -> Bool {
+        deleteSecret(id: signingSecretKey)
+    }
+
+    private static func saveSecret(_ value: String, id: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return ToolSecretsKeychain.saveSecret(
+            trimmed,
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    private static func secret(id: String) -> String? {
+        ToolSecretsKeychain.getSecret(
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    private static func hasSecret(id: String) -> Bool {
+        ToolSecretsKeychain.hasSecret(
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    @discardableResult
+    private static func deleteSecret(id: String) -> Bool {
+        ToolSecretsKeychain.deleteSecret(
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+}
+
+protocol SlackCredentialStorage: Sendable {
+    func saveBotToken(_ token: String) -> Bool
+    func botToken() -> String?
+    func hasBotToken() -> Bool
+    func deleteBotToken() -> Bool
+    func saveSigningSecret(_ secret: String) -> Bool
+    func signingSecret() -> String?
+    func hasSigningSecret() -> Bool
+    func deleteSigningSecret() -> Bool
+}
+
+struct KeychainSlackCredentialStorage: SlackCredentialStorage {
+    func saveBotToken(_ token: String) -> Bool {
+        SlackCredentialStore.saveBotToken(token)
+    }
+
+    func botToken() -> String? {
+        SlackCredentialStore.botToken()
+    }
+
+    func hasBotToken() -> Bool {
+        SlackCredentialStore.hasBotToken()
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        SlackCredentialStore.deleteBotToken()
+    }
+
+    func saveSigningSecret(_ secret: String) -> Bool {
+        SlackCredentialStore.saveSigningSecret(secret)
+    }
+
+    func signingSecret() -> String? {
+        SlackCredentialStore.signingSecret()
+    }
+
+    func hasSigningSecret() -> Bool {
+        SlackCredentialStore.hasSigningSecret()
+    }
+
+    @discardableResult
+    func deleteSigningSecret() -> Bool {
+        SlackCredentialStore.deleteSigningSecret()
+    }
+}
+
+enum SlackSecurity {
+    static func redact(_ text: String, token: String?, signingSecret: String? = nil) -> String {
+        var redacted = redactValue(text, value: token, replacement: "[REDACTED:SLACK_BOT_TOKEN]")
+        redacted = redactValue(redacted, value: signingSecret, replacement: "[REDACTED:SLACK_SIGNING_SECRET]")
+        return redacted
+    }
+
+    private static func redactValue(_ text: String, value: String?, replacement: String) -> String {
+        guard let value, value.count >= SecretScrubber.minimumValueLength else {
+            return text
+        }
+        return text.replacingOccurrences(of: value, with: replacement)
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
@@ -28,7 +28,7 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
         case .emptyConnectionId:
             return "Agent channel connection id is required."
         case .reservedConnectionId(let id):
-            return "`\(id)` is reserved for the native Discord connection."
+            return "`\(id)` is reserved for a native Agent Channel connection."
         case .emptyName:
             return "Agent channel connection name is required."
         case .missingSupportedActions(let id):
@@ -60,7 +60,10 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
 final class AgentChannelConnectionManager: @unchecked Sendable {
     static let shared = AgentChannelConnectionManager()
 
-    private static let reservedConnectionIds = Set([AgentChannelConnection.nativeDiscordConnectionId])
+    private static let reservedConnectionIds = Set([
+        AgentChannelConnection.nativeDiscordConnectionId,
+        AgentChannelConnection.nativeSlackConnectionId,
+    ])
     private static let supportedHTTPMethods = Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
 
     func configurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -31,24 +31,31 @@ enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
 }
 
 final class AgentChannelConnectionService: @unchecked Sendable {
-    static let shared = AgentChannelConnectionService(discordService: .shared)
+    static let shared = AgentChannelConnectionService(discordService: .shared, slackService: .shared)
 
     private static let discordConnectionId = AgentChannelConnection.nativeDiscordConnectionId
+    private static let slackConnectionId = AgentChannelConnection.nativeSlackConnectionId
     private let discordService: DiscordConnectionService
+    private let slackService: SlackConnectionService
     private let customJSONRunner: any AgentChannelCustomJSONRunning
 
     init(
         discordService: DiscordConnectionService,
+        slackService: SlackConnectionService = .shared,
         customJSONRunner: any AgentChannelCustomJSONRunning = AgentChannelCustomJSONRunner()
     ) {
         self.discordService = discordService
+        self.slackService = slackService
         self.customJSONRunner = customJSONRunner
     }
 
     func listConnections() -> [[String: Any]] {
-        var rows = [discordConnectionDictionary()]
+        var rows = [discordConnectionDictionary(), slackConnectionDictionary()]
         let customRows = AgentChannelConfigurationStore.load().connections
-            .filter { $0.id.lowercased() != Self.discordConnectionId }
+            .filter { connection in
+                let id = connection.id.lowercased()
+                return id != Self.discordConnectionId && id != Self.slackConnectionId
+            }
             .map(connectionDictionary)
         rows.append(contentsOf: customRows)
         return rows
@@ -67,6 +74,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 payload["message_store"] = discordService.messageStoreDiagnostics()
                 return payload
+            case .slack:
+                var payload = await slackService.diagnostics().dictionary
+                payload["connection_id"] = connection.id
+                payload["kind"] = connection.kind.rawValue
+                payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
+                payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
+                payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
+                payload["message_store"] = slackService.messageStoreDiagnostics()
+                return payload
             case .customHTTP:
                 var payload = await customJSONRunner.diagnostics(connection: connection)
                 payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
@@ -74,7 +90,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 return payload
-            case .slack, .telegram:
+            case .telegram:
                 return [
                     "connection_id": connection.id,
                     "kind": connection.kind.rawValue,
@@ -106,9 +122,19 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .slack:
+            return try await slackService.listWorkspaces().map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": "workspace",
+                    "connection_id": connection.id,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listSpaces(connection: connection)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -129,9 +155,22 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .slack:
+            return try await slackService.listChannels(teamId: spaceId).map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": "room",
+                    "space_id": spaceId,
+                    "connection_id": connection.id,
+                    "read_allowed": row["read_allowed"] ?? false,
+                    "write_allowed": row["write_allowed"] ?? false,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listRooms(connection: connection, spaceId: spaceId)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -145,9 +184,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "channel_messages"
             return payload
+        case .slack:
+            var payload = try await slackService.readChannel(channelId: roomId, limit: limit)
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "channel_messages"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.readMessages(connection: connection, roomId: roomId, limit: limit)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -161,9 +206,14 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["thread_id"] = threadId
             payload["standard_kind"] = "thread_messages"
             return payload
+        case .slack:
+            var payload = try await slackService.readThread(threadId: threadId, limit: limit)
+            payload["connection_id"] = connection.id
+            payload["standard_kind"] = "thread_messages"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.readThread(connection: connection, threadId: threadId, limit: limit)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -188,6 +238,17 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_ids"] = roomIds ?? []
             payload["standard_kind"] = "message_search"
             return payload
+        case .slack:
+            var payload = try await slackService.findRecentMessages(
+                query: query,
+                channelIds: roomIds,
+                limitPerChannel: limitPerRoom,
+                maxMatches: maxMatches
+            )
+            payload["connection_id"] = connection.id
+            payload["room_ids"] = roomIds ?? []
+            payload["standard_kind"] = "message_search"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.searchMessages(
                 connection: connection,
@@ -196,7 +257,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 limitPerRoom: limitPerRoom,
                 maxMatches: maxMatches
             )
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -210,9 +271,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_draft"
             return payload
+        case .slack:
+            var payload = try slackService.draftMessage(channelId: roomId, content: content)
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_draft"
+            return payload
         case .customHTTP:
             return try customJSONRunner.draftMessage(connection: connection, roomId: roomId, content: content)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -235,6 +302,16 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_sent"
             return payload
+        case .slack:
+            var payload = try await slackService.sendMessage(
+                channelId: roomId,
+                content: content,
+                confirmSend: confirmSend
+            )
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_sent"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.sendMessage(
                 connection: connection,
@@ -242,7 +319,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 content: content,
                 confirmSend: confirmSend
             )
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -264,6 +341,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["connection_id"] = connection.id
             payload["standard_kind"] = "thread_reply_sent"
             return payload
+        case .slack:
+            var payload = try await slackService.replyToThread(
+                threadId: threadId,
+                content: content,
+                confirmSend: confirmSend
+            )
+            payload["connection_id"] = connection.id
+            payload["standard_kind"] = "thread_reply_sent"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.replyThread(
                 connection: connection,
@@ -271,7 +357,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 content: content,
                 confirmSend: confirmSend
             )
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -420,6 +506,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         if resolvedId.lowercased() == Self.discordConnectionId {
             return discordConnection()
         }
+        if resolvedId.lowercased() == Self.slackConnectionId {
+            return slackConnection()
+        }
         guard let connection = AgentChannelConfigurationStore.load().connection(id: resolvedId) else {
             throw AgentChannelConnectionServiceError.connectionNotFound(resolvedId)
         }
@@ -457,6 +546,41 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         )
     }
 
+    private func slackConnection() -> AgentChannelConnection {
+        let config = slackService.configuration()
+        return AgentChannelConnection(
+            id: Self.slackConnectionId,
+            name: "Slack",
+            kind: .slack,
+            enabled: true,
+            supportedActions: [
+                .diagnostics,
+                .listSpaces,
+                .listRooms,
+                .readMessages,
+                .searchMessages,
+                .draftMessage,
+                .sendMessage,
+                .replyThread,
+            ],
+            spaceAllowlist: config.configuredTeamIds,
+            readRoomAllowlist: config.readableChannelIds,
+            writeRoomAllowlist: config.writableChannelIds,
+            writeEnabled: config.writeEnabled,
+            defaultReadLimit: config.defaultReadLimit,
+            secrets: [
+                AgentChannelSecretReference(
+                    name: "bot_token",
+                    keychainId: SlackCredentialStore.botTokenKey
+                ),
+                AgentChannelSecretReference(
+                    name: "signing_secret",
+                    keychainId: SlackCredentialStore.signingSecretKey
+                ),
+            ]
+        )
+    }
+
     private func discordConnectionDictionary() -> [String: Any] {
         var row = connectionDictionary(discordConnection())
         row["credential_saved"] = discordService.hasBotToken()
@@ -464,6 +588,18 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         let writeRooms = row["write_room_allowlist"] as? [String] ?? []
         row["configured"] =
             discordService.hasBotToken()
+            && (!readRooms.isEmpty || !writeRooms.isEmpty)
+        return row
+    }
+
+    private func slackConnectionDictionary() -> [String: Any] {
+        var row = connectionDictionary(slackConnection())
+        row["credential_saved"] = slackService.hasBotToken()
+        row["bot_token_saved"] = slackService.hasBotToken()
+        row["signing_secret_saved"] = slackService.hasSigningSecret()
+        let readRooms = row["read_room_allowlist"] as? [String] ?? []
+        let writeRooms = row["write_room_allowlist"] as? [String] ?? []
+        row["configured"] = slackService.hasBotToken()
             && (!readRooms.isEmpty || !writeRooms.isEmpty)
         return row
     }
@@ -554,9 +690,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 }
                 return (.available, nil)
             }
-        case .slack, .telegram:
+        case .telegram:
             return (.configuredOnly, "Provider adapter is configured, but execution is not implemented yet.")
-        case .discord:
+        case .discord, .slack:
             switch action {
             case .diagnostics, .listSpaces:
                 return (.available, nil)

--- a/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
@@ -1,0 +1,354 @@
+//
+//  SlackAPIClient.swift
+//  osaurus
+//
+//  Minimal Slack Web API client for the native Agent Channel adapter.
+//
+
+import Foundation
+
+struct SlackAuthIdentity: Codable, Equatable, Sendable {
+    let url: String?
+    let team: String?
+    let user: String?
+    let teamId: String
+    let userId: String?
+    let botId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case url
+        case team
+        case user
+        case teamId = "team_id"
+        case userId = "user_id"
+        case botId = "bot_id"
+    }
+}
+
+struct SlackConversation: Codable, Equatable, Sendable {
+    let id: String
+    let name: String?
+    let isChannel: Bool?
+    let isGroup: Bool?
+    let isIM: Bool?
+    let isMPIM: Bool?
+    let isPrivate: Bool?
+    let isArchived: Bool?
+    let isMember: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case isChannel = "is_channel"
+        case isGroup = "is_group"
+        case isIM = "is_im"
+        case isMPIM = "is_mpim"
+        case isPrivate = "is_private"
+        case isArchived = "is_archived"
+        case isMember = "is_member"
+    }
+
+    var displayName: String {
+        guard let name, !name.isEmpty else { return id }
+        return name
+    }
+
+    var kind: String {
+        if isIM == true { return "im" }
+        if isMPIM == true { return "mpim" }
+        if isGroup == true { return "private_channel" }
+        return "channel"
+    }
+}
+
+struct SlackMessage: Codable, Equatable, Sendable {
+    let type: String?
+    let user: String?
+    let username: String?
+    let botId: String?
+    let text: String?
+    let ts: String
+    let threadTs: String?
+    let replyCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case user
+        case username
+        case botId = "bot_id"
+        case text
+        case ts
+        case threadTs = "thread_ts"
+        case replyCount = "reply_count"
+    }
+}
+
+enum SlackAPIError: LocalizedError, Equatable, Sendable {
+    case invalidToken
+    case missingPermissions(String)
+    case notFound(String)
+    case rateLimited(String)
+    case invalidResponse(String)
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidToken:
+            return "Slack rejected the bot token."
+        case .missingPermissions(let message):
+            return message
+        case .notFound(let message):
+            return message
+        case .rateLimited(let message):
+            return message
+        case .invalidResponse(let message):
+            return message
+        case .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+protocol SlackAPIClientProtocol: Sendable {
+    func authTest(token: String) async throws -> SlackAuthIdentity
+    func conversations(token: String, limit: Int) async throws -> [SlackConversation]
+    func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage]
+    func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage]
+    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage
+}
+
+final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
+    private struct ConversationListPayload: Decodable {
+        let channels: [SlackConversation]
+    }
+
+    private struct MessageListPayload: Decodable {
+        let messages: [SlackMessage]
+    }
+
+    private struct PostMessagePayload: Decodable {
+        let message: SlackMessage?
+        let ts: String?
+        let channel: String?
+    }
+
+    private let baseURL: URL
+    private let sessionProvider: @Sendable () -> URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://slack.com/api")!,
+        sessionProvider: @escaping @Sendable () -> URLSession = { GlobalProxySettings.sharedSession() }
+    ) {
+        self.baseURL = baseURL
+        self.sessionProvider = sessionProvider
+    }
+
+    func authTest(token: String) async throws -> SlackAuthIdentity {
+        try await postForm(method: "auth.test", token: token, form: [:])
+    }
+
+    func conversations(token: String, limit: Int) async throws -> [SlackConversation] {
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit)
+        let payload: ConversationListPayload = try await postForm(
+            method: "conversations.list",
+            token: token,
+            form: [
+                "exclude_archived": "true",
+                "limit": "\(safeLimit)",
+                "types": "public_channel,private_channel,mpim,im",
+            ]
+        )
+        return payload.channels
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        try validateSlackId(channelId, label: "channel_id")
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit)
+        let payload: MessageListPayload = try await postForm(
+            method: "conversations.history",
+            token: token,
+            form: [
+                "channel": channelId,
+                "inclusive": "true",
+                "limit": "\(safeLimit)",
+            ]
+        )
+        return payload.messages
+    }
+
+    func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        try validateSlackId(channelId, label: "channel_id")
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit)
+        let payload: MessageListPayload = try await postForm(
+            method: "conversations.replies",
+            token: token,
+            form: [
+                "channel": channelId,
+                "inclusive": "true",
+                "limit": "\(safeLimit)",
+                "ts": threadTs,
+            ]
+        )
+        return payload.messages
+    }
+
+    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
+        try validateSlackId(channelId, label: "channel_id")
+        var body: [String: Any] = [
+            "channel": channelId,
+            "text": content,
+            "parse": "none",
+            "link_names": false,
+            "unfurl_links": false,
+            "unfurl_media": false,
+            "reply_broadcast": false,
+        ]
+        if let threadTs, !threadTs.isEmpty {
+            body["thread_ts"] = threadTs
+        }
+        let payload: PostMessagePayload = try await postJSON(method: "chat.postMessage", token: token, body: body)
+        if let message = payload.message {
+            return message
+        }
+        if let ts = payload.ts {
+            return SlackMessage(
+                type: "message",
+                user: nil,
+                username: nil,
+                botId: nil,
+                text: content,
+                ts: ts,
+                threadTs: threadTs,
+                replyCount: nil
+            )
+        }
+        throw SlackAPIError.invalidResponse("Slack postMessage response did not include a message timestamp.")
+    }
+
+    private func postForm<Payload: Decodable>(
+        method: String,
+        token: String,
+        form: [String: String]
+    ) async throws -> Payload {
+        var request = makeRequest(method: method, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = form
+            .map { key, value in
+                "\(Self.urlEncode(key))=\(Self.urlEncode(value))"
+            }
+            .joined(separator: "&")
+            .data(using: .utf8)
+        return try await perform(request, token: token)
+    }
+
+    private func postJSON<Payload: Decodable>(
+        method: String,
+        token: String,
+        body: [String: Any]
+    ) async throws -> Payload {
+        var request = makeRequest(method: method, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .osaurusCanonical)
+        return try await perform(request, token: token)
+    }
+
+    private func makeRequest(method: String, token: String) -> URLRequest {
+        let url = baseURL.appendingPathComponent(method)
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Osaurus Slack Native Agent Channel", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 30
+        return request
+    }
+
+    private func perform<Payload: Decodable>(_ request: URLRequest, token: String) async throws -> Payload {
+        do {
+            let (data, response) = try await sessionProvider().data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw SlackAPIError.invalidResponse("Slack returned a non-HTTP response.")
+            }
+            guard http.statusCode != 429 else {
+                throw SlackAPIError.rateLimited("Slack rate limited this request.")
+            }
+            guard (200 ..< 300).contains(http.statusCode) else {
+                throw mapHTTPError(status: http.statusCode, data: data, token: token)
+            }
+            do {
+                let status = try JSONDecoder().decode(SlackStatusEnvelope.self, from: data)
+                guard status.ok else {
+                    throw mapSlackError(status.error, token: token)
+                }
+                return try JSONDecoder().decode(Payload.self, from: data)
+            } catch let error as SlackAPIError {
+                throw error
+            } catch {
+                throw SlackAPIError.invalidResponse("Slack response could not be decoded.")
+            }
+        } catch let error as SlackAPIError {
+            throw error
+        } catch {
+            throw SlackAPIError.requestFailed(
+                SlackSecurity.redact(error.localizedDescription, token: token)
+            )
+        }
+    }
+
+    private func mapHTTPError(status: Int, data: Data, token: String) -> SlackAPIError {
+        let message = slackErrorMessage(from: data)
+            .map { SlackSecurity.redact($0, token: token) }
+        switch status {
+        case 401:
+            return .invalidToken
+        case 403:
+            return .missingPermissions(message ?? "Slack denied access for this bot or channel.")
+        case 404:
+            return .notFound(message ?? "Slack resource was not found.")
+        default:
+            return .requestFailed(message ?? "Slack request failed with HTTP \(status).")
+        }
+    }
+
+    private func mapSlackError(_ error: String?, token: String) -> SlackAPIError {
+        let code = error ?? "unknown_error"
+        let message = SlackSecurity.redact("Slack API returned `\(code)`.", token: token)
+        switch code {
+        case "invalid_auth", "not_authed", "account_inactive", "token_revoked":
+            return .invalidToken
+        case "missing_scope", "no_permission", "not_in_channel", "is_archived", "restricted_action":
+            return .missingPermissions(message)
+        case "channel_not_found", "user_not_found", "team_not_found", "thread_not_found":
+            return .notFound(message)
+        case "ratelimited":
+            return .rateLimited(message)
+        default:
+            return .requestFailed(message)
+        }
+    }
+
+    private func slackErrorMessage(from data: Data) -> String? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = object["error"] as? String,
+            !error.isEmpty
+        else { return nil }
+        return "Slack API returned `\(error)`."
+    }
+
+    private func validateSlackId(_ id: String, label: String) throws {
+        guard SlackConnectionConfiguration.isValidSlackId(id) else {
+            throw SlackAPIError.invalidResponse("Invalid Slack \(label).")
+        }
+    }
+
+    private static func urlEncode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+    }
+}
+
+private struct SlackStatusEnvelope: Decodable {
+    let ok: Bool
+    let error: String?
+}

--- a/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
@@ -28,13 +28,13 @@ struct SlackAuthIdentity: Codable, Equatable, Sendable {
 struct SlackConversation: Codable, Equatable, Sendable {
     let id: String
     let name: String?
-    let isChannel: Bool?
-    let isGroup: Bool?
-    let isIM: Bool?
-    let isMPIM: Bool?
-    let isPrivate: Bool?
-    let isArchived: Bool?
-    let isMember: Bool?
+    let isChannel: Bool
+    let isGroup: Bool
+    let isIM: Bool
+    let isMPIM: Bool
+    let isPrivate: Bool
+    let isArchived: Bool
+    let isMember: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -48,15 +48,52 @@ struct SlackConversation: Codable, Equatable, Sendable {
         case isMember = "is_member"
     }
 
+    init(
+        id: String,
+        name: String? = nil,
+        isChannel: Bool = false,
+        isGroup: Bool = false,
+        isIM: Bool = false,
+        isMPIM: Bool = false,
+        isPrivate: Bool = false,
+        isArchived: Bool = false,
+        isMember: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.isChannel = isChannel
+        self.isGroup = isGroup
+        self.isIM = isIM
+        self.isMPIM = isMPIM
+        self.isPrivate = isPrivate
+        self.isArchived = isArchived
+        self.isMember = isMember
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decode(String.self, forKey: .id),
+            name: try container.decodeIfPresent(String.self, forKey: .name),
+            isChannel: try container.decodeIfPresent(Bool.self, forKey: .isChannel) ?? false,
+            isGroup: try container.decodeIfPresent(Bool.self, forKey: .isGroup) ?? false,
+            isIM: try container.decodeIfPresent(Bool.self, forKey: .isIM) ?? false,
+            isMPIM: try container.decodeIfPresent(Bool.self, forKey: .isMPIM) ?? false,
+            isPrivate: try container.decodeIfPresent(Bool.self, forKey: .isPrivate) ?? false,
+            isArchived: try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false,
+            isMember: try container.decodeIfPresent(Bool.self, forKey: .isMember) ?? false
+        )
+    }
+
     var displayName: String {
         guard let name, !name.isEmpty else { return id }
         return name
     }
 
     var kind: String {
-        if isIM == true { return "im" }
-        if isMPIM == true { return "mpim" }
-        if isGroup == true { return "private_channel" }
+        if isIM { return "im" }
+        if isMPIM { return "mpim" }
+        if isGroup { return "private_channel" }
         return "channel"
     }
 }
@@ -80,6 +117,53 @@ struct SlackMessage: Codable, Equatable, Sendable {
         case ts
         case threadTs = "thread_ts"
         case replyCount = "reply_count"
+    }
+}
+
+struct SlackOutboundMessageRequest: Equatable, Sendable {
+    let channelId: String
+    let content: String
+    let threadTs: String?
+    let parse: String
+    let linkNames: Bool
+    let unfurlLinks: Bool
+    let unfurlMedia: Bool
+    let replyBroadcast: Bool
+
+    init(
+        channelId: String,
+        content: String,
+        threadTs: String? = nil,
+        parse: String = "none",
+        linkNames: Bool = false,
+        unfurlLinks: Bool = false,
+        unfurlMedia: Bool = false,
+        replyBroadcast: Bool = false
+    ) {
+        self.channelId = channelId
+        self.content = content
+        self.threadTs = threadTs
+        self.parse = parse
+        self.linkNames = linkNames
+        self.unfurlLinks = unfurlLinks
+        self.unfurlMedia = unfurlMedia
+        self.replyBroadcast = replyBroadcast
+    }
+
+    var jsonBody: [String: Any] {
+        var body: [String: Any] = [
+            "channel": channelId,
+            "text": content,
+            "parse": parse,
+            "link_names": linkNames,
+            "unfurl_links": unfurlLinks,
+            "unfurl_media": unfurlMedia,
+            "reply_broadcast": replyBroadcast,
+        ]
+        if let threadTs, !threadTs.isEmpty {
+            body["thread_ts"] = threadTs
+        }
+        return body
     }
 }
 
@@ -114,7 +198,7 @@ protocol SlackAPIClientProtocol: Sendable {
     func conversations(token: String, limit: Int) async throws -> [SlackConversation]
     func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage]
     func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage]
-    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage
+    func sendMessage(_ request: SlackOutboundMessageRequest, token: String) async throws -> SlackMessage
 }
 
 final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
@@ -192,21 +276,13 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
         return payload.messages
     }
 
-    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
-        try validateSlackId(channelId, label: "channel_id")
-        var body: [String: Any] = [
-            "channel": channelId,
-            "text": content,
-            "parse": "none",
-            "link_names": false,
-            "unfurl_links": false,
-            "unfurl_media": false,
-            "reply_broadcast": false,
-        ]
-        if let threadTs, !threadTs.isEmpty {
-            body["thread_ts"] = threadTs
-        }
-        let payload: PostMessagePayload = try await postJSON(method: "chat.postMessage", token: token, body: body)
+    func sendMessage(_ request: SlackOutboundMessageRequest, token: String) async throws -> SlackMessage {
+        try validateSlackId(request.channelId, label: "channel_id")
+        let payload: PostMessagePayload = try await postJSON(
+            method: "chat.postMessage",
+            token: token,
+            body: request.jsonBody
+        )
         if let message = payload.message {
             return message
         }
@@ -216,9 +292,9 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
                 user: nil,
                 username: nil,
                 botId: nil,
-                text: content,
+                text: request.content,
                 ts: ts,
-                threadTs: threadTs,
+                threadTs: request.threadTs,
                 replyCount: nil
             )
         }
@@ -271,7 +347,9 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
                 throw SlackAPIError.invalidResponse("Slack returned a non-HTTP response.")
             }
             guard http.statusCode != 429 else {
-                throw SlackAPIError.rateLimited("Slack rate limited this request.")
+                let retryAfter = http.value(forHTTPHeaderField: "Retry-After")
+                let suffix = retryAfter.map { " Retry after \($0) seconds." } ?? ""
+                throw SlackAPIError.rateLimited("Slack rate limited this request.\(suffix)")
             }
             guard (200 ..< 300).contains(http.statusCode) else {
                 throw mapHTTPError(status: http.statusCode, data: data, token: token)
@@ -344,7 +422,9 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
     }
 
     private static func urlEncode(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 }
 

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -1,0 +1,574 @@
+//
+//  SlackConnectionService.swift
+//  osaurus
+//
+//  Policy and diagnostics layer for the native Slack Agent Channel adapter.
+//
+
+import Foundation
+
+struct SlackConfiguredTeamDiagnostic: Equatable, Sendable {
+    let id: String
+    let name: String
+    let status: String
+    let reason: String?
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "id": id,
+            "name": name,
+            "status": status,
+        ]
+        if let reason {
+            result["reason"] = reason
+        }
+        return result
+    }
+}
+
+struct SlackConnectionDiagnostics: Equatable, Sendable {
+    let botTokenSaved: Bool
+    let signingSecretSaved: Bool
+    let identity: SlackAuthIdentity?
+    let configuredTeams: [SlackConfiguredTeamDiagnostic]
+    let readableChannelIds: [String]
+    let writableChannelIds: [String]
+    let writeEnabled: Bool
+    let allowBroadcastMentions: Bool
+    let status: String
+    let failures: [String]
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "bot_token_saved": botTokenSaved,
+            "signing_secret_saved": signingSecretSaved,
+            "configured_teams": configuredTeams.map(\.dictionary),
+            "readable_channel_ids": readableChannelIds,
+            "writable_channel_ids": writableChannelIds,
+            "write_enabled": writeEnabled,
+            "allow_broadcast_mentions": allowBroadcastMentions,
+            "status": status,
+            "failures": failures,
+        ]
+        if let identity {
+            result["bot"] = [
+                "bot_id": identity.botId ?? "",
+                "team": identity.team ?? "",
+                "team_id": identity.teamId,
+                "user": identity.user ?? "",
+                "user_id": identity.userId ?? "",
+            ]
+        }
+        return result
+    }
+}
+
+enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
+    case notConfigured
+    case invalidId(field: String)
+    case teamNotConfigured(String)
+    case channelNotReadable(String)
+    case channelNotWritable(String)
+    case writeDisabled
+    case sendConfirmationRequired
+    case messageTooLong
+    case emptyMessage
+    case broadcastMentionDenied
+    case invalidThreadId(String)
+    case configurationSaveFailed(String)
+    case api(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Slack is not configured. Add a bot token and allowlist at least one channel."
+        case .invalidId(let field):
+            return "`\(field)` must be a Slack ID."
+        case .teamNotConfigured(let teamId):
+            return "Slack workspace `\(teamId)` is not allowlisted in settings."
+        case .channelNotReadable(let channelId):
+            return "Slack channel `\(channelId)` is not allowlisted for read access."
+        case .channelNotWritable(let channelId):
+            return "Slack channel `\(channelId)` is not allowlisted for write access."
+        case .writeDisabled:
+            return "Slack write access is disabled in settings."
+        case .sendConfirmationRequired:
+            return "`confirm_send` must be true before Osaurus posts to Slack."
+        case .messageTooLong:
+            return "Slack messages must be 40000 characters or fewer."
+        case .emptyMessage:
+            return "Slack message content must not be empty."
+        case .broadcastMentionDenied:
+            return "Slack broadcast mentions are disabled for this connection."
+        case .invalidThreadId(let threadId):
+            return "Slack thread id `\(threadId)` must use `channel_id:thread_ts`."
+        case .configurationSaveFailed(let message):
+            return "Slack configuration could not be saved: \(message)"
+        case .api(let message):
+            return message
+        }
+    }
+}
+
+final class SlackConnectionService: @unchecked Sendable {
+    static let shared = SlackConnectionService(
+        client: SlackAPIClient(),
+        credentialStore: KeychainSlackCredentialStorage()
+    )
+
+    private let client: SlackAPIClientProtocol
+    private let credentialStore: any SlackCredentialStorage
+
+    init(
+        client: SlackAPIClientProtocol,
+        credentialStore: any SlackCredentialStorage = KeychainSlackCredentialStorage()
+    ) {
+        self.client = client
+        self.credentialStore = credentialStore
+    }
+
+    func configuration() -> SlackConnectionConfiguration {
+        SlackConnectionConfigurationStore.load()
+    }
+
+    func saveConfiguration(_ configuration: SlackConnectionConfiguration) throws {
+        do {
+            try SlackConnectionConfigurationStore.save(configuration)
+        } catch {
+            throw SlackConnectionServiceError.configurationSaveFailed(error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    func saveBotToken(_ token: String) throws -> Bool {
+        let saved = credentialStore.saveBotToken(token)
+        if !saved {
+            throw SlackConnectionServiceError.configurationSaveFailed(
+                "The bot token was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        credentialStore.deleteBotToken()
+    }
+
+    func hasBotToken() -> Bool {
+        credentialStore.hasBotToken()
+    }
+
+    @discardableResult
+    func saveSigningSecret(_ secret: String) throws -> Bool {
+        let saved = credentialStore.saveSigningSecret(secret)
+        if !saved {
+            throw SlackConnectionServiceError.configurationSaveFailed(
+                "The signing secret was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteSigningSecret() -> Bool {
+        credentialStore.deleteSigningSecret()
+    }
+
+    func hasSigningSecret() -> Bool {
+        credentialStore.hasSigningSecret()
+    }
+
+    func diagnostics() async -> SlackConnectionDiagnostics {
+        let config = configuration()
+        guard let token = credentialStore.botToken() else {
+            return SlackConnectionDiagnostics(
+                botTokenSaved: false,
+                signingSecretSaved: credentialStore.hasSigningSecret(),
+                identity: nil,
+                configuredTeams: [],
+                readableChannelIds: config.readableChannelIds,
+                writableChannelIds: config.writableChannelIds,
+                writeEnabled: config.writeEnabled,
+                allowBroadcastMentions: config.allowBroadcastMentions,
+                status: "not_configured",
+                failures: ["No Slack bot token is saved."]
+            )
+        }
+        let signingSecret = credentialStore.signingSecret()
+
+        let identity: SlackAuthIdentity?
+        var failures: [String] = []
+        do {
+            identity = try await client.authTest(token: token)
+        } catch {
+            identity = nil
+            failures.append(redacted(error, token: token, signingSecret: signingSecret))
+        }
+
+        var teamRows: [SlackConfiguredTeamDiagnostic] = []
+        if let identity {
+            let allowed = config.canUseTeam(teamId: identity.teamId)
+            teamRows.append(SlackConfiguredTeamDiagnostic(
+                id: identity.teamId,
+                name: identity.team ?? "",
+                status: allowed ? "accessible" : "not_allowlisted",
+                reason: allowed ? nil : "Workspace is not in configuredTeamIds."
+            ))
+        }
+        for teamId in config.configuredTeamIds where teamRows.allSatisfy({ $0.id != teamId }) {
+            teamRows.append(SlackConfiguredTeamDiagnostic(
+                id: teamId,
+                name: "",
+                status: "configured_not_current_token_team",
+                reason: "The saved bot token did not authenticate as this workspace."
+            ))
+        }
+
+        let status: String
+        if identity == nil {
+            status = "token_invalid_or_unavailable"
+        } else if let identity, !config.canUseTeam(teamId: identity.teamId) {
+            status = "connected_team_not_allowlisted"
+        } else if config.readableChannelIds.isEmpty && config.writableChannelIds.isEmpty {
+            status = "connected_needs_allowlist"
+        } else if config.writeEnabled && config.writableChannelIds.isEmpty {
+            status = "connected_read_only_write_needs_channels"
+        } else if config.writeEnabled {
+            status = "connected_read_write"
+        } else {
+            status = "connected_read_only"
+        }
+
+        return SlackConnectionDiagnostics(
+            botTokenSaved: true,
+            signingSecretSaved: signingSecret != nil,
+            identity: identity,
+            configuredTeams: teamRows,
+            readableChannelIds: config.readableChannelIds,
+            writableChannelIds: config.writableChannelIds,
+            writeEnabled: config.writeEnabled,
+            allowBroadcastMentions: config.allowBroadcastMentions,
+            status: status,
+            failures: failures
+        )
+    }
+
+    func listWorkspaces() async throws -> [[String: Any]] {
+        let token = try requireToken()
+        let config = configuration()
+        let identity = try await client.authTest(token: token)
+        guard config.canUseTeam(teamId: identity.teamId) else {
+            throw SlackConnectionServiceError.teamNotConfigured(identity.teamId)
+        }
+        return [[
+            "id": identity.teamId,
+            "name": identity.team ?? identity.teamId,
+            "configured": config.configuredTeamIds.isEmpty || config.configuredTeamIds.contains(identity.teamId),
+        ]]
+    }
+
+    func listChannels(teamId: String) async throws -> [[String: Any]] {
+        let token = try requireToken()
+        let config = configuration()
+        let normalizedTeamId = try requireSlackId(teamId, field: "team_id")
+        guard config.canUseTeam(teamId: normalizedTeamId) else {
+            throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
+        }
+        let identity = try await client.authTest(token: token)
+        guard identity.teamId == normalizedTeamId else {
+            throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
+        }
+
+        let channels = try await client.conversations(token: token, limit: 100)
+        return channels.map { channel in
+            [
+                "id": channel.id,
+                "name": channel.displayName,
+                "type": channel.kind,
+                "team_id": normalizedTeamId,
+                "is_private": channel.isPrivate ?? false,
+                "is_member": channel.isMember ?? false,
+                "read_allowed": config.canRead(channelId: channel.id),
+                "write_allowed": config.canWrite(channelId: channel.id),
+            ]
+        }
+    }
+
+    func readChannel(channelId: String, limit: Int?) async throws -> [String: Any] {
+        let token = try requireToken()
+        let config = configuration()
+        let normalizedChannelId = try requireReadableChannel(channelId, config: config)
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit ?? config.defaultReadLimit)
+        let messages = try await client.messages(
+            channelId: normalizedChannelId,
+            token: token,
+            limit: safeLimit
+        )
+        return [
+            "kind": "slack_recent_messages",
+            "channel_id": normalizedChannelId,
+            "limit": safeLimit,
+            "partial": true,
+            "messages": messages.map { Self.messageDictionary($0, channelId: normalizedChannelId) },
+        ]
+    }
+
+    func readThread(threadId: String, limit: Int?) async throws -> [String: Any] {
+        let token = try requireToken()
+        let config = configuration()
+        let parsed = try parseThreadId(threadId)
+        let normalizedChannelId = try requireReadableChannel(parsed.channelId, config: config)
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit ?? config.defaultReadLimit)
+        let messages = try await client.threadMessages(
+            channelId: normalizedChannelId,
+            threadTs: parsed.threadTs,
+            token: token,
+            limit: safeLimit
+        )
+        return [
+            "kind": "slack_thread_messages",
+            "channel_id": normalizedChannelId,
+            "thread_id": "\(normalizedChannelId):\(parsed.threadTs)",
+            "thread_ts": parsed.threadTs,
+            "limit": safeLimit,
+            "partial": true,
+            "messages": messages.map { Self.messageDictionary($0, channelId: normalizedChannelId) },
+        ]
+    }
+
+    func findRecentMessages(
+        query: String,
+        channelIds: [String]?,
+        limitPerChannel: Int?,
+        maxMatches: Int?
+    ) async throws -> [String: Any] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else {
+            throw SlackConnectionServiceError.emptyMessage
+        }
+
+        let config = configuration()
+        let candidateChannels = SlackConnectionConfiguration.normalizedIds(
+            channelIds ?? config.readableChannelIds
+        )
+        let allowedChannels = candidateChannels.filter { config.canRead(channelId: $0) }
+        guard !allowedChannels.isEmpty else {
+            throw SlackConnectionServiceError.channelNotReadable(candidateChannels.first ?? "")
+        }
+
+        let token = try requireToken()
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limitPerChannel ?? config.defaultReadLimit)
+        let safeMaxMatches = min(max(maxMatches ?? 25, 1), 50)
+        let needle = trimmedQuery.lowercased()
+        var matches: [[String: Any]] = []
+
+        for channelId in allowedChannels {
+            let messages = try await client.messages(channelId: channelId, token: token, limit: safeLimit)
+            for message in messages {
+                let haystack = "\(message.text ?? "") \(message.user ?? "") \(message.username ?? "")"
+                    .lowercased()
+                guard haystack.contains(needle) else { continue }
+                matches.append(Self.messageDictionary(message, channelId: channelId))
+                if matches.count >= safeMaxMatches { break }
+            }
+            if matches.count >= safeMaxMatches { break }
+        }
+
+        return [
+            "kind": "slack_recent_message_search",
+            "query": trimmedQuery,
+            "searched_channel_ids": allowedChannels,
+            "limit_per_channel": safeLimit,
+            "max_matches": safeMaxMatches,
+            "match_count": matches.count,
+            "partial": true,
+            "messages": matches,
+        ]
+    }
+
+    func draftMessage(channelId: String, content: String) throws -> [String: Any] {
+        let config = configuration()
+        let normalizedChannelId = try requireWritableChannel(channelId, config: config)
+        let trimmedContent = try validateMessageContent(content, config: config)
+        return [
+            "kind": "slack_message_draft",
+            "channel_id": normalizedChannelId,
+            "content": trimmedContent,
+            "requires_send_confirmation": true,
+            "mention_policy": mentionPolicyDictionary(config: config),
+        ]
+    }
+
+    func sendMessage(
+        channelId: String,
+        content: String,
+        confirmSend: Bool
+    ) async throws -> [String: Any] {
+        guard confirmSend else {
+            throw SlackConnectionServiceError.sendConfirmationRequired
+        }
+        let token = try requireToken()
+        let config = configuration()
+        let normalizedChannelId = try requireWritableChannel(channelId, config: config)
+        let trimmedContent = try validateMessageContent(content, config: config)
+        let message = try await client.sendMessage(
+            channelId: normalizedChannelId,
+            content: trimmedContent,
+            threadTs: nil,
+            token: token
+        )
+        return [
+            "kind": "slack_message_sent",
+            "channel_id": normalizedChannelId,
+            "message": Self.messageDictionary(message, channelId: normalizedChannelId),
+            "mention_policy": mentionPolicyDictionary(config: config),
+        ]
+    }
+
+    func replyToThread(
+        threadId: String,
+        content: String,
+        confirmSend: Bool
+    ) async throws -> [String: Any] {
+        guard confirmSend else {
+            throw SlackConnectionServiceError.sendConfirmationRequired
+        }
+        let token = try requireToken()
+        let config = configuration()
+        let parsed = try parseThreadId(threadId)
+        let normalizedChannelId = try requireWritableChannel(parsed.channelId, config: config)
+        let trimmedContent = try validateMessageContent(content, config: config)
+        let message = try await client.sendMessage(
+            channelId: normalizedChannelId,
+            content: trimmedContent,
+            threadTs: parsed.threadTs,
+            token: token
+        )
+        return [
+            "kind": "slack_thread_reply_sent",
+            "channel_id": normalizedChannelId,
+            "thread_id": "\(normalizedChannelId):\(parsed.threadTs)",
+            "thread_ts": parsed.threadTs,
+            "message": Self.messageDictionary(message, channelId: normalizedChannelId),
+            "mention_policy": mentionPolicyDictionary(config: config),
+        ]
+    }
+
+    private func requireToken() throws -> String {
+        guard let token = credentialStore.botToken() else {
+            throw SlackConnectionServiceError.notConfigured
+        }
+        return token
+    }
+
+    private func requireSlackId(_ id: String, field: String) throws -> String {
+        let normalized = SlackConnectionConfiguration.normalizedId(id)
+        guard SlackConnectionConfiguration.isValidSlackId(normalized) else {
+            throw SlackConnectionServiceError.invalidId(field: field)
+        }
+        return normalized
+    }
+
+    private func requireReadableChannel(
+        _ channelId: String,
+        config: SlackConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireSlackId(channelId, field: "channel_id")
+        guard config.canRead(channelId: normalized) else {
+            throw SlackConnectionServiceError.channelNotReadable(normalized)
+        }
+        return normalized
+    }
+
+    private func requireWritableChannel(
+        _ channelId: String,
+        config: SlackConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireSlackId(channelId, field: "channel_id")
+        guard config.writeEnabled else {
+            throw SlackConnectionServiceError.writeDisabled
+        }
+        guard config.canWrite(channelId: normalized) else {
+            throw SlackConnectionServiceError.channelNotWritable(normalized)
+        }
+        return normalized
+    }
+
+    private func validateMessageContent(
+        _ content: String,
+        config: SlackConnectionConfiguration
+    ) throws -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw SlackConnectionServiceError.emptyMessage
+        }
+        guard trimmed.count <= 40_000 else {
+            throw SlackConnectionServiceError.messageTooLong
+        }
+        if !config.allowBroadcastMentions && Self.containsBroadcastMention(trimmed) {
+            throw SlackConnectionServiceError.broadcastMentionDenied
+        }
+        return trimmed
+    }
+
+    private func parseThreadId(_ threadId: String) throws -> (channelId: String, threadTs: String) {
+        let normalized = SlackConnectionConfiguration.normalizedId(threadId)
+        let parts = normalized.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2,
+              SlackConnectionConfiguration.isValidSlackId(String(parts[0])),
+              Self.isValidThreadTimestamp(String(parts[1]))
+        else {
+            throw SlackConnectionServiceError.invalidThreadId(normalized)
+        }
+        return (String(parts[0]), String(parts[1]))
+    }
+
+    private func redacted(_ error: Error, token: String, signingSecret: String?) -> String {
+        SlackSecurity.redact(error.localizedDescription, token: token, signingSecret: signingSecret)
+    }
+
+    private func mentionPolicyDictionary(config: SlackConnectionConfiguration) -> [String: Any] {
+        [
+            "parse": "none",
+            "link_names": false,
+            "reply_broadcast": false,
+            "allow_broadcast_mentions": config.allowBroadcastMentions,
+        ]
+    }
+
+    private static func containsBroadcastMention(_ content: String) -> Bool {
+        let lowered = content.lowercased()
+        return lowered.contains("<!channel")
+            || lowered.contains("<!here")
+            || lowered.contains("<!everyone")
+    }
+
+    private static func isValidThreadTimestamp(_ value: String) -> Bool {
+        let parts = value.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2 else { return false }
+        return parts.allSatisfy { part in
+            !part.isEmpty && part.allSatisfy { $0.isASCII && $0.isNumber }
+        }
+    }
+
+    private static func messageDictionary(_ message: SlackMessage, channelId: String) -> [String: Any] {
+        let threadTs = message.threadTs ?? message.ts
+        return [
+            "id": message.ts,
+            "channel_id": channelId,
+            "content": message.text ?? "",
+            "timestamp": message.ts,
+            "thread_id": "\(channelId):\(threadTs)",
+            "thread_ts": threadTs,
+            "author": [
+                "id": message.user ?? message.botId ?? "",
+                "username": message.username ?? "",
+                "display_name": message.username ?? message.user ?? message.botId ?? "",
+                "is_bot": message.botId != nil,
+            ],
+            "reply_count": message.replyCount ?? 0,
+            "attachments": [] as [[String: Any]],
+        ]
+    }
+}

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -63,6 +63,81 @@ struct SlackConnectionDiagnostics: Equatable, Sendable {
     }
 }
 
+struct SlackEventEnvelope: Codable, Equatable, Sendable {
+    let token: String?
+    let teamId: String?
+    let apiAppId: String?
+    let event: SlackEventMessage?
+    let type: String?
+    let eventId: String?
+    let eventTime: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case teamId = "team_id"
+        case apiAppId = "api_app_id"
+        case event
+        case type
+        case eventId = "event_id"
+        case eventTime = "event_time"
+    }
+}
+
+struct SlackEventMessage: Codable, Equatable, Sendable {
+    let type: String?
+    let subtype: String?
+    let channel: String?
+    let user: String?
+    let botId: String?
+    let text: String?
+    let ts: String?
+    let threadTs: String?
+    let channelType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case subtype
+        case channel
+        case user
+        case botId = "bot_id"
+        case text
+        case ts
+        case threadTs = "thread_ts"
+        case channelType = "channel_type"
+    }
+}
+
+struct SlackNormalizedInboundMessage: Equatable, Sendable {
+    let connectionId: String
+    let providerEventId: String
+    let teamId: String?
+    let roomId: String
+    let providerMessageId: String
+    let threadId: String
+    let threadTs: String
+    let authorId: String?
+    let content: String
+    let isThreadReply: Bool
+    let isMention: Bool
+    let mentionedUserIds: [String]
+    let payloadJSON: String
+
+    var storedMessage: AgentChannelStoredMessage {
+        AgentChannelStoredMessage(
+            connectionId: connectionId,
+            roomId: roomId,
+            providerMessageId: providerMessageId,
+            direction: .inbound,
+            threadId: threadId,
+            authorId: authorId,
+            authorName: nil,
+            content: content,
+            payloadJSON: payloadJSON,
+            providerTimestamp: providerMessageId
+        )
+    }
+}
+
 enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
     case notConfigured
     case invalidId(field: String)
@@ -76,6 +151,9 @@ enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
     case broadcastMentionDenied
     case invalidThreadId(String)
     case configurationSaveFailed(String)
+    case signingSecretNotConfigured
+    case signatureVerificationFailed
+    case invalidInboundPayload
     case api(String)
 
     var errorDescription: String? {
@@ -104,6 +182,12 @@ enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
             return "Slack thread id `\(threadId)` must use `channel_id:thread_ts`."
         case .configurationSaveFailed(let message):
             return "Slack configuration could not be saved: \(message)"
+        case .signingSecretNotConfigured:
+            return "Slack signing secret is not configured."
+        case .signatureVerificationFailed:
+            return "Slack request signature could not be verified."
+        case .invalidInboundPayload:
+            return "Slack inbound event payload could not be decoded."
         case .api(let message):
             return message
         }
@@ -113,18 +197,25 @@ enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
 final class SlackConnectionService: @unchecked Sendable {
     static let shared = SlackConnectionService(
         client: SlackAPIClient(),
-        credentialStore: KeychainSlackCredentialStorage()
+        credentialStore: KeychainSlackCredentialStorage(),
+        messageStore: AgentChannelMessageStore.shared
     )
 
     private let client: SlackAPIClientProtocol
     private let credentialStore: any SlackCredentialStorage
+    private let messageStore: AgentChannelMessageStore?
+    private let recordMessageSnapshotsInline: Bool
 
     init(
         client: SlackAPIClientProtocol,
-        credentialStore: any SlackCredentialStorage = KeychainSlackCredentialStorage()
+        credentialStore: any SlackCredentialStorage = KeychainSlackCredentialStorage(),
+        messageStore: AgentChannelMessageStore? = nil,
+        recordMessageSnapshotsInline: Bool = false
     ) {
         self.client = client
         self.credentialStore = credentialStore
+        self.messageStore = messageStore
+        self.recordMessageSnapshotsInline = recordMessageSnapshotsInline
     }
 
     func configuration() -> SlackConnectionConfiguration {
@@ -136,6 +227,20 @@ final class SlackConnectionService: @unchecked Sendable {
             try SlackConnectionConfigurationStore.save(configuration)
         } catch {
             throw SlackConnectionServiceError.configurationSaveFailed(error.localizedDescription)
+        }
+    }
+
+    private func persistIdentity(_ identity: SlackAuthIdentity) {
+        var config = configuration()
+        guard config.botUserId != identity.userId || config.botId != identity.botId else {
+            return
+        }
+        config.botUserId = identity.userId
+        config.botId = identity.botId
+        do {
+            try SlackConnectionConfigurationStore.save(config)
+        } catch {
+            NSLog("[Slack] Failed to persist bot identity: \(error.localizedDescription)")
         }
     }
 
@@ -179,6 +284,16 @@ final class SlackConnectionService: @unchecked Sendable {
         credentialStore.hasSigningSecret()
     }
 
+    func messageStoreDiagnostics() -> [String: Any] {
+        [
+            "enabled": messageStore != nil,
+            "open": messageStore?.isOpen ?? false,
+            "database_path": OsaurusPaths.agentChannelMessagesDatabaseFile().path,
+            "message_dedupe": "connection_id + room_id + provider_message_id",
+            "event_dedupe": "connection_id + provider_event_id",
+        ]
+    }
+
     func diagnostics() async -> SlackConnectionDiagnostics {
         let config = configuration()
         guard let token = credentialStore.botToken() else {
@@ -201,6 +316,9 @@ final class SlackConnectionService: @unchecked Sendable {
         var failures: [String] = []
         do {
             identity = try await client.authTest(token: token)
+            if let identity {
+                persistIdentity(identity)
+            }
         } catch {
             identity = nil
             failures.append(redacted(error, token: token, signingSecret: signingSecret))
@@ -258,6 +376,7 @@ final class SlackConnectionService: @unchecked Sendable {
         let token = try requireToken()
         let config = configuration()
         let identity = try await client.authTest(token: token)
+        persistIdentity(identity)
         guard config.canUseTeam(teamId: identity.teamId) else {
             throw SlackConnectionServiceError.teamNotConfigured(identity.teamId)
         }
@@ -276,6 +395,7 @@ final class SlackConnectionService: @unchecked Sendable {
             throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
         }
         let identity = try await client.authTest(token: token)
+        persistIdentity(identity)
         guard identity.teamId == normalizedTeamId else {
             throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
         }
@@ -287,8 +407,8 @@ final class SlackConnectionService: @unchecked Sendable {
                 "name": channel.displayName,
                 "type": channel.kind,
                 "team_id": normalizedTeamId,
-                "is_private": channel.isPrivate ?? false,
-                "is_member": channel.isMember ?? false,
+                "is_private": channel.isPrivate,
+                "is_member": channel.isMember,
                 "read_allowed": config.canRead(channelId: channel.id),
                 "write_allowed": config.canWrite(channelId: channel.id),
             ]
@@ -305,6 +425,7 @@ final class SlackConnectionService: @unchecked Sendable {
             token: token,
             limit: safeLimit
         )
+        recordMessages(messages, channelId: normalizedChannelId, direction: .inbound)
         return [
             "kind": "slack_recent_messages",
             "channel_id": normalizedChannelId,
@@ -326,6 +447,7 @@ final class SlackConnectionService: @unchecked Sendable {
             token: token,
             limit: safeLimit
         )
+        recordMessages(messages, channelId: normalizedChannelId, direction: .inbound)
         return [
             "kind": "slack_thread_messages",
             "channel_id": normalizedChannelId,
@@ -365,6 +487,7 @@ final class SlackConnectionService: @unchecked Sendable {
 
         for channelId in allowedChannels {
             let messages = try await client.messages(channelId: channelId, token: token, limit: safeLimit)
+            recordMessages(messages, channelId: channelId, direction: .inbound)
             for message in messages {
                 let haystack = "\(message.text ?? "") \(message.user ?? "") \(message.username ?? "")"
                     .lowercased()
@@ -412,12 +535,13 @@ final class SlackConnectionService: @unchecked Sendable {
         let config = configuration()
         let normalizedChannelId = try requireWritableChannel(channelId, config: config)
         let trimmedContent = try validateMessageContent(content, config: config)
-        let message = try await client.sendMessage(
+        let request = SlackOutboundMessageRequest(
             channelId: normalizedChannelId,
             content: trimmedContent,
-            threadTs: nil,
-            token: token
+            threadTs: nil
         )
+        let message = try await client.sendMessage(request, token: token)
+        recordMessages([message], channelId: normalizedChannelId, direction: .outbound)
         return [
             "kind": "slack_message_sent",
             "channel_id": normalizedChannelId,
@@ -439,12 +563,13 @@ final class SlackConnectionService: @unchecked Sendable {
         let parsed = try parseThreadId(threadId)
         let normalizedChannelId = try requireWritableChannel(parsed.channelId, config: config)
         let trimmedContent = try validateMessageContent(content, config: config)
-        let message = try await client.sendMessage(
+        let request = SlackOutboundMessageRequest(
             channelId: normalizedChannelId,
             content: trimmedContent,
-            threadTs: parsed.threadTs,
-            token: token
+            threadTs: parsed.threadTs
         )
+        let message = try await client.sendMessage(request, token: token)
+        recordMessages([message], channelId: normalizedChannelId, direction: .outbound)
         return [
             "kind": "slack_thread_reply_sent",
             "channel_id": normalizedChannelId,
@@ -528,6 +653,188 @@ final class SlackConnectionService: @unchecked Sendable {
         SlackSecurity.redact(error.localizedDescription, token: token, signingSecret: signingSecret)
     }
 
+    func normalizeInboundEvent(_ envelope: SlackEventEnvelope) -> SlackNormalizedInboundMessage? {
+        normalizeInboundEvent(envelope, config: configuration())
+    }
+
+    func normalizeInboundEvent(
+        _ envelope: SlackEventEnvelope,
+        config: SlackConnectionConfiguration
+    ) -> SlackNormalizedInboundMessage? {
+        guard let providerEventId = envelope.eventId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !providerEventId.isEmpty,
+              let event = envelope.event,
+              ["message", "app_mention"].contains(event.type ?? ""),
+              event.subtype == nil,
+              let teamId = envelope.teamId.map(SlackConnectionConfiguration.normalizedId),
+              SlackConnectionConfiguration.isValidSlackId(teamId),
+              let channelId = event.channel.map(SlackConnectionConfiguration.normalizedId),
+              SlackConnectionConfiguration.isValidSlackId(channelId),
+              let messageTs = event.ts?.trimmingCharacters(in: .whitespacesAndNewlines),
+              Self.isValidThreadTimestamp(messageTs)
+        else {
+            return nil
+        }
+        guard config.canUseTeam(teamId: teamId),
+              config.canRead(channelId: channelId),
+              config.botUserId != nil || config.botId != nil
+        else {
+            return nil
+        }
+
+        guard !Self.isOwnMessage(event: event, config: config) else {
+            return nil
+        }
+
+        let content = event.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let threadTs = event.threadTs.flatMap { candidate -> String? in
+            let normalized = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            return Self.isValidThreadTimestamp(normalized) ? normalized : nil
+        } ?? messageTs
+        let mentionedUserIds = Self.mentionedUserIds(in: content)
+        let mentionsBot = config.botUserId.map(mentionedUserIds.contains) ?? false
+        return SlackNormalizedInboundMessage(
+            connectionId: AgentChannelConnection.nativeSlackConnectionId,
+            providerEventId: providerEventId,
+            teamId: teamId,
+            roomId: channelId,
+            providerMessageId: messageTs,
+            threadId: "\(channelId):\(threadTs)",
+            threadTs: threadTs,
+            authorId: event.user ?? event.botId,
+            content: content,
+            isThreadReply: threadTs != messageTs,
+            isMention: event.type == "app_mention" || mentionsBot,
+            mentionedUserIds: mentionedUserIds,
+            payloadJSON: Self.encodedInboundPayload(envelope)
+        )
+    }
+
+    func recordVerifiedInboundEvent(
+        body: Data,
+        timestamp: String,
+        signature: String,
+        now: Date = Date()
+    ) throws -> SlackNormalizedInboundMessage? {
+        guard let signingSecret = credentialStore.signingSecret() else {
+            throw SlackConnectionServiceError.signingSecretNotConfigured
+        }
+        guard SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: body,
+            signature: signature,
+            now: now
+        ) else {
+            throw SlackConnectionServiceError.signatureVerificationFailed
+        }
+        guard let envelope = try? JSONDecoder().decode(SlackEventEnvelope.self, from: body) else {
+            throw SlackConnectionServiceError.invalidInboundPayload
+        }
+        return try recordInboundEvent(envelope)
+    }
+
+    func recordInboundEvent(_ envelope: SlackEventEnvelope) throws -> SlackNormalizedInboundMessage? {
+        guard let normalized = normalizeInboundEvent(envelope) else { return nil }
+        guard let messageStore else { return normalized }
+        try messageStore.openIfNeeded()
+        guard try messageStore.markEventSeen(
+            connectionId: normalized.connectionId,
+            providerEventId: normalized.providerEventId
+        ) else {
+            return nil
+        }
+        guard try messageStore.markEventSeen(
+            connectionId: normalized.connectionId,
+            providerEventId: Self.inboundDispatchEventId(normalized)
+        ) else {
+            return nil
+        }
+        _ = try messageStore.recordMessages([normalized.storedMessage])
+        return normalized
+    }
+
+    private static func inboundDispatchEventId(_ message: SlackNormalizedInboundMessage) -> String {
+        "slack-dispatch:\(message.roomId):\(message.providerMessageId)"
+    }
+
+    private func recordMessages(
+        _ messages: [SlackMessage],
+        channelId: String,
+        direction: AgentChannelStoredMessageDirection
+    ) {
+        guard let messageStore, !messages.isEmpty else { return }
+        let rows = messages.map { message in
+            Self.storedMessage(
+                message,
+                channelId: channelId,
+                direction: direction
+            )
+        }
+        if recordMessageSnapshotsInline {
+            Self.persistMessages(rows, messageStore: messageStore)
+        } else {
+            Task.detached(priority: .utility) {
+                Self.persistMessages(rows, messageStore: messageStore)
+            }
+        }
+    }
+
+    private static func persistMessages(
+        _ rows: [AgentChannelStoredMessage],
+        messageStore: AgentChannelMessageStore
+    ) {
+        do {
+            try messageStore.openIfNeeded()
+            _ = try messageStore.recordMessages(rows)
+        } catch {
+            NSLog("[Slack] Failed to record Agent Channel messages: \(error.localizedDescription)")
+        }
+    }
+
+    private static func storedMessage(
+        _ message: SlackMessage,
+        channelId: String,
+        direction: AgentChannelStoredMessageDirection
+    ) -> AgentChannelStoredMessage {
+        let threadTs = message.threadTs ?? message.ts
+        return AgentChannelStoredMessage(
+            connectionId: AgentChannelConnection.nativeSlackConnectionId,
+            roomId: channelId,
+            providerMessageId: message.ts,
+            direction: direction,
+            threadId: "\(channelId):\(threadTs)",
+            authorId: message.user ?? message.botId,
+            authorName: message.username,
+            content: message.text ?? "",
+            payloadJSON: encodedPayload(message),
+            providerTimestamp: message.ts
+        )
+    }
+
+    private static func encodedPayload<Payload: Encodable>(_ payload: Payload) -> String {
+        guard let data = try? JSONEncoder().encode(payload),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func encodedInboundPayload(_ envelope: SlackEventEnvelope) -> String {
+        encodedPayload(
+            SlackEventEnvelope(
+                token: nil,
+                teamId: envelope.teamId,
+                apiAppId: envelope.apiAppId,
+                event: envelope.event,
+                type: envelope.type,
+                eventId: envelope.eventId,
+                eventTime: envelope.eventTime
+            )
+        )
+    }
+
     private func mentionPolicyDictionary(config: SlackConnectionConfiguration) -> [String: Any] {
         [
             "parse": "none",
@@ -542,6 +849,33 @@ final class SlackConnectionService: @unchecked Sendable {
         return lowered.contains("<!channel")
             || lowered.contains("<!here")
             || lowered.contains("<!everyone")
+            || lowered.contains("<!subteam^")
+    }
+
+    private static func mentionedUserIds(in content: String) -> [String] {
+        let pattern = #"<@([A-Z0-9][A-Z0-9.-]{1,63})(?:\|[^>]+)?>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(content.startIndex ..< content.endIndex, in: content)
+        var seen = Set<String>()
+        return regex.matches(in: content, range: range).compactMap { match in
+            guard match.numberOfRanges == 2,
+                  let idRange = Range(match.range(at: 1), in: content)
+            else {
+                return nil
+            }
+            let id = String(content[idRange])
+            return seen.insert(id).inserted ? id : nil
+        }
+    }
+
+    private static func isOwnMessage(
+        event: SlackEventMessage,
+        config: SlackConnectionConfiguration
+    ) -> Bool {
+        let userId = SlackConnectionConfiguration.normalizedOptionalId(event.user)
+        let botId = SlackConnectionConfiguration.normalizedOptionalId(event.botId)
+        return userId.map { $0 == config.botUserId } == true
+            || botId.map { $0 == config.botId } == true
     }
 
     private static func isValidThreadTimestamp(_ value: String) -> Bool {

--- a/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
@@ -1,0 +1,652 @@
+//
+//  SlackConnectionTests.swift
+//  osaurusTests
+//
+//  Unit and security coverage for the native Slack Agent Channel adapter.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SlackConnectionTests {
+
+    @Test func configurationPersistsAllowlistsButNeverSecrets() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let botToken = "xoxb-slack-bot-token-super-secret"
+            let signingSecret = "slack-signing-secret-super-secret"
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveBotToken(botToken)
+            try service.saveSigningSecret(signingSecret)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: [" T12345 ", "T12345"],
+                    readableChannelIds: ["C23456"],
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true,
+                    defaultReadLimit: 250
+                )
+            )
+
+            let saved = SlackConnectionConfigurationStore.load()
+            #expect(saved.configuredTeamIds == ["T12345"])
+            #expect(saved.defaultReadLimit == 100)
+            #expect(!SlackConnectionConfiguration.isValidSlackId("T١٢٣"))
+
+            let disk = try String(
+                contentsOf: SlackConnectionConfigurationStore.configurationFileURL(),
+                encoding: .utf8
+            )
+            #expect(disk.contains("C23456"))
+            #expect(!disk.contains(botToken))
+            #expect(!disk.contains(signingSecret))
+            #expect(!disk.localizedCaseInsensitiveContains("bot_token"))
+            #expect(!disk.localizedCaseInsensitiveContains("signing_secret"))
+        }
+    }
+
+    @Test func diagnosticsRedactsSavedSecretsEchoedByTransportError() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let botToken = "xoxb-slack-bot-token-super-secret"
+            let signingSecret = "slack-signing-secret-super-secret"
+            let fake = FakeSlackAPIClient()
+            await fake.setAuthFailureEchoingSecrets(botToken: botToken, signingSecret: signingSecret)
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken(botToken)
+            try service.saveSigningSecret(signingSecret)
+
+            let diagnostics = await service.diagnostics()
+
+            #expect(diagnostics.botTokenSaved)
+            #expect(diagnostics.signingSecretSaved)
+            #expect(diagnostics.status == "token_invalid_or_unavailable")
+            let failures = diagnostics.failures.joined(separator: " ")
+            #expect(failures.contains("[REDACTED:SLACK_BOT_TOKEN]"))
+            #expect(failures.contains("[REDACTED:SLACK_SIGNING_SECRET]"))
+            #expect(!failures.contains(botToken))
+            #expect(!failures.contains(signingSecret))
+            #expect(!String(describing: diagnostics.dictionary).contains(botToken))
+            #expect(!String(describing: diagnostics.dictionary).contains(signingSecret))
+        }
+    }
+
+    @Test func apiClientRedactsTokenEchoedBySlackErrorBody() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 200,
+            body: #"{"ok":false,"error":"invalid_auth \#(token)"}"#
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.authTest(token: token)
+            Issue.record("Slack request should have failed")
+        } catch let error as SlackAPIError {
+            #expect(error.localizedDescription.contains("[REDACTED:SLACK_BOT_TOKEN]"))
+            #expect(!error.localizedDescription.contains(token))
+        }
+    }
+
+    @Test func apiClientUsesConservativeMentionControlsWhenSendingMessage() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 200,
+            body: """
+            {
+              "ok": true,
+              "channel": "C34567",
+              "ts": "1718800000.000100",
+              "message": {
+                "type": "message",
+                "user": "U12345",
+                "text": "Hello @channel <@U23456>",
+                "ts": "1718800000.000100"
+              }
+            }
+            """
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        _ = try await client.sendMessage(
+            channelId: "C34567",
+            content: "Hello @channel <@U23456>",
+            threadTs: nil,
+            token: token
+        )
+
+        let body = try #require(SlackHTTPStubProtocol.lastRequestJSONBody())
+        #expect(body["parse"] as? String == "none")
+        #expect(body["link_names"] as? Bool == false)
+        #expect(body["reply_broadcast"] as? Bool == false)
+        #expect(body["unfurl_links"] as? Bool == false)
+        #expect(body["unfurl_media"] as? Bool == false)
+    }
+
+    @Test func apiClientHonorsBoundedConversationListLimit() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 200,
+            body: #"{"ok":true,"channels":[]}"#
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        _ = try await client.conversations(token: token, limit: 10)
+
+        let form = SlackHTTPStubProtocol.lastRequestFormBody()
+        #expect(form["limit"] == "10")
+        #expect(form["exclude_archived"] == "true")
+    }
+
+    @Test func readChannelReturnsBoundedMessagesForAllowlistedSlackChannel() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            await fake.setMessages([
+                "C23456": [
+                    .fixture(ts: "1718800000.000100", text: "eval reports landed"),
+                    .fixture(ts: "1718800001.000200", text: "review requested"),
+                ],
+            ])
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["T12345"],
+                    readableChannelIds: ["C23456"],
+                    defaultReadLimit: 2
+                )
+            )
+
+            let result = try await service.readChannel(channelId: "C23456", limit: nil)
+            #expect(result["channel_id"] as? String == "C23456")
+            #expect(result["partial"] as? Bool == true)
+            let messages = try #require(result["messages"] as? [[String: Any]])
+            #expect(messages.count == 2)
+            #expect(messages.first?["content"] as? String == "eval reports landed")
+            #expect(messages.first?["thread_id"] as? String == "C23456:1718800000.000100")
+        }
+    }
+
+    @Test func agentChannelReadToolDispatchesThroughSlackConnection() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            await fake.setMessages([
+                "C23456": [.fixture(ts: "1718800000.000100", text: "hello from Slack")],
+            ])
+            let slackService = SlackConnectionService(client: fake, credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelReadMessagesTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON: #"{"connection_id":"slack","room_id":"C23456"}"#
+            )
+
+            let payload = try #require(EnvelopeAssertions.successPayload(result))
+            #expect(payload["connection_id"] as? String == "slack")
+            #expect(payload["standard_kind"] as? String == "channel_messages")
+            #expect(payload["kind"] as? String == "slack_recent_messages")
+        }
+    }
+
+    @Test func agentChannelReadToolRejectsRoomsOutsideSlackReadAllowlist() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let slackService = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelReadMessagesTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON: #"{"connection_id":"slack","room_id":"C99999"}"#
+            )
+            #expect(EnvelopeAssertions.failureKind(result) == "rejected")
+            #expect(EnvelopeAssertions.failureMessage(result)?.contains("not allowlisted") == true)
+        }
+    }
+
+    @Test func agentChannelSendToolRequiresConfirmSendForSlack() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let slackService = SlackConnectionService(client: fake, credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelSendMessageTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON:
+                    #"{"connection_id":"slack","room_id":"C34567","content":"Ship it","confirm_send":false}"#
+            )
+            #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+            #expect(await fake.sentMessageCount() == 0)
+        }
+    }
+
+    @Test func agentChannelSendToolPostsOnlyWhenSlackWriteEnabledAllowlistedAndConfirmed() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let slackService = SlackConnectionService(client: fake, credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelSendMessageTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON:
+                    #"{"connection_id":"slack","room_id":"C34567","content":"Ship it","confirm_send":true}"#
+            )
+            let payload = try #require(EnvelopeAssertions.successPayload(result))
+            #expect(payload["standard_kind"] as? String == "message_sent")
+            #expect(payload["kind"] as? String == "slack_message_sent")
+            #expect(await fake.sentMessageCount() == 1)
+            #expect(await fake.lastSentContent() == "Ship it")
+        }
+    }
+
+    @Test func slackSendRejectsBroadcastMentionByDefaultBeforeNetworkCall() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+
+            #expect(throws: SlackConnectionServiceError.broadcastMentionDenied) {
+                try service.draftMessage(channelId: "C34567", content: "Heads up <!channel>")
+            }
+            #expect(await fake.sentMessageCount() == 0)
+        }
+    }
+
+    @Test func slackThreadReplyUsesChannelAndThreadTimestamp() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+
+            let result = try await service.replyToThread(
+                threadId: "C34567:1718800000.000100",
+                content: "Thread reply",
+                confirmSend: true
+            )
+
+            #expect(result["kind"] as? String == "slack_thread_reply_sent")
+            #expect(result["thread_ts"] as? String == "1718800000.000100")
+            #expect(await fake.lastThreadTs() == "1718800000.000100")
+        }
+    }
+
+    @Test func nativeSlackConnectionIsListedAndReserved() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let slackService = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+
+            let slackRow = try #require(
+                channelService.listConnections().first { $0["id"] as? String == "slack" }
+            )
+            #expect(slackRow["kind"] as? String == "slack")
+            #expect(slackRow["configured"] as? Bool == true)
+            #expect(slackRow["secret_names"] as? [String] == ["bot_token", "signing_secret"])
+
+            let manager = AgentChannelConnectionManager()
+            #expect(throws: AgentChannelConnectionManagerError.reservedConnectionId("slack")) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "slack",
+                        name: "Shadow Slack",
+                        kind: .customHTTP,
+                        supportedActions: [.diagnostics],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [String: AgentChannelCustomHTTPAction]()
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    private func withIsolatedSlackStores(
+        _ body: (any SlackCredentialStorage) async throws -> Void
+    ) async throws {
+        let previousDirectory = SlackConnectionConfigurationStore.overrideDirectory
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-slack-tests-\(UUID().uuidString)", isDirectory: true)
+        let credentials = FakeSlackCredentialStore()
+        SlackConnectionConfigurationStore.overrideDirectory = directory
+        defer {
+            SlackConnectionConfigurationStore.overrideDirectory = previousDirectory
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try await body(credentials)
+    }
+}
+
+private final class FakeSlackCredentialStore: SlackCredentialStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedBotToken: String?
+    private var storedSigningSecret: String?
+
+    func saveBotToken(_ token: String) -> Bool {
+        save(token, assign: { storedBotToken = $0 })
+    }
+
+    func botToken() -> String? {
+        lock.withLock { storedBotToken }
+    }
+
+    func hasBotToken() -> Bool {
+        botToken() != nil
+    }
+
+    func deleteBotToken() -> Bool {
+        lock.withLock { storedBotToken = nil }
+        return true
+    }
+
+    func saveSigningSecret(_ secret: String) -> Bool {
+        save(secret, assign: { storedSigningSecret = $0 })
+    }
+
+    func signingSecret() -> String? {
+        lock.withLock { storedSigningSecret }
+    }
+
+    func hasSigningSecret() -> Bool {
+        signingSecret() != nil
+    }
+
+    func deleteSigningSecret() -> Bool {
+        lock.withLock { storedSigningSecret = nil }
+        return true
+    }
+
+    private func save(_ value: String, assign: (String) -> Void) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        lock.withLock { assign(trimmed) }
+        return true
+    }
+}
+
+private actor FakeSlackAPIClient: SlackAPIClientProtocol {
+    private var authFailureMessage: String?
+    private var messagesByChannel: [String: [SlackMessage]] = [:]
+    private var sentMessages: [(channelId: String, content: String, threadTs: String?)] = []
+
+    func setAuthFailureEchoingSecrets(botToken: String, signingSecret: String) {
+        authFailureMessage = "transport included token \(botToken) and signing secret \(signingSecret)"
+    }
+
+    func setMessages(_ messagesByChannel: [String: [SlackMessage]]) {
+        self.messagesByChannel = messagesByChannel
+    }
+
+    func sentMessageCount() -> Int {
+        sentMessages.count
+    }
+
+    func lastSentContent() -> String? {
+        sentMessages.last?.content
+    }
+
+    func lastThreadTs() -> String? {
+        sentMessages.last?.threadTs
+    }
+
+    func authTest(token: String) async throws -> SlackAuthIdentity {
+        if let authFailureMessage {
+            throw SlackAPIError.requestFailed(authFailureMessage)
+        }
+        return SlackAuthIdentity(
+            url: "https://example.slack.com/",
+            team: "Example",
+            user: "osaurus",
+            teamId: "T12345",
+            userId: "U12345",
+            botId: "B12345"
+        )
+    }
+
+    func conversations(token: String, limit: Int) async throws -> [SlackConversation] {
+        [
+            SlackConversation(
+                id: "C23456",
+                name: "dev",
+                isChannel: true,
+                isGroup: false,
+                isIM: false,
+                isMPIM: false,
+                isPrivate: false,
+                isArchived: false,
+                isMember: true
+            ),
+            SlackConversation(
+                id: "C34567",
+                name: "maintainers",
+                isChannel: true,
+                isGroup: false,
+                isIM: false,
+                isMPIM: false,
+                isPrivate: false,
+                isArchived: false,
+                isMember: true
+            ),
+        ]
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        Array((messagesByChannel[channelId] ?? []).prefix(limit))
+    }
+
+    func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        Array((messagesByChannel[channelId] ?? []).filter { ($0.threadTs ?? $0.ts) == threadTs }.prefix(limit))
+    }
+
+    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
+        sentMessages.append((channelId: channelId, content: content, threadTs: threadTs))
+        return .fixture(
+            ts: "171880000\(sentMessages.count).000100",
+            text: content,
+            threadTs: threadTs
+        )
+    }
+}
+
+private final class FakeDiscordCredentialStoreForSlackTests: DiscordCredentialStorage, @unchecked Sendable {
+    func saveBotToken(_ token: String) -> Bool { true }
+    func botToken() -> String? { nil }
+    func hasBotToken() -> Bool { false }
+    func deleteBotToken() -> Bool { true }
+}
+
+private actor FakeDiscordAPIClientForSlackTests: DiscordAPIClientProtocol {
+    func currentUser(token: String) async throws -> DiscordBotIdentity {
+        throw DiscordAPIError.invalidToken
+    }
+
+    func guild(id: String, token: String) async throws -> DiscordGuild {
+        throw DiscordAPIError.notFound("unused")
+    }
+
+    func channels(guildId: String, token: String) async throws -> [DiscordChannel] {
+        []
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [DiscordMessage] {
+        []
+    }
+
+    func sendMessage(channelId: String, content: String, token: String) async throws -> DiscordMessage {
+        throw DiscordAPIError.requestFailed("unused")
+    }
+}
+
+private final class SlackHTTPStubProtocol: URLProtocol {
+    nonisolated(unsafe) private static var statusCode: Int = 200
+    nonisolated(unsafe) private static var body = Data()
+    nonisolated(unsafe) private static var requestBody = Data()
+
+    static func session(statusCode: Int, body: String) -> URLSession {
+        self.statusCode = statusCode
+        self.body = Data(body.utf8)
+        requestBody = Data()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SlackHTTPStubProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    static func lastRequestJSONBody() -> [String: Any]? {
+        guard !requestBody.isEmpty else { return nil }
+        return try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+    }
+
+    static func lastRequestFormBody() -> [String: String] {
+        guard let body = String(data: requestBody, encoding: .utf8) else { return [:] }
+        return body
+            .split(separator: "&")
+            .reduce(into: [String: String]()) { result, pair in
+                let parts = pair.split(separator: "=", maxSplits: 1)
+                guard let name = parts.first else { return }
+                let value = parts.dropFirst().first.map(String.init) ?? ""
+                result[String(name)] = value.removingPercentEncoding ?? value
+            }
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let data = request.httpBody {
+            return data
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestBody = Self.bodyData(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private extension SlackMessage {
+    static func fixture(
+        ts: String,
+        text: String,
+        threadTs: String? = nil,
+        user: String = "U55555"
+    ) -> SlackMessage {
+        SlackMessage(
+            type: "message",
+            user: user,
+            username: "mike",
+            botId: nil,
+            text: text,
+            ts: ts,
+            threadTs: threadTs,
+            replyCount: nil
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CryptoKit
 import Testing
 
 @testable import OsaurusCore
@@ -72,6 +73,57 @@ struct SlackConnectionTests {
         }
     }
 
+    @Test func diagnosticsPersistsBotIdentityForInboundSelfFiltering() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+
+            let diagnostics = await service.diagnostics()
+            let saved = SlackConnectionConfigurationStore.load()
+
+            #expect(diagnostics.identity?.userId == "U12345")
+            #expect(diagnostics.identity?.botId == "B12345")
+            #expect(saved.botUserId == "U12345")
+            #expect(saved.botId == "B12345")
+        }
+    }
+
+    @Test func signatureVerifierAuthorizesSlackSignedRequestOnlyWithinTolerance() throws {
+        let signingSecret = "8f742231b10e8888abcd99yyyzzz85a5"
+        let timestamp = "1531420618"
+        let body = Data(
+            """
+            token=xyzz0WbapA4vBCDEFasx0Fqz&team_id=T1DC2J9E1&team_domain=testteamnow&channel_id=C2147483705&channel_name=test&user_id=U2147483697&user_name=Steve&command=/weather&text=94070&response_url=https://hooks.slack.com/commands/1234/5678&trigger_id=13345224609.738474920.8088930838d88f008e0
+            """.utf8
+        )
+        let signature = "v0=4d19b371acb8c24626ae294d086e5dc1513e8e0c04781438c439143315cb807e"
+
+        #expect(SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: body,
+            signature: signature,
+            now: Date(timeIntervalSince1970: 1_531_420_618)
+        ))
+        #expect(!SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: body,
+            signature: signature,
+            now: Date(timeIntervalSince1970: 1_531_421_000)
+        ))
+        #expect(!SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: Data("tampered".utf8),
+            signature: signature,
+            now: Date(timeIntervalSince1970: 1_531_420_618)
+        ))
+    }
+
     @Test func apiClientRedactsTokenEchoedBySlackErrorBody() async throws {
         let token = "xoxb-slack-bot-token-super-secret"
         let session = SlackHTTPStubProtocol.session(
@@ -116,9 +168,11 @@ struct SlackConnectionTests {
         )
 
         _ = try await client.sendMessage(
-            channelId: "C34567",
-            content: "Hello @channel <@U23456>",
-            threadTs: nil,
+            SlackOutboundMessageRequest(
+                channelId: "C34567",
+                content: "Hello @channel <@U23456>",
+                threadTs: nil
+            ),
             token: token
         )
 
@@ -146,6 +200,28 @@ struct SlackConnectionTests {
         let form = SlackHTTPStubProtocol.lastRequestFormBody()
         #expect(form["limit"] == "10")
         #expect(form["exclude_archived"] == "true")
+        #expect(SlackHTTPStubProtocol.lastRawRequestBody()
+            .contains("types=public_channel%2Cprivate_channel%2Cmpim%2Cim"))
+    }
+
+    @Test func apiClientMapsSlackRateLimitWithRetryAfterHint() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 429,
+            body: #"{"ok":false,"error":"ratelimited"}"#,
+            headers: ["Retry-After": "7"]
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.messages(channelId: "C23456", token: token, limit: 1)
+            Issue.record("Slack request should have been rate limited")
+        } catch let error as SlackAPIError {
+            #expect(error == .rateLimited("Slack rate limited this request. Retry after 7 seconds."))
+        }
     }
 
     @Test func readChannelReturnsBoundedMessagesForAllowlistedSlackChannel() async throws {
@@ -174,6 +250,460 @@ struct SlackConnectionTests {
             #expect(messages.count == 2)
             #expect(messages.first?["content"] as? String == "eval reports landed")
             #expect(messages.first?["thread_id"] as? String == "C23456:1718800000.000100")
+        }
+    }
+
+    @Test func readAndSendRecordSlackMessagesInAgentChannelStore() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeSlackAPIClient()
+            await fake.setMessages([
+                "C23456": [
+                    .fixture(ts: "1718800000.000100", text: "eval reports landed"),
+                    .fixture(ts: "1718800001.000200", text: "review requested"),
+                ],
+            ])
+            let service = SlackConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    writableChannelIds: ["C23456"],
+                    writeEnabled: true,
+                    defaultReadLimit: 2
+                )
+            )
+
+            _ = try await service.readChannel(channelId: "C23456", limit: nil)
+            _ = try await service.readChannel(channelId: "C23456", limit: nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 2)
+
+            _ = try await service.sendMessage(
+                channelId: "C23456",
+                content: "Ship it",
+                confirmSend: true
+            )
+            let rows = try store.recentMessages(connectionId: "slack", roomId: "C23456", limit: 10)
+            #expect(rows.contains { $0.providerMessageId == "1718800001.000100" && $0.direction == .outbound })
+            #expect(rows.allSatisfy { !$0.payloadJSON.localizedCaseInsensitiveContains("xoxb-slack") })
+        }
+    }
+
+    @Test func slackInboundEventNormalizationCapturesMentionThreadAndStoreDedupe() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: "legacy-verification-secret",
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> can you check this?",
+                    ts: "1718800001.000200",
+                    threadTs: "1718800000.000100",
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "Ev12345",
+                eventTime: 1_718_800_001
+            )
+
+            let normalized = try #require(try service.recordInboundEvent(envelope))
+            #expect(normalized.providerEventId == "Ev12345")
+            #expect(normalized.roomId == "C23456")
+            #expect(normalized.threadId == "C23456:1718800000.000100")
+            #expect(normalized.isThreadReply)
+            #expect(normalized.isMention)
+            #expect(normalized.mentionedUserIds == ["UOSABOT"])
+            #expect(!normalized.payloadJSON.contains("legacy-verification-secret"))
+            #expect(try service.recordInboundEvent(envelope) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+        }
+    }
+
+    @Test func slackInboundEventRequiresSignedBodyForWebhookEntryPoint() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let signingSecret = "slack-signing-secret-super-secret"
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveSigningSecret(signingSecret)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: "legacy-verification-secret",
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> signed event",
+                    ts: "1718800001.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSigned12345",
+                eventTime: 1_718_800_001
+            )
+            let body = try JSONEncoder().encode(envelope)
+            let timestamp = "1718800001"
+            let signature = slackSignature(secret: signingSecret, timestamp: timestamp, body: body)
+
+            let normalized = try #require(try service.recordVerifiedInboundEvent(
+                body: body,
+                timestamp: timestamp,
+                signature: signature,
+                now: Date(timeIntervalSince1970: 1_718_800_001)
+            ))
+
+            #expect(normalized.providerEventId == "EvSigned12345")
+            #expect(!normalized.payloadJSON.contains("legacy-verification-secret"))
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+
+            do {
+                _ = try service.recordVerifiedInboundEvent(
+                    body: body,
+                    timestamp: timestamp,
+                    signature: "v0=bad",
+                    now: Date(timeIntervalSince1970: 1_718_800_001)
+                )
+                Issue.record("Slack webhook entry should reject invalid signatures")
+            } catch let error as SlackConnectionServiceError {
+                #expect(error == .signatureVerificationFailed)
+            }
+        }
+    }
+
+    @Test func signedSlackInboundEventRequiresReadableChannelAllowlistBeforeStorage() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let signingSecret = "slack-signing-secret-super-secret"
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveSigningSecret(signingSecret)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C99999"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> signed but not allowlisted",
+                    ts: "1718800001.000300",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSignedDenied12345",
+                eventTime: 1_718_800_001
+            )
+            let body = try JSONEncoder().encode(envelope)
+            let timestamp = "1718800001"
+            let signature = slackSignature(secret: signingSecret, timestamp: timestamp, body: body)
+
+            let normalized = try service.recordVerifiedInboundEvent(
+                body: body,
+                timestamp: timestamp,
+                signature: signature,
+                now: Date(timeIntervalSince1970: 1_718_800_001)
+            )
+
+            #expect(normalized == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 0)
+        }
+    }
+
+    @Test func slackInboundEventMentionAndSelfMessagePolicyAvoidsOverTriggering() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT",
+                    botId: "BOSABOT",
+                    apiAppId: "AOSABOT"
+                )
+            )
+
+            let thirdPartyMention = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "cc <@UOTHER|teammate>",
+                    ts: "1718800002.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvOtherMention",
+                eventTime: 1_718_800_002
+            )
+            let normalized = try #require(service.normalizeInboundEvent(thirdPartyMention))
+            #expect(normalized.mentionedUserIds == ["UOTHER"])
+            #expect(!normalized.isMention)
+
+            let ownBotDirectMessage = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "AOSABOT",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: nil,
+                    botId: "BOSABOT",
+                    text: "self echo without subtype",
+                    ts: "1718800003.000100",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSelfBotDirect",
+                eventTime: 1_718_800_003
+            )
+            #expect(service.normalizeInboundEvent(ownBotDirectMessage) == nil)
+
+            let ownBotMessage = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "AOSABOT",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: "bot_message",
+                    channel: "C23456",
+                    user: nil,
+                    botId: "BOSABOT",
+                    text: "self echo",
+                    ts: "1718800003.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSelfBot",
+                eventTime: 1_718_800_003
+            )
+            #expect(service.normalizeInboundEvent(ownBotMessage) == nil)
+        }
+    }
+
+    @Test func slackInboundEventRejectsUnconfiguredTeamAndMissingBotIdentity() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "TOTHER",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> hello",
+                    ts: "1718800003.000400",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvWrongTeam",
+                eventTime: 1_718_800_003
+            )
+
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["T12345"],
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            #expect(service.normalizeInboundEvent(envelope) == nil)
+
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["TOTHER"],
+                    readableChannelIds: ["C23456"]
+                )
+            )
+            #expect(service.normalizeInboundEvent(envelope) == nil)
+        }
+    }
+
+    @Test func slackInboundEventDedupesMessageAndAppMentionForSameSlackMessage() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let appMention = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> same message",
+                    ts: "1718800004.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvAppMention",
+                eventTime: 1_718_800_004
+            )
+            let messageEcho = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> same message",
+                    ts: "1718800004.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvMessageEcho",
+                eventTime: 1_718_800_004
+            )
+
+            #expect(try service.recordInboundEvent(appMention) != nil)
+            #expect(try service.recordInboundEvent(messageEcho) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+        }
+    }
+
+    @Test func slackInboundDispatchSurvivesPassiveSnapshotCollision() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            _ = try store.recordMessages([
+                AgentChannelStoredMessage(
+                    connectionId: "slack",
+                    roomId: "C23456",
+                    providerMessageId: "1718800005.000200",
+                    direction: .inbound,
+                    threadId: "C23456:1718800005.000200",
+                    authorId: "U55555",
+                    authorName: "Mika",
+                    content: "<@UOSABOT> cached before event",
+                    providerTimestamp: "1718800005.000200"
+                ),
+            ])
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> cached before event",
+                    ts: "1718800005.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvPassiveCollision",
+                eventTime: 1_718_800_005
+            )
+
+            #expect(try service.recordInboundEvent(envelope) != nil)
+            #expect(try service.recordInboundEvent(envelope) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
         }
     }
 
@@ -308,6 +838,9 @@ struct SlackConnectionTests {
             #expect(throws: SlackConnectionServiceError.broadcastMentionDenied) {
                 try service.draftMessage(channelId: "C34567", content: "Heads up <!channel>")
             }
+            #expect(throws: SlackConnectionServiceError.broadcastMentionDenied) {
+                try service.draftMessage(channelId: "C34567", content: "Heads up <!subteam^S12345|@ops>")
+            }
             #expect(await fake.sentMessageCount() == 0)
         }
     }
@@ -393,6 +926,14 @@ struct SlackConnectionTests {
             try? FileManager.default.removeItem(at: directory)
         }
         try await body(credentials)
+    }
+
+    private func slackSignature(secret: String, timestamp: String, body: Data) -> String {
+        var base = Data("v0:\(timestamp):".utf8)
+        base.append(body)
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let digest = HMAC<SHA256>.authenticationCode(for: base, using: key)
+        return "v0=" + digest.map { String(format: "%02x", $0) }.joined()
     }
 }
 
@@ -517,12 +1058,12 @@ private actor FakeSlackAPIClient: SlackAPIClientProtocol {
         Array((messagesByChannel[channelId] ?? []).filter { ($0.threadTs ?? $0.ts) == threadTs }.prefix(limit))
     }
 
-    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
-        sentMessages.append((channelId: channelId, content: content, threadTs: threadTs))
+    func sendMessage(_ request: SlackOutboundMessageRequest, token: String) async throws -> SlackMessage {
+        sentMessages.append((channelId: request.channelId, content: request.content, threadTs: request.threadTs))
         return .fixture(
             ts: "171880000\(sentMessages.count).000100",
-            text: content,
-            threadTs: threadTs
+            text: request.content,
+            threadTs: request.threadTs
         )
     }
 }
@@ -559,11 +1100,13 @@ private actor FakeDiscordAPIClientForSlackTests: DiscordAPIClientProtocol {
 private final class SlackHTTPStubProtocol: URLProtocol {
     nonisolated(unsafe) private static var statusCode: Int = 200
     nonisolated(unsafe) private static var body = Data()
+    nonisolated(unsafe) private static var headers: [String: String] = [:]
     nonisolated(unsafe) private static var requestBody = Data()
 
-    static func session(statusCode: Int, body: String) -> URLSession {
+    static func session(statusCode: Int, body: String, headers: [String: String] = [:]) -> URLSession {
         self.statusCode = statusCode
         self.body = Data(body.utf8)
+        self.headers = headers
         requestBody = Data()
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [SlackHTTPStubProtocol.self]
@@ -573,6 +1116,10 @@ private final class SlackHTTPStubProtocol: URLProtocol {
     static func lastRequestJSONBody() -> [String: Any]? {
         guard !requestBody.isEmpty else { return nil }
         return try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+    }
+
+    static func lastRawRequestBody() -> String {
+        String(data: requestBody, encoding: .utf8) ?? ""
     }
 
     static func lastRequestFormBody() -> [String: String] {
@@ -621,7 +1168,7 @@ private final class SlackHTTPStubProtocol: URLProtocol {
             url: request.url!,
             statusCode: Self.statusCode,
             httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"]
+            headerFields: ["Content-Type": "application/json"].merging(Self.headers) { _, new in new }
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Self.body)

--- a/Packages/OsaurusCore/Tools/AgentChannelTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentChannelTools.swift
@@ -147,6 +147,69 @@ private extension OsaurusTool {
             }
         }
 
+        if let error = error as? SlackConnectionServiceError {
+            switch error {
+            case .invalidId, .sendConfirmationRequired, .messageTooLong, .emptyMessage, .invalidThreadId:
+                return ToolEnvelope.failure(kind: .invalidArgs, message: error.localizedDescription, tool: tool)
+            case .teamNotConfigured, .channelNotReadable, .channelNotWritable, .writeDisabled, .broadcastMentionDenied:
+                return ToolEnvelope.failure(kind: .rejected, message: error.localizedDescription, tool: tool)
+            case .notConfigured:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .configurationSaveFailed, .api:
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            }
+        }
+
+        if let error = error as? SlackAPIError {
+            switch error {
+            case .invalidToken:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .missingPermissions:
+                return ToolEnvelope.failure(
+                    kind: .rejected,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .notFound:
+                return ToolEnvelope.failure(
+                    kind: .notFound,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .rateLimited:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: true
+                )
+            case .invalidResponse, .requestFailed:
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            }
+        }
+
         return ToolEnvelope.failure(
             kind: .executionError,
             message: error.localizedDescription,

--- a/Packages/OsaurusCore/Tools/AgentChannelTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentChannelTools.swift
@@ -160,6 +160,15 @@ private extension OsaurusTool {
                     tool: tool,
                     retryable: false
                 )
+            case .signingSecretNotConfigured:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .signatureVerificationFailed, .invalidInboundPayload:
+                return ToolEnvelope.failure(kind: .invalidArgs, message: error.localizedDescription, tool: tool)
             case .configurationSaveFailed, .api:
                 return ToolEnvelope.failure(
                     kind: .executionError,

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -300,7 +300,8 @@ The JSON configuration stores only non-secret IDs and policy in `slack.json`:
   `confirm_send: true`.
 - `allowBroadcastMentions` defaults to false. When false, outbound messages
   containing Slack broadcast markup such as `<!channel>`, `<!here>`, or
-  `<!everyone>` are rejected before any network call.
+  `<!everyone>`, plus user-group markup such as `<!subteam^...>`, are rejected
+  before any network call.
 
 Slack thread ids use `channel_id:thread_ts` so the canonical
 `agent_channel_read_thread` and `agent_channel_reply_thread` tools can route
@@ -308,6 +309,24 @@ Slack thread operations without adding Slack-only tool names. Sent messages use
 conservative Slack posting controls: automatic name linking is disabled,
 message parsing is set to `none`, unfurls are disabled, and thread replies do
 not broadcast.
+
+The native adapter keeps live Slack calls behind `SlackAPIClientProtocol`.
+Outbound sends are represented as a `SlackOutboundMessageRequest` before
+transport so tests can assert channel id, text, thread timestamp, parsing,
+unfurl, and broadcast controls without Slack credentials. Slack Events API
+message and `app_mention` payloads normalize into
+`SlackNormalizedInboundMessage`, preserving the provider event id, workspace id,
+room id, message timestamp, canonical `channel_id:thread_ts`, mention user ids,
+and payload JSON for the shared Agent Channel store. A repeated Slack event id
+is recorded once through `channel_seen_events`, and message snapshots from
+read/search/send paths are keyed as `slack + channel_id + message_ts`.
+Inbound event storage is also gated by `readableChannelIds`; a valid Slack
+signature does not authorize events from non-allowlisted channels. Inbound
+normalization also requires the saved bot identity (`botUserId` or `botId`) so
+the adapter can suppress self/echo messages before dispatch.
+Webhook receivers should use `SlackSignatureVerifier` with the saved
+`signing_secret` to validate `X-Slack-Request-Timestamp`,
+`X-Slack-Signature`, and the exact raw request body before normalizing content.
 
 ## Message State And Dedupe
 

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -17,7 +17,7 @@ definitions.
 
 The model-facing tools use these standard verbs through `agent_channel_*`
 tools. Provider-specific adapters translate the standard action into the
-provider API. Discord is the first executable adapter.
+provider API. Native adapters currently include Discord and Slack.
 
 Each connection also reports provider-neutral action policy metadata in
 `agent_channel_list_connections` and `agent_channel_diagnostics`:
@@ -252,6 +252,7 @@ requests.
 The connection center validates channel definitions before saving:
 
 - `discord` is reserved for the native Discord adapter.
+- `slack` is reserved for the native Slack adapter.
 - Custom HTTP connections require an HTTP or HTTPS base URL.
 - Custom HTTP base URLs run through the same blocked-host policy used by the
   runner, so localhost/private/link-local targets are rejected before save.
@@ -278,6 +279,35 @@ non-secret IDs and policy:
   `reply_thread` can target.
 - `writeEnabled` must be true, and send/reply actions still require
   `confirm_send: true`.
+
+## Slack Connection
+
+Slack is a native Agent Channel connection. It is addressed through
+`connection_id: "slack"` on the `agent_channel_*` tools rather than through a
+separate Slack-specific model-facing tool set.
+
+The Slack bot token and optional signing secret are stored in Keychain under
+the native Slack credential reference names `bot_token` and `signing_secret`.
+The JSON configuration stores only non-secret IDs and policy in `slack.json`:
+
+- `configuredTeamIds` limits which workspace can be inspected. Leave it empty
+  to allow the workspace authenticated by the saved bot token.
+- `readableChannelIds` limits rooms that `read_messages`, `read_thread`, and
+  `search_messages` can read.
+- `writableChannelIds` limits rooms that `draft_message`, `send_message`, and
+  `reply_thread` can target.
+- `writeEnabled` must be true, and send/reply actions still require
+  `confirm_send: true`.
+- `allowBroadcastMentions` defaults to false. When false, outbound messages
+  containing Slack broadcast markup such as `<!channel>`, `<!here>`, or
+  `<!everyone>` are rejected before any network call.
+
+Slack thread ids use `channel_id:thread_ts` so the canonical
+`agent_channel_read_thread` and `agent_channel_reply_thread` tools can route
+Slack thread operations without adding Slack-only tool names. Sent messages use
+conservative Slack posting controls: automatic name linking is disabled,
+message parsing is set to `none`, unfurls are disabled, and thread replies do
+not broadcast.
 
 ## Message State And Dedupe
 


### PR DESCRIPTION
## Summary
- Adds a native Slack Agent Channel adapter with workspace/channel allowlists, read/search/send/thread routing, signed inbound event normalization, and conservative mention controls.
- Rebased onto the merged Agent Channel JSON runner, inbox/audit foundations, Settings IA cleanup, and current vmlx pin; native Slack dispatch now coexists with custom JSON channel execution.
- Stores Slack message snapshots in the shared Agent Channel message store after authorization and keeps bot credentials/signing secrets out of JSON config and diagnostics.
- Hardens channel safety: signed inbound events must target readable allowlisted channels, bot identity is required for self/echo suppression, user-group broadcasts are denied by default, and Slack form encoding now escapes reserved form characters.

## Validation
- git diff --check origin/main...HEAD
- swiftlint lint Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift Packages/OsaurusCore/Tools/AgentChannelTools.swift
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-slack-post-rebase swift test --package-path Packages/OsaurusCore --filter SlackConnectionTests
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-slack-agent-channel-post-rebase swift test --package-path Packages/OsaurusCore --filter AgentChannelAsyncSubstrateTests

## Draft gate
- Kept draft intentionally while GitHub CI reruns on the rebased branch.
- Keep draft until the final public channel registration/UI placement is confirmed.
- No prompt, default tool-schema, or model-routing changes are included, so no eval evidence is required for this service-level adapter refresh.