### PR TITLE
fix: use veryShortWeekdaySymbols for schedule weekday display

### DIFF
--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -1486,7 +1486,7 @@ private struct WeekdayButton: View {
     @State private var isHovering = false
 
     private var dayLetter: String {
-        String(Calendar.current.shortWeekdaySymbols[day - 1].prefix(1))
+        String(Calendar.current.veryShortWeekdaySymbols[day - 1])
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

[Weekly display error (Closes #1721)](https://github.com/osaurus-ai/osaurus/issues/1721)

## Changes

[Weekly display error (Closes #1721)](https://github.com/osaurus-ai/osaurus/issues/1721)

## Screenshots

before
<img width="2024" height="1584" alt="Osaurus - 2026-06-26 at 11 24 36 - hDKKMDES@2x" src="https://github.com/user-attachments/assets/1b993693-578c-4183-8b97-59fb0fb0442b" />

after
<img width="2024" height="1584" alt="Osaurus - 2026-06-26 at 11 24 07 - FZ68lImQ@2x" src="https://github.com/user-attachments/assets/0a05943f-5af6-4b6c-877d-9a0d82caf13b" />

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
