### PR TITLE
Add native Telegram Agent Channel

### DIFF
--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
@@ -570,6 +570,7 @@ struct AgentChannelCustomHTTPConfiguration: Codable, Equatable, Sendable {
 
 struct AgentChannelConnection: Codable, Equatable, Identifiable, Sendable {
     static let nativeDiscordConnectionId = "discord"
+    static let nativeTelegramConnectionId = "telegram"
 
     var id: String
     var name: String

--- a/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
@@ -1,0 +1,244 @@
+//
+//  TelegramConnectionConfiguration.swift
+//  osaurus
+//
+//  Non-secret configuration for the native Telegram connection.
+//
+
+import Foundation
+
+struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
+    var readableChatIds: [String]
+    var writableChatIds: [String]
+    var senderAllowlist: [String]
+    var writeEnabled: Bool
+    var defaultReadLimit: Int
+    var ignoreSelfMessages: Bool
+    var ignoreBotMessages: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case readableChatIds
+        case writableChatIds
+        case senderAllowlist
+        case writeEnabled
+        case defaultReadLimit
+        case ignoreSelfMessages
+        case ignoreBotMessages
+    }
+
+    init(
+        readableChatIds: [String] = [],
+        writableChatIds: [String] = [],
+        senderAllowlist: [String] = [],
+        writeEnabled: Bool = false,
+        defaultReadLimit: Int = 50,
+        ignoreSelfMessages: Bool = true,
+        ignoreBotMessages: Bool = true
+    ) {
+        self.readableChatIds = Self.normalizedIds(readableChatIds)
+        self.writableChatIds = Self.normalizedIds(writableChatIds)
+        self.senderAllowlist = Self.normalizedIds(senderAllowlist)
+        self.writeEnabled = writeEnabled
+        self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
+        self.ignoreSelfMessages = ignoreSelfMessages
+        self.ignoreBotMessages = ignoreBotMessages
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            readableChatIds: try container.decodeIfPresent([String].self, forKey: .readableChatIds) ?? [],
+            writableChatIds: try container.decodeIfPresent([String].self, forKey: .writableChatIds) ?? [],
+            senderAllowlist: try container.decodeIfPresent([String].self, forKey: .senderAllowlist) ?? [],
+            writeEnabled: try container.decodeIfPresent(Bool.self, forKey: .writeEnabled) ?? false,
+            defaultReadLimit: try container.decodeIfPresent(Int.self, forKey: .defaultReadLimit) ?? 50,
+            ignoreSelfMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreSelfMessages) ?? true,
+            ignoreBotMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreBotMessages) ?? true
+        )
+    }
+
+    var normalized: TelegramConnectionConfiguration {
+        TelegramConnectionConfiguration(
+            readableChatIds: readableChatIds,
+            writableChatIds: writableChatIds,
+            senderAllowlist: senderAllowlist,
+            writeEnabled: writeEnabled,
+            defaultReadLimit: defaultReadLimit,
+            ignoreSelfMessages: ignoreSelfMessages,
+            ignoreBotMessages: ignoreBotMessages
+        )
+    }
+
+    func canRead(chatId: String) -> Bool {
+        readableChatIds.contains(Self.normalizedChatId(chatId))
+    }
+
+    func readableRoomId(for chat: TelegramChat) -> String? {
+        let stableId = chat.stableId
+        if canRead(chatId: stableId) {
+            return stableId
+        }
+        if let username = chat.username?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !username.isEmpty {
+            let handle = Self.normalizedChatId("@\(username)")
+            if canRead(chatId: handle) {
+                return handle
+            }
+        }
+        return nil
+    }
+
+    func canWrite(chatId: String) -> Bool {
+        writeEnabled && writableChatIds.contains(Self.normalizedChatId(chatId))
+    }
+
+    var configuredChatIds: [String] {
+        Self.normalizedIds(readableChatIds + writableChatIds)
+    }
+
+    static func normalizedIds(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return
+            ids
+            .map(normalizedChatId)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    static func normalizedChatId(_ id: String) -> String {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("@") {
+            return trimmed.lowercased()
+        }
+        return trimmed
+    }
+
+    static func isValidChatId(_ id: String) -> Bool {
+        let trimmed = normalizedChatId(id)
+        guard !trimmed.isEmpty else { return false }
+        if trimmed.hasPrefix("@") {
+            let username = String(trimmed.dropFirst())
+            guard (5 ... 32).contains(username.count) else { return false }
+            return username.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "_") }
+        }
+        let digits = trimmed.hasPrefix("-") ? String(trimmed.dropFirst()) : trimmed
+        guard (1 ... 32).contains(digits.count) else { return false }
+        return digits.allSatisfy { $0.isASCII && $0.isNumber }
+    }
+
+    static func clampReadLimit(_ value: Int) -> Int {
+        min(max(value, 1), 100)
+    }
+}
+
+enum TelegramConnectionConfigurationStore {
+    nonisolated(unsafe) static var overrideDirectory: URL?
+
+    private static let fileName = "telegram.json"
+
+    static func load() -> TelegramConnectionConfiguration {
+        let url = configurationFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return TelegramConnectionConfiguration()
+        }
+        do {
+            return try JSONDecoder()
+                .decode(TelegramConnectionConfiguration.self, from: Data(contentsOf: url))
+                .normalized
+        } catch {
+            NSLog("[Telegram] Failed to load Telegram configuration: \(error.localizedDescription)")
+            return TelegramConnectionConfiguration()
+        }
+    }
+
+    static func save(_ configuration: TelegramConnectionConfiguration) throws {
+        let url = configurationFileURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(configuration.normalized).write(to: url, options: [.atomic])
+    }
+
+    static func configurationFileURL() -> URL {
+        if let overrideDirectory {
+            return overrideDirectory.appendingPathComponent(fileName)
+        }
+        return OsaurusPaths.config().appendingPathComponent(fileName)
+    }
+}
+
+enum TelegramCredentialStore {
+    static let pluginId = "osaurus.telegram"
+    static let botTokenKey = "bot_token"
+
+    @discardableResult
+    static func saveBotToken(_ token: String) -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return ToolSecretsKeychain.saveSecret(
+            trimmed,
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    static func botToken() -> String? {
+        ToolSecretsKeychain.getSecret(
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    static func hasBotToken() -> Bool {
+        ToolSecretsKeychain.hasSecret(
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    @discardableResult
+    static func deleteBotToken() -> Bool {
+        ToolSecretsKeychain.deleteSecret(
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+}
+
+protocol TelegramCredentialStorage: Sendable {
+    func saveBotToken(_ token: String) -> Bool
+    func botToken() -> String?
+    func hasBotToken() -> Bool
+    func deleteBotToken() -> Bool
+}
+
+struct KeychainTelegramCredentialStorage: TelegramCredentialStorage {
+    func saveBotToken(_ token: String) -> Bool {
+        TelegramCredentialStore.saveBotToken(token)
+    }
+
+    func botToken() -> String? {
+        TelegramCredentialStore.botToken()
+    }
+
+    func hasBotToken() -> Bool {
+        TelegramCredentialStore.hasBotToken()
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        TelegramCredentialStore.deleteBotToken()
+    }
+}
+
+enum TelegramSecurity {
+    static func redact(_ text: String, token: String?) -> String {
+        guard let token, token.count >= SecretScrubber.minimumValueLength else {
+            return text
+        }
+        return text.replacingOccurrences(of: token, with: "[REDACTED:TELEGRAM_BOT_TOKEN]")
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
@@ -28,7 +28,7 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
         case .emptyConnectionId:
             return "Agent channel connection id is required."
         case .reservedConnectionId(let id):
-            return "`\(id)` is reserved for the native Discord connection."
+            return "`\(id)` is reserved for a native Agent Channel connection."
         case .emptyName:
             return "Agent channel connection name is required."
         case .missingSupportedActions(let id):
@@ -60,7 +60,10 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
 final class AgentChannelConnectionManager: @unchecked Sendable {
     static let shared = AgentChannelConnectionManager()
 
-    private static let reservedConnectionIds = Set([AgentChannelConnection.nativeDiscordConnectionId])
+    private static let reservedConnectionIds = Set([
+        AgentChannelConnection.nativeDiscordConnectionId,
+        AgentChannelConnection.nativeTelegramConnectionId,
+    ])
     private static let supportedHTTPMethods = Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
 
     func configurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -31,24 +31,31 @@ enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
 }
 
 final class AgentChannelConnectionService: @unchecked Sendable {
-    static let shared = AgentChannelConnectionService(discordService: .shared)
+    static let shared = AgentChannelConnectionService(discordService: .shared, telegramService: .shared)
 
     private static let discordConnectionId = AgentChannelConnection.nativeDiscordConnectionId
+    private static let telegramConnectionId = AgentChannelConnection.nativeTelegramConnectionId
     private let discordService: DiscordConnectionService
+    private let telegramService: TelegramConnectionService
     private let customJSONRunner: any AgentChannelCustomJSONRunning
 
     init(
         discordService: DiscordConnectionService,
+        telegramService: TelegramConnectionService = .shared,
         customJSONRunner: any AgentChannelCustomJSONRunning = AgentChannelCustomJSONRunner()
     ) {
         self.discordService = discordService
+        self.telegramService = telegramService
         self.customJSONRunner = customJSONRunner
     }
 
     func listConnections() -> [[String: Any]] {
-        var rows = [discordConnectionDictionary()]
+        var rows = [discordConnectionDictionary(), telegramConnectionDictionary()]
         let customRows = AgentChannelConfigurationStore.load().connections
-            .filter { $0.id.lowercased() != Self.discordConnectionId }
+            .filter {
+                let id = $0.id.lowercased()
+                return id != Self.discordConnectionId && id != Self.telegramConnectionId
+            }
             .map(connectionDictionary)
         rows.append(contentsOf: customRows)
         return rows
@@ -67,6 +74,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 payload["message_store"] = discordService.messageStoreDiagnostics()
                 return payload
+            case .telegram:
+                var payload = await telegramService.diagnostics().dictionary
+                payload["connection_id"] = connection.id
+                payload["kind"] = connection.kind.rawValue
+                payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
+                payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
+                payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
+                payload["message_store"] = telegramService.messageStoreDiagnostics()
+                return payload
             case .customHTTP:
                 var payload = await customJSONRunner.diagnostics(connection: connection)
                 payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
@@ -74,7 +90,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 return payload
-            case .slack, .telegram:
+            case .slack:
                 return [
                     "connection_id": connection.id,
                     "kind": connection.kind.rawValue,
@@ -106,9 +122,19 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .telegram:
+            return telegramService.listSpaces().map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": row["kind"] ?? "messaging_network",
+                    "connection_id": connection.id,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listSpaces(connection: connection)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -129,9 +155,22 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .telegram:
+            return try await telegramService.listChats().map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": row["kind"] ?? "chat",
+                    "space_id": spaceId,
+                    "connection_id": connection.id,
+                    "read_allowed": row["read_allowed"] ?? false,
+                    "write_allowed": row["write_allowed"] ?? false,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listRooms(connection: connection, spaceId: spaceId)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -145,9 +184,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "channel_messages"
             return payload
+        case .telegram:
+            var payload = try telegramService.readChat(TelegramReadRequest(chatId: roomId, limit: limit))
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "chat_messages"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.readMessages(connection: connection, roomId: roomId, limit: limit)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -188,6 +233,17 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_ids"] = roomIds ?? []
             payload["standard_kind"] = "message_search"
             return payload
+        case .telegram:
+            var payload = try telegramService.searchMessages(
+                query: query,
+                chatIds: roomIds,
+                limitPerChat: limitPerRoom,
+                maxMatches: maxMatches
+            )
+            payload["connection_id"] = connection.id
+            payload["room_ids"] = roomIds ?? []
+            payload["standard_kind"] = "message_search"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.searchMessages(
                 connection: connection,
@@ -196,7 +252,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 limitPerRoom: limitPerRoom,
                 maxMatches: maxMatches
             )
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -210,9 +266,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_draft"
             return payload
+        case .telegram:
+            var payload = try telegramService.draftMessage(chatId: roomId, content: content)
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_draft"
+            return payload
         case .customHTTP:
             return try customJSONRunner.draftMessage(connection: connection, roomId: roomId, content: content)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -235,6 +297,19 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_sent"
             return payload
+        case .telegram:
+            var payload = try await telegramService.sendMessage(
+                TelegramWriteRequest(
+                    chatId: roomId,
+                    text: content,
+                    replyToMessageId: nil,
+                    confirmSend: confirmSend
+                )
+            )
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_sent"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.sendMessage(
                 connection: connection,
@@ -242,7 +317,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 content: content,
                 confirmSend: confirmSend
             )
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -420,6 +495,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         if resolvedId.lowercased() == Self.discordConnectionId {
             return discordConnection()
         }
+        if resolvedId.lowercased() == Self.telegramConnectionId {
+            return telegramConnection()
+        }
         guard let connection = AgentChannelConfigurationStore.load().connection(id: resolvedId) else {
             throw AgentChannelConnectionServiceError.connectionNotFound(resolvedId)
         }
@@ -464,6 +542,56 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         let writeRooms = row["write_room_allowlist"] as? [String] ?? []
         row["configured"] =
             discordService.hasBotToken()
+            && (!readRooms.isEmpty || !writeRooms.isEmpty)
+        return row
+    }
+
+    private func telegramConnection() -> AgentChannelConnection {
+        let config = telegramService.configuration()
+        return AgentChannelConnection(
+            id: Self.telegramConnectionId,
+            name: "Telegram",
+            kind: .telegram,
+            enabled: true,
+            supportedActions: [
+                .diagnostics,
+                .listSpaces,
+                .listRooms,
+                .readMessages,
+                .searchMessages,
+                .draftMessage,
+                .sendMessage,
+            ],
+            spaceAllowlist: ["telegram"],
+            readRoomAllowlist: config.readableChatIds,
+            writeRoomAllowlist: config.writableChatIds,
+            writeEnabled: config.writeEnabled,
+            defaultReadLimit: config.defaultReadLimit,
+            secrets: [
+                AgentChannelSecretReference(
+                    name: "bot_token",
+                    keychainId: TelegramCredentialStore.botTokenKey
+                )
+            ],
+            inboundAuthorization: AgentChannelInboundAuthorizationPolicy(
+                senderAllowlist: config.senderAllowlist,
+                roomAllowlist: config.readableChatIds,
+                allowUnscopedSpaces: false,
+                allowBotMessages: !config.ignoreBotMessages,
+                allowSelfMessages: !config.ignoreSelfMessages,
+                requireProviderEventId: true,
+                auditDecisionReason: "telegram_receive_authorization"
+            )
+        )
+    }
+
+    private func telegramConnectionDictionary() -> [String: Any] {
+        var row = connectionDictionary(telegramConnection())
+        row["credential_saved"] = telegramService.hasBotToken()
+        let readRooms = row["read_room_allowlist"] as? [String] ?? []
+        let writeRooms = row["write_room_allowlist"] as? [String] ?? []
+        row["configured"] =
+            telegramService.hasBotToken()
             && (!readRooms.isEmpty || !writeRooms.isEmpty)
         return row
     }
@@ -554,9 +682,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 }
                 return (.available, nil)
             }
-        case .slack, .telegram:
+        case .slack:
             return (.configuredOnly, "Provider adapter is configured, but execution is not implemented yet.")
-        case .discord:
+        case .discord, .telegram:
             switch action {
             case .diagnostics, .listSpaces:
                 return (.available, nil)

--- a/Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift
@@ -1,0 +1,338 @@
+//
+//  TelegramAPIClient.swift
+//  osaurus
+//
+//  Minimal Telegram Bot API client for the native agent channel.
+//
+
+import Foundation
+
+struct TelegramUser: Codable, Equatable, Sendable {
+    let id: Int64
+    let isBot: Bool
+    let firstName: String
+    let lastName: String?
+    let username: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case isBot = "is_bot"
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case username
+    }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return "@\(username)" }
+        if let lastName, !lastName.isEmpty { return "\(firstName) \(lastName)" }
+        return firstName
+    }
+}
+
+struct TelegramChat: Codable, Equatable, Sendable {
+    let id: Int64
+    let type: String
+    let title: String?
+    let username: String?
+    let firstName: String?
+    let lastName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case title
+        case username
+        case firstName = "first_name"
+        case lastName = "last_name"
+    }
+
+    var stableId: String { "\(id)" }
+
+    var displayName: String {
+        if let title, !title.isEmpty { return title }
+        if let username, !username.isEmpty { return "@\(username)" }
+        if let firstName, let lastName, !lastName.isEmpty { return "\(firstName) \(lastName)" }
+        if let firstName, !firstName.isEmpty { return firstName }
+        return stableId
+    }
+}
+
+struct TelegramMessageReference: Codable, Equatable, Sendable {
+    let messageId: Int
+
+    enum CodingKeys: String, CodingKey {
+        case messageId = "message_id"
+    }
+}
+
+struct TelegramMessage: Codable, Equatable, Sendable {
+    let messageId: Int
+    let date: Int
+    let chat: TelegramChat
+    let from: TelegramUser?
+    let senderChat: TelegramChat?
+    let text: String?
+    let caption: String?
+    let replyToMessage: TelegramMessageReference?
+
+    enum CodingKeys: String, CodingKey {
+        case messageId = "message_id"
+        case date
+        case chat
+        case from
+        case senderChat = "sender_chat"
+        case text
+        case caption
+        case replyToMessage = "reply_to_message"
+    }
+
+    var contentText: String {
+        text ?? caption ?? ""
+    }
+}
+
+struct TelegramUpdate: Codable, Equatable, Sendable {
+    let updateId: Int64
+    let message: TelegramMessage?
+    let editedMessage: TelegramMessage?
+    let channelPost: TelegramMessage?
+    let editedChannelPost: TelegramMessage?
+
+    enum CodingKeys: String, CodingKey {
+        case updateId = "update_id"
+        case message
+        case editedMessage = "edited_message"
+        case channelPost = "channel_post"
+        case editedChannelPost = "edited_channel_post"
+    }
+
+    var primaryMessage: TelegramMessage? {
+        message ?? editedMessage ?? channelPost ?? editedChannelPost
+    }
+}
+
+enum TelegramDeliveryStatus: String, Codable, Equatable, Sendable {
+    case accepted
+    case sent
+    case duplicate
+    case ignored
+    case unauthorized
+    case failed
+}
+
+struct TelegramReadRequest: Equatable, Sendable {
+    let chatId: String
+    let limit: Int?
+}
+
+struct TelegramWriteRequest: Equatable, Sendable {
+    let chatId: String
+    let text: String
+    let replyToMessageId: Int?
+    let confirmSend: Bool
+}
+
+struct TelegramNormalizedInboundEvent: Equatable, Sendable {
+    let providerEventId: String
+    let roomId: String
+    let providerMessageId: String
+    let content: String
+    let senderId: String?
+    let authorName: String?
+    let isBotMessage: Bool
+    let isSelfMessage: Bool
+    let providerTimestamp: String
+    let payloadJSON: String
+}
+
+struct TelegramReceiveResult: Equatable, Sendable {
+    let providerEventId: String
+    let roomId: String?
+    let providerMessageId: String?
+    let status: TelegramDeliveryStatus
+    let reason: String?
+}
+
+struct TelegramReceiveBatchResult: Equatable, Sendable {
+    let source: String
+    let received: Int
+    let stored: Int
+    let results: [TelegramReceiveResult]
+}
+
+enum TelegramAPIError: LocalizedError, Equatable, Sendable {
+    case invalidToken
+    case forbidden(String)
+    case notFound(String)
+    case rateLimited(String)
+    case invalidResponse(String)
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidToken:
+            return "Telegram rejected the bot token."
+        case .forbidden(let message),
+            .notFound(let message),
+            .rateLimited(let message),
+            .invalidResponse(let message),
+            .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+protocol TelegramAPIClientProtocol: Sendable {
+    func getMe(token: String) async throws -> TelegramUser
+    func getChat(chatId: String, token: String) async throws -> TelegramChat
+    func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate]
+    func sendMessage(
+        chatId: String,
+        text: String,
+        replyToMessageId: Int?,
+        token: String
+    ) async throws -> TelegramMessage
+}
+
+final class TelegramAPIClient: TelegramAPIClientProtocol, @unchecked Sendable {
+    private let baseURL: URL
+    private let sessionProvider: @Sendable () -> URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://api.telegram.org")!,
+        sessionProvider: @escaping @Sendable () -> URLSession = { GlobalProxySettings.sharedSession() }
+    ) {
+        self.baseURL = baseURL
+        self.sessionProvider = sessionProvider
+    }
+
+    func getMe(token: String) async throws -> TelegramUser {
+        try await post(method: "getMe", token: token, body: [:])
+    }
+
+    func getChat(chatId: String, token: String) async throws -> TelegramChat {
+        try await post(method: "getChat", token: token, body: ["chat_id": chatId])
+    }
+
+    func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate] {
+        var body: [String: Any] = [
+            "limit": min(max(limit, 1), 100),
+            "timeout": min(max(timeout, 0), 50),
+            "allowed_updates": ["message", "edited_message", "channel_post", "edited_channel_post"],
+        ]
+        if let offset {
+            body["offset"] = offset
+        }
+        return try await post(method: "getUpdates", token: token, body: body)
+    }
+
+    func sendMessage(
+        chatId: String,
+        text: String,
+        replyToMessageId: Int?,
+        token: String
+    ) async throws -> TelegramMessage {
+        var body: [String: Any] = [
+            "chat_id": chatId,
+            "text": text,
+            "disable_web_page_preview": true,
+        ]
+        if let replyToMessageId {
+            body["reply_to_message_id"] = replyToMessageId
+        }
+        return try await post(method: "sendMessage", token: token, body: body)
+    }
+
+    private func post<T: Decodable>(method: String, token: String, body: [String: Any]) async throws -> T {
+        var request = try makeRequest(method: method, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .osaurusCanonical)
+        return try await perform(request, token: token)
+    }
+
+    private func makeRequest(method: String, token: String) throws -> URLRequest {
+        guard !method.contains("/") else {
+            throw TelegramAPIError.invalidResponse("Telegram method name is invalid.")
+        }
+        let url = baseURL
+            .appendingPathComponent("bot\(token)")
+            .appendingPathComponent(method)
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Osaurus Telegram Native Agent Channel", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 30
+        return request
+    }
+
+    private func perform<T: Decodable>(_ request: URLRequest, token: String) async throws -> T {
+        do {
+            let (data, response) = try await sessionProvider().data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw TelegramAPIError.invalidResponse("Telegram returned a non-HTTP response.")
+            }
+            let envelope = try decodeEnvelope(T.self, from: data, token: token)
+            guard (200 ..< 300).contains(http.statusCode), envelope.ok, let result = envelope.result else {
+                throw mapHTTPError(status: http.statusCode, envelope: envelope, token: token)
+            }
+            return result
+        } catch let error as TelegramAPIError {
+            throw error
+        } catch {
+            throw TelegramAPIError.requestFailed(
+                TelegramSecurity.redact(error.localizedDescription, token: token)
+            )
+        }
+    }
+
+    private func decodeEnvelope<T: Decodable>(
+        _ type: T.Type,
+        from data: Data,
+        token: String
+    ) throws -> TelegramAPIEnvelope<T> {
+        do {
+            return try JSONDecoder().decode(TelegramAPIEnvelope<T>.self, from: data)
+        } catch {
+            throw TelegramAPIError.invalidResponse(
+                TelegramSecurity.redact("Telegram response could not be decoded.", token: token)
+            )
+        }
+    }
+
+    private func mapHTTPError<T>(
+        status: Int,
+        envelope: TelegramAPIEnvelope<T>,
+        token: String
+    ) -> TelegramAPIError {
+        let message = TelegramSecurity.redact(
+            envelope.description ?? "Telegram request failed with HTTP \(status).",
+            token: token
+        )
+        switch status {
+        case 401:
+            return .invalidToken
+        case 403:
+            return .forbidden(message)
+        case 404:
+            return .notFound(message)
+        case 429:
+            return .rateLimited(message)
+        default:
+            return .requestFailed(message)
+        }
+    }
+}
+
+private struct TelegramAPIEnvelope<Result: Decodable>: Decodable {
+    let ok: Bool
+    let result: Result?
+    let description: String?
+    let errorCode: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case result
+        case description
+        case errorCode = "error_code"
+    }
+}

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -1,0 +1,746 @@
+//
+//  TelegramConnectionService.swift
+//  osaurus
+//
+//  Policy, normalization, and diagnostics layer for the native Telegram channel.
+//
+
+import Foundation
+
+struct TelegramConnectionDiagnostics: Equatable, Sendable {
+    let tokenSaved: Bool
+    let bot: TelegramUser?
+    let readableChatIds: [String]
+    let writableChatIds: [String]
+    let senderAllowlist: [String]
+    let writeEnabled: Bool
+    let status: String
+    let failures: [String]
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "token_saved": tokenSaved,
+            "readable_chat_ids": readableChatIds,
+            "writable_chat_ids": writableChatIds,
+            "sender_allowlist": senderAllowlist,
+            "write_enabled": writeEnabled,
+            "status": status,
+            "failures": failures,
+        ]
+        if let bot {
+            result["bot"] = [
+                "id": "\(bot.id)",
+                "username": bot.username ?? "",
+                "display_name": bot.displayName,
+                "is_bot": bot.isBot,
+            ]
+        }
+        return result
+    }
+}
+
+enum TelegramConnectionServiceError: LocalizedError, Equatable, Sendable {
+    case notConfigured
+    case invalidChatId(String)
+    case chatNotReadable(String)
+    case chatNotWritable(String)
+    case writeDisabled
+    case sendConfirmationRequired
+    case messageTooLong
+    case emptyMessage
+    case configurationSaveFailed(String)
+    case messageStoreUnavailable
+    case invalidWebhookSecret
+    case api(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Telegram is not configured. Add a bot token in Settings and allowlist at least one chat."
+        case .invalidChatId(let chatId):
+            return "`\(chatId)` is not a valid Telegram chat id or @channel username."
+        case .chatNotReadable(let chatId):
+            return "Telegram chat `\(chatId)` is not allowlisted for read access."
+        case .chatNotWritable(let chatId):
+            return "Telegram chat `\(chatId)` is not allowlisted for write access."
+        case .writeDisabled:
+            return "Telegram write access is disabled in settings."
+        case .sendConfirmationRequired:
+            return "`confirm_send` must be true before Osaurus posts to Telegram."
+        case .messageTooLong:
+            return "Telegram messages must fit Telegram's 4096-character limit."
+        case .emptyMessage:
+            return "Telegram message content must not be empty."
+        case .configurationSaveFailed(let message):
+            return "Telegram configuration could not be saved: \(message)"
+        case .messageStoreUnavailable:
+            return "Telegram message store is unavailable."
+        case .invalidWebhookSecret:
+            return "Telegram webhook secret token did not match the configured value."
+        case .api(let message):
+            return message
+        }
+    }
+}
+
+enum TelegramUpdateNormalizer {
+    static let connectionId = "telegram"
+    static let maxInboundContentLength = 4096
+
+    static func normalize(
+        update: TelegramUpdate,
+        botId: Int64?,
+        configuration: TelegramConnectionConfiguration
+    ) -> TelegramReceiveResultOrEvent {
+        let providerEventId = "\(update.updateId)"
+        guard let message = update.primaryMessage else {
+            return .result(
+                TelegramReceiveResult(
+                    providerEventId: providerEventId,
+                    roomId: nil,
+                    providerMessageId: nil,
+                    status: .ignored,
+                    reason: "update_has_no_message"
+                )
+            )
+        }
+
+        let stableRoomId = message.chat.stableId
+        let providerMessageId = "\(message.messageId)"
+        let roomId = configuration.readableRoomId(for: message.chat) ?? stableRoomId
+        let senderId = message.from.map { "\($0.id)" } ?? message.senderChat.map { "\($0.id)" }
+        let content = message.contentText
+        guard !content.isEmpty else {
+            return .result(
+                TelegramReceiveResult(
+                    providerEventId: providerEventId,
+                    roomId: stableRoomId,
+                    providerMessageId: providerMessageId,
+                    status: .ignored,
+                    reason: "empty_message_content"
+                )
+            )
+        }
+        guard content.utf16.count <= Self.maxInboundContentLength else {
+            return .result(
+                TelegramReceiveResult(
+                    providerEventId: providerEventId,
+                    roomId: roomId,
+                    providerMessageId: providerMessageId,
+                    status: .ignored,
+                    reason: "message_too_long"
+                )
+            )
+        }
+
+        return .event(
+            TelegramNormalizedInboundEvent(
+                providerEventId: providerEventId,
+                roomId: roomId,
+                providerMessageId: providerMessageId,
+                content: content,
+                senderId: senderId,
+                authorName: message.from?.displayName ?? message.senderChat?.displayName,
+                isBotMessage: message.from?.isBot == true,
+                isSelfMessage: botId != nil && message.from?.id == botId,
+                providerTimestamp: Self.iso8601Timestamp(fromTelegramDate: message.date),
+                payloadJSON: encodedPayload(update)
+            )
+        )
+    }
+
+    static func storedMessage(_ event: TelegramNormalizedInboundEvent) -> AgentChannelStoredMessage {
+        AgentChannelStoredMessage(
+            connectionId: connectionId,
+            roomId: event.roomId,
+            providerMessageId: event.providerMessageId,
+            direction: .inbound,
+            authorId: event.senderId,
+            authorName: event.authorName,
+            content: event.content,
+            payloadJSON: event.payloadJSON,
+            providerTimestamp: event.providerTimestamp
+        )
+    }
+
+    private static func encodedPayload(_ update: TelegramUpdate) -> String {
+        guard let data = try? JSONEncoder().encode(update),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func iso8601Timestamp(fromTelegramDate date: Int) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(date)))
+    }
+}
+
+enum TelegramReceiveResultOrEvent: Equatable, Sendable {
+    case result(TelegramReceiveResult)
+    case event(TelegramNormalizedInboundEvent)
+}
+
+private enum TelegramReceivePendingResult {
+    case result(TelegramReceiveResult)
+    case event(TelegramNormalizedInboundEvent)
+}
+
+final class TelegramConnectionService: @unchecked Sendable {
+    static let shared = TelegramConnectionService(
+        client: TelegramAPIClient(),
+        credentialStore: KeychainTelegramCredentialStorage(),
+        messageStore: AgentChannelMessageStore.shared
+    )
+
+    private static let connectionId = TelegramUpdateNormalizer.connectionId
+    private static let updatesCursorRoomId = "__telegram_updates__"
+
+    private let client: TelegramAPIClientProtocol
+    private let credentialStore: any TelegramCredentialStorage
+    private let messageStore: AgentChannelMessageStore?
+    private let recordMessageSnapshotsInline: Bool
+    private let botIdentityLock = NSLock()
+    private var cachedBotId: Int64?
+
+    init(
+        client: TelegramAPIClientProtocol,
+        credentialStore: any TelegramCredentialStorage = KeychainTelegramCredentialStorage(),
+        messageStore: AgentChannelMessageStore? = nil,
+        recordMessageSnapshotsInline: Bool = false
+    ) {
+        self.client = client
+        self.credentialStore = credentialStore
+        self.messageStore = messageStore
+        self.recordMessageSnapshotsInline = recordMessageSnapshotsInline
+    }
+
+    func configuration() -> TelegramConnectionConfiguration {
+        TelegramConnectionConfigurationStore.load()
+    }
+
+    func saveConfiguration(_ configuration: TelegramConnectionConfiguration) throws {
+        do {
+            try TelegramConnectionConfigurationStore.save(configuration)
+        } catch {
+            throw TelegramConnectionServiceError.configurationSaveFailed(error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    func saveBotToken(_ token: String) throws -> Bool {
+        clearCachedBotIdentity()
+        let saved = credentialStore.saveBotToken(token)
+        if !saved {
+            throw TelegramConnectionServiceError.configurationSaveFailed(
+                "The token was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        clearCachedBotIdentity()
+        return credentialStore.deleteBotToken()
+    }
+
+    func hasBotToken() -> Bool {
+        credentialStore.hasBotToken()
+    }
+
+    func diagnostics() async -> TelegramConnectionDiagnostics {
+        let config = configuration()
+        guard let token = credentialStore.botToken() else {
+            return TelegramConnectionDiagnostics(
+                tokenSaved: false,
+                bot: nil,
+                readableChatIds: config.readableChatIds,
+                writableChatIds: config.writableChatIds,
+                senderAllowlist: config.senderAllowlist,
+                writeEnabled: config.writeEnabled,
+                status: "not_configured",
+                failures: ["No Telegram bot token is saved."]
+            )
+        }
+
+        var failures: [String] = []
+        let bot: TelegramUser?
+        do {
+            bot = try await client.getMe(token: token)
+        } catch {
+            bot = nil
+            failures.append(redacted(error, token: token))
+        }
+
+        let status: String
+        if bot == nil {
+            status = "token_invalid_or_unavailable"
+        } else if config.readableChatIds.isEmpty {
+            status = "connected_needs_allowlist"
+        } else if config.writeEnabled && config.writableChatIds.isEmpty {
+            status = "connected_read_only_write_needs_chats"
+        } else if config.writeEnabled {
+            status = "connected_read_write"
+        } else {
+            status = "connected_read_only"
+        }
+
+        return TelegramConnectionDiagnostics(
+            tokenSaved: true,
+            bot: bot,
+            readableChatIds: config.readableChatIds,
+            writableChatIds: config.writableChatIds,
+            senderAllowlist: config.senderAllowlist,
+            writeEnabled: config.writeEnabled,
+            status: status,
+            failures: failures
+        )
+    }
+
+    func messageStoreDiagnostics() -> [String: Any] {
+        [
+            "enabled": messageStore != nil,
+            "open": messageStore?.isOpen ?? false,
+            "database_path": OsaurusPaths.agentChannelMessagesDatabaseFile().path,
+            "message_dedupe": "connection_id + room_id + provider_message_id",
+            "event_dedupe": "connection_id + provider_event_id",
+            "cursor": "telegram getUpdates offset stored in channel_receive_cursors",
+        ]
+    }
+
+    func listSpaces() -> [[String: Any]] {
+        [
+            [
+                "id": "telegram",
+                "name": "Telegram",
+                "kind": "messaging_network",
+            ]
+        ]
+    }
+
+    func listChats() async throws -> [[String: Any]] {
+        let config = configuration()
+        let token = credentialStore.botToken()
+        var rows: [[String: Any]] = []
+        for chatId in config.configuredChatIds {
+            var row: [String: Any] = [
+                "id": chatId,
+                "name": chatId,
+                "kind": "chat",
+                "read_allowed": config.canRead(chatId: chatId),
+                "write_allowed": config.canWrite(chatId: chatId),
+            ]
+            if let token {
+                do {
+                    let chat = try await client.getChat(chatId: chatId, token: token)
+                    row["provider_chat_id"] = chat.stableId
+                    row["name"] = chat.displayName
+                    row["type"] = chat.type
+                    row["username"] = chat.username ?? ""
+                } catch {
+                    row["error"] = redacted(error, token: token)
+                }
+            }
+            rows.append(row)
+        }
+        return rows
+    }
+
+    func readChat(_ request: TelegramReadRequest) throws -> [String: Any] {
+        let config = configuration()
+        let chatId = try requireReadableChat(request.chatId, config: config)
+        let safeLimit = TelegramConnectionConfiguration.clampReadLimit(request.limit ?? config.defaultReadLimit)
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+        let rows = try messageStore.recentMessages(
+            connectionId: Self.connectionId,
+            roomId: chatId,
+            limit: safeLimit
+        )
+        return [
+            "kind": "telegram_stored_messages",
+            "chat_id": chatId,
+            "limit": safeLimit,
+            "partial": true,
+            "messages": rows.map(Self.storedMessageDictionary),
+        ]
+    }
+
+    func searchMessages(
+        query: String,
+        chatIds: [String]?,
+        limitPerChat: Int?,
+        maxMatches: Int?
+    ) throws -> [String: Any] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else {
+            throw TelegramConnectionServiceError.emptyMessage
+        }
+        let config = configuration()
+        let candidateChats = TelegramConnectionConfiguration.normalizedIds(chatIds ?? config.readableChatIds)
+        let allowedChats = candidateChats.filter { config.canRead(chatId: $0) }
+        guard !allowedChats.isEmpty else {
+            throw TelegramConnectionServiceError.chatNotReadable(candidateChats.first ?? "")
+        }
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+
+        let safeLimit = TelegramConnectionConfiguration.clampReadLimit(limitPerChat ?? config.defaultReadLimit)
+        let safeMaxMatches = min(max(maxMatches ?? 25, 1), 50)
+        let needle = trimmedQuery.lowercased()
+        var matches: [[String: Any]] = []
+
+        for chatId in allowedChats {
+            let rows = try messageStore.recentMessages(
+                connectionId: Self.connectionId,
+                roomId: chatId,
+                limit: safeLimit
+            )
+            for row in rows {
+                let haystack = "\(row.content) \(row.authorName ?? "") \(row.authorId ?? "")".lowercased()
+                guard haystack.contains(needle) else { continue }
+                matches.append(Self.storedMessageDictionary(row))
+                if matches.count >= safeMaxMatches { break }
+            }
+            if matches.count >= safeMaxMatches { break }
+        }
+
+        return [
+            "kind": "telegram_stored_message_search",
+            "query": trimmedQuery,
+            "searched_chat_ids": allowedChats,
+            "limit_per_chat": safeLimit,
+            "max_matches": safeMaxMatches,
+            "match_count": matches.count,
+            "partial": true,
+            "messages": matches,
+        ]
+    }
+
+    func draftMessage(chatId: String, content: String) throws -> [String: Any] {
+        let config = configuration()
+        let normalizedChatId = try requireWritableChat(chatId, config: config)
+        let trimmedContent = try validateMessageContent(content)
+        return [
+            "kind": "telegram_message_draft",
+            "chat_id": normalizedChatId,
+            "content": trimmedContent,
+            "requires_send_confirmation": true,
+        ]
+    }
+
+    func sendMessage(_ request: TelegramWriteRequest) async throws -> [String: Any] {
+        guard request.confirmSend else {
+            throw TelegramConnectionServiceError.sendConfirmationRequired
+        }
+        let token = try requireToken()
+        let config = configuration()
+        let chatId = try requireWritableChat(request.chatId, config: config)
+        let text = try validateMessageContent(request.text)
+        let message = try await client.sendMessage(
+            chatId: chatId,
+            text: text,
+            replyToMessageId: request.replyToMessageId,
+            token: token
+        )
+        recordMessages([Self.storedMessage(message, roomId: chatId, direction: .outbound)])
+        return [
+            "kind": "telegram_message_sent",
+            "chat_id": chatId,
+            "delivery_status": TelegramDeliveryStatus.sent.rawValue,
+            "message": Self.messageDictionary(message),
+        ]
+    }
+
+    func processWebhookPayload(
+        _ data: Data,
+        secretTokenHeader: String? = nil,
+        expectedSecretToken: String? = nil
+    ) async throws -> TelegramReceiveBatchResult {
+        if let expectedSecretToken, secretTokenHeader != expectedSecretToken {
+            throw TelegramConnectionServiceError.invalidWebhookSecret
+        }
+        let update = try JSONDecoder().decode(TelegramUpdate.self, from: data)
+        return try await processUpdates([update], source: "webhook")
+    }
+
+    func pollUpdates(limit: Int = 100, timeout: Int = 0) async throws -> TelegramReceiveBatchResult {
+        let token = try requireToken()
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+        let cursor = try messageStore.cursor(
+            connectionId: Self.connectionId,
+            roomId: Self.updatesCursorRoomId
+        )
+        let offset = cursor.flatMap(Int64.init)
+        let updates = try await client.getUpdates(
+            offset: offset,
+            limit: min(max(limit, 1), 100),
+            timeout: min(max(timeout, 0), 50),
+            token: token
+        )
+        return try await processUpdates(updates, source: "long_poll")
+    }
+
+    func processUpdates(_ updates: [TelegramUpdate], source: String) async throws -> TelegramReceiveBatchResult {
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+
+        let config = configuration()
+        let botId = await currentBotIdForNormalization()
+        var pending: [TelegramReceivePendingResult] = []
+        var maxUpdateId: Int64?
+
+        for update in updates {
+            maxUpdateId = max(maxUpdateId ?? update.updateId, update.updateId)
+            switch TelegramUpdateNormalizer.normalize(update: update, botId: botId, configuration: config) {
+            case .result(let result):
+                pending.append(.result(result))
+            case .event(let event):
+                pending.append(.event(event))
+            }
+        }
+
+        var inserted = 0
+        var results: [TelegramReceiveResult] = []
+        let authorizationService = AgentChannelConnectionService(
+            discordService: .shared,
+            telegramService: self
+        )
+        for item in pending {
+            switch item {
+            case .result(let result):
+                results.append(result)
+            case .event(let event):
+                let authorization = try authorizationService.authorizeInboundMessage(
+                    AgentChannelInboundMessageAuthorizationRequest(
+                        connectionId: Self.connectionId,
+                        providerEventId: event.providerEventId,
+                        providerMessageId: event.providerMessageId,
+                        spaceId: "telegram",
+                        roomId: event.roomId,
+                        senderId: event.senderId,
+                        isBotMessage: event.isBotMessage,
+                        isSelfMessage: event.isSelfMessage
+                    ),
+                    messageStore: messageStore
+                )
+                let receive = try messageStore.recordReceiveEvent(
+                    connectionId: Self.connectionId,
+                    providerEventId: event.providerEventId,
+                    authorization: authorization,
+                    message: TelegramUpdateNormalizer.storedMessage(event)
+                )
+                if receive.messageInserted { inserted += 1 }
+                results.append(
+                    TelegramReceiveResult(
+                        providerEventId: event.providerEventId,
+                        roomId: event.roomId,
+                        providerMessageId: event.providerMessageId,
+                        status: Self.deliveryStatus(for: receive),
+                        reason: receive.disposition == .accepted ? nil : receive.authorizationReason
+                    )
+                )
+            }
+        }
+        if source == "long_poll", let maxUpdateId {
+            try messageStore.upsertCursor(
+                connectionId: Self.connectionId,
+                roomId: Self.updatesCursorRoomId,
+                cursor: "\(maxUpdateId + 1)"
+            )
+        }
+
+        return TelegramReceiveBatchResult(
+            source: source,
+            received: updates.count,
+            stored: inserted,
+            results: results
+        )
+    }
+
+    private func currentBotIdForNormalization() async -> Int64? {
+        if let cached = botIdentityLock.withLock({ cachedBotId }) {
+            return cached
+        }
+        guard let token = credentialStore.botToken() else { return nil }
+        do {
+            let botId = try await client.getMe(token: token).id
+            botIdentityLock.withLock { cachedBotId = botId }
+            return botId
+        } catch {
+            return botIdentityLock.withLock { cachedBotId }
+        }
+    }
+
+    private func clearCachedBotIdentity() {
+        botIdentityLock.withLock { cachedBotId = nil }
+    }
+
+    private func requireToken() throws -> String {
+        guard let token = credentialStore.botToken() else {
+            throw TelegramConnectionServiceError.notConfigured
+        }
+        return token
+    }
+
+    private func requireChatId(_ chatId: String) throws -> String {
+        let normalized = TelegramConnectionConfiguration.normalizedChatId(chatId)
+        guard TelegramConnectionConfiguration.isValidChatId(normalized) else {
+            throw TelegramConnectionServiceError.invalidChatId(chatId)
+        }
+        return normalized
+    }
+
+    private func requireReadableChat(
+        _ chatId: String,
+        config: TelegramConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireChatId(chatId)
+        guard config.canRead(chatId: normalized) else {
+            throw TelegramConnectionServiceError.chatNotReadable(normalized)
+        }
+        return normalized
+    }
+
+    private func requireWritableChat(
+        _ chatId: String,
+        config: TelegramConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireChatId(chatId)
+        guard config.writeEnabled else {
+            throw TelegramConnectionServiceError.writeDisabled
+        }
+        guard config.canWrite(chatId: normalized) else {
+            throw TelegramConnectionServiceError.chatNotWritable(normalized)
+        }
+        return normalized
+    }
+
+    private func validateMessageContent(_ content: String) throws -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw TelegramConnectionServiceError.emptyMessage
+        }
+        guard trimmed.utf16.count <= TelegramUpdateNormalizer.maxInboundContentLength else {
+            throw TelegramConnectionServiceError.messageTooLong
+        }
+        return trimmed
+    }
+
+    private static func deliveryStatus(for receive: AgentChannelReceiveResult) -> TelegramDeliveryStatus {
+        switch receive.disposition {
+        case .accepted:
+            return .accepted
+        case .duplicate:
+            return .duplicate
+        case .denied:
+            switch receive.authorizationReason {
+            case "self_message_denied", "bot_message_denied":
+                return .ignored
+            default:
+                return .unauthorized
+            }
+        }
+    }
+
+    private func redacted(_ error: Error, token: String) -> String {
+        TelegramSecurity.redact(error.localizedDescription, token: token)
+    }
+
+    private func recordMessages(_ messages: [AgentChannelStoredMessage]) {
+        guard let messageStore, !messages.isEmpty else { return }
+        if recordMessageSnapshotsInline {
+            Self.persistMessages(messages, messageStore: messageStore)
+        } else {
+            Task.detached(priority: .utility) {
+                Self.persistMessages(messages, messageStore: messageStore)
+            }
+        }
+    }
+
+    private static func persistMessages(
+        _ rows: [AgentChannelStoredMessage],
+        messageStore: AgentChannelMessageStore
+    ) {
+        do {
+            try messageStore.openIfNeeded()
+            _ = try messageStore.recordMessages(rows)
+        } catch {
+            NSLog("[Telegram] Failed to record Agent Channel messages: \(error.localizedDescription)")
+        }
+    }
+
+    private static func storedMessage(
+        _ message: TelegramMessage,
+        roomId: String? = nil,
+        direction: AgentChannelStoredMessageDirection
+    ) -> AgentChannelStoredMessage {
+        AgentChannelStoredMessage(
+            connectionId: connectionId,
+            roomId: roomId ?? message.chat.stableId,
+            providerMessageId: "\(message.messageId)",
+            direction: direction,
+            threadId: message.replyToMessage.map { "\($0.messageId)" },
+            authorId: message.from.map { "\($0.id)" } ?? message.senderChat.map { "\($0.id)" },
+            authorName: message.from?.displayName ?? message.senderChat?.displayName,
+            content: message.contentText,
+            payloadJSON: encodedPayload(message),
+            providerTimestamp: TelegramUpdateNormalizer.iso8601TimestampForService(message.date)
+        )
+    }
+
+    private static func encodedPayload(_ message: TelegramMessage) -> String {
+        guard let data = try? JSONEncoder().encode(message),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func storedMessageDictionary(_ message: AgentChannelStoredMessage) -> [String: Any] {
+        [
+            "id": message.providerMessageId,
+            "chat_id": message.roomId,
+            "content": message.content,
+            "timestamp": message.providerTimestamp ?? "",
+            "author": [
+                "id": message.authorId ?? "",
+                "display_name": message.authorName ?? "",
+            ],
+            "direction": message.direction.rawValue,
+            "raw": message.payloadJSON,
+        ]
+    }
+
+    private static func messageDictionary(_ message: TelegramMessage) -> [String: Any] {
+        [
+            "id": "\(message.messageId)",
+            "chat_id": message.chat.stableId,
+            "content": message.contentText,
+            "timestamp": TelegramUpdateNormalizer.iso8601TimestampForService(message.date),
+            "author": [
+                "id": message.from.map { "\($0.id)" } ?? "",
+                "display_name": message.from?.displayName ?? "",
+                "is_bot": message.from?.isBot ?? false,
+            ],
+        ]
+    }
+}
+
+private extension TelegramUpdateNormalizer {
+    static func iso8601TimestampForService(_ date: Int) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(date)))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
@@ -1,0 +1,920 @@
+//
+//  TelegramConnectionTests.swift
+//  osaurusTests
+//
+//  Fixture coverage for the native Telegram agent channel.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct TelegramConnectionTests {
+
+    @Test func configurationPersistsAllowlistsButNeverBotToken() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let token = "123456:telegram-bot-token-super-secret"
+            try TelegramConnectionService(client: FakeTelegramAPIClient(), credentialStore: credentials)
+                .saveBotToken(token)
+            try TelegramConnectionService(client: FakeTelegramAPIClient(), credentialStore: credentials)
+                .saveConfiguration(
+                    TelegramConnectionConfiguration(
+                        readableChatIds: [" -100111222333 ", "-100111222333", "@Ops_Channel"],
+                        writableChatIds: ["-100444555666"],
+                        senderAllowlist: [" 7 ", "7"],
+                        writeEnabled: true,
+                        defaultReadLimit: 250
+                    )
+                )
+
+            let saved = TelegramConnectionConfigurationStore.load()
+            #expect(saved.readableChatIds == ["-100111222333", "@ops_channel"])
+            #expect(saved.senderAllowlist == ["7"])
+            #expect(saved.defaultReadLimit == 100)
+            #expect(!TelegramConnectionConfiguration.isValidChatId("١٢٣٤"))
+
+            let disk = try String(
+                contentsOf: TelegramConnectionConfigurationStore.configurationFileURL(),
+                encoding: .utf8
+            )
+            #expect(disk.contains("-100111222333"))
+            #expect(!disk.contains(token))
+            #expect(!disk.localizedCaseInsensitiveContains("bot_token"))
+        }
+    }
+
+    @Test func connectionManagerRejectsNativeTelegramId() async throws {
+        try await withIsolatedTelegramStores { _ in
+            let manager = AgentChannelConnectionManager()
+
+            #expect(throws: AgentChannelConnectionManagerError.reservedConnectionId("telegram")) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "telegram",
+                        name: "Shadow Telegram",
+                        kind: .customHTTP,
+                        supportedActions: [.diagnostics],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [:]
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test func apiClientRedactsTokenEchoedByTelegramErrorBody() async throws {
+        let token = "123456:telegram-bot-token-super-secret"
+        let session = TelegramHTTPStubProtocol.session(
+            statusCode: 403,
+            body: #"{"ok":false,"error_code":403,"description":"Telegram echoed \#(token)"}"#
+        )
+        let client = TelegramAPIClient(
+            baseURL: URL(string: "https://telegram.test")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.getChat(chatId: "-100111222333", token: token)
+            Issue.record("Telegram request should have failed")
+        } catch let error as TelegramAPIError {
+            #expect(error.localizedDescription.contains("[REDACTED:TELEGRAM_BOT_TOKEN]"))
+            #expect(!error.localizedDescription.contains(token))
+        }
+    }
+
+    @Test func apiClientSendsPlainTextWithoutParseMode() async throws {
+        let token = "123456:telegram-bot-token-super-secret"
+        let session = TelegramHTTPStubProtocol.session(
+            statusCode: 200,
+            body: """
+                {
+                  "ok": true,
+                  "result": {
+                    "message_id": 77,
+                    "date": 1782427200,
+                    "chat": { "id": -100111222333, "type": "group", "title": "Ops" },
+                    "from": { "id": 42, "is_bot": true, "first_name": "Osaurus", "username": "osaurus_bot" },
+                    "text": "Hello <b>ops</b>"
+                  }
+                }
+                """
+        )
+        let client = TelegramAPIClient(
+            baseURL: URL(string: "https://telegram.test")!,
+            sessionProvider: { session }
+        )
+
+        _ = try await client.sendMessage(
+            chatId: "-100111222333",
+            text: "Hello <b>ops</b>",
+            replyToMessageId: 12,
+            token: token
+        )
+
+        let body = try #require(TelegramHTTPStubProtocol.lastRequestJSONBody())
+        #expect(body["chat_id"] as? String == "-100111222333")
+        #expect(body["text"] as? String == "Hello <b>ops</b>")
+        #expect(body["reply_to_message_id"] as? Int == 12)
+        #expect(body["parse_mode"] == nil)
+    }
+
+    @Test func webhookPayloadNormalizesStoresAndDeduplicatesUpdates() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let data = Data(Self.updateJSON(updateId: 9001, messageId: 501, text: "deploy finished").utf8)
+            let first = try await service.processWebhookPayload(
+                data,
+                secretTokenHeader: "hook-secret",
+                expectedSecretToken: "hook-secret"
+            )
+            await #expect(throws: TelegramConnectionServiceError.invalidWebhookSecret) {
+                _ = try await service.processWebhookPayload(
+                    data,
+                    secretTokenHeader: "wrong-secret",
+                    expectedSecretToken: "hook-secret"
+                )
+            }
+            let duplicate = try await service.processWebhookPayload(data)
+
+            #expect(first.source == "webhook")
+            #expect(first.stored == 1)
+            #expect(first.results.first?.status == .accepted)
+            #expect(duplicate.stored == 0)
+            #expect(duplicate.results.first?.status == .duplicate)
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 1)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == nil)
+        }
+    }
+
+    @Test func longPollUsesStoredOffsetAndUpdatesCursor() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+            try store.upsertCursor(
+                connectionId: "telegram",
+                roomId: "__telegram_updates__",
+                cursor: "42"
+            )
+
+            let fake = FakeTelegramAPIClient()
+            await fake.setUpdates([
+                .fixture(updateId: 42, messageId: 10, chatId: -100111222333, text: "from poll")
+            ])
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let result = try await service.pollUpdates(limit: 10, timeout: 0)
+
+            #expect(result.source == "long_poll")
+            #expect(result.stored == 1)
+            #expect(await fake.lastUpdateOffset() == 42)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == "43")
+        }
+    }
+
+    @Test func normalizationSkipsUnauthorizedSelfAndBotMessages() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let result = try await service.processUpdates(
+                [
+                    .fixture(updateId: 1, messageId: 1, chatId: -100999888777, text: "blocked"),
+                    .fixture(
+                        updateId: 2,
+                        messageId: 2,
+                        chatId: -100111222333,
+                        text: "self",
+                        from: .fixture(id: 42, isBot: true)
+                    ),
+                    .fixture(
+                        updateId: 3,
+                        messageId: 3,
+                        chatId: -100111222333,
+                        text: "another bot",
+                        from: .fixture(id: 99, isBot: true)
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.map(\.status) == [.unauthorized, .ignored, .ignored])
+            #expect(result.results.map(\.reason) == [
+                "room_not_allowlisted",
+                "self_message_denied",
+                "bot_message_denied",
+            ])
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+        }
+    }
+
+    @Test func inboundReceiveRequiresSenderAllowlistBeforeStorage() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["99"])
+            )
+
+            let result = try await service.processUpdates(
+                [.fixture(updateId: 9, messageId: 9, chatId: -100111222333, text: "do the thing")],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.first?.status == .unauthorized)
+            #expect(result.results.first?.reason == "sender_not_allowlisted")
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "9") == false)
+        }
+    }
+
+    @Test func inboundReceiveDeniesWhenSenderAllowlistIsEmpty() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"])
+            )
+
+            let result = try await service.processUpdates(
+                [.fixture(updateId: 10, messageId: 10, chatId: -100111222333, text: "no sender policy")],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.first?.status == .unauthorized)
+            #expect(result.results.first?.reason == "sender_not_allowlisted")
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "10") == false)
+        }
+    }
+
+    @Test func cachedBotIdentityPreservesSelfDenialWhenGetMeFails() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7", "42"]
+                )
+            )
+
+            let warm = try await service.processUpdates(
+                [.fixture(updateId: 21, messageId: 21, chatId: -100111222333, text: "warm cache")],
+                source: "fixture"
+            )
+            await fake.failNextGetMe()
+            let selfMessage = try await service.processUpdates(
+                [
+                    .fixture(
+                        updateId: 22,
+                        messageId: 22,
+                        chatId: -100111222333,
+                        text: "self echo",
+                        from: .fixture(id: 42, isBot: false)
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(warm.stored == 1)
+            #expect(selfMessage.stored == 0)
+            #expect(selfMessage.results.first?.status == .ignored)
+            #expect(selfMessage.results.first?.reason == "self_message_denied")
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 1)
+        }
+    }
+
+    @Test func inboundReceiveDropsEmptyAndOversizedContentBeforeStorage() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let twoCodeUnitScalar = String(UnicodeScalar(0x1F600)!)
+            let result = try await service.processUpdates(
+                [
+                    .fixture(updateId: 31, messageId: 31, chatId: -100111222333, text: ""),
+                    .fixture(
+                        updateId: 32,
+                        messageId: 32,
+                        chatId: -100111222333,
+                        text: String(repeating: "x", count: 4097)
+                    ),
+                    .fixture(
+                        updateId: 33,
+                        messageId: 33,
+                        chatId: -100111222333,
+                        text: String(repeating: twoCodeUnitScalar, count: 2049)
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.map(\.status) == [.ignored, .ignored, .ignored])
+            #expect(result.results.map(\.reason) == [
+                "empty_message_content",
+                "message_too_long",
+                "message_too_long",
+            ])
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "31") == false)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "32") == false)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "33") == false)
+        }
+    }
+
+    @Test func readAndSearchUseSQLiteBackedTelegramMessages() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+            _ = try await service.processUpdates(
+                [
+                    .fixture(updateId: 10, messageId: 1, chatId: -100111222333, text: "eval reports landed"),
+                    .fixture(updateId: 11, messageId: 2, chatId: -100111222333, text: "ordinary update"),
+                ],
+                source: "fixture"
+            )
+
+            let read = try service.readChat(TelegramReadRequest(chatId: "-100111222333", limit: 5))
+            let messages = try #require(read["messages"] as? [[String: Any]])
+            #expect(messages.count == 2)
+
+            let search = try service.searchMessages(
+                query: "eval",
+                chatIds: ["-100111222333"],
+                limitPerChat: 10,
+                maxMatches: 10
+            )
+            #expect(search["match_count"] as? Int == 1)
+        }
+    }
+
+    @Test func usernameAllowlistStoresAndReadsByConfiguredHandle() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["@Ops_Channel"],
+                    writableChatIds: ["@Ops_Channel"],
+                    senderAllowlist: ["7"],
+                    writeEnabled: true
+                )
+            )
+            _ = try await service.processUpdates(
+                [
+                    .fixture(
+                        updateId: 20,
+                        messageId: 3,
+                        chatId: -100111222333,
+                        text: "eval report ready",
+                        chatUsername: "Ops_Channel"
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "@ops_channel") == 1)
+
+            let listed = try await service.listChats()
+            let room = try #require(listed.first)
+            #expect(room["id"] as? String == "@ops_channel")
+            #expect(room["provider_chat_id"] as? String == "-100111222333")
+            _ = try await service.sendMessage(
+                TelegramWriteRequest(
+                    chatId: "@OPS_CHANNEL",
+                    text: "ack",
+                    replyToMessageId: nil,
+                    confirmSend: true
+                )
+            )
+
+            let read = try service.readChat(TelegramReadRequest(chatId: "@OPS_CHANNEL", limit: 5))
+            let messages = try #require(read["messages"] as? [[String: Any]])
+            #expect(messages.count == 2)
+            #expect(messages.contains { $0["direction"] as? String == "outbound" })
+
+            let search = try service.searchMessages(
+                query: "eval",
+                chatIds: ["@OPS_CHANNEL"],
+                limitPerChat: 10,
+                maxMatches: 10
+            )
+            #expect(search["match_count"] as? Int == 1)
+        }
+    }
+
+    @Test func sendMessageRequiresConfirmationMapsStatusAndRecordsOutbound() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    writableChatIds: ["-100111222333"],
+                    writeEnabled: true
+                )
+            )
+
+            await #expect(throws: TelegramConnectionServiceError.sendConfirmationRequired) {
+                _ = try await service.sendMessage(
+                    TelegramWriteRequest(
+                        chatId: "-100111222333",
+                        text: "ship it",
+                        replyToMessageId: nil,
+                        confirmSend: false
+                    )
+                )
+            }
+            await #expect(throws: TelegramConnectionServiceError.messageTooLong) {
+                let twoCodeUnitScalar = String(UnicodeScalar(0x1F600)!)
+                _ = try await service.sendMessage(
+                    TelegramWriteRequest(
+                        chatId: "-100111222333",
+                        text: String(repeating: twoCodeUnitScalar, count: 2049),
+                        replyToMessageId: nil,
+                        confirmSend: true
+                    )
+                )
+            }
+
+            let sent = try await service.sendMessage(
+                TelegramWriteRequest(
+                    chatId: "-100111222333",
+                    text: "ship it",
+                    replyToMessageId: 99,
+                    confirmSend: true
+                )
+            )
+
+            #expect(sent["delivery_status"] as? String == TelegramDeliveryStatus.sent.rawValue)
+            #expect(await fake.lastSentText() == "ship it")
+            #expect(await fake.lastReplyToMessageId() == 99)
+            let row = try #require(
+                try store.recentMessages(
+                    connectionId: "telegram",
+                    roomId: "-100111222333",
+                    limit: 1
+                ).first
+            )
+            #expect(row.direction == .outbound)
+            #expect(row.content == "ship it")
+            #expect(!row.payloadJSON.localizedCaseInsensitiveContains("telegram-bot-token-super-secret"))
+        }
+    }
+
+    @Test func standardAgentChannelServiceRoutesTelegramConnection() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let telegram = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try telegram.saveBotToken("123456:telegram-bot-token-super-secret")
+            try telegram.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    writableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    writeEnabled: true
+                )
+            )
+            _ = try await telegram.processUpdates(
+                [.fixture(updateId: 700, messageId: 17, chatId: -100111222333, text: "ops ready")],
+                source: "fixture"
+            )
+
+            let service = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForTelegramTests(),
+                    credentialStore: FakeDiscordCredentialStoreForTelegramTests()
+                ),
+                telegramService: telegram
+            )
+
+            let telegramRow = try #require(
+                service.listConnections().first { $0["id"] as? String == "telegram" }
+            )
+            #expect(telegramRow["configured"] as? Bool == true)
+            #expect(telegramRow["credential_saved"] as? Bool == true)
+            let inboundAuthorization = try #require(
+                telegramRow["inbound_authorization"] as? [String: Any]
+            )
+            #expect(inboundAuthorization["sender_allowlist"] as? [String] == ["7"])
+            #expect(inboundAuthorization["room_allowlist"] as? [String] == ["-100111222333"])
+            #expect(
+                inboundAuthorization["dispatch_contract"] as? String
+                    == "authorize_before_agent_context_or_tool_input"
+            )
+
+            let read = try await service.readMessages(
+                connectionId: "telegram",
+                roomId: "-100111222333",
+                limit: 5
+            )
+            let messages = try #require(read["messages"] as? [[String: Any]])
+            #expect(messages.first?["content"] as? String == "ops ready")
+        }
+    }
+
+    private static func updateJSON(updateId: Int64, messageId: Int, text: String) -> String {
+        """
+        {
+          "update_id": \(updateId),
+          "message": {
+            "message_id": \(messageId),
+            "date": 1782427200,
+            "chat": { "id": -100111222333, "type": "group", "title": "Ops" },
+            "from": { "id": 7, "is_bot": false, "first_name": "Mika", "username": "mika" },
+            "text": "\(text)"
+          }
+        }
+        """
+    }
+
+    private func withIsolatedTelegramStores(
+        _ body: (any TelegramCredentialStorage) async throws -> Void
+    ) async throws {
+        let previousTelegramDirectory = TelegramConnectionConfigurationStore.overrideDirectory
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-telegram-tests-\(UUID().uuidString)", isDirectory: true)
+        let credentials = FakeTelegramCredentialStore()
+        TelegramConnectionConfigurationStore.overrideDirectory = directory
+        defer {
+            TelegramConnectionConfigurationStore.overrideDirectory = previousTelegramDirectory
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try await body(credentials)
+    }
+}
+
+private final class FakeTelegramCredentialStore: TelegramCredentialStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedToken: String?
+
+    func saveBotToken(_ token: String) -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        lock.withLock { storedToken = trimmed }
+        return true
+    }
+
+    func botToken() -> String? {
+        lock.withLock { storedToken }
+    }
+
+    func hasBotToken() -> Bool {
+        botToken() != nil
+    }
+
+    func deleteBotToken() -> Bool {
+        lock.withLock { storedToken = nil }
+        return true
+    }
+}
+
+private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
+    private var updates: [TelegramUpdate] = []
+    private var lastOffset: Int64?
+    private var sentMessages: [(chatId: String, text: String, replyToMessageId: Int?)] = []
+    private var getMeFailuresRemaining = 0
+
+    func setUpdates(_ updates: [TelegramUpdate]) {
+        self.updates = updates
+    }
+
+    func failNextGetMe() {
+        getMeFailuresRemaining += 1
+    }
+
+    func lastUpdateOffset() -> Int64? {
+        lastOffset
+    }
+
+    func lastSentText() -> String? {
+        sentMessages.last?.text
+    }
+
+    func lastReplyToMessageId() -> Int? {
+        sentMessages.last?.replyToMessageId
+    }
+
+    func getMe(token: String) async throws -> TelegramUser {
+        if getMeFailuresRemaining > 0 {
+            getMeFailuresRemaining -= 1
+            throw TelegramAPIError.requestFailed("temporary getMe failure")
+        }
+        return TelegramUser.fixture(id: 42, isBot: true)
+    }
+
+    func getChat(chatId: String, token: String) async throws -> TelegramChat {
+        TelegramChat(
+            id: Int64(chatId) ?? -100111222333,
+            type: "group",
+            title: "Ops",
+            username: chatId.hasPrefix("@") ? String(chatId.dropFirst()) : nil,
+            firstName: nil,
+            lastName: nil
+        )
+    }
+
+    func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate] {
+        lastOffset = offset
+        return Array(updates.prefix(limit))
+    }
+
+    func sendMessage(
+        chatId: String,
+        text: String,
+        replyToMessageId: Int?,
+        token: String
+    ) async throws -> TelegramMessage {
+        sentMessages.append((chatId: chatId, text: text, replyToMessageId: replyToMessageId))
+        return TelegramMessage.fixture(
+            messageId: 800 + sentMessages.count,
+            chatId: Int64(chatId) ?? -100111222333,
+            text: text,
+            from: .fixture(id: 42, isBot: true),
+            replyToMessageId: replyToMessageId
+        )
+    }
+}
+
+private actor FakeDiscordAPIClientForTelegramTests: DiscordAPIClientProtocol {
+    func currentUser(token: String) async throws -> DiscordBotIdentity {
+        DiscordBotIdentity(id: "1", username: "bot", globalName: "Bot", bot: true)
+    }
+
+    func guild(id: String, token: String) async throws -> DiscordGuild {
+        DiscordGuild(id: id, name: "Guild")
+    }
+
+    func channels(guildId: String, token: String) async throws -> [DiscordChannel] {
+        []
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [DiscordMessage] {
+        []
+    }
+
+    func sendMessage(channelId: String, content: String, token: String) async throws -> DiscordMessage {
+        DiscordMessage(
+            id: "1",
+            channelId: channelId,
+            content: content,
+            timestamp: "2026-06-25T00:00:00Z",
+            author: DiscordMessageAuthor(id: "1", username: "bot", globalName: "Bot", bot: true),
+            attachments: []
+        )
+    }
+}
+
+private final class FakeDiscordCredentialStoreForTelegramTests: DiscordCredentialStorage, @unchecked Sendable {
+    func saveBotToken(_ token: String) -> Bool { true }
+    func botToken() -> String? { nil }
+    func hasBotToken() -> Bool { false }
+    func deleteBotToken() -> Bool { true }
+}
+
+private final class TelegramHTTPStubProtocol: URLProtocol {
+    nonisolated(unsafe) private static var statusCode: Int = 200
+    nonisolated(unsafe) private static var body = Data()
+    nonisolated(unsafe) private static var requestBody = Data()
+
+    static func session(statusCode: Int, body: String) -> URLSession {
+        self.statusCode = statusCode
+        self.body = Data(body.utf8)
+        requestBody = Data()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TelegramHTTPStubProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    static func lastRequestJSONBody() -> [String: Any]? {
+        guard !requestBody.isEmpty else { return nil }
+        return try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let data = request.httpBody {
+            return data
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestBody = Self.bodyData(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private extension TelegramUser {
+    static func fixture(id: Int64, isBot: Bool) -> TelegramUser {
+        TelegramUser(
+            id: id,
+            isBot: isBot,
+            firstName: isBot ? "Bot" : "Mika",
+            lastName: nil,
+            username: isBot ? "bot" : "mika"
+        )
+    }
+}
+
+private extension TelegramUpdate {
+    static func fixture(
+        updateId: Int64,
+        messageId: Int,
+        chatId: Int64,
+        text: String,
+        from: TelegramUser = .fixture(id: 7, isBot: false),
+        chatUsername: String? = nil
+    ) -> TelegramUpdate {
+        TelegramUpdate(
+            updateId: updateId,
+            message: .fixture(
+                messageId: messageId,
+                chatId: chatId,
+                text: text,
+                from: from,
+                chatUsername: chatUsername
+            ),
+            editedMessage: nil,
+            channelPost: nil,
+            editedChannelPost: nil
+        )
+    }
+}
+
+private extension TelegramMessage {
+    static func fixture(
+        messageId: Int,
+        chatId: Int64,
+        text: String,
+        from: TelegramUser?,
+        replyToMessageId: Int? = nil,
+        chatUsername: String? = nil
+    ) -> TelegramMessage {
+        TelegramMessage(
+            messageId: messageId,
+            date: 1_782_427_200,
+            chat: TelegramChat(
+                id: chatId,
+                type: "group",
+                title: "Ops",
+                username: chatUsername,
+                firstName: nil,
+                lastName: nil
+            ),
+            from: from,
+            senderChat: nil,
+            text: text,
+            caption: nil,
+            replyToMessage: replyToMessageId.map { TelegramMessageReference(messageId: $0) }
+        )
+    }
+}

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -252,6 +252,7 @@ requests.
 The connection center validates channel definitions before saving:
 
 - `discord` is reserved for the native Discord adapter.
+- `telegram` is reserved for the native Telegram adapter.
 - Custom HTTP connections require an HTTP or HTTPS base URL.
 - Custom HTTP base URLs run through the same blocked-host policy used by the
   runner, so localhost/private/link-local targets are rejected before save.
@@ -304,6 +305,47 @@ message. Discord does this for `read_messages`, `search_messages`, and
 `send_message`, so repeated reads cannot duplicate the same provider message in
 the local store. The store keeps only the newest 1,000 message snapshots per
 connection/room pair so busy channels do not grow the database without bound.
+Read and search results reflect messages that were authorized at ingest time.
+If an operator later tightens sender allowlists, previously stored snapshots may
+remain readable until they age out or are pruned.
+
+Telegram is native as well. The Bot API does not expose arbitrary prior chat
+history to bots, so Telegram `read_messages` and `search_messages` read from the
+local Agent Channel message store. The adapter exposes webhook and long-poll
+service entry points for populating that store; a production HTTP receiver,
+background poller, and visible settings surface are separate integration work.
+The native Telegram adapter:
+
+- stores non-secret allowlists in `telegram.json` and keeps the bot token in
+  Keychain;
+- authorizes reads and writes against explicit chat allowlists, and authorizes
+  inbound receives against explicit chat and sender allowlists;
+- supports numeric chat ids and `@username` room ids, but `@username`
+  allowlists only match updates where Telegram includes the chat username. Use
+  numeric ids for private groups or any chat where Telegram may omit the handle.
+- runs the shared inbound authorization gate before storing message text or
+  making it dispatchable, so inbound Telegram text remains untrusted external
+  data rather than instruction text;
+- normalizes webhook and long-poll updates into candidate provider-neutral
+  external message snapshots, then stores snapshots only after authorization;
+- deduplicates by Telegram `update_id` with `recordReceiveEvent(...)` before
+  dispatch/storage, while long-poll batches store the next global `getUpdates`
+  offset as a receive cursor;
+- stores one snapshot per `connection_id + room_id + provider_message_id`; if
+  Telegram later sends an edited message update for the same provider message,
+  reads may show the original stored snapshot until edit-refresh support lands.
+- ignores self messages and bot messages by default to avoid bot loops;
+- drops empty or oversized inbound message content before storage;
+- requires `confirm_send: true` before posting and records sent messages with a
+  Telegram delivery status.
+
+The production Telegram webhook receiver must pass the configured Telegram
+secret token into the service verifier before decoding update content. Direct
+service calls that omit an expected secret are test/in-process entry points, not
+the public HTTP receiver contract. Because Telegram bot tokens are part of Bot
+API request paths, any future network proxy, crash-report, or HTTP-diagnostics
+surface must redact full request URLs with the same token-redaction policy used
+for provider errors.
 
 Relay or webhook receivers should follow the same sequence used by the Telegram
 plugin pattern:


### PR DESCRIPTION
## Summary
- Adds a native Telegram Agent Channel adapter with token storage, chat allowlists, read/search/send routing, and explicit send confirmation.
- Normalizes webhook and long-poll updates into the shared Agent Channel message store after authorization, with update-id dedupe and cursor tracking.
- Rebased onto the merged Agent Channel JSON runner and inbox/audit foundations; the native Telegram route now coexists with custom JSON channel execution instead of shadowing it.
- Documents current service boundaries: production HTTP receiver, background poller, and visible settings surface remain follow-up integration work.

## Validation
- git diff --check
- swiftlint lint Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-telegram swift test --package-path Packages/OsaurusCore --filter TelegramConnectionTests
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-agent-channel swift test --package-path Packages/OsaurusCore --filter AgentChannelAsyncSubstrateTests
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-telegram-final-2 swift test --package-path Packages/OsaurusCore --filter TelegramConnectionTests

## Draft gate
- Kept draft intentionally while GitHub CI reruns on the rebased branch.
- Keep draft until the final public channel registration/UI placement is confirmed.
- No agent-loop prompt/tool-schema behavior changes are included, so no eval evidence is required for this service-level adapter refresh.