### PR TITLE
Add model library evidence center

### DIFF
--- a/Packages/OsaurusCore/Models/Evidence/EvidenceReportRegistry.swift
+++ b/Packages/OsaurusCore/Models/Evidence/EvidenceReportRegistry.swift
@@ -16,6 +16,8 @@ public enum EvidenceReportKind: String, Codable, CaseIterable, Hashable, Sendabl
     case liveProof = "live_proof"
     case runTrace = "run_trace"
     case provider
+    case modelCompatibility = "model_compatibility"
+    case cache
     case custom
 }
 

--- a/Packages/OsaurusCore/Models/Evidence/EvidenceReportRegistry.swift
+++ b/Packages/OsaurusCore/Models/Evidence/EvidenceReportRegistry.swift
@@ -7,6 +7,7 @@
 //  a projection over existing files; it does not own or move artifacts.
 //
 
+import CryptoKit
 import Foundation
 
 public enum EvidenceReportKind: String, Codable, CaseIterable, Hashable, Sendable {
@@ -65,19 +66,175 @@ public struct EvidenceReportCounts: Codable, Equatable, Hashable, Sendable {
     }
 }
 
+enum EvidenceReportIdentity {
+    static func digest(_ value: String) -> String {
+        digest(Data(value.utf8))
+    }
+
+    static func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func contentDigest(at url: URL, fileManager: FileManager = .default) -> String? {
+        guard
+            let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+            attributes[.type] as? FileAttributeType == .typeRegular,
+            let handle = try? FileHandle(forReadingFrom: url)
+        else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        do {
+            while let data = try handle.read(upToCount: 64 * 1024), !data.isEmpty {
+                hasher.update(data: data)
+            }
+        } catch {
+            return nil
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func normalizedLogicalValue(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .precomposedStringWithCanonicalMapping
+            .replacingOccurrences(of: "\\", with: "/")
+    }
+
+    static func normalizedLocator(_ locator: String) -> String? {
+        let normalized = normalizedLogicalValue(locator)
+        guard
+            !normalized.isEmpty,
+            !normalized.hasPrefix("/"),
+            URL(string: normalized)?.scheme == nil,
+            !looksLikeWindowsAbsolutePath(normalized)
+        else {
+            return nil
+        }
+
+        var components: [String] = []
+        for component in normalized.split(separator: "/", omittingEmptySubsequences: true) {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                return nil
+            default:
+                components.append(String(component))
+            }
+        }
+        guard !components.isEmpty else { return nil }
+        return components.joined(separator: "/")
+    }
+
+    static func opaqueLocator(seed: String, pathExtension: String = "") -> String {
+        let suffix = normalizedPathExtension(pathExtension).map { ".\($0)" } ?? ""
+        return "artifacts/\(digest(seed))\(suffix)"
+    }
+
+    static func containsAbsoluteLocalPath(_ value: String) -> Bool {
+        let normalized = normalizedLogicalValue(value)
+        if normalized.hasPrefix("/") || normalized.lowercased().contains("file://") {
+            return true
+        }
+        if looksLikeWindowsAbsolutePath(normalized) {
+            return true
+        }
+        return normalized.split(whereSeparator: { $0 == "|" || $0 == "," }).contains {
+            let component = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            return component.hasPrefix("/") || looksLikeWindowsAbsolutePath(component)
+        }
+    }
+
+    private static func normalizedPathExtension(_ value: String) -> String? {
+        let normalized = value.lowercased().filter { $0.isASCII && ($0.isLetter || $0.isNumber) }
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func looksLikeWindowsAbsolutePath(_ value: String) -> Bool {
+        guard value.count >= 3 else { return false }
+        let characters = Array(value)
+        return characters[0].isLetter && characters[1] == ":" && characters[2] == "/"
+    }
+}
+
 public struct EvidenceReportArtifact: Codable, Equatable, Hashable, Sendable {
     public var path: String
     public var availability: EvidenceArtifactAvailability
     public var message: String?
+    private var machineLocalPath: String?
 
     public init(
         path: String,
         availability: EvidenceArtifactAvailability,
         message: String? = nil
     ) {
-        self.path = path
+        if let locator = EvidenceReportIdentity.normalizedLocator(path) {
+            self.path = locator
+            machineLocalPath = nil
+        } else {
+            let url: URL?
+            if path.lowercased().hasPrefix("file://") {
+                url = URL(string: path)?.standardizedFileURL
+            } else if EvidenceReportIdentity.containsAbsoluteLocalPath(path) {
+                url = URL(fileURLWithPath: path).standardizedFileURL
+            } else {
+                url = nil
+            }
+            self.path = EvidenceReportIdentity.opaqueLocator(
+                seed: path,
+                pathExtension: url?.pathExtension ?? URL(fileURLWithPath: path).pathExtension
+            )
+            machineLocalPath = url?.path
+        }
         self.availability = availability
         self.message = message
+    }
+
+    public func resolvedURL(relativeTo directoryURL: URL) -> URL? {
+        if let machineLocalPath {
+            return URL(fileURLWithPath: machineLocalPath).standardizedFileURL
+        }
+        guard let locator = EvidenceReportIdentity.normalizedLocator(path) else {
+            return nil
+        }
+        return directoryURL.appendingPathComponent(locator).standardizedFileURL
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case availability
+        case message
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            path: try container.decode(String.self, forKey: .path),
+            availability: try container.decode(EvidenceArtifactAvailability.self, forKey: .availability),
+            message: try container.decodeIfPresent(String.self, forKey: .message)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(path, forKey: .path)
+        try container.encode(availability, forKey: .availability)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+    public static func == (lhs: EvidenceReportArtifact, rhs: EvidenceReportArtifact) -> Bool {
+        lhs.path == rhs.path
+            && lhs.availability == rhs.availability
+            && lhs.message == rhs.message
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(path)
+        hasher.combine(availability)
+        hasher.combine(message)
     }
 }
 
@@ -86,6 +243,7 @@ public struct EvidenceReportDescriptor: Codable, Equatable, Sendable {
     public var kind: EvidenceReportKind
     public var source: String
     public var artifactPath: String
+    public var artifactLocator: String?
     public var status: EvidenceReportStatus
     public var counts: EvidenceReportCounts
     public var startedAt: Date?
@@ -98,6 +256,7 @@ public struct EvidenceReportDescriptor: Codable, Equatable, Sendable {
         kind: EvidenceReportKind,
         source: String,
         artifactPath: String,
+        artifactLocator: String? = nil,
         status: EvidenceReportStatus = .unknown,
         counts: EvidenceReportCounts = EvidenceReportCounts(),
         startedAt: Date? = nil,
@@ -109,6 +268,7 @@ public struct EvidenceReportDescriptor: Codable, Equatable, Sendable {
         self.kind = kind
         self.source = source
         self.artifactPath = artifactPath
+        self.artifactLocator = artifactLocator
         self.status = status
         self.counts = counts
         self.startedAt = startedAt
@@ -122,6 +282,7 @@ public struct EvidenceReportDescriptor: Codable, Equatable, Sendable {
         kind: EvidenceReportKind,
         source: String,
         artifactURL: URL,
+        artifactLocator: String? = nil,
         status: EvidenceReportStatus = .unknown,
         counts: EvidenceReportCounts = EvidenceReportCounts(),
         startedAt: Date? = nil,
@@ -134,6 +295,7 @@ public struct EvidenceReportDescriptor: Codable, Equatable, Sendable {
             kind: kind,
             source: source,
             artifactPath: artifactURL.path,
+            artifactLocator: artifactLocator,
             status: status,
             counts: counts,
             startedAt: startedAt,
@@ -154,6 +316,7 @@ public struct EvidenceReportSummary: Codable, Equatable, Hashable, Sendable {
     public var startedAt: Date?
     public var completedAt: Date?
     public var registeredAt: Date
+    public var generation: UInt64
     public var metadata: [String: String]
 
     public init(
@@ -166,6 +329,7 @@ public struct EvidenceReportSummary: Codable, Equatable, Hashable, Sendable {
         startedAt: Date? = nil,
         completedAt: Date? = nil,
         registeredAt: Date,
+        generation: UInt64 = 0,
         metadata: [String: String] = [:]
     ) {
         self.id = id
@@ -177,7 +341,52 @@ public struct EvidenceReportSummary: Codable, Equatable, Hashable, Sendable {
         self.startedAt = startedAt
         self.completedAt = completedAt
         self.registeredAt = registeredAt
+        self.generation = generation
         self.metadata = metadata
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case source
+        case artifact
+        case status
+        case counts
+        case startedAt
+        case completedAt
+        case registeredAt
+        case generation
+        case metadata
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        kind = try container.decode(EvidenceReportKind.self, forKey: .kind)
+        source = try container.decode(String.self, forKey: .source)
+        artifact = try container.decode(EvidenceReportArtifact.self, forKey: .artifact)
+        status = try container.decode(EvidenceReportStatus.self, forKey: .status)
+        counts = try container.decodeIfPresent(EvidenceReportCounts.self, forKey: .counts) ?? EvidenceReportCounts()
+        startedAt = try container.decodeIfPresent(Date.self, forKey: .startedAt)
+        completedAt = try container.decodeIfPresent(Date.self, forKey: .completedAt)
+        registeredAt = try container.decode(Date.self, forKey: .registeredAt)
+        generation = try container.decodeIfPresent(UInt64.self, forKey: .generation) ?? 0
+        metadata = try container.decodeIfPresent([String: String].self, forKey: .metadata) ?? [:]
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(source, forKey: .source)
+        try container.encode(artifact, forKey: .artifact)
+        try container.encode(status, forKey: .status)
+        try container.encode(counts, forKey: .counts)
+        try container.encodeIfPresent(startedAt, forKey: .startedAt)
+        try container.encodeIfPresent(completedAt, forKey: .completedAt)
+        try container.encode(registeredAt, forKey: .registeredAt)
+        try container.encode(generation, forKey: .generation)
+        try container.encode(metadata, forKey: .metadata)
     }
 
     public func stableJSONData(prettyPrinted: Bool = false) throws -> Data {
@@ -216,8 +425,7 @@ public struct EvidenceReportFilter: Equatable, Sendable {
             return false
         }
         if !artifactAvailability.isEmpty,
-            !artifactAvailability.contains(summary.artifact.availability)
-        {
+            !artifactAvailability.contains(summary.artifact.availability) {
             return false
         }
         return true
@@ -236,7 +444,7 @@ public enum EvidenceReportMetadataRedactor {
     }
 
     public static func redactedValue(forKey key: String, value: String) -> String {
-        if isSensitiveKey(key) || looksSensitive(value) {
+        if isSensitiveKey(key) || looksSensitive(value) || EvidenceReportIdentity.containsAbsoluteLocalPath(value) {
             return redactedValue
         }
         return value
@@ -277,8 +485,7 @@ public enum EvidenceReportMetadataRedactor {
             || lowercased.contains("api_key=")
             || lowercased.contains("apikey=")
             || lowercased.contains("password=")
-            || lowercased.contains("secret=")
-        {
+            || lowercased.contains("secret=") {
             return true
         }
 
@@ -293,10 +500,34 @@ public enum EvidenceReportMetadataRedactor {
 }
 
 public struct EvidenceReportRegistrySnapshot: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 2
+
+    public var schemaVersion: Int
     public var reports: [EvidenceReportSummary]
 
-    public init(reports: [EvidenceReportSummary]) {
+    public init(
+        schemaVersion: Int = EvidenceReportRegistrySnapshot.currentSchemaVersion,
+        reports: [EvidenceReportSummary]
+    ) {
+        self.schemaVersion = schemaVersion
         self.reports = reports
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case reports
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        reports = try container.decodeIfPresent([EvidenceReportSummary].self, forKey: .reports) ?? []
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(reports, forKey: .reports)
     }
 
     public func stableJSONData(prettyPrinted: Bool = false) throws -> Data {

--- a/Packages/OsaurusCore/Models/Evidence/ModelLibraryEvidence.swift
+++ b/Packages/OsaurusCore/Models/Evidence/ModelLibraryEvidence.swift
@@ -1,0 +1,178 @@
+//
+//  ModelLibraryEvidence.swift
+//  osaurus
+//
+//  Read-only model-library projection over the shared evidence registry.
+//
+
+import Foundation
+
+enum ModelEvidenceSupportState: String, Codable, CaseIterable, Hashable, Sendable {
+    case supported
+    case partial
+    case unsupported
+    case unproven
+
+    var reportStatus: EvidenceReportStatus {
+        switch self {
+        case .supported:
+            return .passed
+        case .partial:
+            return .partial
+        case .unsupported:
+            return .failed
+        case .unproven:
+            return .unknown
+        }
+    }
+
+    var counts: EvidenceReportCounts {
+        switch self {
+        case .supported:
+            return EvidenceReportCounts(total: 1, passed: 1)
+        case .partial:
+            return EvidenceReportCounts(total: 1, warnings: 1)
+        case .unsupported:
+            return EvidenceReportCounts(total: 1, failed: 1)
+        case .unproven:
+            return EvidenceReportCounts(total: 1, skipped: 1)
+        }
+    }
+}
+
+enum ModelEvidenceProofKind: String, Codable, CaseIterable, Hashable, Sendable {
+    case cache
+    case benchmark
+    case runtime
+
+    var reportKind: EvidenceReportKind {
+        switch self {
+        case .cache:
+            return .cache
+        case .benchmark:
+            return .benchmark
+        case .runtime:
+            return .runtime
+        }
+    }
+}
+
+enum ModelEvidenceGroupKind: String, Codable, CaseIterable, Hashable, Sendable {
+    case ready
+    case catalog
+    case incomplete
+    case externalCache
+
+    var isVisibleByDefault: Bool {
+        switch self {
+        case .ready, .catalog:
+            return true
+        case .incomplete, .externalCache:
+            return false
+        }
+    }
+}
+
+struct ModelEvidenceProofDescriptor: Equatable, Sendable {
+    var modelId: String
+    var kind: ModelEvidenceProofKind
+    var source: String
+    var artifactPath: String
+    var status: EvidenceReportStatus
+    var counts: EvidenceReportCounts
+    var startedAt: Date?
+    var completedAt: Date?
+    var metadata: [String: String]
+    var artifactError: String?
+
+    init(
+        modelId: String,
+        kind: ModelEvidenceProofKind,
+        source: String? = nil,
+        artifactPath: String,
+        status: EvidenceReportStatus,
+        counts: EvidenceReportCounts = EvidenceReportCounts(total: 1),
+        startedAt: Date? = nil,
+        completedAt: Date? = nil,
+        metadata: [String: String] = [:],
+        artifactError: String? = nil
+    ) {
+        self.modelId = modelId
+        self.kind = kind
+        self.source = source ?? "model-library-\(kind.rawValue)-proof"
+        self.artifactPath = artifactPath
+        self.status = status
+        self.counts = counts
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.metadata = metadata
+        self.artifactError = artifactError
+    }
+}
+
+struct ModelEvidenceFilter: Equatable, Sendable {
+    var includeIncomplete: Bool
+    var includeExternalCacheCandidates: Bool
+    var supportStates: Set<ModelEvidenceSupportState>
+
+    init(
+        includeIncomplete: Bool = false,
+        includeExternalCacheCandidates: Bool = false,
+        supportStates: Set<ModelEvidenceSupportState> = []
+    ) {
+        self.includeIncomplete = includeIncomplete
+        self.includeExternalCacheCandidates = includeExternalCacheCandidates
+        self.supportStates = supportStates
+    }
+
+    func includes(_ row: ModelEvidenceRow) -> Bool {
+        if !supportStates.isEmpty, !supportStates.contains(row.supportState) {
+            return false
+        }
+        switch row.groupKind {
+        case .ready, .catalog:
+            return true
+        case .incomplete:
+            return includeIncomplete
+        case .externalCache:
+            return includeExternalCacheCandidates
+        }
+    }
+}
+
+struct ModelEvidenceRow: Equatable, Identifiable, Sendable {
+    var id: String { modelId }
+
+    var modelId: String
+    var displayName: String
+    var supportState: ModelEvidenceSupportState
+    var groupKind: ModelEvidenceGroupKind
+    var cacheReportID: String
+    var compatibilityReportID: String
+    var proofReportIDs: [String]
+    var redactedBundlePath: String?
+    var metadata: [String: String]
+
+    var isVisibleByDefault: Bool {
+        groupKind.isVisibleByDefault
+    }
+}
+
+struct ModelEvidenceGroup: Equatable, Identifiable, Sendable {
+    var kind: ModelEvidenceGroupKind
+    var count: Int
+    var visibleByDefault: Bool
+
+    var id: ModelEvidenceGroupKind { kind }
+}
+
+struct ModelEvidenceSnapshot: Equatable, Sendable {
+    var rows: [ModelEvidenceRow]
+    var visibleRows: [ModelEvidenceRow]
+    var groups: [ModelEvidenceGroup]
+    var reports: [EvidenceReportSummary]
+
+    func report(id: String) -> EvidenceReportSummary? {
+        reports.first { $0.id == id }
+    }
+}

--- a/Packages/OsaurusCore/Models/Evidence/ModelLibraryEvidence.swift
+++ b/Packages/OsaurusCore/Models/Evidence/ModelLibraryEvidence.swift
@@ -43,6 +43,8 @@ enum ModelEvidenceSupportState: String, Codable, CaseIterable, Hashable, Sendabl
 enum ModelEvidenceProofKind: String, Codable, CaseIterable, Hashable, Sendable {
     case cache
     case benchmark
+    case eval
+    case memory
     case runtime
 
     var reportKind: EvidenceReportKind {
@@ -51,10 +53,42 @@ enum ModelEvidenceProofKind: String, Codable, CaseIterable, Hashable, Sendable {
             return .cache
         case .benchmark:
             return .benchmark
+        case .eval:
+            return .eval
+        case .memory:
+            return .runtime
         case .runtime:
             return .runtime
         }
     }
+}
+
+enum ModelEvidenceRequirementKind: String, Codable, CaseIterable, Hashable, Sendable {
+    case importState = "import_state"
+    case compatibilityPreflight = "compatibility_preflight"
+    case runtimeGeneration = "runtime_generation"
+    case tokenRate = "token_rate"
+    case memoryFootprint = "memory_footprint"
+    case cacheBehavior = "cache_behavior"
+    case benchmarkOrEval = "benchmark_or_eval"
+}
+
+enum ModelEvidenceRequirementState: String, Codable, CaseIterable, Hashable, Sendable {
+    case passed
+    case partial
+    case failed
+    case blocked
+    case missing
+    case unavailable
+}
+
+struct ModelEvidenceRequirementStatus: Equatable, Identifiable, Sendable {
+    var kind: ModelEvidenceRequirementKind
+    var state: ModelEvidenceRequirementState
+    var reportID: String?
+    var detail: String
+
+    var id: ModelEvidenceRequirementKind { kind }
 }
 
 enum ModelEvidenceGroupKind: String, Codable, CaseIterable, Hashable, Sendable {
@@ -150,6 +184,7 @@ struct ModelEvidenceRow: Equatable, Identifiable, Sendable {
     var cacheReportID: String
     var compatibilityReportID: String
     var proofReportIDs: [String]
+    var requirements: [ModelEvidenceRequirementStatus]
     var redactedBundlePath: String?
     var metadata: [String: String]
 

--- a/Packages/OsaurusCore/Models/Evidence/ModelLibraryEvidence.swift
+++ b/Packages/OsaurusCore/Models/Evidence/ModelLibraryEvidence.swift
@@ -131,10 +131,15 @@ struct ModelEvidenceProofDescriptor: Equatable, Sendable {
         metadata: [String: String] = [:],
         artifactError: String? = nil
     ) {
-        self.modelId = modelId
+        self.modelId = EvidenceReportIdentity.normalizedLogicalValue(modelId)
         self.kind = kind
-        self.source = source ?? "model-library-\(kind.rawValue)-proof"
-        self.artifactPath = artifactPath
+        let normalizedSource = source.map(EvidenceReportIdentity.normalizedLogicalValue)
+        if let normalizedSource, !normalizedSource.isEmpty {
+            self.source = normalizedSource
+        } else {
+            self.source = "model-library-\(kind.rawValue)-proof"
+        }
+        self.artifactPath = artifactPath.trimmingCharacters(in: .whitespacesAndNewlines)
         self.status = status
         self.counts = counts
         self.startedAt = startedAt

--- a/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
@@ -130,8 +130,14 @@ public final class EvidenceReportRegistryService {
         case .available:
             return descriptorStatus
         case .unavailable:
+            if descriptorStatus == .failed || descriptorStatus == .error {
+                return descriptorStatus
+            }
             return .unavailable
         case .error:
+            if descriptorStatus == .failed || descriptorStatus == .error {
+                return descriptorStatus
+            }
             return .error
         }
     }

--- a/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
@@ -56,6 +56,12 @@ public final class EvidenceReportRegistryService {
         summariesByID.removeAll()
     }
 
+    public func remove(ids: Set<String>) {
+        for id in ids {
+            summariesByID.removeValue(forKey: id)
+        }
+    }
+
     private func makeSummary(
         from descriptor: EvidenceReportDescriptor,
         relativeTo baseURL: URL?
@@ -155,26 +161,10 @@ public final class EvidenceReportRegistryService {
         _ existing: EvidenceReportSummary,
         _ incoming: EvidenceReportSummary
     ) -> EvidenceReportSummary {
-        let existingRank = availabilityRank(existing.artifact.availability)
-        let incomingRank = availabilityRank(incoming.artifact.availability)
-        if incomingRank != existingRank {
-            return incomingRank > existingRank ? incoming : existing
-        }
         if incoming.registeredAt != existing.registeredAt {
             return incoming.registeredAt > existing.registeredAt ? incoming : existing
         }
-        return Self.sortSummaries(existing, incoming) ? existing : incoming
-    }
-
-    private func availabilityRank(_ availability: EvidenceArtifactAvailability) -> Int {
-        switch availability {
-        case .available:
-            return 3
-        case .error:
-            return 2
-        case .unavailable:
-            return 1
-        }
+        return incoming
     }
 
     private static func sortSummaries(

--- a/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
@@ -296,27 +296,31 @@ public final class EvidenceReportRegistryService: @unchecked Sendable {
     ) -> EvidenceReportCounts {
         guard descriptorStatus != resolvedStatus else { return counts }
 
-        var resolved = counts
-        resolved.passed = 0
+        let normalizedTotal = max(
+            1,
+            max(
+                counts.total,
+                counts.passed + counts.failed + counts.errored + counts.skipped
+                    + counts.blocked + counts.warnings
+            )
+        )
+        var resolved = EvidenceReportCounts(total: normalizedTotal)
         switch resolvedStatus {
         case .failed:
-            resolved.failed = max(1, resolved.failed)
+            resolved.failed = normalizedTotal
         case .error:
-            resolved.errored = max(1, resolved.errored)
+            resolved.errored = normalizedTotal
         case .blocked:
-            resolved.blocked = max(1, resolved.blocked)
+            resolved.blocked = normalizedTotal
         case .unavailable:
-            resolved.skipped = max(1, resolved.skipped)
+            resolved.skipped = normalizedTotal
         case .partial:
-            resolved.warnings = max(1, resolved.warnings)
-        case .passed, .unknown:
-            break
+            resolved.warnings = normalizedTotal
+        case .passed:
+            resolved.passed = normalizedTotal
+        case .unknown:
+            resolved.total = 0
         }
-        resolved.total = max(
-            resolved.total,
-            resolved.passed + resolved.failed + resolved.errored + resolved.skipped
-                + resolved.blocked + resolved.warnings
-        )
         return resolved
     }
 

--- a/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
@@ -7,10 +7,19 @@
 
 import Foundation
 
-public final class EvidenceReportRegistryService {
-    private var summariesByID: [String: EvidenceReportSummary] = [:]
+public final class EvidenceReportRegistryService: @unchecked Sendable {
+    private struct StoredReport {
+        let summary: EvidenceReportSummary
+        let localArtifactURL: URL
+    }
+
+    private static let unscopedProducer = "\u{0}unscoped"
+
+    private var reportsByProducer: [String: [String: StoredReport]] = [:]
+    private var nextGeneration: UInt64 = 0
     private let fileManager: FileManager
     private let now: () -> Date
+    private let lock = NSLock()
 
     public init(
         fileManager: FileManager = .default,
@@ -25,7 +34,25 @@ public final class EvidenceReportRegistryService {
         _ descriptors: [EvidenceReportDescriptor],
         relativeTo baseURL: URL? = nil
     ) -> [EvidenceReportSummary] {
-        descriptors.map { register($0, relativeTo: baseURL) }
+        withLock {
+            guard !descriptors.isEmpty else { return [] }
+            let generation = advanceGenerationLocked()
+            let registeredAt = now()
+            var reports = reportsByProducer[Self.unscopedProducer] ?? [:]
+            let stored = descriptors.map {
+                makeStoredReport(
+                    from: $0,
+                    relativeTo: baseURL,
+                    generation: generation,
+                    registeredAt: registeredAt
+                )
+            }
+            for report in stored {
+                reports[report.summary.id] = report
+            }
+            reportsByProducer[Self.unscopedProducer] = reports
+            return stored.map(\.summary)
+        }
     }
 
     @discardableResult
@@ -33,99 +60,209 @@ public final class EvidenceReportRegistryService {
         _ descriptor: EvidenceReportDescriptor,
         relativeTo baseURL: URL? = nil
     ) -> EvidenceReportSummary {
-        let summary = makeSummary(from: descriptor, relativeTo: baseURL)
-        if let existing = summariesByID[summary.id] {
-            summariesByID[summary.id] = preferredSummary(existing, summary)
-        } else {
-            summariesByID[summary.id] = summary
+        register([descriptor], relativeTo: baseURL)[0]
+    }
+
+    @discardableResult
+    public func reconcile(
+        producer: String,
+        descriptors: [EvidenceReportDescriptor],
+        relativeTo baseURL: URL? = nil
+    ) -> [EvidenceReportSummary] {
+        let producer = normalizedProducer(producer)
+        precondition(!producer.isEmpty, "Evidence report producer must not be empty.")
+
+        return withLock {
+            let generation = advanceGenerationLocked()
+            let registeredAt = now()
+            var replacement: [String: StoredReport] = [:]
+            for descriptor in descriptors {
+                let report = makeStoredReport(
+                    from: descriptor,
+                    relativeTo: baseURL,
+                    generation: generation,
+                    registeredAt: registeredAt
+                )
+                replacement[report.summary.id] = report
+            }
+            reportsByProducer[producer] = replacement
+            return replacement.values.map(\.summary).sorted(by: Self.sortSummaries)
         }
-        return summariesByID[summary.id] ?? summary
     }
 
     public func list(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> [EvidenceReportSummary] {
-        summariesByID.values
-            .filter { filter.includes($0) }
-            .sorted(by: Self.sortSummaries)
+        withLock {
+            projectedReportsLocked().values
+                .map(\.summary)
+                .filter { filter.includes($0) }
+                .sorted(by: Self.sortSummaries)
+        }
+    }
+
+    public func list(
+        producer: String,
+        filter: EvidenceReportFilter = EvidenceReportFilter()
+    ) -> [EvidenceReportSummary] {
+        let producer = normalizedProducer(producer)
+        return withLock {
+            (reportsByProducer[producer] ?? [:]).values
+                .map(\.summary)
+                .filter { filter.includes($0) }
+                .sorted(by: Self.sortSummaries)
+        }
     }
 
     public func snapshot(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> EvidenceReportRegistrySnapshot {
         EvidenceReportRegistrySnapshot(reports: list(filter))
     }
 
+    public func snapshot(
+        producer: String,
+        filter: EvidenceReportFilter = EvidenceReportFilter()
+    ) -> EvidenceReportRegistrySnapshot {
+        EvidenceReportRegistrySnapshot(reports: list(producer: producer, filter: filter))
+    }
+
+    public func localArtifactURL(
+        forReportID reportID: String,
+        producer: String? = nil
+    ) -> URL? {
+        withLock {
+            if let producer {
+                return reportsByProducer[normalizedProducer(producer)]?[reportID]?.localArtifactURL
+            }
+            return projectedReportsLocked()[reportID]?.localArtifactURL
+        }
+    }
+
     public func removeAll() {
-        summariesByID.removeAll()
+        withLock {
+            reportsByProducer.removeAll()
+        }
     }
 
     public func remove(ids: Set<String>) {
-        for id in ids {
-            summariesByID.removeValue(forKey: id)
+        withLock {
+            for producer in Array(reportsByProducer.keys) {
+                for id in ids {
+                    reportsByProducer[producer]?.removeValue(forKey: id)
+                }
+            }
+            reportsByProducer = reportsByProducer.filter { !$0.value.isEmpty }
         }
     }
 
-    private func makeSummary(
+    private func makeStoredReport(
         from descriptor: EvidenceReportDescriptor,
-        relativeTo baseURL: URL?
-    ) -> EvidenceReportSummary {
-        let artifactPath = normalizedArtifactPath(descriptor.artifactPath, relativeTo: baseURL)
+        relativeTo baseURL: URL?,
+        generation: UInt64,
+        registeredAt: Date
+    ) -> StoredReport {
+        let localArtifactURL = normalizedArtifactURL(descriptor.artifactPath, relativeTo: baseURL)
+        let identity = artifactIdentity(
+            descriptor: descriptor,
+            localArtifactURL: localArtifactURL
+        )
+        let id = reportID(for: descriptor, artifactIdentity: identity)
+        let locator = EvidenceReportIdentity.normalizedLocator(descriptor.artifactLocator ?? "")
+            ?? EvidenceReportIdentity.opaqueLocator(
+                seed: "\(id)|\(identity)",
+                pathExtension: localArtifactURL.pathExtension
+            )
         let artifact = artifactReference(
-            path: artifactPath,
+            locator: locator,
+            localArtifactURL: localArtifactURL,
             descriptorError: descriptor.artifactError
         )
-        let status = status(for: descriptor.status, artifact: artifact)
-        let id =
-            descriptor.id
-            ?? stableID(
+        let resolvedStatus = status(for: descriptor.status, artifact: artifact)
+
+        return StoredReport(
+            summary: EvidenceReportSummary(
+                id: id,
                 kind: descriptor.kind,
                 source: descriptor.source,
-                artifactPath: artifactPath
-            )
-
-        return EvidenceReportSummary(
-            id: id,
-            kind: descriptor.kind,
-            source: descriptor.source,
-            artifact: artifact,
-            status: status,
-            counts: descriptor.counts,
-            startedAt: descriptor.startedAt,
-            completedAt: descriptor.completedAt,
-            registeredAt: now(),
-            metadata: EvidenceReportMetadataRedactor.redact(descriptor.metadata)
+                artifact: artifact,
+                status: resolvedStatus,
+                counts: normalizedCounts(
+                    descriptor.counts,
+                    descriptorStatus: descriptor.status,
+                    resolvedStatus: resolvedStatus
+                ),
+                startedAt: descriptor.startedAt,
+                completedAt: descriptor.completedAt,
+                registeredAt: registeredAt,
+                generation: generation,
+                metadata: EvidenceReportMetadataRedactor.redact(descriptor.metadata)
+            ),
+            localArtifactURL: localArtifactURL
         )
     }
 
-    private func normalizedArtifactPath(_ path: String, relativeTo baseURL: URL?) -> String {
-        guard let baseURL, !path.hasPrefix("/") else {
-            return URL(fileURLWithPath: path).standardizedFileURL.path
+    private func normalizedArtifactURL(_ path: String, relativeTo baseURL: URL?) -> URL {
+        let path = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if path.lowercased().hasPrefix("file://"), let url = URL(string: path), url.isFileURL {
+            return url.standardizedFileURL
         }
-        return
-            baseURL
-            .appendingPathComponent(path)
-            .standardizedFileURL
-            .path
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path).standardizedFileURL
+        }
+        if let baseURL {
+            return baseURL.appendingPathComponent(path).standardizedFileURL
+        }
+        return URL(fileURLWithPath: path).standardizedFileURL
+    }
+
+    private func artifactIdentity(
+        descriptor: EvidenceReportDescriptor,
+        localArtifactURL: URL
+    ) -> String {
+        if let digest = EvidenceReportIdentity.contentDigest(at: localArtifactURL, fileManager: fileManager) {
+            return "sha256:\(digest)"
+        }
+        if let locator = EvidenceReportIdentity.normalizedLocator(descriptor.artifactLocator ?? "") {
+            return "locator:\(locator)"
+        }
+        let fileName = EvidenceReportIdentity.normalizedLogicalValue(localArtifactURL.lastPathComponent)
+        return "name:\(fileName)"
+    }
+
+    private func reportID(
+        for descriptor: EvidenceReportDescriptor,
+        artifactIdentity: String
+    ) -> String {
+        if let requestedID = descriptor.id.map(EvidenceReportIdentity.normalizedLogicalValue),
+            !requestedID.isEmpty,
+            !EvidenceReportIdentity.containsAbsoluteLocalPath(requestedID) {
+            return requestedID
+        }
+        let seed = [descriptor.kind.rawValue, descriptor.source, artifactIdentity]
+            .map(EvidenceReportIdentity.normalizedLogicalValue)
+            .joined(separator: "|")
+        return "evidence-report:\(EvidenceReportIdentity.digest(seed))"
     }
 
     private func artifactReference(
-        path: String,
+        locator: String,
+        localArtifactURL: URL,
         descriptorError: String?
     ) -> EvidenceReportArtifact {
         if let descriptorError, !descriptorError.isEmpty {
             return EvidenceReportArtifact(
-                path: path,
+                path: locator,
                 availability: .error,
                 message: descriptorError
             )
         }
 
-        guard fileManager.fileExists(atPath: path) else {
+        guard fileManager.fileExists(atPath: localArtifactURL.path) else {
             return EvidenceReportArtifact(
-                path: path,
+                path: locator,
                 availability: .unavailable,
                 message: "Artifact is not present at the registered path."
             )
         }
 
-        return EvidenceReportArtifact(path: path, availability: .available)
+        return EvidenceReportArtifact(path: locator, availability: .available)
     }
 
     private func status(
@@ -136,35 +273,84 @@ public final class EvidenceReportRegistryService {
         case .available:
             return descriptorStatus
         case .unavailable:
-            if descriptorStatus == .failed || descriptorStatus == .error {
+            switch descriptorStatus {
+            case .failed, .error, .blocked, .partial:
                 return descriptorStatus
+            case .passed, .unavailable, .unknown:
+                return .unavailable
             }
-            return .unavailable
         case .error:
-            if descriptorStatus == .failed || descriptorStatus == .error {
+            switch descriptorStatus {
+            case .failed, .error, .blocked, .partial:
                 return descriptorStatus
+            case .passed, .unavailable, .unknown:
+                return .error
             }
-            return .error
         }
     }
 
-    private func stableID(
-        kind: EvidenceReportKind,
-        source: String,
-        artifactPath: String
-    ) -> String {
-        [kind.rawValue, source, artifactPath]
-            .joined(separator: "|")
+    private func normalizedCounts(
+        _ counts: EvidenceReportCounts,
+        descriptorStatus: EvidenceReportStatus,
+        resolvedStatus: EvidenceReportStatus
+    ) -> EvidenceReportCounts {
+        guard descriptorStatus != resolvedStatus else { return counts }
+
+        var resolved = counts
+        resolved.passed = 0
+        switch resolvedStatus {
+        case .failed:
+            resolved.failed = max(1, resolved.failed)
+        case .error:
+            resolved.errored = max(1, resolved.errored)
+        case .blocked:
+            resolved.blocked = max(1, resolved.blocked)
+        case .unavailable:
+            resolved.skipped = max(1, resolved.skipped)
+        case .partial:
+            resolved.warnings = max(1, resolved.warnings)
+        case .passed, .unknown:
+            break
+        }
+        resolved.total = max(
+            resolved.total,
+            resolved.passed + resolved.failed + resolved.errored + resolved.skipped
+                + resolved.blocked + resolved.warnings
+        )
+        return resolved
     }
 
-    private func preferredSummary(
-        _ existing: EvidenceReportSummary,
-        _ incoming: EvidenceReportSummary
-    ) -> EvidenceReportSummary {
-        if incoming.registeredAt != existing.registeredAt {
-            return incoming.registeredAt > existing.registeredAt ? incoming : existing
+    private func projectedReportsLocked() -> [String: StoredReport] {
+        var projected: [String: (producer: String, report: StoredReport)] = [:]
+        for (producer, reports) in reportsByProducer {
+            for (id, report) in reports {
+                guard let existing = projected[id] else {
+                    projected[id] = (producer, report)
+                    continue
+                }
+                if report.summary.generation > existing.report.summary.generation
+                    || (report.summary.generation == existing.report.summary.generation
+                        && producer > existing.producer) {
+                    projected[id] = (producer, report)
+                }
+            }
         }
-        return incoming
+        return projected.mapValues(\.report)
+    }
+
+    private func advanceGenerationLocked() -> UInt64 {
+        nextGeneration &+= 1
+        return nextGeneration
+    }
+
+    private func normalizedProducer(_ producer: String) -> String {
+        EvidenceReportIdentity.normalizedLogicalValue(producer)
+    }
+
+    private func withLock<T>(_ operation: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try operation()
     }
 
     private static func sortSummaries(

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -297,14 +297,14 @@ final class ModelLibraryEvidenceService {
         if preflightState == .unsupported {
             return .unsupported
         }
+        if proofAssessments.contains(where: { $0.status == .failed || $0.status == .error }) {
+            return .unsupported
+        }
         if preflightState == .partial {
             return .partial
         }
         if report.localBundle.kind != .available {
             return .unproven
-        }
-        if proofAssessments.contains(where: { $0.status == .failed || $0.status == .error }) {
-            return .unsupported
         }
 
         let runtimeProof = proofAssessments.contains {

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -1,0 +1,340 @@
+//
+//  ModelLibraryEvidenceService.swift
+//  osaurus
+//
+//  Aggregates model-library cache, compatibility, and proof artifacts into the
+//  shared evidence registry.
+//
+
+import Foundation
+
+final class ModelLibraryEvidenceService {
+    private let registry: EvidenceReportRegistryService
+
+    init(registry: EvidenceReportRegistryService = EvidenceReportRegistryService()) {
+        self.registry = registry
+    }
+
+    @discardableResult
+    func registerEvidence(
+        for models: [MLXModel],
+        proofDescriptors: [ModelEvidenceProofDescriptor] = [],
+        filter: ModelEvidenceFilter = ModelEvidenceFilter()
+    ) -> ModelEvidenceSnapshot {
+        let proofDescriptorsByModel = Dictionary(grouping: proofDescriptors, by: { $0.modelId })
+        var rows: [ModelEvidenceRow] = []
+
+        for model in models {
+            let report = Self.compatibilityReport(for: model)
+            let supportState = Self.supportState(from: report.preflight.status)
+            let groupKind = Self.groupKind(from: report)
+            let modelProofDescriptors = proofDescriptorsByModel[model.id] ?? []
+
+            let descriptors =
+                Self.registryDescriptors(
+                    for: model,
+                    report: report,
+                    supportState: supportState,
+                    proofDescriptors: modelProofDescriptors
+                )
+            let summaries = registry.register(descriptors)
+            let proofIDPrefix = "model-library-"
+            let proofIDs = summaries
+                .filter { $0.id.hasPrefix(proofIDPrefix) && $0.id.contains("-proof|") }
+                .map(\.id)
+                .sorted()
+
+            rows.append(
+                ModelEvidenceRow(
+                    modelId: model.id,
+                    displayName: model.name,
+                    supportState: supportState,
+                    groupKind: groupKind,
+                    cacheReportID: Self.localCacheID(for: model.id),
+                    compatibilityReportID: Self.compatibilityID(for: model.id),
+                    proofReportIDs: proofIDs,
+                    redactedBundlePath: Self.redactedPath(report.localBundle.path),
+                    metadata: Self.rowMetadata(for: model, report: report, supportState: supportState)
+                )
+            )
+        }
+
+        let sortedRows = rows.sorted(by: Self.sortRows)
+        return ModelEvidenceSnapshot(
+            rows: sortedRows,
+            visibleRows: sortedRows.filter(filter.includes),
+            groups: Self.groups(from: sortedRows),
+            reports: registry.list()
+        )
+    }
+
+    func snapshot(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> EvidenceReportRegistrySnapshot {
+        registry.snapshot(filter)
+    }
+
+    private static func compatibilityReport(for model: MLXModel) -> ModelCompatibilityDiagnostics.Report {
+        ModelCompatibilityDiagnostics.report(
+            modelId: model.id,
+            modelName: model.name,
+            modelTypeHint: model.modelType,
+            bundleURL: candidateBundleURL(for: model),
+            externalSource: model.externalSource
+        )
+    }
+
+    private static func candidateBundleURL(for model: MLXModel) -> URL? {
+        if model.isDownloaded {
+            return model.localDirectory
+        }
+        if model.bundleDirectory != nil {
+            return model.localDirectory
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: model.localDirectory.path, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            return nil
+        }
+        return model.localDirectory
+    }
+
+    private static func registryDescriptors(
+        for model: MLXModel,
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState,
+        proofDescriptors: [ModelEvidenceProofDescriptor]
+    ) -> [EvidenceReportDescriptor] {
+        var descriptors = [
+            localCacheDescriptor(for: model, report: report, supportState: supportState),
+            compatibilityDescriptor(for: model, report: report, supportState: supportState),
+        ]
+        descriptors.append(contentsOf: proofDescriptors.map { proofDescriptor($0, model: model) })
+        return descriptors
+    }
+
+    private static func localCacheDescriptor(
+        for model: MLXModel,
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState
+    ) -> EvidenceReportDescriptor {
+        EvidenceReportDescriptor(
+            id: localCacheID(for: model.id),
+            kind: .cache,
+            source: "model-library-cache",
+            artifactPath: report.localBundle.path ?? model.localDirectory.path,
+            status: cacheStatus(from: report.localBundle.kind),
+            counts: cacheCounts(from: report.localBundle.kind),
+            metadata: descriptorMetadata(
+                for: model,
+                report: report,
+                supportState: supportState,
+                extra: [
+                    "evidence_role": "local_cache_import",
+                    "bundle_status": report.localBundle.kind.rawValue,
+                ]
+            )
+        )
+    }
+
+    private static func compatibilityDescriptor(
+        for model: MLXModel,
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState
+    ) -> EvidenceReportDescriptor {
+        EvidenceReportDescriptor(
+            id: compatibilityID(for: model.id),
+            kind: .modelCompatibility,
+            source: "model-library-preflight",
+            artifactPath: compatibilityArtifactPath(for: model, report: report),
+            status: supportState.reportStatus,
+            counts: supportState.counts,
+            metadata: descriptorMetadata(
+                for: model,
+                report: report,
+                supportState: supportState,
+                extra: [
+                    "evidence_role": "compatibility_preflight",
+                    "preflight_reason": report.preflight.reason.rawValue,
+                    "runtime_status": report.runtime.kind.rawValue,
+                ]
+            )
+        )
+    }
+
+    private static func proofDescriptor(
+        _ proof: ModelEvidenceProofDescriptor,
+        model: MLXModel
+    ) -> EvidenceReportDescriptor {
+        var metadata = proof.metadata
+        metadata["model_id"] = model.id
+        metadata["model_name"] = model.name
+        metadata["evidence_role"] = "\(proof.kind.rawValue)_proof"
+        return EvidenceReportDescriptor(
+            id: proofID(modelId: model.id, kind: proof.kind, artifactPath: proof.artifactPath),
+            kind: proof.kind.reportKind,
+            source: proof.source,
+            artifactPath: proof.artifactPath,
+            status: proof.status,
+            counts: proof.counts,
+            startedAt: proof.startedAt,
+            completedAt: proof.completedAt,
+            metadata: metadata,
+            artifactError: proof.artifactError
+        )
+    }
+
+    private static func descriptorMetadata(
+        for model: MLXModel,
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState,
+        extra: [String: String]
+    ) -> [String: String] {
+        var metadata: [String: String] = [
+            "model_id": model.id,
+            "model_name": model.name,
+            "support_state": supportState.rawValue,
+            "source_kind": report.source.kind.rawValue,
+            "bundle_path": "<redacted>",
+        ]
+        if let externalSource = model.externalSource {
+            metadata["external_source"] = externalSource
+        }
+        if let redacted = redactedPath(report.localBundle.path) {
+            metadata["bundle_path_display"] = redacted
+        }
+        for (key, value) in extra {
+            metadata[key] = value
+        }
+        return metadata
+    }
+
+    private static func rowMetadata(
+        for model: MLXModel,
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState
+    ) -> [String: String] {
+        descriptorMetadata(
+            for: model,
+            report: report,
+            supportState: supportState,
+            extra: [
+                "group": groupKind(from: report).rawValue,
+                "preflight_title": report.preflight.title,
+            ]
+        )
+    }
+
+    private static func compatibilityArtifactPath(
+        for model: MLXModel,
+        report: ModelCompatibilityDiagnostics.Report
+    ) -> String {
+        guard let bundlePath = report.localBundle.path else {
+            return model.localDirectory.appendingPathComponent("config.json").path
+        }
+        let configPath = URL(fileURLWithPath: bundlePath)
+            .appendingPathComponent("config.json")
+            .path
+        if FileManager.default.fileExists(atPath: configPath) {
+            return configPath
+        }
+        return bundlePath
+    }
+
+    private static func supportState(
+        from status: ModelCompatibilityDiagnostics.PreflightStatus.Status
+    ) -> ModelEvidenceSupportState {
+        switch status {
+        case .supported:
+            return .supported
+        case .partial:
+            return .partial
+        case .unsupported:
+            return .unsupported
+        case .unproven:
+            return .unproven
+        }
+    }
+
+    private static func groupKind(
+        from report: ModelCompatibilityDiagnostics.Report
+    ) -> ModelEvidenceGroupKind {
+        switch report.localBundle.kind {
+        case .incomplete:
+            return .incomplete
+        case .notDownloaded:
+            return .catalog
+        case .available:
+            return report.source.kind == .external ? .externalCache : .ready
+        }
+    }
+
+    private static func cacheStatus(
+        from kind: ModelCompatibilityDiagnostics.LocalBundleStatus.Kind
+    ) -> EvidenceReportStatus {
+        switch kind {
+        case .available:
+            return .passed
+        case .incomplete:
+            return .partial
+        case .notDownloaded:
+            return .unavailable
+        }
+    }
+
+    private static func cacheCounts(
+        from kind: ModelCompatibilityDiagnostics.LocalBundleStatus.Kind
+    ) -> EvidenceReportCounts {
+        switch kind {
+        case .available:
+            return EvidenceReportCounts(total: 1, passed: 1)
+        case .incomplete:
+            return EvidenceReportCounts(total: 1, warnings: 1)
+        case .notDownloaded:
+            return EvidenceReportCounts(total: 1, skipped: 1)
+        }
+    }
+
+    private static func groups(from rows: [ModelEvidenceRow]) -> [ModelEvidenceGroup] {
+        let grouped = Dictionary(grouping: rows, by: \.groupKind)
+        return ModelEvidenceGroupKind.allCases.compactMap { kind in
+            guard let rows = grouped[kind], !rows.isEmpty else { return nil }
+            return ModelEvidenceGroup(
+                kind: kind,
+                count: rows.count,
+                visibleByDefault: kind.isVisibleByDefault
+            )
+        }
+    }
+
+    private static func sortRows(_ lhs: ModelEvidenceRow, _ rhs: ModelEvidenceRow) -> Bool {
+        if lhs.groupKind.rawValue != rhs.groupKind.rawValue {
+            return lhs.groupKind.rawValue < rhs.groupKind.rawValue
+        }
+        return lhs.modelId.localizedStandardCompare(rhs.modelId) == .orderedAscending
+    }
+
+    private static func localCacheID(for modelId: String) -> String {
+        "model-library-cache|\(modelId)"
+    }
+
+    private static func compatibilityID(for modelId: String) -> String {
+        "model-library-preflight|\(modelId)"
+    }
+
+    private static func proofID(
+        modelId: String,
+        kind: ModelEvidenceProofKind,
+        artifactPath: String
+    ) -> String {
+        "model-library-\(kind.rawValue)-proof|\(modelId)|\(artifactPath)"
+    }
+
+    private static func redactedPath(_ path: String?) -> String? {
+        guard let path, !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        let last = URL(fileURLWithPath: path).lastPathComponent
+        guard !last.isEmpty else { return "<redacted>" }
+        return ".../\(last)"
+    }
+}

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -26,16 +26,23 @@ final class ModelLibraryEvidenceService {
 
         for model in models {
             let report = Self.compatibilityReport(for: model)
-            let supportState = Self.supportState(from: report.preflight.status)
+            let preflightState = Self.supportState(from: report.preflight.status)
             let groupKind = Self.groupKind(from: report)
             let modelProofDescriptors = proofDescriptorsByModel[model.id] ?? []
+            let proofAssessments = Self.proofAssessments(for: model, descriptors: modelProofDescriptors)
+            let supportState = Self.supportState(
+                preflightState: preflightState,
+                report: report,
+                proofAssessments: proofAssessments
+            )
 
             let descriptors =
                 Self.registryDescriptors(
                     for: model,
                     report: report,
                     supportState: supportState,
-                    proofDescriptors: modelProofDescriptors
+                    preflightState: preflightState,
+                    proofAssessments: proofAssessments
                 )
             let summaries = registry.register(descriptors)
             let proofIDPrefix = "model-library-"
@@ -53,8 +60,18 @@ final class ModelLibraryEvidenceService {
                     cacheReportID: Self.localCacheID(for: model.id),
                     compatibilityReportID: Self.compatibilityID(for: model.id),
                     proofReportIDs: proofIDs,
+                    requirements: Self.requirementStatuses(
+                        report: report,
+                        supportState: supportState,
+                        proofAssessments: proofAssessments
+                    ),
                     redactedBundlePath: Self.redactedPath(report.localBundle.path),
-                    metadata: Self.rowMetadata(for: model, report: report, supportState: supportState)
+                    metadata: Self.rowMetadata(
+                        for: model,
+                        report: report,
+                        supportState: supportState,
+                        preflightState: preflightState
+                    )
                 )
             )
         }
@@ -102,13 +119,19 @@ final class ModelLibraryEvidenceService {
         for model: MLXModel,
         report: ModelCompatibilityDiagnostics.Report,
         supportState: ModelEvidenceSupportState,
-        proofDescriptors: [ModelEvidenceProofDescriptor]
+        preflightState: ModelEvidenceSupportState,
+        proofAssessments: [ProofAssessment]
     ) -> [EvidenceReportDescriptor] {
         var descriptors = [
             localCacheDescriptor(for: model, report: report, supportState: supportState),
-            compatibilityDescriptor(for: model, report: report, supportState: supportState),
+            compatibilityDescriptor(
+                for: model,
+                report: report,
+                supportState: supportState,
+                preflightState: preflightState
+            ),
         ]
-        descriptors.append(contentsOf: proofDescriptors.map { proofDescriptor($0, model: model) })
+        descriptors.append(contentsOf: proofAssessments.map { proofDescriptor($0, model: model) })
         return descriptors
     }
 
@@ -139,21 +162,23 @@ final class ModelLibraryEvidenceService {
     private static func compatibilityDescriptor(
         for model: MLXModel,
         report: ModelCompatibilityDiagnostics.Report,
-        supportState: ModelEvidenceSupportState
+        supportState: ModelEvidenceSupportState,
+        preflightState: ModelEvidenceSupportState
     ) -> EvidenceReportDescriptor {
         EvidenceReportDescriptor(
             id: compatibilityID(for: model.id),
             kind: .modelCompatibility,
             source: "model-library-preflight",
             artifactPath: compatibilityArtifactPath(for: model, report: report),
-            status: supportState.reportStatus,
-            counts: supportState.counts,
+            status: preflightState.reportStatus,
+            counts: preflightState.counts,
             metadata: descriptorMetadata(
                 for: model,
                 report: report,
                 supportState: supportState,
                 extra: [
                     "evidence_role": "compatibility_preflight",
+                    "preflight_state": preflightState.rawValue,
                     "preflight_reason": report.preflight.reason.rawValue,
                     "runtime_status": report.runtime.kind.rawValue,
                 ]
@@ -162,19 +187,26 @@ final class ModelLibraryEvidenceService {
     }
 
     private static func proofDescriptor(
-        _ proof: ModelEvidenceProofDescriptor,
+        _ assessment: ProofAssessment,
         model: MLXModel
     ) -> EvidenceReportDescriptor {
+        let proof = assessment.descriptor
         var metadata = proof.metadata
         metadata["model_id"] = model.id
         metadata["model_name"] = model.name
         metadata["evidence_role"] = "\(proof.kind.rawValue)_proof"
+        if let tokensPerSecond = assessment.tokensPerSecond {
+            metadata["tokens_per_second"] = String(tokensPerSecond)
+        }
+        if !assessment.validationMessages.isEmpty {
+            metadata["evidence_validation"] = assessment.validationMessages.joined(separator: "; ")
+        }
         return EvidenceReportDescriptor(
-            id: proofID(modelId: model.id, kind: proof.kind, artifactPath: proof.artifactPath),
+            id: assessment.reportID,
             kind: proof.kind.reportKind,
             source: proof.source,
             artifactPath: proof.artifactPath,
-            status: proof.status,
+            status: assessment.status,
             counts: proof.counts,
             startedAt: proof.startedAt,
             completedAt: proof.completedAt,
@@ -211,7 +243,8 @@ final class ModelLibraryEvidenceService {
     private static func rowMetadata(
         for model: MLXModel,
         report: ModelCompatibilityDiagnostics.Report,
-        supportState: ModelEvidenceSupportState
+        supportState: ModelEvidenceSupportState,
+        preflightState: ModelEvidenceSupportState
     ) -> [String: String] {
         descriptorMetadata(
             for: model,
@@ -219,6 +252,7 @@ final class ModelLibraryEvidenceService {
             supportState: supportState,
             extra: [
                 "group": groupKind(from: report).rawValue,
+                "preflight_state": preflightState.rawValue,
                 "preflight_title": report.preflight.title,
             ]
         )
@@ -253,6 +287,46 @@ final class ModelLibraryEvidenceService {
         case .unproven:
             return .unproven
         }
+    }
+
+    private static func supportState(
+        preflightState: ModelEvidenceSupportState,
+        report: ModelCompatibilityDiagnostics.Report,
+        proofAssessments: [ProofAssessment]
+    ) -> ModelEvidenceSupportState {
+        if preflightState == .unsupported {
+            return .unsupported
+        }
+        if preflightState == .partial {
+            return .partial
+        }
+        if report.localBundle.kind != .available {
+            return .unproven
+        }
+        if proofAssessments.contains(where: { $0.status == .failed || $0.status == .error }) {
+            return .unsupported
+        }
+
+        let runtimeProof = proofAssessments.contains {
+            $0.kind == .runtime && $0.status == .passed && $0.hasPositiveTokenRate
+        }
+        let memoryProof = proofAssessments.contains {
+            ($0.kind == .runtime || $0.kind == .memory) && $0.status == .passed && $0.provesMemoryFootprint
+        }
+        let cacheProof = proofAssessments.contains {
+            $0.kind == .cache && $0.status == .passed
+        }
+        let benchmarkOrEvalProof = proofAssessments.contains {
+            ($0.kind == .benchmark || $0.kind == .eval) && $0.status == .passed
+        }
+
+        if runtimeProof && memoryProof && cacheProof && benchmarkOrEvalProof {
+            return .supported
+        }
+        if proofAssessments.isEmpty {
+            return .unproven
+        }
+        return .partial
     }
 
     private static func groupKind(
@@ -306,6 +380,248 @@ final class ModelLibraryEvidenceService {
         }
     }
 
+    private static func requirementStatuses(
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState,
+        proofAssessments: [ProofAssessment]
+    ) -> [ModelEvidenceRequirementStatus] {
+        [
+            importRequirement(report: report),
+            preflightRequirement(report: report, supportState: supportState),
+            proofRequirement(
+                kind: .runtimeGeneration,
+                assessments: proofAssessments.filter { $0.kind == .runtime },
+                passed: { $0.status == .passed && $0.hasPositiveTokenRate },
+                missingDetail: "No passing runtime generation proof with token/s is registered."
+            ),
+            proofRequirement(
+                kind: .tokenRate,
+                assessments: proofAssessments.filter { $0.kind == .runtime || $0.kind == .benchmark },
+                passed: { $0.status == .passed && $0.hasPositiveTokenRate },
+                missingDetail: "No runtime or benchmark row records token/s."
+            ),
+            proofRequirement(
+                kind: .memoryFootprint,
+                assessments: proofAssessments.filter { $0.kind == .runtime || $0.kind == .memory },
+                passed: { $0.status == .passed && $0.provesMemoryFootprint },
+                missingDetail: "No runtime or memory row proves physical footprint stayed within the intended gate."
+            ),
+            proofRequirement(
+                kind: .cacheBehavior,
+                assessments: proofAssessments.filter { $0.kind == .cache },
+                passed: { $0.status == .passed },
+                missingDetail: "No cache proof row is registered."
+            ),
+            proofRequirement(
+                kind: .benchmarkOrEval,
+                assessments: proofAssessments.filter { $0.kind == .benchmark || $0.kind == .eval },
+                passed: { $0.status == .passed },
+                missingDetail: "No benchmark or eval row is registered."
+            ),
+        ]
+    }
+
+    private static func importRequirement(
+        report: ModelCompatibilityDiagnostics.Report
+    ) -> ModelEvidenceRequirementStatus {
+        switch report.localBundle.kind {
+        case .available:
+            return ModelEvidenceRequirementStatus(
+                kind: .importState,
+                state: .passed,
+                reportID: localCacheID(for: report.modelId),
+                detail: report.localBundle.title
+            )
+        case .incomplete:
+            return ModelEvidenceRequirementStatus(
+                kind: .importState,
+                state: .partial,
+                reportID: localCacheID(for: report.modelId),
+                detail: report.localBundle.detail ?? report.localBundle.title
+            )
+        case .notDownloaded:
+            return ModelEvidenceRequirementStatus(
+                kind: .importState,
+                state: .unavailable,
+                reportID: localCacheID(for: report.modelId),
+                detail: report.localBundle.detail ?? report.localBundle.title
+            )
+        }
+    }
+
+    private static func preflightRequirement(
+        report: ModelCompatibilityDiagnostics.Report,
+        supportState: ModelEvidenceSupportState
+    ) -> ModelEvidenceRequirementStatus {
+        let state: ModelEvidenceRequirementState
+        switch report.preflight.status {
+        case .supported:
+            state = .passed
+        case .partial:
+            state = .partial
+        case .unsupported:
+            state = .failed
+        case .unproven:
+            state = .missing
+        }
+        let detail = supportState == .supported
+            ? report.preflight.detail
+            : "\(report.preflight.detail) Row support is \(supportState.rawValue) until proof requirements pass."
+        return ModelEvidenceRequirementStatus(
+            kind: .compatibilityPreflight,
+            state: state,
+            reportID: compatibilityID(for: report.modelId),
+            detail: detail
+        )
+    }
+
+    private static func proofRequirement(
+        kind: ModelEvidenceRequirementKind,
+        assessments: [ProofAssessment],
+        passed: (ProofAssessment) -> Bool,
+        missingDetail: String
+    ) -> ModelEvidenceRequirementStatus {
+        if let passing = assessments.first(where: passed) {
+            return ModelEvidenceRequirementStatus(
+                kind: kind,
+                state: .passed,
+                reportID: passing.reportID,
+                detail: passing.summaryDetail
+            )
+        }
+        if assessments.isEmpty {
+            return ModelEvidenceRequirementStatus(
+                kind: kind,
+                state: .missing,
+                reportID: nil,
+                detail: missingDetail
+            )
+        }
+
+        let ranked = assessments.sorted { lhs, rhs in
+            requirementStateRank(state(from: lhs.status)) > requirementStateRank(state(from: rhs.status))
+        }
+        let best = ranked[0]
+        return ModelEvidenceRequirementStatus(
+            kind: kind,
+            state: state(from: best.status),
+            reportID: best.reportID,
+            detail: best.summaryDetail
+        )
+    }
+
+    private static func state(from status: EvidenceReportStatus) -> ModelEvidenceRequirementState {
+        switch status {
+        case .passed:
+            return .passed
+        case .partial:
+            return .partial
+        case .failed, .error:
+            return .failed
+        case .blocked:
+            return .blocked
+        case .unavailable:
+            return .unavailable
+        case .unknown:
+            return .missing
+        }
+    }
+
+    private static func requirementStateRank(_ state: ModelEvidenceRequirementState) -> Int {
+        switch state {
+        case .passed:
+            return 6
+        case .failed:
+            return 5
+        case .blocked:
+            return 4
+        case .partial:
+            return 3
+        case .unavailable:
+            return 2
+        case .missing:
+            return 1
+        }
+    }
+
+    private static func proofAssessments(
+        for model: MLXModel,
+        descriptors: [ModelEvidenceProofDescriptor]
+    ) -> [ProofAssessment] {
+        descriptors.map { descriptor in
+            let reportID = proofID(
+                modelId: model.id,
+                kind: descriptor.kind,
+                artifactPath: descriptor.artifactPath
+            )
+            let artifactUnavailable =
+                descriptor.artifactError?.isEmpty == false
+                || !FileManager.default.fileExists(atPath: descriptor.artifactPath)
+            let tokensPerSecond = tokenRate(from: descriptor.metadata)
+            let provesMemoryFootprint = memoryProof(from: descriptor.metadata) == true
+            var status = descriptor.status
+            var validationMessages: [String] = []
+
+            if artifactUnavailable {
+                status = descriptor.artifactError?.isEmpty == false ? .error : .unavailable
+            } else if descriptor.status == .passed {
+                switch descriptor.kind {
+                case .runtime, .benchmark:
+                    if tokensPerSecond == nil || tokensPerSecond ?? 0 <= 0 {
+                        status = .blocked
+                        validationMessages.append("passing generation proof must record token/s")
+                    }
+                case .memory:
+                    if !provesMemoryFootprint {
+                        status = .blocked
+                        validationMessages.append("passing memory proof must record physical footprint within limit")
+                    }
+                case .cache, .eval:
+                    break
+                }
+            }
+
+            return ProofAssessment(
+                descriptor: descriptor,
+                reportID: reportID,
+                status: status,
+                tokensPerSecond: tokensPerSecond,
+                provesMemoryFootprint: provesMemoryFootprint,
+                validationMessages: validationMessages
+            )
+        }
+    }
+
+    private static func tokenRate(from metadata: [String: String]) -> Double? {
+        for key in ["tokens_per_second", "token_s", "tokens_s", "tps"] {
+            if let value = metadata[key], let parsed = Double(value.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return parsed
+            }
+        }
+        return nil
+    }
+
+    private static func memoryProof(from metadata: [String: String]) -> Bool? {
+        for key in [
+            "physical_footprint_within_limit",
+            "memory_within_limit",
+            "ram_within_limit",
+            "memory_proof",
+            "ram_proof",
+        ] {
+            guard let value = metadata[key]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() else {
+                continue
+            }
+            if ["true", "yes", "passed", "pass", "within_limit", "1"].contains(value) {
+                return true
+            }
+            if ["false", "no", "failed", "fail", "over_limit", "0"].contains(value) {
+                return false
+            }
+        }
+        return nil
+    }
+
     private static func sortRows(_ lhs: ModelEvidenceRow, _ rhs: ModelEvidenceRow) -> Bool {
         if lhs.groupKind.rawValue != rhs.groupKind.rawValue {
             return lhs.groupKind.rawValue < rhs.groupKind.rawValue
@@ -336,5 +652,32 @@ final class ModelLibraryEvidenceService {
         let last = URL(fileURLWithPath: path).lastPathComponent
         guard !last.isEmpty else { return "<redacted>" }
         return ".../\(last)"
+    }
+
+    private struct ProofAssessment {
+        let descriptor: ModelEvidenceProofDescriptor
+        let reportID: String
+        let status: EvidenceReportStatus
+        let tokensPerSecond: Double?
+        let provesMemoryFootprint: Bool
+        let validationMessages: [String]
+
+        var kind: ModelEvidenceProofKind {
+            descriptor.kind
+        }
+
+        var hasPositiveTokenRate: Bool {
+            (tokensPerSecond ?? 0) > 0
+        }
+
+        var summaryDetail: String {
+            if !validationMessages.isEmpty {
+                return validationMessages.joined(separator: "; ")
+            }
+            if let tokensPerSecond {
+                return "\(descriptor.source) \(status.rawValue), \(tokensPerSecond) token/s."
+            }
+            return "\(descriptor.source) \(status.rawValue)."
+        }
     }
 }

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -563,7 +563,12 @@ final class ModelLibraryEvidenceService {
             var validationMessages: [String] = []
 
             if artifactUnavailable {
-                status = descriptor.artifactError?.isEmpty == false ? .error : .unavailable
+                switch descriptor.status {
+                case .failed, .error:
+                    status = descriptor.status
+                default:
+                    status = descriptor.artifactError?.isEmpty == false ? .error : .unavailable
+                }
             } else if descriptor.status == .passed {
                 switch descriptor.kind {
                 case .runtime, .benchmark:

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -618,9 +618,9 @@ final class ModelLibraryEvidenceService: @unchecked Sendable {
                 validationMessages.append("physical footprint exceeded the intended limit")
             } else if artifactUnavailable {
                 switch descriptor.status {
-                case .failed, .error:
+                case .failed, .error, .blocked, .partial:
                     status = descriptor.status
-                default:
+                case .passed, .unavailable, .unknown:
                     status = descriptor.artifactError?.isEmpty == false ? .error : .unavailable
                 }
             } else if descriptor.status == .passed {
@@ -663,27 +663,31 @@ final class ModelLibraryEvidenceService: @unchecked Sendable {
     ) -> EvidenceReportCounts {
         guard resolvedStatus != originalStatus else { return counts }
 
-        var resolved = counts
-        resolved.passed = 0
+        let normalizedTotal = max(
+            1,
+            max(
+                counts.total,
+                counts.passed + counts.failed + counts.errored + counts.skipped
+                    + counts.blocked + counts.warnings
+            )
+        )
+        var resolved = EvidenceReportCounts(total: normalizedTotal)
         switch resolvedStatus {
         case .failed:
-            resolved.failed = max(1, resolved.failed)
+            resolved.failed = normalizedTotal
         case .error:
-            resolved.errored = max(1, resolved.errored)
+            resolved.errored = normalizedTotal
         case .blocked:
-            resolved.blocked = max(1, resolved.blocked)
+            resolved.blocked = normalizedTotal
         case .unavailable:
-            resolved.skipped = max(1, resolved.skipped)
+            resolved.skipped = normalizedTotal
         case .partial:
-            resolved.warnings = max(1, resolved.warnings)
-        case .passed, .unknown:
-            break
+            resolved.warnings = normalizedTotal
+        case .passed:
+            resolved.passed = normalizedTotal
+        case .unknown:
+            resolved.total = 0
         }
-        resolved.total = max(
-            resolved.total,
-            resolved.passed + resolved.failed + resolved.errored + resolved.skipped
-                + resolved.blocked + resolved.warnings
-        )
         return resolved
     }
 

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -10,6 +10,7 @@ import Foundation
 
 final class ModelLibraryEvidenceService {
     private let registry: EvidenceReportRegistryService
+    private var ownedReportIDs: Set<String> = []
 
     init(registry: EvidenceReportRegistryService = EvidenceReportRegistryService()) {
         self.registry = registry
@@ -23,6 +24,7 @@ final class ModelLibraryEvidenceService {
     ) -> ModelEvidenceSnapshot {
         let proofDescriptorsByModel = Dictionary(grouping: proofDescriptors, by: { $0.modelId })
         var rows: [ModelEvidenceRow] = []
+        var currentReportIDs: Set<String> = []
 
         for model in models {
             let report = Self.compatibilityReport(for: model)
@@ -44,12 +46,9 @@ final class ModelLibraryEvidenceService {
                     preflightState: preflightState,
                     proofAssessments: proofAssessments
                 )
-            let summaries = registry.register(descriptors)
-            let proofIDPrefix = "model-library-"
-            let proofIDs = summaries
-                .filter { $0.id.hasPrefix(proofIDPrefix) && $0.id.contains("-proof|") }
-                .map(\.id)
-                .sorted()
+            registry.register(descriptors)
+            currentReportIDs.formUnion(descriptors.compactMap(\.id))
+            let proofIDs = proofAssessments.map(\.reportID).sorted()
 
             rows.append(
                 ModelEvidenceRow(
@@ -75,6 +74,11 @@ final class ModelLibraryEvidenceService {
                 )
             )
         }
+
+        // Reconcile only rows registered by this service instance so a shared
+        // registry can retain reports from independent evidence producers.
+        registry.remove(ids: ownedReportIDs.subtracting(currentReportIDs))
+        ownedReportIDs = currentReportIDs
 
         let sortedRows = rows.sorted(by: Self.sortRows)
         return ModelEvidenceSnapshot(
@@ -207,7 +211,7 @@ final class ModelLibraryEvidenceService {
             source: proof.source,
             artifactPath: proof.artifactPath,
             status: assessment.status,
-            counts: proof.counts,
+            counts: assessment.counts,
             startedAt: proof.startedAt,
             completedAt: proof.completedAt,
             metadata: metadata,
@@ -305,6 +309,9 @@ final class ModelLibraryEvidenceService {
         }
         if report.localBundle.kind != .available {
             return .unproven
+        }
+        if preflightState == .unproven {
+            return proofAssessments.isEmpty ? .unproven : .partial
         }
 
         let runtimeProof = proofAssessments.contains {
@@ -558,11 +565,19 @@ final class ModelLibraryEvidenceService {
                 descriptor.artifactError?.isEmpty == false
                 || !FileManager.default.fileExists(atPath: descriptor.artifactPath)
             let tokensPerSecond = tokenRate(from: descriptor.metadata)
-            let provesMemoryFootprint = memoryProof(from: descriptor.metadata) == true
+            let memoryProofResult = memoryProof(from: descriptor.metadata)
+            let provesMemoryFootprint = memoryProofResult == .passed
             var status = descriptor.status
             var validationMessages: [String] = []
 
-            if artifactUnavailable {
+            let isMemoryEvidence = descriptor.kind == .runtime || descriptor.kind == .memory
+            if isMemoryEvidence,
+                memoryProofResult == .failed,
+                descriptor.status != .failed,
+                descriptor.status != .error {
+                status = .failed
+                validationMessages.append("physical footprint exceeded the intended limit")
+            } else if artifactUnavailable {
                 switch descriptor.status {
                 case .failed, .error:
                     status = descriptor.status
@@ -590,11 +605,46 @@ final class ModelLibraryEvidenceService {
                 descriptor: descriptor,
                 reportID: reportID,
                 status: status,
+                counts: assessmentCounts(
+                    descriptor.counts,
+                    resolvedStatus: status,
+                    originalStatus: descriptor.status
+                ),
                 tokensPerSecond: tokensPerSecond,
                 provesMemoryFootprint: provesMemoryFootprint,
                 validationMessages: validationMessages
             )
         }
+    }
+
+    private static func assessmentCounts(
+        _ counts: EvidenceReportCounts,
+        resolvedStatus: EvidenceReportStatus,
+        originalStatus: EvidenceReportStatus
+    ) -> EvidenceReportCounts {
+        guard resolvedStatus != originalStatus else { return counts }
+
+        var resolved = counts
+        resolved.passed = 0
+        switch resolvedStatus {
+        case .failed:
+            resolved.failed = max(1, resolved.failed)
+        case .error:
+            resolved.errored = max(1, resolved.errored)
+        case .blocked:
+            resolved.blocked = max(1, resolved.blocked)
+        case .unavailable:
+            resolved.skipped = max(1, resolved.skipped)
+        case .partial:
+            resolved.warnings = max(1, resolved.warnings)
+        case .passed, .unknown:
+            break
+        }
+        resolved.total = max(
+            resolved.total,
+            resolved.passed + resolved.failed + resolved.errored + resolved.skipped + resolved.blocked
+        )
+        return resolved
     }
 
     private static func tokenRate(from metadata: [String: String]) -> Double? {
@@ -606,7 +656,7 @@ final class ModelLibraryEvidenceService {
         return nil
     }
 
-    private static func memoryProof(from metadata: [String: String]) -> Bool? {
+    private static func memoryProof(from metadata: [String: String]) -> MemoryProofResult {
         for key in [
             "physical_footprint_within_limit",
             "memory_within_limit",
@@ -618,13 +668,13 @@ final class ModelLibraryEvidenceService {
                 continue
             }
             if ["true", "yes", "passed", "pass", "within_limit", "1"].contains(value) {
-                return true
+                return .passed
             }
             if ["false", "no", "failed", "fail", "over_limit", "0"].contains(value) {
-                return false
+                return .failed
             }
         }
-        return nil
+        return .missing
     }
 
     private static func sortRows(_ lhs: ModelEvidenceRow, _ rhs: ModelEvidenceRow) -> Bool {
@@ -663,6 +713,7 @@ final class ModelLibraryEvidenceService {
         let descriptor: ModelEvidenceProofDescriptor
         let reportID: String
         let status: EvidenceReportStatus
+        let counts: EvidenceReportCounts
         let tokensPerSecond: Double?
         let provesMemoryFootprint: Bool
         let validationMessages: [String]
@@ -684,5 +735,11 @@ final class ModelLibraryEvidenceService {
             }
             return "\(descriptor.source) \(status.rawValue)."
         }
+    }
+
+    private enum MemoryProofResult {
+        case passed
+        case failed
+        case missing
     }
 }

--- a/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/ModelLibraryEvidenceService.swift
@@ -8,9 +8,11 @@
 
 import Foundation
 
-final class ModelLibraryEvidenceService {
+final class ModelLibraryEvidenceService: @unchecked Sendable {
+    private static let registryProducer = "model-library-evidence"
+
     private let registry: EvidenceReportRegistryService
-    private var ownedReportIDs: Set<String> = []
+    private let lock = NSLock()
 
     init(registry: EvidenceReportRegistryService = EvidenceReportRegistryService()) {
         self.registry = registry
@@ -22,15 +24,21 @@ final class ModelLibraryEvidenceService {
         proofDescriptors: [ModelEvidenceProofDescriptor] = [],
         filter: ModelEvidenceFilter = ModelEvidenceFilter()
     ) -> ModelEvidenceSnapshot {
-        let proofDescriptorsByModel = Dictionary(grouping: proofDescriptors, by: { $0.modelId })
+        lock.lock()
+        defer { lock.unlock() }
+
+        let proofDescriptorsByModel = Dictionary(
+            grouping: proofDescriptors,
+            by: { Self.normalizedProofInput($0.modelId) }
+        )
         var rows: [ModelEvidenceRow] = []
-        var currentReportIDs: Set<String> = []
+        var registryDescriptors: [EvidenceReportDescriptor] = []
 
         for model in models {
             let report = Self.compatibilityReport(for: model)
             let preflightState = Self.supportState(from: report.preflight.status)
             let groupKind = Self.groupKind(from: report)
-            let modelProofDescriptors = proofDescriptorsByModel[model.id] ?? []
+            let modelProofDescriptors = proofDescriptorsByModel[Self.normalizedProofInput(model.id)] ?? []
             let proofAssessments = Self.proofAssessments(for: model, descriptors: modelProofDescriptors)
             let supportState = Self.supportState(
                 preflightState: preflightState,
@@ -46,8 +54,7 @@ final class ModelLibraryEvidenceService {
                     preflightState: preflightState,
                     proofAssessments: proofAssessments
                 )
-            registry.register(descriptors)
-            currentReportIDs.formUnion(descriptors.compactMap(\.id))
+            registryDescriptors.append(contentsOf: descriptors)
             let proofIDs = proofAssessments.map(\.reportID).sorted()
 
             rows.append(
@@ -75,22 +82,24 @@ final class ModelLibraryEvidenceService {
             )
         }
 
-        // Reconcile only rows registered by this service instance so a shared
-        // registry can retain reports from independent evidence producers.
-        registry.remove(ids: ownedReportIDs.subtracting(currentReportIDs))
-        ownedReportIDs = currentReportIDs
+        let reports = registry.reconcile(
+            producer: Self.registryProducer,
+            descriptors: registryDescriptors
+        )
 
         let sortedRows = rows.sorted(by: Self.sortRows)
         return ModelEvidenceSnapshot(
             rows: sortedRows,
             visibleRows: sortedRows.filter(filter.includes),
             groups: Self.groups(from: sortedRows),
-            reports: registry.list()
+            reports: reports
         )
     }
 
     func snapshot(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> EvidenceReportRegistrySnapshot {
-        registry.snapshot(filter)
+        lock.lock()
+        defer { lock.unlock() }
+        return registry.snapshot(producer: Self.registryProducer, filter: filter)
     }
 
     private static func compatibilityReport(for model: MLXModel) -> ModelCompatibilityDiagnostics.Report {
@@ -488,6 +497,14 @@ final class ModelLibraryEvidenceService {
         passed: (ProofAssessment) -> Bool,
         missingDetail: String
     ) -> ModelEvidenceRequirementStatus {
+        if let failure = assessments.first(where: { $0.status == .failed || $0.status == .error }) {
+            return ModelEvidenceRequirementStatus(
+                kind: kind,
+                state: .failed,
+                reportID: failure.reportID,
+                detail: failure.summaryDetail
+            )
+        }
         if let passing = assessments.first(where: passed) {
             return ModelEvidenceRequirementStatus(
                 kind: kind,
@@ -506,15 +523,33 @@ final class ModelLibraryEvidenceService {
         }
 
         let ranked = assessments.sorted { lhs, rhs in
-            requirementStateRank(state(from: lhs.status)) > requirementStateRank(state(from: rhs.status))
+            requirementStateRank(proofRequirementState(for: lhs, passed: passed))
+                > requirementStateRank(proofRequirementState(for: rhs, passed: passed))
         }
         let best = ranked[0]
+        let bestState = proofRequirementState(for: best, passed: passed)
+        let detail = best.status == .passed
+            ? "\(best.summaryDetail) \(missingDetail)"
+            : best.summaryDetail
         return ModelEvidenceRequirementStatus(
             kind: kind,
-            state: state(from: best.status),
+            state: bestState,
             reportID: best.reportID,
-            detail: best.summaryDetail
+            detail: detail
         )
+    }
+
+    private static func proofRequirementState(
+        for assessment: ProofAssessment,
+        passed: (ProofAssessment) -> Bool
+    ) -> ModelEvidenceRequirementState {
+        if passed(assessment) {
+            return .passed
+        }
+        if assessment.status == .passed {
+            return .blocked
+        }
+        return state(from: assessment.status)
     }
 
     private static func state(from status: EvidenceReportStatus) -> ModelEvidenceRequirementState {
@@ -536,11 +571,11 @@ final class ModelLibraryEvidenceService {
 
     private static func requirementStateRank(_ state: ModelEvidenceRequirementState) -> Int {
         switch state {
-        case .passed:
-            return 6
         case .failed:
-            return 5
+            return 6
         case .blocked:
+            return 5
+        case .passed:
             return 4
         case .partial:
             return 3
@@ -559,11 +594,15 @@ final class ModelLibraryEvidenceService {
             let reportID = proofID(
                 modelId: model.id,
                 kind: descriptor.kind,
+                source: descriptor.source,
                 artifactPath: descriptor.artifactPath
             )
+            let artifactURL = URL(
+                fileURLWithPath: descriptor.artifactPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            ).standardizedFileURL
             let artifactUnavailable =
                 descriptor.artifactError?.isEmpty == false
-                || !FileManager.default.fileExists(atPath: descriptor.artifactPath)
+                || !FileManager.default.fileExists(atPath: artifactURL.path)
             let tokensPerSecond = tokenRate(from: descriptor.metadata)
             let memoryProofResult = memoryProof(from: descriptor.metadata)
             let provesMemoryFootprint = memoryProofResult == .passed
@@ -642,7 +681,8 @@ final class ModelLibraryEvidenceService {
         }
         resolved.total = max(
             resolved.total,
-            resolved.passed + resolved.failed + resolved.errored + resolved.skipped + resolved.blocked
+            resolved.passed + resolved.failed + resolved.errored + resolved.skipped
+                + resolved.blocked + resolved.warnings
         )
         return resolved
     }
@@ -685,19 +725,40 @@ final class ModelLibraryEvidenceService {
     }
 
     private static func localCacheID(for modelId: String) -> String {
-        "model-library-cache|\(modelId)"
+        stableModelReportID(prefix: "model-library-cache", modelId: modelId)
     }
 
     private static func compatibilityID(for modelId: String) -> String {
-        "model-library-preflight|\(modelId)"
+        stableModelReportID(prefix: "model-library-preflight", modelId: modelId)
     }
 
     private static func proofID(
         modelId: String,
         kind: ModelEvidenceProofKind,
+        source: String,
         artifactPath: String
     ) -> String {
-        "model-library-\(kind.rawValue)-proof|\(modelId)|\(artifactPath)"
+        let artifactURL = URL(
+            fileURLWithPath: artifactPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        ).standardizedFileURL
+        let artifactIdentity = EvidenceReportIdentity.contentDigest(at: artifactURL)
+            .map { "sha256:\($0)" }
+            ?? "name:\(normalizedProofInput(artifactURL.lastPathComponent))"
+        let seed = [
+            normalizedProofInput(modelId),
+            kind.rawValue,
+            normalizedProofInput(source),
+            artifactIdentity,
+        ].joined(separator: "|")
+        return "model-library-\(kind.rawValue)-proof:\(EvidenceReportIdentity.digest(seed))"
+    }
+
+    private static func stableModelReportID(prefix: String, modelId: String) -> String {
+        "\(prefix):\(EvidenceReportIdentity.digest(normalizedProofInput(modelId)))"
+    }
+
+    private static func normalizedProofInput(_ value: String) -> String {
+        EvidenceReportIdentity.normalizedLogicalValue(value)
     }
 
     private static func redactedPath(_ path: String?) -> String? {

--- a/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
@@ -92,6 +92,34 @@ struct EvidenceReportRegistryTests {
     }
 
     @Test
+    func missingArtifactsPreserveExplicitFailureStatuses() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+
+        service.register([
+            EvidenceReportDescriptor(
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactPath: fixture.root.appendingPathComponent("missing/failed.json").path,
+                status: .failed,
+                counts: EvidenceReportCounts(total: 1, failed: 1)
+            ),
+            EvidenceReportDescriptor(
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactPath: fixture.root.appendingPathComponent("missing/error.json").path,
+                status: .error,
+                counts: EvidenceReportCounts(total: 1, errored: 1)
+            ),
+        ])
+
+        let reports = service.list()
+        #expect(reports.count == 2)
+        #expect(reports.allSatisfy { $0.artifact.availability == .unavailable })
+        #expect(Set(reports.map(\.status)) == [.failed, .error])
+    }
+
+    @Test
     func descriptorErrorsBecomeErrorRows() throws {
         let fixture = try RegistryFixture()
         let service = EvidenceReportRegistryService(now: fixture.clock)

--- a/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
@@ -120,6 +120,55 @@ struct EvidenceReportRegistryTests {
     }
 
     @Test
+    func sameIDReregistrationRefreshesDeletedArtifactAndFailureTruth() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let artifact = try fixture.writeArtifact(named: "runtime/refresh.json")
+        let reportID = "runtime-refresh"
+
+        let available = service.register(
+            EvidenceReportDescriptor(
+                id: reportID,
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactURL: artifact,
+                status: .passed,
+                counts: EvidenceReportCounts(total: 1, passed: 1)
+            )
+        )
+        #expect(available.status == .passed)
+        #expect(available.artifact.availability == .available)
+
+        try FileManager.default.removeItem(at: artifact)
+        let unavailable = service.register(
+            EvidenceReportDescriptor(
+                id: reportID,
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactURL: artifact,
+                status: .passed,
+                counts: EvidenceReportCounts(total: 1, passed: 1)
+            )
+        )
+        #expect(unavailable.status == .unavailable)
+        #expect(unavailable.artifact.availability == .unavailable)
+
+        let failed = service.register(
+            EvidenceReportDescriptor(
+                id: reportID,
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactURL: artifact,
+                status: .failed,
+                counts: EvidenceReportCounts(total: 1, failed: 1)
+            )
+        )
+        #expect(failed.status == .failed)
+        #expect(failed.artifact.availability == .unavailable)
+        #expect(service.list() == [failed])
+    }
+
+    @Test
     func descriptorErrorsBecomeErrorRows() throws {
         let fixture = try RegistryFixture()
         let service = EvidenceReportRegistryService(now: fixture.clock)

--- a/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
@@ -89,6 +89,8 @@ struct EvidenceReportRegistryTests {
         #expect(report.status == .unavailable)
         #expect(report.artifact.availability == .unavailable)
         #expect(report.artifact.message?.contains("not present") == true)
+        #expect(report.counts.passed == 0)
+        #expect(report.counts.skipped == 1)
     }
 
     @Test
@@ -152,6 +154,9 @@ struct EvidenceReportRegistryTests {
         )
         #expect(unavailable.status == .unavailable)
         #expect(unavailable.artifact.availability == .unavailable)
+        #expect(unavailable.counts.passed == 0)
+        #expect(unavailable.counts.skipped == 1)
+        #expect(unavailable.generation > available.generation)
 
         let failed = service.register(
             EvidenceReportDescriptor(
@@ -166,6 +171,190 @@ struct EvidenceReportRegistryTests {
         #expect(failed.status == .failed)
         #expect(failed.artifact.availability == .unavailable)
         #expect(service.list() == [failed])
+    }
+
+    @Test
+    func missingArtifactsPreserveBlockedAndPartialTruth() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+
+        service.register([
+            EvidenceReportDescriptor(
+                id: "blocked-proof",
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactPath: fixture.root.appendingPathComponent("missing/blocked.json").path,
+                status: .blocked,
+                counts: EvidenceReportCounts(total: 1, blocked: 1)
+            ),
+            EvidenceReportDescriptor(
+                id: "partial-proof",
+                kind: .runtime,
+                source: "runtime-live-proof",
+                artifactPath: fixture.root.appendingPathComponent("missing/partial.json").path,
+                status: .partial,
+                counts: EvidenceReportCounts(total: 2, passed: 1, warnings: 1)
+            ),
+        ])
+
+        let reports = service.list()
+        let blocked = try #require(reports.first { $0.id == "blocked-proof" })
+        let partial = try #require(reports.first { $0.id == "partial-proof" })
+        #expect(blocked.status == .blocked)
+        #expect(blocked.counts == EvidenceReportCounts(total: 1, blocked: 1))
+        #expect(partial.status == .partial)
+        #expect(partial.counts == EvidenceReportCounts(total: 2, passed: 1, warnings: 1))
+        #expect(reports.allSatisfy { $0.artifact.availability == .unavailable })
+    }
+
+    @Test
+    func producerReconciliationRevealsCollidingUnrelatedReportAfterRemoval() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let unrelatedArtifact = try fixture.writeArtifact(named: "unrelated/report.json")
+        let producerArtifact = try fixture.writeArtifact(named: "producer/report.json")
+
+        service.register(
+            EvidenceReportDescriptor(
+                id: "shared-id",
+                kind: .provider,
+                source: "unrelated",
+                artifactURL: unrelatedArtifact,
+                status: .failed,
+                counts: EvidenceReportCounts(total: 1, failed: 1)
+            )
+        )
+        service.reconcile(
+            producer: "model-library-evidence",
+            descriptors: [
+                EvidenceReportDescriptor(
+                    id: "shared-id",
+                    kind: .runtime,
+                    source: "model-library",
+                    artifactURL: producerArtifact,
+                    status: .passed,
+                    counts: EvidenceReportCounts(total: 1, passed: 1)
+                ),
+            ]
+        )
+
+        #expect(service.list().first?.source == "model-library")
+        #expect(service.list(producer: "model-library-evidence").count == 1)
+
+        service.reconcile(producer: "model-library-evidence", descriptors: [])
+
+        #expect(service.list().first?.source == "unrelated")
+        #expect(service.list().first?.status == .failed)
+        #expect(service.list(producer: "model-library-evidence").isEmpty)
+    }
+
+    @Test
+    func reportIdentityAndSerializedArtifactLocatorDoNotExposeLocalPaths() throws {
+        let firstFixture = try RegistryFixture()
+        let secondFixture = try RegistryFixture()
+        let firstArtifact = try firstFixture.writeArtifact(named: "proof/report.json")
+        let secondArtifact = try secondFixture.writeArtifact(named: "proof/report.json")
+        let firstService = EvidenceReportRegistryService(now: firstFixture.clock)
+        let secondService = EvidenceReportRegistryService(now: secondFixture.clock)
+        let first = firstService.register(
+            EvidenceReportDescriptor(
+                kind: .runtime,
+                source: "runtime-proof",
+                artifactURL: firstArtifact,
+                status: .passed
+            )
+        )
+        let second = secondService.register(
+            EvidenceReportDescriptor(
+                kind: .runtime,
+                source: "runtime-proof",
+                artifactURL: secondArtifact,
+                status: .passed
+            )
+        )
+        let sanitizedExplicitID = firstService.register(
+            EvidenceReportDescriptor(
+                id: "runtime-proof|\(firstArtifact.path)",
+                kind: .runtime,
+                source: "runtime-proof",
+                artifactURL: firstArtifact,
+                status: .passed
+            )
+        )
+
+        #expect(first.id == second.id)
+        #expect(sanitizedExplicitID.id == first.id)
+        #expect(first.artifact.path == second.artifact.path)
+        #expect(!first.id.contains(firstFixture.root.path))
+        #expect(!first.artifact.path.contains(firstFixture.root.path))
+        #expect(!first.artifact.path.hasPrefix("/"))
+        #expect(firstService.localArtifactURL(forReportID: first.id) == firstArtifact.standardizedFileURL)
+
+        let encoded = String(decoding: try first.stableJSONData(), as: UTF8.self)
+        #expect(!encoded.contains(firstFixture.root.path))
+        #expect(!encoded.contains(secondFixture.root.path))
+    }
+
+    @Test
+    func legacySnapshotDecodingIsTolerantAndReencodingIsPrivacySafe() throws {
+        let fixture = try RegistryFixture()
+        let artifact = try fixture.writeArtifact(named: "legacy/summary.json")
+        let legacyJSON = """
+            {
+              "reports": [{
+                "id": "legacy-report",
+                "kind": "eval",
+                "source": "legacy-evals",
+                "artifact": {
+                  "path": "\(artifact.path)",
+                  "availability": "available"
+                },
+                "status": "passed",
+                "counts": {"total": 1, "passed": 1, "failed": 0, "errored": 0, "skipped": 0, "blocked": 0, "warnings": 0},
+                "registeredAt": "2025-06-15T15:06:40Z"
+              }]
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let snapshot = try decoder.decode(
+            EvidenceReportRegistrySnapshot.self,
+            from: Data(legacyJSON.utf8)
+        )
+        let report = try #require(snapshot.reports.first)
+
+        #expect(snapshot.schemaVersion == 1)
+        #expect(report.generation == 0)
+        #expect(report.artifact.path != artifact.path)
+        #expect(report.artifact.resolvedURL(relativeTo: fixture.root) == artifact.standardizedFileURL)
+        #expect(!String(decoding: try snapshot.stableJSONData(), as: UTF8.self).contains(fixture.root.path))
+    }
+
+    @Test
+    func concurrentRegistrationsRemainConsistent() async throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let artifact = try fixture.writeArtifact(named: "concurrent/report.json")
+
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<50 {
+                group.addTask {
+                    service.register(
+                        EvidenceReportDescriptor(
+                            id: "concurrent-\(index)",
+                            kind: .runtime,
+                            source: "concurrency-test",
+                            artifactURL: artifact,
+                            status: .passed
+                        )
+                    )
+                }
+            }
+        }
+
+        #expect(service.list().count == 50)
+        #expect(Set(service.list().map(\.generation)).count == 50)
     }
 
     @Test
@@ -243,6 +432,7 @@ struct EvidenceReportRegistryTests {
         #expect(first == second)
         #expect(body.hasPrefix("{\"artifact\""))
         #expect(body.contains("\"completedAt\":\"2025-06-15T15:06:40Z\""))
+        #expect(!body.contains("/tmp/live.json"))
         #expect(
             body.range(of: "\"a\":\"first\"")?.lowerBound ?? body.endIndex
                 < body.range(of: "\"z\":\"last\"")?.lowerBound ?? body.startIndex

--- a/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
@@ -149,13 +149,17 @@ struct EvidenceReportRegistryTests {
                 source: "runtime-live-proof",
                 artifactURL: artifact,
                 status: .passed,
-                counts: EvidenceReportCounts(total: 1, passed: 1)
+                counts: EvidenceReportCounts(
+                    total: 3,
+                    passed: 1,
+                    blocked: 1,
+                    warnings: 1
+                )
             )
         )
         #expect(unavailable.status == .unavailable)
         #expect(unavailable.artifact.availability == .unavailable)
-        #expect(unavailable.counts.passed == 0)
-        #expect(unavailable.counts.skipped == 1)
+        #expect(unavailable.counts == EvidenceReportCounts(total: 3, skipped: 3))
         #expect(unavailable.generation > available.generation)
 
         let failed = service.register(

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -234,6 +234,53 @@ struct ModelLibraryEvidenceServiceTests {
     }
 
     @Test
+    func missingFailedOrErroredProofArtifactStillMarksRowUnsupported() throws {
+        let fixture = try ModelEvidenceFixture()
+        let failed = try fixture.model(id: "org/missing-failed-proof", config: #"{"model_type":"qwen3"}"#)
+        let errored = try fixture.model(id: "org/missing-error-proof", config: #"{"model_type":"qwen3"}"#)
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(
+            for: [failed, errored],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: failed.id,
+                    kind: .runtime,
+                    artifactPath: fixture.root.appendingPathComponent("proof/missing-failed.json").path,
+                    status: .failed
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: errored.id,
+                    kind: .runtime,
+                    artifactPath: fixture.root.appendingPathComponent("proof/missing-error.json").path,
+                    status: .error
+                ),
+            ]
+        )
+
+        #expect(snapshot.rows.first { $0.modelId == failed.id }?.supportState == .unsupported)
+        #expect(snapshot.rows.first { $0.modelId == errored.id }?.supportState == .unsupported)
+        #expect(
+            snapshot.reports
+                .first {
+                    $0.metadata["model_id"] == failed.id
+                        && $0.metadata["evidence_role"] == "runtime_proof"
+                }?
+                .status == .failed
+        )
+        #expect(
+            snapshot.reports
+                .first {
+                    $0.metadata["model_id"] == errored.id
+                        && $0.metadata["evidence_role"] == "runtime_proof"
+                }?
+                .status == .error
+        )
+    }
+
+    @Test
     func registryMetadataAndRowsDoNotExposeFullBundlePaths() throws {
         let fixture = try ModelEvidenceFixture()
         let model = try fixture.model(id: "org/redacted", config: #"{"model_type":"qwen3"}"#)

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -1,0 +1,218 @@
+//
+//  ModelLibraryEvidenceServiceTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Model library evidence service")
+struct ModelLibraryEvidenceServiceTests {
+    @Test
+    func registersSupportedPartialUnsupportedAndUnprovenRowsThroughRegistry() throws {
+        let fixture = try ModelEvidenceFixture()
+        let supported = try fixture.model(id: "org/supported", config: #"{"model_type":"qwen3"}"#)
+        let partial = try fixture.model(id: "org/partial", config: #"{"model_type":"dflash"}"#)
+        let unsupported = try fixture.model(id: "org/unsupported", config: #"{"model_type":"longcat_next"}"#)
+        let unproven = MLXModel(
+            id: "org/not-local",
+            name: "Not Local",
+            description: "",
+            downloadURL: "",
+            rootDirectory: fixture.root
+        )
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(for: [supported, partial, unsupported, unproven])
+
+        #expect(Set(snapshot.rows.map(\.supportState)) == [.supported, .partial, .unsupported, .unproven])
+
+        let compatibility = snapshot.reports.filter { $0.kind == .modelCompatibility }
+        #expect(compatibility.count == 4)
+        #expect(report(for: supported.id, in: compatibility)?.status == .passed)
+        #expect(report(for: partial.id, in: compatibility)?.status == .partial)
+        #expect(report(for: unsupported.id, in: compatibility)?.status == .failed)
+        #expect(report(for: unproven.id, in: compatibility)?.status == .unavailable)
+        #expect(
+            report(for: unproven.id, in: compatibility)?.metadata["support_state"] == "unproven"
+        )
+    }
+
+    @Test
+    func incompleteAndExternalCacheCandidatesAreGroupedAndHiddenByDefault() throws {
+        let fixture = try ModelEvidenceFixture()
+        let ready = try fixture.model(id: "org/ready", config: #"{"model_type":"qwen3"}"#)
+        let incomplete = try fixture.model(
+            id: "org/incomplete",
+            config: #"{"model_type":"qwen3"}"#,
+            weights: false
+        )
+        let externalURL = try fixture.writeBundle(
+            relativePath: "external/cache-model",
+            config: #"{"model_type":"qwen3"}"#
+        )
+        let external = MLXModel(
+            id: "org/external",
+            name: "External",
+            description: "",
+            downloadURL: "",
+            bundleDirectory: externalURL,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(for: [ready, incomplete, external])
+
+        #expect(snapshot.rows.first { $0.modelId == incomplete.id }?.groupKind == .incomplete)
+        #expect(snapshot.rows.first { $0.modelId == external.id }?.groupKind == .externalCache)
+        #expect(snapshot.visibleRows.map(\.modelId) == [ready.id])
+        #expect(snapshot.groups.contains(ModelEvidenceGroup(kind: .incomplete, count: 1, visibleByDefault: false)))
+        #expect(snapshot.groups.contains(ModelEvidenceGroup(kind: .externalCache, count: 1, visibleByDefault: false)))
+
+        let expanded = service.registerEvidence(
+            for: [ready, incomplete, external],
+            filter: ModelEvidenceFilter(
+                includeIncomplete: true,
+                includeExternalCacheCandidates: true
+            )
+        )
+        #expect(Set(expanded.visibleRows.map(\.modelId)) == [ready.id, incomplete.id, external.id])
+    }
+
+    @Test
+    func proofArtifactsRegisterAsCacheBenchmarkAndRuntimeEvidence() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/proven", config: #"{"model_type":"qwen3"}"#)
+        let cacheArtifact = try fixture.writeArtifact(named: "proof/cache.json")
+        let benchmarkArtifact = try fixture.writeArtifact(named: "proof/benchmark.json")
+        let missingRuntime = fixture.root.appendingPathComponent("proof/runtime.json").path
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .cache,
+                    artifactPath: cacheArtifact.path,
+                    status: .passed,
+                    counts: EvidenceReportCounts(total: 1, passed: 1)
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .benchmark,
+                    artifactPath: benchmarkArtifact.path,
+                    status: .partial,
+                    counts: EvidenceReportCounts(total: 2, passed: 1, warnings: 1)
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    source: "custom-live-proof",
+                    artifactPath: missingRuntime,
+                    status: .passed
+                ),
+            ]
+        )
+
+        let row = try #require(snapshot.rows.first)
+        #expect(row.proofReportIDs.count == 3)
+        #expect(snapshot.reports.contains { $0.kind == .cache && $0.source == "model-library-cache-proof" })
+        #expect(snapshot.reports.contains { $0.kind == .benchmark && $0.status == .partial })
+        #expect(snapshot.reports.contains { $0.kind == .runtime && $0.source == "custom-live-proof" && $0.status == .unavailable })
+    }
+
+    @Test
+    func registryMetadataAndRowsDoNotExposeFullBundlePaths() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/redacted", config: #"{"model_type":"qwen3"}"#)
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(for: [model])
+        let row = try #require(snapshot.rows.first)
+        let cacheReport = try #require(snapshot.report(id: row.cacheReportID))
+
+        #expect(row.redactedBundlePath == ".../redacted")
+        #expect(row.redactedBundlePath?.contains(fixture.root.path) == false)
+        #expect(row.metadata.values.allSatisfy { !$0.contains(fixture.root.path) })
+        #expect(cacheReport.metadata["bundle_path"] == "<redacted>")
+        #expect(cacheReport.metadata.values.allSatisfy { !$0.contains(fixture.root.path) })
+    }
+
+    private func report(
+        for modelId: String,
+        in reports: [EvidenceReportSummary]
+    ) -> EvidenceReportSummary? {
+        reports.first { $0.metadata["model_id"] == modelId }
+    }
+}
+
+private struct ModelEvidenceFixture {
+    let root: URL
+    let currentDate = Date(timeIntervalSince1970: 1_750_000_000)
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-model-evidence-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    func clock() -> Date {
+        currentDate
+    }
+
+    func model(
+        id: String,
+        config: String,
+        tokenizer: Bool = true,
+        weights: Bool = true
+    ) throws -> MLXModel {
+        try writeBundle(relativePath: id, config: config, tokenizer: tokenizer, weights: weights)
+        return MLXModel(
+            id: id,
+            name: id.split(separator: "/").last.map(String.init) ?? id,
+            description: "",
+            downloadURL: "",
+            rootDirectory: root
+        )
+    }
+
+    @discardableResult
+    func writeBundle(
+        relativePath: String,
+        config: String,
+        tokenizer: Bool = true,
+        weights: Bool = true
+    ) throws -> URL {
+        let directory = root.appendingPathComponent(relativePath, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(config.utf8).write(to: directory.appendingPathComponent("config.json"))
+        if tokenizer {
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("tokenizer.json"))
+        }
+        if weights {
+            try Data("w".utf8).write(to: directory.appendingPathComponent("model.safetensors"))
+        }
+        return directory
+    }
+
+    func writeArtifact(named relativePath: String) throws -> URL {
+        let url = root.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("{\"ok\":true}".utf8).write(to: url)
+        return url
+    }
+}

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -194,6 +194,46 @@ struct ModelLibraryEvidenceServiceTests {
     }
 
     @Test
+    func failedProofOverridesPartialAndUnprovenPreflightStates() throws {
+        let fixture = try ModelEvidenceFixture()
+        let partial = try fixture.model(id: "org/partial-proof-failed", config: #"{"model_type":"dflash"}"#)
+        let notLocal = MLXModel(
+            id: "org/not-local-proof-failed",
+            name: "Not Local Proof Failed",
+            description: "",
+            downloadURL: "",
+            rootDirectory: fixture.root
+        )
+        let partialArtifact = try fixture.writeArtifact(named: "proof/partial-failed.json")
+        let notLocalArtifact = try fixture.writeArtifact(named: "proof/not-local-failed.json")
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(
+            for: [partial, notLocal],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: partial.id,
+                    kind: .runtime,
+                    artifactPath: partialArtifact.path,
+                    status: .failed
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: notLocal.id,
+                    kind: .runtime,
+                    artifactPath: notLocalArtifact.path,
+                    status: .failed
+                ),
+            ]
+        )
+
+        #expect(snapshot.rows.first { $0.modelId == partial.id }?.supportState == .unsupported)
+        #expect(snapshot.rows.first { $0.modelId == notLocal.id }?.supportState == .unsupported)
+        #expect(snapshot.reports.filter { $0.kind == .runtime }.allSatisfy { $0.status == .failed })
+    }
+
+    @Test
     func registryMetadataAndRowsDoNotExposeFullBundlePaths() throws {
         let fixture = try ModelEvidenceFixture()
         let model = try fixture.model(id: "org/redacted", config: #"{"model_type":"qwen3"}"#)

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -27,7 +27,10 @@ struct ModelLibraryEvidenceServiceTests {
         let service = ModelLibraryEvidenceService(
             registry: EvidenceReportRegistryService(now: fixture.clock)
         )
-        let snapshot = service.registerEvidence(for: [supported, partial, unsupported, unproven])
+        let snapshot = service.registerEvidence(
+            for: [supported, partial, unsupported, unproven],
+            proofDescriptors: try fixture.completeProofDescriptors(for: supported.id)
+        )
 
         #expect(Set(snapshot.rows.map(\.supportState)) == [.supported, .partial, .unsupported, .unproven])
 
@@ -40,6 +43,25 @@ struct ModelLibraryEvidenceServiceTests {
         #expect(
             report(for: unproven.id, in: compatibility)?.metadata["support_state"] == "unproven"
         )
+    }
+
+    @Test
+    func localPreflightPassWithoutProofStaysUnproven() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/preflight-only", config: #"{"model_type":"qwen3"}"#)
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(for: [model])
+        let row = try #require(snapshot.rows.first)
+        let compatibility = try #require(snapshot.report(id: row.compatibilityReportID))
+
+        #expect(row.supportState == .unproven)
+        #expect(compatibility.status == .passed)
+        #expect(row.requirements.first { $0.kind == .runtimeGeneration }?.state == .missing)
+        #expect(row.requirements.first { $0.kind == .tokenRate }?.state == .missing)
+        #expect(row.requirements.first { $0.kind == .memoryFootprint }?.state == .missing)
     }
 
     @Test
@@ -91,6 +113,7 @@ struct ModelLibraryEvidenceServiceTests {
         let model = try fixture.model(id: "org/proven", config: #"{"model_type":"qwen3"}"#)
         let cacheArtifact = try fixture.writeArtifact(named: "proof/cache.json")
         let benchmarkArtifact = try fixture.writeArtifact(named: "proof/benchmark.json")
+        let evalArtifact = try fixture.writeArtifact(named: "proof/eval.json")
         let missingRuntime = fixture.root.appendingPathComponent("proof/runtime.json").path
 
         let service = ModelLibraryEvidenceService(
@@ -111,7 +134,15 @@ struct ModelLibraryEvidenceServiceTests {
                     kind: .benchmark,
                     artifactPath: benchmarkArtifact.path,
                     status: .partial,
-                    counts: EvidenceReportCounts(total: 2, passed: 1, warnings: 1)
+                    counts: EvidenceReportCounts(total: 2, passed: 1, warnings: 1),
+                    metadata: ["tokens_per_second": "12.5"]
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .eval,
+                    artifactPath: evalArtifact.path,
+                    status: .passed,
+                    counts: EvidenceReportCounts(total: 3, passed: 3)
                 ),
                 ModelEvidenceProofDescriptor(
                     modelId: model.id,
@@ -124,10 +155,42 @@ struct ModelLibraryEvidenceServiceTests {
         )
 
         let row = try #require(snapshot.rows.first)
-        #expect(row.proofReportIDs.count == 3)
+        #expect(row.proofReportIDs.count == 4)
         #expect(snapshot.reports.contains { $0.kind == .cache && $0.source == "model-library-cache-proof" })
         #expect(snapshot.reports.contains { $0.kind == .benchmark && $0.status == .partial })
+        #expect(snapshot.reports.contains { $0.kind == .eval && $0.status == .passed })
         #expect(snapshot.reports.contains { $0.kind == .runtime && $0.source == "custom-live-proof" && $0.status == .unavailable })
+    }
+
+    @Test
+    func missingTokenRateBlocksPassedGenerationProofAndKeepsRowPartial() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/no-token-rate", config: #"{"model_type":"qwen3"}"#)
+        let runtimeArtifact = try fixture.writeArtifact(named: "proof/runtime-no-tps.json")
+
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: runtimeArtifact.path,
+                    status: .passed,
+                    metadata: ["physical_footprint_within_limit": "true"]
+                ),
+            ]
+        )
+
+        let row = try #require(snapshot.rows.first)
+        let runtimeReport = try #require(snapshot.reports.first { $0.kind == .runtime })
+
+        #expect(row.supportState == .partial)
+        #expect(runtimeReport.status == .blocked)
+        #expect(runtimeReport.metadata["evidence_validation"] == "passing generation proof must record token/s")
+        #expect(row.requirements.first { $0.kind == .tokenRate }?.state == .blocked)
     }
 
     @Test
@@ -214,5 +277,36 @@ private struct ModelEvidenceFixture {
         )
         try Data("{\"ok\":true}".utf8).write(to: url)
         return url
+    }
+
+    func completeProofDescriptors(for modelId: String) throws -> [ModelEvidenceProofDescriptor] {
+        let runtime = try writeArtifact(named: "proof/\(modelId)-runtime.json")
+        let cache = try writeArtifact(named: "proof/\(modelId)-cache.json")
+        let benchmark = try writeArtifact(named: "proof/\(modelId)-benchmark.json")
+        return [
+            ModelEvidenceProofDescriptor(
+                modelId: modelId,
+                kind: .runtime,
+                artifactPath: runtime.path,
+                status: .passed,
+                metadata: [
+                    "tokens_per_second": "18.4",
+                    "physical_footprint_within_limit": "true",
+                ]
+            ),
+            ModelEvidenceProofDescriptor(
+                modelId: modelId,
+                kind: .cache,
+                artifactPath: cache.path,
+                status: .passed
+            ),
+            ModelEvidenceProofDescriptor(
+                modelId: modelId,
+                kind: .benchmark,
+                artifactPath: benchmark.path,
+                status: .passed,
+                metadata: ["tokens_per_second": "18.4"]
+            ),
+        ]
     }
 }

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -146,7 +146,7 @@ struct ModelLibraryEvidenceServiceTests {
     }
 
     @Test
-    func laterScanRemovesOwnedReportsForRemovedModelAndPreservesOtherProducers() throws {
+    func recreatedServiceReconcilesRemovedModelsAndPreservesOtherProducers() throws {
         let fixture = try ModelEvidenceFixture()
         let retained = try fixture.model(id: "org/retained", config: #"{"model_type":"qwen3"}"#)
         let removed = try fixture.model(id: "org/removed", config: #"{"model_type":"qwen3"}"#)
@@ -161,9 +161,9 @@ struct ModelLibraryEvidenceServiceTests {
                 status: .passed
             )
         )
-        let service = ModelLibraryEvidenceService(registry: registry)
+        let firstService = ModelLibraryEvidenceService(registry: registry)
 
-        let first = service.registerEvidence(
+        let first = firstService.registerEvidence(
             for: [retained, removed],
             proofDescriptors: try fixture.completeProofDescriptors(for: removed.id)
         )
@@ -173,12 +173,14 @@ struct ModelLibraryEvidenceServiceTests {
                 + removedRow.proofReportIDs
         )
 
-        let second = service.registerEvidence(for: [retained])
+        let recreatedService = ModelLibraryEvidenceService(registry: registry)
+        let second = recreatedService.registerEvidence(for: [retained])
         let remainingReportIDs = Set(second.reports.map(\.id))
 
         #expect(removedRow.proofReportIDs.count == 3)
         #expect(removedReportIDs.isDisjoint(with: remainingReportIDs))
-        #expect(second.reports.contains { $0.id == "unrelated-report" })
+        #expect(!second.reports.contains { $0.id == "unrelated-report" })
+        #expect(!recreatedService.snapshot().reports.contains { $0.id == "unrelated-report" })
         #expect(registry.list().contains { $0.id == "unrelated-report" })
     }
 
@@ -296,6 +298,76 @@ struct ModelLibraryEvidenceServiceTests {
         #expect(runtimeReport.counts.blocked == 1)
         #expect(runtimeReport.metadata["evidence_validation"] == "passing generation proof must record token/s")
         #expect(row.requirements.first { $0.kind == .tokenRate }?.state == .blocked)
+    }
+
+    @Test
+    func passingRuntimeWithoutMemoryProofDoesNotPassMemoryRequirement() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/runtime-without-memory", config: #"{"model_type":"qwen3"}"#)
+        let runtimeArtifact = try fixture.writeArtifact(named: "proof/runtime-without-memory.json")
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: runtimeArtifact.path,
+                    status: .passed,
+                    counts: EvidenceReportCounts(total: 1, passed: 1),
+                    metadata: ["tokens_per_second": "17.2"]
+                ),
+            ]
+        )
+        let row = try #require(snapshot.rows.first)
+        let runtimeReport = try #require(snapshot.reports.first { $0.kind == .runtime })
+
+        #expect(row.supportState == .partial)
+        #expect(runtimeReport.status == .passed)
+        #expect(row.requirements.first { $0.kind == .runtimeGeneration }?.state == .passed)
+        #expect(row.requirements.first { $0.kind == .tokenRate }?.state == .passed)
+        #expect(row.requirements.first { $0.kind == .memoryFootprint }?.state == .blocked)
+    }
+
+    @Test
+    func failedMemoryProofOverridesBarePassingRuntimeForMemoryRequirement() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/mixed-memory-proof", config: #"{"model_type":"qwen3"}"#)
+        let runtimeArtifact = try fixture.writeArtifact(named: "proof/mixed-runtime.json")
+        let memoryArtifact = try fixture.writeArtifact(named: "proof/mixed-memory.json")
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: runtimeArtifact.path,
+                    status: .passed,
+                    counts: EvidenceReportCounts(total: 1, passed: 1),
+                    metadata: ["tokens_per_second": "15.8"]
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .memory,
+                    artifactPath: memoryArtifact.path,
+                    status: .failed,
+                    counts: EvidenceReportCounts(total: 1, failed: 1),
+                    metadata: ["physical_footprint_within_limit": "false"]
+                ),
+            ]
+        )
+        let row = try #require(snapshot.rows.first)
+
+        #expect(row.supportState == .unsupported)
+        #expect(row.requirements.first { $0.kind == .runtimeGeneration }?.state == .passed)
+        #expect(row.requirements.first { $0.kind == .memoryFootprint }?.state == .failed)
     }
 
     @Test
@@ -428,9 +500,8 @@ struct ModelLibraryEvidenceServiceTests {
     func registryMetadataAndRowsDoNotExposeFullBundlePaths() throws {
         let fixture = try ModelEvidenceFixture()
         let model = try fixture.model(id: "org/redacted", config: #"{"model_type":"qwen3"}"#)
-        let service = ModelLibraryEvidenceService(
-            registry: EvidenceReportRegistryService(now: fixture.clock)
-        )
+        let registry = EvidenceReportRegistryService(now: fixture.clock)
+        let service = ModelLibraryEvidenceService(registry: registry)
 
         let snapshot = service.registerEvidence(for: [model])
         let row = try #require(snapshot.rows.first)
@@ -441,6 +512,65 @@ struct ModelLibraryEvidenceServiceTests {
         #expect(row.metadata.values.allSatisfy { !$0.contains(fixture.root.path) })
         #expect(cacheReport.metadata["bundle_path"] == "<redacted>")
         #expect(cacheReport.metadata.values.allSatisfy { !$0.contains(fixture.root.path) })
+        #expect(!cacheReport.id.contains(fixture.root.path))
+        #expect(!cacheReport.artifact.path.contains(fixture.root.path))
+        #expect(!cacheReport.artifact.path.hasPrefix("/"))
+        #expect(
+            registry.localArtifactURL(forReportID: cacheReport.id, producer: "model-library-evidence")
+                == model.localDirectory.standardizedFileURL
+        )
+        #expect(
+            !String(decoding: try service.snapshot().stableJSONData(), as: UTF8.self)
+                .contains(fixture.root.path)
+        )
+    }
+
+    @Test
+    func proofIdentityNormalizesModelAndArtifactInputsWithoutPublishingPaths() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/stable-proof", config: #"{"model_type":"qwen3"}"#)
+        let artifact = try fixture.writeArtifact(named: "proof/stable-runtime.json")
+        let registry = EvidenceReportRegistryService(now: fixture.clock)
+        let firstService = ModelLibraryEvidenceService(registry: registry)
+        let first = firstService.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: "  \(model.id)  ",
+                    kind: .runtime,
+                    artifactPath: artifact.path,
+                    status: .passed,
+                    metadata: ["tokens_per_second": "12.0"]
+                ),
+            ]
+        )
+        let firstProofID = try #require(first.rows.first?.proofReportIDs.first)
+
+        let aliasedPath = artifact.deletingLastPathComponent()
+            .appendingPathComponent("alias")
+            .appendingPathComponent("..")
+            .appendingPathComponent(artifact.lastPathComponent)
+            .path
+        let recreatedService = ModelLibraryEvidenceService(registry: registry)
+        let second = recreatedService.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: aliasedPath,
+                    status: .passed,
+                    metadata: ["tokens_per_second": "12.0"]
+                ),
+            ]
+        )
+        let secondProofID = try #require(second.rows.first?.proofReportIDs.first)
+        let proofReport = try #require(second.report(id: secondProofID))
+
+        #expect(firstProofID == secondProofID)
+        #expect(!secondProofID.contains(fixture.root.path))
+        #expect(!proofReport.artifact.path.contains(fixture.root.path))
+        #expect(!proofReport.artifact.path.hasPrefix("/"))
     }
 
     private func report(

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -497,6 +497,84 @@ struct ModelLibraryEvidenceServiceTests {
     }
 
     @Test
+    func missingBlockedAndPartialProofArtifactsPreserveIncompleteTruth() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/missing-incomplete-proofs", config: #"{"model_type":"qwen3"}"#)
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: fixture.root.appendingPathComponent("proof/missing-blocked.json").path,
+                    status: .blocked,
+                    counts: EvidenceReportCounts(total: 1, blocked: 1)
+                ),
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .benchmark,
+                    artifactPath: fixture.root.appendingPathComponent("proof/missing-partial.json").path,
+                    status: .partial,
+                    counts: EvidenceReportCounts(total: 2, passed: 1, warnings: 1)
+                ),
+            ]
+        )
+        let row = try #require(snapshot.rows.first)
+        let runtime = try #require(snapshot.reports.first { $0.kind == .runtime })
+        let benchmark = try #require(snapshot.reports.first { $0.kind == .benchmark })
+
+        #expect(row.supportState == .partial)
+        #expect(runtime.status == .blocked)
+        #expect(runtime.counts == EvidenceReportCounts(total: 1, blocked: 1))
+        #expect(runtime.artifact.availability == .unavailable)
+        #expect(benchmark.status == .partial)
+        #expect(benchmark.counts == EvidenceReportCounts(total: 2, passed: 1, warnings: 1))
+        #expect(benchmark.artifact.availability == .unavailable)
+        #expect(row.requirements.first { $0.kind == .runtimeGeneration }?.state == .blocked)
+        #expect(row.requirements.first { $0.kind == .benchmarkOrEval }?.state == .partial)
+    }
+
+    @Test
+    func unavailableProofRewriteNormalizesAllOutcomeCounts() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/missing-mixed-count-proof", config: #"{"model_type":"qwen3"}"#)
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: fixture.root.appendingPathComponent("proof/missing-mixed.json").path,
+                    status: .passed,
+                    counts: EvidenceReportCounts(
+                        total: 4,
+                        passed: 1,
+                        failed: 1,
+                        blocked: 1,
+                        warnings: 1
+                    ),
+                    metadata: [
+                        "tokens_per_second": "12.0",
+                        "physical_footprint_within_limit": "true",
+                    ]
+                ),
+            ]
+        )
+        let runtime = try #require(snapshot.reports.first { $0.kind == .runtime })
+
+        #expect(runtime.status == .unavailable)
+        #expect(runtime.counts == EvidenceReportCounts(total: 4, skipped: 4))
+    }
+
+    @Test
     func registryMetadataAndRowsDoNotExposeFullBundlePaths() throws {
         let fixture = try ModelEvidenceFixture()
         let model = try fixture.model(id: "org/redacted", config: #"{"model_type":"qwen3"}"#)

--- a/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/ModelLibraryEvidenceServiceTests.swift
@@ -65,6 +65,44 @@ struct ModelLibraryEvidenceServiceTests {
     }
 
     @Test
+    func externalBundleWithFullProofsStaysPartialWhilePreflightIsMissing() throws {
+        let fixture = try ModelEvidenceFixture()
+        let externalURL = try fixture.writeBundle(
+            relativePath: "external/full-proofs",
+            config: #"{"model_type":"qwen3"}"#
+        )
+        let model = MLXModel(
+            id: "org/external-full-proofs",
+            name: "External Full Proofs",
+            description: "",
+            downloadURL: "",
+            bundleDirectory: externalURL,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: try fixture.completeProofDescriptors(for: model.id)
+        )
+        let row = try #require(snapshot.rows.first)
+        let preflight = try #require(
+            row.requirements.first { $0.kind == .compatibilityPreflight }
+        )
+
+        #expect(row.supportState == .partial)
+        #expect(row.supportState != .supported)
+        #expect(preflight.state == .missing)
+        #expect(
+            row.requirements
+                .filter { $0.kind != .compatibilityPreflight }
+                .allSatisfy { $0.state == .passed }
+        )
+    }
+
+    @Test
     func incompleteAndExternalCacheCandidatesAreGroupedAndHiddenByDefault() throws {
         let fixture = try ModelEvidenceFixture()
         let ready = try fixture.model(id: "org/ready", config: #"{"model_type":"qwen3"}"#)
@@ -105,6 +143,70 @@ struct ModelLibraryEvidenceServiceTests {
             )
         )
         #expect(Set(expanded.visibleRows.map(\.modelId)) == [ready.id, incomplete.id, external.id])
+    }
+
+    @Test
+    func laterScanRemovesOwnedReportsForRemovedModelAndPreservesOtherProducers() throws {
+        let fixture = try ModelEvidenceFixture()
+        let retained = try fixture.model(id: "org/retained", config: #"{"model_type":"qwen3"}"#)
+        let removed = try fixture.model(id: "org/removed", config: #"{"model_type":"qwen3"}"#)
+        let unrelatedArtifact = try fixture.writeArtifact(named: "other/report.json")
+        let registry = EvidenceReportRegistryService(now: fixture.clock)
+        registry.register(
+            EvidenceReportDescriptor(
+                id: "unrelated-report",
+                kind: .provider,
+                source: "independent-producer",
+                artifactURL: unrelatedArtifact,
+                status: .passed
+            )
+        )
+        let service = ModelLibraryEvidenceService(registry: registry)
+
+        let first = service.registerEvidence(
+            for: [retained, removed],
+            proofDescriptors: try fixture.completeProofDescriptors(for: removed.id)
+        )
+        let removedRow = try #require(first.rows.first { $0.modelId == removed.id })
+        let removedReportIDs = Set(
+            [removedRow.cacheReportID, removedRow.compatibilityReportID]
+                + removedRow.proofReportIDs
+        )
+
+        let second = service.registerEvidence(for: [retained])
+        let remainingReportIDs = Set(second.reports.map(\.id))
+
+        #expect(removedRow.proofReportIDs.count == 3)
+        #expect(removedReportIDs.isDisjoint(with: remainingReportIDs))
+        #expect(second.reports.contains { $0.id == "unrelated-report" })
+        #expect(registry.list().contains { $0.id == "unrelated-report" })
+    }
+
+    @Test
+    func laterScanRemovesProofReportsNoLongerSuppliedForRetainedModel() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/proof-removed", config: #"{"model_type":"qwen3"}"#)
+        let registry = EvidenceReportRegistryService(now: fixture.clock)
+        let service = ModelLibraryEvidenceService(registry: registry)
+
+        let first = service.registerEvidence(
+            for: [model],
+            proofDescriptors: try fixture.completeProofDescriptors(for: model.id)
+        )
+        let firstRow = try #require(first.rows.first)
+        let removedProofIDs = Set(firstRow.proofReportIDs)
+
+        let second = service.registerEvidence(for: [model])
+        let secondRow = try #require(second.rows.first)
+        let remainingReportIDs = Set(second.reports.map(\.id))
+
+        #expect(removedProofIDs.count == 3)
+        #expect(secondRow.proofReportIDs.isEmpty)
+        #expect(secondRow.supportState == .unproven)
+        #expect(removedProofIDs.isDisjoint(with: remainingReportIDs))
+        #expect(remainingReportIDs.contains(secondRow.cacheReportID))
+        #expect(remainingReportIDs.contains(secondRow.compatibilityReportID))
+        #expect(registry.list().map(\.id).allSatisfy { !removedProofIDs.contains($0) })
     }
 
     @Test
@@ -179,6 +281,7 @@ struct ModelLibraryEvidenceServiceTests {
                     kind: .runtime,
                     artifactPath: runtimeArtifact.path,
                     status: .passed,
+                    counts: EvidenceReportCounts(total: 1, passed: 1),
                     metadata: ["physical_footprint_within_limit": "true"]
                 ),
             ]
@@ -189,8 +292,49 @@ struct ModelLibraryEvidenceServiceTests {
 
         #expect(row.supportState == .partial)
         #expect(runtimeReport.status == .blocked)
+        #expect(runtimeReport.counts.passed == 0)
+        #expect(runtimeReport.counts.blocked == 1)
         #expect(runtimeReport.metadata["evidence_validation"] == "passing generation proof must record token/s")
         #expect(row.requirements.first { $0.kind == .tokenRate }?.state == .blocked)
+    }
+
+    @Test
+    func explicitOverLimitPhysicalFootprintFailsProofAndSupportRow() throws {
+        let fixture = try ModelEvidenceFixture()
+        let model = try fixture.model(id: "org/over-memory-limit", config: #"{"model_type":"qwen3"}"#)
+        let runtimeArtifact = try fixture.writeArtifact(named: "proof/runtime-over-limit.json")
+        let service = ModelLibraryEvidenceService(
+            registry: EvidenceReportRegistryService(now: fixture.clock)
+        )
+
+        let snapshot = service.registerEvidence(
+            for: [model],
+            proofDescriptors: [
+                ModelEvidenceProofDescriptor(
+                    modelId: model.id,
+                    kind: .runtime,
+                    artifactPath: runtimeArtifact.path,
+                    status: .passed,
+                    counts: EvidenceReportCounts(total: 1, passed: 1),
+                    metadata: [
+                        "tokens_per_second": "18.4",
+                        "physical_footprint_within_limit": "false",
+                    ]
+                ),
+            ]
+        )
+        let row = try #require(snapshot.rows.first)
+        let runtimeReport = try #require(snapshot.reports.first { $0.kind == .runtime })
+
+        #expect(row.supportState == .unsupported)
+        #expect(runtimeReport.status == .failed)
+        #expect(runtimeReport.counts.passed == 0)
+        #expect(runtimeReport.counts.failed == 1)
+        #expect(
+            runtimeReport.metadata["evidence_validation"]
+                == "physical footprint exceeded the intended limit"
+        )
+        #expect(row.requirements.first { $0.kind == .memoryFootprint }?.state == .failed)
     }
 
     @Test

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift
@@ -362,6 +362,7 @@ public struct EvalReviewReportBundle: Sendable, Codable, Equatable {
             kind: .eval,
             source: Self.evidenceSource,
             artifactPath: path,
+            artifactLocator: URL(fileURLWithPath: path).lastPathComponent,
             status: evidenceStatus,
             counts: evidenceCounts,
             startedAt: parseEvalReviewEvidenceDate(manifest.generatedAt),

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalScoreboard.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalScoreboard.swift
@@ -70,6 +70,7 @@ public struct EvalScoreboardBundle: Sendable, Codable, Equatable {
             kind: .eval,
             source: Self.evidenceSource,
             artifactPath: scoreboardPath,
+            artifactLocator: URL(fileURLWithPath: scoreboardPath).lastPathComponent,
             status: hasBlockingRegressions || hasRunFailures ? .failed : .passed,
             counts: evidenceCounts,
             startedAt: parseEvalScoreboardEvidenceDate(generatedAt),
@@ -349,9 +350,11 @@ public struct EvalReleaseCandidateScoreSummary: Sendable, Codable, Equatable {
     public let artifactPath: String
     public let baselinePath: String?
     public let verdict: String
+    // swiftlint:disable discouraged_optional_boolean
     /// Suite-derived run failure state. Optional so previously written
     /// scoreboard artifacts remain decodable.
     public let hasRunFailures: Bool?
+    // swiftlint:enable discouraged_optional_boolean
     public let noRegressionAllowed: Int
     public let noRegressionObserved: Int
     public let noRegressionPassed: Bool
@@ -424,6 +427,12 @@ public struct EvalScoreboardComparisonSummary: Sendable, Codable, Equatable {
 }
 
 public enum EvalScoreboardBuilder {
+    private struct LocatedEvidenceSummary {
+        let summary: EvidenceReportSummary
+        let artifactURL: URL
+        let registryURL: URL
+    }
+
     public static func build(
         generatedAt: String? = nil,
         sourceRoots: [URL],
@@ -476,7 +485,7 @@ public enum EvalScoreboardBuilder {
     public static func loadBundlesRecursively(from roots: [URL]) throws -> [EvalScoreboardInput] {
         let summaries = try loadEvidenceSummariesRecursively(from: roots)
             .filter {
-                $0.kind == .eval && $0.source == EvalReviewReportBundle.evidenceSource
+                $0.summary.kind == .eval && $0.summary.source == EvalReviewReportBundle.evidenceSource
             }
         guard !summaries.isEmpty else {
             throw EvalScoreboardError.noBundles(roots.map(\.path).joined(separator: ", "))
@@ -485,8 +494,9 @@ public enum EvalScoreboardBuilder {
         let fm = FileManager.default
         let decoder = JSONDecoder()
         var inputs: [EvalScoreboardInput] = []
-        for summary in summaries.sorted(by: evidenceSummarySort) {
-            let url = URL(fileURLWithPath: summary.artifact.path)
+        for located in summaries.sorted(by: locatedEvidenceSummarySort) {
+            let summary = located.summary
+            let url = located.artifactURL
             guard summary.artifact.availability == .available,
                   fm.fileExists(atPath: url.path)
             else {
@@ -518,15 +528,11 @@ public enum EvalScoreboardBuilder {
         return inputs
     }
 
-    private static func loadEvidenceSummariesRecursively(from roots: [URL]) throws -> [EvidenceReportSummary] {
+    private static func loadEvidenceSummariesRecursively(from roots: [URL]) throws -> [LocatedEvidenceSummary] {
         let fm = FileManager.default
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        var registeredAt = Date.distantPast
-        let registry = EvidenceReportRegistryService(
-            fileManager: fm,
-            now: { registeredAt }
-        )
+        var summariesByID: [String: LocatedEvidenceSummary] = [:]
         for root in roots {
             var isDirectory: ObjCBool = false
             guard fm.fileExists(atPath: root.path, isDirectory: &isDirectory) else {
@@ -567,36 +573,78 @@ public enum EvalScoreboardBuilder {
                 do {
                     let snapshot = try decoder.decode(EvidenceReportRegistrySnapshot.self, from: data)
                     for summary in snapshot.reports {
-                        registeredAt = summary.registeredAt
-                        let artifactError =
-                            summary.artifact.availability == .error
-                            ? summary.artifact.message ?? "registered artifact error"
-                            : nil
-                        registry.register(
-                            EvidenceReportDescriptor(
-                                id: summary.id,
-                                kind: summary.kind,
-                                source: summary.source,
-                                artifactPath: summary.artifact.path,
-                                status: summary.status,
-                                counts: summary.counts,
-                                startedAt: summary.startedAt,
-                                completedAt: summary.completedAt,
-                                metadata: summary.metadata,
-                                artifactError: artifactError
+                        guard let artifactURL = summary.artifact.resolvedURL(
+                            relativeTo: url.deletingLastPathComponent()
+                        ) else {
+                            throw EvalScoreboardError.invalidEvidenceRegistry(
+                                url.path,
+                                "report '\(summary.id)' has an invalid artifact locator"
                             )
+                        }
+                        let located = LocatedEvidenceSummary(
+                            summary: summary,
+                            artifactURL: artifactURL,
+                            registryURL: url
                         )
+                        if let existing = summariesByID[summary.id] {
+                            if prefers(located, over: existing, fileManager: fm) {
+                                summariesByID[summary.id] = located
+                            }
+                        } else {
+                            summariesByID[summary.id] = located
+                        }
                     }
                 } catch {
+                    if let error = error as? EvalScoreboardError {
+                        throw error
+                    }
                     throw EvalScoreboardError.invalidEvidenceRegistry(url.path, error.localizedDescription)
                 }
             }
         }
-        let summaries = registry.list()
+        let summaries = Array(summariesByID.values)
         guard !summaries.isEmpty else {
             throw EvalScoreboardError.noEvidenceRegistries(roots.map(\.path).joined(separator: ", "))
         }
         return summaries
+    }
+
+    private static func prefers(
+        _ incoming: LocatedEvidenceSummary,
+        over existing: LocatedEvidenceSummary,
+        fileManager: FileManager
+    ) -> Bool {
+        let incomingDate = incoming.summary.completedAt ?? incoming.summary.registeredAt
+        let existingDate = existing.summary.completedAt ?? existing.summary.registeredAt
+        if incomingDate != existingDate {
+            return incomingDate > existingDate
+        }
+        if incoming.summary.registeredAt != existing.summary.registeredAt {
+            return incoming.summary.registeredAt > existing.summary.registeredAt
+        }
+        if incoming.summary.generation != existing.summary.generation {
+            return incoming.summary.generation > existing.summary.generation
+        }
+
+        let incomingExists = fileManager.fileExists(atPath: incoming.artifactURL.path)
+        let existingExists = fileManager.fileExists(atPath: existing.artifactURL.path)
+        if incomingExists != existingExists {
+            return incomingExists
+        }
+        return incoming.registryURL.path > existing.registryURL.path
+    }
+
+    private static func locatedEvidenceSummarySort(
+        _ lhs: LocatedEvidenceSummary,
+        _ rhs: LocatedEvidenceSummary
+    ) -> Bool {
+        if evidenceSummarySort(lhs.summary, rhs.summary) {
+            return true
+        }
+        if evidenceSummarySort(rhs.summary, lhs.summary) {
+            return false
+        }
+        return lhs.artifactURL.path < rhs.artifactURL.path
     }
 
     private static func evidenceSummarySort(

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift
@@ -288,18 +288,22 @@ struct EvalReviewReportTests {
         decoder.dateDecodingStrategy = .iso8601
         let snapshot = try decoder.decode(EvidenceReportRegistrySnapshot.self, from: data)
         let report = try #require(snapshot.reports.first)
+        let encoded = try #require(String(bytes: data, encoding: .utf8))
 
+        #expect(snapshot.schemaVersion == EvidenceReportRegistrySnapshot.currentSchemaVersion)
         #expect(snapshot.reports.count == 1)
         #expect(report.kind == .eval)
         #expect(report.source == EvalReviewReportBundle.evidenceSource)
         #expect(report.status == .failed)
-        #expect(report.artifact.path == summaryURL.path)
+        #expect(report.artifact.path == EvalReviewReportBundle.summaryFileName)
         #expect(report.artifact.availability == .available)
         #expect(report.counts.total == 2)
         #expect(report.counts.passed == 1)
         #expect(report.counts.failed == 1)
         #expect(report.metadata["artifact_id"] == "eval-smoke-1")
         #expect(report.metadata["judge_model"] == "<redacted>")
+        #expect(!report.id.contains(root.path))
+        #expect(!encoded.contains(root.path))
     }
 
     @Test func loadingStoredBundleUsesManifestModelRoles() throws {

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalScoreboardTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalScoreboardTests.swift
@@ -252,6 +252,47 @@ struct EvalScoreboardTests {
         #expect(scoreboard.models.first?.counts.total == 6)
     }
 
+    @Test func loadBundlesRecursivelyKeepsDistinctReportsWithoutArtifactIds() throws {
+        let root = try temporaryDirectory()
+        let firstDir = root.appendingPathComponent("main/first/report", isDirectory: true)
+        let secondDir = root.appendingPathComponent("main/second/report", isDirectory: true)
+        let first = EvalReviewReportBuilder.build(
+            manifest: manifest(
+                generatedAt: "2026-06-17T00:00:00Z",
+                commit: "first-commit",
+                artifactPath: firstDir.path
+            ),
+            reports: [
+                input(
+                    suite: "AgentLoop",
+                    reportPath: firstDir.appendingPathComponent("AgentLoop.json").path,
+                    report: passingFixtureReport()
+                ),
+            ]
+        )
+        let second = EvalReviewReportBuilder.build(
+            manifest: manifest(
+                generatedAt: "2026-06-18T00:00:00Z",
+                commit: "second-commit",
+                artifactPath: secondDir.path
+            ),
+            reports: [
+                input(
+                    suite: "AgentLoop",
+                    reportPath: secondDir.appendingPathComponent("AgentLoop.json").path,
+                    report: try fixtureReport("current")
+                ),
+            ]
+        )
+        try writeBundle(first, to: firstDir)
+        try writeBundle(second, to: secondDir)
+
+        let loaded = try EvalScoreboardBuilder.loadBundlesRecursively(from: [root])
+
+        #expect(loaded.count == 2)
+        #expect(Set(loaded.map { $0.bundle.manifest.commit }) == ["first-commit", "second-commit"])
+    }
+
     @Test func loadBundlesRecursivelyFailsOnInvalidRegistryBackedSummaryJSON() throws {
         let baselineReport = try fixtureReport("baseline")
         let bundle = EvalReviewReportBuilder.build(

--- a/docs/EVIDENCE_REPORT_REGISTRY.md
+++ b/docs/EVIDENCE_REPORT_REGISTRY.md
@@ -1,18 +1,18 @@
 # Evidence Report Registry
 
 The evidence report registry is the shared projection layer for report
-artifacts produced by eval, benchmark, runtime, live-proof, run-trace, and
-provider validation flows. It does not create a new report destination or move
-artifact files; callers register local artifact descriptors and receive typed
-summaries that can be listed, filtered, serialized, and rendered by future
-surfaces.
+artifacts produced by eval, benchmark, runtime, live-proof, run-trace, provider
+validation, and model-library evidence flows. It does not create a new report
+destination or move artifact files; callers register local artifact descriptors
+and receive typed summaries that can be listed, filtered, serialized, and
+rendered by future surfaces.
 
 ## Model
 
 `EvidenceReportDescriptor` is the input from a local producer:
 
 - `kind`: one of `eval`, `benchmark`, `runtime`, `live_proof`, `run_trace`,
-  `provider`, or `custom`.
+  `provider`, `model_compatibility`, `cache`, or `custom`.
 - `source`: the producing flow, such as `evals-pr-evidence` or
   `provider-connectivity`.
 - `artifactPath`: the local artifact path. Relative paths can be resolved
@@ -54,3 +54,29 @@ watcher scoreboard. It does not scan arbitrary `summary.json` files as a second
 report source; it follows registry summaries, fails closed when a registered
 artifact is unavailable or invalid, and writes its own scoreboard registry
 snapshot with source `osaurus-evals-scoreboard`.
+
+## Model Library Evidence
+
+`ModelLibraryEvidenceService` is the model-library producer for the shared
+registry. It registers read-only rows for:
+
+- local cache/import status (`kind = cache`, `source = model-library-cache`);
+- compatibility and preflight status (`kind = model_compatibility`,
+  `source = model-library-preflight`);
+- optional cache, benchmark, and runtime proof artifacts supplied by proof
+  producers.
+
+The service preserves model state as `supported`, `partial`, `unsupported`, or
+`unproven` metadata while mapping registry status to the common report
+vocabulary. Missing local/proof artifacts stay explicit `unavailable` rows
+rather than becoming support claims.
+
+The model projection also returns grouping metadata for consumers. Incomplete
+local directories and external cache/import candidates are grouped and excluded
+from default visible rows, so large local caches do not flood model views. A
+consumer can opt into those groups for repair or audit workflows.
+
+Full bundle paths are not copied into model row metadata. The registry artifact
+path remains the local source-of-truth pointer, but model evidence metadata uses
+redacted display paths such as `.../repo-name` and stores `bundle_path` as
+`<redacted>`.

--- a/docs/EVIDENCE_REPORT_REGISTRY.md
+++ b/docs/EVIDENCE_REPORT_REGISTRY.md
@@ -15,26 +15,31 @@ rendered by future surfaces.
   `provider`, `model_compatibility`, `cache`, or `custom`.
 - `source`: the producing flow, such as `evals-pr-evidence` or
   `provider-connectivity`.
-- `artifactPath`: the local artifact path. Relative paths can be resolved
-  against a caller-provided base URL.
+- `artifactPath`: the machine-local artifact path used during registration and
+  resolution. It is never serialized as an absolute path.
+- `artifactLocator`: an optional privacy-safe relative locator exported in the
+  summary. When omitted, the registry derives an opaque content/path digest.
 - `status` and `counts`: summary outcome fields from the producer.
 - `startedAt`, `completedAt`, and registration time.
 - `metadata`: string metadata, redacted at registration before storage.
 
-`EvidenceReportSummary` is the canonical output. Missing artifact paths are
-kept as explicit rows with `status = unavailable` and
-`artifact.availability = unavailable`. Descriptors that already know they
-failed to parse or validate can pass `artifactError`, which produces an
-explicit `error` row.
+`EvidenceReportSummary` is the canonical output. Its `artifact.path` is a safe
+relative or opaque locator; machine-local resolution remains private to the
+registry service. Missing artifacts stay explicit with unavailable or error
+availability. Known failed, errored, blocked, and partial outcomes retain that
+status instead of being rewritten as successful or merely unavailable.
 
 ## Behavior
 
-`EvidenceReportRegistryService` stores summaries in memory, dedupes repeated
-descriptors by explicit `id` or by `(kind, source, artifactPath)`, and supports
-filters for kind, source, status, and artifact availability. Re-registering the
-same identity is a deliberate refresh: the incoming summary replaces the prior
-one even when its artifact has since become unavailable. Stable JSON output uses
-the package canonical encoder with sorted keys and ISO-8601 dates.
+`EvidenceReportRegistryService` stores summaries in memory, derives stable IDs
+from an explicit privacy-safe ID or normalized artifact content/locator
+identity, and supports filters for kind, source, status, and artifact
+availability. Re-registering the same identity is a deliberate refresh: the
+incoming summary replaces the prior one even when its artifact has since become
+unavailable. Producer-scoped reconciliation atomically replaces one producer's
+complete report set without deleting unrelated producers. Monotonic generations
+determine projection precedence. Stable JSON output uses the package canonical
+encoder with sorted keys and ISO-8601 dates.
 
 Metadata is redacted before it reaches the registry. Sensitive keys such as API
 keys, authorization headers, passwords, private keys, credentials, and token
@@ -75,7 +80,7 @@ local directories and external cache/import candidates are grouped and excluded
 from default visible rows, so large local caches do not flood model views. A
 consumer can opt into those groups for repair or audit workflows.
 
-Full bundle paths are not copied into model row metadata. The registry artifact
-path remains the local source-of-truth pointer, but model evidence metadata uses
-redacted display paths such as `.../repo-name` and stores `bundle_path` as
-`<redacted>`.
+Full bundle paths are not copied into model row metadata or serialized artifact
+locators. Model evidence metadata uses redacted display paths such as
+`.../repo-name` and stores `bundle_path` as `<redacted>`; machine-local artifact
+resolution remains an in-process registry concern.

--- a/docs/EVIDENCE_REPORT_REGISTRY.md
+++ b/docs/EVIDENCE_REPORT_REGISTRY.md
@@ -31,11 +31,10 @@ explicit `error` row.
 
 `EvidenceReportRegistryService` stores summaries in memory, dedupes repeated
 descriptors by explicit `id` or by `(kind, source, artifactPath)`, and supports
-filters for kind, source, status, and artifact availability. Stable JSON output
-uses the package canonical encoder with sorted keys and ISO-8601 dates.
-Watcher scoreboard discovery uses the same registry service precedence, so a
-newer registration replaces an older available summary when an explicit ID is
-reused.
+filters for kind, source, status, and artifact availability. Re-registering the
+same identity is a deliberate refresh: the incoming summary replaces the prior
+one even when its artifact has since become unavailable. Stable JSON output uses
+the package canonical encoder with sorted keys and ISO-8601 dates.
 
 Metadata is redacted before it reaches the registry. Sensitive keys such as API
 keys, authorization headers, passwords, private keys, credentials, and token

--- a/docs/MODEL_EVIDENCE_COMPATIBILITY_CENTER.md
+++ b/docs/MODEL_EVIDENCE_COMPATIBILITY_CENTER.md
@@ -1,0 +1,38 @@
+# Model Evidence and Compatibility Center
+
+The model evidence projection separates file-level compatibility from support
+claims. A model can pass compatibility preflight and still remain `unproven`
+until live evidence rows are registered.
+
+## Status contract
+
+- `supported`: local/import state is available, compatibility is not blocked,
+  and passing runtime, token/s, memory, cache, and benchmark or eval evidence is
+  registered for the exact model row.
+- `partial`: compatibility or proof evidence exists, but at least one required
+  dimension is incomplete, blocked, unavailable, or only partially proven.
+- `unsupported`: compatibility preflight blocks the model, or a registered proof
+  row failed or errored.
+- `unproven`: the model is catalog-only, externally discovered without proof, or
+  locally loadable but has no live proof rows yet.
+
+## Proof metadata
+
+Generation proof rows (`runtime` and `benchmark`) must record positive
+`tokens_per_second` metadata to be treated as passing evidence. Memory proof can
+come from a `runtime` or `memory` proof row with one of:
+
+- `physical_footprint_within_limit=true`
+- `memory_within_limit=true`
+- `ram_within_limit=true`
+- `memory_proof=passed`
+- `ram_proof=passed`
+
+Cache proof is a separate `cache` row so import state and runtime cache behavior
+do not get conflated. Benchmark and eval artifacts register as their own report
+kinds; either a passing benchmark or a passing eval row can satisfy the
+benchmark/eval requirement.
+
+Missing artifacts, descriptor errors, missing token/s on passing generation
+proof, and missing memory proof on passing memory rows are downgraded before the
+row support state is computed.

--- a/docs/MODEL_EVIDENCE_COMPATIBILITY_CENTER.md
+++ b/docs/MODEL_EVIDENCE_COMPATIBILITY_CENTER.md
@@ -38,7 +38,7 @@ Missing artifacts, descriptor errors, missing token/s on passing generation
 proof, and missing memory proof on passing memory rows are downgraded before the
 row support state is computed.
 
-Each scan reconciles only report IDs previously registered by the same model
-evidence service instance. Removed models and omitted proofs therefore leave no
-orphaned projection rows, while reports from other registry producers remain
-untouched.
+Each scan atomically replaces the complete `model-library-evidence` producer
+scope in the registry. Removed models and omitted proofs therefore leave no
+orphaned projection rows even when the service is recreated, while reports from
+other registry producers remain untouched.

--- a/docs/MODEL_EVIDENCE_COMPATIBILITY_CENTER.md
+++ b/docs/MODEL_EVIDENCE_COMPATIBILITY_CENTER.md
@@ -6,7 +6,8 @@ until live evidence rows are registered.
 
 ## Status contract
 
-- `supported`: local/import state is available, compatibility is not blocked,
+- `supported`: local/import state is available, compatibility preflight is
+  supported,
   and passing runtime, token/s, memory, cache, and benchmark or eval evidence is
   registered for the exact model row.
 - `partial`: compatibility or proof evidence exists, but at least one required
@@ -36,3 +37,8 @@ benchmark/eval requirement.
 Missing artifacts, descriptor errors, missing token/s on passing generation
 proof, and missing memory proof on passing memory rows are downgraded before the
 row support state is computed.
+
+Each scan reconciles only report IDs previously registered by the same model
+evidence service instance. Removed models and omitted proofs therefore leave no
+orphaned projection rows, while reports from other registry producers remain
+untouched.


### PR DESCRIPTION
## Summary

- Defines one internal evidence registry for compatibility, benchmark, cache, and proof reports.
- Reconciles producer-owned rows atomically across service recreation without deleting unrelated producers.
- Separates proven, partial, unsupported, failed, blocked, and unproven outcomes without inferring support from a load-only or bare report pass.
- Gives serialized reports privacy-safe IDs and relative artifact locators; machine-local resolution remains private.
- Adds tolerant schema decoding and deterministic proof-input normalization for eval consumers.

## Evidence truth

- A report-level pass cannot satisfy a dimension whose own predicate is false.
- Missing artifacts preserve explicit failed, error, blocked, and partial outcomes.
- When a status changes, contradictory count buckets are cleared and rebuilt consistently.
- Supported rows require a supported compatibility preflight.
- Explicit over-limit physical-footprint evidence remains failed or unsupported.
- Eval locator resolution and deduplication fail closed.

## Validation

- 30 focused OsaurusCore evidence tests passed.
- 23 focused OsaurusEvals review and scoreboard tests passed.
- Final independent reruns produced the same results.
- Scoped strict SwiftLint: 0 violations.
- `git diff --check origin/main...HEAD` passed.
- Rebased cleanly on current `main` containing #2078.

## Draft gate

This PR is intentionally draft. It is an internal correctness foundation and does not yet provide a complete user workflow. Promotion requires:

- durable shared registry persistence and migration across app launches;
- production model-library UI, filtering, detail presentation, and refresh lifecycle;
- live watcher/proof ingestion and artifact lifecycle management;
- a stable public locator and identity contract with machine-local resolver integration;
- real production proof generation rather than caller-supplied fixtures.

External full-proof rows remain partial unless a supported compatibility preflight exists.
