### PR TITLE
Fix LFM2 tool-calling: repin vmlx native 'List of tools' format

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "29d05174151894f2a4072c93079736860480ae4e"
+        "revision" : "9e0b60f8288ca682913e0e33c20287af6f57281d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "29d05174151894f2a4072c93079736860480ae4e"
+        "revision" : "9e0b60f8288ca682913e0e33c20287af6f57281d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "29d05174151894f2a4072c93079736860480ae4e"
+            revision: "9e0b60f8288ca682913e0e33c20287af6f57281d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -71,10 +71,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "29d05174151894f2a4072c93079736860480ae4e""#))
-        #expect(packageResolved.contains(#""revision" : "29d05174151894f2a4072c93079736860480ae4e""#))
-        #expect(workspaceResolved.contains(#""revision" : "29d05174151894f2a4072c93079736860480ae4e""#))
-        #expect(appResolved.contains(#""revision" : "29d05174151894f2a4072c93079736860480ae4e""#))
+        #expect(packageSwift.contains(#"revision: "9e0b60f8288ca682913e0e33c20287af6f57281d""#))
+        #expect(packageResolved.contains(#""revision" : "9e0b60f8288ca682913e0e33c20287af6f57281d""#))
+        #expect(workspaceResolved.contains(#""revision" : "9e0b60f8288ca682913e0e33c20287af6f57281d""#))
+        #expect(appResolved.contains(#""revision" : "9e0b60f8288ca682913e0e33c20287af6f57281d""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -635,7 +635,7 @@ struct RuntimePolicySourceTests {
         // attention falls back to flat rope_theta and the processor config
         // accepts both nested and flat image-processor layouts (fixes the
         // Sentry EXC_BREAKPOINT on Mistral-Small / Ministral / Pixtral).
-        let expectedRuntimeHardenedRevision = "29d05174151894f2a4072c93079736860480ae4e"
+        let expectedRuntimeHardenedRevision = "9e0b60f8288ca682913e0e33c20287af6f57281d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -1384,8 +1384,8 @@ struct SwiftTransformersTokenizerLoaderTests {
         )
         let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
 
-        #expect(decoded.contains("Available functions:"), "Decoded: \(decoded)")
-        #expect(decoded.contains("- line_count:"), "Decoded: \(decoded)")
+        #expect(decoded.contains("List of tools:"), "Decoded: \(decoded)")
+        #expect(decoded.contains("line_count"), "Decoded: \(decoded)")
         #expect(decoded.contains("The API requires a tool call for the next assistant turn."), "Decoded: \(decoded)")
         #expect(decoded.contains("Function name: line_count"), "Decoded: \(decoded)")
         #expect(decoded.contains("Required arguments: text"), "Decoded: \(decoded)")
@@ -1424,12 +1424,10 @@ struct SwiftTransformersTokenizerLoaderTests {
             decoded.contains("Do not write reasoning, XML-style tool tags, markdown, or prose."),
             "Decoded: \(decoded)"
         )
-        #expect(!decoded.contains("List of tools:"), "Decoded: \(decoded)")
         #expect(decoded.contains(#"["line_count", {"text":"red\ngreen\nblue"}]"#), "Decoded: \(decoded)")
         #expect(!decoded.contains("line_count(text='red\\ngreen\\nblue')"), "Decoded: \(decoded)")
         #expect(!decoded.contains("<tools>"), "Decoded: \(decoded)")
         #expect(!decoded.contains("</tool_call>"), "Decoded: \(decoded)")
-        #expect(!decoded.contains(#""name":"line_count""#), "Decoded: \(decoded)")
         #expect(
             decoded.contains("Use the line_count tool on this exact text: red\ngreen\nblue"),
             "Decoded: \(decoded)"

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "29d05174151894f2a4072c93079736860480ae4e"
+        "revision" : "9e0b60f8288ca682913e0e33c20287af6f57281d"
       }
     },
     {


### PR DESCRIPTION
## Problem
LFM2 models don't pick up tools in osaurus — they answer in prose instead of calling the tool. Reported on `OsaurusAI/LFM2.5-230M-MXFP8`; affects **all** LFM2 models (`lfm2`/`lfm2_moe`).

## Root cause (engine side)
The tokenizer bridge applies the `lfm2ToolMinimal` fallback for LFM2 whenever tools are present. That fallback rendered a bare `Available functions: - name: desc` summary (no parameter schema) instead of the **native Liquid format** the model is trained on: the full JSON tool schemas under `List of tools: [ ... ]` + `<|tool_call_start|>` emission. So the model never recognized the tools as callable.

Regression introduced **2026-05-29 in vmlx `46973d1` "Remove LFM tool schema markup"**. Fixed in **vmlx-swift #90** (merged, `9e0b60f`), which restores `List of tools: [JSON]`.

## This PR
Repins osaurus to vmlx main `9e0b60f` (the fix). No osaurus source changes — engine-only fix.

## Proven live on the dev app — real bridge path, no override (`lfm2.5-230m-mxfp8`)
| case | before | after |
|---|---|---|
| auto | prose, no call | `get_weather{city:Tokyo}`, finish=tool_calls |
| required | (limped) | `get_weather{city:Paris}` |
| multi-turn | — | consumes tool result: "The weather in Tokyo is sunny … 22°C" |

Verified the same fix also matches the native template rendering for LFM2.5-8B-A1B (same `List of tools: [JSON]` format).