### PR TITLE
Don't treat a bare `tools uninstall` name as a CWD path (avoid deleting the wrong directory)

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsUninstall.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsUninstall.swift
@@ -15,55 +15,7 @@ public struct ToolsUninstall {
         }
         let fm = FileManager.default
         let root = Configuration.toolsRootDirectory()
-        var dirToRemove: URL?
-        // If target looks like a path and exists, use it
-        let tURL = URL(fileURLWithPath: target)
-        var isDir: ObjCBool = false
-        if fm.fileExists(atPath: tURL.path, isDirectory: &isDir), isDir.boolValue {
-            dirToRemove = tURL
-        } else {
-            // Try direct folder under Tools root (directory name is plugin_id)
-            let candidate = root.appendingPathComponent(target, isDirectory: true)
-            if fm.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
-                dirToRemove = candidate
-            } else {
-                // Match by plugin_id from receipt.json
-                if let contents = try? fm.contentsOfDirectory(atPath: root.path) {
-                    for entry in contents {
-                        // Skip hidden files
-                        if entry.hasPrefix(".") { continue }
-
-                        let pluginDir = root.appendingPathComponent(entry, isDirectory: true)
-
-                        // Try to read receipt.json from current version
-                        let currentLink = pluginDir.appendingPathComponent("current")
-                        if let versionName = try? fm.destinationOfSymbolicLink(atPath: currentLink.path) {
-                            let receiptURL =
-                                pluginDir
-                                .appendingPathComponent(versionName, isDirectory: true)
-                                .appendingPathComponent("receipt.json")
-
-                            if let data = try? Data(contentsOf: receiptURL),
-                                let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-                            {
-                                let pluginId = (obj["plugin_id"] as? String) ?? ""
-                                if pluginId == target {
-                                    dirToRemove = pluginDir
-                                    break
-                                }
-                            }
-                        }
-
-                        // Also match by directory name (which should be the plugin_id)
-                        if entry == target {
-                            dirToRemove = pluginDir
-                            break
-                        }
-                    }
-                }
-            }
-        }
-        guard let dir = dirToRemove else {
+        guard let dir = resolveTargetDirectory(target, root: root, fileManager: fm) else {
             fputs("Could not locate installed plugin for '\(target)'\n", stderr)
             exit(EXIT_FAILURE)
         }
@@ -77,5 +29,66 @@ public struct ToolsUninstall {
         // Notify app to reload
         AppControl.postDistributedNotification(name: "com.dinoki.osaurus.control.toolsReload", userInfo: [:])
         exit(EXIT_SUCCESS)
+    }
+
+    /// `true` when `target` is unambiguously a filesystem path (not a bare
+    /// plugin id / folder name). Mirrors ToolsInstall's path convention.
+    static func looksLikeExplicitPath(_ target: String) -> Bool {
+        target.hasPrefix("/") || target.hasPrefix("./") || target.hasPrefix("../")
+            || target.hasPrefix("~") || target.contains("/")
+    }
+
+    /// Resolve the directory to remove for `target`, checking sources in order:
+    /// (1) an explicit filesystem path — only when `target` actually looks like a
+    /// path, so a bare name like `foo` can never resolve to a same-named
+    /// directory in the current working directory; (2) a folder directly under
+    /// the tools root (its name is the plugin id); (3) a plugin whose
+    /// `receipt.json` plugin_id (or directory name) matches `target`.
+    static func resolveTargetDirectory(
+        _ target: String,
+        root: URL,
+        fileManager fm: FileManager = .default
+    ) -> URL? {
+        var isDir: ObjCBool = false
+
+        // (1) Explicit path mode — gated so a bare plugin name is never treated
+        // as a current-working-directory path (which would delete the wrong dir).
+        if looksLikeExplicitPath(target) {
+            let tURL = URL(fileURLWithPath: (target as NSString).expandingTildeInPath)
+            if fm.fileExists(atPath: tURL.path, isDirectory: &isDir), isDir.boolValue {
+                return tURL
+            }
+        }
+
+        // (2) Direct folder under the Tools root (directory name is plugin_id).
+        let candidate = root.appendingPathComponent(target, isDirectory: true)
+        if fm.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+            return candidate
+        }
+
+        // (3) Match by plugin_id from receipt.json, then by directory name.
+        guard let contents = try? fm.contentsOfDirectory(atPath: root.path) else { return nil }
+        for entry in contents {
+            if entry.hasPrefix(".") { continue }
+            let pluginDir = root.appendingPathComponent(entry, isDirectory: true)
+
+            let currentLink = pluginDir.appendingPathComponent("current")
+            if let versionName = try? fm.destinationOfSymbolicLink(atPath: currentLink.path) {
+                let receiptURL =
+                    pluginDir
+                    .appendingPathComponent(versionName, isDirectory: true)
+                    .appendingPathComponent("receipt.json")
+                if let data = try? Data(contentsOf: receiptURL),
+                    let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                {
+                    let pluginId = (obj["plugin_id"] as? String) ?? ""
+                    if pluginId == target { return pluginDir }
+                }
+            }
+
+            // Also match by directory name (which should be the plugin_id).
+            if entry == target { return pluginDir }
+        }
+        return nil
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsUninstallTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsUninstallTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ToolsUninstallTests: XCTestCase {
+    private func tempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-uninstall-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func resolved(_ path: URL?) -> String? {
+        path?.resolvingSymlinksInPath().path
+    }
+
+    /// A bare plugin name must never resolve to a same-named directory in the
+    /// current working directory (that would delete the wrong directory).
+    func testBareNameDoesNotResolveToCurrentDirectory() throws {
+        let fm = FileManager.default
+        let cwd = tempDir()
+        let root = tempDir()  // empty tools root — no matching plugin
+        try fm.createDirectory(
+            at: cwd.appendingPathComponent("collide", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let saved = fm.currentDirectoryPath
+        fm.changeCurrentDirectoryPath(cwd.path)
+        defer { fm.changeCurrentDirectoryPath(saved) }
+
+        XCTAssertNil(ToolsUninstall.resolveTargetDirectory("collide", root: root))
+    }
+
+    /// An explicit filesystem path is still honored.
+    func testExplicitAbsolutePathIsResolved() throws {
+        let fm = FileManager.default
+        let base = tempDir()
+        let target = base.appendingPathComponent("plug", isDirectory: true)
+        try fm.createDirectory(at: target, withIntermediateDirectories: true)
+
+        XCTAssertEqual(
+            resolved(ToolsUninstall.resolveTargetDirectory(target.path, root: tempDir())),
+            resolved(target)
+        )
+    }
+
+    /// A relative "./name" path is treated as a path, not a plugin id.
+    func testDotSlashNameIsPathMode() throws {
+        let fm = FileManager.default
+        let cwd = tempDir()
+        let dir = cwd.appendingPathComponent("rel", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let saved = fm.currentDirectoryPath
+        fm.changeCurrentDirectoryPath(cwd.path)
+        defer { fm.changeCurrentDirectoryPath(saved) }
+
+        XCTAssertEqual(
+            resolved(ToolsUninstall.resolveTargetDirectory("./rel", root: tempDir())),
+            resolved(dir)
+        )
+    }
+
+    /// A folder directly under the tools root resolves by its (plugin-id) name.
+    func testFolderUnderRootResolves() throws {
+        let fm = FileManager.default
+        let root = tempDir()
+        let plugin = root.appendingPathComponent("my-plugin", isDirectory: true)
+        try fm.createDirectory(at: plugin, withIntermediateDirectories: true)
+
+        XCTAssertEqual(
+            resolved(ToolsUninstall.resolveTargetDirectory("my-plugin", root: root)),
+            resolved(plugin)
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`tools uninstall <target>` resolves `target` as a filesystem path **first**:

```swift
let tURL = URL(fileURLWithPath: target)
var isDir: ObjCBool = false
if fm.fileExists(atPath: tURL.path, isDirectory: &isDir), isDir.boolValue {
    dirToRemove = tURL          // <- matched before the tools-root / plugin-id lookup
}
```

`URL(fileURLWithPath:)` resolves a **relative** string against the current working directory. So `osaurus tools uninstall foo`, run from any directory that happens to contain a subdirectory named `foo`, matches `<cwd>/foo` and `removeItem`s it — **deleting an unrelated local directory instead of the installed plugin, with no confirmation.** A normal plugin-id argument can trigger silent data loss.

## Fix

Gate the path interpretation behind an explicit path indicator — a leading `/`, `./`, `../`, `~`, or any embedded `/` — mirroring `ToolsInstall`'s existing convention (`src.hasPrefix("/") || src.hasPrefix("./") ...`). A bare name can then only resolve to a folder under the tools root or a plugin whose `receipt.json` id matches. Explicit paths (`./plugin`, `/abs/path`, `~/path`) still work exactly as before.

The resolution is extracted into a testable `resolveTargetDirectory(_:root:fileManager:)` (the old logic lived inline in `execute()`, which `exit()`s and isn't unit-testable).

## Tests

Adds `ToolsUninstallTests` (OsaurusCLI is a light, MLX-free package): a bare name must not resolve to a same-named CWD directory; explicit absolute and `./name` paths still resolve; a folder under the tools root resolves by name. `tools uninstall` had no prior test coverage.

3-state verified: removing the gate (unconditional path mode) makes the bare-name test resolve `collide` to `<cwd>/collide` — the exact directory that would be deleted — and the fix makes it return nil. `swift-format lint --strict` clean; full OsaurusCLI suite green.