### PR TITLE
Add Business Document I/O Workbench

### DIFF
--- a/App/osaurus/osaurusApp.swift
+++ b/App/osaurus/osaurusApp.swift
@@ -95,6 +95,14 @@ private extension osaurusApp {
         CommandGroup(after: .newItem) {
             Divider()
 
+            Button {
+                BusinessDocumentStudioLauncher.openDocumentPicker()
+            } label: {
+                Text(verbatim: L("Open Business Document..."))
+            }
+
+            Divider()
+
             Button(vadToggleLabel) {
                 toggleVAD()
             }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -29800,6 +29800,9 @@
     "Business Document Studio" : {
       "shouldTranslate" : false
     },
+    "Business Document Workbench" : {
+      "shouldTranslate" : false
+    },
     "Bundle" : {
       "localizations" : {
         "de" : {
@@ -34608,6 +34611,9 @@
       }
     },
     "Choose a supported document to inspect preview, security, and export availability." : {
+      "shouldTranslate" : false
+    },
+    "Choose a business document to inspect preview, extraction, and export availability." : {
       "shouldTranslate" : false
     },
     "Choose a SKILL.md file or a ZIP bundle to import" : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -29797,6 +29797,9 @@
         }
       }
     },
+    "Business Document Studio" : {
+      "shouldTranslate" : false
+    },
     "Bundle" : {
       "localizations" : {
         "de" : {
@@ -34603,6 +34606,9 @@
           }
         }
       }
+    },
+    "Choose a supported document to inspect preview, security, and export availability." : {
+      "shouldTranslate" : false
     },
     "Choose a SKILL.md file or a ZIP bundle to import" : {
       "localizations" : {
@@ -110982,6 +110988,12 @@
           }
         }
       }
+    },
+    "Open Business Document" : {
+      "shouldTranslate" : false
+    },
+    "Open Business Document..." : {
+      "shouldTranslate" : false
     },
     "Open Chat" : {
       "localizations" : {

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -97,6 +97,7 @@ public struct BusinessDocumentStudioInspection: Codable, Equatable, Sendable {
     public let registryRoles: [DocumentFormatRegistrationRole]
     public let parseLimitBytes: Int64
     public let security: DocumentSecurityMetadata
+    public let extractionSummary: BusinessDocumentStudioExtractionSummary
     public let preview: BusinessDocumentStudioPreview
     public let exportOptions: [BusinessDocumentStudioExportOption]
 }
@@ -277,6 +278,38 @@ public struct BusinessDocumentTextPreview: Codable, Equatable, Sendable {
     public let isTruncated: Bool
 }
 
+public struct BusinessDocumentStudioExtractionSummary: Codable, Equatable, Sendable {
+    public let headline: String
+    public let fields: [BusinessDocumentStudioFieldSummary]
+    public let tables: [BusinessDocumentStudioTableSummary]
+    public let attachmentHandoff: BusinessDocumentStudioAttachmentHandoff
+}
+
+public struct BusinessDocumentStudioFieldSummary: Codable, Equatable, Sendable {
+    public let name: String
+    public let source: String
+    public let valueKind: String
+    public let filledCount: Int
+    public let emptyCount: Int
+    public let sampleValues: [String]
+}
+
+public struct BusinessDocumentStudioTableSummary: Codable, Equatable, Sendable {
+    public let label: String
+    public let source: String
+    public let rowCount: Int
+    public let columnCount: Int
+    public let cellCount: Int
+    public let sampleText: String?
+}
+
+public struct BusinessDocumentStudioAttachmentHandoff: Codable, Equatable, Sendable {
+    public let isAvailable: Bool
+    public let label: String
+    public let message: String
+    public let fallbackUTF8Bytes: Int
+}
+
 public struct BusinessDocumentCreationAvailability: Codable, Equatable, Sendable {
     public let formatId: String
     public let reasonCode: BusinessDocumentCreationReasonCode
@@ -328,6 +361,7 @@ public enum BusinessDocumentStudioError: LocalizedError, Sendable {
     case unsafeTextPackageTarget(fileExtension: String)
     case packageTargetExtensionMismatch(targetFormatId: String, fileExtension: String)
     case textExportTooLarge(actual: Int, limit: Int)
+    case attachmentHandoffUnavailable(String)
     case writeFailed(String)
 
     public var errorDescription: String? {
@@ -350,6 +384,8 @@ public enum BusinessDocumentStudioError: LocalizedError, Sendable {
             return "Export target '\(targetFormatId)' cannot write package extension .\(fileExtension)."
         case .textExportTooLarge(let actual, let limit):
             return "Text fallback export is \(actual) bytes, limit is \(limit) bytes."
+        case .attachmentHandoffUnavailable(let message):
+            return message
         case .writeFailed(let message):
             return "Business document export failed: \(message)"
         }
@@ -413,14 +449,25 @@ public struct BusinessDocumentStudioService: Sendable {
     ) throws -> BusinessDocumentStudioInspection {
         let roles = registry.registrationRoles(forFormatId: document.formatId)
             .sorted { $0.rawValue < $1.rawValue }
+        let preview = try preview(for: document, policy: policy)
         return BusinessDocumentStudioInspection(
             summary: BusinessDocumentStudioSummary(document: document),
             registryRoles: roles,
             parseLimitBytes: parseLimitBytes ?? DocumentLimits.limit(forFormatId: document.formatId),
             security: document.security,
-            preview: try preview(for: document, policy: policy),
+            extractionSummary: Self.extractionSummary(for: document, preview: preview),
+            preview: preview,
             exportOptions: exportOptions(for: document, policy: policy)
         )
+    }
+
+    public func makeAttachment(for document: StructuredDocument) throws -> Attachment {
+        guard !document.textFallback.isEmpty else {
+            throw BusinessDocumentStudioError.attachmentHandoffUnavailable(
+                "Workspace attachment handoff requires a non-empty text fallback."
+            )
+        }
+        return Attachment.structuredDocument(document)
     }
 
     public func export(
@@ -857,6 +904,137 @@ public struct BusinessDocumentStudioService: Sendable {
             blockCount: richText.blocks.count,
             isBlockSampleTruncated: richText.blocks.count > policy.maxRichBlocks
         )
+    }
+
+    private static func extractionSummary(
+        for document: StructuredDocument,
+        preview: BusinessDocumentStudioPreview
+    ) -> BusinessDocumentStudioExtractionSummary {
+        let handoff = BusinessDocumentStudioAttachmentHandoff(
+            isAvailable: !document.textFallback.isEmpty,
+            label: "Structured document attachment",
+            message: document.textFallback.isEmpty
+                ? "No text fallback is available for workspace attachment handoff."
+                : "Can be handed to workspace attachments with structured metadata and text fallback.",
+            fallbackUTF8Bytes: document.textFallback.utf8.count
+        )
+
+        switch preview {
+        case .table(let table):
+            return BusinessDocumentStudioExtractionSummary(
+                headline: "\(table.columnCount) field(s), \(table.rowsScanned) scanned row(s)",
+                fields: table.columns.map { column in
+                    BusinessDocumentStudioFieldSummary(
+                        name: column.name,
+                        source: "Column \(column.index + 1)",
+                        valueKind: column.inferredType.rawValue,
+                        filledCount: column.nonEmptyCount,
+                        emptyCount: column.emptyCount,
+                        sampleValues: column.sampleValues
+                    )
+                },
+                tables: [
+                    BusinessDocumentStudioTableSummary(
+                        label: table.filename,
+                        source: table.delimiter == .tab ? "TSV" : "CSV",
+                        rowCount: table.rowsScanned,
+                        columnCount: table.columnCount,
+                        cellCount: table.rowsScanned * table.columnCount,
+                        sampleText: table.sampledRows.first?.values.joined(separator: " | ")
+                    ),
+                ],
+                attachmentHandoff: handoff
+            )
+
+        case .workbook(let workbook):
+            return BusinessDocumentStudioExtractionSummary(
+                headline: "\(workbook.inspection.sheetSummaries.count) sheet(s), \(workbook.inspection.totalCells) cell(s)",
+                fields: [],
+                tables: workbook.sheets.map { sheet in
+                    BusinessDocumentStudioTableSummary(
+                        label: sheet.name,
+                        source: "Worksheet \(sheet.index + 1)",
+                        rowCount: sheet.rowCount,
+                        columnCount: sheet.maxColumn,
+                        cellCount: sheet.cellCount,
+                        sampleText: sheet.sampleRows.first?.cells.map(\.text.text).joined(separator: " | ")
+                    )
+                },
+                attachmentHandoff: handoff
+            )
+
+        case .pdf(let pdf):
+            return BusinessDocumentStudioExtractionSummary(
+                headline: "\(pdf.pageCount) page(s), \(pdf.tableCount) detected table(s)",
+                fields: [],
+                tables: pdf.pages.flatMap { page in
+                    page.tables.map { table in
+                        BusinessDocumentStudioTableSummary(
+                            label: "Page \(page.pageIndex + 1) table \(table.index + 1)",
+                            source: "PDF page \(page.pageIndex + 1)",
+                            rowCount: table.rowCount,
+                            columnCount: table.columnCount,
+                            cellCount: table.cellCount,
+                            sampleText: table.sampleRows.first?.cells.map(\.text.text).joined(separator: " | ")
+                        )
+                    }
+                },
+                attachmentHandoff: handoff
+            )
+
+        case .presentation(let presentation):
+            return BusinessDocumentStudioExtractionSummary(
+                headline: "\(presentation.slideCount) slide(s), \(presentation.tableCount) table(s)",
+                fields: presentation.slides.map { slide in
+                    BusinessDocumentStudioFieldSummary(
+                        name: slide.label,
+                        source: "Slide \(slide.slideNumber)",
+                        valueKind: "slide text",
+                        filledCount: slide.text.text.isEmpty ? 0 : 1,
+                        emptyCount: slide.text.text.isEmpty ? 1 : 0,
+                        sampleValues: slide.text.text.isEmpty ? [] : [slide.text.text]
+                    )
+                },
+                tables: presentation.slides.flatMap { slide in
+                    slide.tables.map { table in
+                        BusinessDocumentStudioTableSummary(
+                            label: "\(slide.label) table \(table.index + 1)",
+                            source: "Slide \(slide.slideNumber)",
+                            rowCount: table.rowCount,
+                            columnCount: table.columnCount,
+                            cellCount: table.cellCount,
+                            sampleText: table.sampleRows.first?.cells.map(\.text.text).joined(separator: " | ")
+                        )
+                    }
+                },
+                attachmentHandoff: handoff
+            )
+
+        case .richText(let richText):
+            return BusinessDocumentStudioExtractionSummary(
+                headline: "\(richText.blockCount) rich text block(s)",
+                fields: richText.sampledBlocks.map { block in
+                    BusinessDocumentStudioFieldSummary(
+                        name: block.kind.rawValue,
+                        source: "Block \(block.sourceIndex + 1)",
+                        valueKind: block.kind.rawValue,
+                        filledCount: block.text.text.isEmpty ? 0 : 1,
+                        emptyCount: block.text.text.isEmpty ? 1 : 0,
+                        sampleValues: block.text.text.isEmpty ? [] : [block.text.text]
+                    )
+                },
+                tables: [],
+                attachmentHandoff: handoff
+            )
+
+        case .text(let text):
+            return BusinessDocumentStudioExtractionSummary(
+                headline: "\(text.fullUTF16Length) UTF-16 unit text fallback",
+                fields: [],
+                tables: [],
+                attachmentHandoff: handoff
+            )
+        }
     }
 
     private static func textPreview(_ preview: PDFPPTXTextPreview) -> BusinessDocumentTextPreview {

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -773,33 +773,56 @@ public struct BusinessDocumentStudioService: Sendable {
         }
     }
 
-    /// Resolve only filesystem components that already exist. This keeps
-    /// firmlink aliases such as `/var` and `/private/var` symmetric for a new
-    /// leaf while still following an existing symlink leaf or parent to expose
-    /// an escape from the allowed root.
+    /// Resolve every symlink component while retaining a lexical tail that
+    /// does not exist yet. Unlike `resolvingSymlinksInPath`, this also follows
+    /// dangling links so an existing leaf cannot conceal an outside target.
     private static func isContainedDestination(_ destination: URL, in allowedDirectory: URL) -> Bool {
-        guard allowedDirectory.isFileURL else { return false }
-        let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().standardizedFileURL
-        let candidate = destination.standardizedFileURL
-        var existingAncestor = candidate
+        guard let root = canonicalURLAllowingMissing(allowedDirectory),
+            let candidate = canonicalURLAllowingMissing(destination)
+        else {
+            return false
+        }
+        let rootComponents = root.pathComponents
+        let candidateComponents = candidate.pathComponents
+        return candidateComponents.count > rootComponents.count
+            && candidateComponents.starts(with: rootComponents)
+    }
 
-        while !FileManager.default.fileExists(atPath: existingAncestor.path) {
-            let parent = existingAncestor.deletingLastPathComponent()
-            guard parent.path != existingAncestor.path else { break }
-            existingAncestor = parent
+    private static func canonicalURLAllowingMissing(_ url: URL) -> URL? {
+        guard url.isFileURL else { return nil }
+        let filesystemRoot = URL(fileURLWithPath: "/", isDirectory: true)
+        var current = filesystemRoot
+        var unresolvedComponents = url.path.split(separator: "/").map(String.init)
+        var resolvedSymlinkCount = 0
+
+        while !unresolvedComponents.isEmpty {
+            let component = unresolvedComponents.removeFirst()
+            switch component {
+            case ".":
+                continue
+            case "..":
+                current = current.deletingLastPathComponent()
+                continue
+            default:
+                break
+            }
+
+            let next = current.appendingPathComponent(component)
+            guard let linkTarget = try? FileManager.default.destinationOfSymbolicLink(atPath: next.path) else {
+                current = next
+                continue
+            }
+
+            guard resolvedSymlinkCount < 64 else { return nil }
+            resolvedSymlinkCount += 1
+            if linkTarget.hasPrefix("/") {
+                current = filesystemRoot
+            }
+            let targetComponents = linkTarget.split(separator: "/").map(String.init)
+            unresolvedComponents.insert(contentsOf: targetComponents, at: 0)
         }
 
-        let resolvedAncestor = existingAncestor.resolvingSymlinksInPath().standardizedFileURL
-        let existingComponentCount = existingAncestor.pathComponents.count
-        let unresolvedTail = candidate.pathComponents.dropFirst(existingComponentCount)
-        guard !unresolvedTail.contains("."), !unresolvedTail.contains("..") else { return false }
-        let resolvedCandidate = unresolvedTail.reduce(resolvedAncestor) { partialURL, component in
-            partialURL.appendingPathComponent(component)
-        }.standardizedFileURL
-        let rootPath = root.path
-        return rootPath == "/"
-            ? resolvedCandidate.path != rootPath
-            : resolvedCandidate.path.hasPrefix(rootPath + "/")
+        return current
     }
 
     private func rejectTextExportPackageTarget(_ url: URL) throws {

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -381,7 +381,8 @@ public enum BusinessDocumentStudioError: LocalizedError, Sendable {
         case .unsafeTextPackageTarget(let fileExtension):
             return "Text fallback export cannot write structured package target .\(fileExtension)."
         case .packageTargetExtensionMismatch(let targetFormatId, let fileExtension):
-            return "Export target '\(targetFormatId)' cannot write package extension .\(fileExtension)."
+            let displayExtension = fileExtension.isEmpty ? "without an extension" : ".\(fileExtension)"
+            return "Export target '\(targetFormatId)' cannot write \(displayExtension). Use an allowed package extension for that target."
         case .textExportTooLarge(let actual, let limit):
             return "Text fallback export is \(actual) bytes, limit is \(limit) bytes."
         case .attachmentHandoffUnavailable(let message):
@@ -744,8 +745,8 @@ public struct BusinessDocumentStudioService: Sendable {
         targetFormatId: String
     ) throws {
         let extensionName = url.pathExtension.lowercased()
-        guard Self.structuredPackageExtensions.contains(extensionName) else { return }
         guard let allowedExtensions = Self.structuredTargetExtensions[targetFormatId] else {
+            guard Self.structuredPackageExtensions.contains(extensionName) else { return }
             throw BusinessDocumentStudioError.unsafeTextPackageTarget(fileExtension: extensionName)
         }
         guard allowedExtensions.contains(extensionName) else {

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -8,6 +8,7 @@
 //  entry point for inspect, preview, and explicit export checks.
 //
 
+import Darwin
 import Foundation
 import UniformTypeIdentifiers
 
@@ -465,7 +466,7 @@ public struct BusinessDocumentStudioService: Sendable {
     public func makeAttachment(for document: StructuredDocument) throws -> Attachment {
         guard !document.textFallback.isEmpty else {
             throw BusinessDocumentStudioError.attachmentHandoffUnavailable(
-                "Workspace attachment handoff requires a non-empty text fallback."
+                "Attachment payload validation requires a non-empty text fallback."
             )
         }
         return Attachment.structuredDocument(document)
@@ -479,35 +480,60 @@ public struct BusinessDocumentStudioService: Sendable {
     ) async throws -> BusinessDocumentStudioExportResult {
         let normalizedTarget = targetFormatId.trimmedLowercased
         try validateDestination(url, policy: policy)
+        try validateTargetExtension(url, targetFormatId: normalizedTarget, document: document)
 
+        let stagingURL = Self.stagingURL(for: url)
+        defer { try? FileManager.default.removeItem(at: stagingURL) }
+        let rendered = try await renderExport(
+            document,
+            as: normalizedTarget,
+            to: stagingURL,
+            policy: policy
+        )
+
+        // Arbitrary emitters may ignore cancellation. They only own the random
+        // staging leaf; cancellation is enforced here before final-path commit.
+        try Task.checkCancellation()
+        try validateDestination(url, policy: policy)
+        try Task.checkCancellation()
+        try Self.commit(stagingURL, to: url, allowOverwrite: policy.allowOverwrite)
+
+        return BusinessDocumentStudioExportResult(
+            url: url,
+            sourceFormatId: document.formatId,
+            targetFormatId: rendered.targetFormatId,
+            bytesWritten: Self.fileSize(url),
+            message: rendered.message
+        )
+    }
+
+    private func renderExport(
+        _ document: StructuredDocument,
+        as normalizedTarget: String,
+        to stagingURL: URL,
+        policy: BusinessDocumentStudioExportPolicy
+    ) async throws -> RenderedExport {
         switch normalizedTarget {
         case "csv", "tsv":
-            try rejectTextExportPackageTarget(url)
             let delimiter: CSVDelimiter = normalizedTarget == "tsv" ? .tab : .comma
-            let result = try await CSVTableWorkflowService.export(document, to: url, delimiter: delimiter)
+            let result = try await CSVTableWorkflowService.export(document, to: stagingURL, delimiter: delimiter)
             let rowLabel = result.rowCount == 1 ? "1 row" : "\(result.rowCount) rows"
             let columnLabel = result.columnCount == 1 ? "1 column" : "\(result.columnCount) columns"
-            return BusinessDocumentStudioExportResult(
-                url: result.url,
-                sourceFormatId: document.formatId,
+            return RenderedExport(
                 targetFormatId: result.formatId,
-                bytesWritten: result.bytesWritten,
                 message: "Exported \(rowLabel) and \(columnLabel)."
             )
 
         case "xlsx":
-            try validateStructuredPackageTarget(url, targetFormatId: normalizedTarget)
-            let result = try await WorkbookWorkflowService.export(document, to: url, registry: registry)
-            return BusinessDocumentStudioExportResult(
-                url: result.url,
-                sourceFormatId: document.formatId,
+            let result = try await WorkbookWorkflowService.export(document, to: stagingURL, registry: registry)
+            return RenderedExport(
                 targetFormatId: result.formatId,
-                bytesWritten: result.bytesWritten,
                 message: "Exported workbook through the registered '\(result.formatId)' emitter."
             )
 
         case "txt", "text", "plaintext":
-            return try exportTextFallback(document, to: url, policy: policy)
+            let result = try exportTextFallback(document, to: stagingURL, policy: policy)
+            return RenderedExport(targetFormatId: result.targetFormatId, message: result.message)
 
         default:
             guard let emitter = registry.emitter(for: document),
@@ -518,19 +544,37 @@ public struct BusinessDocumentStudioService: Sendable {
                     targetFormatId: normalizedTarget
                 )
             }
-            try validateEmitterPackageTarget(url, targetFormatId: emitter.formatId.trimmedLowercased)
             do {
-                try await emitter.emit(document, to: url)
-                return BusinessDocumentStudioExportResult(
-                    url: url,
-                    sourceFormatId: document.formatId,
+                try await emitter.emit(document, to: stagingURL)
+                return RenderedExport(
                     targetFormatId: emitter.formatId,
-                    bytesWritten: Self.fileSize(url),
                     message: "Exported document through the registered '\(emitter.formatId)' emitter."
                 )
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 throw BusinessDocumentStudioError.writeFailed(error.localizedDescription)
             }
+        }
+    }
+
+    private func validateTargetExtension(
+        _ url: URL,
+        targetFormatId: String,
+        document: StructuredDocument
+    ) throws {
+        switch targetFormatId {
+        case "csv", "tsv", "txt", "text", "plaintext":
+            try rejectTextExportPackageTarget(url)
+        case "xlsx":
+            try validateStructuredPackageTarget(url, targetFormatId: targetFormatId)
+        default:
+            guard let emitter = registry.emitter(for: document),
+                emitter.formatId.lowercased() == targetFormatId
+            else {
+                return
+            }
+            try validateEmitterPackageTarget(url, targetFormatId: emitter.formatId.trimmedLowercased)
         }
     }
 
@@ -558,8 +602,7 @@ public struct BusinessDocumentStudioService: Sendable {
         }
 
         if let pdfPPTX = try? PDFPPTXWorkflowService(registry: registry)
-            .preview(document, policy: policy.pdfPPTXPreview)
-        {
+            .preview(document, policy: policy.pdfPPTXPreview) {
             switch pdfPPTX {
             case .pdf(let preview):
                 return .pdf(Self.pdfPreview(preview))
@@ -713,7 +756,7 @@ public struct BusinessDocumentStudioService: Sendable {
         )
     }
 
-    private func validateDestination(
+    func validateDestination(
         _ url: URL,
         policy: BusinessDocumentStudioExportPolicy
     ) throws {
@@ -721,15 +764,42 @@ public struct BusinessDocumentStudioService: Sendable {
             throw BusinessDocumentStudioError.destinationIsNotFileURL(url)
         }
         if let allowedDirectory = policy.allowedDirectory {
-            let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().path
-            let parent = url.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().path
-            guard parent == root || parent.hasPrefix(root + "/") else {
+            guard Self.isContainedDestination(url, in: allowedDirectory) else {
                 throw BusinessDocumentStudioError.destinationOutsideAllowedDirectory(url)
             }
         }
         if !policy.allowOverwrite, FileManager.default.fileExists(atPath: url.path) {
             throw BusinessDocumentStudioError.destinationAlreadyExists(url)
         }
+    }
+
+    /// Resolve only filesystem components that already exist. This keeps
+    /// firmlink aliases such as `/var` and `/private/var` symmetric for a new
+    /// leaf while still following an existing symlink leaf or parent to expose
+    /// an escape from the allowed root.
+    private static func isContainedDestination(_ destination: URL, in allowedDirectory: URL) -> Bool {
+        guard allowedDirectory.isFileURL else { return false }
+        let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().standardizedFileURL
+        let candidate = destination.standardizedFileURL
+        var existingAncestor = candidate
+
+        while !FileManager.default.fileExists(atPath: existingAncestor.path) {
+            let parent = existingAncestor.deletingLastPathComponent()
+            guard parent.path != existingAncestor.path else { break }
+            existingAncestor = parent
+        }
+
+        let resolvedAncestor = existingAncestor.resolvingSymlinksInPath().standardizedFileURL
+        let existingComponentCount = existingAncestor.pathComponents.count
+        let unresolvedTail = candidate.pathComponents.dropFirst(existingComponentCount)
+        guard !unresolvedTail.contains("."), !unresolvedTail.contains("..") else { return false }
+        let resolvedCandidate = unresolvedTail.reduce(resolvedAncestor) { partialURL, component in
+            partialURL.appendingPathComponent(component)
+        }.standardizedFileURL
+        let rootPath = root.path
+        return rootPath == "/"
+            ? resolvedCandidate.path != rootPath
+            : resolvedCandidate.path.hasPrefix(rootPath + "/")
     }
 
     private func rejectTextExportPackageTarget(_ url: URL) throws {
@@ -915,8 +985,8 @@ public struct BusinessDocumentStudioService: Sendable {
             isAvailable: !document.textFallback.isEmpty,
             label: "Structured document attachment",
             message: document.textFallback.isEmpty
-                ? "No text fallback is available for workspace attachment handoff."
-                : "Can be handed to workspace attachments with structured metadata and text fallback.",
+                ? "No text fallback is available for attachment payload validation."
+                : "A structured attachment payload with metadata and text fallback can be validated.",
             fallbackUTF8Bytes: document.textFallback.utf8.count
         )
 
@@ -1104,8 +1174,46 @@ public struct BusinessDocumentStudioService: Sendable {
         }
     }
 
+    private static func stagingURL(for destination: URL) -> URL {
+        let fileExtension = destination.pathExtension
+        let stem = destination.deletingPathExtension().lastPathComponent
+        let suffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
+        let filename = ".\(stem).osaurus-export-\(UUID().uuidString)\(suffix)"
+        return destination.deletingLastPathComponent().appendingPathComponent(filename)
+    }
+
+    /// The rename itself carries overwrite policy so a destination appearing
+    /// after validation cannot be clobbered without consent. Both paths are
+    /// siblings, making the successful commit atomic on the containing volume.
+    private static func commit(
+        _ stagingURL: URL,
+        to destination: URL,
+        allowOverwrite: Bool
+    ) throws {
+        let status = stagingURL.path.withCString { sourcePath in
+            destination.path.withCString { destinationPath in
+                if allowOverwrite {
+                    return Darwin.rename(sourcePath, destinationPath)
+                }
+                return renamex_np(sourcePath, destinationPath, UInt32(RENAME_EXCL))
+            }
+        }
+        guard status == 0 else {
+            let errorCode = errno
+            if !allowOverwrite, errorCode == EEXIST {
+                throw BusinessDocumentStudioError.destinationAlreadyExists(destination)
+            }
+            throw BusinessDocumentStudioError.writeFailed(String(cString: strerror(errorCode)))
+        }
+    }
+
     private static func fileSize(_ url: URL) -> Int64 {
         Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+    }
+
+    private struct RenderedExport {
+        let targetFormatId: String
+        let message: String
     }
 
     private static let structuredPackageExtensions: Set<String> = [

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioLauncherTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioLauncherTests.swift
@@ -64,6 +64,34 @@ struct BusinessDocumentStudioLauncherTests {
         #expect(cache.sourceURL(for: secondWindow) == secondSource.standardizedFileURL)
     }
 
+    @Test func sourceAndSymlinkAliasShareOneWindowIdentity() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("business-document-source-\(UUID().uuidString)", isDirectory: true)
+        let source = directory.appendingPathComponent("report.pdf")
+        let alias = directory.appendingPathComponent("report-alias.pdf")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("fixture".utf8).write(to: source)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: source)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = BusinessDocumentStudioWindowCache<WindowToken>()
+        let sourceWindow = WindowToken()
+        let aliasWindow = WindowToken()
+        guard case .claimed = cache.claim(source, for: sourceWindow) else {
+            Issue.record("Expected the source window claim to succeed")
+            return
+        }
+        guard case .occupied(let owner) = cache.claim(alias, for: aliasWindow) else {
+            Issue.record("Expected the symlink alias to resolve to the existing owner")
+            return
+        }
+
+        #expect(owner === sourceWindow)
+        #expect(cache.window(for: alias) === sourceWindow)
+        #expect(cache.sourceURL(for: sourceWindow) == source.resolvingSymlinksInPath().standardizedFileURL)
+        #expect(BusinessDocumentStudioSourceIdentity.standardized(alias) == source.resolvingSymlinksInPath())
+    }
+
     @Test func sourceTransitionRequiresClaimBeforeReturningAcceptedURL() {
         let selected = URL(fileURLWithPath: "/tmp/folder/../report.pdf")
         var claimedURL: URL?

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioLauncherTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioLauncherTests.swift
@@ -1,0 +1,87 @@
+//
+//  BusinessDocumentStudioLauncherTests.swift
+//  osaurusTests
+//
+//  Focused coverage for Business Document Studio window identity state.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite("Business document studio launcher")
+struct BusinessDocumentStudioLauncherTests {
+
+    @Test func rekeyMovesWindowIdentityAndCloseRemovesCurrentSource() {
+        let cache = BusinessDocumentStudioWindowCache<WindowToken>()
+        let window = WindowToken()
+        let first = URL(fileURLWithPath: "/tmp/first.pdf")
+        let second = URL(fileURLWithPath: "/tmp/second.pdf")
+
+        guard case .claimed = cache.claim(first, for: window) else {
+            Issue.record("Expected the first source claim to succeed")
+            return
+        }
+        guard case .claimed = cache.claim(second, for: window) else {
+            Issue.record("Expected the replacement source claim to succeed")
+            return
+        }
+
+        #expect(cache.window(for: first) == nil)
+        #expect(cache.window(for: second) === window)
+        #expect(cache.sourceURL(for: window) == second.standardizedFileURL)
+
+        cache.remove(window)
+
+        #expect(cache.window(for: second) == nil)
+        #expect(cache.sourceURL(for: window) == nil)
+    }
+
+    @Test func selfReimportSucceedsAndCollisionPreservesBothExistingIdentities() {
+        let cache = BusinessDocumentStudioWindowCache<WindowToken>()
+        let firstWindow = WindowToken()
+        let secondWindow = WindowToken()
+        let firstSource = URL(fileURLWithPath: "/tmp/first.pdf")
+        let secondSource = URL(fileURLWithPath: "/tmp/second.pdf")
+
+        _ = cache.claim(firstSource, for: firstWindow)
+        _ = cache.claim(secondSource, for: secondWindow)
+
+        guard case .claimed = cache.claim(firstSource, for: firstWindow) else {
+            Issue.record("Expected a window to reclaim its current source")
+            return
+        }
+        guard case .occupied(let owner) = cache.claim(firstSource, for: secondWindow) else {
+            Issue.record("Expected the other window source claim to be rejected")
+            return
+        }
+
+        #expect(owner === firstWindow)
+        #expect(cache.window(for: firstSource) === firstWindow)
+        #expect(cache.window(for: secondSource) === secondWindow)
+        #expect(cache.sourceURL(for: secondWindow) == secondSource.standardizedFileURL)
+    }
+
+    @Test func sourceTransitionRequiresClaimBeforeReturningAcceptedURL() {
+        let selected = URL(fileURLWithPath: "/tmp/folder/../report.pdf")
+        var claimedURL: URL?
+
+        let accepted = BusinessDocumentStudioSourceIdentity.acceptedSourceURL(selected) { sourceURL in
+            claimedURL = sourceURL
+            return true
+        }
+        let rejected = BusinessDocumentStudioSourceIdentity.acceptedSourceURL(selected) { _ in false }
+
+        #expect(accepted == selected.standardizedFileURL)
+        #expect(claimedURL == selected.standardizedFileURL)
+        #expect(rejected == nil)
+        #expect(
+            BusinessDocumentStudioSourceIdentity.windowTitle(for: selected, fallback: "Workbench")
+                == "report.pdf"
+        )
+    }
+}
+
+private final class WindowToken {}

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -1,0 +1,363 @@
+//
+//  BusinessDocumentStudioPresenterTests.swift
+//  osaurusTests
+//
+//  Focused coverage for the Business Document Studio UI presenter.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite("Business document studio presenter")
+struct BusinessDocumentStudioPresenterTests {
+
+    @Test func csvInspectionBuildsPreviewAndAvailableExportRows() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let source = try Self.write(
+            """
+            name,age,active
+            Ada,37,true
+            Ben,41,false
+            """,
+            filename: "people.csv"
+        )
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        await presenter.load(url: source)
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.title.hasSuffix("people.csv"))
+        #expect(presentation.previewRows.contains(.init(label: "Preview", value: "Delimited table")))
+        #expect(presentation.previewRows.contains(.init(label: "Columns", value: "3")))
+        #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("csv"))
+        #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("tsv"))
+        #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("txt"))
+        #expect(presentation.unavailableExportOptions.isEmpty)
+    }
+
+    @Test func workbookValidationBlockedExportIsPresented() throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+
+        try presenter.load(document: Self.workbookDocument(includeFormula: true))
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        let xlsx = try #require(presentation.exportOptions.first { $0.targetFormatId == "xlsx" })
+        #expect(xlsx.canExport == false)
+        #expect(xlsx.reason == .validationFailed)
+        #expect(xlsx.reasonLabel == "Validation failed")
+        #expect(presentation.previewRows.contains(.init(label: "Formula cells", value: "1")))
+        #expect(presentation.warnings.contains { warning in
+            warning.severity == .blocked
+                && warning.title == "Export unavailable: XLSX workbook"
+                && warning.message.contains("Validation failed")
+        })
+    }
+
+    @Test func missingEmitterOptionBlocksExportBeforeDestinationWrite() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("report.pdf")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.pdfDocument())
+        let presentation = try Self.loadedPresentation(from: presenter)
+
+        let pdf = try #require(presentation.exportOptions.first { $0.targetFormatId == "pdf" })
+        #expect(pdf.canExport == false)
+        #expect(pdf.reason == .missingEmitter)
+        #expect(pdf.reasonLabel == "Missing emitter")
+
+        await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .unavailableOption)
+        #expect(block.optionID == "pdf")
+        #expect(block.reason == .missingEmitter)
+        #expect(!FileManager.default.fileExists(atPath: target.path))
+    }
+
+    @Test func availableTextFallbackExportSucceeds() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("notes.txt")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        let presentation = try Self.loadedPresentation(from: presenter)
+        let text = try #require(presentation.exportOptions.first { $0.targetFormatId == "txt" })
+        #expect(text.canExport)
+
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .succeeded(let receipt) = presenter.exportState else {
+            Issue.record("Expected succeeded export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(receipt.targetFormatId == "txt")
+        #expect(receipt.bytesWritten > 0)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "hello world")
+    }
+
+    @Test func destinationAlreadyExistsIsBlockedByService() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("existing.txt")
+        try "private".write(to: target, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .destinationAlreadyExists)
+        #expect(block.path == target.path)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "private")
+    }
+
+    @Test func destinationOverwriteSucceedsWhenInteractiveCallerAllowsIt() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("existing.txt")
+        try "old".write(to: target, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(
+            optionID: "txt",
+            to: target,
+            allowedDirectory: outputDirectory,
+            allowOverwrite: true
+        )
+
+        guard case .succeeded(let receipt) = presenter.exportState else {
+            Issue.record("Expected succeeded export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(receipt.targetFormatId == "txt")
+        #expect(try String(contentsOf: target, encoding: .utf8) == "hello world")
+    }
+
+    @Test func outsideAllowedDirectoryIsBlockedByService() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let allowedDirectory = try Self.temporaryDirectory()
+        let outsideDirectory = try Self.temporaryDirectory()
+        let target = outsideDirectory.appendingPathComponent("outside.txt")
+        defer {
+            try? FileManager.default.removeItem(at: allowedDirectory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: allowedDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .destinationOutsideAllowedDirectory)
+        #expect(block.path == target.path)
+        #expect(!FileManager.default.fileExists(atPath: target.path))
+    }
+
+    @Test func presentationRowsUseStableUniqueIdentifiers() throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+
+        try presenter.load(document: Self.workbookDocument())
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(Set(presentation.summaryRows.map(\.id)).count == presentation.summaryRows.count)
+        #expect(Set(presentation.structureRows.map(\.id)).count == presentation.structureRows.count)
+        #expect(Set(presentation.securityRows.map(\.id)).count == presentation.securityRows.count)
+        #expect(Set(presentation.previewRows.map(\.id)).count == presentation.previewRows.count)
+        #expect(Set(presentation.previewSections.map(\.id)).count == presentation.previewSections.count)
+        for section in presentation.previewSections {
+            #expect(Set(section.rows.map(\.id)).count == section.rows.count)
+        }
+    }
+
+    // MARK: - Assertions
+
+    private static func loadedPresentation(
+        from presenter: BusinessDocumentStudioPresenter
+    ) throws -> BusinessDocumentStudioPresentation {
+        guard case .loaded(let presentation) = presenter.loadState else {
+            Issue.record("Expected loaded presentation, got \(presenter.loadState)")
+            throw TestFailure.notLoaded
+        }
+        return presentation
+    }
+
+    private enum TestFailure: Error {
+        case notLoaded
+    }
+
+    // MARK: - Fixtures
+
+    private static func write(_ content: String, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("business-document-studio-presenter-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func plainTextDocument() -> StructuredDocument {
+        StructuredDocument(
+            formatId: "plaintext",
+            filename: "notes.txt",
+            fileSize: 11,
+            representation: AnyStructuredRepresentation(
+                formatId: "plaintext",
+                underlying: PlainTextRepresentation(text: "hello world")
+            ),
+            security: .notInspected(
+                formatId: "plaintext",
+                fileExtension: "txt",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "hello world"
+        )
+    }
+
+    private static func pdfDocument() -> StructuredDocument {
+        let page = PDFPageRepresentation(
+            pageIndex: 0,
+            text: "Quarterly report",
+            anchor: DocumentAnchor(
+                kind: .page,
+                path: [.init(kind: .page, index: 0)],
+                label: "Page 1"
+            )
+        )
+        return StructuredDocument(
+            formatId: "pdf",
+            filename: "report.pdf",
+            fileSize: 128,
+            representation: AnyStructuredRepresentation(
+                formatId: "pdf",
+                underlying: PDFDocumentRepresentation(pages: [page])
+            ),
+            security: .notInspected(
+                formatId: "pdf",
+                fileExtension: "pdf",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Quarterly report"
+        )
+    }
+
+    private static func workbookDocument(includeFormula: Bool = false) -> StructuredDocument {
+        let workbook = Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: [
+                        row(
+                            number: 1,
+                            cells: [
+                                cell("A1", row: 1, column: 1, value: .string("Month")),
+                                cell("B1", row: 1, column: 2, value: .string("Amount")),
+                            ]
+                        ),
+                        row(
+                            number: 2,
+                            cells: [
+                                cell("A2", row: 2, column: 1, value: .string("January")),
+                                cell(
+                                    "B2",
+                                    row: 2,
+                                    column: 2,
+                                    value: .number(1200),
+                                    formula: includeFormula ? "SUM(B2:B2)" : nil
+                                ),
+                            ]
+                        ),
+                    ],
+                    anchor: DocumentAnchor(kind: .sheet, path: [.init(kind: .sheet, index: 0)])
+                ),
+            ]
+        )
+
+        return StructuredDocument(
+            formatId: "xlsx",
+            filename: "workbook.xlsx",
+            fileSize: 256,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Month\tAmount\nJanuary\t1200"
+        )
+    }
+
+    private static func row(number: Int, cells: [Workbook.Cell]) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(kind: .row, path: [.init(kind: .row, index: number - 1)])
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        formula: String? = nil
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            formula: formula,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .row, index: row - 1),
+                    .init(kind: .cell, index: column - 1),
+                ]
+            )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -37,6 +37,11 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(presentation.importRows.contains { $0.label == "Source" && $0.value == source.path })
         #expect(presentation.importRows.contains(.init(label: "Document kind", value: "Table")))
         #expect(presentation.importRows.contains(.init(label: "Extraction", value: "Structured table preview")))
+        #expect(presentation.businessRows.contains(.init(label: "Fields", value: "3")))
+        #expect(presentation.businessRows.contains(.init(label: "Tables", value: "1")))
+        #expect(presentation.fieldRows.contains { $0.label == "age" && $0.value.contains("integer") })
+        #expect(presentation.tableRows.contains { $0.label.hasSuffix("people.csv") && $0.value.contains("3x3") })
+        #expect(presentation.handoffRows.contains(.init(label: "Status", value: "Available")))
         #expect(presentation.previewRows.contains(.init(label: "Preview", value: "Delimited table")))
         #expect(presentation.previewRows.contains(.init(label: "Columns", value: "3")))
         #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("csv"))
@@ -101,6 +106,9 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(xlsx.reason == .validationFailed)
         #expect(xlsx.reasonLabel == "Validation failed")
         #expect(presentation.previewRows.contains(.init(label: "Formula cells", value: "1")))
+        #expect(presentation.fieldRows.isEmpty)
+        #expect(presentation.businessRows.contains(.init(label: "Fields", value: "0")))
+        #expect(presentation.tableRows.contains { $0.label == "Revenue" && $0.value.contains("2x2") })
         #expect(presentation.warnings.contains { warning in
             warning.severity == .blocked
                 && warning.title == "Export unavailable: XLSX workbook"
@@ -142,6 +150,44 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(status.safetyLabel == "No artifact written")
     }
 
+    @Test func workspaceAttachmentHandoffProducesStructuredDocumentAttachment() throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+
+        try presenter.load(document: Self.pdfDocument())
+
+        let attachment = try presenter.makeWorkspaceAttachment()
+
+        #expect(attachment.filename == "report.pdf")
+        #expect(attachment.structuredDocumentMetadata?.formatId == "pdf")
+        #expect(attachment.businessDocumentSummary?.kind == .pdf)
+        #expect(attachment.businessDocumentSummary?.chipDetailLabel.contains("PDF") == true)
+    }
+
+    @Test func emptyTextFallbackShowsUnavailableHandoffAndBlocksAttachmentCreation() throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+
+        try presenter.load(document: Self.plainTextDocument(text: ""))
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.businessRows.contains(.init(label: "Workspace handoff", value: "Unavailable")))
+        #expect(presentation.handoffRows.contains(.init(label: "Status", value: "Unavailable")))
+        let fallbackRow = try #require(presentation.handoffRows.first { $0.label == "Text fallback" })
+        #expect(fallbackRow.value.contains("0") || fallbackRow.value.lowercased().contains("zero"))
+
+        do {
+            _ = try presenter.makeWorkspaceAttachment()
+            Issue.record("Expected empty text fallback to block workspace attachment creation")
+        } catch BusinessDocumentStudioPresenterError.attachmentHandoffUnavailable(let message) {
+            #expect(message.contains("non-empty text fallback"))
+        } catch {
+            Issue.record("Expected attachmentHandoffUnavailable, got \(error)")
+        }
+    }
+
     @Test func presentationPreviewSurfacesSlideExtractionAndMissingEmitter() throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
@@ -160,6 +206,39 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(pptx.canExport == false)
         #expect(pptx.reason == .missingEmitter)
         #expect(pptx.statusLabel == "Missing emitter")
+    }
+
+    @Test func pdfAndSlideTableExtractionSummariesSurfaceSampledTables() throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+
+        try presenter.load(document: Self.pdfDocumentWithTable())
+
+        var presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.businessRows.contains(.init(label: "Tables", value: "1")))
+        #expect(presentation.tableRows.contains { row in
+            row.label == "Page 1 table 1"
+                && row.value.contains("2x2")
+                && row.value.contains("Region | Revenue")
+        })
+        #expect(presentation.previewSections.first?.rows.contains { row in
+            row.label == "Table row 1" && row.value == "Region | Revenue"
+        } == true)
+
+        try presenter.load(document: Self.presentationDocument(includeTable: true))
+
+        presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.businessRows.contains(.init(label: "Tables", value: "1")))
+        #expect(presentation.fieldRows.contains { $0.label == "Slide 1" && $0.value.contains("slide text") })
+        #expect(presentation.tableRows.contains { row in
+            row.label == "Slide 1 table 1"
+                && row.value.contains("2x2")
+                && row.value.contains("Quarter | Status")
+        })
+        #expect(presentation.previewSections.first?.rows.contains { row in
+            row.label == "Table row 1" && row.value == "Quarter | Status"
+        } == true)
     }
 
     @Test func availableTextFallbackExportSucceeds() async throws {
@@ -443,21 +522,21 @@ struct BusinessDocumentStudioPresenterTests {
         return url
     }
 
-    private static func plainTextDocument() -> StructuredDocument {
+    private static func plainTextDocument(text: String = "hello world") -> StructuredDocument {
         StructuredDocument(
             formatId: "plaintext",
             filename: "notes.txt",
-            fileSize: 11,
+            fileSize: Int64(text.utf8.count),
             representation: AnyStructuredRepresentation(
                 formatId: "plaintext",
-                underlying: PlainTextRepresentation(text: "hello world")
+                underlying: PlainTextRepresentation(text: text)
             ),
             security: .notInspected(
                 formatId: "plaintext",
                 fileExtension: "txt",
                 sourceTrust: .generatedArtifact
             ),
-            textFallback: "hello world"
+            textFallback: text
         )
     }
 
@@ -488,8 +567,96 @@ struct BusinessDocumentStudioPresenterTests {
         )
     }
 
-    private static func presentationDocument() -> StructuredDocument {
+    private static func pdfDocumentWithTable() -> StructuredDocument {
+        let table = PDFTable(
+            pageIndex: 0,
+            index: 0,
+            rows: [
+                pdfTableRow(index: 0, values: ["Region", "Revenue"]),
+                pdfTableRow(index: 1, values: ["North", "$1200"]),
+            ],
+            bounds: bounds(),
+            anchor: DocumentAnchor(
+                kind: .table,
+                path: [.init(kind: .page, index: 0), .init(kind: .table, index: 0)]
+            )
+        )
+        let page = PDFPageRepresentation(
+            pageIndex: 0,
+            text: "Quarterly report",
+            tables: [table],
+            anchor: DocumentAnchor(
+                kind: .page,
+                path: [.init(kind: .page, index: 0)],
+                label: "Page 1"
+            )
+        )
+        return StructuredDocument(
+            formatId: "pdf",
+            filename: "report.pdf",
+            fileSize: 128,
+            representation: AnyStructuredRepresentation(
+                formatId: "pdf",
+                underlying: PDFDocumentRepresentation(pages: [page])
+            ),
+            security: .notInspected(
+                formatId: "pdf",
+                fileExtension: "pdf",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Quarterly report\nRegion\tRevenue\nNorth\t$1200"
+        )
+    }
+
+    private static func presentationDocument(includeTable: Bool = false) -> StructuredDocument {
         let sourcePart = "ppt/slides/slide1.xml"
+        let table = PresentationTable(
+            index: 0,
+            sourcePart: sourcePart,
+            anchorId: "slide1/table0",
+            rows: [
+                PresentationTableRow(
+                    index: 0,
+                    anchorId: "slide1/table0/row0",
+                    cells: [
+                        PresentationTableCell(
+                            rowIndex: 0,
+                            columnIndex: 0,
+                            text: "Quarter",
+                            paragraphIndexes: [2],
+                            anchorId: "slide1/table0/r0c0"
+                        ),
+                        PresentationTableCell(
+                            rowIndex: 0,
+                            columnIndex: 1,
+                            text: "Status",
+                            paragraphIndexes: [2],
+                            anchorId: "slide1/table0/r0c1"
+                        ),
+                    ]
+                ),
+                PresentationTableRow(
+                    index: 1,
+                    anchorId: "slide1/table0/row1",
+                    cells: [
+                        PresentationTableCell(
+                            rowIndex: 1,
+                            columnIndex: 0,
+                            text: "Q1",
+                            paragraphIndexes: [3],
+                            anchorId: "slide1/table0/r1c0"
+                        ),
+                        PresentationTableCell(
+                            rowIndex: 1,
+                            columnIndex: 1,
+                            text: "Green",
+                            paragraphIndexes: [3],
+                            anchorId: "slide1/table0/r1c1"
+                        ),
+                    ]
+                ),
+            ]
+        )
         let slide = PresentationSlide(
             index: 0,
             number: 1,
@@ -510,7 +677,8 @@ struct BusinessDocumentStudioPresenterTests {
                     sourcePart: sourcePart,
                     anchorId: "slide1/p1/r0"
                 ),
-            ]
+            ],
+            tables: includeTable ? [table] : []
         )
         let deck = PresentationDocument(
             kind: .presentation,
@@ -611,5 +779,46 @@ struct BusinessDocumentStudioPresenterTests {
                 ]
             )
         )
+    }
+
+    private static func pdfTableRow(index: Int, values: [String]) -> PDFTableRow {
+        PDFTableRow(
+            index: index,
+            cells: values.enumerated().map { columnIndex, value in
+                PDFTableCell(
+                    rowIndex: index,
+                    columnIndex: columnIndex,
+                    text: value,
+                    bounds: bounds(x: Double(columnIndex) * 10, y: Double(index) * 10),
+                    anchor: DocumentAnchor(
+                        kind: .cell,
+                        path: [
+                            .init(kind: .page, index: 0),
+                            .init(kind: .table, index: 0),
+                            .init(kind: .row, index: index),
+                            .init(kind: .cell, index: columnIndex),
+                        ]
+                    )
+                )
+            },
+            bounds: bounds(y: Double(index) * 10),
+            anchor: DocumentAnchor(
+                kind: .row,
+                path: [
+                    .init(kind: .page, index: 0),
+                    .init(kind: .table, index: 0),
+                    .init(kind: .row, index: index),
+                ]
+            )
+        )
+    }
+
+    private static func bounds(
+        x: Double = 0,
+        y: Double = 0,
+        width: Double = 10,
+        height: Double = 10
+    ) -> DocumentBoundingBox {
+        DocumentBoundingBox(x: x, y: y, width: width, height: height, coordinateSpace: .page)
     }
 }

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -34,12 +34,56 @@ struct BusinessDocumentStudioPresenterTests {
 
         let presentation = try Self.loadedPresentation(from: presenter)
         #expect(presentation.title.hasSuffix("people.csv"))
+        #expect(presentation.importRows.contains { $0.label == "Source" && $0.value == source.path })
+        #expect(presentation.importRows.contains(.init(label: "Document kind", value: "Table")))
+        #expect(presentation.importRows.contains(.init(label: "Extraction", value: "Structured table preview")))
         #expect(presentation.previewRows.contains(.init(label: "Preview", value: "Delimited table")))
         #expect(presentation.previewRows.contains(.init(label: "Columns", value: "3")))
         #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("csv"))
         #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("tsv"))
         #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("txt"))
         #expect(presentation.unavailableExportOptions.isEmpty)
+    }
+
+    @Test func unsupportedFormatLoadUsesExplicitUnsupportedState() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let source = try Self.write("not a supported business document", filename: "scan.bmp")
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        await presenter.load(url: source)
+
+        guard case .failed(let failure) = presenter.loadState else {
+            Issue.record("Expected failed load state, got \(presenter.loadState)")
+            return
+        }
+        #expect(failure.kind == .unsupportedFormat)
+        #expect(failure.title == "Unsupported format")
+        #expect(failure.path == source.path)
+        #expect(presenter.artifactStatuses.isEmpty)
+    }
+
+    @Test func malformedWorkbookLoadUsesExtractionFailureState() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let source = try Self.writeData(Data("not a zip package".utf8), filename: "broken.xlsx")
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        await presenter.load(url: source)
+
+        guard case .failed(let failure) = presenter.loadState else {
+            Issue.record("Expected failed load state, got \(presenter.loadState)")
+            return
+        }
+        #expect(failure.kind == .malformedFile)
+        #expect(failure.title == "Document could not be extracted")
+        #expect(failure.message.contains("Document read failed"))
     }
 
     @Test func workbookValidationBlockedExportIsPresented() throws {
@@ -79,6 +123,7 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(pdf.canExport == false)
         #expect(pdf.reason == .missingEmitter)
         #expect(pdf.reasonLabel == "Missing emitter")
+        #expect(pdf.statusLabel == "Missing emitter")
 
         await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory)
 
@@ -90,6 +135,31 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(block.optionID == "pdf")
         #expect(block.reason == .missingEmitter)
         #expect(!FileManager.default.fileExists(atPath: target.path))
+        let status = try #require(presenter.artifactStatuses.first)
+        #expect(status.state == .blocked)
+        #expect(status.optionID == "pdf")
+        #expect(status.reason == .missingEmitter)
+        #expect(status.safetyLabel == "No artifact written")
+    }
+
+    @Test func presentationPreviewSurfacesSlideExtractionAndMissingEmitter() throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+
+        try presenter.load(document: Self.presentationDocument())
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.importRows.contains(.init(label: "Document kind", value: "Slides")))
+        #expect(presentation.importRows.contains(.init(label: "Extraction", value: "Presentation slide preview")))
+        #expect(presentation.previewRows.contains(.init(label: "Preview", value: "Presentation")))
+        #expect(presentation.previewRows.contains(.init(label: "Slides", value: "1")))
+        #expect(presentation.previewSections.first?.rows.contains(.init(label: "Text", value: "Roadmap\nNext steps")) == true)
+
+        let pptx = try #require(presentation.exportOptions.first { $0.targetFormatId == "pptx" })
+        #expect(pptx.canExport == false)
+        #expect(pptx.reason == .missingEmitter)
+        #expect(pptx.statusLabel == "Missing emitter")
     }
 
     @Test func availableTextFallbackExportSucceeds() async throws {
@@ -114,9 +184,15 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(receipt.targetFormatId == "txt")
         #expect(receipt.bytesWritten > 0)
         #expect(try String(contentsOf: target, encoding: .utf8) == "hello world")
+        let status = try #require(presenter.artifactStatuses.first)
+        #expect(status.state == .created)
+        #expect(status.optionID == "txt")
+        #expect(status.path == target.path)
+        #expect(status.bytesWritten == receipt.bytesWritten)
+        #expect(status.safetyLabel == "Written by a registered document workflow")
     }
 
-    @Test func destinationAlreadyExistsIsBlockedByService() async throws {
+    @Test func existingDestinationRequiresOverwriteConsentAndCancelPreservesTarget() async throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         )
@@ -128,16 +204,29 @@ struct BusinessDocumentStudioPresenterTests {
         try presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
 
-        guard case .blocked(let block) = presenter.exportState else {
-            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+        guard case .awaitingOverwriteConsent(let request) = presenter.exportState else {
+            Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
             return
         }
-        #expect(block.kind == .destinationAlreadyExists)
-        #expect(block.path == target.path)
+        #expect(request.optionID == "txt")
+        #expect(request.destination == target)
+        let pending = try #require(presenter.artifactStatuses.first)
+        #expect(pending.state == .needsConsent)
+        #expect(pending.safetyLabel == "No artifact written until replacement is confirmed")
+
+        presenter.cancelPendingOverwrite()
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state after cancel, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .overwriteDeclined)
         #expect(try String(contentsOf: target, encoding: .utf8) == "private")
+        #expect(presenter.artifactStatuses.first?.state == .blocked)
+        #expect(!presenter.artifactStatuses.contains { $0.state == .needsConsent })
     }
 
-    @Test func destinationOverwriteSucceedsWhenInteractiveCallerAllowsIt() async throws {
+    @Test func overwriteConsentConfirmationWritesArtifact() async throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         )
@@ -147,12 +236,14 @@ struct BusinessDocumentStudioPresenterTests {
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
         try presenter.load(document: Self.plainTextDocument())
-        await presenter.export(
-            optionID: "txt",
-            to: target,
-            allowedDirectory: outputDirectory,
-            allowOverwrite: true
-        )
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .awaitingOverwriteConsent = presenter.exportState else {
+            Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
+            return
+        }
+
+        await presenter.confirmPendingOverwrite()
 
         guard case .succeeded(let receipt) = presenter.exportState else {
             Issue.record("Expected succeeded export state, got \(presenter.exportState)")
@@ -160,6 +251,8 @@ struct BusinessDocumentStudioPresenterTests {
         }
         #expect(receipt.targetFormatId == "txt")
         #expect(try String(contentsOf: target, encoding: .utf8) == "hello world")
+        #expect(presenter.artifactStatuses.first?.state == .created)
+        #expect(!presenter.artifactStatuses.contains { $0.state == .needsConsent })
     }
 
     @Test func outsideAllowedDirectoryIsBlockedByService() async throws {
@@ -169,6 +262,7 @@ struct BusinessDocumentStudioPresenterTests {
         let allowedDirectory = try Self.temporaryDirectory()
         let outsideDirectory = try Self.temporaryDirectory()
         let target = outsideDirectory.appendingPathComponent("outside.txt")
+        try "outside".write(to: target, atomically: true, encoding: .utf8)
         defer {
             try? FileManager.default.removeItem(at: allowedDirectory)
             try? FileManager.default.removeItem(at: outsideDirectory)
@@ -183,7 +277,111 @@ struct BusinessDocumentStudioPresenterTests {
         }
         #expect(block.kind == .destinationOutsideAllowedDirectory)
         #expect(block.path == target.path)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "outside")
+        #expect(presenter.artifactStatuses.first?.state == .blocked)
+    }
+
+    @Test func textFallbackExportCannotWritePackageShapedArtifact() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("fake.pdf")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .unsafePackageTarget)
+        #expect(block.path == "pdf")
         #expect(!FileManager.default.fileExists(atPath: target.path))
+        let status = try #require(presenter.artifactStatuses.first)
+        #expect(status.state == .blocked)
+        #expect(status.title == "Unsafe package target blocked")
+        #expect(status.safetyLabel == "No artifact written")
+    }
+
+    @Test func overwriteConsentCannotBypassUnsafePackageTarget() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("fake.pdf")
+        try "old".write(to: target, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .awaitingOverwriteConsent = presenter.exportState else {
+            Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
+            return
+        }
+
+        await presenter.confirmPendingOverwrite()
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .unsafePackageTarget)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "old")
+        #expect(presenter.artifactStatuses.first?.state == .blocked)
+        #expect(!presenter.artifactStatuses.contains { $0.state == .needsConsent })
+    }
+
+    @Test func repeatedIdenticalBlocksDoNotDuplicateArtifactStatusIDs() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("fake.pdf")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        #expect(presenter.artifactStatuses.count == 1)
+        #expect(Set(presenter.artifactStatuses.map(\.id)).count == presenter.artifactStatuses.count)
+        #expect(presenter.artifactStatuses.first?.state == .blocked)
+    }
+
+    @Test func artifactStatusesTrimToMostRecentTenRows() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        for index in 0..<12 {
+            let target = outputDirectory.appendingPathComponent("artifact-\(index).txt")
+            await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+        }
+
+        #expect(presenter.artifactStatuses.count == 10)
+        #expect(Set(presenter.artifactStatuses.map(\.id)).count == presenter.artifactStatuses.count)
+        #expect(presenter.artifactStatuses.first?.path?.hasSuffix("artifact-11.txt") == true)
+        #expect(presenter.artifactStatuses.last?.path?.hasSuffix("artifact-2.txt") == true)
+    }
+
+    @Test func confirmOverwriteWithoutPendingRequestReportsFailure() async {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+
+        await presenter.confirmPendingOverwrite()
+
+        guard case .failed(let message) = presenter.exportState else {
+            Issue.record("Expected failed export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(message == "No overwrite is waiting for confirmation.")
     }
 
     @Test func presentationRowsUseStableUniqueIdentifiers() throws {
@@ -228,6 +426,13 @@ struct BusinessDocumentStudioPresenterTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-\(filename)")
         try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func writeData(_ data: Data, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try data.write(to: url, options: .atomic)
         return url
     }
 
@@ -280,6 +485,53 @@ struct BusinessDocumentStudioPresenterTests {
                 sourceTrust: .generatedArtifact
             ),
             textFallback: "Quarterly report"
+        )
+    }
+
+    private static func presentationDocument() -> StructuredDocument {
+        let sourcePart = "ppt/slides/slide1.xml"
+        let slide = PresentationSlide(
+            index: 0,
+            number: 1,
+            sourcePart: sourcePart,
+            label: "Slide 1",
+            textRuns: [
+                PresentationTextRun(
+                    text: "Roadmap",
+                    paragraphIndex: 0,
+                    runIndex: 0,
+                    sourcePart: sourcePart,
+                    anchorId: "slide1/p0/r0"
+                ),
+                PresentationTextRun(
+                    text: "Next steps",
+                    paragraphIndex: 1,
+                    runIndex: 0,
+                    sourcePart: sourcePart,
+                    anchorId: "slide1/p1/r0"
+                ),
+            ]
+        )
+        let deck = PresentationDocument(
+            kind: .presentation,
+            sourceName: "roadmap.pptx",
+            slides: [slide]
+        )
+
+        return StructuredDocument(
+            formatId: "pptx",
+            filename: "roadmap.pptx",
+            fileSize: 512,
+            representation: AnyStructuredRepresentation(
+                formatId: "pptx",
+                underlying: deck
+            ),
+            security: .notInspected(
+                formatId: "pptx",
+                fileExtension: "pptx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: slide.text
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -467,6 +467,164 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(message == "No overwrite is waiting for confirmation.")
     }
 
+    @Test func newerLoadGenerationWinsWhenEarlierParseCompletesLast() async throws {
+        let gate = BusinessDocumentStudioParseGate()
+        let registry = DocumentFormatRegistry()
+        registry.register(adapter: SuspendedBusinessDocumentAdapter(gate: gate))
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let firstURL = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-first.gate")
+        let secondURL = URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-second.gate")
+
+        let firstLoad = Task { await presenter.load(url: firstURL) }
+        await gate.waitUntilStarted(filename: firstURL.lastPathComponent)
+        let secondLoad = Task { await presenter.load(url: secondURL) }
+        await gate.waitUntilStarted(filename: secondURL.lastPathComponent)
+
+        await gate.complete(
+            filename: secondURL.lastPathComponent,
+            with: Self.plainTextDocument(
+                text: "newer",
+                filename: secondURL.lastPathComponent,
+                formatId: "fixture"
+            )
+        )
+        await secondLoad.value
+        #expect(try Self.loadedPresentation(from: presenter).title == secondURL.lastPathComponent)
+
+        await gate.complete(
+            filename: firstURL.lastPathComponent,
+            with: Self.plainTextDocument(
+                text: "older",
+                filename: firstURL.lastPathComponent,
+                formatId: "fixture"
+            )
+        )
+        await firstLoad.value
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.title == secondURL.lastPathComponent)
+        #expect(presentation.importRows.contains { $0.label == "Source" && $0.value == secondURL.path })
+    }
+
+    @Test func staleExportCompletionCannotPublishAfterDocumentSwitch() async throws {
+        let gate = BusinessDocumentStudioExportGate()
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: SuspendedPDFEmitter(gate: gate))
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("stale.pdf")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.pdfDocument())
+        let export = Task {
+            await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory)
+        }
+        await gate.waitUntilStarted()
+        #expect(presenter.isExportInProgress)
+
+        try presenter.load(
+            document: Self.plainTextDocument(text: "replacement", filename: "replacement.txt")
+        )
+        #expect(!presenter.isExportInProgress)
+        #expect(presenter.exportState == .idle)
+        #expect(presenter.artifactStatuses.isEmpty)
+        #expect(try Self.loadedPresentation(from: presenter).title == "replacement.txt")
+
+        await gate.releaseAll()
+        #expect(await export.value)
+
+        #expect(!presenter.isExportInProgress)
+        #expect(presenter.exportState == .idle)
+        #expect(presenter.artifactStatuses.isEmpty)
+        #expect(try Self.loadedPresentation(from: presenter).title == "replacement.txt")
+    }
+
+    @Test func activeExportRejectsConcurrentExportAndOverwriteActions() async throws {
+        let gate = BusinessDocumentStudioExportGate()
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: SuspendedPDFEmitter(gate: gate))
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("existing.pdf")
+        let otherTarget = outputDirectory.appendingPathComponent("other.pdf")
+        try Data("existing".utf8).write(to: target)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.pdfDocument())
+        #expect(await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory))
+        guard case .awaitingOverwriteConsent(let request) = presenter.exportState else {
+            Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
+            return
+        }
+
+        let confirmedExport = Task {
+            await presenter.confirmPendingOverwrite(requestID: request.id)
+        }
+        await gate.waitUntilStarted()
+        #expect(presenter.isExportInProgress)
+
+        let concurrentExport = await presenter.export(
+            optionID: "pdf",
+            to: otherTarget,
+            allowedDirectory: outputDirectory
+        )
+        let duplicateConfirmation = await presenter.confirmPendingOverwrite(requestID: request.id)
+        let concurrentCancellation = presenter.cancelPendingOverwrite(requestID: request.id)
+
+        #expect(!concurrentExport)
+        #expect(!duplicateConfirmation)
+        #expect(!concurrentCancellation)
+        #expect(await gate.callCount() == 1)
+        guard case .exporting(optionID: "pdf") = presenter.exportState else {
+            Issue.record("Expected active PDF export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(presenter.artifactStatuses.isEmpty)
+
+        await gate.releaseAll()
+        #expect(await confirmedExport.value)
+        #expect(!presenter.isExportInProgress)
+        #expect(await gate.callCount() == 1)
+        #expect(presenter.artifactStatuses.first?.state == .created)
+        #expect(!FileManager.default.fileExists(atPath: otherTarget.path))
+    }
+
+    @Test func oldOverwriteRequestCannotMutateReplacementDocument() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("existing.txt")
+        try "existing".write(to: target, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        #expect(await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory))
+        guard case .awaitingOverwriteConsent(let request) = presenter.exportState else {
+            Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
+            return
+        }
+
+        try presenter.load(
+            document: Self.plainTextDocument(text: "replacement", filename: "replacement.txt")
+        )
+        let staleConfirmation = await presenter.confirmPendingOverwrite(requestID: request.id)
+        let staleCancellation = presenter.cancelPendingOverwrite(requestID: request.id)
+
+        #expect(!staleConfirmation)
+        #expect(!staleCancellation)
+        #expect(presenter.exportState == .idle)
+        #expect(presenter.artifactStatuses.isEmpty)
+        #expect(try Self.loadedPresentation(from: presenter).title == "replacement.txt")
+        #expect(try String(contentsOf: target, encoding: .utf8) == "existing")
+    }
+
     @Test func presentationRowsUseStableUniqueIdentifiers() throws {
         let registry = DocumentFormatRegistry()
         registry.register(emitter: XLSXEmitter())
@@ -526,18 +684,22 @@ struct BusinessDocumentStudioPresenterTests {
         return url
     }
 
-    private static func plainTextDocument(text: String = "hello world") -> StructuredDocument {
+    private static func plainTextDocument(
+        text: String = "hello world",
+        filename: String = "notes.txt",
+        formatId: String = "plaintext"
+    ) -> StructuredDocument {
         StructuredDocument(
-            formatId: "plaintext",
-            filename: "notes.txt",
+            formatId: formatId,
+            filename: filename,
             fileSize: Int64(text.utf8.count),
             representation: AnyStructuredRepresentation(
-                formatId: "plaintext",
+                formatId: formatId,
                 underlying: PlainTextRepresentation(text: text)
             ),
             security: .notInspected(
-                formatId: "plaintext",
-                fileExtension: "txt",
+                formatId: formatId,
+                fileExtension: URL(fileURLWithPath: filename).pathExtension,
                 sourceTrust: .generatedArtifact
             ),
             textFallback: text
@@ -824,5 +986,93 @@ struct BusinessDocumentStudioPresenterTests {
         height: Double = 10
     ) -> DocumentBoundingBox {
         DocumentBoundingBox(x: x, y: y, width: width, height: height, coordinateSpace: .page)
+    }
+}
+
+private actor BusinessDocumentStudioParseGate {
+    private var pending: [String: CheckedContinuation<StructuredDocument, any Error>] = [:]
+    private var startWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    func parse(url: URL) async throws -> StructuredDocument {
+        let filename = url.lastPathComponent
+        return try await withCheckedThrowingContinuation { continuation in
+            pending[filename] = continuation
+            let waiters = startWaiters.removeValue(forKey: filename) ?? []
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    func waitUntilStarted(filename: String) async {
+        guard pending[filename] == nil else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters[filename, default: []].append(continuation)
+        }
+    }
+
+    func complete(filename: String, with document: StructuredDocument) {
+        pending.removeValue(forKey: filename)?.resume(returning: document)
+    }
+}
+
+private struct SuspendedBusinessDocumentAdapter: DocumentFormatAdapter {
+    let gate: BusinessDocumentStudioParseGate
+    let formatId = "fixture"
+
+    func canHandle(url: URL, uti: String?) -> Bool {
+        url.pathExtension == "gate"
+    }
+
+    func parse(url: URL, sizeLimit: Int64) async throws -> StructuredDocument {
+        try await gate.parse(url: url)
+    }
+}
+
+private actor BusinessDocumentStudioExportGate {
+    private var invocationCount = 0
+    private var isReleased = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func suspend() async {
+        invocationCount += 1
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard invocationCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func releaseAll() {
+        isReleased = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func callCount() -> Int {
+        invocationCount
+    }
+}
+
+private struct SuspendedPDFEmitter: DocumentFormatEmitter {
+    let gate: BusinessDocumentStudioExportGate
+    let formatId = "pdf"
+
+    func canEmit(_ document: StructuredDocument) -> Bool {
+        document.representation.underlying is PDFDocumentRepresentation
+    }
+
+    func emit(_ document: StructuredDocument, to url: URL) async throws {
+        await gate.suspend()
+        try Data("fixture-pdf".utf8).write(to: url, options: .atomic)
     }
 }

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -157,6 +157,9 @@ struct BusinessDocumentStudioPresenterTests {
 
         try presenter.load(document: Self.pdfDocument())
 
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.isAttachmentHandoffAvailable)
+
         let attachment = try presenter.makeWorkspaceAttachment()
 
         #expect(attachment.filename == "report.pdf")
@@ -175,6 +178,7 @@ struct BusinessDocumentStudioPresenterTests {
         let presentation = try Self.loadedPresentation(from: presenter)
         #expect(presentation.businessRows.contains(.init(label: "Workspace handoff", value: "Unavailable")))
         #expect(presentation.handoffRows.contains(.init(label: "Status", value: "Unavailable")))
+        #expect(!presentation.isAttachmentHandoffAvailable)
         let fallbackRow = try #require(presentation.handoffRows.first { $0.label == "Text fallback" })
         #expect(fallbackRow.value.contains("0") || fallbackRow.value.lowercased().contains("zero"))
 

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -91,14 +91,14 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(failure.message.contains("Document read failed"))
     }
 
-    @Test func workbookValidationBlockedExportIsPresented() throws {
+    @Test func workbookValidationBlockedExportIsPresented() async throws {
         let registry = DocumentFormatRegistry()
         registry.register(emitter: XLSXEmitter())
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: registry)
         )
 
-        try presenter.load(document: Self.workbookDocument(includeFormula: true))
+        try await presenter.load(document: Self.workbookDocument(includeFormula: true))
 
         let presentation = try Self.loadedPresentation(from: presenter)
         let xlsx = try #require(presentation.exportOptions.first { $0.targetFormatId == "xlsx" })
@@ -124,7 +124,7 @@ struct BusinessDocumentStudioPresenterTests {
         let target = outputDirectory.appendingPathComponent("report.pdf")
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.pdfDocument())
+        try await presenter.load(document: Self.pdfDocument())
         let presentation = try Self.loadedPresentation(from: presenter)
 
         let pdf = try #require(presentation.exportOptions.first { $0.targetFormatId == "pdf" })
@@ -150,17 +150,17 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(status.safetyLabel == "No artifact written")
     }
 
-    @Test func workspaceAttachmentHandoffProducesStructuredDocumentAttachment() throws {
+    @Test func attachmentPayloadValidationProducesStructuredDocumentAttachment() async throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         )
 
-        try presenter.load(document: Self.pdfDocument())
+        try await presenter.load(document: Self.pdfDocument())
 
         let presentation = try Self.loadedPresentation(from: presenter)
         #expect(presentation.isAttachmentHandoffAvailable)
 
-        let attachment = try presenter.makeWorkspaceAttachment()
+        let attachment = try presenter.makeAttachmentPayloadForValidation()
 
         #expect(attachment.filename == "report.pdf")
         #expect(attachment.structuredDocumentMetadata?.formatId == "pdf")
@@ -168,23 +168,23 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(attachment.businessDocumentSummary?.chipDetailLabel.contains("PDF") == true)
     }
 
-    @Test func emptyTextFallbackShowsUnavailableHandoffAndBlocksAttachmentCreation() throws {
+    @Test func emptyTextFallbackShowsUnavailableValidationAndBlocksAttachmentCreation() async throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         )
 
-        try presenter.load(document: Self.plainTextDocument(text: ""))
+        try await presenter.load(document: Self.plainTextDocument(text: ""))
 
         let presentation = try Self.loadedPresentation(from: presenter)
-        #expect(presentation.businessRows.contains(.init(label: "Workspace handoff", value: "Unavailable")))
+        #expect(presentation.businessRows.contains(.init(label: "Attachment validation", value: "Unavailable")))
         #expect(presentation.handoffRows.contains(.init(label: "Status", value: "Unavailable")))
         #expect(!presentation.isAttachmentHandoffAvailable)
         let fallbackRow = try #require(presentation.handoffRows.first { $0.label == "Text fallback" })
         #expect(fallbackRow.value.contains("0") || fallbackRow.value.lowercased().contains("zero"))
 
         do {
-            _ = try presenter.makeWorkspaceAttachment()
-            Issue.record("Expected empty text fallback to block workspace attachment creation")
+            _ = try presenter.makeAttachmentPayloadForValidation()
+            Issue.record("Expected empty text fallback to block attachment payload validation")
         } catch BusinessDocumentStudioPresenterError.attachmentHandoffUnavailable(let message) {
             #expect(message.contains("non-empty text fallback"))
         } catch {
@@ -192,12 +192,12 @@ struct BusinessDocumentStudioPresenterTests {
         }
     }
 
-    @Test func presentationPreviewSurfacesSlideExtractionAndMissingEmitter() throws {
+    @Test func presentationPreviewSurfacesSlideExtractionAndMissingEmitter() async throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         )
 
-        try presenter.load(document: Self.presentationDocument())
+        try await presenter.load(document: Self.presentationDocument())
 
         let presentation = try Self.loadedPresentation(from: presenter)
         #expect(presentation.importRows.contains(.init(label: "Document kind", value: "Slides")))
@@ -212,12 +212,12 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(pptx.statusLabel == "Missing emitter")
     }
 
-    @Test func pdfAndSlideTableExtractionSummariesSurfaceSampledTables() throws {
+    @Test func pdfAndSlideTableExtractionSummariesSurfaceSampledTables() async throws {
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         )
 
-        try presenter.load(document: Self.pdfDocumentWithTable())
+        try await presenter.load(document: Self.pdfDocumentWithTable())
 
         var presentation = try Self.loadedPresentation(from: presenter)
         #expect(presentation.businessRows.contains(.init(label: "Tables", value: "1")))
@@ -230,7 +230,7 @@ struct BusinessDocumentStudioPresenterTests {
             row.label == "Table row 1" && row.value == "Region | Revenue"
         } == true)
 
-        try presenter.load(document: Self.presentationDocument(includeTable: true))
+        try await presenter.load(document: Self.presentationDocument(includeTable: true))
 
         presentation = try Self.loadedPresentation(from: presenter)
         #expect(presentation.businessRows.contains(.init(label: "Tables", value: "1")))
@@ -253,7 +253,7 @@ struct BusinessDocumentStudioPresenterTests {
         let target = outputDirectory.appendingPathComponent("notes.txt")
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         let presentation = try Self.loadedPresentation(from: presenter)
         let text = try #require(presentation.exportOptions.first { $0.targetFormatId == "txt" })
         #expect(text.canExport)
@@ -284,7 +284,7 @@ struct BusinessDocumentStudioPresenterTests {
         try "private".write(to: target, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
 
         guard case .awaitingOverwriteConsent(let request) = presenter.exportState else {
@@ -318,7 +318,7 @@ struct BusinessDocumentStudioPresenterTests {
         try "old".write(to: target, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
 
         guard case .awaitingOverwriteConsent = presenter.exportState else {
@@ -351,7 +351,7 @@ struct BusinessDocumentStudioPresenterTests {
             try? FileManager.default.removeItem(at: outsideDirectory)
         }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: allowedDirectory)
 
         guard case .blocked(let block) = presenter.exportState else {
@@ -372,7 +372,7 @@ struct BusinessDocumentStudioPresenterTests {
         let target = outputDirectory.appendingPathComponent("fake.pdf")
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
 
         guard case .blocked(let block) = presenter.exportState else {
@@ -397,7 +397,7 @@ struct BusinessDocumentStudioPresenterTests {
         try "old".write(to: target, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
 
         guard case .awaitingOverwriteConsent = presenter.exportState else {
@@ -425,7 +425,7 @@ struct BusinessDocumentStudioPresenterTests {
         let target = outputDirectory.appendingPathComponent("fake.pdf")
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
         await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
 
@@ -441,7 +441,7 @@ struct BusinessDocumentStudioPresenterTests {
         let outputDirectory = try Self.temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         for index in 0..<12 {
             let target = outputDirectory.appendingPathComponent("artifact-\(index).txt")
             await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
@@ -508,7 +508,7 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(presentation.importRows.contains { $0.label == "Source" && $0.value == secondURL.path })
     }
 
-    @Test func staleExportCompletionCannotPublishAfterDocumentSwitch() async throws {
+    @Test func documentSwitchCancelsAndJoinsExportWithoutWritingOldDestination() async throws {
         let gate = BusinessDocumentStudioExportGate()
         let registry = DocumentFormatRegistry()
         registry.register(emitter: SuspendedPDFEmitter(gate: gate))
@@ -517,30 +517,43 @@ struct BusinessDocumentStudioPresenterTests {
         )
         let outputDirectory = try Self.temporaryDirectory()
         let target = outputDirectory.appendingPathComponent("stale.pdf")
+        let originalBytes = Data("original-pdf".utf8)
+        try originalBytes.write(to: target)
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.pdfDocument())
+        try await presenter.load(document: Self.pdfDocument())
         let export = Task {
-            await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory)
+            await presenter.export(
+                optionID: "pdf",
+                to: target,
+                allowedDirectory: outputDirectory,
+                allowOverwrite: true
+            )
         }
         await gate.waitUntilStarted()
         #expect(presenter.isExportInProgress)
 
-        try presenter.load(
-            document: Self.plainTextDocument(text: "replacement", filename: "replacement.txt")
-        )
-        #expect(!presenter.isExportInProgress)
-        #expect(presenter.exportState == .idle)
-        #expect(presenter.artifactStatuses.isEmpty)
-        #expect(try Self.loadedPresentation(from: presenter).title == "replacement.txt")
+        let replacementLoad = Task {
+            try await presenter.load(
+                document: Self.plainTextDocument(text: "replacement", filename: "replacement.txt")
+            )
+        }
+        await gate.waitUntilCancellationObserved()
+
+        #expect(presenter.isExportInProgress)
+        #expect(try Data(contentsOf: target) == originalBytes)
 
         await gate.releaseAll()
+        try await replacementLoad.value
         #expect(await export.value)
 
         #expect(!presenter.isExportInProgress)
         #expect(presenter.exportState == .idle)
         #expect(presenter.artifactStatuses.isEmpty)
         #expect(try Self.loadedPresentation(from: presenter).title == "replacement.txt")
+        #expect(try Data(contentsOf: target) == originalBytes)
+        let remainingNames = try FileManager.default.contentsOfDirectory(atPath: outputDirectory.path)
+        #expect(!remainingNames.contains { $0.contains(".osaurus-export-") })
     }
 
     @Test func activeExportRejectsConcurrentExportAndOverwriteActions() async throws {
@@ -556,7 +569,7 @@ struct BusinessDocumentStudioPresenterTests {
         try Data("existing".utf8).write(to: target)
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.pdfDocument())
+        try await presenter.load(document: Self.pdfDocument())
         #expect(await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory))
         guard case .awaitingOverwriteConsent(let request) = presenter.exportState else {
             Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
@@ -604,14 +617,14 @@ struct BusinessDocumentStudioPresenterTests {
         try "existing".write(to: target, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: outputDirectory) }
 
-        try presenter.load(document: Self.plainTextDocument())
+        try await presenter.load(document: Self.plainTextDocument())
         #expect(await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory))
         guard case .awaitingOverwriteConsent(let request) = presenter.exportState else {
             Issue.record("Expected overwrite consent state, got \(presenter.exportState)")
             return
         }
 
-        try presenter.load(
+        try await presenter.load(
             document: Self.plainTextDocument(text: "replacement", filename: "replacement.txt")
         )
         let staleConfirmation = await presenter.confirmPendingOverwrite(requestID: request.id)
@@ -625,14 +638,14 @@ struct BusinessDocumentStudioPresenterTests {
         #expect(try String(contentsOf: target, encoding: .utf8) == "existing")
     }
 
-    @Test func presentationRowsUseStableUniqueIdentifiers() throws {
+    @Test func presentationRowsUseStableUniqueIdentifiers() async throws {
         let registry = DocumentFormatRegistry()
         registry.register(emitter: XLSXEmitter())
         let presenter = BusinessDocumentStudioPresenter(
             service: BusinessDocumentStudioService(registry: registry)
         )
 
-        try presenter.load(document: Self.workbookDocument())
+        try await presenter.load(document: Self.workbookDocument())
 
         let presentation = try Self.loadedPresentation(from: presenter)
         #expect(Set(presentation.summaryRows.map(\.id)).count == presentation.summaryRows.count)
@@ -1030,8 +1043,10 @@ private struct SuspendedBusinessDocumentAdapter: DocumentFormatAdapter {
 private actor BusinessDocumentStudioExportGate {
     private var invocationCount = 0
     private var isReleased = false
+    private var didObserveCancellation = false
     private var startWaiters: [CheckedContinuation<Void, Never>] = []
     private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
 
     func suspend() async {
         invocationCount += 1
@@ -1039,8 +1054,12 @@ private actor BusinessDocumentStudioExportGate {
         startWaiters.removeAll()
         waiters.forEach { $0.resume() }
         guard !isReleased else { return }
-        await withCheckedContinuation { continuation in
-            releaseWaiters.append(continuation)
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        } onCancel: {
+            Task { await self.recordCancellation() }
         }
     }
 
@@ -1048,6 +1067,13 @@ private actor BusinessDocumentStudioExportGate {
         guard invocationCount == 0 else { return }
         await withCheckedContinuation { continuation in
             startWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilCancellationObserved() async {
+        guard !didObserveCancellation else { return }
+        await withCheckedContinuation { continuation in
+            cancellationWaiters.append(continuation)
         }
     }
 
@@ -1061,6 +1087,13 @@ private actor BusinessDocumentStudioExportGate {
     func callCount() -> Int {
         invocationCount
     }
+
+    private func recordCancellation() {
+        didObserveCancellation = true
+        let waiters = cancellationWaiters
+        cancellationWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
 }
 
 private struct SuspendedPDFEmitter: DocumentFormatEmitter {
@@ -1073,6 +1106,8 @@ private struct SuspendedPDFEmitter: DocumentFormatEmitter {
 
     func emit(_ document: StructuredDocument, to url: URL) async throws {
         await gate.suspend()
+        // Deliberately ignore cancellation. The production service must keep
+        // this late write confined to staging rather than the selected path.
         try Data("fixture-pdf".utf8).write(to: url, options: .atomic)
     }
 }

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -69,6 +69,40 @@ struct BusinessDocumentStudioServiceTests {
         #expect(table.rows[1].cells.map(\.text) == ["Ada", "37", "true"])
     }
 
+    @Test func unsupportedImportThrowsExplicitUnsupportedFormat() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let service = BusinessDocumentStudioService(registry: registry)
+        let source = try Self.write("bitmap bytes", filename: "scan.bmp")
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        do {
+            _ = try await service.inspect(url: source)
+            Issue.record("Expected unsupported format error")
+        } catch BusinessDocumentStudioError.unsupportedFormat(let fileExtension) {
+            #expect(fileExtension == "bmp")
+        } catch {
+            Issue.record("Expected unsupportedFormat, got \(error)")
+        }
+    }
+
+    @Test func malformedWorkbookImportThrowsReadFailure() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let service = BusinessDocumentStudioService(registry: registry)
+        let source = try Self.writeData(Data("not a zip package".utf8), filename: "broken.xlsx")
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        do {
+            _ = try await service.parse(url: source)
+            Issue.record("Expected malformed workbook read failure")
+        } catch DocumentAdapterError.readFailed(let underlying) {
+            #expect(!underlying.isEmpty)
+        } catch {
+            Issue.record("Expected DocumentAdapterError.readFailed, got \(error)")
+        }
+    }
+
     @Test func inspectWorkbookSamplesCellsAndReportsValidationBlockedExport() async throws {
         let registry = DocumentFormatRegistry()
         registry.register(emitter: XLSXEmitter())
@@ -259,6 +293,13 @@ struct BusinessDocumentStudioServiceTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-\(filename)")
         try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func writeData(_ data: Data, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try data.write(to: url, options: .atomic)
         return url
     }
 

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -41,6 +41,10 @@ struct BusinessDocumentStudioServiceTests {
         #expect(inspection.registryRoles == [.adapter, .emitter])
         #expect(inspection.exportOptions.contains { $0.targetFormatId == "csv" && $0.canExport })
         #expect(inspection.exportOptions.contains { $0.targetFormatId == "tsv" && $0.canExport })
+        #expect(inspection.extractionSummary.fields.map(\.name) == ["name", "age", "active"])
+        #expect(inspection.extractionSummary.tables.first?.rowCount == 3)
+        #expect(inspection.extractionSummary.tables.first?.columnCount == 3)
+        #expect(inspection.extractionSummary.attachmentHandoff.isAvailable)
 
         guard case let .table(preview) = inspection.preview else {
             Issue.record("Expected table preview")
@@ -53,6 +57,7 @@ struct BusinessDocumentStudioServiceTests {
         let encoded = try JSONEncoder().encode(inspection)
         let decoded = try JSONDecoder().decode(BusinessDocumentStudioInspection.self, from: encoded)
         #expect(decoded.summary.filename == inspection.summary.filename)
+        #expect(decoded.extractionSummary.fields.count == 3)
 
         let result = try await service.export(
             document,
@@ -130,6 +135,8 @@ struct BusinessDocumentStudioServiceTests {
         #expect(preview.inspection.validationIssues.contains { $0.code == .formulaNotWritable })
         #expect(preview.sheets.first?.sampleRows[1].cells[1].hasFormula == true)
         #expect(preview.sheets.first?.sampleRows[1].cells[1].text.text == "1200")
+        #expect(inspection.extractionSummary.fields.isEmpty)
+        #expect(inspection.extractionSummary.tables.first?.label == "Revenue")
 
         do {
             _ = try await service.export(
@@ -287,6 +294,37 @@ struct BusinessDocumentStudioServiceTests {
         #expect(preview.creationAvailability.reasonCode == .missingEmitter)
     }
 
+    @Test func structuredAttachmentHandoffUsesExistingAttachmentAPI() throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let document = Self.pdfDocument()
+
+        let inspection = try service.inspect(document)
+        let attachment = try service.makeAttachment(for: document)
+
+        #expect(inspection.extractionSummary.attachmentHandoff.isAvailable)
+        #expect(attachment.filename == "report.pdf")
+        #expect(attachment.structuredDocumentMetadata?.formatId == "pdf")
+        #expect(attachment.businessDocumentSummary?.kind == .pdf)
+    }
+
+    @Test func emptyTextFallbackDisablesAndBlocksAttachmentHandoff() throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let document = Self.plainTextDocument(text: "")
+
+        let inspection = try service.inspect(document)
+
+        #expect(!inspection.extractionSummary.attachmentHandoff.isAvailable)
+        #expect(inspection.extractionSummary.attachmentHandoff.fallbackUTF8Bytes == 0)
+        do {
+            _ = try service.makeAttachment(for: document)
+            Issue.record("Expected empty text fallback to block attachment handoff")
+        } catch BusinessDocumentStudioError.attachmentHandoffUnavailable(let message) {
+            #expect(message.contains("non-empty text fallback"))
+        } catch {
+            Issue.record("Expected attachmentHandoffUnavailable, got \(error)")
+        }
+    }
+
     // MARK: - Fixtures
 
     private static func write(_ content: String, filename: String) throws -> URL {
@@ -310,21 +348,21 @@ struct BusinessDocumentStudioServiceTests {
         return url
     }
 
-    private static func plainTextDocument() -> StructuredDocument {
+    private static func plainTextDocument(text: String = "hello world") -> StructuredDocument {
         StructuredDocument(
             formatId: "plaintext",
             filename: "notes.txt",
-            fileSize: 11,
+            fileSize: Int64(text.utf8.count),
             representation: AnyStructuredRepresentation(
                 formatId: "plaintext",
-                underlying: PlainTextRepresentation(text: "hello world")
+                underlying: PlainTextRepresentation(text: text)
             ),
             security: .notInspected(
                 formatId: "plaintext",
                 fileExtension: "txt",
                 sourceTrust: .generatedArtifact
             ),
-            textFallback: "hello world"
+            textFallback: text
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -181,6 +181,37 @@ struct BusinessDocumentStudioServiceTests {
         }
     }
 
+    @Test func exportStructuredPackageRejectsNonPackageExtension() async throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let service = BusinessDocumentStudioService(registry: registry)
+        let document = Self.workbookDocument()
+        let outputDirectory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        for filename in ["workbook.txt", "workbook"] {
+            let target = outputDirectory.appendingPathComponent(filename)
+            do {
+                _ = try await service.export(
+                    document,
+                    as: "xlsx",
+                    to: target,
+                    policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+                )
+                Issue.record("Expected non-package extension to be rejected for \(filename)")
+            } catch BusinessDocumentStudioError.packageTargetExtensionMismatch(
+                let targetFormatId,
+                let fileExtension
+            ) {
+                #expect(targetFormatId == "xlsx")
+                #expect(fileExtension == target.pathExtension.lowercased())
+                #expect(!FileManager.default.fileExists(atPath: target.path))
+            } catch {
+                Issue.record("Expected packageTargetExtensionMismatch, got \(error)")
+            }
+        }
+    }
+
     @Test func exportRegisteredEmitterCanOwnStructuredPackageExtension() async throws {
         let registry = DocumentFormatRegistry()
         registry.register(emitter: StubPackageEmitter(formatId: "pptm"))

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -338,6 +338,39 @@ struct BusinessDocumentStudioServiceTests {
         #expect(try symlink.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true)
     }
 
+    @Test func exportRejectsDanglingSymlinkLeafEscapingAllowedDirectory() async throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let outputDirectory = try Self.temporaryDirectory()
+        let outsideDirectory = try Self.temporaryDirectory()
+        let missingOutsideTarget = outsideDirectory.appendingPathComponent("missing.txt")
+        let symlink = outputDirectory.appendingPathComponent("report.txt")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: missingOutsideTarget)
+        defer {
+            try? FileManager.default.removeItem(at: outputDirectory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        do {
+            _ = try await service.export(
+                Self.plainTextDocument(text: "replacement"),
+                as: "txt",
+                to: symlink,
+                policy: BusinessDocumentStudioExportPolicy(
+                    allowedDirectory: outputDirectory,
+                    allowOverwrite: true
+                )
+            )
+            Issue.record("Expected a dangling escaping symlink leaf to be rejected")
+        } catch BusinessDocumentStudioError.destinationOutsideAllowedDirectory(let url) {
+            #expect(url == symlink)
+        } catch {
+            Issue.record("Expected destinationOutsideAllowedDirectory, got \(error)")
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: missingOutsideTarget.path))
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: symlink.path) == missingOutsideTarget.path)
+    }
+
     @Test func exportAllowsExistingSymlinkLeafResolvingWithinAllowedDirectory() async throws {
         let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         let outputDirectory = try Self.temporaryDirectory()

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -304,6 +304,113 @@ struct BusinessDocumentStudioServiceTests {
         #expect(!FileManager.default.fileExists(atPath: missingOutside.path))
     }
 
+    @Test func exportRejectsExistingSymlinkLeafEscapingAllowedDirectory() async throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let outputDirectory = try Self.temporaryDirectory()
+        let outsideDirectory = try Self.temporaryDirectory()
+        let outsideTarget = outsideDirectory.appendingPathComponent("private.txt")
+        let symlink = outputDirectory.appendingPathComponent("report.txt")
+        try "private".write(to: outsideTarget, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: outsideTarget)
+        defer {
+            try? FileManager.default.removeItem(at: outputDirectory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        do {
+            _ = try await service.export(
+                Self.plainTextDocument(text: "replacement"),
+                as: "txt",
+                to: symlink,
+                policy: BusinessDocumentStudioExportPolicy(
+                    allowedDirectory: outputDirectory,
+                    allowOverwrite: true
+                )
+            )
+            Issue.record("Expected an escaping symlink leaf to be rejected")
+        } catch BusinessDocumentStudioError.destinationOutsideAllowedDirectory(let url) {
+            #expect(url == symlink)
+        } catch {
+            Issue.record("Expected destinationOutsideAllowedDirectory, got \(error)")
+        }
+
+        #expect(try String(contentsOf: outsideTarget, encoding: .utf8) == "private")
+        #expect(try symlink.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true)
+    }
+
+    @Test func exportAllowsExistingSymlinkLeafResolvingWithinAllowedDirectory() async throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let outputDirectory = try Self.temporaryDirectory()
+        let inRootTarget = outputDirectory.appendingPathComponent("stored.txt")
+        let symlink = outputDirectory.appendingPathComponent("report.txt")
+        try "stored".write(to: inRootTarget, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: inRootTarget)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let result = try await service.export(
+            Self.plainTextDocument(text: "replacement"),
+            as: "txt",
+            to: symlink,
+            policy: BusinessDocumentStudioExportPolicy(
+                allowedDirectory: outputDirectory,
+                allowOverwrite: true
+            )
+        )
+
+        #expect(result.url == symlink)
+        #expect(try String(contentsOf: symlink, encoding: .utf8) == "replacement")
+        #expect(try String(contentsOf: inRootTarget, encoding: .utf8) == "stored")
+        #expect(try symlink.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == false)
+    }
+
+    @Test func exportTreatsVarAndPrivateVarAsSameAllowedDirectory() async throws {
+        let directoryName = "business-document-studio-firmlink-\(UUID().uuidString)"
+        let privateRoot = URL(fileURLWithPath: "/private/var/tmp")
+            .appendingPathComponent(directoryName, isDirectory: true)
+        let varRoot = URL(fileURLWithPath: "/var/tmp")
+            .appendingPathComponent(directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: privateRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: privateRoot) }
+
+        let target = varRoot.appendingPathComponent("report.txt")
+        let result = try await BusinessDocumentStudioService(registry: DocumentFormatRegistry()).export(
+            Self.plainTextDocument(text: "firmlink-safe"),
+            as: "txt",
+            to: target,
+            policy: BusinessDocumentStudioExportPolicy(allowedDirectory: privateRoot)
+        )
+
+        #expect(result.url == target)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "firmlink-safe")
+    }
+
+    @Test func destinationAppearingDuringRenderIsNotOverwrittenWithoutConsent() async throws {
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("raced.pdf")
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: DestinationCreatingPDFEmitter(finalURL: target))
+        let service = BusinessDocumentStudioService(registry: registry)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        do {
+            _ = try await service.export(
+                Self.pdfDocument(),
+                as: "pdf",
+                to: target,
+                policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+            )
+            Issue.record("Expected the raced destination to retain exclusive ownership")
+        } catch BusinessDocumentStudioError.destinationAlreadyExists(let url) {
+            #expect(url == target)
+        } catch {
+            Issue.record("Expected destinationAlreadyExists, got \(error)")
+        }
+
+        #expect(try String(contentsOf: target, encoding: .utf8) == "racer")
+        let remainingNames = try FileManager.default.contentsOfDirectory(atPath: outputDirectory.path)
+        #expect(!remainingNames.contains { $0.contains(".osaurus-export-") })
+    }
+
     @Test func inspectPDFWrapsPreviewAndMissingEmitterExportOption() throws {
         let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         let inspection = try service.inspect(Self.pdfDocument())
@@ -512,5 +619,19 @@ private struct StubPackageEmitter: DocumentFormatEmitter {
 
     func emit(_ document: StructuredDocument, to url: URL) async throws {
         try Data("emitted:\(formatId)".utf8).write(to: url, options: .atomic)
+    }
+}
+
+private struct DestinationCreatingPDFEmitter: DocumentFormatEmitter {
+    let finalURL: URL
+    let formatId = "pdf"
+
+    func canEmit(_ document: StructuredDocument) -> Bool {
+        document.representation.underlying is PDFDocumentRepresentation
+    }
+
+    func emit(_ document: StructuredDocument, to url: URL) async throws {
+        try Data("rendered".utf8).write(to: url, options: .atomic)
+        try Data("racer".utf8).write(to: finalURL, options: .atomic)
     }
 }

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
@@ -2,7 +2,7 @@
 //  BusinessDocumentStudioLauncher.swift
 //  osaurus
 //
-//  App-facing entry point for opening Business Document Studio windows.
+//  App-facing entry point for opening Business Document Workbench windows.
 //
 
 import AppKit
@@ -52,7 +52,7 @@ public enum BusinessDocumentStudioLauncher {
             defer: false
         )
         window.title = sourceURL.lastPathComponent.isEmpty
-            ? L("Business Document Studio")
+            ? L("Business Document Workbench")
             : sourceURL.lastPathComponent
         window.titlebarAppearsTransparent = true
         window.isReleasedWhenClosed = false

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
@@ -22,7 +22,7 @@ public enum BusinessDocumentStudioLauncher {
         panel.resolvesAliases = true
         panel.title = L("Open Business Document")
         panel.message = L("Choose a supported document to inspect preview, security, and export availability.")
-        panel.allowedContentTypes = supportedContentTypes
+        panel.allowedContentTypes = BusinessDocumentStudioDocumentTypes.supportedContentTypes
 
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
@@ -72,19 +72,21 @@ public enum BusinessDocumentStudioLauncher {
         show(window)
     }
 
-    private static var supportedContentTypes: [UTType] {
-        let extensions = ["csv", "tsv", "xlsx", "pdf", "pptx", "potx", "docx", "doc", "rtf", "rtfd", "txt"]
-        let structuredTypes = extensions.compactMap { UTType(filenameExtension: $0) }
-        let parserTypes = DocumentParser.supportedDocumentTypes
-        var seen = Set<String>()
-        return (parserTypes + structuredTypes).filter { seen.insert($0.identifier).inserted }
-    }
-
     private static func show(_ window: NSWindow) {
         NSApp.unhide(nil)
         NSApp.activate()
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
+    }
+}
+
+enum BusinessDocumentStudioDocumentTypes {
+    static var supportedContentTypes: [UTType] {
+        let extensions = ["csv", "tsv", "xlsx", "pdf", "pptx", "potx", "docx", "doc", "rtf", "rtfd", "txt"]
+        let structuredTypes = extensions.compactMap { UTType(filenameExtension: $0) }
+        let parserTypes = DocumentParser.supportedDocumentTypes
+        var seen = Set<String>()
+        return (parserTypes + structuredTypes).filter { seen.insert($0.identifier).inserted }
     }
 }
 

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
@@ -1,0 +1,103 @@
+//
+//  BusinessDocumentStudioLauncher.swift
+//  osaurus
+//
+//  App-facing entry point for opening Business Document Studio windows.
+//
+
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+@MainActor
+public enum BusinessDocumentStudioLauncher {
+    private static var windows: [URL: NSWindow] = [:]
+    private static var delegates: [ObjectIdentifier: BusinessDocumentStudioWindowDelegate] = [:]
+
+    public static func openDocumentPicker() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.resolvesAliases = true
+        panel.title = L("Open Business Document")
+        panel.message = L("Choose a supported document to inspect preview, security, and export availability.")
+        panel.allowedContentTypes = supportedContentTypes
+
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            Task { @MainActor in
+                open(url: url)
+            }
+        }
+    }
+
+    public static func open(url: URL) {
+        let sourceURL = url.standardizedFileURL
+        if let existing = windows[sourceURL] {
+            show(existing)
+            return
+        }
+
+        let root = BusinessDocumentStudioView(sourceURL: sourceURL)
+        let hostingController = NSHostingController(rootView: root)
+        if #available(macOS 13.0, *) {
+            hostingController.sizingOptions = []
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 860, height: 640),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = sourceURL.lastPathComponent.isEmpty
+            ? L("Business Document Studio")
+            : sourceURL.lastPathComponent
+        window.titlebarAppearsTransparent = true
+        window.isReleasedWhenClosed = false
+        window.isRestorable = false
+        window.contentViewController = hostingController
+        window.center()
+
+        let identifier = ObjectIdentifier(window)
+        let delegate = BusinessDocumentStudioWindowDelegate {
+            windows[sourceURL] = nil
+            delegates[identifier] = nil
+        }
+        delegates[identifier] = delegate
+        window.delegate = delegate
+        windows[sourceURL] = window
+
+        show(window)
+    }
+
+    private static var supportedContentTypes: [UTType] {
+        let extensions = ["csv", "tsv", "xlsx", "pdf", "pptx", "potx", "docx", "doc", "rtf", "rtfd", "txt"]
+        let structuredTypes = extensions.compactMap { UTType(filenameExtension: $0) }
+        let parserTypes = DocumentParser.supportedDocumentTypes
+        var seen = Set<String>()
+        return (parserTypes + structuredTypes).filter { seen.insert($0.identifier).inserted }
+    }
+
+    private static func show(_ window: NSWindow) {
+        NSApp.unhide(nil)
+        NSApp.activate()
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+    }
+}
+
+@MainActor
+private final class BusinessDocumentStudioWindowDelegate: NSObject, NSWindowDelegate {
+    private let onClose: () -> Void
+
+    init(onClose: @escaping () -> Void) {
+        self.onClose = onClose
+        super.init()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onClose()
+    }
+}

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
@@ -105,7 +105,7 @@ public enum BusinessDocumentStudioLauncher {
 
 enum BusinessDocumentStudioSourceIdentity {
     static func standardized(_ url: URL) -> URL {
-        url.standardizedFileURL
+        url.standardizedFileURL.resolvingSymlinksInPath().standardizedFileURL
     }
 
     static func acceptedSourceURL(

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 @MainActor
 public enum BusinessDocumentStudioLauncher {
-    private static var windows: [URL: NSWindow] = [:]
+    private static let windowCache = BusinessDocumentStudioWindowCache<NSWindow>()
     private static var delegates: [ObjectIdentifier: BusinessDocumentStudioWindowDelegate] = [:]
 
     public static func openDocumentPicker() {
@@ -33,16 +33,10 @@ public enum BusinessDocumentStudioLauncher {
     }
 
     public static func open(url: URL) {
-        let sourceURL = url.standardizedFileURL
-        if let existing = windows[sourceURL] {
+        let sourceURL = BusinessDocumentStudioSourceIdentity.standardized(url)
+        if let existing = windowCache.window(for: sourceURL) {
             show(existing)
             return
-        }
-
-        let root = BusinessDocumentStudioView(sourceURL: sourceURL)
-        let hostingController = NSHostingController(rootView: root)
-        if #available(macOS 13.0, *) {
-            hostingController.sizingOptions = []
         }
 
         let window = NSWindow(
@@ -51,9 +45,22 @@ public enum BusinessDocumentStudioLauncher {
             backing: .buffered,
             defer: false
         )
-        window.title = sourceURL.lastPathComponent.isEmpty
-            ? L("Business Document Workbench")
-            : sourceURL.lastPathComponent
+        let root = BusinessDocumentStudioView(
+            sourceURL: sourceURL,
+            claimSourceURL: { [weak window] selectedURL in
+                guard let window else { return false }
+                return claim(selectedURL, for: window)
+            }
+        )
+        let hostingController = NSHostingController(rootView: root)
+        if #available(macOS 13.0, *) {
+            hostingController.sizingOptions = []
+        }
+
+        window.title = BusinessDocumentStudioSourceIdentity.windowTitle(
+            for: sourceURL,
+            fallback: L("Business Document Workbench")
+        )
         window.titlebarAppearsTransparent = true
         window.isReleasedWhenClosed = false
         window.isRestorable = false
@@ -61,15 +68,31 @@ public enum BusinessDocumentStudioLauncher {
         window.center()
 
         let identifier = ObjectIdentifier(window)
-        let delegate = BusinessDocumentStudioWindowDelegate {
-            windows[sourceURL] = nil
-            delegates[identifier] = nil
+        let delegate = BusinessDocumentStudioWindowDelegate { closingWindow in
+            windowCache.remove(closingWindow)
+            delegates[ObjectIdentifier(closingWindow)] = nil
         }
         delegates[identifier] = delegate
         window.delegate = delegate
-        windows[sourceURL] = window
+        _ = windowCache.claim(sourceURL, for: window)
 
         show(window)
+    }
+
+    private static func claim(_ sourceURL: URL, for window: NSWindow) -> Bool {
+        switch windowCache.claim(sourceURL, for: window) {
+        case .claimed:
+            window.title = BusinessDocumentStudioSourceIdentity.windowTitle(
+                for: sourceURL,
+                fallback: L("Business Document Workbench")
+            )
+            return true
+
+        case .occupied(let existing):
+            show(existing)
+            window.close()
+            return false
+        }
     }
 
     private static func show(_ window: NSWindow) {
@@ -77,6 +100,71 @@ public enum BusinessDocumentStudioLauncher {
         NSApp.activate()
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
+    }
+}
+
+enum BusinessDocumentStudioSourceIdentity {
+    static func standardized(_ url: URL) -> URL {
+        url.standardizedFileURL
+    }
+
+    static func acceptedSourceURL(
+        _ url: URL,
+        claim: ((URL) -> Bool)?
+    ) -> URL? {
+        let sourceURL = standardized(url)
+        guard claim?(sourceURL) ?? true else { return nil }
+        return sourceURL
+    }
+
+    static func windowTitle(for url: URL, fallback: String) -> String {
+        let filename = standardized(url).lastPathComponent
+        return filename.isEmpty ? fallback : filename
+    }
+}
+
+@MainActor
+final class BusinessDocumentStudioWindowCache<Window: AnyObject> {
+    enum ClaimResult {
+        case claimed
+        case occupied(Window)
+    }
+
+    private var windowsBySourceURL: [URL: Window] = [:]
+    private var sourceURLsByWindow: [ObjectIdentifier: URL] = [:]
+
+    func window(for sourceURL: URL) -> Window? {
+        windowsBySourceURL[BusinessDocumentStudioSourceIdentity.standardized(sourceURL)]
+    }
+
+    func sourceURL(for window: Window) -> URL? {
+        sourceURLsByWindow[ObjectIdentifier(window)]
+    }
+
+    /// A failed claim leaves both windows under their existing identities.
+    /// This lets the caller focus the owner instead of corrupting either key.
+    func claim(_ sourceURL: URL, for window: Window) -> ClaimResult {
+        let sourceURL = BusinessDocumentStudioSourceIdentity.standardized(sourceURL)
+        if let existing = windowsBySourceURL[sourceURL], existing !== window {
+            return .occupied(existing)
+        }
+
+        let identifier = ObjectIdentifier(window)
+        if let previousSourceURL = sourceURLsByWindow[identifier],
+            windowsBySourceURL[previousSourceURL] === window {
+            windowsBySourceURL[previousSourceURL] = nil
+        }
+        windowsBySourceURL[sourceURL] = window
+        sourceURLsByWindow[identifier] = sourceURL
+        return .claimed
+    }
+
+    func remove(_ window: Window) {
+        let identifier = ObjectIdentifier(window)
+        guard let sourceURL = sourceURLsByWindow.removeValue(forKey: identifier) else { return }
+        if windowsBySourceURL[sourceURL] === window {
+            windowsBySourceURL[sourceURL] = nil
+        }
     }
 }
 
@@ -92,14 +180,15 @@ enum BusinessDocumentStudioDocumentTypes {
 
 @MainActor
 private final class BusinessDocumentStudioWindowDelegate: NSObject, NSWindowDelegate {
-    private let onClose: () -> Void
+    private let onClose: (NSWindow) -> Void
 
-    init(onClose: @escaping () -> Void) {
+    init(onClose: @escaping (NSWindow) -> Void) {
         self.onClose = onClose
         super.init()
     }
 
     func windowWillClose(_ notification: Notification) {
-        onClose()
+        guard let window = notification.object as? NSWindow else { return }
+        onClose(window)
     }
 }

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -16,12 +16,13 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         case idle
         case loading(URL?)
         case loaded(BusinessDocumentStudioPresentation)
-        case failed(String)
+        case failed(BusinessDocumentStudioLoadFailure)
     }
 
     enum ExportState: Equatable {
         case idle
         case exporting(optionID: String)
+        case awaitingOverwriteConsent(BusinessDocumentStudioOverwriteRequest)
         case succeeded(BusinessDocumentStudioExportReceipt)
         case blocked(BusinessDocumentStudioExportBlock)
         case failed(String)
@@ -29,10 +30,12 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
 
     @Published private(set) var loadState: LoadState = .idle
     @Published private(set) var exportState: ExportState = .idle
+    @Published private(set) var artifactStatuses: [BusinessDocumentStudioArtifactStatus] = []
 
     private let service: BusinessDocumentStudioService
     private var document: StructuredDocument?
     private var inspection: BusinessDocumentStudioInspection?
+    private var pendingOverwrite: PendingExport?
 
     init(service: BusinessDocumentStudioService = BusinessDocumentStudioService()) {
         self.service = service
@@ -44,26 +47,31 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
     ) async {
         loadState = .loading(url)
         exportState = .idle
+        artifactStatuses = []
+        clearPendingOverwriteStatus()
 
         do {
             let document = try await service.parse(url: url)
-            try load(document: document, policy: policy)
+            try load(document: document, sourceURL: url, policy: policy)
         } catch {
             self.document = nil
             inspection = nil
-            loadState = .failed(error.localizedDescription)
+            loadState = .failed(BusinessDocumentStudioLoadFailure(url: url, error: error))
         }
     }
 
     func load(
         document: StructuredDocument,
+        sourceURL: URL? = nil,
         policy: BusinessDocumentStudioPolicy = .standard
     ) throws {
         let inspection = try service.inspect(document, policy: policy)
         self.document = document
         self.inspection = inspection
-        loadState = .loaded(BusinessDocumentStudioPresentation(inspection: inspection))
+        loadState = .loaded(BusinessDocumentStudioPresentation(inspection: inspection, sourceURL: sourceURL))
         exportState = .idle
+        artifactStatuses = []
+        clearPendingOverwriteStatus()
     }
 
     func export(
@@ -77,6 +85,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
             exportState = .failed("No document is loaded.")
             return
         }
+        clearPendingOverwriteStatus()
 
         guard let option = inspection.exportOptions.first(where: { $0.targetFormatId == optionID }) else {
             exportState = .failed("Export option '\(optionID)' is not available for this document.")
@@ -84,15 +93,31 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         }
 
         guard option.canExport else {
-            exportState = .blocked(
-                BusinessDocumentStudioExportBlock(
-                    kind: .unavailableOption,
-                    optionID: option.targetFormatId,
-                    message: option.message,
-                    path: nil,
-                    reason: option.reason
-                )
+            let block = BusinessDocumentStudioExportBlock(
+                kind: .unavailableOption,
+                optionID: option.targetFormatId,
+                message: option.message,
+                path: nil,
+                reason: option.reason
             )
+            exportState = .blocked(block)
+            appendArtifactStatus(BusinessDocumentStudioArtifactStatus(block: block))
+            return
+        }
+
+        if !allowOverwrite,
+            Self.canCheckExistence(destination: destination, allowedDirectory: allowedDirectory),
+            FileManager.default.fileExists(atPath: destination.path) {
+            let request = BusinessDocumentStudioOverwriteRequest(
+                optionID: option.targetFormatId,
+                label: option.label,
+                destination: destination,
+                allowedDirectory: allowedDirectory,
+                maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
+            )
+            pendingOverwrite = PendingExport(request: request)
+            exportState = .awaitingOverwriteConsent(request)
+            appendArtifactStatus(BusinessDocumentStudioArtifactStatus(overwriteRequest: request))
             return
         }
 
@@ -109,12 +134,54 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
                     maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
                 )
             )
-            exportState = .succeeded(BusinessDocumentStudioExportReceipt(result: result))
+            let receipt = BusinessDocumentStudioExportReceipt(result: result)
+            exportState = .succeeded(receipt)
+            appendArtifactStatus(BusinessDocumentStudioArtifactStatus(receipt: receipt))
         } catch let error as BusinessDocumentStudioError {
-            exportState = mapServiceError(error, optionID: option.targetFormatId)
+            let mapped = mapServiceError(error, optionID: option.targetFormatId)
+            exportState = mapped
+            if case .failed(let message) = mapped {
+                appendArtifactStatus(.failed(optionID: option.targetFormatId, message: message, path: destination.path))
+            } else {
+                appendArtifactStatus(BusinessDocumentStudioArtifactStatus(exportState: mapped, optionID: option.targetFormatId))
+            }
         } catch {
-            exportState = .failed(error.localizedDescription)
+            let message = error.localizedDescription
+            exportState = .failed(message)
+            appendArtifactStatus(.failed(optionID: option.targetFormatId, message: message, path: destination.path))
         }
+    }
+
+    func confirmPendingOverwrite() async {
+        guard let pendingOverwrite else {
+            exportState = .failed("No overwrite is waiting for confirmation.")
+            return
+        }
+        await export(
+            optionID: pendingOverwrite.request.optionID,
+            to: pendingOverwrite.request.destination,
+            allowedDirectory: pendingOverwrite.request.allowedDirectory,
+            allowOverwrite: true,
+            maxTextExportUTF8Bytes: pendingOverwrite.request.maxTextExportUTF8Bytes
+        )
+    }
+
+    func cancelPendingOverwrite() {
+        guard let pendingOverwrite else {
+            exportState = .idle
+            return
+        }
+        removeArtifactStatus(matching: pendingOverwrite.request)
+        self.pendingOverwrite = nil
+        let block = BusinessDocumentStudioExportBlock(
+            kind: .overwriteDeclined,
+            optionID: pendingOverwrite.request.optionID,
+            message: "Overwrite was cancelled. No artifact was written.",
+            path: pendingOverwrite.request.destination.path,
+            reason: nil
+        )
+        exportState = .blocked(block)
+        appendArtifactStatus(BusinessDocumentStudioArtifactStatus(block: block))
     }
 
     private func mapServiceError(
@@ -205,12 +272,44 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
             return .failed(error.localizedDescription)
         }
     }
+
+    private func appendArtifactStatus(_ status: BusinessDocumentStudioArtifactStatus) {
+        artifactStatuses.removeAll { $0.id == status.id }
+        artifactStatuses.insert(status, at: 0)
+        if artifactStatuses.count > 10 {
+            artifactStatuses.removeLast(artifactStatuses.count - 10)
+        }
+    }
+
+    private func clearPendingOverwriteStatus() {
+        guard let pendingOverwrite else { return }
+        removeArtifactStatus(matching: pendingOverwrite.request)
+        self.pendingOverwrite = nil
+    }
+
+    private func removeArtifactStatus(matching request: BusinessDocumentStudioOverwriteRequest) {
+        let pendingStatusID = BusinessDocumentStudioArtifactStatus(overwriteRequest: request).id
+        artifactStatuses.removeAll { $0.id == pendingStatusID }
+    }
+
+    private static func canCheckExistence(destination: URL, allowedDirectory: URL?) -> Bool {
+        guard destination.isFileURL else { return false }
+        guard let allowedDirectory else { return true }
+        let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().path
+        let parent = destination.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().path
+        return parent == root || parent.hasPrefix(root + "/")
+    }
+
+    private struct PendingExport: Equatable {
+        let request: BusinessDocumentStudioOverwriteRequest
+    }
 }
 
 struct BusinessDocumentStudioPresentation: Equatable {
     let title: String
     let subtitle: String
     let iconSystemName: String
+    let importRows: [BusinessDocumentStudioInfoRow]
     let summaryRows: [BusinessDocumentStudioInfoRow]
     let structureRows: [BusinessDocumentStudioInfoRow]
     let securityRows: [BusinessDocumentStudioInfoRow]
@@ -220,11 +319,12 @@ struct BusinessDocumentStudioPresentation: Equatable {
     let exportOptions: [BusinessDocumentStudioExportOptionPresentation]
     let registryRoleLabels: [String]
 
-    init(inspection: BusinessDocumentStudioInspection) {
+    init(inspection: BusinessDocumentStudioInspection, sourceURL: URL? = nil) {
         let summary = inspection.summary
         title = summary.filename
         subtitle = "\(summary.kind.displayName) - \(summary.formatId.uppercased())"
         iconSystemName = summary.kind.systemImageName
+        importRows = Self.importRows(for: inspection, sourceURL: sourceURL)
         summaryRows = Self.summaryRows(for: inspection)
         structureRows = Self.structureRows(for: summary.structureSummary)
         securityRows = Self.securityRows(for: inspection.security)
@@ -259,6 +359,32 @@ struct BusinessDocumentStudioPresentation: Equatable {
             pairs.insert(("Extension", ".\(fileExtension)"), at: 3)
         }
         return numberedRows(prefix: "summary", pairs)
+    }
+
+    private static func importRows(
+        for inspection: BusinessDocumentStudioInspection,
+        sourceURL: URL?
+    ) -> [BusinessDocumentStudioInfoRow] {
+        let summary = inspection.summary
+        var pairs = [
+            ("Source", sourceURL?.path ?? "In-memory document"),
+            ("Filename", summary.filename),
+            ("Document kind", summary.kind.displayName),
+            ("Adapter format", summary.formatId),
+            ("Extraction", extractionLabel(for: inspection.preview)),
+        ]
+        if !inspection.registryRoles.isEmpty {
+            pairs.append(
+                (
+                    "Registry roles",
+                    inspection.registryRoles
+                        .sorted { $0.rawValue < $1.rawValue }
+                        .map(roleLabel)
+                        .joined(separator: " / ")
+                )
+            )
+        }
+        return numberedRows(prefix: "import", pairs)
     }
 
     private static func structureRows(
@@ -353,6 +479,23 @@ struct BusinessDocumentStudioPresentation: Equatable {
                 ("Text length", countLabel(text.fullUTF16Length, "UTF-16 unit")),
                 ("Truncated", text.isTruncated ? "Yes" : "No"),
             ])
+        }
+    }
+
+    private static func extractionLabel(for preview: BusinessDocumentStudioPreview) -> String {
+        switch preview {
+        case .table:
+            return "Structured table preview"
+        case .workbook:
+            return "Structured workbook preview"
+        case .pdf:
+            return "PDF text and table preview"
+        case .presentation:
+            return "Presentation slide preview"
+        case .richText:
+            return "Rich text block preview"
+        case .text:
+            return "Text fallback preview"
         }
     }
 
@@ -725,8 +868,58 @@ struct BusinessDocumentStudioExportOptionPresentation: Identifiable, Equatable {
         canExport = option.canExport
         reason = option.reason
         reasonLabel = BusinessDocumentStudioPresentation.exportReasonLabel(option.reason)
-        statusLabel = option.canExport ? "Available" : "Unavailable"
+        statusLabel = option.canExport ? "Available" : reasonLabel
         message = option.message
+    }
+}
+
+struct BusinessDocumentStudioLoadFailure: Equatable {
+    enum Kind: String, Equatable {
+        case unsupportedFormat
+        case malformedFile
+        case unexpectedFormat
+        case other
+    }
+
+    let kind: Kind
+    let title: String
+    let message: String
+    let path: String?
+
+    init(url: URL?, error: Error) {
+        path = url?.path
+        message = error.localizedDescription
+
+        if let studioError = error as? BusinessDocumentStudioError {
+            switch studioError {
+            case .unsupportedFormat:
+                kind = .unsupportedFormat
+                title = "Unsupported format"
+            case .adapterReturnedUnexpectedFormat:
+                kind = .unexpectedFormat
+                title = "Unexpected adapter output"
+            case .unsupportedExport,
+                 .destinationOutsideAllowedDirectory,
+                 .destinationAlreadyExists,
+                 .destinationIsNotFileURL,
+                 .unsafeTextPackageTarget,
+                 .packageTargetExtensionMismatch,
+                 .textExportTooLarge,
+                 .writeFailed:
+                kind = .other
+                title = "Document unavailable"
+            }
+            return
+        }
+
+        if error is DocumentAdapterError {
+            kind = .malformedFile
+            title = "Document could not be extracted"
+            return
+        }
+
+        kind = .other
+        title = "Document unavailable"
     }
 }
 
@@ -746,6 +939,18 @@ struct BusinessDocumentStudioExportReceipt: Equatable {
     }
 }
 
+struct BusinessDocumentStudioOverwriteRequest: Equatable {
+    let optionID: String
+    let label: String
+    let destination: URL
+    let allowedDirectory: URL?
+    let maxTextExportUTF8Bytes: Int
+
+    var message: String {
+        "Replace the existing \(label) artifact at \(destination.path)?"
+    }
+}
+
 struct BusinessDocumentStudioExportBlock: Equatable {
     enum Kind: String, Equatable {
         case unavailableOption
@@ -756,6 +961,7 @@ struct BusinessDocumentStudioExportBlock: Equatable {
         case packageExtensionMismatch
         case textFallbackTooLarge
         case unsupportedExport
+        case overwriteDeclined
     }
 
     let kind: Kind
@@ -763,4 +969,136 @@ struct BusinessDocumentStudioExportBlock: Equatable {
     let message: String
     let path: String?
     let reason: BusinessDocumentStudioExportReason?
+}
+
+struct BusinessDocumentStudioArtifactStatus: Identifiable, Equatable {
+    enum State: String, Equatable {
+        case created
+        case needsConsent
+        case blocked
+        case failed
+    }
+
+    let id: String
+    let state: State
+    let optionID: String
+    let title: String
+    let message: String
+    let path: String?
+    let bytesWritten: Int64?
+    let safetyLabel: String
+    let reason: BusinessDocumentStudioExportReason?
+
+    init(receipt: BusinessDocumentStudioExportReceipt) {
+        state = .created
+        optionID = receipt.targetFormatId
+        title = "\(receipt.targetFormatId.uppercased()) artifact created"
+        message = receipt.message
+        path = receipt.url.path
+        bytesWritten = receipt.bytesWritten
+        safetyLabel = "Written by a registered document workflow"
+        reason = nil
+        id = Self.makeID(state: state, optionID: optionID, path: path, message: message)
+    }
+
+    init(overwriteRequest: BusinessDocumentStudioOverwriteRequest) {
+        state = .needsConsent
+        optionID = overwriteRequest.optionID
+        title = "Overwrite consent required"
+        message = overwriteRequest.message
+        path = overwriteRequest.destination.path
+        bytesWritten = nil
+        safetyLabel = "No artifact written until replacement is confirmed"
+        reason = nil
+        id = Self.makeID(state: state, optionID: optionID, path: path, message: message)
+    }
+
+    init(block: BusinessDocumentStudioExportBlock) {
+        state = .blocked
+        optionID = block.optionID
+        title = Self.blockTitle(block.kind)
+        message = block.message
+        path = block.path
+        bytesWritten = nil
+        safetyLabel = "No artifact written"
+        reason = block.reason
+        id = Self.makeID(state: state, optionID: optionID, path: path, message: message)
+    }
+
+    init(exportState: BusinessDocumentStudioPresenter.ExportState, optionID: String) {
+        switch exportState {
+        case .blocked(let block):
+            self.init(block: block)
+        case .failed(let message):
+            self = .failed(optionID: optionID, message: message, path: nil)
+        default:
+            self = .failed(optionID: optionID, message: "Export did not create an artifact.", path: nil)
+        }
+    }
+
+    static func failed(optionID: String, message: String, path: String?) -> BusinessDocumentStudioArtifactStatus {
+        BusinessDocumentStudioArtifactStatus(
+            state: .failed,
+            optionID: optionID,
+            title: "Export failed",
+            message: message,
+            path: path,
+            bytesWritten: nil,
+            safetyLabel: "No artifact written by the workbench",
+            reason: nil
+        )
+    }
+
+    private init(
+        state: State,
+        optionID: String,
+        title: String,
+        message: String,
+        path: String?,
+        bytesWritten: Int64?,
+        safetyLabel: String,
+        reason: BusinessDocumentStudioExportReason?
+    ) {
+        self.state = state
+        self.optionID = optionID
+        self.title = title
+        self.message = message
+        self.path = path
+        self.bytesWritten = bytesWritten
+        self.safetyLabel = safetyLabel
+        self.reason = reason
+        id = Self.makeID(state: state, optionID: optionID, path: path, message: message)
+    }
+
+    private static func blockTitle(_ kind: BusinessDocumentStudioExportBlock.Kind) -> String {
+        switch kind {
+        case .unavailableOption:
+            return "Export unavailable"
+        case .destinationAlreadyExists:
+            return "Destination already exists"
+        case .destinationOutsideAllowedDirectory:
+            return "Destination outside allowed directory"
+        case .destinationIsNotFileURL:
+            return "Destination is not a file URL"
+        case .unsafePackageTarget:
+            return "Unsafe package target blocked"
+        case .packageExtensionMismatch:
+            return "Package extension mismatch"
+        case .textFallbackTooLarge:
+            return "Text fallback too large"
+        case .unsupportedExport:
+            return "Unsupported export"
+        case .overwriteDeclined:
+            return "Overwrite cancelled"
+        }
+    }
+
+    private static func makeID(
+        state: State,
+        optionID: String,
+        path: String?,
+        message: String
+    ) -> String {
+        "\(state.rawValue):\(optionID):\(path ?? ""):\(message)"
+    }
 }

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -1,0 +1,766 @@
+//
+//  BusinessDocumentStudioPresenter.swift
+//  osaurus
+//
+//  Thin presentation layer for the Business Document Studio surface.
+//  BusinessDocumentStudioService remains the authority for parsing,
+//  availability, and destination safety.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class BusinessDocumentStudioPresenter: ObservableObject {
+    enum LoadState: Equatable {
+        case idle
+        case loading(URL?)
+        case loaded(BusinessDocumentStudioPresentation)
+        case failed(String)
+    }
+
+    enum ExportState: Equatable {
+        case idle
+        case exporting(optionID: String)
+        case succeeded(BusinessDocumentStudioExportReceipt)
+        case blocked(BusinessDocumentStudioExportBlock)
+        case failed(String)
+    }
+
+    @Published private(set) var loadState: LoadState = .idle
+    @Published private(set) var exportState: ExportState = .idle
+
+    private let service: BusinessDocumentStudioService
+    private var document: StructuredDocument?
+    private var inspection: BusinessDocumentStudioInspection?
+
+    init(service: BusinessDocumentStudioService = BusinessDocumentStudioService()) {
+        self.service = service
+    }
+
+    func load(
+        url: URL,
+        policy: BusinessDocumentStudioPolicy = .standard
+    ) async {
+        loadState = .loading(url)
+        exportState = .idle
+
+        do {
+            let document = try await service.parse(url: url)
+            try load(document: document, policy: policy)
+        } catch {
+            self.document = nil
+            inspection = nil
+            loadState = .failed(error.localizedDescription)
+        }
+    }
+
+    func load(
+        document: StructuredDocument,
+        policy: BusinessDocumentStudioPolicy = .standard
+    ) throws {
+        let inspection = try service.inspect(document, policy: policy)
+        self.document = document
+        self.inspection = inspection
+        loadState = .loaded(BusinessDocumentStudioPresentation(inspection: inspection))
+        exportState = .idle
+    }
+
+    func export(
+        optionID: String,
+        to destination: URL,
+        allowedDirectory: URL? = nil,
+        allowOverwrite: Bool = false,
+        maxTextExportUTF8Bytes: Int = BusinessDocumentStudioExportPolicy.standard.maxTextExportUTF8Bytes
+    ) async {
+        guard let document, let inspection else {
+            exportState = .failed("No document is loaded.")
+            return
+        }
+
+        guard let option = inspection.exportOptions.first(where: { $0.targetFormatId == optionID }) else {
+            exportState = .failed("Export option '\(optionID)' is not available for this document.")
+            return
+        }
+
+        guard option.canExport else {
+            exportState = .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .unavailableOption,
+                    optionID: option.targetFormatId,
+                    message: option.message,
+                    path: nil,
+                    reason: option.reason
+                )
+            )
+            return
+        }
+
+        exportState = .exporting(optionID: option.targetFormatId)
+
+        do {
+            let result = try await service.export(
+                document,
+                as: option.targetFormatId,
+                to: destination,
+                policy: BusinessDocumentStudioExportPolicy(
+                    allowedDirectory: allowedDirectory,
+                    allowOverwrite: allowOverwrite,
+                    maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
+                )
+            )
+            exportState = .succeeded(BusinessDocumentStudioExportReceipt(result: result))
+        } catch let error as BusinessDocumentStudioError {
+            exportState = mapServiceError(error, optionID: option.targetFormatId)
+        } catch {
+            exportState = .failed(error.localizedDescription)
+        }
+    }
+
+    private func mapServiceError(
+        _ error: BusinessDocumentStudioError,
+        optionID: String
+    ) -> ExportState {
+        switch error {
+        case .destinationAlreadyExists(let url):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .destinationAlreadyExists,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: url.path,
+                    reason: nil
+                )
+            )
+
+        case .destinationOutsideAllowedDirectory(let url):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .destinationOutsideAllowedDirectory,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: url.path,
+                    reason: nil
+                )
+            )
+
+        case .destinationIsNotFileURL(let url):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .destinationIsNotFileURL,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: url.absoluteString,
+                    reason: nil
+                )
+            )
+
+        case .unsafeTextPackageTarget(let fileExtension):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .unsafePackageTarget,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: fileExtension,
+                    reason: nil
+                )
+            )
+
+        case .packageTargetExtensionMismatch(_, let fileExtension):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .packageExtensionMismatch,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: fileExtension,
+                    reason: nil
+                )
+            )
+
+        case .textExportTooLarge:
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .textFallbackTooLarge,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: nil,
+                    reason: .textFallbackTooLarge
+                )
+            )
+
+        case .unsupportedExport:
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .unsupportedExport,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: nil,
+                    reason: .unsupportedFormat
+                )
+            )
+
+        case .unsupportedFormat,
+             .adapterReturnedUnexpectedFormat,
+             .writeFailed:
+            return .failed(error.localizedDescription)
+        }
+    }
+}
+
+struct BusinessDocumentStudioPresentation: Equatable {
+    let title: String
+    let subtitle: String
+    let iconSystemName: String
+    let summaryRows: [BusinessDocumentStudioInfoRow]
+    let structureRows: [BusinessDocumentStudioInfoRow]
+    let securityRows: [BusinessDocumentStudioInfoRow]
+    let previewRows: [BusinessDocumentStudioInfoRow]
+    let previewSections: [BusinessDocumentStudioPreviewSection]
+    let warnings: [BusinessDocumentStudioWarning]
+    let exportOptions: [BusinessDocumentStudioExportOptionPresentation]
+    let registryRoleLabels: [String]
+
+    init(inspection: BusinessDocumentStudioInspection) {
+        let summary = inspection.summary
+        title = summary.filename
+        subtitle = "\(summary.kind.displayName) - \(summary.formatId.uppercased())"
+        iconSystemName = summary.kind.systemImageName
+        summaryRows = Self.summaryRows(for: inspection)
+        structureRows = Self.structureRows(for: summary.structureSummary)
+        securityRows = Self.securityRows(for: inspection.security)
+        previewRows = Self.previewRows(for: inspection.preview)
+        previewSections = Self.previewSections(for: inspection.preview)
+        warnings = Self.warnings(for: inspection)
+        exportOptions = inspection.exportOptions.map(BusinessDocumentStudioExportOptionPresentation.init(option:))
+        registryRoleLabels = inspection.registryRoles.map(Self.roleLabel)
+    }
+
+    var availableExportOptions: [BusinessDocumentStudioExportOptionPresentation] {
+        exportOptions.filter(\.canExport)
+    }
+
+    var unavailableExportOptions: [BusinessDocumentStudioExportOptionPresentation] {
+        exportOptions.filter { !$0.canExport }
+    }
+
+    private static func summaryRows(
+        for inspection: BusinessDocumentStudioInspection
+    ) -> [BusinessDocumentStudioInfoRow] {
+        let summary = inspection.summary
+        var pairs = [
+            ("Kind", summary.kind.displayName),
+            ("Source format", summary.formatId),
+            ("Representation", summary.representationFormatId),
+            ("File size", fileSizeLabel(summary.fileSize)),
+            ("Parse limit", fileSizeLabel(inspection.parseLimitBytes)),
+            ("Text fallback", countLabel(summary.textFallbackUTF16Length, "UTF-16 unit")),
+        ]
+        if let fileExtension = summary.fileExtension {
+            pairs.insert(("Extension", ".\(fileExtension)"), at: 3)
+        }
+        return numberedRows(prefix: "summary", pairs)
+    }
+
+    private static func structureRows(
+        for summary: DocumentStructureSummary
+    ) -> [BusinessDocumentStudioInfoRow] {
+        numberedRows(prefix: "structure", [
+            ("Sheets", "\(summary.sheetCount)"),
+            ("Slides", "\(summary.slideCount)"),
+            ("Pages", "\(summary.pageCount)"),
+            ("Tables", "\(summary.tableCount)"),
+            ("Images", "\(summary.imageCount)"),
+            ("Charts", "\(summary.chartCount)"),
+            ("Text length", countLabel(summary.textLengthUTF16, "UTF-16 unit")),
+        ])
+    }
+
+    private static func securityRows(
+        for security: DocumentSecurityMetadata
+    ) -> [BusinessDocumentStudioInfoRow] {
+        var pairs = [
+            ("Inspection", inspectionLabel(security.inspectionStatus)),
+            ("Source trust", sourceTrustLabel(security.sourceTrust)),
+            ("Active content", security.activeContentTypes.isEmpty ? "None" : activeContentLabel(security.activeContentTypes)),
+            ("External references", "\(security.externalReferences.count)"),
+            ("Findings", "\(security.findings.count)"),
+        ]
+        if let isEncrypted = security.isEncrypted {
+            pairs.append(("Encrypted", isEncrypted ? "Yes" : "No"))
+        }
+        if let sha256 = security.sha256, !sha256.isEmpty {
+            pairs.append(("SHA-256", sha256))
+        }
+        return numberedRows(prefix: "security", pairs)
+    }
+
+    private static func previewRows(
+        for preview: BusinessDocumentStudioPreview
+    ) -> [BusinessDocumentStudioInfoRow] {
+        switch preview {
+        case .table(let table):
+            return numberedRows(prefix: "preview-table", [
+                ("Preview", "Delimited table"),
+                ("Delimiter", table.delimiter == .tab ? "Tab" : "Comma"),
+                ("Rows scanned", "\(table.rowsScanned)"),
+                ("Sampled rows", "\(table.sampledRowCount)"),
+                ("Columns", "\(table.columnCount)"),
+                ("Header", table.hasHeader ? "Detected" : "Not detected"),
+            ])
+
+        case .workbook(let workbook):
+            return numberedRows(prefix: "preview-workbook", [
+                ("Preview", "Workbook"),
+                ("Sheets", "\(workbook.inspection.sheetSummaries.count)"),
+                ("Rows", "\(workbook.inspection.totalRows)"),
+                ("Cells", "\(workbook.inspection.totalCells)"),
+                ("Formula cells", "\(workbook.inspection.formulaCellCount)"),
+                ("Merged ranges", "\(workbook.inspection.mergedRangeCount)"),
+            ])
+
+        case .pdf(let pdf):
+            return numberedRows(prefix: "preview-pdf", [
+                ("Preview", "PDF"),
+                ("Pages", "\(pdf.pageCount)"),
+                ("Sampled pages", "\(pdf.sampledPageCount)"),
+                ("Tables", "\(pdf.tableCount)"),
+                ("Table cells", "\(pdf.tableCellCount)"),
+                ("Text length", countLabel(pdf.totalTextUTF16Units, "UTF-16 unit")),
+            ])
+
+        case .presentation(let presentation):
+            return numberedRows(prefix: "preview-presentation", [
+                ("Preview", "Presentation"),
+                ("Slides", "\(presentation.slideCount)"),
+                ("Sampled slides", "\(presentation.sampledSlideCount)"),
+                ("Hidden slides", "\(presentation.hiddenSlideCount)"),
+                ("Speaker notes", "\(presentation.speakerNotesCount)"),
+                ("Tables", "\(presentation.tableCount)"),
+            ])
+
+        case .richText(let richText):
+            return numberedRows(prefix: "preview-rich-text", [
+                ("Preview", "Rich text"),
+                ("Source", richText.sourceLabel),
+                ("Blocks", "\(richText.blockCount)"),
+                ("Sampled blocks", "\(richText.sampledBlocks.count)"),
+                ("Text length", countLabel(richText.text.fullUTF16Length, "UTF-16 unit")),
+            ])
+
+        case .text(let text):
+            return numberedRows(prefix: "preview-text", [
+                ("Preview", "Text fallback"),
+                ("Text length", countLabel(text.fullUTF16Length, "UTF-16 unit")),
+                ("Truncated", text.isTruncated ? "Yes" : "No"),
+            ])
+        }
+    }
+
+    private static func previewSections(
+        for preview: BusinessDocumentStudioPreview
+    ) -> [BusinessDocumentStudioPreviewSection] {
+        switch preview {
+        case .table(let table):
+            let header = BusinessDocumentStudioPreviewSection(
+                id: "table-columns",
+                title: "Columns",
+                rows: table.columns.enumerated().map { offset, column in
+                    BusinessDocumentStudioInfoRow(
+                        id: "table-column-\(offset)",
+                        label: column.name,
+                        value: "\(column.inferredType.rawValue) - \(column.nonEmptyCount) filled"
+                    )
+                }
+            )
+            let samples = BusinessDocumentStudioPreviewSection(
+                id: "table-sample-rows",
+                title: "Sample rows",
+                rows: table.sampledRows.prefix(8).enumerated().map { offset, row in
+                    BusinessDocumentStudioInfoRow(
+                        id: "table-sample-row-\(offset)",
+                        label: "Row \(row.rowIndex + 1)",
+                        value: row.values.joined(separator: " | ")
+                    )
+                }
+            )
+            return [header, samples].filter { !$0.rows.isEmpty }
+
+        case .workbook(let workbook):
+            return workbook.sheets.enumerated().map { sheetOffset, sheet in
+                var rows = numberedRows(prefix: "workbook-sheet-\(sheetOffset)", [
+                    ("Rows", "\(sheet.rowCount)"),
+                    ("Cells", "\(sheet.cellCount)"),
+                    ("Formula cells", "\(sheet.formulaCellCount)"),
+                    ("Merged ranges", "\(sheet.mergedRangeCount)"),
+                ])
+                rows.append(
+                    contentsOf: sheet.sampleRows.prefix(6).enumerated().map { rowOffset, row in
+                        BusinessDocumentStudioInfoRow(
+                            id: "workbook-sheet-\(sheetOffset)-sample-row-\(rowOffset)",
+                            label: "Row \(row.number)",
+                            value: row.cells.map { cell in
+                                "\(cell.reference): \(cell.text.text)"
+                            }.joined(separator: " | ")
+                        )
+                    }
+                )
+                return BusinessDocumentStudioPreviewSection(
+                    id: "workbook-sheet-\(sheetOffset)",
+                    title: sheet.name,
+                    rows: rows
+                )
+            }
+
+        case .pdf(let pdf):
+            return pdf.pages.enumerated().map { offset, page in
+                BusinessDocumentStudioPreviewSection(
+                    id: "pdf-page-\(offset)",
+                    title: "Page \(page.pageIndex + 1)",
+                    rows: numberedRows(prefix: "pdf-page-\(offset)", [
+                        ("Text", page.text.text),
+                        ("Tables", "\(page.tableCount)"),
+                    ])
+                )
+            }
+
+        case .presentation(let presentation):
+            return presentation.slides.enumerated().map { offset, slide in
+                BusinessDocumentStudioPreviewSection(
+                    id: "presentation-slide-\(offset)",
+                    title: slide.label,
+                    rows: numberedRows(prefix: "presentation-slide-\(offset)", [
+                        ("Slide", "\(slide.slideNumber)"),
+                        ("Hidden", slide.isHidden ? "Yes" : "No"),
+                        ("Text", slide.text.text),
+                        ("Tables", "\(slide.tableCount)"),
+                    ])
+                )
+            }
+
+        case .richText(let richText):
+            return [
+                BusinessDocumentStudioPreviewSection(
+                    id: "rich-text-blocks",
+                    title: "Blocks",
+                    rows: richText.sampledBlocks.enumerated().map { offset, block in
+                        BusinessDocumentStudioInfoRow(
+                            id: "rich-text-block-\(offset)",
+                            label: block.kind.rawValue,
+                            value: block.text.text
+                        )
+                    }
+                ),
+            ]
+
+        case .text(let text):
+            return [
+                BusinessDocumentStudioPreviewSection(
+                    id: "text-sample",
+                    title: "Text",
+                    rows: [BusinessDocumentStudioInfoRow(id: "text-sample-row", label: "Sample", value: text.text)]
+                ),
+            ]
+        }
+    }
+
+    private static func warnings(
+        for inspection: BusinessDocumentStudioInspection
+    ) -> [BusinessDocumentStudioWarning] {
+        var warnings: [BusinessDocumentStudioWarning] = []
+        let security = inspection.security
+
+        if security.inspectionStatus != .inspected {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "Extraction inspection",
+                    message: "Security inspection is \(inspectionLabel(security.inspectionStatus).lowercased())."
+                )
+            )
+        }
+
+        if let isEncrypted = security.isEncrypted, isEncrypted {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "Encrypted content",
+                    message: "The adapter reported encrypted content in this document."
+                )
+            )
+        }
+
+        if !security.activeContentTypes.isEmpty {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "Active content",
+                    message: activeContentLabel(security.activeContentTypes)
+                )
+            )
+        }
+
+        if !security.externalReferences.isEmpty {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "External references",
+                    message: "\(security.externalReferences.count) external reference(s) were recorded."
+                )
+            )
+        }
+
+        warnings.append(contentsOf: security.findings.map { finding in
+            BusinessDocumentStudioWarning(
+                severity: warningSeverity(for: finding.severity),
+                title: finding.kind.rawValue,
+                message: finding.message
+            )
+        })
+
+        warnings.append(contentsOf: previewWarnings(for: inspection.preview))
+        warnings.append(
+            contentsOf: inspection.exportOptions.filter { !$0.canExport }.map { option in
+                BusinessDocumentStudioWarning(
+                    severity: .blocked,
+                    title: "Export unavailable: \(option.label)",
+                    message: "\(exportReasonLabel(option.reason)) - \(option.message)"
+                )
+            }
+        )
+
+        return warnings
+    }
+
+    private static func previewWarnings(
+        for preview: BusinessDocumentStudioPreview
+    ) -> [BusinessDocumentStudioWarning] {
+        switch preview {
+        case .table(let table):
+            var messages: [String] = []
+            if table.truncatedByByteLimit { messages.append("byte limit") }
+            if table.truncatedByRowLimit { messages.append("row limit") }
+            if table.truncatedByColumnLimit { messages.append("column limit") }
+            return truncationWarnings(messages)
+
+        case .workbook(let workbook):
+            var messages: [String] = []
+            if workbook.isSheetSampleTruncated { messages.append("sheet limit") }
+            if workbook.sheets.contains(where: \.isRowSampleTruncated) { messages.append("row limit") }
+            if workbook.sheets.contains(where: \.isColumnSampleTruncated) { messages.append("column limit") }
+            return truncationWarnings(messages)
+
+        case .pdf(let pdf):
+            return truncationWarnings(pdf.isPageSampleTruncated ? ["page limit"] : [])
+
+        case .presentation(let presentation):
+            return truncationWarnings(presentation.isSlideSampleTruncated ? ["slide limit"] : [])
+
+        case .richText(let richText):
+            var messages: [String] = []
+            if richText.isBlockSampleTruncated { messages.append("block limit") }
+            if richText.text.isTruncated { messages.append("text limit") }
+            return truncationWarnings(messages)
+
+        case .text(let text):
+            return truncationWarnings(text.isTruncated ? ["text limit"] : [])
+        }
+    }
+
+    private static func truncationWarnings(_ reasons: [String]) -> [BusinessDocumentStudioWarning] {
+        guard !reasons.isEmpty else { return [] }
+        return [
+            BusinessDocumentStudioWarning(
+                severity: .info,
+                title: "Preview truncated",
+                message: "The preview sample reached the \(reasons.joined(separator: ", "))."
+            ),
+        ]
+    }
+
+    private static func warningSeverity(
+        for severity: DocumentSecurityFinding.Severity
+    ) -> BusinessDocumentStudioWarning.Severity {
+        switch severity {
+        case .informational, .low:
+            return .info
+        case .medium:
+            return .caution
+        case .high, .critical:
+            return .blocked
+        }
+    }
+
+    private static func roleLabel(_ role: DocumentFormatRegistrationRole) -> String {
+        switch role {
+        case .adapter: return "Adapter"
+        case .emitter: return "Emitter"
+        case .streamer: return "Streamer"
+        }
+    }
+
+    private static func inspectionLabel(_ status: DocumentSecurityMetadata.InspectionStatus) -> String {
+        switch status {
+        case .inspected: return "Inspected"
+        case .partiallyInspected: return "Partially inspected"
+        case .notInspected: return "Not inspected"
+        case .failed: return "Failed"
+        }
+    }
+
+    private static func sourceTrustLabel(_ sourceTrust: DocumentSecurityMetadata.SourceTrust) -> String {
+        switch sourceTrust {
+        case .userSelectedLocalFile: return "User-selected local file"
+        case .generatedArtifact: return "Generated artifact"
+        case .pluginProvided: return "Plugin-provided"
+        case .remoteDownload: return "Remote download"
+        case .pastedContent: return "Pasted content"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    private static func activeContentLabel(_ contentTypes: Set<DocumentActiveContentType>) -> String {
+        contentTypes
+            .map(\.rawValue)
+            .sorted()
+            .joined(separator: ", ")
+    }
+
+    fileprivate static func exportReasonLabel(_ reason: BusinessDocumentStudioExportReason) -> String {
+        switch reason {
+        case .available: return "Ready"
+        case .missingEmitter: return "Missing emitter"
+        case .validationFailed: return "Validation failed"
+        case .unsupportedFormat: return "Unsupported format"
+        case .textFallbackAvailable: return "Text fallback"
+        case .textFallbackTooLarge: return "Text fallback too large"
+        }
+    }
+
+    private static func fileSizeLabel(_ byteCount: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file)
+    }
+
+    private static func countLabel(_ count: Int, _ noun: String) -> String {
+        "\(count) \(noun)\(count == 1 ? "" : "s")"
+    }
+
+    private static func numberedRows(
+        prefix: String,
+        _ pairs: [(label: String, value: String)]
+    ) -> [BusinessDocumentStudioInfoRow] {
+        pairs.enumerated().map { offset, pair in
+            BusinessDocumentStudioInfoRow(
+                id: "\(prefix)-\(offset)",
+                label: pair.label,
+                value: pair.value
+            )
+        }
+    }
+}
+
+struct BusinessDocumentStudioInfoRow: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let value: String
+
+    init(id: String? = nil, label: String, value: String) {
+        self.id = id ?? "\(label):\(value)"
+        self.label = label
+        self.value = value
+    }
+
+    static func == (lhs: BusinessDocumentStudioInfoRow, rhs: BusinessDocumentStudioInfoRow) -> Bool {
+        lhs.label == rhs.label && lhs.value == rhs.value
+    }
+}
+
+struct BusinessDocumentStudioPreviewSection: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let rows: [BusinessDocumentStudioInfoRow]
+
+    init(id: String? = nil, title: String, rows: [BusinessDocumentStudioInfoRow]) {
+        self.id = id ?? title
+        self.title = title
+        self.rows = rows
+    }
+}
+
+struct BusinessDocumentStudioWarning: Identifiable, Equatable {
+    enum Severity: String, Equatable {
+        case info
+        case caution
+        case blocked
+    }
+
+    let id: String
+    let severity: Severity
+    let title: String
+    let message: String
+
+    init(severity: Severity, title: String, message: String) {
+        id = "\(severity.rawValue):\(title):\(message)"
+        self.severity = severity
+        self.title = title
+        self.message = message
+    }
+}
+
+struct BusinessDocumentStudioExportOptionPresentation: Identifiable, Equatable {
+    let id: String
+    let targetFormatId: String
+    let fileExtension: String
+    let label: String
+    let canExport: Bool
+    let reason: BusinessDocumentStudioExportReason
+    let reasonLabel: String
+    let statusLabel: String
+    let message: String
+
+    init(option: BusinessDocumentStudioExportOption) {
+        id = option.targetFormatId
+        targetFormatId = option.targetFormatId
+        fileExtension = option.fileExtension
+        label = option.label
+        canExport = option.canExport
+        reason = option.reason
+        reasonLabel = BusinessDocumentStudioPresentation.exportReasonLabel(option.reason)
+        statusLabel = option.canExport ? "Available" : "Unavailable"
+        message = option.message
+    }
+}
+
+struct BusinessDocumentStudioExportReceipt: Equatable {
+    let url: URL
+    let sourceFormatId: String
+    let targetFormatId: String
+    let bytesWritten: Int64
+    let message: String
+
+    init(result: BusinessDocumentStudioExportResult) {
+        url = result.url
+        sourceFormatId = result.sourceFormatId
+        targetFormatId = result.targetFormatId
+        bytesWritten = result.bytesWritten
+        message = result.message
+    }
+}
+
+struct BusinessDocumentStudioExportBlock: Equatable {
+    enum Kind: String, Equatable {
+        case unavailableOption
+        case destinationAlreadyExists
+        case destinationOutsideAllowedDirectory
+        case destinationIsNotFileURL
+        case unsafePackageTarget
+        case packageExtensionMismatch
+        case textFallbackTooLarge
+        case unsupportedExport
+    }
+
+    let kind: Kind
+    let optionID: String
+    let message: String
+    let path: String?
+    let reason: BusinessDocumentStudioExportReason?
+}

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -184,6 +184,17 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         appendArtifactStatus(BusinessDocumentStudioArtifactStatus(block: block))
     }
 
+    func makeWorkspaceAttachment() throws -> Attachment {
+        guard let document else {
+            throw BusinessDocumentStudioPresenterError.noDocumentLoaded
+        }
+        do {
+            return try service.makeAttachment(for: document)
+        } catch BusinessDocumentStudioError.attachmentHandoffUnavailable(let message) {
+            throw BusinessDocumentStudioPresenterError.attachmentHandoffUnavailable(message)
+        }
+    }
+
     private func mapServiceError(
         _ error: BusinessDocumentStudioError,
         optionID: String
@@ -268,6 +279,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
 
         case .unsupportedFormat,
              .adapterReturnedUnexpectedFormat,
+             .attachmentHandoffUnavailable,
              .writeFailed:
             return .failed(error.localizedDescription)
         }
@@ -310,10 +322,14 @@ struct BusinessDocumentStudioPresentation: Equatable {
     let subtitle: String
     let iconSystemName: String
     let importRows: [BusinessDocumentStudioInfoRow]
+    let businessRows: [BusinessDocumentStudioInfoRow]
     let summaryRows: [BusinessDocumentStudioInfoRow]
     let structureRows: [BusinessDocumentStudioInfoRow]
     let securityRows: [BusinessDocumentStudioInfoRow]
     let previewRows: [BusinessDocumentStudioInfoRow]
+    let fieldRows: [BusinessDocumentStudioInfoRow]
+    let tableRows: [BusinessDocumentStudioInfoRow]
+    let handoffRows: [BusinessDocumentStudioInfoRow]
     let previewSections: [BusinessDocumentStudioPreviewSection]
     let warnings: [BusinessDocumentStudioWarning]
     let exportOptions: [BusinessDocumentStudioExportOptionPresentation]
@@ -325,10 +341,14 @@ struct BusinessDocumentStudioPresentation: Equatable {
         subtitle = "\(summary.kind.displayName) - \(summary.formatId.uppercased())"
         iconSystemName = summary.kind.systemImageName
         importRows = Self.importRows(for: inspection, sourceURL: sourceURL)
+        businessRows = Self.businessRows(for: inspection.extractionSummary)
         summaryRows = Self.summaryRows(for: inspection)
         structureRows = Self.structureRows(for: summary.structureSummary)
         securityRows = Self.securityRows(for: inspection.security)
         previewRows = Self.previewRows(for: inspection.preview)
+        fieldRows = Self.fieldRows(for: inspection.extractionSummary.fields)
+        tableRows = Self.tableRows(for: inspection.extractionSummary.tables)
+        handoffRows = Self.handoffRows(for: inspection.extractionSummary.attachmentHandoff)
         previewSections = Self.previewSections(for: inspection.preview)
         warnings = Self.warnings(for: inspection)
         exportOptions = inspection.exportOptions.map(BusinessDocumentStudioExportOptionPresentation.init(option:))
@@ -385,6 +405,17 @@ struct BusinessDocumentStudioPresentation: Equatable {
             )
         }
         return numberedRows(prefix: "import", pairs)
+    }
+
+    private static func businessRows(
+        for summary: BusinessDocumentStudioExtractionSummary
+    ) -> [BusinessDocumentStudioInfoRow] {
+        numberedRows(prefix: "business", [
+            ("Extraction summary", summary.headline),
+            ("Fields", "\(summary.fields.count)"),
+            ("Tables", "\(summary.tables.count)"),
+            ("Workspace handoff", summary.attachmentHandoff.isAvailable ? "Available" : "Unavailable"),
+        ])
     }
 
     private static func structureRows(
@@ -556,27 +587,40 @@ struct BusinessDocumentStudioPresentation: Equatable {
 
         case .pdf(let pdf):
             return pdf.pages.enumerated().map { offset, page in
-                BusinessDocumentStudioPreviewSection(
+                var rows = numberedRows(prefix: "pdf-page-\(offset)", [
+                    ("Text", page.text.text),
+                    ("Tables", "\(page.tableCount)"),
+                ])
+                rows.append(contentsOf: tableSampleRows(page.tables, prefix: "pdf-page-\(offset)-table"))
+                return BusinessDocumentStudioPreviewSection(
                     id: "pdf-page-\(offset)",
                     title: "Page \(page.pageIndex + 1)",
-                    rows: numberedRows(prefix: "pdf-page-\(offset)", [
-                        ("Text", page.text.text),
-                        ("Tables", "\(page.tableCount)"),
-                    ])
+                    rows: rows
                 )
             }
 
         case .presentation(let presentation):
             return presentation.slides.enumerated().map { offset, slide in
-                BusinessDocumentStudioPreviewSection(
+                var rows = numberedRows(prefix: "presentation-slide-\(offset)", [
+                    ("Slide", "\(slide.slideNumber)"),
+                    ("Hidden", slide.isHidden ? "Yes" : "No"),
+                    ("Text", slide.text.text),
+                    ("Tables", "\(slide.tableCount)"),
+                ])
+                if let speakerNotes = slide.speakerNotes {
+                    rows.append(
+                        BusinessDocumentStudioInfoRow(
+                            id: "presentation-slide-\(offset)-speaker-notes",
+                            label: "Speaker notes",
+                            value: speakerNotes.text
+                        )
+                    )
+                }
+                rows.append(contentsOf: tableSampleRows(slide.tables, prefix: "presentation-slide-\(offset)-table"))
+                return BusinessDocumentStudioPreviewSection(
                     id: "presentation-slide-\(offset)",
                     title: slide.label,
-                    rows: numberedRows(prefix: "presentation-slide-\(offset)", [
-                        ("Slide", "\(slide.slideNumber)"),
-                        ("Hidden", slide.isHidden ? "Yes" : "No"),
-                        ("Text", slide.text.text),
-                        ("Tables", "\(slide.tableCount)"),
-                    ])
+                    rows: rows
                 )
             }
 
@@ -604,6 +648,74 @@ struct BusinessDocumentStudioPresentation: Equatable {
                 ),
             ]
         }
+    }
+
+    private static func tableSampleRows(
+        _ tables: [BusinessDocumentTablePreview],
+        prefix: String
+    ) -> [BusinessDocumentStudioInfoRow] {
+        tables.prefix(4).enumerated().flatMap { tableOffset, table in
+            var rows = numberedRows(prefix: "\(prefix)-\(tableOffset)", [
+                (
+                    "Table \(table.index + 1)",
+                    "\(table.rowCount)x\(table.columnCount), \(table.cellCount) cells"
+                ),
+            ])
+            rows.append(
+                contentsOf: table.sampleRows.prefix(4).enumerated().map { rowOffset, row in
+                    BusinessDocumentStudioInfoRow(
+                        id: "\(prefix)-\(tableOffset)-row-\(rowOffset)",
+                        label: "Table row \(row.index + 1)",
+                        value: row.cells.map(\.text.text).joined(separator: " | ")
+                    )
+                }
+            )
+            return rows
+        }
+    }
+
+    private static func fieldRows(
+        for fields: [BusinessDocumentStudioFieldSummary]
+    ) -> [BusinessDocumentStudioInfoRow] {
+        fields.prefix(12).enumerated().map { offset, field in
+            let samples = field.sampleValues.isEmpty
+                ? ""
+                : " - samples: \(field.sampleValues.prefix(3).joined(separator: ", "))"
+            return BusinessDocumentStudioInfoRow(
+                id: "field-\(offset)",
+                label: field.name,
+                value: "\(field.valueKind), \(field.filledCount) filled, \(field.emptyCount) empty\(samples)"
+            )
+        }
+    }
+
+    private static func tableRows(
+        for tables: [BusinessDocumentStudioTableSummary]
+    ) -> [BusinessDocumentStudioInfoRow] {
+        tables.prefix(12).enumerated().map { offset, table in
+            let sample: String
+            if let sampleText = table.sampleText, !sampleText.isEmpty {
+                sample = " - \(sampleText)"
+            } else {
+                sample = ""
+            }
+            return BusinessDocumentStudioInfoRow(
+                id: "table-\(offset)",
+                label: table.label,
+                value: "\(table.source), \(table.rowCount)x\(table.columnCount), \(table.cellCount) cells\(sample)"
+            )
+        }
+    }
+
+    private static func handoffRows(
+        for handoff: BusinessDocumentStudioAttachmentHandoff
+    ) -> [BusinessDocumentStudioInfoRow] {
+        numberedRows(prefix: "handoff", [
+            ("Status", handoff.isAvailable ? "Available" : "Unavailable"),
+            ("Artifact", handoff.label),
+            ("Text fallback", fileSizeLabel(Int64(handoff.fallbackUTF8Bytes))),
+            ("Detail", handoff.message),
+        ])
     }
 
     private static func warnings(
@@ -905,6 +1017,7 @@ struct BusinessDocumentStudioLoadFailure: Equatable {
                  .unsafeTextPackageTarget,
                  .packageTargetExtensionMismatch,
                  .textExportTooLarge,
+                 .attachmentHandoffUnavailable,
                  .writeFailed:
                 kind = .other
                 title = "Document unavailable"
@@ -920,6 +1033,20 @@ struct BusinessDocumentStudioLoadFailure: Equatable {
 
         kind = .other
         title = "Document unavailable"
+    }
+}
+
+enum BusinessDocumentStudioPresenterError: LocalizedError, Equatable {
+    case noDocumentLoaded
+    case attachmentHandoffUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noDocumentLoaded:
+            return "No document is loaded."
+        case .attachmentHandoffUnavailable(let message):
+            return message
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -31,11 +31,14 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
     @Published private(set) var loadState: LoadState = .idle
     @Published private(set) var exportState: ExportState = .idle
     @Published private(set) var artifactStatuses: [BusinessDocumentStudioArtifactStatus] = []
+    @Published private(set) var isExportInProgress = false
 
     private let service: BusinessDocumentStudioService
     private var document: StructuredDocument?
     private var inspection: BusinessDocumentStudioInspection?
     private var pendingOverwrite: PendingExport?
+    private var documentGeneration = UUID()
+    private var activeExportRequest: ExportRequest?
 
     init(service: BusinessDocumentStudioService = BusinessDocumentStudioService()) {
         self.service = service
@@ -45,19 +48,21 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         url: URL,
         policy: BusinessDocumentStudioPolicy = .standard
     ) async {
-        loadState = .loading(url)
-        exportState = .idle
-        artifactStatuses = []
-        clearPendingOverwriteStatus()
+        let generation = beginDocumentTransition(loadState: .loading(url))
 
         do {
             let document = try await service.parse(url: url)
-            guard !Task.isCancelled else { return }
-            try load(document: document, sourceURL: url, policy: policy)
+            guard !Task.isCancelled, generation == documentGeneration else { return }
+            let inspection = try service.inspect(document, policy: policy)
+            guard generation == documentGeneration else { return }
+            commit(
+                document: document,
+                inspection: inspection,
+                sourceURL: url,
+                generation: generation
+            )
         } catch {
-            guard !Task.isCancelled else { return }
-            self.document = nil
-            inspection = nil
+            guard !Task.isCancelled, generation == documentGeneration else { return }
             loadState = .failed(BusinessDocumentStudioLoadFailure(url: url, error: error))
         }
     }
@@ -68,30 +73,33 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         policy: BusinessDocumentStudioPolicy = .standard
     ) throws {
         let inspection = try service.inspect(document, policy: policy)
-        self.document = document
-        self.inspection = inspection
-        loadState = .loaded(BusinessDocumentStudioPresentation(inspection: inspection, sourceURL: sourceURL))
-        exportState = .idle
-        artifactStatuses = []
-        clearPendingOverwriteStatus()
+        let generation = beginDocumentTransition(loadState: .idle)
+        commit(
+            document: document,
+            inspection: inspection,
+            sourceURL: sourceURL,
+            generation: generation
+        )
     }
 
+    @discardableResult
     func export(
         optionID: String,
         to destination: URL,
         allowedDirectory: URL? = nil,
         allowOverwrite: Bool = false,
         maxTextExportUTF8Bytes: Int = BusinessDocumentStudioExportPolicy.standard.maxTextExportUTF8Bytes
-    ) async {
+    ) async -> Bool {
+        guard activeExportRequest == nil else { return false }
         guard let document, let inspection else {
             exportState = .failed("No document is loaded.")
-            return
+            return false
         }
         clearPendingOverwriteStatus()
 
         guard let option = inspection.exportOptions.first(where: { $0.targetFormatId == optionID }) else {
             exportState = .failed("Export option '\(optionID)' is not available for this document.")
-            return
+            return false
         }
 
         guard option.canExport else {
@@ -104,7 +112,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
             )
             exportState = .blocked(block)
             appendArtifactStatus(BusinessDocumentStudioArtifactStatus(block: block))
-            return
+            return false
         }
 
         if !allowOverwrite,
@@ -117,12 +125,15 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
                 allowedDirectory: allowedDirectory,
                 maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
             )
-            pendingOverwrite = PendingExport(request: request)
+            pendingOverwrite = PendingExport(request: request, documentGeneration: documentGeneration)
             exportState = .awaitingOverwriteConsent(request)
             appendArtifactStatus(BusinessDocumentStudioArtifactStatus(overwriteRequest: request))
-            return
+            return true
         }
 
+        let exportRequest = ExportRequest(documentGeneration: documentGeneration)
+        activeExportRequest = exportRequest
+        isExportInProgress = true
         exportState = .exporting(optionID: option.targetFormatId)
 
         do {
@@ -136,10 +147,12 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
                     maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
                 )
             )
+            guard complete(exportRequest) else { return true }
             let receipt = BusinessDocumentStudioExportReceipt(result: result)
             exportState = .succeeded(receipt)
             appendArtifactStatus(BusinessDocumentStudioArtifactStatus(receipt: receipt))
         } catch let error as BusinessDocumentStudioError {
+            guard complete(exportRequest) else { return true }
             let mapped = mapServiceError(error, optionID: option.targetFormatId)
             exportState = mapped
             if case .failed(let message) = mapped {
@@ -148,18 +161,29 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
                 appendArtifactStatus(BusinessDocumentStudioArtifactStatus(exportState: mapped, optionID: option.targetFormatId))
             }
         } catch {
+            guard complete(exportRequest) else { return true }
             let message = error.localizedDescription
             exportState = .failed(message)
             appendArtifactStatus(.failed(optionID: option.targetFormatId, message: message, path: destination.path))
         }
+        return true
     }
 
-    func confirmPendingOverwrite() async {
+    @discardableResult
+    func confirmPendingOverwrite(requestID: UUID? = nil) async -> Bool {
+        guard activeExportRequest == nil else { return false }
         guard let pendingOverwrite else {
-            exportState = .failed("No overwrite is waiting for confirmation.")
-            return
+            if requestID == nil {
+                exportState = .failed("No overwrite is waiting for confirmation.")
+            }
+            return false
         }
-        await export(
+        guard pendingOverwrite.documentGeneration == documentGeneration,
+            requestID.map({ $0 == pendingOverwrite.request.id }) ?? true
+        else {
+            return false
+        }
+        return await export(
             optionID: pendingOverwrite.request.optionID,
             to: pendingOverwrite.request.destination,
             allowedDirectory: pendingOverwrite.request.allowedDirectory,
@@ -168,10 +192,19 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         )
     }
 
-    func cancelPendingOverwrite() {
+    @discardableResult
+    func cancelPendingOverwrite(requestID: UUID? = nil) -> Bool {
+        guard activeExportRequest == nil else { return false }
         guard let pendingOverwrite else {
-            exportState = .idle
-            return
+            if requestID == nil {
+                exportState = .idle
+            }
+            return false
+        }
+        guard pendingOverwrite.documentGeneration == documentGeneration,
+            requestID.map({ $0 == pendingOverwrite.request.id }) ?? true
+        else {
+            return false
         }
         removeArtifactStatus(matching: pendingOverwrite.request)
         self.pendingOverwrite = nil
@@ -184,6 +217,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         )
         exportState = .blocked(block)
         appendArtifactStatus(BusinessDocumentStudioArtifactStatus(block: block))
+        return true
     }
 
     func makeWorkspaceAttachment() throws -> Attachment {
@@ -295,6 +329,47 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         }
     }
 
+    /// Starting a new document abandons prior async ownership. Late callbacks
+    /// can still finish their file work, but cannot publish into this generation.
+    private func beginDocumentTransition(loadState: LoadState) -> UUID {
+        let generation = UUID()
+        documentGeneration = generation
+        activeExportRequest = nil
+        isExportInProgress = false
+        document = nil
+        inspection = nil
+        pendingOverwrite = nil
+        exportState = .idle
+        artifactStatuses = []
+        self.loadState = loadState
+        return generation
+    }
+
+    private func commit(
+        document: StructuredDocument,
+        inspection: BusinessDocumentStudioInspection,
+        sourceURL: URL?,
+        generation: UUID
+    ) {
+        guard generation == documentGeneration else { return }
+        self.document = document
+        self.inspection = inspection
+        loadState = .loaded(BusinessDocumentStudioPresentation(inspection: inspection, sourceURL: sourceURL))
+    }
+
+    /// Only the request that still owns the current generation may publish a
+    /// completion. A newer export or document transition makes this a no-op.
+    private func complete(_ request: ExportRequest) -> Bool {
+        guard activeExportRequest == request,
+            request.documentGeneration == documentGeneration
+        else {
+            return false
+        }
+        activeExportRequest = nil
+        isExportInProgress = false
+        return true
+    }
+
     private func clearPendingOverwriteStatus() {
         guard let pendingOverwrite else { return }
         removeArtifactStatus(matching: pendingOverwrite.request)
@@ -316,6 +391,12 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
 
     private struct PendingExport: Equatable {
         let request: BusinessDocumentStudioOverwriteRequest
+        let documentGeneration: UUID
+    }
+
+    private struct ExportRequest: Equatable {
+        let id = UUID()
+        let documentGeneration: UUID
     }
 }
 
@@ -1071,6 +1152,7 @@ struct BusinessDocumentStudioExportReceipt: Equatable {
 }
 
 struct BusinessDocumentStudioOverwriteRequest: Equatable {
+    let id = UUID()
     let optionID: String
     let label: String
     let destination: URL

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -38,7 +38,8 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
     private var inspection: BusinessDocumentStudioInspection?
     private var pendingOverwrite: PendingExport?
     private var documentGeneration = UUID()
-    private var activeExportRequest: ExportRequest?
+    private var activeDocumentTransition: UUID?
+    private var activeExport: ActiveExport?
 
     init(service: BusinessDocumentStudioService = BusinessDocumentStudioService()) {
         self.service = service
@@ -48,6 +49,10 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         url: URL,
         policy: BusinessDocumentStudioPolicy = .standard
     ) async {
+        let transition = registerDocumentTransition()
+        defer { finishDocumentTransition(transition) }
+        await cancelActiveExportAndWait()
+        guard !Task.isCancelled, transition == activeDocumentTransition else { return }
         let generation = beginDocumentTransition(loadState: .loading(url))
 
         do {
@@ -71,7 +76,12 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         document: StructuredDocument,
         sourceURL: URL? = nil,
         policy: BusinessDocumentStudioPolicy = .standard
-    ) throws {
+    ) async throws {
+        let transition = registerDocumentTransition()
+        defer { finishDocumentTransition(transition) }
+        await cancelActiveExportAndWait()
+        try Task.checkCancellation()
+        guard transition == activeDocumentTransition else { return }
         let inspection = try service.inspect(document, policy: policy)
         let generation = beginDocumentTransition(loadState: .idle)
         commit(
@@ -90,7 +100,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         allowOverwrite: Bool = false,
         maxTextExportUTF8Bytes: Int = BusinessDocumentStudioExportPolicy.standard.maxTextExportUTF8Bytes
     ) async -> Bool {
-        guard activeExportRequest == nil else { return false }
+        guard activeDocumentTransition == nil, activeExport == nil else { return false }
         guard let document, let inspection else {
             exportState = .failed("No document is loaded.")
             return false
@@ -115,8 +125,30 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
             return false
         }
 
+        do {
+            try service.validateDestination(
+                destination,
+                policy: BusinessDocumentStudioExportPolicy(
+                    allowedDirectory: allowedDirectory,
+                    allowOverwrite: true,
+                    maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
+                )
+            )
+        } catch let error as BusinessDocumentStudioError {
+            let mapped = mapServiceError(error, optionID: option.targetFormatId)
+            exportState = mapped
+            appendArtifactStatus(
+                BusinessDocumentStudioArtifactStatus(exportState: mapped, optionID: option.targetFormatId)
+            )
+            return false
+        } catch {
+            let message = error.localizedDescription
+            exportState = .failed(message)
+            appendArtifactStatus(.failed(optionID: option.targetFormatId, message: message, path: destination.path))
+            return false
+        }
+
         if !allowOverwrite,
-            Self.canCheckExistence(destination: destination, allowedDirectory: allowedDirectory),
             FileManager.default.fileExists(atPath: destination.path) {
             let request = BusinessDocumentStudioOverwriteRequest(
                 optionID: option.targetFormatId,
@@ -132,12 +164,8 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         }
 
         let exportRequest = ExportRequest(documentGeneration: documentGeneration)
-        activeExportRequest = exportRequest
-        isExportInProgress = true
-        exportState = .exporting(optionID: option.targetFormatId)
-
-        do {
-            let result = try await service.export(
+        let exportTask = Task { [service] in
+            try await service.export(
                 document,
                 as: option.targetFormatId,
                 to: destination,
@@ -147,10 +175,20 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
                     maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
                 )
             )
+        }
+        activeExport = ActiveExport(request: exportRequest, task: exportTask)
+        isExportInProgress = true
+        exportState = .exporting(optionID: option.targetFormatId)
+
+        do {
+            let result = try await exportTask.value
             guard complete(exportRequest) else { return true }
             let receipt = BusinessDocumentStudioExportReceipt(result: result)
             exportState = .succeeded(receipt)
             appendArtifactStatus(BusinessDocumentStudioArtifactStatus(receipt: receipt))
+        } catch is CancellationError {
+            guard complete(exportRequest) else { return true }
+            exportState = .idle
         } catch let error as BusinessDocumentStudioError {
             guard complete(exportRequest) else { return true }
             let mapped = mapServiceError(error, optionID: option.targetFormatId)
@@ -171,7 +209,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
 
     @discardableResult
     func confirmPendingOverwrite(requestID: UUID? = nil) async -> Bool {
-        guard activeExportRequest == nil else { return false }
+        guard activeExport == nil else { return false }
         guard let pendingOverwrite else {
             if requestID == nil {
                 exportState = .failed("No overwrite is waiting for confirmation.")
@@ -194,7 +232,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
 
     @discardableResult
     func cancelPendingOverwrite(requestID: UUID? = nil) -> Bool {
-        guard activeExportRequest == nil else { return false }
+        guard activeExport == nil else { return false }
         guard let pendingOverwrite else {
             if requestID == nil {
                 exportState = .idle
@@ -220,7 +258,7 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         return true
     }
 
-    func makeWorkspaceAttachment() throws -> Attachment {
+    func makeAttachmentPayloadForValidation() throws -> Attachment {
         guard let document else {
             throw BusinessDocumentStudioPresenterError.noDocumentLoaded
         }
@@ -329,12 +367,35 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         }
     }
 
-    /// Starting a new document abandons prior async ownership. Late callbacks
-    /// can still finish their file work, but cannot publish into this generation.
+    private func registerDocumentTransition() -> UUID {
+        let transition = UUID()
+        activeDocumentTransition = transition
+        return transition
+    }
+
+    private func finishDocumentTransition(_ transition: UUID) {
+        guard activeDocumentTransition == transition else { return }
+        activeDocumentTransition = nil
+    }
+
+    /// A document transition cannot revoke an emitter synchronously. Cancel
+    /// and join the task while the main actor remains suspended; the service's
+    /// staging contract keeps an emitter that ignores cancellation away from
+    /// the selected destination until this join finishes.
+    private func cancelActiveExportAndWait() async {
+        guard let activeExport else { return }
+        activeExport.task.cancel()
+        _ = try? await activeExport.task.value
+        guard self.activeExport?.request == activeExport.request else { return }
+        self.activeExport = nil
+        isExportInProgress = false
+    }
+
+    /// Starting a new document occurs only after prior export ownership has
+    /// been joined, so resetting presentation state cannot hide pending writes.
     private func beginDocumentTransition(loadState: LoadState) -> UUID {
         let generation = UUID()
         documentGeneration = generation
-        activeExportRequest = nil
         isExportInProgress = false
         document = nil
         inspection = nil
@@ -360,12 +421,12 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
     /// Only the request that still owns the current generation may publish a
     /// completion. A newer export or document transition makes this a no-op.
     private func complete(_ request: ExportRequest) -> Bool {
-        guard activeExportRequest == request,
+        guard activeExport?.request == request,
             request.documentGeneration == documentGeneration
         else {
             return false
         }
-        activeExportRequest = nil
+        activeExport = nil
         isExportInProgress = false
         return true
     }
@@ -381,14 +442,6 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
         artifactStatuses.removeAll { $0.id == pendingStatusID }
     }
 
-    private static func canCheckExistence(destination: URL, allowedDirectory: URL?) -> Bool {
-        guard destination.isFileURL else { return false }
-        guard let allowedDirectory else { return true }
-        let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().path
-        let parent = destination.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().path
-        return parent == root || parent.hasPrefix(root + "/")
-    }
-
     private struct PendingExport: Equatable {
         let request: BusinessDocumentStudioOverwriteRequest
         let documentGeneration: UUID
@@ -397,6 +450,11 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
     private struct ExportRequest: Equatable {
         let id = UUID()
         let documentGeneration: UUID
+    }
+
+    private struct ActiveExport {
+        let request: ExportRequest
+        let task: Task<BusinessDocumentStudioExportResult, any Error>
     }
 }
 
@@ -499,7 +557,7 @@ struct BusinessDocumentStudioPresentation: Equatable {
             ("Extraction summary", summary.headline),
             ("Fields", "\(summary.fields.count)"),
             ("Tables", "\(summary.tables.count)"),
-            ("Workspace handoff", summary.attachmentHandoff.isAvailable ? "Available" : "Unavailable"),
+            ("Attachment validation", summary.attachmentHandoff.isAvailable ? "Available" : "Unavailable"),
         ])
     }
 

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -52,8 +52,10 @@ final class BusinessDocumentStudioPresenter: ObservableObject {
 
         do {
             let document = try await service.parse(url: url)
+            guard !Task.isCancelled else { return }
             try load(document: document, sourceURL: url, policy: policy)
         } catch {
+            guard !Task.isCancelled else { return }
             self.document = nil
             inspection = nil
             loadState = .failed(BusinessDocumentStudioLoadFailure(url: url, error: error))
@@ -330,6 +332,7 @@ struct BusinessDocumentStudioPresentation: Equatable {
     let fieldRows: [BusinessDocumentStudioInfoRow]
     let tableRows: [BusinessDocumentStudioInfoRow]
     let handoffRows: [BusinessDocumentStudioInfoRow]
+    let isAttachmentHandoffAvailable: Bool
     let previewSections: [BusinessDocumentStudioPreviewSection]
     let warnings: [BusinessDocumentStudioWarning]
     let exportOptions: [BusinessDocumentStudioExportOptionPresentation]
@@ -349,6 +352,7 @@ struct BusinessDocumentStudioPresentation: Equatable {
         fieldRows = Self.fieldRows(for: inspection.extractionSummary.fields)
         tableRows = Self.tableRows(for: inspection.extractionSummary.tables)
         handoffRows = Self.handoffRows(for: inspection.extractionSummary.attachmentHandoff)
+        isAttachmentHandoffAvailable = inspection.extractionSummary.attachmentHandoff.isAvailable
         previewSections = Self.previewSections(for: inspection.preview)
         warnings = Self.warnings(for: inspection)
         exportOptions = inspection.exportOptions.map(BusinessDocumentStudioExportOptionPresentation.init(option:))

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -11,16 +11,17 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct BusinessDocumentStudioView: View {
-    private let sourceURL: URL?
-
     @StateObject private var presenter: BusinessDocumentStudioPresenter
+    private let sourceURL: URL?
+    @State private var currentSourceURL: URL?
 
     init(
         sourceURL: URL? = nil,
         presenter: BusinessDocumentStudioPresenter = BusinessDocumentStudioPresenter()
     ) {
-        self.sourceURL = sourceURL
         _presenter = StateObject(wrappedValue: presenter)
+        self.sourceURL = sourceURL
+        _currentSourceURL = State(initialValue: sourceURL)
     }
 
     var body: some View {
@@ -30,9 +31,12 @@ struct BusinessDocumentStudioView: View {
             content
         }
         .frame(minWidth: 720, minHeight: 520)
-        .task(id: sourceURL) {
-            guard let sourceURL else { return }
-            await presenter.load(url: sourceURL)
+        .task(id: currentSourceURL) {
+            guard let currentSourceURL else { return }
+            await presenter.load(url: currentSourceURL)
+        }
+        .onChange(of: sourceURL) { _, newValue in
+            currentSourceURL = newValue
         }
     }
 
@@ -52,6 +56,19 @@ struct BusinessDocumentStudioView: View {
             }
 
             Spacer(minLength: 16)
+
+            Button {
+                beginImport()
+            } label: {
+                Label {
+                    Text(verbatim: "Import")
+                } icon: {
+                    Image(systemName: "square.and.arrow.down")
+                }
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 12)
@@ -78,17 +95,20 @@ struct BusinessDocumentStudioView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-        case .failed(let message):
+        case .failed(let failure):
             emptyState(
-                systemImage: "exclamationmark.triangle",
-                title: "Document unavailable",
-                message: message
+                systemImage: failure.kind == .unsupportedFormat ? "doc.badge.questionmark" : "exclamationmark.triangle",
+                title: failure.title,
+                message: failure.message
             )
 
         case .loaded(let presentation):
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     documentHeader(presentation)
+                    StudioSection(title: "Import Summary") {
+                        infoGrid(presentation.importRows)
+                    }
                     StudioSection(title: "Metadata") {
                         infoGrid(presentation.summaryRows)
                     }
@@ -101,7 +121,7 @@ struct BusinessDocumentStudioView: View {
                             warningsView(presentation.warnings)
                         }
                     }
-                    StudioSection(title: "Preview") {
+                    StudioSection(title: "Structured Extraction Preview") {
                         VStack(alignment: .leading, spacing: 14) {
                             infoGrid(presentation.previewRows)
                             previewSections(presentation.previewSections)
@@ -113,6 +133,11 @@ struct BusinessDocumentStudioView: View {
                             ForEach(presentation.exportOptions) { option in
                                 exportOptionRow(option, presentation: presentation)
                             }
+                        }
+                    }
+                    if !presenter.artifactStatuses.isEmpty {
+                        StudioSection(title: "Artifact Status") {
+                            artifactStatusesView(presenter.artifactStatuses)
                         }
                     }
                 }
@@ -245,6 +270,38 @@ struct BusinessDocumentStudioView: View {
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
 
+        case .awaitingOverwriteConsent(let request):
+            HStack(alignment: .center, spacing: 10) {
+                Label {
+                    Text(verbatim: request.message)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle")
+                }
+                    .font(.system(size: 12))
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+
+                Spacer(minLength: 12)
+
+                Button {
+                    presenter.cancelPendingOverwrite()
+                } label: {
+                    Text(verbatim: "Cancel")
+                }
+                .controlSize(.small)
+
+                Button {
+                    Task { @MainActor in
+                        await presenter.confirmPendingOverwrite()
+                    }
+                } label: {
+                    Text(verbatim: "Replace")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .help(request.destination.path)
+
         case .succeeded(let receipt):
             Label {
                 Text(verbatim: receipt.message)
@@ -273,6 +330,53 @@ struct BusinessDocumentStudioView: View {
             }
                 .font(.system(size: 12))
                 .foregroundStyle(.red)
+        }
+    }
+
+    private func artifactStatusesView(_ statuses: [BusinessDocumentStudioArtifactStatus]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(statuses) { status in
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: artifactIconName(for: status.state))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(artifactColor(for: status.state))
+                        .frame(width: 20, height: 20)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 8) {
+                            Text(verbatim: status.title)
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(verbatim: status.safetyLabel)
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(verbatim: status.message)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        if let path = status.path {
+                            Text(verbatim: path)
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .textSelection(.enabled)
+                        }
+                        if let bytesWritten = status.bytesWritten {
+                            Text(verbatim: ByteCountFormatter.string(fromByteCount: bytesWritten, countStyle: .file))
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+
+                    Spacer(minLength: 12)
+                }
+                .padding(10)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                )
+            }
         }
     }
 
@@ -346,8 +450,24 @@ struct BusinessDocumentStudioView: View {
                 optionID: option.id,
                 to: url,
                 allowedDirectory: url.deletingLastPathComponent(),
-                allowOverwrite: true
+                allowOverwrite: false
             )
+        }
+    }
+
+    private func beginImport() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.resolvesAliases = true
+        panel.title = L("Open Business Document")
+        panel.message = L("Choose a business document to inspect or export.")
+        panel.allowedContentTypes = BusinessDocumentStudioDocumentTypes.supportedContentTypes
+
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            currentSourceURL = url.standardizedFileURL
         }
     }
 
@@ -394,6 +514,24 @@ struct BusinessDocumentStudioView: View {
         case .info: return .secondary
         case .caution: return .orange
         case .blocked: return .red
+        }
+    }
+
+    private func artifactIconName(for state: BusinessDocumentStudioArtifactStatus.State) -> String {
+        switch state {
+        case .created: return "checkmark.circle"
+        case .needsConsent: return "exclamationmark.triangle"
+        case .blocked: return "nosign"
+        case .failed: return "xmark.octagon"
+        }
+    }
+
+    private func artifactColor(for state: BusinessDocumentStudioArtifactStatus.State) -> Color {
+        switch state {
+        case .created: return .green
+        case .needsConsent: return .orange
+        case .blocked: return .orange
+        case .failed: return .red
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -1,0 +1,420 @@
+//
+//  BusinessDocumentStudioView.swift
+//  osaurus
+//
+//  UI for inspecting BusinessDocumentStudioService previews and export
+//  availability without routing the document through chat.
+//
+
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BusinessDocumentStudioView: View {
+    private let sourceURL: URL?
+
+    @StateObject private var presenter: BusinessDocumentStudioPresenter
+
+    init(
+        sourceURL: URL? = nil,
+        presenter: BusinessDocumentStudioPresenter = BusinessDocumentStudioPresenter()
+    ) {
+        self.sourceURL = sourceURL
+        _presenter = StateObject(wrappedValue: presenter)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            chrome
+            Divider()
+            content
+        }
+        .frame(minWidth: 720, minHeight: 520)
+        .task(id: sourceURL) {
+            guard let sourceURL else { return }
+            await presenter.load(url: sourceURL)
+        }
+    }
+
+    private var chrome: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: "Business Document Studio")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(verbatim: "Preview and export availability")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 16)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch presenter.loadState {
+        case .idle:
+            emptyState(
+                systemImage: "doc.badge.plus",
+                title: "No document loaded",
+                message: "Open a supported business document to inspect preview, security, and export availability."
+            )
+
+        case .loading(let url):
+            VStack(spacing: 12) {
+                ProgressView()
+                Text(verbatim: url?.lastPathComponent ?? "Loading document")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .failed(let message):
+            emptyState(
+                systemImage: "exclamationmark.triangle",
+                title: "Document unavailable",
+                message: message
+            )
+
+        case .loaded(let presentation):
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    documentHeader(presentation)
+                    StudioSection(title: "Metadata") {
+                        infoGrid(presentation.summaryRows)
+                    }
+                    StudioSection(title: "Structure") {
+                        infoGrid(presentation.structureRows)
+                    }
+                    StudioSection(title: "Security and Extraction") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            infoGrid(presentation.securityRows)
+                            warningsView(presentation.warnings)
+                        }
+                    }
+                    StudioSection(title: "Preview") {
+                        VStack(alignment: .leading, spacing: 14) {
+                            infoGrid(presentation.previewRows)
+                            previewSections(presentation.previewSections)
+                        }
+                    }
+                    StudioSection(title: "Export Options") {
+                        VStack(alignment: .leading, spacing: 10) {
+                            exportStateView
+                            ForEach(presentation.exportOptions) { option in
+                                exportOptionRow(option, presentation: presentation)
+                            }
+                        }
+                    }
+                }
+                .padding(18)
+            }
+        }
+    }
+
+    private func documentHeader(_ presentation: BusinessDocumentStudioPresentation) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: presentation.iconSystemName)
+                .font(.system(size: 22, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: presentation.title)
+                    .font(.system(size: 18, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                HStack(spacing: 8) {
+                    Text(verbatim: presentation.subtitle)
+                    if !presentation.registryRoleLabels.isEmpty {
+                        Text(verbatim: presentation.registryRoleLabels.joined(separator: " / "))
+                    }
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+
+            Spacer(minLength: 16)
+        }
+    }
+
+    private func infoGrid(_ rows: [BusinessDocumentStudioInfoRow]) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 7) {
+            ForEach(rows) { row in
+                GridRow(alignment: .firstTextBaseline) {
+                    Text(verbatim: row.label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 140, alignment: .leading)
+                    Text(verbatim: row.value)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.primary)
+                        .textSelection(.enabled)
+                        .lineLimit(3)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func warningsView(_ warnings: [BusinessDocumentStudioWarning]) -> some View {
+        if warnings.isEmpty {
+            Label {
+                Text(verbatim: "No extraction or export warnings")
+            } icon: {
+                Image(systemName: "checkmark.circle")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(warnings) { warning in
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: iconName(for: warning.severity))
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(color(for: warning.severity))
+                            .frame(width: 16, height: 16)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(verbatim: warning.title)
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(verbatim: warning.message)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func previewSections(_ sections: [BusinessDocumentStudioPreviewSection]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(sections) { section in
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(verbatim: section.title)
+                        .font(.system(size: 12, weight: .semibold))
+                    ForEach(section.rows) { row in
+                        HStack(alignment: .firstTextBaseline, spacing: 10) {
+                            Text(verbatim: row.label)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 96, alignment: .leading)
+                            Text(verbatim: row.value)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.primary)
+                                .lineLimit(3)
+                                .truncationMode(.tail)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var exportStateView: some View {
+        switch presenter.exportState {
+        case .idle:
+            EmptyView()
+
+        case .exporting(let optionID):
+            Label {
+                Text(verbatim: "Exporting \(optionID.uppercased())")
+            } icon: {
+                Image(systemName: "arrow.triangle.2.circlepath")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+        case .succeeded(let receipt):
+            Label {
+                Text(verbatim: receipt.message)
+            } icon: {
+                Image(systemName: "checkmark.circle")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.green)
+                .help(receipt.url.path)
+
+        case .blocked(let block):
+            Label {
+                Text(verbatim: block.message)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.orange)
+                .help(block.path ?? block.optionID)
+
+        case .failed(let message):
+            Label {
+                Text(verbatim: message)
+            } icon: {
+                Image(systemName: "xmark.octagon")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.red)
+        }
+    }
+
+    private func exportOptionRow(
+        _ option: BusinessDocumentStudioExportOptionPresentation,
+        presentation: BusinessDocumentStudioPresentation
+    ) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: option.canExport ? "square.and.arrow.up" : "nosign")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(option.canExport ? Color.secondary : Color.orange)
+                .frame(width: 20, height: 20)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
+                    Text(verbatim: option.label)
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(verbatim: option.statusLabel)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(option.canExport ? Color.secondary : Color.orange)
+                    Text(verbatim: option.reasonLabel)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+                Text(verbatim: option.message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Button {
+                beginExport(option, presentation: presentation)
+            } label: {
+                Label {
+                    Text(verbatim: "Export")
+                } icon: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(!option.canExport)
+            .help(option.canExport ? "Export \(option.label)" : option.message)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+    }
+
+    private func beginExport(
+        _ option: BusinessDocumentStudioExportOptionPresentation,
+        presentation: BusinessDocumentStudioPresentation
+    ) {
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        panel.title = L("Export")
+        panel.message = option.label
+        panel.nameFieldStringValue = defaultExportName(for: option, presentation: presentation)
+        if let contentType = UTType(filenameExtension: option.fileExtension) {
+            panel.allowedContentTypes = [contentType]
+        }
+
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            await presenter.export(
+                optionID: option.id,
+                to: url,
+                allowedDirectory: url.deletingLastPathComponent(),
+                allowOverwrite: true
+            )
+        }
+    }
+
+    private func defaultExportName(
+        for option: BusinessDocumentStudioExportOptionPresentation,
+        presentation: BusinessDocumentStudioPresentation
+    ) -> String {
+        let stem = (presentation.title as NSString).deletingPathExtension
+        let basename = stem.isEmpty ? "document" : stem
+        return "\(basename).\(option.fileExtension)"
+    }
+
+    private func emptyState(
+        systemImage: String,
+        title: String,
+        message: String
+    ) -> some View {
+        VStack(spacing: 9) {
+            Image(systemName: systemImage)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(verbatim: title)
+                .font(.system(size: 14, weight: .semibold))
+            Text(verbatim: message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+
+    private func iconName(for severity: BusinessDocumentStudioWarning.Severity) -> String {
+        switch severity {
+        case .info: return "info.circle"
+        case .caution: return "exclamationmark.triangle"
+        case .blocked: return "xmark.octagon"
+        }
+    }
+
+    private func color(for severity: BusinessDocumentStudioWarning.Severity) -> Color {
+        switch severity {
+        case .info: return .secondary
+        case .caution: return .orange
+        case .blocked: return .red
+        }
+    }
+}
+
+private struct StudioSection<Content: View>: View {
+    let title: String
+    private let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(verbatim: title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            content
+            Divider()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -48,9 +48,9 @@ struct BusinessDocumentStudioView: View {
                 .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(verbatim: "Business Document Studio")
+                Text(verbatim: "Business Document Workbench")
                     .font(.system(size: 15, weight: .semibold))
-                Text(verbatim: "Preview and export availability")
+                Text(verbatim: "Import, extract, export, and hand off")
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
             }
@@ -109,6 +109,17 @@ struct BusinessDocumentStudioView: View {
                     StudioSection(title: "Import Summary") {
                         infoGrid(presentation.importRows)
                     }
+                    StudioSection(title: "Business Extraction Summary") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            infoGrid(presentation.businessRows)
+                            if !presentation.fieldRows.isEmpty {
+                                extractionList(title: "Fields", rows: presentation.fieldRows)
+                            }
+                            if !presentation.tableRows.isEmpty {
+                                extractionList(title: "Tables", rows: presentation.tableRows)
+                            }
+                        }
+                    }
                     StudioSection(title: "Metadata") {
                         infoGrid(presentation.summaryRows)
                     }
@@ -134,6 +145,9 @@ struct BusinessDocumentStudioView: View {
                                 exportOptionRow(option, presentation: presentation)
                             }
                         }
+                    }
+                    StudioSection(title: "Workspace Attachment Handoff") {
+                        infoGrid(presentation.handoffRows)
                     }
                     if !presenter.artifactStatuses.isEmpty {
                         StudioSection(title: "Artifact Status") {
@@ -253,6 +267,38 @@ struct BusinessDocumentStudioView: View {
                 )
             }
         }
+    }
+
+    private func extractionList(
+        title: String,
+        rows: [BusinessDocumentStudioInfoRow]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(verbatim: title)
+                .font(.system(size: 12, weight: .semibold))
+            ForEach(rows) { row in
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text(verbatim: row.label)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 128, alignment: .leading)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(verbatim: row.value)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.primary)
+                        .lineLimit(3)
+                        .truncationMode(.tail)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
     }
 
     @ViewBuilder
@@ -462,7 +508,7 @@ struct BusinessDocumentStudioView: View {
         panel.canChooseFiles = true
         panel.resolvesAliases = true
         panel.title = L("Open Business Document")
-        panel.message = L("Choose a business document to inspect or export.")
+        panel.message = L("Choose a business document to inspect preview, extraction, and export availability.")
         panel.allowedContentTypes = BusinessDocumentStudioDocumentTypes.supportedContentTypes
 
         Task { @MainActor in

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -15,7 +15,7 @@ struct BusinessDocumentStudioView: View {
     private let sourceURL: URL?
     private let claimSourceURL: ((URL) -> Bool)?
     @State private var currentSourceURL: URL?
-    @State private var workspaceAttachmentStatus: WorkspaceAttachmentStatus?
+    @State private var attachmentValidationStatus: AttachmentValidationStatus?
 
     init(
         sourceURL: URL? = nil,
@@ -37,12 +37,12 @@ struct BusinessDocumentStudioView: View {
         }
         .frame(minWidth: 720, minHeight: 520)
         .task(id: currentSourceURL) {
-            workspaceAttachmentStatus = nil
+            attachmentValidationStatus = nil
             guard let currentSourceURL else { return }
             await presenter.load(url: currentSourceURL)
         }
         .onChange(of: sourceURL) { _, newValue in
-            workspaceAttachmentStatus = nil
+            attachmentValidationStatus = nil
             guard let newValue else {
                 currentSourceURL = nil
                 return
@@ -67,7 +67,7 @@ struct BusinessDocumentStudioView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(verbatim: "Business Document Workbench")
                     .font(.system(size: 15, weight: .semibold))
-                Text(verbatim: "Import, extract, export, and hand off")
+                Text(verbatim: "Import, inspect, export, and validate")
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
             }
@@ -163,7 +163,7 @@ struct BusinessDocumentStudioView: View {
                             }
                         }
                     }
-                    StudioSection(title: "Workspace Attachment Handoff") {
+                    StudioSection(title: "Attachment Payload Validation") {
                         handoffView(presentation)
                     }
                     if !presenter.artifactStatuses.isEmpty {
@@ -451,10 +451,10 @@ struct BusinessDocumentStudioView: View {
 
             HStack(alignment: .center, spacing: 10) {
                 Button {
-                    prepareWorkspaceAttachment()
+                    validateAttachmentPayload()
                 } label: {
                     Label {
-                        Text(verbatim: "Check Attachment")
+                        Text(verbatim: "Validate Attachment")
                     } icon: {
                         Image(systemName: "paperclip")
                     }
@@ -466,22 +466,22 @@ struct BusinessDocumentStudioView: View {
                 .help(
                     presentation.isAttachmentHandoffAvailable
                         ? "Validate that this document can become a structured attachment payload"
-                        : "Attachment handoff is unavailable for this document"
+                        : "Attachment payload validation is unavailable for this document"
                 )
 
-                if let workspaceAttachmentStatus {
+                if let attachmentValidationStatus {
                     Label {
-                        Text(verbatim: workspaceAttachmentStatus.message)
+                        Text(verbatim: attachmentValidationStatus.message)
                             .lineLimit(2)
                     } icon: {
                         Image(
-                            systemName: workspaceAttachmentStatus.isFailure
+                            systemName: attachmentValidationStatus.isFailure
                                 ? "xmark.octagon"
                                 : "checkmark.circle"
                         )
                     }
                         .font(.system(size: 12))
-                        .foregroundStyle(workspaceAttachmentStatus.isFailure ? Color.red : Color.secondary)
+                        .foregroundStyle(attachmentValidationStatus.isFailure ? Color.red : Color.secondary)
                 }
             }
         }
@@ -585,16 +585,16 @@ struct BusinessDocumentStudioView: View {
         }
     }
 
-    private func prepareWorkspaceAttachment() {
+    private func validateAttachmentPayload() {
         do {
-            let attachment = try presenter.makeWorkspaceAttachment()
+            let attachment = try presenter.makeAttachmentPayloadForValidation()
             let filename = attachment.filename ?? "structured document"
-            workspaceAttachmentStatus = WorkspaceAttachmentStatus(
+            attachmentValidationStatus = AttachmentValidationStatus(
                 message: "Attachment payload validated for \(filename); no chat or workspace state changed.",
                 isFailure: false
             )
         } catch {
-            workspaceAttachmentStatus = WorkspaceAttachmentStatus(
+            attachmentValidationStatus = AttachmentValidationStatus(
                 message: error.localizedDescription,
                 isFailure: true
             )
@@ -666,7 +666,7 @@ struct BusinessDocumentStudioView: View {
     }
 }
 
-private struct WorkspaceAttachmentStatus: Equatable {
+private struct AttachmentValidationStatus: Equatable {
     let message: String
     let isFailure: Bool
 }

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -13,15 +13,19 @@ import UniformTypeIdentifiers
 struct BusinessDocumentStudioView: View {
     @StateObject private var presenter: BusinessDocumentStudioPresenter
     private let sourceURL: URL?
+    private let claimSourceURL: ((URL) -> Bool)?
     @State private var currentSourceURL: URL?
     @State private var workspaceAttachmentStatus: WorkspaceAttachmentStatus?
 
     init(
         sourceURL: URL? = nil,
-        presenter: BusinessDocumentStudioPresenter = BusinessDocumentStudioPresenter()
+        presenter: BusinessDocumentStudioPresenter = BusinessDocumentStudioPresenter(),
+        claimSourceURL: ((URL) -> Bool)? = nil
     ) {
+        let sourceURL = sourceURL.map(BusinessDocumentStudioSourceIdentity.standardized)
         _presenter = StateObject(wrappedValue: presenter)
         self.sourceURL = sourceURL
+        self.claimSourceURL = claimSourceURL
         _currentSourceURL = State(initialValue: sourceURL)
     }
 
@@ -38,8 +42,18 @@ struct BusinessDocumentStudioView: View {
             await presenter.load(url: currentSourceURL)
         }
         .onChange(of: sourceURL) { _, newValue in
-            currentSourceURL = newValue
             workspaceAttachmentStatus = nil
+            guard let newValue else {
+                currentSourceURL = nil
+                return
+            }
+            guard let acceptedURL = BusinessDocumentStudioSourceIdentity.acceptedSourceURL(
+                newValue,
+                claim: claimSourceURL
+            ) else {
+                return
+            }
+            currentSourceURL = acceptedURL
         }
     }
 
@@ -333,21 +347,23 @@ struct BusinessDocumentStudioView: View {
                 Spacer(minLength: 12)
 
                 Button {
-                    presenter.cancelPendingOverwrite()
+                    presenter.cancelPendingOverwrite(requestID: request.id)
                 } label: {
                     Text(verbatim: "Cancel")
                 }
                 .controlSize(.small)
+                .disabled(presenter.isExportInProgress)
 
                 Button {
                     Task { @MainActor in
-                        await presenter.confirmPendingOverwrite()
+                        await presenter.confirmPendingOverwrite(requestID: request.id)
                     }
                 } label: {
                     Text(verbatim: "Replace")
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
+                .disabled(presenter.isExportInProgress)
             }
             .help(request.destination.path)
 
@@ -512,7 +528,7 @@ struct BusinessDocumentStudioView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .disabled(!option.canExport)
+            .disabled(!option.canExport || presenter.isExportInProgress)
             .help(option.canExport ? "Export \(option.label)" : option.message)
         }
         .padding(10)
@@ -559,7 +575,13 @@ struct BusinessDocumentStudioView: View {
 
         Task { @MainActor in
             guard await panel.beginModal() == .OK, let url = panel.url else { return }
-            currentSourceURL = url.standardizedFileURL
+            guard let acceptedURL = BusinessDocumentStudioSourceIdentity.acceptedSourceURL(
+                url,
+                claim: claimSourceURL
+            ) else {
+                return
+            }
+            currentSourceURL = acceptedURL
         }
     }
 

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -14,6 +14,7 @@ struct BusinessDocumentStudioView: View {
     @StateObject private var presenter: BusinessDocumentStudioPresenter
     private let sourceURL: URL?
     @State private var currentSourceURL: URL?
+    @State private var workspaceAttachmentStatus: WorkspaceAttachmentStatus?
 
     init(
         sourceURL: URL? = nil,
@@ -32,11 +33,13 @@ struct BusinessDocumentStudioView: View {
         }
         .frame(minWidth: 720, minHeight: 520)
         .task(id: currentSourceURL) {
+            workspaceAttachmentStatus = nil
             guard let currentSourceURL else { return }
             await presenter.load(url: currentSourceURL)
         }
         .onChange(of: sourceURL) { _, newValue in
             currentSourceURL = newValue
+            workspaceAttachmentStatus = nil
         }
     }
 
@@ -147,7 +150,7 @@ struct BusinessDocumentStudioView: View {
                         }
                     }
                     StudioSection(title: "Workspace Attachment Handoff") {
-                        infoGrid(presentation.handoffRows)
+                        handoffView(presentation)
                     }
                     if !presenter.artifactStatuses.isEmpty {
                         StudioSection(title: "Artifact Status") {
@@ -426,6 +429,48 @@ struct BusinessDocumentStudioView: View {
         }
     }
 
+    private func handoffView(_ presentation: BusinessDocumentStudioPresentation) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            infoGrid(presentation.handoffRows)
+
+            HStack(alignment: .center, spacing: 10) {
+                Button {
+                    prepareWorkspaceAttachment()
+                } label: {
+                    Label {
+                        Text(verbatim: "Check Attachment")
+                    } icon: {
+                        Image(systemName: "paperclip")
+                    }
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(!presentation.isAttachmentHandoffAvailable)
+                .help(
+                    presentation.isAttachmentHandoffAvailable
+                        ? "Validate that this document can become a structured attachment payload"
+                        : "Attachment handoff is unavailable for this document"
+                )
+
+                if let workspaceAttachmentStatus {
+                    Label {
+                        Text(verbatim: workspaceAttachmentStatus.message)
+                            .lineLimit(2)
+                    } icon: {
+                        Image(
+                            systemName: workspaceAttachmentStatus.isFailure
+                                ? "xmark.octagon"
+                                : "checkmark.circle"
+                        )
+                    }
+                        .font(.system(size: 12))
+                        .foregroundStyle(workspaceAttachmentStatus.isFailure ? Color.red : Color.secondary)
+                }
+            }
+        }
+    }
+
     private func exportOptionRow(
         _ option: BusinessDocumentStudioExportOptionPresentation,
         presentation: BusinessDocumentStudioPresentation
@@ -489,6 +534,7 @@ struct BusinessDocumentStudioView: View {
         if let contentType = UTType(filenameExtension: option.fileExtension) {
             panel.allowedContentTypes = [contentType]
         }
+        panel.allowsOtherFileTypes = false
 
         Task { @MainActor in
             guard await panel.beginModal() == .OK, let url = panel.url else { return }
@@ -514,6 +560,22 @@ struct BusinessDocumentStudioView: View {
         Task { @MainActor in
             guard await panel.beginModal() == .OK, let url = panel.url else { return }
             currentSourceURL = url.standardizedFileURL
+        }
+    }
+
+    private func prepareWorkspaceAttachment() {
+        do {
+            let attachment = try presenter.makeWorkspaceAttachment()
+            let filename = attachment.filename ?? "structured document"
+            workspaceAttachmentStatus = WorkspaceAttachmentStatus(
+                message: "Attachment payload validated for \(filename); no chat or workspace state changed.",
+                isFailure: false
+            )
+        } catch {
+            workspaceAttachmentStatus = WorkspaceAttachmentStatus(
+                message: error.localizedDescription,
+                isFailure: true
+            )
         }
     }
 
@@ -580,6 +642,11 @@ struct BusinessDocumentStudioView: View {
         case .failed: return .red
         }
     }
+}
+
+private struct WorkspaceAttachmentStatus: Equatable {
+    let message: String
+    let isFailure: Bool
 }
 
 private struct StudioSection<Content: View>: View {

--- a/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
+++ b/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
@@ -1,6 +1,6 @@
 # Business Document I/O Workbench
 
-The Business Document Studio is the user-visible workbench for importing,
+The Business Document Workbench is the user-visible surface for importing,
 previewing, extracting, and exporting business documents without routing the
 file through chat.
 
@@ -20,6 +20,25 @@ file through chat.
 
 Unsupported extensions stay in an unsupported import state. Malformed files stay
 in an extraction-failure state with the adapter error surfaced to the user.
+
+## Business Extraction Summary
+
+The workbench now derives a format-neutral business summary from the parsed
+representation:
+
+- Field summaries list CSV columns, workbook header cells, slide text sections,
+  and rich-text blocks with source labels, filled/empty counts, value kinds, and
+  bounded samples.
+- Table summaries list CSV files, worksheets, detected PDF tables, and slide
+  tables with row/column/cell counts and a first sampled row where available.
+- PDF and slide preview sections include sampled table rows, not just table
+  counts, so users can verify extracted structure before exporting.
+- Workspace attachment handoff is surfaced through the existing
+  `Attachment.structuredDocument(_:)` API. The workbench reports whether a text
+  fallback is available and can create an attachment that carries structured
+  document metadata without touching workspace routing code. Empty text
+  fallbacks are reported as unavailable and attachment creation fails with a
+  typed workbench error instead of creating a misleading empty attachment.
 
 ## Export and Artifacts
 

--- a/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
+++ b/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
@@ -1,0 +1,50 @@
+# Business Document I/O Workbench
+
+The Business Document Studio is the user-visible workbench for importing,
+previewing, extracting, and exporting business documents without routing the
+file through chat.
+
+## Import and Preview
+
+- Imports flow through `BusinessDocumentStudioService`, which selects registered
+  document adapters and applies the same high-fidelity parser limits used by the
+  document/file-read stack.
+- CSV and TSV files surface delimited-table previews with inferred columns and
+  sampled rows.
+- XLSX files surface workbook summaries, sheet samples, formula counts, merged
+  ranges, validation findings, and XLSX emitter availability.
+- PDF files surface typed page previews, extracted text, detected tables, and
+  explicit creation availability.
+- PPTX and POTX files surface slide previews, hidden-slide and speaker-note
+  counts, table samples, and explicit creation availability.
+
+Unsupported extensions stay in an unsupported import state. Malformed files stay
+in an extraction-failure state with the adapter error surfaced to the user.
+
+## Export and Artifacts
+
+Export actions are explicit and format-aware:
+
+- CSV and TSV exports use `CSVTableWorkflowService`.
+- XLSX exports use `WorkbookWorkflowService` and require a registered workbook
+  emitter plus validation success.
+- PDF and PPTX creation is reported as unavailable until a structured emitter is
+  registered. The workbench must not fake binary package output through text
+  writes.
+- Text fallback export is allowed only to text-shaped targets and is capped by
+  `BusinessDocumentStudioExportPolicy.maxTextExportUTF8Bytes`.
+
+Existing destinations require overwrite consent before the presenter calls the
+service with `allowOverwrite: true`. The artifact status list records created,
+blocked, failed, and consent-required states so the UI can show whether a file
+was actually written.
+
+## Safety Rules
+
+- Do not write text fallback data to `.xlsx`, `.pdf`, `.pptx`, or related
+  package-shaped extensions.
+- Do not report PDF/PPTX creation as available without a registered structured
+  emitter.
+- Do not inspect destination existence outside the allowed export directory.
+- Keep blocked and failed export states visible as artifact status rows rather
+  than silently dropping them.

--- a/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
+++ b/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
@@ -26,9 +26,10 @@ in an extraction-failure state with the adapter error surfaced to the user.
 The workbench now derives a format-neutral business summary from the parsed
 representation:
 
-- Field summaries list CSV columns, workbook header cells, slide text sections,
-  and rich-text blocks with source labels, filled/empty counts, value kinds, and
-  bounded samples.
+- Field summaries list CSV columns, slide text sections, and rich-text blocks
+  with source labels, filled/empty counts, value kinds, and bounded samples.
+- Workbook extraction surfaces worksheet sample rows through table and preview
+  summaries; it does not infer worksheet headers as fields.
 - Table summaries list CSV files, worksheets, detected PDF tables, and slide
   tables with row/column/cell counts and a first sampled row where available.
 - PDF and slide preview sections include sampled table rows, not just table

--- a/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
+++ b/docs/BUSINESS_DOCUMENT_IO_WORKBENCH.md
@@ -34,12 +34,22 @@ representation:
   tables with row/column/cell counts and a first sampled row where available.
 - PDF and slide preview sections include sampled table rows, not just table
   counts, so users can verify extracted structure before exporting.
-- Workspace attachment handoff is surfaced through the existing
-  `Attachment.structuredDocument(_:)` API. The workbench reports whether a text
-  fallback is available and can create an attachment that carries structured
-  document metadata without touching workspace routing code. Empty text
-  fallbacks are reported as unavailable and attachment creation fails with a
-  typed workbench error instead of creating a misleading empty attachment.
+- Attachment payload validation uses the existing
+  `Attachment.structuredDocument(_:)` API in memory. The workbench reports
+  whether a text fallback is available and validates the structured metadata
+  payload without injecting it into chat or changing workspace state. Empty
+  text fallbacks are reported as unavailable and validation fails with a typed
+  workbench error instead of creating a misleading empty attachment.
+
+### Relationship to chat file changes (#2078)
+
+- A workbench export is an explicit user save to the selected destination. It
+  does not run through chat agent tools, writable combined-mode path routing,
+  or `SandboxWorkspaceChangeTracker`, so it does not appear in the chat
+  Changes sheet and does not claim chat-scoped undo support.
+- Attachment payload validation constructs and checks an attachment in memory.
+  It does not add the attachment to a chat, write into either workspace, or
+  activate #2078's host-folder write mode.
 
 ## Export and Artifacts
 


### PR DESCRIPTION
## Summary

- Expands Business Document Studio into an import, preview, structured-extraction, and export workbench for PDF, document, spreadsheet, presentation, and delimited inputs.
- Surfaces unsupported formats, validation failures, and missing emitters explicitly.
- Keeps attachment handoff on the existing chat attachment API and labels the current handoff as validation-only rather than claiming prompt injection.
- Stages exports in isolated temporary locations, serializes document transitions, propagates cancellation, and uses atomic destination ownership.

## Security and correctness

- Rejects destinations outside the allowed export directory, including existing and dangling symlink escapes.
- Canonicalizes absolute and relative symlink targets, dot components, missing path tails, and the macOS `/var` to `/private/var` alias.
- Prevents a destination created during rendering from being overwritten without consent.
- Preserves structured-package extension ownership and rejects unsafe fallback exports.
- Explicit user document exports remain outside #2078 chat-session Changes/Undo tracking; agent file writes in combined mode remain tracked by #2078.

## Validation

- 43 business-document workflow tests passed before the final containment hardening.
- The complete affected service suite passed 17/17 after the containment fix; the failing baseline was reproduced with 11 issues before repair.
- 64 current-main execution, change-tracker, tool-resolution, and sandbox integration tests passed.
- Scoped strict SwiftLint passed with 0 violations.
- Localization and `git diff --check` passed.
- Unsigned Release app build passed after the current-main rebase and final fix.

## Draft gate

This PR remains draft until the native workflow is proven with screenshots and manual interaction:

- real open and save panels;
- document switching and preview click-through;
- export artifact surfacing in the app;
- unsupported and missing-emitter states;
- attachment handoff into an actual chat.

Path validation is fail-closed, but a writable intermediate parent can still be swapped between path validation and rename. Eliminating that residual TOCTOU requires directory-descriptor-relative filesystem operations rather than additional string/path checks.
