### PR TITLE
Add durable agent task board

### DIFF
--- a/Packages/OsaurusCore/Identity/StorageKeyManager.swift
+++ b/Packages/OsaurusCore/Identity/StorageKeyManager.swift
@@ -370,6 +370,7 @@ public final class StorageKeyManager: @unchecked Sendable {
         let encryptedArtifacts = [
             OsaurusPaths.chatHistoryDatabaseFile(),
             OsaurusPaths.agentChannelMessagesDatabaseFile(),
+            OsaurusPaths.agentTaskBoardDatabaseFile(),
             OsaurusPaths.memoryDatabaseFile(),
             OsaurusPaths.methodsDatabaseFile(),
             OsaurusPaths.toolIndexDatabaseFile(),

--- a/Packages/OsaurusCore/Models/AgentTasks/AgentTaskModels.swift
+++ b/Packages/OsaurusCore/Models/AgentTasks/AgentTaskModels.swift
@@ -1,0 +1,285 @@
+//
+//  AgentTaskModels.swift
+//  osaurus
+//
+//  Durable task-board domain types for local multi-agent orchestration state.
+//  These are storage/service DTOs only; no remote execution or inbox protocol
+//  behavior lives here.
+//
+
+import Foundation
+
+public enum AgentTaskStatus: String, Codable, Sendable, CaseIterable, Equatable {
+    case triage
+    case todo
+    case scheduled
+    case ready
+    case running
+    case blocked
+    case review
+    case done
+    case archived
+
+    public var isTerminal: Bool {
+        self == .done || self == .archived
+    }
+
+    public func canTransition(to next: AgentTaskStatus) -> Bool {
+        guard self != next else { return true }
+        switch self {
+        case .triage:
+            return [.todo, .scheduled, .ready, .blocked, .archived].contains(next)
+        case .todo:
+            return [.triage, .scheduled, .ready, .blocked, .archived].contains(next)
+        case .scheduled:
+            return [.todo, .ready, .blocked, .archived].contains(next)
+        case .ready:
+            return [.todo, .scheduled, .running, .blocked, .archived].contains(next)
+        case .running:
+            return [.ready, .blocked, .review, .done, .archived].contains(next)
+        case .blocked:
+            return [.triage, .todo, .scheduled, .ready, .archived].contains(next)
+        case .review:
+            return [.running, .blocked, .done, .archived].contains(next)
+        case .done:
+            return [.review, .archived].contains(next)
+        case .archived:
+            return false
+        }
+    }
+}
+
+public enum AgentTaskEventKind: String, Codable, Sendable, CaseIterable, Equatable {
+    case create
+    case update
+    case claim
+    case complete
+    case block
+    case archive
+}
+
+public enum AgentTaskRunStatus: String, Codable, Sendable, CaseIterable, Equatable {
+    case running
+    case completed
+    case blocked
+    case expired
+    case abandoned
+}
+
+public enum AgentTaskLinkKind: String, Codable, Sendable, CaseIterable, Equatable {
+    case dependsOn = "depends_on"
+}
+
+public struct AgentTask: Codable, Sendable, Identifiable, Equatable {
+    public var id: UUID
+    public var title: String
+    public var details: String?
+    public var status: AgentTaskStatus
+    public var priority: Int
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var scheduledAt: Date?
+    public var blockedReason: String?
+    public var metadataJSON: String?
+    public var activeRunId: UUID?
+    public var leaseOwner: String?
+    public var leaseExpiresAt: Date?
+    public var archivedAt: Date?
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        details: String? = nil,
+        status: AgentTaskStatus = .triage,
+        priority: Int = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        scheduledAt: Date? = nil,
+        blockedReason: String? = nil,
+        metadataJSON: String? = nil,
+        activeRunId: UUID? = nil,
+        leaseOwner: String? = nil,
+        leaseExpiresAt: Date? = nil,
+        archivedAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.details = details
+        self.status = status
+        self.priority = priority
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.scheduledAt = scheduledAt
+        self.blockedReason = blockedReason
+        self.metadataJSON = metadataJSON
+        self.activeRunId = activeRunId
+        self.leaseOwner = leaseOwner
+        self.leaseExpiresAt = leaseExpiresAt
+        self.archivedAt = archivedAt
+    }
+}
+
+public struct AgentTaskRun: Codable, Sendable, Identifiable, Equatable {
+    public var id: UUID
+    public var taskId: UUID
+    public var workerId: String
+    public var status: AgentTaskRunStatus
+    public var claimedAt: Date
+    public var leaseExpiresAt: Date
+    public var lastHeartbeatAt: Date
+    public var completedAt: Date?
+    public var error: String?
+
+    public init(
+        id: UUID = UUID(),
+        taskId: UUID,
+        workerId: String,
+        status: AgentTaskRunStatus = .running,
+        claimedAt: Date = Date(),
+        leaseExpiresAt: Date,
+        lastHeartbeatAt: Date = Date(),
+        completedAt: Date? = nil,
+        error: String? = nil
+    ) {
+        self.id = id
+        self.taskId = taskId
+        self.workerId = workerId
+        self.status = status
+        self.claimedAt = claimedAt
+        self.leaseExpiresAt = leaseExpiresAt
+        self.lastHeartbeatAt = lastHeartbeatAt
+        self.completedAt = completedAt
+        self.error = error
+    }
+}
+
+public struct AgentTaskEvent: Codable, Sendable, Identifiable, Equatable {
+    public var id: UUID
+    public var taskId: UUID
+    public var kind: AgentTaskEventKind
+    public var createdAt: Date
+    public var workerId: String?
+    public var runId: UUID?
+    public var fromStatus: AgentTaskStatus?
+    public var toStatus: AgentTaskStatus?
+    public var message: String?
+    public var payloadJSON: String?
+
+    public init(
+        id: UUID = UUID(),
+        taskId: UUID,
+        kind: AgentTaskEventKind,
+        createdAt: Date = Date(),
+        workerId: String? = nil,
+        runId: UUID? = nil,
+        fromStatus: AgentTaskStatus? = nil,
+        toStatus: AgentTaskStatus? = nil,
+        message: String? = nil,
+        payloadJSON: String? = nil
+    ) {
+        self.id = id
+        self.taskId = taskId
+        self.kind = kind
+        self.createdAt = createdAt
+        self.workerId = workerId
+        self.runId = runId
+        self.fromStatus = fromStatus
+        self.toStatus = toStatus
+        self.message = message
+        self.payloadJSON = payloadJSON
+    }
+}
+
+public struct AgentTaskLink: Codable, Sendable, Equatable {
+    public var taskId: UUID
+    public var dependsOnTaskId: UUID
+    public var kind: AgentTaskLinkKind
+    public var createdAt: Date
+
+    public init(
+        taskId: UUID,
+        dependsOnTaskId: UUID,
+        kind: AgentTaskLinkKind = .dependsOn,
+        createdAt: Date = Date()
+    ) {
+        self.taskId = taskId
+        self.dependsOnTaskId = dependsOnTaskId
+        self.kind = kind
+        self.createdAt = createdAt
+    }
+}
+
+public struct AgentTaskCreateRequest: Sendable, Equatable {
+    public var id: UUID?
+    public var title: String
+    public var details: String?
+    public var status: AgentTaskStatus
+    public var priority: Int
+    public var scheduledAt: Date?
+    public var metadataJSON: String?
+
+    public init(
+        id: UUID? = nil,
+        title: String,
+        details: String? = nil,
+        status: AgentTaskStatus = .triage,
+        priority: Int = 0,
+        scheduledAt: Date? = nil,
+        metadataJSON: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.details = details
+        self.status = status
+        self.priority = priority
+        self.scheduledAt = scheduledAt
+        self.metadataJSON = metadataJSON
+    }
+}
+
+public struct AgentTaskUpdate: Sendable, Equatable {
+    public var title: String?
+    public var details: String?
+    public var status: AgentTaskStatus?
+    public var priority: Int?
+    public var scheduledAt: Date?
+    public var clearScheduledAt: Bool
+    public var blockedReason: String?
+    public var clearBlockedReason: Bool
+    public var metadataJSON: String?
+    public var clearMetadataJSON: Bool
+
+    public init(
+        title: String? = nil,
+        details: String? = nil,
+        status: AgentTaskStatus? = nil,
+        priority: Int? = nil,
+        scheduledAt: Date? = nil,
+        clearScheduledAt: Bool = false,
+        blockedReason: String? = nil,
+        clearBlockedReason: Bool = false,
+        metadataJSON: String? = nil,
+        clearMetadataJSON: Bool = false
+    ) {
+        self.title = title
+        self.details = details
+        self.status = status
+        self.priority = priority
+        self.scheduledAt = scheduledAt
+        self.clearScheduledAt = clearScheduledAt
+        self.blockedReason = blockedReason
+        self.clearBlockedReason = clearBlockedReason
+        self.metadataJSON = metadataJSON
+        self.clearMetadataJSON = clearMetadataJSON
+    }
+}
+
+public struct AgentTaskClaim: Sendable, Equatable {
+    public var task: AgentTask
+    public var run: AgentTaskRun
+
+    public init(task: AgentTask, run: AgentTaskRun) {
+        self.task = task
+        self.run = run
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardService.swift
+++ b/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardService.swift
@@ -1,0 +1,165 @@
+//
+//  AgentTaskBoardService.swift
+//  osaurus
+//
+//  Public service facade for durable local task-board state. This deliberately
+//  does not spawn agents, poll inboxes, run remote commands, or expose UI
+//  workflows; it is storage and coordination API only.
+//
+
+import Foundation
+
+public final class AgentTaskBoardService: @unchecked Sendable {
+    public static let shared = AgentTaskBoardService(store: .shared)
+
+    private let store: AgentTaskBoardStore
+
+    public init(store: AgentTaskBoardStore) {
+        self.store = store
+    }
+
+    public func open() throws {
+        try store.open()
+    }
+
+    public func close() {
+        store.close()
+    }
+
+    @discardableResult
+    public func createTask(
+        _ request: AgentTaskCreateRequest,
+        now: Date = Date()
+    ) throws -> AgentTask {
+        try store.createTask(request, now: now)
+    }
+
+    public func task(id: UUID) throws -> AgentTask? {
+        try store.task(id: id)
+    }
+
+    public func listTasks(statuses: [AgentTaskStatus]? = nil) throws -> [AgentTask] {
+        try store.listTasks(statuses: statuses)
+    }
+
+    @discardableResult
+    public func updateTask(
+        id: UUID,
+        update: AgentTaskUpdate,
+        now: Date = Date(),
+        message: String? = nil
+    ) throws -> AgentTask {
+        try store.updateTask(id: id, update: update, now: now, message: message)
+    }
+
+    @discardableResult
+    public func addDependency(
+        taskId: UUID,
+        dependsOnTaskId: UUID,
+        now: Date = Date()
+    ) throws -> AgentTaskLink {
+        try store.addDependency(taskId: taskId, dependsOnTaskId: dependsOnTaskId, now: now)
+    }
+
+    public func dependencies(taskId: UUID) throws -> [AgentTaskLink] {
+        try store.dependencies(taskId: taskId)
+    }
+
+    public func removeDependency(
+        taskId: UUID,
+        dependsOnTaskId: UUID,
+        now: Date = Date()
+    ) throws {
+        try store.removeDependency(taskId: taskId, dependsOnTaskId: dependsOnTaskId, now: now)
+    }
+
+    public func claimTask(
+        id: UUID,
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date = Date()
+    ) throws -> AgentTaskClaim? {
+        try store.claimTask(id: id, workerId: workerId, leaseTTL: leaseTTL, now: now)
+    }
+
+    public func claimNext(
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date = Date()
+    ) throws -> AgentTaskClaim? {
+        try store.claimNext(workerId: workerId, leaseTTL: leaseTTL, now: now)
+    }
+
+    public func renewLease(
+        taskId: UUID,
+        runId: UUID,
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date = Date()
+    ) throws -> AgentTaskRun? {
+        try store.renewLease(
+            taskId: taskId,
+            runId: runId,
+            workerId: workerId,
+            leaseTTL: leaseTTL,
+            now: now
+        )
+    }
+
+    @discardableResult
+    public func recoverExpiredLeases(asOf now: Date = Date()) throws -> Int {
+        try store.recoverExpiredLeases(asOf: now)
+    }
+
+    @discardableResult
+    public func completeTask(
+        id: UUID,
+        runId: UUID? = nil,
+        workerId: String? = nil,
+        now: Date = Date(),
+        message: String? = nil
+    ) throws -> AgentTask {
+        try store.completeTask(
+            id: id,
+            runId: runId,
+            workerId: workerId,
+            now: now,
+            message: message
+        )
+    }
+
+    @discardableResult
+    public func blockTask(
+        id: UUID,
+        reason: String,
+        runId: UUID? = nil,
+        workerId: String? = nil,
+        now: Date = Date()
+    ) throws -> AgentTask {
+        try store.blockTask(
+            id: id,
+            reason: reason,
+            runId: runId,
+            workerId: workerId,
+            now: now
+        )
+    }
+
+    @discardableResult
+    public func archiveTask(
+        id: UUID,
+        workerId: String? = nil,
+        now: Date = Date(),
+        message: String? = nil
+    ) throws -> AgentTask {
+        try store.archiveTask(id: id, workerId: workerId, now: now, message: message)
+    }
+
+    public func events(taskId: UUID) throws -> [AgentTaskEvent] {
+        try store.events(taskId: taskId)
+    }
+
+    public func runs(taskId: UUID) throws -> [AgentTaskRun] {
+        try store.runs(taskId: taskId)
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardStore.swift
+++ b/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardStore.swift
@@ -393,6 +393,9 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
             if task.status == .archived, task.archivedAt == nil {
                 task.archivedAt = now
             }
+            if task.status == .scheduled, task.scheduledAt == nil {
+                throw AgentTaskBoardError.invalidInput("scheduled tasks require scheduledAt")
+            }
 
             try updateTaskLocked(task)
             try insertEventLocked(
@@ -598,14 +601,15 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
         now: Date = Date(),
         message: String? = nil
     ) throws -> AgentTask {
-        try inImmediateTransaction {
+        if let workerId { try Self.validateWorker(workerId) }
+        return try inImmediateTransaction {
             var task = try requireTaskLocked(id: id)
             let fromStatus = task.status
             let runForEvent = runId ?? task.activeRunId
             guard task.status.canTransition(to: .done) else {
                 throw AgentTaskBoardError.invalidTransition(from: task.status, to: .done)
             }
-            try validateActiveRunIfPresentLocked(task: task, runId: runId)
+            try validateActiveRunIfPresentLocked(task: task, runId: runId, workerId: workerId, now: now)
 
             if let activeRunId = task.activeRunId {
                 try finishRunLocked(
@@ -649,6 +653,7 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
         guard !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AgentTaskBoardError.invalidInput("block reason cannot be empty")
         }
+        if let workerId { try Self.validateWorker(workerId) }
         return try inImmediateTransaction {
             var task = try requireTaskLocked(id: id)
             let fromStatus = task.status
@@ -656,7 +661,7 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
             guard task.status.canTransition(to: .blocked) else {
                 throw AgentTaskBoardError.invalidTransition(from: task.status, to: .blocked)
             }
-            try validateActiveRunIfPresentLocked(task: task, runId: runId)
+            try validateActiveRunIfPresentLocked(task: task, runId: runId, workerId: workerId, now: now)
 
             if let activeRunId = task.activeRunId {
                 try finishRunLocked(
@@ -992,11 +997,30 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
         return count == 0
     }
 
-    private func validateActiveRunIfPresentLocked(task: AgentTask, runId: UUID?) throws {
+    private func validateActiveRunIfPresentLocked(
+        task: AgentTask,
+        runId: UUID?,
+        workerId: String?,
+        now: Date
+    ) throws {
         guard let activeRunId = task.activeRunId else { return }
         if let runId, runId != activeRunId {
             throw AgentTaskBoardError.invalidInput(
                 "run \(runId.uuidString) does not own task \(task.id.uuidString)"
+            )
+        }
+        guard task.status == .running else { return }
+        guard let leaseOwner = task.leaseOwner,
+            let workerId,
+            workerId == leaseOwner
+        else {
+            throw AgentTaskBoardError.invalidInput(
+                "worker does not own the active lease for task \(task.id.uuidString)"
+            )
+        }
+        if let leaseExpiresAt = task.leaseExpiresAt, leaseExpiresAt <= now {
+            throw AgentTaskBoardError.invalidInput(
+                "active lease for task \(task.id.uuidString) has expired"
             )
         }
     }

--- a/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardStore.swift
+++ b/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardStore.swift
@@ -69,7 +69,10 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
     public func open() throws {
         StorageMutationGate.blockingAwaitNotMutating()
         try queue.sync {
-            guard db == nil else { return }
+            guard db == nil else {
+                registerMaintenanceHandleIfNeededLocked()
+                return
+            }
             OsaurusPaths.ensureExistsSilent(OsaurusPaths.agentTasks())
             do {
                 db = try EncryptedSQLiteOpener.open(
@@ -83,10 +86,7 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
             } catch {
                 throw AgentTaskBoardError.failedToOpen(error.localizedDescription)
             }
-        }
-        if !registeredMaintenanceHandle {
-            OsaurusDatabaseHandle.register(maintenanceHandle)
-            registeredMaintenanceHandle = true
+            registerMaintenanceHandleIfNeededLocked()
         }
     }
 
@@ -110,11 +110,11 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
     }
 
     public func close() {
-        if registeredMaintenanceHandle {
-            OsaurusDatabaseHandle.deregister(name: "agent-task-board")
-            registeredMaintenanceHandle = false
-        }
         queue.sync {
+            if registeredMaintenanceHandle {
+                OsaurusDatabaseHandle.deregister(name: "agent-task-board")
+                registeredMaintenanceHandle = false
+            }
             guard let connection = db else { return }
             try? executeRaw("PRAGMA optimize")
             sqlite3_close(connection)
@@ -135,6 +135,12 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
         closer: { [weak self] in self?.close() },
         reopener: { [weak self] in try? self?.open() }
     )
+
+    private func registerMaintenanceHandleIfNeededLocked() {
+        guard !registeredMaintenanceHandle else { return }
+        OsaurusDatabaseHandle.register(maintenanceHandle)
+        registeredMaintenanceHandle = true
+    }
 
     // MARK: - Schema
 
@@ -256,6 +262,11 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
         now: Date = Date()
     ) throws -> AgentTask {
         try Self.validateTitle(request.title)
+        guard Self.validInitialStatuses.contains(request.status) else {
+            throw AgentTaskBoardError.invalidInput(
+                "\(request.status.rawValue) is not a valid initial task status"
+            )
+        }
         if request.status == .scheduled, request.scheduledAt == nil {
             throw AgentTaskBoardError.invalidInput("scheduled tasks require scheduledAt")
         }
@@ -328,6 +339,7 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
                 throw AgentTaskBoardError.invalidTransition(from: .archived, to: update.status ?? .archived)
             }
             let fromStatus = task.status
+            var clearedRunId: UUID?
 
             if let title = update.title {
                 try Self.validateTitle(title)
@@ -362,6 +374,17 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
                 if next == .scheduled, task.scheduledAt == nil {
                     throw AgentTaskBoardError.invalidInput("scheduled tasks require scheduledAt")
                 }
+                if task.status == .running, [.ready, .review].contains(next) {
+                    clearedRunId = try finishActiveRunForManualTransitionLocked(
+                        task: &task,
+                        to: next,
+                        now: now
+                    )
+                } else if [.ready, .review].contains(next), Self.hasActiveRunOrLease(task) {
+                    throw AgentTaskBoardError.invalidInput(
+                        "cannot move task with an active run or lease to \(next.rawValue)"
+                    )
+                }
                 task.status = next
                 if next != .blocked { task.blockedReason = nil }
                 if next != .archived { task.archivedAt = nil }
@@ -377,6 +400,7 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
                     taskId: task.id,
                     kind: .update,
                     createdAt: now,
+                    runId: clearedRunId,
                     fromStatus: fromStatus,
                     toStatus: task.status,
                     message: message
@@ -785,6 +809,21 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
         }
     }
 
+    func setActiveRunForTesting(
+        taskId: UUID,
+        activeRunId: UUID?,
+        leaseOwner: String? = nil,
+        leaseExpiresAt: Date? = nil
+    ) throws {
+        try inImmediateTransaction {
+            var task = try requireTaskLocked(id: taskId)
+            task.activeRunId = activeRunId
+            task.leaseOwner = leaseOwner
+            task.leaseExpiresAt = leaseExpiresAt
+            try updateTaskLocked(task)
+        }
+    }
+
     // MARK: - Claim internals
 
     private func claimTaskLocked(
@@ -846,6 +885,7 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
                         AND t.scheduled_at <= ?1
                     )
                 )
+                AND t.active_run_id IS NULL
                 AND NOT EXISTS (
                     SELECT 1
                     FROM task_links AS l
@@ -959,6 +999,60 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
                 "run \(runId.uuidString) does not own task \(task.id.uuidString)"
             )
         }
+    }
+
+    private func finishActiveRunForManualTransitionLocked(
+        task: inout AgentTask,
+        to next: AgentTaskStatus,
+        now: Date
+    ) throws -> UUID? {
+        let runId: UUID?
+        if let activeRunId = task.activeRunId {
+            runId = activeRunId
+        } else {
+            runId = try runningRunIdForTaskLocked(taskId: task.id)
+        }
+        guard let runId else {
+            throw AgentTaskBoardError.invalidInput(
+                "cannot move running task to \(next.rawValue) without an active run to finish"
+            )
+        }
+        let runStatus: AgentTaskRunStatus = next == .review ? .completed : .abandoned
+        let error = next == .review ? nil : "task returned to ready"
+        try finishRunLocked(
+            id: runId,
+            status: runStatus,
+            completedAt: now,
+            error: error
+        )
+        task.activeRunId = nil
+        task.leaseOwner = nil
+        task.leaseExpiresAt = nil
+        return runId
+    }
+
+    private func runningRunIdForTaskLocked(taskId: UUID) throws -> UUID? {
+        var runId: UUID?
+        try prepareAndStep(
+            """
+                SELECT id
+                FROM task_runs
+                WHERE task_id = ?1 AND status = 'running'
+                ORDER BY claimed_at DESC
+                LIMIT 1
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: taskId.uuidString)
+        } process: { stmt in
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                runId = Self.uuidColumn(stmt, 0)
+            }
+        }
+        return runId
+    }
+
+    private static func hasActiveRunOrLease(_ task: AgentTask) -> Bool {
+        task.activeRunId != nil || task.leaseOwner != nil || task.leaseExpiresAt != nil
     }
 
     // MARK: - Dependency internals
@@ -1311,6 +1405,8 @@ public final class AgentTaskBoardStore: @unchecked Sendable {
             throw AgentTaskBoardError.failedToExecute("\(context): \(message)")
         }
     }
+
+    private static let validInitialStatuses: Set<AgentTaskStatus> = [.triage, .todo, .scheduled, .ready]
 
     private static func bindTask(_ task: AgentTask, stmt: OpaquePointer) {
         bindText(stmt, index: 1, value: task.id.uuidString)

--- a/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardStore.swift
+++ b/Packages/OsaurusCore/Services/AgentTasks/AgentTaskBoardStore.swift
@@ -1,0 +1,1387 @@
+//
+//  AgentTaskBoardStore.swift
+//  osaurus
+//
+//  Durable local task-board storage for spawned/remote-agent orchestration.
+//  The on-disk database is always opened through SQLCipher with the shared
+//  Osaurus storage key. In-memory test stores are plaintext by design.
+//
+
+import CryptoKit
+import Foundation
+import OsaurusSQLCipher
+
+public enum AgentTaskBoardError: Error, LocalizedError, Equatable {
+    case failedToOpen(String)
+    case failedToExecute(String)
+    case failedToPrepare(String)
+    case migrationFailed(String)
+    case notOpen
+    case notFound(UUID)
+    case invalidInput(String)
+    case invalidTransition(from: AgentTaskStatus, to: AgentTaskStatus)
+    case dependencyCycle(taskId: UUID, dependsOnTaskId: UUID)
+
+    public var errorDescription: String? {
+        switch self {
+        case .failedToOpen(let message):
+            return "Failed to open agent task board: \(message)"
+        case .failedToExecute(let message):
+            return "Failed to execute agent task board query: \(message)"
+        case .failedToPrepare(let message):
+            return "Failed to prepare agent task board query: \(message)"
+        case .migrationFailed(let message):
+            return "Agent task board migration failed: \(message)"
+        case .notOpen:
+            return "Agent task board is not open"
+        case .notFound(let id):
+            return "Agent task not found: \(id.uuidString)"
+        case .invalidInput(let message):
+            return "Invalid agent task input: \(message)"
+        case .invalidTransition(let from, let to):
+            return "Invalid agent task status transition: \(from.rawValue) -> \(to.rawValue)"
+        case .dependencyCycle(let taskId, let dependsOnTaskId):
+            return
+                "Dependency would create a cycle: \(taskId.uuidString) depends on \(dependsOnTaskId.uuidString)"
+        }
+    }
+}
+
+public final class AgentTaskBoardStore: @unchecked Sendable {
+    public static let shared = AgentTaskBoardStore()
+
+    private static let latestSchemaVersion = 1
+    private static let sqliteTransient = unsafeBitCast(
+        OpaquePointer(bitPattern: -1),
+        to: sqlite3_destructor_type.self
+    )
+
+    private let queue = DispatchQueue(label: "ai.osaurus.agent-tasks.board-store")
+    private var db: OpaquePointer?
+    private var registeredMaintenanceHandle = false
+
+    public init() {}
+
+    deinit { close() }
+
+    // MARK: - Lifecycle
+
+    public func open() throws {
+        StorageMutationGate.blockingAwaitNotMutating()
+        try queue.sync {
+            guard db == nil else { return }
+            OsaurusPaths.ensureExistsSilent(OsaurusPaths.agentTasks())
+            do {
+                db = try EncryptedSQLiteOpener.open(
+                    path: OsaurusPaths.agentTaskBoardDatabaseFile().path,
+                    key: StorageKeyManager.shared.currentKey()
+                )
+                try applyConnectionPragmas()
+                try runMigrations()
+            } catch let error as EncryptedSQLiteError {
+                throw AgentTaskBoardError.failedToOpen(error.localizedDescription)
+            } catch {
+                throw AgentTaskBoardError.failedToOpen(error.localizedDescription)
+            }
+        }
+        if !registeredMaintenanceHandle {
+            OsaurusDatabaseHandle.register(maintenanceHandle)
+            registeredMaintenanceHandle = true
+        }
+    }
+
+    /// Test seam for deterministic on-disk stores with an inline key, and
+    /// plaintext `:memory:` stores. Production callers should use `open()`.
+    func openForTesting(path: String = ":memory:", key: SymmetricKey? = nil) throws {
+        try queue.sync {
+            guard db == nil else { return }
+            if path != ":memory:" {
+                let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
+                try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            }
+            db = try EncryptedSQLiteOpener.open(
+                path: path,
+                key: key,
+                applyPerfPragmas: path != ":memory:"
+            )
+            try applyConnectionPragmas()
+            try runMigrations()
+        }
+    }
+
+    public func close() {
+        if registeredMaintenanceHandle {
+            OsaurusDatabaseHandle.deregister(name: "agent-task-board")
+            registeredMaintenanceHandle = false
+        }
+        queue.sync {
+            guard let connection = db else { return }
+            try? executeRaw("PRAGMA optimize")
+            sqlite3_close(connection)
+            db = nil
+        }
+    }
+
+    public var isOpen: Bool { queue.sync { db != nil } }
+
+    private lazy var maintenanceHandle = OsaurusDatabaseHandle(
+        name: "agent-task-board",
+        exec: { [weak self] sql in
+            self?.queue.sync {
+                guard self?.db != nil else { return }
+                try? self?.executeRaw(sql)
+            }
+        },
+        closer: { [weak self] in self?.close() },
+        reopener: { [weak self] in try? self?.open() }
+    )
+
+    // MARK: - Schema
+
+    public func schemaVersionForTesting() throws -> Int {
+        try queue.sync { try getSchemaVersion() }
+    }
+
+    private func runMigrations() throws {
+        let current = try getSchemaVersion()
+        guard current <= Self.latestSchemaVersion else {
+            throw AgentTaskBoardError.migrationFailed(
+                "on-disk schema v\(current) is newer than supported v\(Self.latestSchemaVersion)"
+            )
+        }
+        do {
+            if current < 1 { try migrateToV1() }
+        } catch {
+            throw AgentTaskBoardError.migrationFailed(error.localizedDescription)
+        }
+    }
+
+    private func migrateToV1() throws {
+        try executeRaw(
+            """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    id               TEXT PRIMARY KEY,
+                    title            TEXT NOT NULL,
+                    details          TEXT,
+                    status           TEXT NOT NULL,
+                    priority         INTEGER NOT NULL DEFAULT 0,
+                    created_at       REAL NOT NULL,
+                    updated_at       REAL NOT NULL,
+                    scheduled_at     REAL,
+                    blocked_reason   TEXT,
+                    metadata_json    TEXT,
+                    active_run_id    TEXT,
+                    lease_owner      TEXT,
+                    lease_expires_at REAL,
+                    archived_at      REAL,
+                    CHECK (
+                        status IN (
+                            'triage', 'todo', 'scheduled', 'ready',
+                            'running', 'blocked', 'review', 'done', 'archived'
+                        )
+                    )
+                )
+            """
+        )
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)")
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_tasks_claimable ON tasks(status, scheduled_at, priority)")
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_tasks_lease ON tasks(status, lease_expires_at)")
+
+        try executeRaw(
+            """
+                CREATE TABLE IF NOT EXISTS task_runs (
+                    id                TEXT PRIMARY KEY,
+                    task_id           TEXT NOT NULL,
+                    worker_id         TEXT NOT NULL,
+                    status            TEXT NOT NULL,
+                    claimed_at        REAL NOT NULL,
+                    lease_expires_at  REAL NOT NULL,
+                    last_heartbeat_at REAL NOT NULL,
+                    completed_at      REAL,
+                    error             TEXT,
+                    CHECK (status IN ('running', 'completed', 'blocked', 'expired', 'abandoned')),
+                    FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
+                )
+            """
+        )
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_task_runs_task ON task_runs(task_id, claimed_at DESC)")
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_task_runs_status ON task_runs(status, lease_expires_at)")
+
+        try executeRaw(
+            """
+                CREATE TABLE IF NOT EXISTS task_events (
+                    id            TEXT PRIMARY KEY,
+                    task_id       TEXT NOT NULL,
+                    kind          TEXT NOT NULL,
+                    created_at    REAL NOT NULL,
+                    worker_id     TEXT,
+                    run_id        TEXT,
+                    from_status   TEXT,
+                    to_status     TEXT,
+                    message       TEXT,
+                    payload_json  TEXT,
+                    CHECK (kind IN ('create', 'update', 'claim', 'complete', 'block', 'archive')),
+                    FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+                    FOREIGN KEY(run_id) REFERENCES task_runs(id) ON DELETE SET NULL
+                )
+            """
+        )
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_task_events_task ON task_events(task_id, created_at ASC)")
+
+        try executeRaw(
+            """
+                CREATE TABLE IF NOT EXISTS task_links (
+                    task_id            TEXT NOT NULL,
+                    depends_on_task_id TEXT NOT NULL,
+                    kind               TEXT NOT NULL DEFAULT 'depends_on',
+                    created_at         REAL NOT NULL,
+                    PRIMARY KEY(task_id, depends_on_task_id, kind),
+                    CHECK(task_id != depends_on_task_id),
+                    CHECK(kind IN ('depends_on')),
+                    FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+                    FOREIGN KEY(depends_on_task_id) REFERENCES tasks(id) ON DELETE CASCADE
+                )
+            """
+        )
+        try executeRaw("CREATE INDEX IF NOT EXISTS idx_task_links_depends ON task_links(depends_on_task_id)")
+
+        try setSchemaVersion(1)
+    }
+
+    // MARK: - CRUD
+
+    @discardableResult
+    public func createTask(
+        _ request: AgentTaskCreateRequest,
+        now: Date = Date()
+    ) throws -> AgentTask {
+        try Self.validateTitle(request.title)
+        if request.status == .scheduled, request.scheduledAt == nil {
+            throw AgentTaskBoardError.invalidInput("scheduled tasks require scheduledAt")
+        }
+
+        return try inImmediateTransaction {
+            let task = AgentTask(
+                id: request.id ?? UUID(),
+                title: request.title,
+                details: request.details,
+                status: request.status,
+                priority: request.priority,
+                createdAt: now,
+                updatedAt: now,
+                scheduledAt: request.scheduledAt,
+                metadataJSON: request.metadataJSON
+            )
+            try insertTaskLocked(task)
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: task.id,
+                    kind: .create,
+                    createdAt: now,
+                    toStatus: task.status
+                )
+            )
+            return task
+        }
+    }
+
+    public func task(id: UUID) throws -> AgentTask? {
+        try queue.sync { try readTaskLocked(id: id) }
+    }
+
+    public func listTasks(statuses: [AgentTaskStatus]? = nil) throws -> [AgentTask] {
+        try queue.sync {
+            let columns = Self.taskColumns
+            var sql = "SELECT \(columns) FROM tasks"
+            if let statuses, !statuses.isEmpty {
+                let placeholders = statuses.enumerated().map { "?\($0.offset + 1)" }.joined(separator: ", ")
+                sql += " WHERE status IN (\(placeholders))"
+            }
+            sql += " ORDER BY priority DESC, created_at ASC"
+
+            var tasks: [AgentTask] = []
+            try prepareAndStep(sql) { stmt in
+                if let statuses {
+                    for (index, status) in statuses.enumerated() {
+                        Self.bindText(stmt, index: index + 1, value: status.rawValue)
+                    }
+                }
+            } process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    tasks.append(Self.readTask(stmt))
+                }
+            }
+            return tasks
+        }
+    }
+
+    @discardableResult
+    public func updateTask(
+        id: UUID,
+        update: AgentTaskUpdate,
+        now: Date = Date(),
+        message: String? = nil
+    ) throws -> AgentTask {
+        try inImmediateTransaction {
+            var task = try requireTaskLocked(id: id)
+            guard task.status != .archived else {
+                throw AgentTaskBoardError.invalidTransition(from: .archived, to: update.status ?? .archived)
+            }
+            let fromStatus = task.status
+
+            if let title = update.title {
+                try Self.validateTitle(title)
+                task.title = title
+            }
+            if update.details != nil { task.details = update.details }
+            if let priority = update.priority { task.priority = priority }
+            if update.clearScheduledAt {
+                task.scheduledAt = nil
+            } else if let scheduledAt = update.scheduledAt {
+                task.scheduledAt = scheduledAt
+            }
+            if update.clearBlockedReason {
+                task.blockedReason = nil
+            } else if update.blockedReason != nil {
+                task.blockedReason = update.blockedReason
+            }
+            if update.clearMetadataJSON {
+                task.metadataJSON = nil
+            } else if update.metadataJSON != nil {
+                task.metadataJSON = update.metadataJSON
+            }
+            if let next = update.status {
+                guard ![.running, .blocked, .done, .archived].contains(next) else {
+                    throw AgentTaskBoardError.invalidInput(
+                        "\(next.rawValue) status must be reached through the dedicated task-board API"
+                    )
+                }
+                guard task.status.canTransition(to: next) else {
+                    throw AgentTaskBoardError.invalidTransition(from: task.status, to: next)
+                }
+                if next == .scheduled, task.scheduledAt == nil {
+                    throw AgentTaskBoardError.invalidInput("scheduled tasks require scheduledAt")
+                }
+                task.status = next
+                if next != .blocked { task.blockedReason = nil }
+                if next != .archived { task.archivedAt = nil }
+            }
+            task.updatedAt = now
+            if task.status == .archived, task.archivedAt == nil {
+                task.archivedAt = now
+            }
+
+            try updateTaskLocked(task)
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: task.id,
+                    kind: .update,
+                    createdAt: now,
+                    fromStatus: fromStatus,
+                    toStatus: task.status,
+                    message: message
+                )
+            )
+            return task
+        }
+    }
+
+    // MARK: - Dependencies
+
+    @discardableResult
+    public func addDependency(
+        taskId: UUID,
+        dependsOnTaskId: UUID,
+        now: Date = Date()
+    ) throws -> AgentTaskLink {
+        try inImmediateTransaction {
+            _ = try requireTaskLocked(id: taskId)
+            _ = try requireTaskLocked(id: dependsOnTaskId)
+            guard taskId != dependsOnTaskId else {
+                throw AgentTaskBoardError.dependencyCycle(taskId: taskId, dependsOnTaskId: dependsOnTaskId)
+            }
+            if try dependencyWouldCreateCycleLocked(taskId: taskId, dependsOnTaskId: dependsOnTaskId) {
+                throw AgentTaskBoardError.dependencyCycle(taskId: taskId, dependsOnTaskId: dependsOnTaskId)
+            }
+
+            let link = AgentTaskLink(taskId: taskId, dependsOnTaskId: dependsOnTaskId, createdAt: now)
+            try prepareAndStep(
+                """
+                    INSERT OR IGNORE INTO task_links
+                        (task_id, depends_on_task_id, kind, created_at)
+                    VALUES (?1, ?2, ?3, ?4)
+                """
+            ) { stmt in
+                Self.bindText(stmt, index: 1, value: taskId.uuidString)
+                Self.bindText(stmt, index: 2, value: dependsOnTaskId.uuidString)
+                Self.bindText(stmt, index: 3, value: AgentTaskLinkKind.dependsOn.rawValue)
+                Self.bindDate(stmt, index: 4, value: now)
+            } process: { stmt in
+                try Self.requireDone(stmt, connection: db, context: "addDependency")
+            }
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: taskId,
+                    kind: .update,
+                    createdAt: now,
+                    message: "dependency added",
+                    payloadJSON: #"{"depends_on":"\#(dependsOnTaskId.uuidString)"}"#
+                )
+            )
+            return link
+        }
+    }
+
+    public func dependencies(taskId: UUID) throws -> [AgentTaskLink] {
+        try queue.sync {
+            var links: [AgentTaskLink] = []
+            try prepareAndStep(
+                """
+                    SELECT task_id, depends_on_task_id, kind, created_at
+                    FROM task_links
+                    WHERE task_id = ?1
+                    ORDER BY created_at ASC
+                """
+            ) { stmt in
+                Self.bindText(stmt, index: 1, value: taskId.uuidString)
+            } process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    if let link = Self.readLink(stmt) {
+                        links.append(link)
+                    }
+                }
+            }
+            return links
+        }
+    }
+
+    public func removeDependency(
+        taskId: UUID,
+        dependsOnTaskId: UUID,
+        now: Date = Date()
+    ) throws {
+        try inImmediateTransaction {
+            try prepareAndStep(
+                """
+                    DELETE FROM task_links
+                    WHERE task_id = ?1 AND depends_on_task_id = ?2 AND kind = 'depends_on'
+                """
+            ) { stmt in
+                Self.bindText(stmt, index: 1, value: taskId.uuidString)
+                Self.bindText(stmt, index: 2, value: dependsOnTaskId.uuidString)
+            } process: { stmt in
+                try Self.requireDone(stmt, connection: db, context: "removeDependency")
+            }
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: taskId,
+                    kind: .update,
+                    createdAt: now,
+                    message: "dependency removed",
+                    payloadJSON: #"{"depends_on_removed":"\#(dependsOnTaskId.uuidString)"}"#
+                )
+            )
+        }
+    }
+
+    // MARK: - Claiming and leases
+
+    public func claimTask(
+        id: UUID,
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date = Date()
+    ) throws -> AgentTaskClaim? {
+        try Self.validateWorker(workerId)
+        try Self.validateLeaseTTL(leaseTTL)
+        return try inImmediateTransaction {
+            _ = try expireLeasesLocked(asOf: now)
+            return try claimTaskLocked(id: id, workerId: workerId, leaseTTL: leaseTTL, now: now)
+        }
+    }
+
+    public func claimNext(
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date = Date()
+    ) throws -> AgentTaskClaim? {
+        try Self.validateWorker(workerId)
+        try Self.validateLeaseTTL(leaseTTL)
+        return try inImmediateTransaction {
+            _ = try expireLeasesLocked(asOf: now)
+            guard let candidate = try nextClaimableTaskLocked(asOf: now) else { return nil }
+            return try claimTaskLocked(id: candidate.id, workerId: workerId, leaseTTL: leaseTTL, now: now)
+        }
+    }
+
+    public func renewLease(
+        taskId: UUID,
+        runId: UUID,
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date = Date()
+    ) throws -> AgentTaskRun? {
+        try Self.validateWorker(workerId)
+        try Self.validateLeaseTTL(leaseTTL)
+        return try inImmediateTransaction {
+            guard var task = try readTaskLocked(id: taskId),
+                task.status == .running,
+                task.activeRunId == runId,
+                task.leaseOwner == workerId,
+                let leaseExpiresAt = task.leaseExpiresAt,
+                leaseExpiresAt > now
+            else {
+                return nil
+            }
+
+            let newExpiry = now.addingTimeInterval(leaseTTL)
+            task.leaseExpiresAt = newExpiry
+            task.updatedAt = now
+            try updateTaskLocked(task)
+
+            try prepareAndStep(
+                """
+                    UPDATE task_runs
+                    SET lease_expires_at = ?2,
+                        last_heartbeat_at = ?3
+                    WHERE id = ?1 AND status = 'running'
+                """
+            ) { stmt in
+                Self.bindText(stmt, index: 1, value: runId.uuidString)
+                Self.bindDate(stmt, index: 2, value: newExpiry)
+                Self.bindDate(stmt, index: 3, value: now)
+            } process: { stmt in
+                try Self.requireDone(stmt, connection: db, context: "renewLease")
+            }
+            return try readRunLocked(id: runId)
+        }
+    }
+
+    @discardableResult
+    public func recoverExpiredLeases(asOf now: Date = Date()) throws -> Int {
+        try inImmediateTransaction {
+            try expireLeasesLocked(asOf: now)
+        }
+    }
+
+    // MARK: - Terminal operations
+
+    @discardableResult
+    public func completeTask(
+        id: UUID,
+        runId: UUID? = nil,
+        workerId: String? = nil,
+        now: Date = Date(),
+        message: String? = nil
+    ) throws -> AgentTask {
+        try inImmediateTransaction {
+            var task = try requireTaskLocked(id: id)
+            let fromStatus = task.status
+            let runForEvent = runId ?? task.activeRunId
+            guard task.status.canTransition(to: .done) else {
+                throw AgentTaskBoardError.invalidTransition(from: task.status, to: .done)
+            }
+            try validateActiveRunIfPresentLocked(task: task, runId: runId)
+
+            if let activeRunId = task.activeRunId {
+                try finishRunLocked(
+                    id: activeRunId,
+                    status: .completed,
+                    completedAt: now,
+                    error: nil
+                )
+            }
+            task.status = .done
+            task.updatedAt = now
+            task.activeRunId = nil
+            task.leaseOwner = nil
+            task.leaseExpiresAt = nil
+            task.blockedReason = nil
+            try updateTaskLocked(task)
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: task.id,
+                    kind: .complete,
+                    createdAt: now,
+                    workerId: workerId,
+                    runId: runForEvent,
+                    fromStatus: fromStatus,
+                    toStatus: .done,
+                    message: message
+                )
+            )
+            return task
+        }
+    }
+
+    @discardableResult
+    public func blockTask(
+        id: UUID,
+        reason: String,
+        runId: UUID? = nil,
+        workerId: String? = nil,
+        now: Date = Date()
+    ) throws -> AgentTask {
+        guard !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentTaskBoardError.invalidInput("block reason cannot be empty")
+        }
+        return try inImmediateTransaction {
+            var task = try requireTaskLocked(id: id)
+            let fromStatus = task.status
+            let runForEvent = runId ?? task.activeRunId
+            guard task.status.canTransition(to: .blocked) else {
+                throw AgentTaskBoardError.invalidTransition(from: task.status, to: .blocked)
+            }
+            try validateActiveRunIfPresentLocked(task: task, runId: runId)
+
+            if let activeRunId = task.activeRunId {
+                try finishRunLocked(
+                    id: activeRunId,
+                    status: .blocked,
+                    completedAt: now,
+                    error: reason
+                )
+            }
+            task.status = .blocked
+            task.updatedAt = now
+            task.blockedReason = reason
+            task.activeRunId = nil
+            task.leaseOwner = nil
+            task.leaseExpiresAt = nil
+            try updateTaskLocked(task)
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: task.id,
+                    kind: .block,
+                    createdAt: now,
+                    workerId: workerId,
+                    runId: runForEvent,
+                    fromStatus: fromStatus,
+                    toStatus: .blocked,
+                    message: reason
+                )
+            )
+            return task
+        }
+    }
+
+    @discardableResult
+    public func archiveTask(
+        id: UUID,
+        workerId: String? = nil,
+        now: Date = Date(),
+        message: String? = nil
+    ) throws -> AgentTask {
+        try inImmediateTransaction {
+            var task = try requireTaskLocked(id: id)
+            let fromStatus = task.status
+            let runForEvent = task.activeRunId
+            guard task.status.canTransition(to: .archived) else {
+                throw AgentTaskBoardError.invalidTransition(from: task.status, to: .archived)
+            }
+            if let activeRunId = task.activeRunId {
+                try finishRunLocked(
+                    id: activeRunId,
+                    status: .abandoned,
+                    completedAt: now,
+                    error: "task archived"
+                )
+            }
+            task.status = .archived
+            task.updatedAt = now
+            task.archivedAt = now
+            task.activeRunId = nil
+            task.leaseOwner = nil
+            task.leaseExpiresAt = nil
+            try updateTaskLocked(task)
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: task.id,
+                    kind: .archive,
+                    createdAt: now,
+                    workerId: workerId,
+                    runId: runForEvent,
+                    fromStatus: fromStatus,
+                    toStatus: .archived,
+                    message: message
+                )
+            )
+            return task
+        }
+    }
+
+    // MARK: - History
+
+    public func events(taskId: UUID) throws -> [AgentTaskEvent] {
+        try queue.sync {
+            var events: [AgentTaskEvent] = []
+            try prepareAndStep(
+                """
+                    SELECT id, task_id, kind, created_at, worker_id, run_id,
+                           from_status, to_status, message, payload_json
+                    FROM task_events
+                    WHERE task_id = ?1
+                    ORDER BY created_at ASC
+                """
+            ) { stmt in
+                Self.bindText(stmt, index: 1, value: taskId.uuidString)
+            } process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    if let event = Self.readEvent(stmt) {
+                        events.append(event)
+                    }
+                }
+            }
+            return events
+        }
+    }
+
+    public func runs(taskId: UUID) throws -> [AgentTaskRun] {
+        try queue.sync {
+            var runs: [AgentTaskRun] = []
+            try prepareAndStep(
+                """
+                    SELECT id, task_id, worker_id, status, claimed_at,
+                           lease_expires_at, last_heartbeat_at, completed_at, error
+                    FROM task_runs
+                    WHERE task_id = ?1
+                    ORDER BY claimed_at ASC
+                """
+            ) { stmt in
+                Self.bindText(stmt, index: 1, value: taskId.uuidString)
+            } process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    if let run = Self.readRun(stmt) {
+                        runs.append(run)
+                    }
+                }
+            }
+            return runs
+        }
+    }
+
+    func tableNamesForTesting() throws -> Set<String> {
+        try queue.sync {
+            var names = Set<String>()
+            try prepareAndStep(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ) { _ in } process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    if let raw = sqlite3_column_text(stmt, 0) {
+                        names.insert(String(cString: raw))
+                    }
+                }
+            }
+            return names
+        }
+    }
+
+    func deleteAllForTesting() throws {
+        try inImmediateTransaction {
+            try executeRaw("DELETE FROM task_links")
+            try executeRaw("DELETE FROM task_events")
+            try executeRaw("DELETE FROM task_runs")
+            try executeRaw("DELETE FROM tasks")
+        }
+    }
+
+    // MARK: - Claim internals
+
+    private func claimTaskLocked(
+        id: UUID,
+        workerId: String,
+        leaseTTL: TimeInterval,
+        now: Date
+    ) throws -> AgentTaskClaim? {
+        let task = try requireTaskLocked(id: id)
+        guard Self.isClaimable(task, asOf: now) else { return nil }
+        guard try dependenciesSatisfiedLocked(taskId: id) else { return nil }
+
+        let runId = UUID()
+        let expires = now.addingTimeInterval(leaseTTL)
+        let run = AgentTaskRun(
+            id: runId,
+            taskId: id,
+            workerId: workerId,
+            claimedAt: now,
+            leaseExpiresAt: expires,
+            lastHeartbeatAt: now
+        )
+        try insertRunLocked(run)
+
+        var claimed = task
+        claimed.status = .running
+        claimed.updatedAt = now
+        claimed.activeRunId = runId
+        claimed.leaseOwner = workerId
+        claimed.leaseExpiresAt = expires
+        claimed.blockedReason = nil
+        try updateTaskLocked(claimed)
+
+        try insertEventLocked(
+            AgentTaskEvent(
+                taskId: id,
+                kind: .claim,
+                createdAt: now,
+                workerId: workerId,
+                runId: runId,
+                fromStatus: task.status,
+                toStatus: .running
+            )
+        )
+        return AgentTaskClaim(task: claimed, run: run)
+    }
+
+    private func nextClaimableTaskLocked(asOf now: Date) throws -> AgentTask? {
+        var task: AgentTask?
+        try prepareAndStep(
+            """
+                SELECT \(Self.taskColumns)
+                FROM tasks AS t
+                WHERE (
+                    t.status = 'ready'
+                    OR (
+                        t.status = 'scheduled'
+                        AND t.scheduled_at IS NOT NULL
+                        AND t.scheduled_at <= ?1
+                    )
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM task_links AS l
+                    JOIN tasks AS dep ON dep.id = l.depends_on_task_id
+                    WHERE l.task_id = t.id
+                      AND l.kind = 'depends_on'
+                      AND dep.status != 'done'
+                )
+                ORDER BY t.priority DESC, COALESCE(t.scheduled_at, t.created_at) ASC, t.created_at ASC
+                LIMIT 1
+            """
+        ) { stmt in
+            Self.bindDate(stmt, index: 1, value: now)
+        } process: { stmt in
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                task = Self.readTask(stmt)
+            }
+        }
+        return task
+    }
+
+    private func expireLeasesLocked(asOf now: Date) throws -> Int {
+        var expired: [(taskId: UUID, runId: UUID?)] = []
+        try prepareAndStep(
+            """
+                SELECT id, active_run_id
+                FROM tasks
+                WHERE status = 'running'
+                  AND lease_expires_at IS NOT NULL
+                  AND lease_expires_at <= ?1
+            """
+        ) { stmt in
+            Self.bindDate(stmt, index: 1, value: now)
+        } process: { stmt in
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let taskId = Self.uuidColumn(stmt, 0) else { continue }
+                expired.append((taskId, Self.uuidColumn(stmt, 1)))
+            }
+        }
+
+        for item in expired {
+            if let runId = item.runId {
+                try finishRunLocked(
+                    id: runId,
+                    status: .expired,
+                    completedAt: now,
+                    error: "lease expired"
+                )
+            }
+            var task = try requireTaskLocked(id: item.taskId)
+            let fromStatus = task.status
+            task.status = .ready
+            task.updatedAt = now
+            task.activeRunId = nil
+            task.leaseOwner = nil
+            task.leaseExpiresAt = nil
+            task.blockedReason = nil
+            try updateTaskLocked(task)
+            try insertEventLocked(
+                AgentTaskEvent(
+                    taskId: item.taskId,
+                    kind: .update,
+                    createdAt: now,
+                    runId: item.runId,
+                    fromStatus: fromStatus,
+                    toStatus: .ready,
+                    message: "lease expired; task returned to ready"
+                )
+            )
+        }
+        return expired.count
+    }
+
+    private static func isClaimable(_ task: AgentTask, asOf now: Date) -> Bool {
+        switch task.status {
+        case .ready:
+            return task.activeRunId == nil
+        case .scheduled:
+            guard let scheduledAt = task.scheduledAt else { return false }
+            return scheduledAt <= now && task.activeRunId == nil
+        default:
+            return false
+        }
+    }
+
+    private func dependenciesSatisfiedLocked(taskId: UUID) throws -> Bool {
+        var count = 0
+        try prepareAndStep(
+            """
+                SELECT COUNT(*)
+                FROM task_links AS l
+                JOIN tasks AS dep ON dep.id = l.depends_on_task_id
+                WHERE l.task_id = ?1
+                  AND l.kind = 'depends_on'
+                  AND dep.status != 'done'
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: taskId.uuidString)
+        } process: { stmt in
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                count = Int(sqlite3_column_int(stmt, 0))
+            }
+        }
+        return count == 0
+    }
+
+    private func validateActiveRunIfPresentLocked(task: AgentTask, runId: UUID?) throws {
+        guard let activeRunId = task.activeRunId else { return }
+        if let runId, runId != activeRunId {
+            throw AgentTaskBoardError.invalidInput(
+                "run \(runId.uuidString) does not own task \(task.id.uuidString)"
+            )
+        }
+    }
+
+    // MARK: - Dependency internals
+
+    private func dependencyWouldCreateCycleLocked(
+        taskId: UUID,
+        dependsOnTaskId: UUID
+    ) throws -> Bool {
+        var found = false
+        try prepareAndStep(
+            """
+                WITH RECURSIVE dependency_chain(id) AS (
+                    SELECT ?1
+                    UNION
+                    SELECT l.depends_on_task_id
+                    FROM task_links AS l
+                    JOIN dependency_chain AS c ON l.task_id = c.id
+                    WHERE l.kind = 'depends_on'
+                )
+                SELECT 1 FROM dependency_chain WHERE id = ?2 LIMIT 1
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: dependsOnTaskId.uuidString)
+            Self.bindText(stmt, index: 2, value: taskId.uuidString)
+        } process: { stmt in
+            found = sqlite3_step(stmt) == SQLITE_ROW
+        }
+        return found
+    }
+
+    // MARK: - Row writers
+
+    private func insertTaskLocked(_ task: AgentTask) throws {
+        try prepareAndStep(
+            """
+                INSERT INTO tasks (
+                    id, title, details, status, priority, created_at, updated_at,
+                    scheduled_at, blocked_reason, metadata_json, active_run_id,
+                    lease_owner, lease_expires_at, archived_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            """
+        ) { stmt in
+            Self.bindTask(task, stmt: stmt)
+        } process: { stmt in
+            try Self.requireDone(stmt, connection: db, context: "insertTask")
+        }
+    }
+
+    private func updateTaskLocked(_ task: AgentTask) throws {
+        try prepareAndStep(
+            """
+                UPDATE tasks SET
+                    title = ?2,
+                    details = ?3,
+                    status = ?4,
+                    priority = ?5,
+                    created_at = ?6,
+                    updated_at = ?7,
+                    scheduled_at = ?8,
+                    blocked_reason = ?9,
+                    metadata_json = ?10,
+                    active_run_id = ?11,
+                    lease_owner = ?12,
+                    lease_expires_at = ?13,
+                    archived_at = ?14
+                WHERE id = ?1
+            """
+        ) { stmt in
+            Self.bindTask(task, stmt: stmt)
+        } process: { stmt in
+            try Self.requireDone(stmt, connection: db, context: "updateTask")
+        }
+    }
+
+    private func insertRunLocked(_ run: AgentTaskRun) throws {
+        try prepareAndStep(
+            """
+                INSERT INTO task_runs (
+                    id, task_id, worker_id, status, claimed_at, lease_expires_at,
+                    last_heartbeat_at, completed_at, error
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: run.id.uuidString)
+            Self.bindText(stmt, index: 2, value: run.taskId.uuidString)
+            Self.bindText(stmt, index: 3, value: run.workerId)
+            Self.bindText(stmt, index: 4, value: run.status.rawValue)
+            Self.bindDate(stmt, index: 5, value: run.claimedAt)
+            Self.bindDate(stmt, index: 6, value: run.leaseExpiresAt)
+            Self.bindDate(stmt, index: 7, value: run.lastHeartbeatAt)
+            Self.bindOptionalDate(stmt, index: 8, value: run.completedAt)
+            Self.bindText(stmt, index: 9, value: run.error)
+        } process: { stmt in
+            try Self.requireDone(stmt, connection: db, context: "insertRun")
+        }
+    }
+
+    private func finishRunLocked(
+        id: UUID,
+        status: AgentTaskRunStatus,
+        completedAt: Date,
+        error: String?
+    ) throws {
+        try prepareAndStep(
+            """
+                UPDATE task_runs
+                SET status = ?2,
+                    completed_at = ?3,
+                    error = COALESCE(?4, error)
+                WHERE id = ?1 AND status = 'running'
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: id.uuidString)
+            Self.bindText(stmt, index: 2, value: status.rawValue)
+            Self.bindDate(stmt, index: 3, value: completedAt)
+            Self.bindText(stmt, index: 4, value: error)
+        } process: { stmt in
+            try Self.requireDone(stmt, connection: db, context: "finishRun")
+        }
+    }
+
+    private func insertEventLocked(_ event: AgentTaskEvent) throws {
+        try prepareAndStep(
+            """
+                INSERT INTO task_events (
+                    id, task_id, kind, created_at, worker_id, run_id,
+                    from_status, to_status, message, payload_json
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: event.id.uuidString)
+            Self.bindText(stmt, index: 2, value: event.taskId.uuidString)
+            Self.bindText(stmt, index: 3, value: event.kind.rawValue)
+            Self.bindDate(stmt, index: 4, value: event.createdAt)
+            Self.bindText(stmt, index: 5, value: event.workerId)
+            Self.bindText(stmt, index: 6, value: event.runId?.uuidString)
+            Self.bindText(stmt, index: 7, value: event.fromStatus?.rawValue)
+            Self.bindText(stmt, index: 8, value: event.toStatus?.rawValue)
+            Self.bindText(stmt, index: 9, value: event.message)
+            Self.bindText(stmt, index: 10, value: event.payloadJSON)
+        } process: { stmt in
+            try Self.requireDone(stmt, connection: db, context: "insertEvent")
+        }
+    }
+
+    // MARK: - Row readers
+
+    private static let taskColumns =
+        """
+            id, title, details, status, priority, created_at, updated_at,
+            scheduled_at, blocked_reason, metadata_json, active_run_id,
+            lease_owner, lease_expires_at, archived_at
+        """
+
+    private func requireTaskLocked(id: UUID) throws -> AgentTask {
+        guard let task = try readTaskLocked(id: id) else {
+            throw AgentTaskBoardError.notFound(id)
+        }
+        return task
+    }
+
+    private func readTaskLocked(id: UUID) throws -> AgentTask? {
+        var task: AgentTask?
+        try prepareAndStep(
+            "SELECT \(Self.taskColumns) FROM tasks WHERE id = ?1"
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: id.uuidString)
+        } process: { stmt in
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                task = Self.readTask(stmt)
+            }
+        }
+        return task
+    }
+
+    private func readRunLocked(id: UUID) throws -> AgentTaskRun? {
+        var run: AgentTaskRun?
+        try prepareAndStep(
+            """
+                SELECT id, task_id, worker_id, status, claimed_at,
+                       lease_expires_at, last_heartbeat_at, completed_at, error
+                FROM task_runs
+                WHERE id = ?1
+            """
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: id.uuidString)
+        } process: { stmt in
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                run = Self.readRun(stmt)
+            }
+        }
+        return run
+    }
+
+    private static func readTask(_ stmt: OpaquePointer) -> AgentTask {
+        AgentTask(
+            id: uuidColumn(stmt, 0) ?? UUID(),
+            title: textColumn(stmt, 1) ?? "",
+            details: textColumn(stmt, 2),
+            status: AgentTaskStatus(rawValue: textColumn(stmt, 3) ?? "") ?? .triage,
+            priority: Int(sqlite3_column_int64(stmt, 4)),
+            createdAt: dateColumn(stmt, 5) ?? Date(timeIntervalSince1970: 0),
+            updatedAt: dateColumn(stmt, 6) ?? Date(timeIntervalSince1970: 0),
+            scheduledAt: dateColumn(stmt, 7),
+            blockedReason: textColumn(stmt, 8),
+            metadataJSON: textColumn(stmt, 9),
+            activeRunId: uuidColumn(stmt, 10),
+            leaseOwner: textColumn(stmt, 11),
+            leaseExpiresAt: dateColumn(stmt, 12),
+            archivedAt: dateColumn(stmt, 13)
+        )
+    }
+
+    private static func readRun(_ stmt: OpaquePointer) -> AgentTaskRun? {
+        guard let id = uuidColumn(stmt, 0),
+            let taskId = uuidColumn(stmt, 1),
+            let workerId = textColumn(stmt, 2),
+            let status = AgentTaskRunStatus(rawValue: textColumn(stmt, 3) ?? ""),
+            let claimedAt = dateColumn(stmt, 4),
+            let leaseExpiresAt = dateColumn(stmt, 5),
+            let lastHeartbeatAt = dateColumn(stmt, 6)
+        else {
+            return nil
+        }
+        return AgentTaskRun(
+            id: id,
+            taskId: taskId,
+            workerId: workerId,
+            status: status,
+            claimedAt: claimedAt,
+            leaseExpiresAt: leaseExpiresAt,
+            lastHeartbeatAt: lastHeartbeatAt,
+            completedAt: dateColumn(stmt, 7),
+            error: textColumn(stmt, 8)
+        )
+    }
+
+    private static func readEvent(_ stmt: OpaquePointer) -> AgentTaskEvent? {
+        guard let id = uuidColumn(stmt, 0),
+            let taskId = uuidColumn(stmt, 1),
+            let kind = AgentTaskEventKind(rawValue: textColumn(stmt, 2) ?? ""),
+            let createdAt = dateColumn(stmt, 3)
+        else {
+            return nil
+        }
+        return AgentTaskEvent(
+            id: id,
+            taskId: taskId,
+            kind: kind,
+            createdAt: createdAt,
+            workerId: textColumn(stmt, 4),
+            runId: uuidColumn(stmt, 5),
+            fromStatus: textColumn(stmt, 6).flatMap(AgentTaskStatus.init(rawValue:)),
+            toStatus: textColumn(stmt, 7).flatMap(AgentTaskStatus.init(rawValue:)),
+            message: textColumn(stmt, 8),
+            payloadJSON: textColumn(stmt, 9)
+        )
+    }
+
+    private static func readLink(_ stmt: OpaquePointer) -> AgentTaskLink? {
+        guard let taskId = uuidColumn(stmt, 0),
+            let dependsOnTaskId = uuidColumn(stmt, 1),
+            let kind = AgentTaskLinkKind(rawValue: textColumn(stmt, 2) ?? ""),
+            let createdAt = dateColumn(stmt, 3)
+        else {
+            return nil
+        }
+        return AgentTaskLink(
+            taskId: taskId,
+            dependsOnTaskId: dependsOnTaskId,
+            kind: kind,
+            createdAt: createdAt
+        )
+    }
+
+    // MARK: - SQL helpers
+
+    private func applyConnectionPragmas() throws {
+        try executeRaw("PRAGMA busy_timeout = 5000")
+        try executeRaw("PRAGMA foreign_keys = ON")
+    }
+
+    private func getSchemaVersion() throws -> Int {
+        var version = 0
+        try prepareAndStep("PRAGMA user_version") { _ in } process: { stmt in
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                version = Int(sqlite3_column_int(stmt, 0))
+            }
+        }
+        return version
+    }
+
+    private func setSchemaVersion(_ version: Int) throws {
+        try executeRaw("PRAGMA user_version = \(version)")
+    }
+
+    private func inImmediateTransaction<T>(_ operation: () throws -> T) throws -> T {
+        try queue.sync {
+            guard db != nil else { throw AgentTaskBoardError.notOpen }
+            try executeRaw("BEGIN IMMEDIATE")
+            do {
+                let result = try operation()
+                try executeRaw("COMMIT")
+                return result
+            } catch {
+                try? executeRaw("ROLLBACK")
+                throw error
+            }
+        }
+    }
+
+    private func executeRaw(_ sql: String) throws {
+        guard let connection = db else { throw AgentTaskBoardError.notOpen }
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(connection, sql, nil, nil, &errorMessage)
+        if result != SQLITE_OK {
+            let message = errorMessage.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(connection))
+            sqlite3_free(errorMessage)
+            throw AgentTaskBoardError.failedToExecute(message)
+        }
+    }
+
+    private func prepareAndStep(
+        _ sql: String,
+        bind: (OpaquePointer) throws -> Void,
+        process: (OpaquePointer) throws -> Void
+    ) throws {
+        guard let connection = db else { throw AgentTaskBoardError.notOpen }
+        var stmt: OpaquePointer?
+        let prepareResult = sqlite3_prepare_v2(connection, sql, -1, &stmt, nil)
+        guard prepareResult == SQLITE_OK, let statement = stmt else {
+            throw AgentTaskBoardError.failedToPrepare(String(cString: sqlite3_errmsg(connection)))
+        }
+        defer { sqlite3_finalize(statement) }
+        try bind(statement)
+        try process(statement)
+    }
+
+    private static func requireDone(
+        _ stmt: OpaquePointer,
+        connection: OpaquePointer?,
+        context: String
+    ) throws {
+        let step = sqlite3_step(stmt)
+        guard step == SQLITE_DONE else {
+            let message = connection.map { String(cString: sqlite3_errmsg($0)) } ?? "step returned \(step)"
+            throw AgentTaskBoardError.failedToExecute("\(context): \(message)")
+        }
+    }
+
+    private static func bindTask(_ task: AgentTask, stmt: OpaquePointer) {
+        bindText(stmt, index: 1, value: task.id.uuidString)
+        bindText(stmt, index: 2, value: task.title)
+        bindText(stmt, index: 3, value: task.details)
+        bindText(stmt, index: 4, value: task.status.rawValue)
+        sqlite3_bind_int64(stmt, 5, Int64(task.priority))
+        bindDate(stmt, index: 6, value: task.createdAt)
+        bindDate(stmt, index: 7, value: task.updatedAt)
+        bindOptionalDate(stmt, index: 8, value: task.scheduledAt)
+        bindText(stmt, index: 9, value: task.blockedReason)
+        bindText(stmt, index: 10, value: task.metadataJSON)
+        bindText(stmt, index: 11, value: task.activeRunId?.uuidString)
+        bindText(stmt, index: 12, value: task.leaseOwner)
+        bindOptionalDate(stmt, index: 13, value: task.leaseExpiresAt)
+        bindOptionalDate(stmt, index: 14, value: task.archivedAt)
+    }
+
+    private static func bindText(_ stmt: OpaquePointer, index: Int, value: String?) {
+        if let value {
+            sqlite3_bind_text(stmt, Int32(index), value, -1, sqliteTransient)
+        } else {
+            sqlite3_bind_null(stmt, Int32(index))
+        }
+    }
+
+    private static func bindDate(_ stmt: OpaquePointer, index: Int, value: Date) {
+        sqlite3_bind_double(stmt, Int32(index), value.timeIntervalSince1970)
+    }
+
+    private static func bindOptionalDate(_ stmt: OpaquePointer, index: Int, value: Date?) {
+        if let value {
+            bindDate(stmt, index: index, value: value)
+        } else {
+            sqlite3_bind_null(stmt, Int32(index))
+        }
+    }
+
+    private static func textColumn(_ stmt: OpaquePointer, _ index: Int32) -> String? {
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL,
+            let raw = sqlite3_column_text(stmt, index)
+        else {
+            return nil
+        }
+        return String(cString: raw)
+    }
+
+    private static func uuidColumn(_ stmt: OpaquePointer, _ index: Int32) -> UUID? {
+        textColumn(stmt, index).flatMap(UUID.init(uuidString:))
+    }
+
+    private static func dateColumn(_ stmt: OpaquePointer, _ index: Int32) -> Date? {
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL else { return nil }
+        return Date(timeIntervalSince1970: sqlite3_column_double(stmt, index))
+    }
+
+    private static func validateTitle(_ title: String) throws {
+        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentTaskBoardError.invalidInput("title cannot be empty")
+        }
+    }
+
+    private static func validateWorker(_ workerId: String) throws {
+        guard !workerId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AgentTaskBoardError.invalidInput("workerId cannot be empty")
+        }
+    }
+
+    private static func validateLeaseTTL(_ ttl: TimeInterval) throws {
+        guard ttl.isFinite, ttl > 0 else {
+            throw AgentTaskBoardError.invalidInput("leaseTTL must be positive")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Storage/StorageDatabaseCatalog.swift
+++ b/Packages/OsaurusCore/Storage/StorageDatabaseCatalog.swift
@@ -13,6 +13,14 @@
 import Foundation
 
 public enum StorageDatabaseCatalog {
+    public enum TargetAtRestPolicy: Sendable, Equatable {
+        /// The target follows the user-selected storage encryption posture.
+        case followsGlobalPolicy
+        /// The target must remain SQLCipher-encrypted even when other stores
+        /// are converged to plaintext.
+        case alwaysEncrypted
+    }
+
     /// One unified target description so callers stay flat. The
     /// `label` is only used for human-readable logging; rekey and
     /// export operate on `path`. Core databases use short labels
@@ -21,10 +29,16 @@ public enum StorageDatabaseCatalog {
     public struct DatabaseTarget: Sendable {
         public let label: String
         public let path: String
+        public let atRestPolicy: TargetAtRestPolicy
 
-        public init(label: String, path: String) {
+        public init(
+            label: String,
+            path: String,
+            atRestPolicy: TargetAtRestPolicy = .followsGlobalPolicy
+        ) {
             self.label = label
             self.path = path
+            self.atRestPolicy = atRestPolicy
         }
 
         /// Convenience constructor for plugin targets — keeps the
@@ -41,6 +55,11 @@ public enum StorageDatabaseCatalog {
             .init(label: "memory", path: OsaurusPaths.memoryDatabaseFile().path),
             .init(label: "methods", path: OsaurusPaths.methodsDatabaseFile().path),
             .init(label: "tool index", path: OsaurusPaths.toolIndexDatabaseFile().path),
+            .init(
+                label: "agent task board",
+                path: OsaurusPaths.agentTaskBoardDatabaseFile().path,
+                atRestPolicy: .alwaysEncrypted
+            ),
             // Both Agent DB stores are created encrypted on first open
             // via `EncryptedSQLiteOpener`; they're listed here so
             // `StorageExportService.rotate(...)` rekeys them along with

--- a/Packages/OsaurusCore/Storage/StorageMigrationCoordinator.swift
+++ b/Packages/OsaurusCore/Storage/StorageMigrationCoordinator.swift
@@ -164,7 +164,7 @@ public actor StorageMigrationCoordinator {
         var report = Report(mode: mode)
 
         let dbTargets = StorageDatabaseCatalog.databaseTargets()
-        let needing = dbTargets.filter { Self.needsConversion(path: $0.path, to: mode) }
+        let needing = dbTargets.filter { Self.needsConversion(target: $0, to: mode) }
         let needsBlobs = Self.blobsNeedConversion(to: mode)
 
         guard !needing.isEmpty || needsBlobs else {
@@ -231,7 +231,9 @@ public actor StorageMigrationCoordinator {
     public nonisolated static func detectOnDiskPosture() -> StorageOnDiskPosture {
         var sawPlaintext = false
         var sawEncrypted = false
-        for target in StorageDatabaseCatalog.databaseTargets() {
+        for target in StorageDatabaseCatalog.databaseTargets()
+            where target.atRestPolicy == .followsGlobalPolicy
+        {
             switch StorageFileFormat.detect(path: target.path) {
             case .plaintext: sawPlaintext = true
             case .encrypted: sawEncrypted = true
@@ -313,6 +315,25 @@ public actor StorageMigrationCoordinator {
         }
     }
 
+    static func needsConversion(
+        target: StorageDatabaseCatalog.DatabaseTarget,
+        to mode: StorageEncryptionMode
+    ) -> Bool {
+        needsConversion(path: target.path, to: effectiveMode(for: target, globalMode: mode))
+    }
+
+    private static func effectiveMode(
+        for target: StorageDatabaseCatalog.DatabaseTarget,
+        globalMode: StorageEncryptionMode
+    ) -> StorageEncryptionMode {
+        switch target.atRestPolicy {
+        case .followsGlobalPolicy:
+            return globalMode
+        case .alwaysEncrypted:
+            return .encrypted
+        }
+    }
+
     /// True when any attachment blob's on-disk form differs from `mode`
     /// (encrypted `.osec` while plaintext is desired, or vice versa).
     static func blobsNeedConversion(to mode: StorageEncryptionMode) -> Bool {
@@ -366,7 +387,8 @@ public actor StorageMigrationCoordinator {
                 var matched = 0
                 var skipped: [String] = []
                 for target in targets {
-                    guard needsConversion(path: target.path, to: mode) else {
+                    let targetMode = effectiveMode(for: target, globalMode: mode)
+                    guard needsConversion(path: target.path, to: targetMode) else {
                         matched += 1
                         continue
                     }
@@ -383,7 +405,7 @@ public actor StorageMigrationCoordinator {
                         continue
                     }
                     do {
-                        switch mode {
+                        switch targetMode {
                         case .plaintext:
                             try StorageFormatConverter.decryptInPlace(path: target.path, key: key)
                         case .encrypted:

--- a/Packages/OsaurusCore/Tests/AgentTasks/AgentTaskBoardStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentTasks/AgentTaskBoardStoreTests.swift
@@ -110,6 +110,183 @@ struct AgentTaskBoardStoreTests {
     }
 
     @Test
+    func createRejectsInvalidInitialStatuses() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        for status in [AgentTaskStatus.running, .blocked, .review, .done, .archived] {
+            #expect(throws: AgentTaskBoardError.self) {
+                try store.createTask(
+                    AgentTaskCreateRequest(title: "Invalid \(status.rawValue)", status: status),
+                    now: fixedDate()
+                )
+            }
+        }
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.createTask(
+                AgentTaskCreateRequest(title: "Missing schedule", status: .scheduled),
+                now: fixedDate()
+            )
+        }
+
+        let scheduled = try store.createTask(
+            AgentTaskCreateRequest(
+                title: "Scheduled",
+                status: .scheduled,
+                scheduledAt: fixedDate(60)
+            ),
+            now: fixedDate()
+        )
+        #expect(scheduled.status == .scheduled)
+    }
+
+    @Test
+    func updateFromRunningToReadyOrReviewFinishesRunAndClearsLease() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let readyTarget = try store.createTask(
+            AgentTaskCreateRequest(title: "Return to ready", status: .ready),
+            now: fixedDate()
+        )
+        let readyClaim = try #require(
+            try store.claimTask(
+                id: readyTarget.id,
+                workerId: "worker-a",
+                leaseTTL: 60,
+                now: fixedDate(1)
+            )
+        )
+        try store.setActiveRunForTesting(
+            taskId: readyTarget.id,
+            activeRunId: nil,
+            leaseOwner: "worker-a",
+            leaseExpiresAt: fixedDate(61)
+        )
+
+        let returned = try store.updateTask(
+            id: readyTarget.id,
+            update: AgentTaskUpdate(status: .ready),
+            now: fixedDate(2),
+            message: "manual requeue"
+        )
+        #expect(returned.status == .ready)
+        #expect(returned.activeRunId == nil)
+        #expect(returned.leaseOwner == nil)
+        #expect(returned.leaseExpiresAt == nil)
+        #expect(try store.runs(taskId: readyTarget.id).map(\.status) == [.abandoned])
+        #expect(try store.events(taskId: readyTarget.id).last?.runId == readyClaim.run.id)
+
+        let reviewTarget = try store.createTask(
+            AgentTaskCreateRequest(title: "Move to review", status: .ready),
+            now: fixedDate(3)
+        )
+        let reviewClaim = try #require(
+            try store.claimTask(
+                id: reviewTarget.id,
+                workerId: "worker-b",
+                leaseTTL: 60,
+                now: fixedDate(4)
+            )
+        )
+
+        let reviewed = try store.updateTask(
+            id: reviewTarget.id,
+            update: AgentTaskUpdate(status: .review),
+            now: fixedDate(5),
+            message: "ready for review"
+        )
+        #expect(reviewed.status == .review)
+        #expect(reviewed.activeRunId == nil)
+        #expect(reviewed.leaseOwner == nil)
+        #expect(reviewed.leaseExpiresAt == nil)
+        #expect(try store.runs(taskId: reviewTarget.id).map(\.status) == [.completed])
+        #expect(try store.events(taskId: reviewTarget.id).last?.runId == reviewClaim.run.id)
+    }
+
+    @Test
+    func updateToClaimableStatusRejectsNonRunningTaskWithActiveRunOrLease() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let staleRun = try store.createTask(
+            AgentTaskCreateRequest(title: "Stale active run", status: .todo),
+            now: fixedDate()
+        )
+        try store.setActiveRunForTesting(
+            taskId: staleRun.id,
+            activeRunId: UUID(),
+            leaseOwner: "stale-worker",
+            leaseExpiresAt: fixedDate(60)
+        )
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.updateTask(
+                id: staleRun.id,
+                update: AgentTaskUpdate(status: .ready),
+                now: fixedDate(1)
+            )
+        }
+        #expect(try store.task(id: staleRun.id)?.status == .todo)
+        #expect(try store.task(id: staleRun.id)?.activeRunId != nil)
+
+        let staleLease = try store.createTask(
+            AgentTaskCreateRequest(title: "Stale lease", status: .todo),
+            now: fixedDate(2)
+        )
+        try store.setActiveRunForTesting(
+            taskId: staleLease.id,
+            activeRunId: nil,
+            leaseOwner: "stale-worker",
+            leaseExpiresAt: fixedDate(62)
+        )
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.updateTask(
+                id: staleLease.id,
+                update: AgentTaskUpdate(status: .ready),
+                now: fixedDate(3)
+            )
+        }
+        #expect(try store.task(id: staleLease.id)?.status == .todo)
+        #expect(try store.task(id: staleLease.id)?.leaseOwner == "stale-worker")
+    }
+
+    @Test
+    func claimNextSkipsReadyRowsWithActiveRunId() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let orphaned = try store.createTask(
+            AgentTaskCreateRequest(title: "Stale active row", status: .ready, priority: 100),
+            now: fixedDate()
+        )
+        let claimable = try store.createTask(
+            AgentTaskCreateRequest(title: "Claimable row", status: .ready, priority: 1),
+            now: fixedDate(1)
+        )
+        try store.setActiveRunForTesting(
+            taskId: orphaned.id,
+            activeRunId: UUID(),
+            leaseOwner: "stale-worker",
+            leaseExpiresAt: fixedDate(120)
+        )
+
+        let claim = try #require(
+            try store.claimNext(
+                workerId: "worker-next",
+                leaseTTL: 60,
+                now: fixedDate(2)
+            )
+        )
+
+        #expect(claim.task.id == claimable.id)
+        #expect(try store.task(id: orphaned.id)?.status == .ready)
+        #expect(try store.task(id: orphaned.id)?.activeRunId != nil)
+    }
+
+    @Test
     func dependencyInsertRejectsCycles() throws {
         let store = try openInMemory()
         defer { store.close() }

--- a/Packages/OsaurusCore/Tests/AgentTasks/AgentTaskBoardStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentTasks/AgentTaskBoardStoreTests.swift
@@ -1,0 +1,331 @@
+//
+//  AgentTaskBoardStoreTests.swift
+//  OsaurusCoreTests
+//
+//  Focused coverage for the durable local AgentTasks board foundation.
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct AgentTaskBoardStoreTests {
+    private func openInMemory() throws -> AgentTaskBoardStore {
+        let store = AgentTaskBoardStore()
+        try store.openForTesting()
+        return store
+    }
+
+    private func tempDir(_ name: String = "agent-task-board") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "\(name)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func key(seed: UInt8) -> SymmetricKey {
+        SymmetricKey(data: Data(repeating: seed, count: 32))
+    }
+
+    private func fixedDate(_ offset: TimeInterval = 0) -> Date {
+        Date(timeIntervalSince1970: 1_800_000_000 + offset)
+    }
+
+    @Test
+    func migrationsCreateExpectedTables() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        #expect(try store.schemaVersionForTesting() == 1)
+        let tables = try store.tableNamesForTesting()
+        #expect(tables.contains("tasks"))
+        #expect(tables.contains("task_events"))
+        #expect(tables.contains("task_runs"))
+        #expect(tables.contains("task_links"))
+    }
+
+    @Test
+    func createUpdateArchiveRoundTripsAndAppendsEvents() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let task = try store.createTask(
+            AgentTaskCreateRequest(
+                title: "Investigate flaky worker",
+                details: "Capture local evidence",
+                metadataJSON: #"{"issue":1714}"#
+            ),
+            now: fixedDate()
+        )
+
+        let updated = try store.updateTask(
+            id: task.id,
+            update: AgentTaskUpdate(
+                title: "Investigate durable worker",
+                status: .todo,
+                priority: 7
+            ),
+            now: fixedDate(1),
+            message: "triaged"
+        )
+        #expect(updated.title == "Investigate durable worker")
+        #expect(updated.status == .todo)
+        #expect(updated.priority == 7)
+
+        let archived = try store.archiveTask(
+            id: task.id,
+            workerId: "tester",
+            now: fixedDate(2),
+            message: "not needed"
+        )
+        #expect(archived.status == .archived)
+        #expect(archived.archivedAt == fixedDate(2))
+
+        let maybeLoaded = try store.task(id: task.id)
+        let loaded = try #require(maybeLoaded)
+        #expect(loaded.status == .archived)
+        #expect(try store.listTasks(statuses: [.archived]).map(\.id) == [task.id])
+        #expect(try store.events(taskId: task.id).map(\.kind) == [.create, .update, .archive])
+    }
+
+    @Test
+    func invalidStatusTransitionIsRejected() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+        let task = try store.createTask(AgentTaskCreateRequest(title: "Needs work"), now: fixedDate())
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.updateTask(
+                id: task.id,
+                update: AgentTaskUpdate(status: .done),
+                now: fixedDate(1)
+            )
+        }
+        #expect(try store.task(id: task.id)?.status == .triage)
+    }
+
+    @Test
+    func dependencyInsertRejectsCycles() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let a = try store.createTask(AgentTaskCreateRequest(title: "A"), now: fixedDate())
+        let b = try store.createTask(AgentTaskCreateRequest(title: "B"), now: fixedDate(1))
+        let c = try store.createTask(AgentTaskCreateRequest(title: "C"), now: fixedDate(2))
+
+        try store.addDependency(taskId: a.id, dependsOnTaskId: b.id, now: fixedDate(3))
+        try store.addDependency(taskId: b.id, dependsOnTaskId: c.id, now: fixedDate(4))
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.addDependency(taskId: c.id, dependsOnTaskId: a.id, now: fixedDate(5))
+        }
+        #expect(try store.dependencies(taskId: c.id).isEmpty)
+    }
+
+    @Test
+    func claimRespectsDependenciesUntilPrerequisiteCompletes() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let prerequisite = try store.createTask(
+            AgentTaskCreateRequest(title: "Prerequisite", status: .ready),
+            now: fixedDate()
+        )
+        let dependent = try store.createTask(
+            AgentTaskCreateRequest(title: "Dependent", status: .ready),
+            now: fixedDate(1)
+        )
+        try store.addDependency(
+            taskId: dependent.id,
+            dependsOnTaskId: prerequisite.id,
+            now: fixedDate(2)
+        )
+
+        #expect(
+            try store.claimTask(
+                id: dependent.id,
+                workerId: "worker-a",
+                leaseTTL: 60,
+                now: fixedDate(3)
+            ) == nil
+        )
+
+        let maybePrerequisiteClaim = try store.claimTask(
+            id: prerequisite.id,
+            workerId: "worker-a",
+            leaseTTL: 60,
+            now: fixedDate(4)
+        )
+        let prerequisiteClaim = try #require(maybePrerequisiteClaim)
+        try store.completeTask(
+            id: prerequisite.id,
+            runId: prerequisiteClaim.run.id,
+            workerId: "worker-a",
+            now: fixedDate(5)
+        )
+
+        let maybeDependentClaim = try store.claimTask(
+            id: dependent.id,
+            workerId: "worker-b",
+            leaseTTL: 60,
+            now: fixedDate(6)
+        )
+        let dependentClaim = try #require(maybeDependentClaim)
+        #expect(dependentClaim.task.status == .running)
+        #expect(dependentClaim.task.leaseOwner == "worker-b")
+    }
+
+    @Test
+    func concurrentAtomicClaimOnlyAllowsOneWinner() async throws {
+        let dir = try tempDir("agent-task-board-claim")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let path = dir.appendingPathComponent("board.sqlite").path
+        let keyData = Data(repeating: 0x34, count: 32)
+        let primary = AgentTaskBoardStore()
+        try primary.openForTesting(path: path, key: SymmetricKey(data: keyData))
+        defer { primary.close() }
+
+        let task = try primary.createTask(
+            AgentTaskCreateRequest(title: "Claim once", status: .ready),
+            now: fixedDate()
+        )
+
+        let winners = await withTaskGroup(of: String?.self) { group -> [String] in
+            for i in 0 ..< 20 {
+                group.addTask {
+                    let store = AgentTaskBoardStore()
+                    do {
+                        try store.openForTesting(path: path, key: SymmetricKey(data: keyData))
+                        defer { store.close() }
+                        return try store.claimTask(
+                            id: task.id,
+                            workerId: "worker-\(i)",
+                            leaseTTL: 60,
+                            now: fixedDate(1)
+                        )?.run.workerId
+                    } catch {
+                        store.close()
+                        return nil
+                    }
+                }
+            }
+
+            var output: [String] = []
+            for await winner in group {
+                if let winner { output.append(winner) }
+            }
+            return output
+        }
+
+        #expect(winners.count == 1)
+        let maybeLoaded = try primary.task(id: task.id)
+        let loaded = try #require(maybeLoaded)
+        #expect(loaded.status == .running)
+        #expect(loaded.leaseOwner == winners.first)
+        #expect(try primary.runs(taskId: task.id).count == 1)
+    }
+
+    @Test
+    func staleLeaseCanBeReclaimedByAnotherWorker() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let task = try store.createTask(
+            AgentTaskCreateRequest(title: "Reclaim me", status: .ready),
+            now: fixedDate()
+        )
+        let maybeFirst = try store.claimTask(
+            id: task.id,
+            workerId: "worker-a",
+            leaseTTL: 10,
+            now: fixedDate(1)
+        )
+        let first = try #require(maybeFirst)
+        let maybeSecond = try store.claimTask(
+            id: task.id,
+            workerId: "worker-b",
+            leaseTTL: 10,
+            now: fixedDate(12)
+        )
+        let second = try #require(maybeSecond)
+
+        #expect(first.run.id != second.run.id)
+        #expect(second.task.leaseOwner == "worker-b")
+        let runs = try store.runs(taskId: task.id)
+        #expect(runs.map(\.status) == [.expired, .running])
+        #expect(try store.events(taskId: task.id).map(\.kind) == [.create, .claim, .update, .claim])
+    }
+
+    @Test
+    func crashStyleRecoveryReturnsExpiredRunningTaskToReadyAfterReopen() throws {
+        let dir = try tempDir("agent-task-board-recovery")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let path = dir.appendingPathComponent("board.sqlite").path
+        let dbKey = key(seed: 0x44)
+        let taskId: UUID
+
+        do {
+            let firstOpen = AgentTaskBoardStore()
+            try firstOpen.openForTesting(path: path, key: dbKey)
+            defer { firstOpen.close() }
+            let task = try firstOpen.createTask(
+                AgentTaskCreateRequest(title: "Recover me", status: .ready),
+                now: fixedDate()
+            )
+            taskId = task.id
+            let maybeClaim = try firstOpen.claimTask(
+                id: task.id,
+                workerId: "worker-a",
+                leaseTTL: 5,
+                now: fixedDate(1)
+            )
+            _ = try #require(maybeClaim)
+        }
+
+        let reopened = AgentTaskBoardStore()
+        try reopened.openForTesting(path: path, key: dbKey)
+        defer { reopened.close() }
+        #expect(try reopened.recoverExpiredLeases(asOf: fixedDate(7)) == 1)
+
+        let maybeRecovered = try reopened.task(id: taskId)
+        let recovered = try #require(maybeRecovered)
+        #expect(recovered.status == .ready)
+        #expect(recovered.activeRunId == nil)
+        #expect(recovered.leaseOwner == nil)
+        #expect(try reopened.runs(taskId: taskId).map(\.status) == [.expired])
+    }
+
+    @Test
+    func productionOpenCreatesEncryptedBoardEvenWhenGlobalPolicyIsPlaintext() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try tempDir("agent-task-board-encrypted")
+            let dbKey = key(seed: 0x55)
+            OsaurusPaths.overrideRoot = root
+            StorageKeyManager.shared._setKeyForTesting(dbKey)
+            try StorageEncryptionPolicy.shared.setDesiredMode(.plaintext)
+            defer {
+                OsaurusPaths.overrideRoot = nil
+                StorageEncryptionPolicy.shared.invalidateCache()
+                StorageKeyManager.shared.wipeCache()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            let store = AgentTaskBoardStore()
+            try store.open()
+            try store.createTask(
+                AgentTaskCreateRequest(title: "Encrypted board", status: .ready),
+                now: fixedDate()
+            )
+            store.close()
+
+            let path = OsaurusPaths.agentTaskBoardDatabaseFile().path
+            #expect(StorageFileFormat.detect(path: path) == .encrypted)
+            #expect(StorageMigrationCoordinator.detectOnDiskPosture() == .empty)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentTasks/AgentTaskBoardStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentTasks/AgentTaskBoardStoreTests.swift
@@ -142,6 +142,33 @@ struct AgentTaskBoardStoreTests {
     }
 
     @Test
+    func updateCannotStrandScheduledTaskWithoutScheduledAt() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let scheduled = try store.createTask(
+            AgentTaskCreateRequest(
+                title: "Scheduled",
+                status: .scheduled,
+                scheduledAt: fixedDate(60)
+            ),
+            now: fixedDate()
+        )
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.updateTask(
+                id: scheduled.id,
+                update: AgentTaskUpdate(clearScheduledAt: true),
+                now: fixedDate(1)
+            )
+        }
+
+        let reloaded = try #require(try store.task(id: scheduled.id))
+        #expect(reloaded.status == .scheduled)
+        #expect(reloaded.scheduledAt == fixedDate(60))
+    }
+
+    @Test
     func updateFromRunningToReadyOrReviewFinishesRunAndClearsLease() throws {
         let store = try openInMemory()
         defer { store.close() }
@@ -436,6 +463,167 @@ struct AgentTaskBoardStoreTests {
         let runs = try store.runs(taskId: task.id)
         #expect(runs.map(\.status) == [.expired, .running])
         #expect(try store.events(taskId: task.id).map(\.kind) == [.create, .claim, .update, .claim])
+    }
+
+    @Test
+    func leaseRenewalRequiresCurrentOwnerRunAndUnexpiredLease() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let task = try store.createTask(
+            AgentTaskCreateRequest(title: "Renew me", status: .ready),
+            now: fixedDate()
+        )
+        let claim = try #require(
+            try store.claimTask(
+                id: task.id,
+                workerId: "worker-a",
+                leaseTTL: 10,
+                now: fixedDate(1)
+            )
+        )
+
+        #expect(
+            try store.renewLease(
+                taskId: task.id,
+                runId: claim.run.id,
+                workerId: "worker-b",
+                leaseTTL: 20,
+                now: fixedDate(5)
+            ) == nil
+        )
+        #expect(
+            try store.renewLease(
+                taskId: task.id,
+                runId: UUID(),
+                workerId: "worker-a",
+                leaseTTL: 20,
+                now: fixedDate(5)
+            ) == nil
+        )
+
+        let renewed = try #require(
+            try store.renewLease(
+                taskId: task.id,
+                runId: claim.run.id,
+                workerId: "worker-a",
+                leaseTTL: 20,
+                now: fixedDate(5)
+            )
+        )
+        #expect(renewed.leaseExpiresAt == fixedDate(25))
+        #expect(renewed.lastHeartbeatAt == fixedDate(5))
+        #expect(try store.task(id: task.id)?.leaseExpiresAt == fixedDate(25))
+
+        #expect(
+            try store.renewLease(
+                taskId: task.id,
+                runId: claim.run.id,
+                workerId: "worker-a",
+                leaseTTL: 20,
+                now: fixedDate(26)
+            ) == nil
+        )
+        #expect(try store.task(id: task.id)?.leaseExpiresAt == fixedDate(25))
+    }
+
+    @Test
+    func completeAndBlockRequireCurrentLeaseOwnerForRunningTasks() throws {
+        let store = try openInMemory()
+        defer { store.close() }
+
+        let completable = try store.createTask(
+            AgentTaskCreateRequest(title: "Complete me", status: .ready),
+            now: fixedDate()
+        )
+        let completeClaim = try #require(
+            try store.claimTask(
+                id: completable.id,
+                workerId: "worker-a",
+                leaseTTL: 60,
+                now: fixedDate(1)
+            )
+        )
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.completeTask(
+                id: completable.id,
+                runId: completeClaim.run.id,
+                workerId: "worker-b",
+                now: fixedDate(2)
+            )
+        }
+        #expect(try store.task(id: completable.id)?.status == .running)
+        #expect(try store.runs(taskId: completable.id).map(\.status) == [.running])
+
+        let completed = try store.completeTask(
+            id: completable.id,
+            runId: completeClaim.run.id,
+            workerId: "worker-a",
+            now: fixedDate(3)
+        )
+        #expect(completed.status == .done)
+        #expect(try store.runs(taskId: completable.id).map(\.status) == [.completed])
+
+        let blockable = try store.createTask(
+            AgentTaskCreateRequest(title: "Block me", status: .ready),
+            now: fixedDate(4)
+        )
+        let blockClaim = try #require(
+            try store.claimTask(
+                id: blockable.id,
+                workerId: "worker-c",
+                leaseTTL: 60,
+                now: fixedDate(5)
+            )
+        )
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.blockTask(
+                id: blockable.id,
+                reason: "needs human input",
+                runId: blockClaim.run.id,
+                workerId: "worker-d",
+                now: fixedDate(6)
+            )
+        }
+        #expect(try store.task(id: blockable.id)?.status == .running)
+        #expect(try store.runs(taskId: blockable.id).map(\.status) == [.running])
+
+        let blocked = try store.blockTask(
+            id: blockable.id,
+            reason: "needs human input",
+            runId: blockClaim.run.id,
+            workerId: "worker-c",
+            now: fixedDate(7)
+        )
+        #expect(blocked.status == .blocked)
+        #expect(blocked.blockedReason == "needs human input")
+        #expect(try store.runs(taskId: blockable.id).map(\.status) == [.blocked])
+
+        let expired = try store.createTask(
+            AgentTaskCreateRequest(title: "Expired lease", status: .ready),
+            now: fixedDate(8)
+        )
+        let expiredClaim = try #require(
+            try store.claimTask(
+                id: expired.id,
+                workerId: "worker-e",
+                leaseTTL: 5,
+                now: fixedDate(9)
+            )
+        )
+
+        #expect(throws: AgentTaskBoardError.self) {
+            try store.completeTask(
+                id: expired.id,
+                runId: expiredClaim.run.id,
+                workerId: "worker-e",
+                now: fixedDate(15)
+            )
+        }
+        #expect(try store.task(id: expired.id)?.status == .running)
+        #expect(try store.runs(taskId: expired.id).map(\.status) == [.running])
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -124,7 +124,11 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             modelId: "scripted",
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous)),
-            feed: SubagentFeed(toolCallId: "evidence-ax", kindId: "computer_use", title: "read the title field"),
+            feed: SubagentFeed(
+                toolCallId: "evidence-ax",
+                kindId: SubagentCapabilityRegistry.computerUse.id,
+                title: "read the title field"
+            ),
             interrupt: InterruptToken(),
             confirm: { _ in true },
             limits: RunLimits(maxSteps: 2, wallClockSeconds: 30),
@@ -209,7 +213,10 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted)),
             feed: SubagentFeed(
-                toolCallId: "evidence-browser-form", kindId: "computer_use", title: "Fill out the form"),
+                toolCallId: "evidence-browser-form",
+                kindId: SubagentCapabilityRegistry.computerUse.id,
+                title: "Fill out the form"
+            ),
             interrupt: InterruptToken(),
             confirm: { preview in
                 await confirmationRecorder.record(preview)

--- a/Packages/OsaurusCore/Tests/Storage/StorageDatabaseCatalogTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/StorageDatabaseCatalogTests.swift
@@ -99,6 +99,7 @@ struct StorageDatabaseCatalogTests {
             #expect(
                 labels == [
                     "agent channels",
+                    "agent task board",
                     "chat history",
                     "memory",
                     "methods",

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -127,6 +127,11 @@ public enum OsaurusPaths {
         root().appendingPathComponent("agent-channels", isDirectory: true)
     }
 
+    /// Durable local task-board state for spawned/remote-agent orchestration.
+    public static func agentTasks() -> URL {
+        root().appendingPathComponent("agent-tasks", isDirectory: true)
+    }
+
     /// Schedules directory
     public static func schedules() -> URL {
         root().appendingPathComponent("schedules", isDirectory: true)
@@ -475,6 +480,9 @@ public enum OsaurusPaths {
     }
     public static func agentChannelMessagesDatabaseFile() -> URL {
         agentChannels().appendingPathComponent("messages.sqlite")
+    }
+    public static func agentTaskBoardDatabaseFile() -> URL {
+        agentTasks().appendingPathComponent("board.sqlite")
     }
     public static func methodsDatabaseFile() -> URL { methods().appendingPathComponent("methods.sqlite") }
     /// Encrypted on-device Osaurus Router billing ledger: `~/.osaurus/billing/ledger.sqlite`.

--- a/docs/AGENT_TASK_BOARD.md
+++ b/docs/AGENT_TASK_BOARD.md
@@ -1,0 +1,92 @@
+# Durable Agent Task Board
+
+PR-C adds a durable local task-board foundation for future spawned and remote
+agent orchestration. It is intentionally limited to storage, service APIs, and
+tests.
+
+## Scope
+
+Included:
+
+- SQLCipher-backed local SQLite store at `~/.osaurus/agent-tasks/board.sqlite`.
+- `AgentTaskBoardService` facade for task CRUD, dependencies, claiming, lease
+  renewal, completion, blocking, archiving, event history, run history, and
+  crash recovery.
+- Tables for `tasks`, `task_events`, `task_runs`, and `task_links`.
+- DAG dependency validation with cycle rejection.
+- Atomic claim semantics with lease TTLs and stale reclaim.
+
+Not included:
+
+- Team protocol.
+- Channel inboxes or Agent Channel UI.
+- Remote command center.
+- Remote agent execution.
+- UI-heavy workflows.
+
+## Threat Model
+
+The board is encrypted at rest with the existing Osaurus storage key and the
+vendored SQLCipher opener. This protects against offline theft of the database
+file, including direct reads of task titles, details, metadata, events, run
+records, and dependency links.
+
+This does not protect against a compromised Osaurus process, malicious code
+running with the user's privileges while the process has the storage key in
+memory, screen capture of rendered UI, or data intentionally exported through a
+future orchestration protocol.
+
+The task-board database is marked as `alwaysEncrypted` in the storage catalog.
+It remains SQLCipher-encrypted even when the rest of local storage follows the
+global plaintext/FileVault posture. The catalog still includes it for storage
+key rotation and plaintext backup/export flows.
+
+## Schema
+
+`tasks` is the current task state:
+
+- Status values: `triage`, `todo`, `scheduled`, `ready`, `running`, `blocked`,
+  `review`, `done`, `archived`.
+- Claim state lives on the task row as `active_run_id`, `lease_owner`, and
+  `lease_expires_at`.
+- `archived` is terminal.
+
+`task_runs` records claim attempts and their outcome:
+
+- A claim inserts a `running` run.
+- Completion marks the active run `completed`.
+- Blocking marks the active run `blocked`.
+- Lease expiry marks the old active run `expired`.
+- Archiving a running task marks the active run `abandoned`.
+
+`task_events` is append-only history for user-visible mutations:
+
+- `create`
+- `update`
+- `claim`
+- `complete`
+- `block`
+- `archive`
+
+`task_links` stores dependencies:
+
+- `task_id` depends on `depends_on_task_id`.
+- `addDependency` rejects self-dependencies and transitive cycles.
+- A task is claimable only when all dependencies are `done`.
+
+## Claim And Recovery Semantics
+
+Claims use `BEGIN IMMEDIATE` and update the task, insert the run row, and append
+the claim event in one transaction. A task can only be claimed when it is:
+
+- `ready`, or
+- `scheduled` with `scheduled_at <= now`.
+
+Running tasks are not claimable until their lease expires. Every claim path
+first expires stale leases in the same transaction. Expiring a lease marks the
+old run `expired`, clears the task lease fields, returns the task to `ready`,
+and appends an `update` event. A later worker may then claim it with a new run
+row.
+
+`recoverExpiredLeases(asOf:)` exposes the same recovery step for startup or
+crash-style cleanup. It is safe to call repeatedly.


### PR DESCRIPTION
## Summary

Addresses #1714 by adding a durable local task-board foundation for future spawned and remote agent orchestration.

- adds task, event, run, and dependency models
- stores the board in an always-encrypted SQLCipher database
- records append-only task events
- supports lease-based atomic claims, stale lease reclaim, and crash-style recovery
- rejects dependency cycles
- documents the storage threat model and the non-goals for this foundation PR

This does not add agent teams, channel inboxes, remote execution, or UI workflows.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-task-board swift test --package-path Packages/OsaurusCore --filter 'AgentTaskBoardStoreTests|StorageDatabaseCatalogTests|StorageOptInEncryptionTests'`

## Review Notes

- Claude review found no blocking issues after building the package targets and running the relevant storage tests.
- Grok compact review found no visible blocking issue in the shown foundation diff.

## Risk

The board is storage/API only. Future callers should open it off the main thread because first open may touch the storage key. The docs state that SQLCipher protects offline database theft, not a compromised local process.
