### PR TITLE
Fix same-turn capability tool activation

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -921,19 +921,153 @@ enum AgentToolLoop {
         "[System Notice] Your todo list still has \(pending) unchecked item\(pending == 1 ? "" : "s") and has not been updated recently. If you finished any, re-send the full list with those boxes checked now; if the plan changed, rewrite the list."
     }
 
-    /// Appended to a successful `capabilities_load` result under the
-    /// deferred-schema policy: the loaded tool is callable immediately
-    /// (registry dispatch is by name), but the rendered tool-schema block
-    /// stays frozen until the next compose so the prompt prefix — and the
-    /// paged-KV cache built on it — stays byte-stable mid-run.
-    ///
-    /// The anti-rediscovery clause is load-bearing: small models read "not in
-    /// the tool list yet" as "I can't call it" and loop back into
-    /// `capabilities_discover` / a redundant `capabilities_load` (observed on
-    /// gemma-12B after a `plugin/<id>` group load). Stating outright that the
-    /// tools are ready and must NOT be re-discovered cuts that detour.
+    /// Legacy prose kept only for older call sites/tests. New code must use
+    /// `annotateCapabilityLoadResult(_:activation:)` so the tool result remains
+    /// one valid JSON envelope with a structured activation object.
     static let deferredSchemaNotice =
         "\nNote: the tools just loaded are callable NOW — invoke them directly by name with JSON arguments. Do NOT call capabilities_discover or capabilities_load for them again; they are already available. Their schemas are omitted from the tool list until the next user turn, but calling them by name works immediately."
+
+    /// Maximum number of schema-activation continuation attempts a surface may
+    /// perform when it cannot expose newly loaded schemas on the next agent-loop
+    /// model request. The shared loop surfaces can safely update the next
+    /// request's `tools` array, so they report `continuation.required = false`;
+    /// stricter providers still get a bounded, machine-readable contract.
+    static let maxCapabilityActivationContinuations = 2
+
+    enum CapabilitySchemaActivationMode: Sendable {
+        case sameTurnNextRequest
+        case continuationRequired
+
+        var rawValue: String {
+            switch self {
+            case .sameTurnNextRequest: return "same_turn_next_request"
+            case .continuationRequired: return "continuation_required"
+            }
+        }
+    }
+
+    struct CapabilitySchemaActivationReport: Sendable {
+        let mode: CapabilitySchemaActivationMode
+        let activatedToolNames: [String]
+        let duplicateToolNames: [String]
+        let diagnostics: [CapabilitySchemaDiagnostic]
+        let maxContinuationRetries: Int
+
+        var isEmpty: Bool {
+            activatedToolNames.isEmpty && duplicateToolNames.isEmpty && diagnostics.isEmpty
+        }
+
+        var allToolNames: [String] {
+            AgentToolLoop.orderedUnique(activatedToolNames + duplicateToolNames)
+        }
+
+        func dictionary() -> [String: Any] {
+            let continuationRequired: Bool
+            switch mode {
+            case .sameTurnNextRequest:
+                continuationRequired = false
+            case .continuationRequired:
+                continuationRequired = true
+            }
+
+            return [
+                "kind": "capability_schema_activation",
+                "mode": mode.rawValue,
+                "status": continuationRequired
+                    ? "continuation_required"
+                    : "activated_for_same_turn_next_request",
+                "schema_visible_on_next_agent_loop_request": !continuationRequired,
+                "activated_tool_names": activatedToolNames,
+                "duplicate_tool_names": duplicateToolNames,
+                "diagnostics": diagnostics.map { $0.dictionary() },
+                "instruction":
+                    "Do not call capabilities_discover or capabilities_load for these tools again in this turn. Call the activated tool by name with JSON arguments.",
+                "continuation": [
+                    "required": continuationRequired,
+                    "max_retries": maxContinuationRetries,
+                    "retry_after": "recompose_request_with_loaded_tool_schema",
+                    "bounded": true,
+                ],
+            ]
+        }
+    }
+
+    /// Merge schemas loaded via `capabilities_load` into the active request
+    /// schema for the next loop iteration. This is safe for the shared loop
+    /// surfaces because every iteration is a fresh provider request; no current
+    /// streaming request is mutated mid-flight.
+    @MainActor
+    static func activateCapabilitySchemas(
+        loadedTools: [Tool],
+        currentTools: [Tool],
+        mode: CapabilitySchemaActivationMode = .sameTurnNextRequest,
+        maxContinuationRetries: Int = maxCapabilityActivationContinuations
+    ) -> (tools: [Tool], report: CapabilitySchemaActivationReport) {
+        var byName = Dictionary(currentTools.map { ($0.function.name, $0) }) { _, latest in latest }
+        var activated: [String] = []
+        var duplicates: [String] = []
+
+        for tool in loadedTools {
+            let name = tool.function.name
+            if byName[name] == nil {
+                activated.append(name)
+            } else {
+                duplicates.append(name)
+            }
+            byName[name] = tool
+        }
+
+        let merged = SystemPromptComposer.canonicalToolOrder(Array(byName.values))
+        let report = CapabilitySchemaActivationReport(
+            mode: mode,
+            activatedToolNames: orderedUnique(activated),
+            duplicateToolNames: orderedUnique(duplicates),
+            diagnostics: [],
+            maxContinuationRetries: max(1, maxContinuationRetries)
+        )
+        return (merged, report)
+    }
+
+    /// Keep a `capabilities_load` result as a single valid `ToolEnvelope`
+    /// success and attach machine-readable activation metadata under
+    /// `result.activation`. If the result is an error or cannot be decoded,
+    /// return it unchanged rather than fabricating a success.
+    static func annotateCapabilityLoadResult(
+        _ result: String,
+        activation: CapabilitySchemaActivationReport
+    ) -> String {
+        guard !activation.isEmpty, !ToolEnvelope.isError(result),
+            let data = result.data(using: .utf8),
+            var envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            (envelope["ok"] as? Bool) == true
+        else { return result }
+
+        var payload: [String: Any]
+        if let existing = envelope["result"] as? [String: Any] {
+            payload = existing
+        } else if let existing = envelope["result"] {
+            payload = ["value": existing]
+        } else {
+            payload = [:]
+        }
+        payload["activation"] = activation.dictionary()
+        envelope["result"] = payload
+
+        guard JSONSerialization.isValidJSONObject(envelope),
+            let encoded = try? JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys]),
+            let json = String(data: encoded, encoding: .utf8)
+        else { return result }
+        return json
+    }
+
+    private static func orderedUnique(_ names: [String]) -> [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for name in names where seen.insert(name).inserted {
+            ordered.append(name)
+        }
+        return ordered
+    }
 
     /// Stable call-id assignment: preserve the model-supplied id when
     /// present (OpenAI `call_xxx`), otherwise mint one in the same shape.

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -77,6 +77,25 @@ private func inv(_ name: String, _ args: String = "{}", callId: String? = nil) -
     ServiceToolInvocation(toolName: name, jsonArguments: args, toolCallId: callId)
 }
 
+private func loopTestTool(_ name: String) -> Tool {
+    Tool(
+        type: "function",
+        function: ToolFunction(
+            name: name,
+            description: "Loop test tool \(name)",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+            ])
+        )
+    )
+}
+
+private func parsedJSONObject(_ json: String) throws -> [String: Any] {
+    let data = try #require(json.data(using: .utf8))
+    return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
 private func chatPolicy(maxIterations: Int = 15) -> AgentLoopPolicy {
     AgentLoopPolicy(
         maxIterations: maxIterations,
@@ -130,6 +149,115 @@ struct AgentToolLoopTests {
         #expect(surface.batchOutcomes.count == 1)
         #expect(surface.batchOutcomes[0].map { $0.invocation.toolName } == ["file_search", "shell_run"])
         #expect(surface.batchOutcomes[0].allSatisfy { !$0.wasDeduped && !$0.wasError })
+    }
+
+    @Test func capabilitiesLoadActivatesSchemaForSameTurnNextIteration() async throws {
+        let loadedTool = loopTestTool("miyo_search")
+        var activeTools = [loopTestTool("capabilities_load")]
+        var schemaNamesSeen: [[String]] = []
+        var loadResult = ""
+
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("capabilities_load", #"{"ids":["tool/miyo_search"]}"#)]),
+            .toolCalls([inv("miyo_search", #"{"query":"water"}"#)]),
+            .finalResponse,
+        ])
+        var hooks = surface.makeHooks()
+        hooks.buildMessages = { notices in
+            surface.builtNotices.append(notices)
+            schemaNamesSeen.append(activeTools.map { $0.function.name })
+            return AgentLoopIterationInput(messages: [ChatMessage(role: "user", content: "task")])
+        }
+        hooks.executeTool = { inv, callId in
+            surface.executedCalls.append((inv.toolName, inv.jsonArguments, callId))
+            if inv.toolName == "capabilities_load" {
+                let activation = AgentToolLoop.activateCapabilitySchemas(
+                    loadedTools: [loadedTool],
+                    currentTools: activeTools,
+                    mode: .sameTurnNextRequest
+                )
+                activeTools = activation.tools
+                loadResult = AgentToolLoop.annotateCapabilityLoadResult(
+                    ToolEnvelope.success(tool: inv.toolName, text: "Tool 'miyo_search' loaded."),
+                    activation: activation.report
+                )
+                return AgentLoopToolExecution(result: loadResult)
+            }
+            return AgentLoopToolExecution(result: ToolEnvelope.success(tool: inv.toolName, text: "ran"))
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 4),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result.exit == .finalResponse)
+        #expect(surface.executedCalls.map(\.name) == ["capabilities_load", "miyo_search"])
+        #expect(schemaNamesSeen.first == ["capabilities_load"])
+        #expect(schemaNamesSeen.dropFirst().first?.contains("miyo_search") == true)
+
+        let envelope = try parsedJSONObject(loadResult)
+        let payload = try #require(envelope["result"] as? [String: Any])
+        let activation = try #require(payload["activation"] as? [String: Any])
+        #expect(activation["status"] as? String == "activated_for_same_turn_next_request")
+        #expect(activation["schema_visible_on_next_agent_loop_request"] as? Bool == true)
+        #expect((activation["activated_tool_names"] as? [String]) == ["miyo_search"])
+        #expect(!loadResult.contains(AgentToolLoop.deferredSchemaNotice))
+    }
+
+    @Test func continuationActivationEnvelopeIsStructuredAndBounded() throws {
+        let report = AgentToolLoop.CapabilitySchemaActivationReport(
+            mode: .continuationRequired,
+            activatedToolNames: ["miyo_search"],
+            duplicateToolNames: [],
+            diagnostics: [],
+            maxContinuationRetries: AgentToolLoop.maxCapabilityActivationContinuations
+        )
+        let annotated = AgentToolLoop.annotateCapabilityLoadResult(
+            ToolEnvelope.success(tool: "capabilities_load", text: "Tool loaded."),
+            activation: report
+        )
+
+        let envelope = try parsedJSONObject(annotated)
+        let payload = try #require(envelope["result"] as? [String: Any])
+        let activation = try #require(payload["activation"] as? [String: Any])
+        let continuation = try #require(activation["continuation"] as? [String: Any])
+
+        #expect(envelope["ok"] as? Bool == true)
+        #expect(activation["status"] as? String == "continuation_required")
+        #expect(continuation["required"] as? Bool == true)
+        #expect(continuation["bounded"] as? Bool == true)
+        #expect(continuation["max_retries"] as? Int == AgentToolLoop.maxCapabilityActivationContinuations)
+        #expect(!annotated.contains(AgentToolLoop.deferredSchemaNotice))
+    }
+
+    @Test func duplicateCapabilityActivationIsIdempotent() throws {
+        let loadedTool = loopTestTool("miyo_search")
+        let first = AgentToolLoop.activateCapabilitySchemas(
+            loadedTools: [loadedTool],
+            currentTools: [loopTestTool("capabilities_load")],
+            mode: .sameTurnNextRequest
+        )
+        let second = AgentToolLoop.activateCapabilitySchemas(
+            loadedTools: [loadedTool],
+            currentTools: first.tools,
+            mode: .sameTurnNextRequest
+        )
+        let annotated = AgentToolLoop.annotateCapabilityLoadResult(
+            ToolEnvelope.success(tool: "capabilities_load", text: "Tool loaded again."),
+            activation: second.report
+        )
+
+        #expect(first.report.activatedToolNames == ["miyo_search"])
+        #expect(second.tools.filter { $0.function.name == "miyo_search" }.count == 1)
+        #expect(second.report.activatedToolNames.isEmpty)
+        #expect(second.report.duplicateToolNames == ["miyo_search"])
+
+        let envelope = try parsedJSONObject(annotated)
+        let payload = try #require(envelope["result"] as? [String: Any])
+        let activation = try #require(payload["activation"] as? [String: Any])
+        #expect((activation["duplicate_tool_names"] as? [String]) == ["miyo_search"])
     }
 
     @Test func preservesModelSuppliedCallIds() async throws {

--- a/Packages/OsaurusCore/Tests/Chat/SessionPreflightCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SessionPreflightCacheTests.swift
@@ -28,6 +28,27 @@ struct SessionPreflightCacheTests {
     }
 
     @Test
+    func sessionToolStateStore_appendLoadedToolsPersistsIdempotently() async {
+        let sessionId = "same-turn-load-\(UUID().uuidString)"
+        await SessionToolStateStore.shared.appendLoadedTools(
+            sessionId,
+            names: ["miyo_search", "miyo_search"],
+            fallbackAlwaysLoadedNames: ["capabilities_load"]
+        )
+        await SessionToolStateStore.shared.appendLoadedTools(
+            sessionId,
+            names: ["calendar_lookup"],
+            fallbackAlwaysLoadedNames: nil
+        )
+
+        let state = await SessionToolStateStore.shared.get(sessionId)
+        #expect(state?.loadedToolNames == ["miyo_search", "calendar_lookup"])
+        #expect(state?.initialAlwaysLoadedNames == ["capabilities_load"])
+
+        await SessionToolStateStore.shared.invalidate(sessionId)
+    }
+
+    @Test
     func resolveTools_includesAdditionalToolNames() async {
         await withSessionPreflightAgent { agentId in
 

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -18,11 +18,25 @@ struct CapabilityLoadBufferTests {
         let buffer = CapabilityLoadBuffer()
         let tool1 = Tool(
             type: "function",
-            function: ToolFunction(name: "test_tool_1", description: "A test", parameters: nil)
+            function: ToolFunction(
+                name: "test_tool_1",
+                description: "A test",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([:]),
+                ])
+            )
         )
         let tool2 = Tool(
             type: "function",
-            function: ToolFunction(name: "test_tool_2", description: "Another test", parameters: nil)
+            function: ToolFunction(
+                name: "test_tool_2",
+                description: "Another test",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([:]),
+                ])
+            )
         )
 
         await buffer.add(tool1)
@@ -41,6 +55,65 @@ struct CapabilityLoadBufferTests {
         let buffer = CapabilityLoadBuffer()
         let result = await buffer.drain()
         #expect(result.isEmpty)
+    }
+
+    @Test func duplicateAddsAreIdempotentWithinOneTurn() async {
+        let buffer = CapabilityLoadBuffer()
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "duplicate_loaded_tool",
+                description: "A test",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([:]),
+                ])
+            )
+        )
+
+        await buffer.add(tool)
+        await buffer.add(tool)
+
+        let drained = await buffer.drain()
+        #expect(drained.map { $0.function.name } == ["duplicate_loaded_tool"])
+        #expect(await buffer.drain().isEmpty)
+    }
+
+    @Test func noArgumentDynamicSchemaBuffersAsEmptyObjectTool() async {
+        let buffer = CapabilityLoadBuffer()
+        let noArgumentTool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "no_argument_loaded_tool",
+                description: "A test",
+                parameters: nil
+            )
+        )
+
+        let diagnostic = await buffer.add(noArgumentTool)
+
+        #expect(diagnostic == nil)
+        let drained = await buffer.drain()
+        #expect(drained.map { $0.function.name } == ["no_argument_loaded_tool"])
+        #expect(drained.first?.function.parameters == nil)
+    }
+
+    @Test func malformedDynamicSchemaFailsClosedBeforeBuffering() async {
+        let buffer = CapabilityLoadBuffer()
+        let malformed = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "malformed_schema_tool",
+                description: "A test",
+                parameters: .string("not an object")
+            )
+        )
+
+        let diagnostic = await buffer.add(malformed)
+
+        #expect(diagnostic?.kind == .invalidArgs)
+        #expect(diagnostic?.field == "parameters")
+        #expect(await buffer.drain().isEmpty)
     }
 }
 
@@ -486,6 +559,13 @@ struct CapabilitiesLoadToolTests {
                     spec: SandboxToolSpec(
                         id: "probe",
                         description: "Probe tool governed by the skill",
+                        parameters: [
+                            "mode": SandboxParameterSpec(
+                                type: "string",
+                                description: "Optional probe mode",
+                                default: "default"
+                            )
+                        ],
                         run: "echo hi"
                     ),
                     plugin: plugin
@@ -640,6 +720,31 @@ struct CapabilitiesLoadToolTests {
             await SessionToolStateStore.shared.invalidate(sessionId)
         }
     }
+
+    @Test @MainActor
+    func toolLoadRejectsMalformedDynamicSchemaWithTypedDiagnostic() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let toolName =
+                "lane_b_malformed_schema_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+            let fixture = MalformedSchemaFixtureTool(name: toolName)
+            ToolRegistry.shared.registerPluginTool(fixture)
+            ToolRegistry.shared.setEnabled(true, for: fixture.name)
+            defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+            _ = await CapabilityLoadBuffer.shared.drain()
+
+            let tool = CapabilitiesLoadTool()
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"tool/\(fixture.name)\"]}")
+            }
+
+            #expect(ToolEnvelope.isError(result))
+            #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+            #expect(EnvelopeAssertions.failureField(result) == "parameters")
+            #expect(result.contains("non-object parameter schema"))
+            #expect(await CapabilityLoadBuffer.shared.drain().isEmpty)
+        }
+    }
 }
 
 private struct CapabilityPolicyFixtureTool: OsaurusTool {
@@ -658,6 +763,16 @@ private struct CapabilityPolicyFixtureTool: OsaurusTool {
         ]),
         "required": .array([.string("query")]),
     ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        argumentsJSON
+    }
+}
+
+private struct MalformedSchemaFixtureTool: OsaurusTool {
+    let name: String
+    let description = "Fixture with a malformed schema"
+    let parameters: JSONValue? = .string("not an object")
 
     func execute(argumentsJSON: String) async throws -> String {
         argumentsJSON

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -11,22 +11,132 @@ import Foundation
 
 // MARK: - CapabilityLoadBuffer
 
+/// Structured diagnostic for a dynamically-loaded tool schema that cannot be
+/// exposed safely. Dynamic schemas must fail closed: a missing/malformed
+/// provider schema is not silently replaced with `{}` because that teaches the
+/// model to call an underspecified tool and then rely on parser repair.
+struct CapabilitySchemaDiagnostic: Sendable {
+    let toolName: String
+    let kind: ToolEnvelope.Kind
+    let message: String
+    let field: String?
+    let expected: String?
+
+    func dictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "tool_name": toolName,
+            "kind": kind.rawValue,
+            "message": message,
+        ]
+        if let field { dict["field"] = field }
+        if let expected { dict["expected"] = expected }
+        return dict
+    }
+}
+
 /// Shared buffer for communicating newly loaded tool specs from capabilities_load
 /// back to the execution loop. The loop drains pending tools after each
 /// capabilities_load call and appends them to the active tool set.
 actor CapabilityLoadBuffer {
     static let shared = CapabilityLoadBuffer()
 
-    private var pendingTools: [Tool] = []
+    private var pendingToolOrder: [String] = []
+    private var pendingToolsByName: [String: Tool] = [:]
 
-    func add(_ tool: Tool) {
-        pendingTools.append(tool)
+    @discardableResult
+    func add(_ tool: Tool) -> CapabilitySchemaDiagnostic? {
+        if let diagnostic = Self.validateDynamicToolSchema(tool) {
+            return diagnostic
+        }
+        let name = tool.function.name
+        if pendingToolsByName[name] == nil {
+            pendingToolOrder.append(name)
+        }
+        // Idempotent duplicate loads in one turn: keep one activation slot,
+        // but let the latest spec replace an earlier copy if the registry
+        // refreshed it before the buffer drained.
+        pendingToolsByName[name] = tool
+        return nil
     }
 
     func drain() -> [Tool] {
-        let tools = pendingTools
-        pendingTools = []
+        let tools = pendingToolOrder.compactMap { pendingToolsByName[$0] }
+        pendingToolOrder = []
+        pendingToolsByName = [:]
         return tools
+    }
+
+    static func validateDynamicToolSchema(_ tool: Tool) -> CapabilitySchemaDiagnostic? {
+        let name = tool.function.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return CapabilitySchemaDiagnostic(
+                toolName: tool.function.name,
+                kind: .invalidArgs,
+                message: "Loaded tool schema is missing a function name.",
+                field: "name",
+                expected: "non-empty function name"
+            )
+        }
+        guard tool.type == "function" else {
+            return CapabilitySchemaDiagnostic(
+                toolName: name,
+                kind: .invalidArgs,
+                message: "Loaded tool '\(name)' has unsupported tool type '\(tool.type)'.",
+                field: "type",
+                expected: "function"
+            )
+        }
+        guard let parameters = tool.function.parameters else {
+            // Existing no-argument tools legitimately use nil parameters; the
+            // OpenAI encoder normalizes nil to an empty object schema.
+            return nil
+        }
+        guard case .object(let schema) = parameters else {
+            return CapabilitySchemaDiagnostic(
+                toolName: name,
+                kind: .invalidArgs,
+                message: "Loaded tool '\(name)' has a non-object parameter schema.",
+                field: "parameters",
+                expected: "JSON Schema object with type: object"
+            )
+        }
+        guard case .string("object")? = schema["type"] else {
+            return CapabilitySchemaDiagnostic(
+                toolName: name,
+                kind: .invalidArgs,
+                message: "Loaded tool '\(name)' parameter schema must declare type: object.",
+                field: "parameters.type",
+                expected: "object"
+            )
+        }
+        if let properties = schema["properties"], case .object = properties {
+            // Valid.
+        } else if schema["properties"] != nil {
+            return CapabilitySchemaDiagnostic(
+                toolName: name,
+                kind: .invalidArgs,
+                message: "Loaded tool '\(name)' parameter schema has non-object properties.",
+                field: "parameters.properties",
+                expected: "object mapping property names to schemas"
+            )
+        }
+        if let required = schema["required"] {
+            guard case .array(let values) = required,
+                values.allSatisfy({
+                    if case .string = $0 { return true }
+                    return false
+                })
+            else {
+                return CapabilitySchemaDiagnostic(
+                    toolName: name,
+                    kind: .invalidArgs,
+                    message: "Loaded tool '\(name)' parameter schema has malformed required fields.",
+                    field: "parameters.required",
+                    expected: "array of strings"
+                )
+            }
+        }
+        return nil
     }
 }
 
@@ -529,7 +639,8 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                         kind: .invalidArgs,
                         message:
                             "Invalid ID format '\(id)' — expected `<type>/<id>` "
-                            + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). Use IDs from the Enabled capabilities list or `capabilities_discover`."
+                            + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). Use IDs from the Enabled capabilities list or `capabilities_discover`.",
+                        field: "ids"
                     )
                 )
                 continue
@@ -578,7 +689,8 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             return ToolEnvelope.failure(
                 kind: first.kind,
                 message: combined,
-                field: first.kind == .invalidArgs ? "ids" : nil,
+                field: first.field ?? (first.kind == .invalidArgs ? "ids" : nil),
+                expected: first.expected,
                 tool: name,
                 retryable: !deterministicKinds.contains(first.kind)
             )
@@ -599,6 +711,8 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     private struct LoadFailure {
         let kind: ToolEnvelope.Kind
         let message: String
+        var field: String? = nil
+        var expected: String? = nil
     }
 
     private enum LoadOutcome {
@@ -785,7 +899,16 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                 )
             )
         }
-        await CapabilityLoadBuffer.shared.add(spec)
+        if let diagnostic = await CapabilityLoadBuffer.shared.add(spec) {
+            return .failure(
+                LoadFailure(
+                    kind: diagnostic.kind,
+                    message: diagnostic.message,
+                    field: diagnostic.field,
+                    expected: diagnostic.expected
+                )
+            )
+        }
         return .success("Tool '\(toolId)' loaded and available.\n")
     }
 
@@ -825,10 +948,23 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     private func bufferToolSpecs(named names: [String]) async -> String {
         guard !names.isEmpty else { return "" }
         let specs = await MainActor.run { ToolRegistry.shared.specs(forTools: names) }
+        var loadedNames: [String] = []
+        var skippedLines: [String] = []
         for spec in specs {
-            await CapabilityLoadBuffer.shared.add(spec)
+            if let diagnostic = await CapabilityLoadBuffer.shared.add(spec) {
+                skippedLines.append("Skipped tool '\(diagnostic.toolName)': \(diagnostic.message)")
+            } else {
+                loadedNames.append(spec.function.name)
+            }
         }
-        return "Auto-loaded tools: \(names.joined(separator: ", "))\n"
+        var output = ""
+        if !loadedNames.isEmpty {
+            output += "Auto-loaded tools: \(loadedNames.joined(separator: ", "))\n"
+        }
+        if !skippedLines.isEmpty {
+            output += skippedLines.joined(separator: "\n") + "\n"
+        }
+        return output
     }
 
     private func loadSkill(_ skillName: String) async -> LoadOutcome {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3400,12 +3400,12 @@ final class ChatSession: ObservableObject {
                         }
                     }
 
-                    // Frozen for the whole run (deferred-schema policy): the
-                    // tool schema never changes mid-run, even after
-                    // `capabilities_load` — see the drain block below. In Mode 2
-                    // we send no tools: the remote agent advertises and executes
-                    // its own tools server-side and only streams text back.
-                    let toolSpecs = isRemoteAgentTarget ? [] : context.tools
+                    // Each agent-loop iteration is a fresh provider request.
+                    // `capabilities_load` may refresh this array for the next
+                    // same-turn request after validating the loaded schemas. In
+                    // Mode 2 we still send no tools: the remote agent advertises
+                    // and executes its own tools server-side and streams text.
+                    var toolSpecs = isRemoteAgentTarget ? [] : context.tools
                     let isManualTools = liveToolMode == .manual
                     cachedContext = context
 
@@ -3656,15 +3656,10 @@ final class ChatSession: ObservableObject {
                         }
 
                         // Tools loaded via capabilities_load / sandbox_plugin_register.
-                        // Deferred-schema policy (KV stability): loaded tools
-                        // are callable IMMEDIATELY — the registry dispatches by
-                        // name and schema visibility is not an execution gate —
-                        // but `toolSpecs` stays FROZEN for the rest of this run.
-                        // Hot-patching it mid-run rewrote the rendered `<tools>`
-                        // block and busted the paged-KV cache for the whole
-                        // conversation. The names persist into the session's
-                        // tool union so the next user turn composes their full
-                        // schemas in.
+                        // Each loop iteration is a fresh model request, so it
+                        // is safe to expose validated schemas on the NEXT
+                        // iteration in this same user turn. We still never
+                        // mutate an in-flight stream.
                         if inv.toolName == "capabilities_load"
                             || inv.toolName == "sandbox_plugin_register"
                         {
@@ -3672,18 +3667,26 @@ final class ChatSession: ObservableObject {
                             // unrelated run; persist only in auto mode (manual
                             // mode keeps the user's explicit tool set fixed).
                             let newTools = await CapabilityLoadBuffer.shared.drain()
-                            if !isManualTools, !newTools.isEmpty {
-                                if !ToolEnvelope.isError(resultText) {
-                                    resultText += AgentToolLoop.deferredSchemaNotice
-                                }
+                            if !newTools.isEmpty {
+                                let activation = AgentToolLoop.activateCapabilitySchemas(
+                                    loadedTools: newTools,
+                                    currentTools: toolSpecs,
+                                    mode: .sameTurnNextRequest
+                                )
+                                toolSpecs = activation.tools
+                                resultText = AgentToolLoop.annotateCapabilityLoadResult(
+                                    resultText,
+                                    activation: activation.report
+                                )
                                 if let sid = self.sessionId {
-                                    let names = newTools.map { $0.function.name }
-                                    let snapshot = context.alwaysLoadedNames
-                                    await SessionToolStateStore.shared.appendLoadedTools(
-                                        self.sessionStateKey(sid),
-                                        names: names,
-                                        fallbackAlwaysLoadedNames: snapshot
-                                    )
+                                    if !isManualTools {
+                                        let snapshot = context.alwaysLoadedNames
+                                        await SessionToolStateStore.shared.appendLoadedTools(
+                                            self.sessionStateKey(sid),
+                                            names: activation.report.allToolNames,
+                                            fallbackAlwaysLoadedNames: snapshot
+                                        )
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

Addresses #1718 by making tools loaded through `capabilities_load` usable on the next model request inside the same agent-loop turn when the surface can safely refresh the tool schema.

- validates dynamically loaded schemas before exposing them
- preserves existing no-argument tool behavior by treating nil parameters as an empty object schema
- attaches structured activation metadata to the existing tool envelope instead of appending prose
- bounds continuation-style recovery for surfaces that cannot refresh schemas immediately
- refreshes the in-app loop tool list without mutating an in-flight stream

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-same-turn swift test --package-path Packages/OsaurusCore --filter 'CapabilityLoadBufferTests|CapabilitiesLoadToolTests|AgentToolLoopTests|SessionPreflightCacheTests'`
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"`

## Review Notes

- Claude review found that the first version rejected existing no-argument sandbox plugin tools. Fixed with a regression test.
- Grok compact review raised a possible actor-isolation compile concern; the focused test build and app build compiled the affected call sites successfully.

## Risk

Schema refresh changes the prompt/tool prefix within a same-turn continuation, so large-context runs may pay a re-prefill cost after loading tools. That is intentional for same-turn usability and is covered by focused agent-loop tests.
