### PR TITLE
[WIP] DeepSeek-OCR / Unlimited-OCR model compatibility

### DIFF
--- a/docs/DEEPSEEK_OCR_INTEGRATION.md
+++ b/docs/DEEPSEEK_OCR_INTEGRATION.md
@@ -1,0 +1,19 @@
+# DeepSeek-OCR / Unlimited-OCR osaurus integration (WIP)
+
+Tracks osaurus-side support for the DeepSeek-OCR family (DeepseekOCRForCausalLM,
+`model_type: deepseek_vl_v2`) — `deepseek-ai/DeepSeek-OCR` + `baidu/Unlimited-OCR`.
+
+The engine work lives in vmlx-swift PR #89 (the SAM+CLIP DeepEncoder + DeepSeek-V2
+MoE decoder + tiling processor). osaurus's VLM detection reads vmlx's
+`VLMModelFactory.supportedModelTypes`, so once vmlx registers `deepseek_vl_v2`
+the model is recognized as a VLM automatically.
+
+osaurus changes in this PR (land when the vmlx model is functional + merged):
+- [ ] repin vmlx to the commit that adds DeepseekOCR (Package.swift + Package.resolved x3)
+- [ ] ModelFamilyNames: display name + (if needed) isDeepseekOCR family helper
+- [ ] media capabilities: image input for the OCR family
+- [ ] live-prove OCR end-to-end on the dev app (read back a known test image),
+      watch for incoherence/looping/leaking; RAM-safe (ram_feasibility gated)
+
+Status: blocked on vmlx PR #89 reaching a functional, behaviorally-verified state
+(Swift port reproduces mlx-vlm's OCR output on a test image).


### PR DESCRIPTION
Adds osaurus support for the DeepSeek-OCR family — `deepseek-ai/DeepSeek-OCR` and `baidu/Unlimited-OCR` (DeepseekOCRForCausalLM, `model_type: deepseek_vl_v2`).

The inference engine work lives in **vmlx-swift PR #89** (SAM-ViT-B + CLIP-L/14 DeepEncoder → DeepSeek-V2 MoE decoder + 2D long-document tiling). osaurus's VLM detection reads vmlx's `supportedModelTypes`, so this PR's substance is the repin + family display name + media-capability wiring + live OCR proof, which land once the engine model is functional and behaviorally verified against the mlx-vlm Python reference.

See `docs/DEEPSEEK_OCR_INTEGRATION.md` for the checklist. Draft until vmlx #89 is functional + merged.