### PR TITLE
Add `osaurus serve --supervise` keep-alive loop to survive app quit

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
@@ -105,9 +105,13 @@ struct OsaurusCLI {
             osaurus - CLI for Osaurus
 
             Usage:
-              osaurus serve [--port N] [--expose] [--yes|-y]
+              osaurus serve [--port N] [--expose] [--yes|-y] [--supervise] [--interval N]
                                       Start the server (default: localhost only). If --expose
                                       is set, a warning prompt will appear unless --yes is provided.
+                                      With --supervise, run a long-lived keep-alive loop that
+                                      relaunches the server whenever it goes down (probe every
+                                      --interval seconds, default 15) — intended to run under a
+                                      launchd KeepAlive LaunchAgent so the server survives quit.
               osaurus stop            Stop the server
               osaurus mcp [--access-key KEY]
                                       Run MCP stdio server proxying to local HTTP. When

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
@@ -15,6 +15,8 @@ public struct ServeCommand: Command {
         var desiredPort: Int? = nil
         var expose: Bool = false
         var assumeYes: Bool = false
+        var supervise: Bool = false
+        var probeInterval: TimeInterval = 15.0
         var i = 0
         while i < args.count {
             let a = args[i]
@@ -29,6 +31,14 @@ public struct ServeCommand: Command {
             } else if a == "--yes" || a == "-y" {
                 assumeYes = true
                 i += 1
+                continue
+            } else if a == "--supervise" {
+                supervise = true
+                i += 1
+                continue
+            } else if a == "--interval", i + 1 < args.count {
+                if let n = Double(args[i + 1]), n > 0 { probeInterval = n }
+                i += 2
                 continue
             }
             i += 1
@@ -55,14 +65,40 @@ public struct ServeCommand: Command {
             }
         }
 
-        // Launch the app if not running, then post local-only distributed notification to start
-        await AppControl.launchAppIfNeeded()
         let buildInfo: () -> [AnyHashable: Any] = {
             var info: [AnyHashable: Any] = [:]
             if let p = desiredPort { info["port"] = p }
             if expose { info["expose"] = true }
             return info
         }
+
+        // Supervise mode: keep the server alive indefinitely instead of a
+        // one-shot start. Probes /health and relaunches the app whenever it is
+        // down. Intended to run under a launchd KeepAlive LaunchAgent so the
+        // server (and its in-app scheduler) survives quit/crash/logout/reboot.
+        if supervise {
+            let serveDesiredPort = desiredPort
+            let serveExpose = expose
+            let supervisor = ServerSupervisor(
+                port: desiredPort ?? (Configuration.resolveConfiguredPort() ?? 1337),
+                probeInterval: probeInterval,
+                ensureServing: {
+                    await AppControl.launchAppIfNeeded()
+                    var info: [AnyHashable: Any] = [:]
+                    if let p = serveDesiredPort { info["port"] = p }
+                    if serveExpose { info["expose"] = true }
+                    AppControl.postDistributedNotification(
+                        name: "com.dinoki.osaurus.control.serve",
+                        userInfo: info
+                    )
+                }
+            )
+            await supervisor.run()
+            return
+        }
+
+        // Launch the app if not running, then post local-only distributed notification to start
+        await AppControl.launchAppIfNeeded()
         AppControl.postDistributedNotification(
             name: "com.dinoki.osaurus.control.serve",
             userInfo: buildInfo()

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/ServerSupervisor.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/ServerSupervisor.swift
@@ -1,0 +1,78 @@
+//
+//  ServerSupervisor.swift
+//  osaurus
+//
+//  Keeps the Osaurus server alive across app quit/crash. Periodically probes
+//  /health and re-launches the app when it is down. Intended to run as a
+//  long-lived process under a launchd KeepAlive LaunchAgent, so the server
+//  (and the in-app scheduler that only ticks while the app is running)
+//  survives quit, crash, logout, and reboot.
+//
+
+import Foundation
+
+/// A long-running keep-alive loop for the Osaurus server.
+///
+/// On each iteration it probes `/health`; if the server is down it asks for it
+/// to be brought back up. All collaborators are injected so the loop logic is
+/// unit-testable without a real server, app, or sleep.
+public struct ServerSupervisor: Sendable {
+    /// Port to probe for health.
+    public let port: Int
+    /// Seconds between health probes.
+    public let probeInterval: TimeInterval
+    /// Number of iterations to run before returning. `nil` runs forever
+    /// (production); a finite value bounds the loop for tests.
+    public let maxIterations: Int?
+
+    /// Probe the server's health. Injectable for testing.
+    let healthCheck: @Sendable (Int) async -> Bool
+    /// Bring the server back up (launch app + request serve). Injectable for testing.
+    let ensureServing: @Sendable () async -> Void
+    /// Sleep between probes. Injectable for testing.
+    let sleep: @Sendable (TimeInterval) async -> Void
+    /// Emit a log line. Injectable for testing.
+    let log: @Sendable (String) -> Void
+
+    public init(
+        port: Int,
+        probeInterval: TimeInterval = 15.0,
+        maxIterations: Int? = nil,
+        healthCheck: @escaping @Sendable (Int) async -> Bool = {
+            await ServerControl.checkHealth(port: $0)
+        },
+        ensureServing: @escaping @Sendable () async -> Void,
+        sleep: @escaping @Sendable (TimeInterval) async -> Void = {
+            try? await Task.sleep(nanoseconds: UInt64(max(0, $0) * 1_000_000_000))
+        },
+        log: @escaping @Sendable (String) -> Void = { print($0) }
+    ) {
+        self.port = port
+        self.probeInterval = probeInterval
+        self.maxIterations = maxIterations
+        self.healthCheck = healthCheck
+        self.ensureServing = ensureServing
+        self.sleep = sleep
+        self.log = log
+    }
+
+    /// Run the supervise loop. Returns only after `maxIterations` iterations;
+    /// in production (`maxIterations == nil`) it never returns.
+    public func run() async {
+        log("supervising osaurus server on port \(port) (probe every \(Int(probeInterval))s)")
+        var wasHealthy = true
+        var iteration = 0
+        while maxIterations.map({ iteration < $0 }) ?? true {
+            let healthy = await healthCheck(port)
+            if !healthy {
+                log("server on port \(port) is not responding — relaunching")
+                await ensureServing()
+            } else if !wasHealthy {
+                log("server on port \(port) is back up")
+            }
+            wasHealthy = healthy
+            iteration += 1
+            await sleep(probeInterval)
+        }
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ServerSupervisorTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ServerSupervisorTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ServerSupervisorTests: XCTestCase {
+    /// Records probe outcomes and relaunch calls, and scripts the health sequence.
+    private actor Recorder {
+        private var healthSequence: [Bool]
+        private var index = 0
+        private(set) var ensureCount = 0
+        private(set) var probeCount = 0
+
+        init(_ healthSequence: [Bool]) {
+            self.healthSequence = healthSequence
+        }
+
+        func nextHealth() -> Bool {
+            defer { index += 1 }
+            probeCount += 1
+            if index < healthSequence.count { return healthSequence[index] }
+            return healthSequence.last ?? true
+        }
+
+        func recordEnsure() {
+            ensureCount += 1
+        }
+    }
+
+    private func supervisor(_ rec: Recorder, iterations: Int) -> ServerSupervisor {
+        ServerSupervisor(
+            port: 1337,
+            probeInterval: 0,
+            maxIterations: iterations,
+            healthCheck: { _ in await rec.nextHealth() },
+            ensureServing: { await rec.recordEnsure() },
+            sleep: { _ in },
+            log: { _ in }
+        )
+    }
+
+    func testRelaunchesOnEveryDownTick() async {
+        let rec = Recorder([false, false, false])
+        await supervisor(rec, iterations: 3).run()
+
+        let ensureCount = await rec.ensureCount
+        let probeCount = await rec.probeCount
+        XCTAssertEqual(probeCount, 3)
+        XCTAssertEqual(ensureCount, 3)
+    }
+
+    func testNeverRelaunchesWhileHealthy() async {
+        let rec = Recorder([true, true, true, true])
+        await supervisor(rec, iterations: 4).run()
+
+        let ensureCount = await rec.ensureCount
+        XCTAssertEqual(ensureCount, 0)
+    }
+
+    func testRelaunchesOnlyWhileDownAcrossRecovery() async {
+        // down, down, up, up -> two relaunches, then it leaves the server alone.
+        let rec = Recorder([false, false, true, true])
+        await supervisor(rec, iterations: 4).run()
+
+        let ensureCount = await rec.ensureCount
+        XCTAssertEqual(ensureCount, 2)
+    }
+}


### PR DESCRIPTION
## Motivation

The Osaurus server — and the in-app scheduler that only ticks while the app is running — lives inside `Osaurus.app`. `osaurus serve` is a one-shot *client*: it launches the app, requests serving, polls `/health` once, and exits. If the app later **quits, crashes, or the machine logs out**, nothing brings the server back. There's no `launchd` / LaunchAgent backbone anywhere in the app, so an Osaurus you rely on for background/scheduled work silently stops the moment the GUI app isn't running.

## What this adds

A long-lived **supervise mode**:

```
osaurus serve --supervise [--interval N] [--port N] [--expose --yes]
```

`--supervise` runs a loop that probes `/health` every `--interval` seconds (default 15) and, whenever the server is down, relaunches it via the **same** launch + serve-notification path the one-shot mode already uses. It never exits, so it can run under a `launchd` **KeepAlive** LaunchAgent: launchd keeps the supervisor alive, the supervisor keeps the server alive — giving quit/crash/logout/reboot resilience. `--port` / `--expose` are honored exactly as in one-shot mode.

## Design

The loop is a small `ServerSupervisor` value (`OsaurusCLICore/Services/ServerSupervisor.swift`) whose collaborators — health check, relaunch, sleep, log — are injected, so the behavior is unit-testable without a real server, app, or wall-clock sleep. `serve` constructs the production supervisor (real `ServerControl.checkHealth` + `AppControl.launchAppIfNeeded` + serve notification) and runs it. Everything is in the light, MLX-free `OsaurusCLI` package.

## Deploying as a LaunchAgent

`~/Library/LaunchAgents/ai.osaurus.serve.plist`:

```xml
<dict>
  <key>Label</key>            <string>ai.osaurus.serve</string>
  <key>ProgramArguments</key> <array>
      <string>/opt/homebrew/bin/osaurus</string>
      <string>serve</string><string>--supervise</string>
  </array>
  <key>RunAtLoad</key> <true/>
  <key>KeepAlive</key> <true/>
  <key>StandardOutPath</key>  <string>/tmp/osaurus-serve.out.log</string>
  <key>StandardErrorPath</key> <string>/tmp/osaurus-serve.err.log</string>
</dict>
```

```sh
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.osaurus.serve.plist
```

(If you'd like a `osaurus serve install-agent` / `uninstall-agent` convenience command to generate and load this plist, happy to add it as a follow-up.)

## Tests

`ServerSupervisorTests` drives the loop with injected collaborators and a bounded iteration count: it relaunches on every down tick, never relaunches while healthy, and stops relaunching once the server recovers. Full `OsaurusCLI` suite stays green (91 tests). `swift-format lint --strict` clean. Verified end-to-end: `osaurus help` shows the new flags and the executable builds.

Mutation-checked: inverting the down-detection makes the relaunch tests fail, confirming they pin the behavior.