### PR TITLE
Add Agent Channel security foundation

### DIFF
--- a/Packages/OsaurusCore/Models/Channels/ChannelIdentity.swift
+++ b/Packages/OsaurusCore/Models/Channels/ChannelIdentity.swift
@@ -1,0 +1,286 @@
+//
+//  ChannelIdentity.swift
+//  osaurus
+//
+//  Provider-neutral identities for remote agent channels.
+//
+
+import Foundation
+
+enum ChannelKind: String, Codable, CaseIterable, Sendable {
+    case discord
+    case slack
+    case telegram
+    case jsonAgent = "json_agent"
+}
+
+enum ChannelTrustLevel: String, Codable, CaseIterable, Comparable, Sendable {
+    case untrusted
+    case known
+    case verified
+    case owner
+
+    static func < (lhs: ChannelTrustLevel, rhs: ChannelTrustLevel) -> Bool {
+        lhs.rank < rhs.rank
+    }
+
+    private var rank: Int {
+        switch self {
+        case .untrusted: return 0
+        case .known: return 1
+        case .verified: return 2
+        case .owner: return 3
+        }
+    }
+}
+
+struct ChannelSenderMetadata: Codable, Equatable, Sendable {
+    var senderId: String
+    var displayName: String?
+    var username: String?
+    var email: String?
+    var avatarURL: String?
+    var metadata: [String: String]
+
+    init(
+        senderId: String,
+        displayName: String? = nil,
+        username: String? = nil,
+        email: String? = nil,
+        avatarURL: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.senderId = ChannelIdentity.normalizedRequiredId(senderId)
+        self.displayName = ChannelIdentity.normalizedOptionalId(displayName)
+        self.username = ChannelIdentity.normalizedOptionalId(username)
+        self.email = ChannelIdentity.normalizedOptionalId(email)
+        self.avatarURL = ChannelIdentity.normalizedOptionalId(avatarURL)
+        self.metadata = metadata.mapValues { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case senderId, displayName, username, email, avatarURL, metadata
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            senderId: try container.decode(String.self, forKey: .senderId),
+            displayName: try container.decodeIfPresent(String.self, forKey: .displayName),
+            username: try container.decodeIfPresent(String.self, forKey: .username),
+            email: try container.decodeIfPresent(String.self, forKey: .email),
+            avatarURL: try container.decodeIfPresent(String.self, forKey: .avatarURL),
+            metadata: try container.decodeIfPresent([String: String].self, forKey: .metadata) ?? [:]
+        )
+    }
+}
+
+struct ChannelIdentity: Codable, Equatable, Sendable {
+    var kind: ChannelKind
+    var installationId: String
+    var groupId: String?
+    var threadId: String?
+    var sender: ChannelSenderMetadata
+    var trustLevel: ChannelTrustLevel
+
+    init(
+        kind: ChannelKind,
+        installationId: String,
+        groupId: String? = nil,
+        threadId: String? = nil,
+        sender: ChannelSenderMetadata,
+        trustLevel: ChannelTrustLevel = .untrusted
+    ) {
+        self.kind = kind
+        self.installationId = Self.normalizedRequiredId(installationId)
+        self.groupId = Self.normalizedOptionalId(groupId)
+        self.threadId = Self.normalizedOptionalId(threadId)
+        self.sender = sender
+        self.trustLevel = trustLevel
+    }
+
+    var senderId: String { sender.senderId }
+
+    var binding: ChannelIdentityBinding {
+        ChannelIdentityBinding(identity: self)
+    }
+
+    static func normalizedRequiredId(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func isValidRequiredId(_ value: String) -> Bool {
+        !normalizedRequiredId(value).isEmpty
+    }
+
+    static func normalizedOptionalId(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func normalizedIds(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return ids
+            .map(normalizedRequiredId)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    var hasValidRequiredIds: Bool {
+        Self.isValidRequiredId(installationId) && Self.isValidRequiredId(senderId)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, installationId, groupId, threadId, sender, trustLevel
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            kind: try container.decode(ChannelKind.self, forKey: .kind),
+            installationId: try container.decode(String.self, forKey: .installationId),
+            groupId: try container.decodeIfPresent(String.self, forKey: .groupId),
+            threadId: try container.decodeIfPresent(String.self, forKey: .threadId),
+            sender: try container.decode(ChannelSenderMetadata.self, forKey: .sender),
+            // Trust is assigned by adapter-side verification, not accepted from
+            // serialized remote input.
+            trustLevel: .untrusted
+        )
+        guard hasValidRequiredIds else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .installationId,
+                in: container,
+                debugDescription: "Channel identity requires non-empty installationId and sender.senderId"
+            )
+        }
+    }
+}
+
+struct ChannelIdentityBinding: Codable, Equatable, Sendable {
+    var kind: ChannelKind
+    var installationId: String
+    var groupId: String?
+    var threadId: String?
+    var senderId: String
+
+    init(
+        kind: ChannelKind,
+        installationId: String,
+        groupId: String? = nil,
+        threadId: String? = nil,
+        senderId: String
+    ) {
+        self.kind = kind
+        self.installationId = ChannelIdentity.normalizedRequiredId(installationId)
+        self.groupId = ChannelIdentity.normalizedOptionalId(groupId)
+        self.threadId = ChannelIdentity.normalizedOptionalId(threadId)
+        self.senderId = ChannelIdentity.normalizedRequiredId(senderId)
+    }
+
+    init(identity: ChannelIdentity) {
+        self.init(
+            kind: identity.kind,
+            installationId: identity.installationId,
+            groupId: identity.groupId,
+            threadId: identity.threadId,
+            senderId: identity.senderId
+        )
+    }
+
+    func matches(_ identity: ChannelIdentity) -> Bool {
+        self == identity.binding
+    }
+
+    var nonceScopeKey: String {
+        [
+            kind.rawValue,
+            installationId,
+            groupId ?? "_",
+            threadId ?? "_",
+            senderId,
+        ].map(Self.scopeComponent).joined(separator: ".")
+    }
+
+    private static func scopeComponent(_ value: String) -> String {
+        Data(value.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    var hasValidRequiredIds: Bool {
+        ChannelIdentity.isValidRequiredId(installationId)
+            && ChannelIdentity.isValidRequiredId(senderId)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, installationId, groupId, threadId, senderId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            kind: try container.decode(ChannelKind.self, forKey: .kind),
+            installationId: try container.decode(String.self, forKey: .installationId),
+            groupId: try container.decodeIfPresent(String.self, forKey: .groupId),
+            threadId: try container.decodeIfPresent(String.self, forKey: .threadId),
+            senderId: try container.decode(String.self, forKey: .senderId)
+        )
+        guard hasValidRequiredIds else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .installationId,
+                in: container,
+                debugDescription: "Channel identity binding requires non-empty installationId and senderId"
+            )
+        }
+    }
+}
+
+struct ChannelCredentialScope: Codable, Equatable, Sendable {
+    var kind: ChannelKind
+    var installationId: String
+    var groupId: String?
+    var threadId: String?
+
+    init(
+        kind: ChannelKind,
+        installationId: String,
+        groupId: String? = nil,
+        threadId: String? = nil
+    ) {
+        self.kind = kind
+        self.installationId = ChannelIdentity.normalizedRequiredId(installationId)
+        self.groupId = ChannelIdentity.normalizedOptionalId(groupId)
+        self.threadId = ChannelIdentity.normalizedOptionalId(threadId)
+    }
+
+    init(identity: ChannelIdentity) {
+        self.init(
+            kind: identity.kind,
+            installationId: identity.installationId,
+            groupId: identity.groupId,
+            threadId: identity.threadId
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, installationId, groupId, threadId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            kind: try container.decode(ChannelKind.self, forKey: .kind),
+            installationId: try container.decode(String.self, forKey: .installationId),
+            groupId: try container.decodeIfPresent(String.self, forKey: .groupId),
+            threadId: try container.decodeIfPresent(String.self, forKey: .threadId)
+        )
+        guard ChannelIdentity.isValidRequiredId(installationId) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .installationId,
+                in: container,
+                debugDescription: "Channel credential scope requires non-empty installationId"
+            )
+        }
+    }
+}

--- a/Packages/OsaurusCore/Models/Channels/ChannelSecurityPolicy.swift
+++ b/Packages/OsaurusCore/Models/Channels/ChannelSecurityPolicy.swift
@@ -1,0 +1,197 @@
+//
+//  ChannelSecurityPolicy.swift
+//  osaurus
+//
+//  Policy-only authorization model for remote agent channels.
+//
+
+import Foundation
+
+enum ChannelSecurityAction: String, Codable, CaseIterable, Sendable {
+    case read
+    case reply
+    case write
+
+    var requiresWritePermission: Bool {
+        switch self {
+        case .read: return false
+        case .reply, .write: return true
+        }
+    }
+}
+
+enum ChannelSecurityDiagnosticReason: String, Codable, Equatable, Sendable {
+    case allowed
+    case disabled
+    case invalidIdentity = "invalid_identity"
+    case senderDenied = "denied_sender"
+    case groupDenied = "denied_group"
+    case threadDenied = "denied_thread"
+    case trustDenied = "denied_trust"
+    case writeDisabled = "write_disabled"
+    case writeSenderDenied = "write_denied_sender"
+    case writeGroupDenied = "write_denied_group"
+    case writeThreadDenied = "write_denied_thread"
+    case expired
+    case replayed
+    case revoked
+    case tokenInvalid = "token_invalid"
+    case identityMismatch = "identity_mismatch"
+    case purposeMismatch = "purpose_mismatch"
+    case actionMismatch = "action_mismatch"
+    case notYetValid = "not_yet_valid"
+    case storeUnavailable = "store_unavailable"
+}
+
+struct ChannelWritePermission: Codable, Equatable, Sendable {
+    var enabled: Bool
+    var allowedSenderIds: [String]
+    var allowedGroupIds: [String]
+    var allowedThreadIds: [String]
+
+    init(
+        enabled: Bool = false,
+        allowedSenderIds: [String] = [],
+        allowedGroupIds: [String] = [],
+        allowedThreadIds: [String] = []
+    ) {
+        self.enabled = enabled
+        self.allowedSenderIds = ChannelIdentity.normalizedIds(allowedSenderIds)
+        self.allowedGroupIds = ChannelIdentity.normalizedIds(allowedGroupIds)
+        self.allowedThreadIds = ChannelIdentity.normalizedIds(allowedThreadIds)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled, allowedSenderIds, allowedGroupIds, allowedThreadIds
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            enabled: try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false,
+            allowedSenderIds: try container.decodeIfPresent([String].self, forKey: .allowedSenderIds) ?? [],
+            allowedGroupIds: try container.decodeIfPresent([String].self, forKey: .allowedGroupIds) ?? [],
+            allowedThreadIds: try container.decodeIfPresent([String].self, forKey: .allowedThreadIds) ?? []
+        )
+    }
+}
+
+struct ChannelSecurityPolicy: Codable, Equatable, Sendable {
+    var enabled: Bool
+    var minimumTrustLevel: ChannelTrustLevel
+    var allowedSenderIds: [String]
+    var allowedGroupIds: [String]
+    var allowedThreadIds: [String]
+    var writePermission: ChannelWritePermission?
+
+    init(
+        enabled: Bool = true,
+        minimumTrustLevel: ChannelTrustLevel = .untrusted,
+        allowedSenderIds: [String] = [],
+        allowedGroupIds: [String] = [],
+        allowedThreadIds: [String] = [],
+        writePermission: ChannelWritePermission? = nil
+    ) {
+        self.enabled = enabled
+        self.minimumTrustLevel = minimumTrustLevel
+        self.allowedSenderIds = ChannelIdentity.normalizedIds(allowedSenderIds)
+        self.allowedGroupIds = ChannelIdentity.normalizedIds(allowedGroupIds)
+        self.allowedThreadIds = ChannelIdentity.normalizedIds(allowedThreadIds)
+        self.writePermission = writePermission
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled, minimumTrustLevel, allowedSenderIds, allowedGroupIds, allowedThreadIds, writePermission
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            enabled: try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true,
+            minimumTrustLevel: try container.decodeIfPresent(ChannelTrustLevel.self, forKey: .minimumTrustLevel)
+                ?? .untrusted,
+            allowedSenderIds: try container.decodeIfPresent([String].self, forKey: .allowedSenderIds) ?? [],
+            allowedGroupIds: try container.decodeIfPresent([String].self, forKey: .allowedGroupIds) ?? [],
+            allowedThreadIds: try container.decodeIfPresent([String].self, forKey: .allowedThreadIds) ?? [],
+            writePermission: try container.decodeIfPresent(ChannelWritePermission.self, forKey: .writePermission)
+        )
+    }
+}
+
+struct ChannelAuthorizationDecision: Equatable, Sendable {
+    var allowed: Bool
+    var reason: ChannelSecurityDiagnosticReason
+    var message: String
+
+    static func allow() -> ChannelAuthorizationDecision {
+        ChannelAuthorizationDecision(
+            allowed: true,
+            reason: .allowed,
+            message: ChannelSecurityDiagnostics.message(for: .allowed)
+        )
+    }
+
+    static func deny(_ reason: ChannelSecurityDiagnosticReason) -> ChannelAuthorizationDecision {
+        ChannelAuthorizationDecision(
+            allowed: false,
+            reason: reason,
+            message: ChannelSecurityDiagnostics.message(for: reason)
+        )
+    }
+}
+
+struct ChannelReplyTokenPayload: Codable, Equatable, Sendable {
+    var version: Int
+    var purpose: String
+    var action: ChannelSecurityAction
+    var binding: ChannelIdentityBinding
+    var nonce: String
+    var issuedAt: TimeInterval
+    var expiresAt: TimeInterval
+    var writeGateGeneration: Int
+
+    init(
+        version: Int = 1,
+        purpose: String,
+        action: ChannelSecurityAction,
+        binding: ChannelIdentityBinding,
+        nonce: String,
+        issuedAt: TimeInterval,
+        expiresAt: TimeInterval,
+        writeGateGeneration: Int
+    ) {
+        self.version = version
+        self.purpose = purpose
+        self.action = action
+        self.binding = binding
+        self.nonce = nonce
+        self.issuedAt = issuedAt
+        self.expiresAt = expiresAt
+        self.writeGateGeneration = writeGateGeneration
+    }
+}
+
+struct ChannelReplyTokenValidation: Equatable, Sendable {
+    var accepted: Bool
+    var reason: ChannelSecurityDiagnosticReason
+    var message: String
+    var payload: ChannelReplyTokenPayload?
+
+    static func accept(_ payload: ChannelReplyTokenPayload) -> ChannelReplyTokenValidation {
+        ChannelReplyTokenValidation(
+            accepted: true,
+            reason: .allowed,
+            message: ChannelSecurityDiagnostics.message(for: .allowed),
+            payload: payload
+        )
+    }
+
+    static func deny(_ reason: ChannelSecurityDiagnosticReason) -> ChannelReplyTokenValidation {
+        ChannelReplyTokenValidation(
+            accepted: false,
+            reason: reason,
+            message: ChannelSecurityDiagnostics.message(for: reason),
+            payload: nil
+        )
+    }
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelCredentialVault.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelCredentialVault.swift
@@ -1,0 +1,146 @@
+//
+//  ChannelCredentialVault.swift
+//  osaurus
+//
+//  Channel-scoped Keychain wrapper for future adapter credentials.
+//
+
+import Foundation
+
+protocol ChannelCredentialVaultBackingStore: Sendable {
+    func write(service: String, account: String, data: Data) -> Bool
+    func read(service: String, account: String) -> Data?
+    func delete(service: String, account: String) -> Bool
+}
+
+struct KeychainChannelCredentialVaultBackingStore: ChannelCredentialVaultBackingStore {
+    func write(service: String, account: String, data: Data) -> Bool {
+        Keychain.write(service: service, account: account, data: data)
+    }
+
+    func read(service: String, account: String) -> Data? {
+        Keychain.read(service: service, account: account)
+    }
+
+    func delete(service: String, account: String) -> Bool {
+        Keychain.delete(service: service, account: account)
+    }
+}
+
+final class InMemoryChannelCredentialVaultBackingStore: ChannelCredentialVaultBackingStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String: Data] = [:]
+
+    func write(service: String, account: String, data: Data) -> Bool {
+        lock.lock()
+        values[key(service: service, account: account)] = data
+        lock.unlock()
+        return true
+    }
+
+    func read(service: String, account: String) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return values[key(service: service, account: account)]
+    }
+
+    func delete(service: String, account: String) -> Bool {
+        lock.lock()
+        values.removeValue(forKey: key(service: service, account: account))
+        lock.unlock()
+        return true
+    }
+
+    private func key(service: String, account: String) -> String {
+        "\(service)\u{1F}\(account)"
+    }
+}
+
+final class ChannelCredentialVault: @unchecked Sendable {
+    static let shared = ChannelCredentialVault()
+
+    private static let service = "ai.osaurus.channels"
+
+    private let backingStore: any ChannelCredentialVaultBackingStore
+    private let keychainDisabled: @Sendable () -> Bool
+
+    init(
+        backingStore: (any ChannelCredentialVaultBackingStore)? = nil,
+        keychainDisabled: @escaping @Sendable () -> Bool = {
+            KeychainQueryHelpers.disablesKeychainForProcess
+        }
+    ) {
+        self.backingStore = backingStore ?? Self.defaultBackingStore()
+        self.keychainDisabled = keychainDisabled
+    }
+
+    @discardableResult
+    func saveSecret(_ value: String, credentialId: String, scope: ChannelCredentialScope) -> Bool {
+        guard !keychainDisabled() else { return false }
+        let normalizedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let account = account(credentialId: credentialId, scope: scope),
+            let data = normalizedValue.data(using: .utf8),
+            !normalizedValue.isEmpty
+        else {
+            return false
+        }
+        return backingStore.write(service: Self.service, account: account, data: data)
+    }
+
+    func secret(credentialId: String, scope: ChannelCredentialScope) -> String? {
+        guard !keychainDisabled() else { return nil }
+        guard let account = account(credentialId: credentialId, scope: scope) else { return nil }
+        return backingStore.read(service: Self.service, account: account)
+            .flatMap { String(data: $0, encoding: .utf8) }
+    }
+
+    func hasSecret(credentialId: String, scope: ChannelCredentialScope) -> Bool {
+        secret(credentialId: credentialId, scope: scope) != nil
+    }
+
+    @discardableResult
+    func deleteSecret(credentialId: String, scope: ChannelCredentialScope) -> Bool {
+        guard !keychainDisabled() else { return true }
+        guard let account = account(credentialId: credentialId, scope: scope) else { return true }
+        return backingStore.delete(service: Self.service, account: account)
+    }
+
+    func accountForDiagnostics(credentialId: String, scope: ChannelCredentialScope) -> String? {
+        account(credentialId: credentialId, scope: scope)
+    }
+
+    private static func defaultBackingStore() -> any ChannelCredentialVaultBackingStore {
+        if KeychainQueryHelpers.usesInMemoryKeychainStoreForTests {
+            return InMemoryChannelCredentialVaultBackingStore()
+        }
+        return KeychainChannelCredentialVaultBackingStore()
+    }
+
+    private func account(credentialId: String, scope: ChannelCredentialScope) -> String? {
+        let credentialId = ChannelIdentity.normalizedRequiredId(credentialId)
+        guard !credentialId.isEmpty,
+            !scope.installationId.isEmpty,
+            !containsLineBreak(credentialId),
+            !containsLineBreak(scope.installationId),
+            !containsLineBreak(scope.groupId),
+            !containsLineBreak(scope.threadId)
+        else {
+            return nil
+        }
+
+        let parts = [
+            "v1",
+            scope.kind.rawValue,
+            scope.installationId,
+            scope.groupId ?? "_",
+            scope.threadId ?? "_",
+            credentialId,
+        ].map(ChannelSecurityEncoding.accountComponent)
+        return parts.joined(separator: ".")
+    }
+
+    private func containsLineBreak(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return value.contains("\n") || value.contains("\r")
+    }
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelReplayNonceStore.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelReplayNonceStore.swift
@@ -1,0 +1,173 @@
+//
+//  ChannelReplayNonceStore.swift
+//  osaurus
+//
+//  Persistent nonce/replay store for scoped channel reply tokens.
+//
+
+import Foundation
+
+enum ChannelNonceConsumeResult: Equatable, Sendable {
+    case consumed
+    case replayed
+    case revoked
+}
+
+protocol ChannelReplyTokenNonceStore: Sendable {
+    func consume(
+        scope: String,
+        nonce: String,
+        expiresAt: Date,
+        now: Date
+    ) throws -> ChannelNonceConsumeResult
+
+    func revoke(
+        scope: String,
+        nonce: String,
+        expiresAt: Date,
+        now: Date
+    ) throws
+
+    @discardableResult
+    func prune(expiredBefore: Date) throws -> Int
+}
+
+final class ChannelReplayNonceStore: ChannelReplyTokenNonceStore, @unchecked Sendable {
+    // The file backend is process-local serialized. Future multi-process
+    // receive services should move this table behind SQLite or another
+    // compare-and-insert store before sharing the same nonce file concurrently.
+    static let shared = ChannelReplayNonceStore()
+
+    private struct Envelope: Codable {
+        var schemaVersion: Int
+        var scopes: [String: [String: Record]]
+
+        init(schemaVersion: Int = 1, scopes: [String: [String: Record]] = [:]) {
+            self.schemaVersion = schemaVersion
+            self.scopes = scopes
+        }
+    }
+
+    private struct Record: Codable {
+        var expiresAt: Date
+        var usedAt: Date?
+        var revokedAt: Date?
+    }
+
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "ai.osaurus.channels.replay-nonces")
+
+    init(fileURL: URL? = nil) {
+        self.fileURL = fileURL
+            ?? OsaurusPaths.agentChannels().appendingPathComponent("reply-token-nonces.json")
+    }
+
+    func consume(
+        scope: String,
+        nonce: String,
+        expiresAt: Date,
+        now: Date = Date()
+    ) throws -> ChannelNonceConsumeResult {
+        try queue.sync {
+            let scope = normalized(scope)
+            let nonce = normalized(nonce)
+            guard !scope.isEmpty, !nonce.isEmpty else {
+                throw ChannelReplayNonceStoreError.invalidScope
+            }
+
+            var envelope = try loadUnlocked()
+            var records = envelope.scopes[scope] ?? [:]
+            if let existing = records[nonce] {
+                if existing.revokedAt != nil {
+                    return .revoked
+                }
+                if existing.usedAt != nil {
+                    return .replayed
+                }
+            }
+
+            records[nonce] = Record(
+                expiresAt: expiresAt,
+                usedAt: now,
+                revokedAt: records[nonce]?.revokedAt
+            )
+            envelope.scopes[scope] = records
+            try saveUnlocked(envelope)
+            return .consumed
+        }
+    }
+
+    func revoke(
+        scope: String,
+        nonce: String,
+        expiresAt: Date,
+        now: Date = Date()
+    ) throws {
+        try queue.sync {
+            let scope = normalized(scope)
+            let nonce = normalized(nonce)
+            guard !scope.isEmpty, !nonce.isEmpty else {
+                throw ChannelReplayNonceStoreError.invalidScope
+            }
+
+            var envelope = try loadUnlocked()
+            var records = envelope.scopes[scope] ?? [:]
+            let existing = records[nonce]
+            records[nonce] = Record(
+                expiresAt: existing?.expiresAt ?? expiresAt,
+                usedAt: existing?.usedAt,
+                revokedAt: now
+            )
+            envelope.scopes[scope] = records
+            try saveUnlocked(envelope)
+        }
+    }
+
+    @discardableResult
+    func prune(expiredBefore: Date) throws -> Int {
+        try queue.sync {
+            var envelope = try loadUnlocked()
+            var removed = 0
+            for scope in Array(envelope.scopes.keys) {
+                var records = envelope.scopes[scope] ?? [:]
+                let before = records.count
+                records = records.filter { _, record in
+                    record.expiresAt >= expiredBefore
+                }
+                let after = records.count
+                removed += before - after
+                if records.isEmpty {
+                    envelope.scopes.removeValue(forKey: scope)
+                } else {
+                    envelope.scopes[scope] = records
+                }
+            }
+            if removed > 0 {
+                try saveUnlocked(envelope)
+            }
+            return removed
+        }
+    }
+
+    private func loadUnlocked() throws -> Envelope {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return Envelope()
+        }
+        return try JSONDecoder().decode(Envelope.self, from: Data(contentsOf: fileURL))
+    }
+
+    private func saveUnlocked(_ envelope: Envelope) throws {
+        OsaurusPaths.ensureExistsSilent(fileURL.deletingLastPathComponent())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(envelope).write(to: fileURL, options: [.atomic])
+    }
+
+    private func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum ChannelReplayNonceStoreError: Error, Equatable {
+    case invalidScope
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelReplyTokenService.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelReplyTokenService.swift
@@ -1,0 +1,189 @@
+//
+//  ChannelReplyTokenService.swift
+//  osaurus
+//
+//  Scoped, expiring reply tokens for future channel receive flows.
+//
+
+import CryptoKit
+import Foundation
+
+enum ChannelReplyTokenServiceError: Error, Equatable {
+    case weakSigningKey
+    case invalidTTL
+    case disabled
+    case invalidIdentity
+}
+
+struct ChannelReplyTokenIssue: Equatable, Sendable {
+    var token: String
+    var payload: ChannelReplyTokenPayload
+}
+
+final class ChannelReplyTokenService: @unchecked Sendable {
+    static let tokenPrefix = "osaurus_channel_reply_v1"
+    static let minimumSigningKeyBytes = 32
+
+    private let signingKey: SymmetricKey
+    private let nonceStore: any ChannelReplyTokenNonceStore
+    private let writeKillSwitch: ChannelWriteKillSwitch
+    private let clockSkew: TimeInterval
+    private let maxTTL: TimeInterval
+
+    init(
+        signingKey: Data,
+        nonceStore: any ChannelReplyTokenNonceStore = ChannelReplayNonceStore.shared,
+        writeKillSwitch: ChannelWriteKillSwitch = .shared,
+        clockSkew: TimeInterval = 60,
+        maxTTL: TimeInterval = 15 * 60
+    ) throws {
+        guard signingKey.count >= Self.minimumSigningKeyBytes else {
+            throw ChannelReplyTokenServiceError.weakSigningKey
+        }
+        self.signingKey = SymmetricKey(data: signingKey)
+        self.nonceStore = nonceStore
+        self.writeKillSwitch = writeKillSwitch
+        self.clockSkew = max(0, clockSkew)
+        self.maxTTL = max(1, maxTTL)
+    }
+
+    func issueToken(
+        purpose: String,
+        action: ChannelSecurityAction,
+        identity: ChannelIdentity,
+        ttl: TimeInterval,
+        now: Date = Date()
+    ) throws -> ChannelReplyTokenIssue {
+        guard ttl > 0, ttl <= maxTTL else { throw ChannelReplyTokenServiceError.invalidTTL }
+        guard identity.hasValidRequiredIds else { throw ChannelReplyTokenServiceError.invalidIdentity }
+        let gate = writeKillSwitch.snapshot()
+        if action.requiresWritePermission, !gate.writeEnabled {
+            throw ChannelReplyTokenServiceError.disabled
+        }
+
+        let payload = ChannelReplyTokenPayload(
+            purpose: purpose.trimmingCharacters(in: .whitespacesAndNewlines),
+            action: action,
+            binding: identity.binding,
+            nonce: UUID().uuidString.lowercased(),
+            issuedAt: now.timeIntervalSince1970,
+            expiresAt: now.addingTimeInterval(ttl).timeIntervalSince1970,
+            writeGateGeneration: gate.generation
+        )
+        let payloadData = try encodedPayload(payload)
+        let payloadSegment = ChannelSecurityEncoding.base64URLEncode(payloadData)
+        let signatureSegment = signature(for: payloadSegment)
+        _ = try? nonceStore.prune(expiredBefore: now.addingTimeInterval(-maxTTL - clockSkew))
+        return ChannelReplyTokenIssue(
+            token: "\(Self.tokenPrefix).\(payloadSegment).\(signatureSegment)",
+            payload: payload
+        )
+    }
+
+    func validateToken(
+        _ token: String,
+        expectedPurpose: String,
+        expectedAction: ChannelSecurityAction,
+        identity: ChannelIdentity,
+        now: Date = Date()
+    ) -> ChannelReplyTokenValidation {
+        guard let decoded = decodeAndVerify(token) else {
+            return .deny(.tokenInvalid)
+        }
+        let payload = decoded
+        guard payload.version == 1 else { return .deny(.tokenInvalid) }
+        guard payload.purpose == expectedPurpose.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return .deny(.purposeMismatch)
+        }
+        guard payload.action == expectedAction else { return .deny(.actionMismatch) }
+        guard identity.hasValidRequiredIds else { return .deny(.invalidIdentity) }
+        guard payload.binding.matches(identity) else { return .deny(.identityMismatch) }
+
+        let gate = writeKillSwitch.snapshot()
+        if payload.action.requiresWritePermission {
+            guard gate.writeEnabled else { return .deny(.disabled) }
+            guard payload.writeGateGeneration == gate.generation else { return .deny(.revoked) }
+        }
+
+        if now.timeIntervalSince1970 + clockSkew < payload.issuedAt {
+            return .deny(.notYetValid)
+        }
+        if now.timeIntervalSince1970 - clockSkew > payload.expiresAt {
+            return .deny(.expired)
+        }
+
+        do {
+            let result = try nonceStore.consume(
+                scope: payload.binding.nonceScopeKey,
+                nonce: payload.nonce,
+                expiresAt: Date(timeIntervalSince1970: payload.expiresAt),
+                now: now
+            )
+            switch result {
+            case .consumed:
+                return .accept(payload)
+            case .replayed:
+                return .deny(.replayed)
+            case .revoked:
+                return .deny(.revoked)
+            }
+        } catch {
+            return .deny(.storeUnavailable)
+        }
+    }
+
+    func revokeToken(_ token: String, now: Date = Date()) -> ChannelReplyTokenValidation {
+        guard let payload = decodeAndVerify(token) else { return .deny(.tokenInvalid) }
+        do {
+            try nonceStore.revoke(
+                scope: payload.binding.nonceScopeKey,
+                nonce: payload.nonce,
+                expiresAt: Date(timeIntervalSince1970: payload.expiresAt),
+                now: now
+            )
+            return .deny(.revoked)
+        } catch {
+            return .deny(.storeUnavailable)
+        }
+    }
+
+    private func decodeAndVerify(_ token: String) -> ChannelReplyTokenPayload? {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3, parts[0] == Substring(Self.tokenPrefix) else {
+            return nil
+        }
+        let payloadSegment = String(parts[1])
+        let signatureSegment = String(parts[2])
+        guard constantTimeEqual(signatureSegment, signature(for: payloadSegment)),
+            let payloadData = ChannelSecurityEncoding.base64URLDecode(payloadSegment)
+        else {
+            return nil
+        }
+        return try? JSONDecoder().decode(ChannelReplyTokenPayload.self, from: payloadData)
+    }
+
+    private func encodedPayload(_ payload: ChannelReplyTokenPayload) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload)
+    }
+
+    private func signature(for payloadSegment: String) -> String {
+        let signature = HMAC<SHA256>.authenticationCode(
+            for: Data(payloadSegment.utf8),
+            using: signingKey
+        )
+        return ChannelSecurityEncoding.base64URLEncode(Data(signature))
+    }
+
+    private func constantTimeEqual(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        guard lhsBytes.count == rhsBytes.count else { return false }
+        var diff: UInt8 = 0
+        for index in lhsBytes.indices {
+            diff |= lhsBytes[index] ^ rhsBytes[index]
+        }
+        return diff == 0
+    }
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelSecurityDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelSecurityDiagnostics.swift
@@ -1,0 +1,108 @@
+//
+//  ChannelSecurityDiagnostics.swift
+//  osaurus
+//
+//  Redaction and operator-facing explanations for channel security decisions.
+//
+
+import Foundation
+
+enum ChannelSecurityDiagnostics {
+    static let replyTokenMarker = "[REDACTED:CHANNEL_REPLY_TOKEN]"
+    static let credentialMarker = "[REDACTED:CHANNEL_CREDENTIAL]"
+
+    static func message(for reason: ChannelSecurityDiagnosticReason) -> String {
+        switch reason {
+        case .allowed:
+            return "Allowed by channel security policy."
+        case .disabled:
+            return "Denied: the global remote/channel write kill switch is disabled."
+        case .invalidIdentity:
+            return "Denied: channel identity is missing a required installation or sender id."
+        case .senderDenied:
+            return "Denied: sender is not allowlisted for this channel."
+        case .groupDenied:
+            return "Denied: group is not allowlisted for this channel."
+        case .threadDenied:
+            return "Denied: thread is not allowlisted for this channel."
+        case .trustDenied:
+            return "Denied: sender trust level is below the channel policy minimum."
+        case .writeDisabled:
+            return "Denied: channel write permission is disabled."
+        case .writeSenderDenied:
+            return "Denied: sender is not allowlisted for channel writes."
+        case .writeGroupDenied:
+            return "Denied: group is not allowlisted for channel writes."
+        case .writeThreadDenied:
+            return "Denied: thread is not allowlisted for channel writes."
+        case .expired:
+            return "Denied: reply token expired."
+        case .replayed:
+            return "Denied: reply token nonce was already used."
+        case .revoked:
+            return "Denied: reply token was revoked or predates the current write gate generation."
+        case .tokenInvalid:
+            return "Denied: reply token is malformed or has an invalid signature."
+        case .identityMismatch:
+            return "Denied: reply token is bound to a different channel identity."
+        case .purposeMismatch:
+            return "Denied: reply token purpose does not match the requested action."
+        case .actionMismatch:
+            return "Denied: reply token action does not match the requested action."
+        case .notYetValid:
+            return "Denied: reply token was issued in the future beyond allowed clock skew."
+        case .storeUnavailable:
+            return "Denied: channel replay store is unavailable, so the request failed closed."
+        }
+    }
+
+    static func redact(
+        _ text: String,
+        credentials: [String] = [],
+        tokens: [String] = []
+    ) -> String {
+        guard !text.isEmpty else { return text }
+        var result = text
+
+        let exactCredentials = credentials
+            .filter { $0.count >= SecretScrubber.minimumValueLength }
+            .sorted { $0.count > $1.count }
+        for credential in exactCredentials where result.contains(credential) {
+            result = result.replacingOccurrences(of: credential, with: credentialMarker)
+        }
+
+        let exactTokens = tokens
+            .filter { $0.count >= SecretScrubber.minimumValueLength }
+            .sorted { $0.count > $1.count }
+        for token in exactTokens where result.contains(token) {
+            result = result.replacingOccurrences(of: token, with: replyTokenMarker)
+        }
+
+        result = replacingMatches(
+            in: result,
+            pattern: #"osaurus_channel_reply_v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#,
+            replacement: replyTokenMarker
+        )
+        result = replacingMatches(
+            in: result,
+            pattern: #"(?i)\b(token|secret|api[_-]?key|authorization)\s*[:=]\s*[A-Za-z0-9._~+/=-]{6,}"#,
+            replacement: "$1=\(credentialMarker)"
+        )
+        return result
+    }
+
+    private static func replacingMatches(
+        in text: String,
+        pattern: String,
+        replacement: String
+    ) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        return regex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: replacement
+        )
+    }
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelSecurityEncoding.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelSecurityEncoding.swift
@@ -1,0 +1,32 @@
+//
+//  ChannelSecurityEncoding.swift
+//  osaurus
+//
+//  Small URL-safe encoding helpers for channel tokens and Keychain accounts.
+//
+
+import Foundation
+
+enum ChannelSecurityEncoding {
+    static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    static func base64URLDecode(_ string: String) -> Data? {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder != 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: base64)
+    }
+
+    static func accountComponent(_ value: String) -> String {
+        base64URLEncode(Data(value.utf8))
+    }
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelSecurityPolicyEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelSecurityPolicyEvaluator.swift
@@ -1,0 +1,54 @@
+//
+//  ChannelSecurityPolicyEvaluator.swift
+//  osaurus
+//
+//  Strictest-wins allowlist evaluator for inbound channel requests.
+//
+
+import Foundation
+
+struct ChannelSecurityPolicyEvaluator: Sendable {
+    func evaluate(
+        identity: ChannelIdentity,
+        action: ChannelSecurityAction,
+        policy: ChannelSecurityPolicy,
+        writeGate: ChannelWriteKillSwitchSnapshot = ChannelWriteKillSwitch.shared.snapshot()
+    ) -> ChannelAuthorizationDecision {
+        guard policy.enabled else { return .deny(.disabled) }
+        guard identity.hasValidRequiredIds else { return .deny(.invalidIdentity) }
+        guard identity.trustLevel >= policy.minimumTrustLevel else { return .deny(.trustDenied) }
+        guard isAllowed(identity.senderId, by: policy.allowedSenderIds) else {
+            return .deny(.senderDenied)
+        }
+        guard isAllowed(identity.groupId, by: policy.allowedGroupIds) else {
+            return .deny(.groupDenied)
+        }
+        guard isAllowed(identity.threadId, by: policy.allowedThreadIds) else {
+            return .deny(.threadDenied)
+        }
+        guard action.requiresWritePermission else { return .allow() }
+
+        if !writeGate.writeEnabled {
+            return .deny(.disabled)
+        }
+        guard let writePermission = policy.writePermission, writePermission.enabled else {
+            return .deny(.writeDisabled)
+        }
+        guard isAllowed(identity.senderId, by: writePermission.allowedSenderIds) else {
+            return .deny(.writeSenderDenied)
+        }
+        guard isAllowed(identity.groupId, by: writePermission.allowedGroupIds) else {
+            return .deny(.writeGroupDenied)
+        }
+        guard isAllowed(identity.threadId, by: writePermission.allowedThreadIds) else {
+            return .deny(.writeThreadDenied)
+        }
+        return .allow()
+    }
+
+    private func isAllowed(_ value: String?, by allowlist: [String]) -> Bool {
+        guard !allowlist.isEmpty else { return true }
+        guard let value else { return false }
+        return allowlist.contains(value)
+    }
+}

--- a/Packages/OsaurusCore/Services/Channels/ChannelWriteKillSwitch.swift
+++ b/Packages/OsaurusCore/Services/Channels/ChannelWriteKillSwitch.swift
@@ -1,0 +1,144 @@
+//
+//  ChannelWriteKillSwitch.swift
+//  osaurus
+//
+//  Persistent global write gate for remote/channel actions.
+//
+
+import Foundation
+
+struct ChannelWriteKillSwitchSnapshot: Codable, Equatable, Sendable {
+    var schemaVersion: Int
+    var writeEnabled: Bool
+    var generation: Int
+    var updatedAt: Date
+
+    init(
+        schemaVersion: Int = 1,
+        writeEnabled: Bool = true,
+        generation: Int = 0,
+        updatedAt: Date = Date(timeIntervalSince1970: 0)
+    ) {
+        self.schemaVersion = schemaVersion
+        self.writeEnabled = writeEnabled
+        self.generation = generation
+        self.updatedAt = updatedAt
+    }
+}
+
+final class ChannelWriteKillSwitch: @unchecked Sendable {
+    static let shared = ChannelWriteKillSwitch()
+    private static let corruptionRecoveryBaseGeneration = Int.max / 2
+
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "ai.osaurus.channels.write-kill-switch")
+
+    init(fileURL: URL? = nil) {
+        self.fileURL = fileURL
+            ?? OsaurusPaths.config().appendingPathComponent("channel-write-kill-switch.json")
+    }
+
+    func snapshot() -> ChannelWriteKillSwitchSnapshot {
+        queue.sync {
+            switch loadStateUnlocked() {
+            case .loaded(let snapshot):
+                return snapshot
+            case .missing:
+                return ChannelWriteKillSwitchSnapshot()
+            case .corrupt:
+                return failClosedSnapshot(now: Date())
+            }
+        }
+    }
+
+    @discardableResult
+    func disableWrites(now: Date = Date()) throws -> ChannelWriteKillSwitchSnapshot {
+        try setWriteEnabled(false, now: now)
+    }
+
+    @discardableResult
+    func enableWrites(now: Date = Date()) throws -> ChannelWriteKillSwitchSnapshot {
+        try setWriteEnabled(true, now: now)
+    }
+
+    @discardableResult
+    func setWriteEnabled(_ enabled: Bool, now: Date = Date()) throws -> ChannelWriteKillSwitchSnapshot {
+        try queue.sync {
+            let loaded = loadForMutationUnlocked(now: now)
+            var current = loaded.snapshot
+            var shouldSave = loaded.recoveredFromCorruption
+            if current.writeEnabled != enabled {
+                current.writeEnabled = enabled
+                if !enabled {
+                    current.generation += 1
+                }
+                current.updatedAt = now
+                shouldSave = true
+            } else if loaded.recoveredFromCorruption {
+                current.updatedAt = now
+            }
+            if shouldSave {
+                try saveUnlocked(current)
+            }
+            return current
+        }
+    }
+
+    private enum LoadState {
+        case loaded(ChannelWriteKillSwitchSnapshot)
+        case missing
+        case corrupt
+    }
+
+    private func loadStateUnlocked() -> LoadState {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .missing
+        }
+        do {
+            return .loaded(
+                try JSONDecoder().decode(
+                    ChannelWriteKillSwitchSnapshot.self,
+                    from: Data(contentsOf: fileURL)
+                )
+            )
+        } catch {
+            return .corrupt
+        }
+    }
+
+    private func loadForMutationUnlocked(now: Date) -> (
+        snapshot: ChannelWriteKillSwitchSnapshot,
+        recoveredFromCorruption: Bool
+    ) {
+        switch loadStateUnlocked() {
+        case .loaded(let snapshot):
+            return (snapshot, false)
+        case .missing:
+            return (ChannelWriteKillSwitchSnapshot(), false)
+        case .corrupt:
+            return (failClosedSnapshot(now: now), true)
+        }
+    }
+
+    private func failClosedSnapshot(now: Date = Date()) -> ChannelWriteKillSwitchSnapshot {
+        ChannelWriteKillSwitchSnapshot(
+            writeEnabled: false,
+            generation: Self.corruptionRecoveryGeneration(now: now),
+            updatedAt: now
+        )
+    }
+
+    private static func corruptionRecoveryGeneration(now: Date) -> Int {
+        let maxOffset = Int.max - corruptionRecoveryBaseGeneration - 1
+        let rawOffset = max(0, now.timeIntervalSince1970 * 1_000_000)
+        let boundedOffset = min(rawOffset, Double(maxOffset))
+        return corruptionRecoveryBaseGeneration + Int(boundedOffset)
+    }
+
+    private func saveUnlocked(_ snapshot: ChannelWriteKillSwitchSnapshot) throws {
+        OsaurusPaths.ensureExistsSilent(fileURL.deletingLastPathComponent())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(snapshot).write(to: fileURL, options: [.atomic])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Channels/ChannelSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Channels/ChannelSecurityTests.swift
@@ -1,0 +1,861 @@
+//
+//  ChannelSecurityTests.swift
+//  osaurusTests
+//
+//  Security coverage for the policy-only Agent Channel foundation.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ChannelSecurityTests {
+    @Test func spoofedSenderIsDeniedByPolicy() {
+        let policy = ChannelSecurityPolicy(
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"]
+        )
+        let identity = Self.channelIdentity(senderId: "user-b", groupId: "ops")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .read,
+            policy: policy
+        )
+
+        #expect(!decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.senderDenied)
+        #expect(decision.message.contains("sender"))
+    }
+
+    @Test func allowlistedSenderCannotEscalateIntoAnotherGroup() {
+        let policy = ChannelSecurityPolicy(
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"]
+        )
+        let identity = Self.channelIdentity(senderId: "user-a", groupId: "finance")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .read,
+            policy: policy
+        )
+
+        #expect(!decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.groupDenied)
+        #expect(decision.message.contains("group"))
+    }
+
+    @Test func writeRequestsRequireExplicitWritePermission() {
+        let policy = ChannelSecurityPolicy(
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"]
+        )
+        let identity = Self.channelIdentity(senderId: "user-a", groupId: "ops")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .reply,
+            policy: policy,
+            writeGate: ChannelWriteKillSwitchSnapshot(writeEnabled: true)
+        )
+
+        #expect(!decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.writeDisabled)
+        #expect(decision.message.contains("write"))
+    }
+
+    @Test func authorizedReadIsAllowedEvenWhenWriteGateIsDisabled() {
+        let policy = ChannelSecurityPolicy(
+            minimumTrustLevel: .known,
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"]
+        )
+        let identity = Self.channelIdentity(senderId: "user-a", groupId: "ops")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .read,
+            policy: policy,
+            writeGate: ChannelWriteKillSwitchSnapshot(writeEnabled: false, generation: 3)
+        )
+
+        #expect(decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.allowed)
+    }
+
+    @Test func minimumTrustLevelIsEnforced() {
+        let policy = ChannelSecurityPolicy(
+            minimumTrustLevel: .verified,
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"]
+        )
+        let knownIdentity = ChannelIdentity(
+            kind: .discord,
+            installationId: "discord-installation",
+            groupId: "ops",
+            sender: ChannelSenderMetadata(senderId: "user-a"),
+            trustLevel: .known
+        )
+        let verifiedIdentity = Self.channelIdentity(senderId: "user-a", groupId: "ops")
+
+        let denied = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: knownIdentity,
+            action: .read,
+            policy: policy
+        )
+        let allowed = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: verifiedIdentity,
+            action: .read,
+            policy: policy
+        )
+
+        #expect(!denied.allowed)
+        #expect(denied.reason == ChannelSecurityDiagnosticReason.trustDenied)
+        #expect(allowed.allowed)
+    }
+
+    @Test func globalWriteGateDisabledDeniesWriteRequest() {
+        let policy = ChannelSecurityPolicy(
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"],
+            writePermission: ChannelWritePermission(enabled: true)
+        )
+        let identity = Self.channelIdentity(senderId: "user-a", groupId: "ops")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .reply,
+            policy: policy,
+            writeGate: ChannelWriteKillSwitchSnapshot(writeEnabled: false, generation: 7)
+        )
+
+        #expect(!decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.disabled)
+    }
+
+    @Test func strictestWinsAcrossSenderGroupAndWriteAllowlists() {
+        let policy = ChannelSecurityPolicy(
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"],
+            writePermission: ChannelWritePermission(
+                enabled: true,
+                allowedSenderIds: ["user-a"],
+                allowedGroupIds: ["incident-room"]
+            )
+        )
+        let identity = Self.channelIdentity(senderId: "user-a", groupId: "ops")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .write,
+            policy: policy,
+            writeGate: ChannelWriteKillSwitchSnapshot(writeEnabled: true)
+        )
+
+        #expect(!decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.writeGroupDenied)
+    }
+
+    @Test func fullyAllowlistedWriteRequestIsAllowed() {
+        let policy = ChannelSecurityPolicy(
+            allowedSenderIds: ["user-a"],
+            allowedGroupIds: ["ops"],
+            allowedThreadIds: ["thread-1"],
+            writePermission: ChannelWritePermission(
+                enabled: true,
+                allowedSenderIds: ["user-a"],
+                allowedGroupIds: ["ops"],
+                allowedThreadIds: ["thread-1"]
+            )
+        )
+        let identity = Self.channelIdentity(senderId: "user-a", groupId: "ops", threadId: "thread-1")
+
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: identity,
+            action: .write,
+            policy: policy,
+            writeGate: ChannelWriteKillSwitchSnapshot(writeEnabled: true)
+        )
+
+        #expect(decision.allowed)
+        #expect(decision.reason == ChannelSecurityDiagnosticReason.allowed)
+    }
+
+    @Test func expiredReplyTokenIsRejectedWithoutConsumingNonce() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 10,
+            now: fixture.now
+        )
+
+        let validation = fixture.service.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(11)
+        )
+
+        #expect(!validation.accepted)
+        #expect(validation.reason == ChannelSecurityDiagnosticReason.expired)
+        #expect(validation.message.contains("expired"))
+    }
+
+    @Test func replyTokenReplayPersistsAcrossStoreRestart() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+
+        let first = fixture.service.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+        #expect(first.accepted)
+
+        let restartedStore = ChannelReplayNonceStore(fileURL: fixture.nonceURL)
+        let restartedService = try ChannelReplyTokenService(
+            signingKey: fixture.signingKey,
+            nonceStore: restartedStore,
+            writeKillSwitch: fixture.killSwitch,
+            clockSkew: 0,
+            maxTTL: 120
+        )
+        let replay = restartedService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(2)
+        )
+
+        #expect(!replay.accepted)
+        #expect(replay.reason == ChannelSecurityDiagnosticReason.replayed)
+        #expect(replay.message.contains("nonce"))
+    }
+
+    @Test func tokenCannotBeUsedByDifferentSenderIdentity() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+        let spoofed = Self.channelIdentity(senderId: "user-b", groupId: "ops", threadId: "thread-1")
+
+        let validation = fixture.service.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: spoofed,
+            now: fixture.now.addingTimeInterval(1)
+        )
+
+        #expect(!validation.accepted)
+        #expect(validation.reason == ChannelSecurityDiagnosticReason.identityMismatch)
+    }
+
+    @Test func tamperedOrWrongKeyReplyTokenIsInvalid() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+        let tampered = String(issue.token.dropLast()) + (issue.token.last == "a" ? "b" : "a")
+
+        let tamperedValidation = fixture.service.validateToken(
+            tampered,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+        #expect(!tamperedValidation.accepted)
+        #expect(tamperedValidation.reason == ChannelSecurityDiagnosticReason.tokenInvalid)
+
+        let wrongKeyService = try ChannelReplyTokenService(
+            signingKey: Data("wrong-channel-signing-key-32-bytes".utf8),
+            nonceStore: fixture.nonceStore,
+            writeKillSwitch: fixture.killSwitch,
+            clockSkew: 0,
+            maxTTL: 120
+        )
+        let wrongKeyValidation = wrongKeyService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+        #expect(!wrongKeyValidation.accepted)
+        #expect(wrongKeyValidation.reason == ChannelSecurityDiagnosticReason.tokenInvalid)
+    }
+
+    @Test func replyTokenPurposeActionAndClockSkewAreBound() throws {
+        let fixture = try TokenFixture(clockSkew: 5)
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+
+        let purposeMismatch = fixture.service.validateToken(
+            issue.token,
+            expectedPurpose: "different",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+        #expect(purposeMismatch.reason == ChannelSecurityDiagnosticReason.purposeMismatch)
+
+        let actionMismatch = fixture.service.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .write,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+        #expect(actionMismatch.reason == ChannelSecurityDiagnosticReason.actionMismatch)
+
+        let futureIssue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now.addingTimeInterval(30)
+        )
+        let notYetValid = fixture.service.validateToken(
+            futureIssue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now
+        )
+        #expect(notYetValid.reason == ChannelSecurityDiagnosticReason.notYetValid)
+    }
+
+    @Test func weakSigningKeysAreRejected() throws {
+        #expect(throws: ChannelReplyTokenServiceError.weakSigningKey) {
+            _ = try ChannelReplyTokenService(signingKey: Data("short".utf8))
+        }
+    }
+
+    @Test func nonceStoreErrorsFailClosed() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+        let failingService = try ChannelReplyTokenService(
+            signingKey: fixture.signingKey,
+            nonceStore: FailingNonceStore(),
+            writeKillSwitch: fixture.killSwitch,
+            clockSkew: 0,
+            maxTTL: 120
+        )
+
+        let validation = failingService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+
+        #expect(!validation.accepted)
+        #expect(validation.reason == ChannelSecurityDiagnosticReason.storeUnavailable)
+        #expect(validation.message.contains("failed closed"))
+    }
+
+    @Test func replayNonceStorePrunesExpiredRecordsAndRetainsLiveRecords() throws {
+        let root = try Self.temporaryDirectory()
+        let store = ChannelReplayNonceStore(fileURL: root.appendingPathComponent("nonces.json"))
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let scope = "discord.ops.thread.user"
+
+        let expired = try store.consume(
+            scope: scope,
+            nonce: "expired",
+            expiresAt: now.addingTimeInterval(-1),
+            now: now.addingTimeInterval(-2)
+        )
+        let live = try store.consume(
+            scope: scope,
+            nonce: "live",
+            expiresAt: now.addingTimeInterval(60),
+            now: now
+        )
+        let pruned = try store.prune(expiredBefore: now)
+        let expiredAfterPrune = try store.consume(
+            scope: scope,
+            nonce: "expired",
+            expiresAt: now.addingTimeInterval(60),
+            now: now.addingTimeInterval(1)
+        )
+        let liveAfterPrune = try store.consume(
+            scope: scope,
+            nonce: "live",
+            expiresAt: now.addingTimeInterval(60),
+            now: now.addingTimeInterval(1)
+        )
+
+        #expect(expired == ChannelNonceConsumeResult.consumed)
+        #expect(live == ChannelNonceConsumeResult.consumed)
+        #expect(pruned == 1)
+        #expect(expiredAfterPrune == ChannelNonceConsumeResult.consumed)
+        #expect(liveAfterPrune == ChannelNonceConsumeResult.replayed)
+    }
+
+    @Test func killSwitchSurvivesRestartAndInvalidatesOutstandingTokens() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+
+        try fixture.killSwitch.disableWrites(now: fixture.now.addingTimeInterval(1))
+        let restartedGate = ChannelWriteKillSwitch(fileURL: fixture.killSwitchURL)
+        #expect(!restartedGate.snapshot().writeEnabled)
+
+        let disabledService = try ChannelReplyTokenService(
+            signingKey: fixture.signingKey,
+            nonceStore: fixture.nonceStore,
+            writeKillSwitch: restartedGate,
+            clockSkew: 0,
+            maxTTL: 120
+        )
+        let disabledValidation = disabledService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(2)
+        )
+        #expect(!disabledValidation.accepted)
+        #expect(disabledValidation.reason == ChannelSecurityDiagnosticReason.disabled)
+
+        try restartedGate.enableWrites(now: fixture.now.addingTimeInterval(3))
+        let reenabledValidation = disabledService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(4)
+        )
+        #expect(!reenabledValidation.accepted)
+        #expect(reenabledValidation.reason == ChannelSecurityDiagnosticReason.revoked)
+    }
+
+    @Test func corruptKillSwitchFailsClosedAndDoesNotResetGeneration() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+        try Data("not-json".utf8).write(to: fixture.killSwitchURL)
+
+        let corruptGate = ChannelWriteKillSwitch(fileURL: fixture.killSwitchURL)
+        let corruptSnapshot = corruptGate.snapshot()
+        #expect(!corruptSnapshot.writeEnabled)
+        #expect(corruptSnapshot.generation > issue.payload.writeGateGeneration)
+
+        let corruptService = try ChannelReplyTokenService(
+            signingKey: fixture.signingKey,
+            nonceStore: fixture.nonceStore,
+            writeKillSwitch: corruptGate,
+            clockSkew: 0,
+            maxTTL: 120
+        )
+        let disabledValidation = corruptService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(1)
+        )
+        #expect(!disabledValidation.accepted)
+        #expect(disabledValidation.reason == ChannelSecurityDiagnosticReason.disabled)
+
+        try corruptGate.enableWrites(now: fixture.now.addingTimeInterval(2))
+        let recoveredSnapshot = corruptGate.snapshot()
+        #expect(recoveredSnapshot.writeEnabled)
+        #expect(recoveredSnapshot.generation > issue.payload.writeGateGeneration)
+
+        let recoveredValidation = corruptService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(3)
+        )
+        #expect(!recoveredValidation.accepted)
+        #expect(recoveredValidation.reason == ChannelSecurityDiagnosticReason.revoked)
+    }
+
+    @Test func repeatedKillSwitchCorruptionRecoveryInvalidatesLaterTokens() throws {
+        let fixture = try TokenFixture()
+        try Data("not-json".utf8).write(to: fixture.killSwitchURL)
+
+        let recoveredGate = ChannelWriteKillSwitch(fileURL: fixture.killSwitchURL)
+        try recoveredGate.enableWrites(now: fixture.now.addingTimeInterval(1))
+        let recoveredService = try ChannelReplyTokenService(
+            signingKey: fixture.signingKey,
+            nonceStore: fixture.nonceStore,
+            writeKillSwitch: recoveredGate,
+            clockSkew: 0,
+            maxTTL: 120
+        )
+        let issue = try recoveredService.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now.addingTimeInterval(2)
+        )
+
+        try Data("not-json".utf8).write(to: fixture.killSwitchURL)
+        try recoveredGate.enableWrites(now: fixture.now.addingTimeInterval(3))
+
+        let validation = recoveredService.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(4)
+        )
+
+        #expect(recoveredGate.snapshot().generation > issue.payload.writeGateGeneration)
+        #expect(!validation.accepted)
+        #expect(validation.reason == ChannelSecurityDiagnosticReason.revoked)
+    }
+
+    @Test func manualRevocationRejectsOutstandingToken() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+
+        let revoked = fixture.service.revokeToken(issue.token, now: fixture.now.addingTimeInterval(1))
+        #expect(!revoked.accepted)
+        #expect(revoked.reason == ChannelSecurityDiagnosticReason.revoked)
+
+        let validation = fixture.service.validateToken(
+            issue.token,
+            expectedPurpose: "reply",
+            expectedAction: .reply,
+            identity: fixture.identity,
+            now: fixture.now.addingTimeInterval(2)
+        )
+        #expect(!validation.accepted)
+        #expect(validation.reason == ChannelSecurityDiagnosticReason.revoked)
+    }
+
+    @Test func diagnosticsRedactCredentialsAndReplyTokens() throws {
+        let fixture = try TokenFixture()
+        let issue = try fixture.service.issueToken(
+            purpose: "reply",
+            action: .reply,
+            identity: fixture.identity,
+            ttl: 60,
+            now: fixture.now
+        )
+        let secret = "channel-super-secret"
+
+        let redacted = ChannelSecurityDiagnostics.redact(
+            "denied token=\(issue.token) secret=\(secret) api_key=abcdef123456",
+            credentials: [secret],
+            tokens: [issue.token]
+        )
+
+        #expect(!redacted.contains(issue.token))
+        #expect(!redacted.contains(secret))
+        #expect(redacted.contains(ChannelSecurityDiagnostics.replyTokenMarker))
+        #expect(redacted.contains(ChannelSecurityDiagnostics.credentialMarker))
+        #expect(ChannelSecurityDiagnostics.message(for: .senderDenied).contains("sender"))
+        #expect(ChannelSecurityDiagnostics.message(for: .groupDenied).contains("group"))
+        #expect(ChannelSecurityDiagnostics.message(for: .writeDisabled).contains("write"))
+        #expect(ChannelSecurityDiagnostics.message(for: .expired).contains("expired"))
+        #expect(ChannelSecurityDiagnostics.message(for: .replayed).contains("nonce"))
+        #expect(ChannelSecurityDiagnostics.message(for: .disabled).contains("disabled"))
+    }
+
+    @Test func credentialVaultScopesSecretsByChannelAndNoopsWhenKeychainDisabled() {
+        let backingStore = RecordingCredentialBackingStore()
+        let vault = ChannelCredentialVault(backingStore: backingStore, keychainDisabled: { false })
+        let discordScope = ChannelCredentialScope(kind: .discord, installationId: "guild-1")
+        let slackScope = ChannelCredentialScope(kind: .slack, installationId: "workspace-1")
+
+        #expect(vault.saveSecret(" discord-token-secret ", credentialId: "bot_token", scope: discordScope))
+        #expect(vault.saveSecret("slack-token-secret", credentialId: "bot_token", scope: slackScope))
+        #expect(vault.secret(credentialId: "bot_token", scope: discordScope) == "discord-token-secret")
+        #expect(vault.secret(credentialId: "bot_token", scope: slackScope) == "slack-token-secret")
+        #expect(backingStore.writtenAccounts.count == 2)
+        #expect(backingStore.writtenAccounts[0] != backingStore.writtenAccounts[1])
+        #expect(vault.deleteSecret(credentialId: "bot_token", scope: discordScope))
+        #expect(vault.secret(credentialId: "bot_token", scope: discordScope) == nil)
+        #expect(
+            !vault.saveSecret(
+                "bad-secret",
+                credentialId: "bot\ntoken",
+                scope: ChannelCredentialScope(kind: .discord, installationId: "guild-1")
+            )
+        )
+
+        let disabledBackingStore = RecordingCredentialBackingStore()
+        let disabledVault = ChannelCredentialVault(
+            backingStore: disabledBackingStore,
+            keychainDisabled: { true }
+        )
+        #expect(!disabledVault.saveSecret("should-not-write", credentialId: "bot_token", scope: discordScope))
+        #expect(disabledVault.secret(credentialId: "bot_token", scope: discordScope) == nil)
+        #expect(disabledVault.deleteSecret(credentialId: "bot_token", scope: discordScope))
+        #expect(disabledBackingStore.calls.isEmpty)
+    }
+
+    @Test func decodedPolicyAndIdentityAreNormalized() throws {
+        let policyData = Data(
+            #"""
+            {
+              "enabled": true,
+              "minimumTrustLevel": "known",
+              "allowedSenderIds": [" user-a ", "user-a", " "],
+              "allowedGroupIds": [" ops ", "ops"],
+              "allowedThreadIds": [" thread-1 ", ""],
+              "writePermission": {
+                "enabled": true,
+                "allowedSenderIds": [" user-a ", "user-a"],
+                "allowedGroupIds": [" ops "],
+                "allowedThreadIds": [" thread-1 "]
+              }
+            }
+            """#.utf8
+        )
+        let policy = try JSONDecoder().decode(ChannelSecurityPolicy.self, from: policyData)
+
+        #expect(policy.allowedSenderIds == ["user-a"])
+        #expect(policy.allowedGroupIds == ["ops"])
+        #expect(policy.allowedThreadIds == ["thread-1"])
+        #expect(policy.writePermission?.allowedSenderIds == ["user-a"])
+
+        let identityData = Data(
+            #"""
+            {
+              "kind": "discord",
+              "installationId": " discord-installation ",
+              "groupId": " ops ",
+              "threadId": " ",
+              "sender": {
+                "senderId": " user-a ",
+                "displayName": " A. User ",
+                "username": " user-a ",
+                "metadata": {"team": " ops "}
+              },
+              "trustLevel": "verified"
+            }
+            """#.utf8
+        )
+        let identity = try JSONDecoder().decode(ChannelIdentity.self, from: identityData)
+
+        #expect(identity.installationId == "discord-installation")
+        #expect(identity.groupId == "ops")
+        #expect(identity.threadId == nil)
+        #expect(identity.senderId == "user-a")
+        #expect(identity.sender.displayName == "A. User")
+        #expect(identity.sender.metadata["team"] == "ops")
+        #expect(identity.trustLevel == .untrusted)
+    }
+
+    @Test func emptyRequiredChannelIdsFailClosed() throws {
+        let invalidIdentity = ChannelIdentity(
+            kind: .discord,
+            installationId: " ",
+            groupId: "ops",
+            sender: ChannelSenderMetadata(senderId: " "),
+            trustLevel: .verified
+        )
+        let decision = ChannelSecurityPolicyEvaluator().evaluate(
+            identity: invalidIdentity,
+            action: .read,
+            policy: ChannelSecurityPolicy()
+        )
+
+        #expect(!decision.allowed)
+        #expect(decision.reason == .invalidIdentity)
+
+        let invalidData = Data(
+            #"""
+            {
+              "kind": "discord",
+              "installationId": " ",
+              "sender": {"senderId": "user-a"},
+              "trustLevel": "verified"
+            }
+            """#.utf8
+        )
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(ChannelIdentity.self, from: invalidData)
+        }
+
+        let fixture = try TokenFixture()
+        #expect(throws: ChannelReplyTokenServiceError.invalidIdentity) {
+            _ = try fixture.service.issueToken(
+                purpose: "reply",
+                action: .reply,
+                identity: invalidIdentity,
+                ttl: 30,
+                now: fixture.now
+            )
+        }
+    }
+
+    fileprivate static func channelIdentity(
+        senderId: String = "user-a",
+        groupId: String? = "ops",
+        threadId: String? = "thread-1"
+    ) -> ChannelIdentity {
+        ChannelIdentity(
+            kind: .discord,
+            installationId: "discord-installation",
+            groupId: groupId,
+            threadId: threadId,
+            sender: ChannelSenderMetadata(
+                senderId: senderId,
+                displayName: "A. User",
+                username: senderId
+            ),
+            trustLevel: .verified
+        )
+    }
+
+    fileprivate static func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-channel-security-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}
+
+private struct TokenFixture {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let signingKey = Data("channel-signing-key-32-bytes-long".utf8)
+    let root: URL
+    let nonceURL: URL
+    let killSwitchURL: URL
+    let nonceStore: ChannelReplayNonceStore
+    let killSwitch: ChannelWriteKillSwitch
+    let service: ChannelReplyTokenService
+    let identity: ChannelIdentity
+
+    init(clockSkew: TimeInterval = 0) throws {
+        root = try ChannelSecurityTests.temporaryDirectory()
+        nonceURL = root.appendingPathComponent("nonces.json")
+        killSwitchURL = root.appendingPathComponent("kill-switch.json")
+        nonceStore = ChannelReplayNonceStore(fileURL: nonceURL)
+        killSwitch = ChannelWriteKillSwitch(fileURL: killSwitchURL)
+        service = try ChannelReplyTokenService(
+            signingKey: signingKey,
+            nonceStore: nonceStore,
+            writeKillSwitch: killSwitch,
+            clockSkew: clockSkew,
+            maxTTL: 120
+        )
+        identity = ChannelSecurityTests.channelIdentity()
+    }
+}
+
+private enum FailingNonceStoreError: Error {
+    case unavailable
+}
+
+private struct FailingNonceStore: ChannelReplyTokenNonceStore {
+    func consume(
+        scope: String,
+        nonce: String,
+        expiresAt: Date,
+        now: Date
+    ) throws -> ChannelNonceConsumeResult {
+        throw FailingNonceStoreError.unavailable
+    }
+
+    func revoke(
+        scope: String,
+        nonce: String,
+        expiresAt: Date,
+        now: Date
+    ) throws {
+        throw FailingNonceStoreError.unavailable
+    }
+
+    func prune(expiredBefore: Date) throws -> Int {
+        throw FailingNonceStoreError.unavailable
+    }
+}
+
+private final class RecordingCredentialBackingStore: ChannelCredentialVaultBackingStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String: Data] = [:]
+    private(set) var calls: [String] = []
+    private(set) var writtenAccounts: [String] = []
+
+    func write(service: String, account: String, data: Data) -> Bool {
+        lock.lock()
+        calls.append("write")
+        writtenAccounts.append(account)
+        values[key(service: service, account: account)] = data
+        lock.unlock()
+        return true
+    }
+
+    func read(service: String, account: String) -> Data? {
+        lock.lock()
+        calls.append("read")
+        let value = values[key(service: service, account: account)]
+        lock.unlock()
+        return value
+    }
+
+    func delete(service: String, account: String) -> Bool {
+        lock.lock()
+        calls.append("delete")
+        values.removeValue(forKey: key(service: service, account: account))
+        lock.unlock()
+        return true
+    }
+
+    private func key(service: String, account: String) -> String {
+        "\(service)\u{1F}\(account)"
+    }
+}

--- a/docs/AGENT_CHANNEL_SECURITY.md
+++ b/docs/AGENT_CHANNEL_SECURITY.md
@@ -1,0 +1,110 @@
+# Agent Channel Security Foundation
+
+This document covers the policy-only foundation for future Discord, Slack,
+Telegram, and JSON Agent Channel receive flows. It does not implement adapter
+routing, an inbox UI, a remote command center, or computer-use triggers.
+
+## Identity Model
+
+Every inbound channel event must be normalized into a `ChannelIdentity` before
+policy evaluation:
+
+- `kind`: provider family, such as Discord, Slack, Telegram, or JSON Agent.
+- `installationId`: workspace, guild, bot installation, or equivalent provider
+  boundary.
+- `groupId` and `threadId`: the room, group, channel, topic, thread, or message
+  context where the event originated.
+- `sender`: stable sender id plus display metadata for diagnostics.
+- `trustLevel`: provider-derived trust signal; policy can require a minimum.
+
+Tokens bind to `ChannelIdentityBinding`, which includes kind, installation,
+group, thread, and sender id. A reply token issued for one sender or group is
+not valid for another.
+
+## Policy Evaluation
+
+`ChannelSecurityPolicyEvaluator` enforces strictest-wins allowlists:
+
+- Sender allowlists gate which users may receive a response.
+- Group and thread allowlists gate which shared spaces may dispatch to the
+  agent.
+- Write actions require explicit `ChannelWritePermission`.
+- Write allowlists are additional restrictions, not replacements for the read
+  policy.
+- If the global channel write kill switch is supplied and disabled, write
+  actions are denied even when channel policy allows them.
+
+Empty allowlists mean that dimension is unrestricted. If multiple dimensions are
+configured, all of them must pass.
+
+A default enabled policy with no allowlists permits any sender that satisfies
+the minimum trust level. Channel setup should configure sender, group, or thread
+allowlists before enabling receive flows in shared spaces.
+
+## Reply Tokens
+
+`ChannelReplyTokenService` issues scoped HMAC-signed reply tokens with:
+
+- purpose and action binding;
+- channel identity binding;
+- nonce;
+- issue and expiry timestamps;
+- clock-skew enforcement;
+- persisted write-gate generation.
+
+Validation verifies signature, purpose, action, identity, kill-switch state,
+clock skew, expiry, and then consumes the nonce. A valid token can be used once.
+Manual revocation records the nonce as revoked. If the replay store errors,
+validation fails closed.
+
+The service requires a caller-provided signing key of at least 32 bytes. This PR
+does not generate, store, or rotate that key; adapter wiring should provision it
+through a channel-scoped secret before receive flows are enabled.
+
+Reply tokens are scoped capability grants. Validation does not re-evaluate a
+mutable `ChannelSecurityPolicy`; callers should evaluate policy before issuing
+or accepting a channel response, and use short TTLs, explicit nonce revocation,
+or the global kill switch when policy changes must invalidate outstanding write
+tokens immediately.
+
+## Replay Store
+
+`ChannelReplayNonceStore` persists nonce records under the Agent Channels data
+directory. Records are scoped by channel identity so nonces cannot collide
+across providers, installations, groups, threads, or senders.
+
+## Write Kill Switch
+
+`ChannelWriteKillSwitch` persists a global remote/channel write gate in
+configuration. Disabling writes increments a generation counter. Outstanding
+write tokens issued under older generations are rejected while disabled and
+remain rejected after writes are re-enabled.
+
+If the kill-switch state file is missing, writes use the default enabled state.
+If the state file is corrupt or unreadable, writes fail closed until the state is
+explicitly recovered.
+
+## Credential Vault
+
+`ChannelCredentialVault` stores adapter secrets in Keychain under the
+`ai.osaurus.channels` service with channel-scoped account ids. Account ids bind
+to provider kind, installation, optional group/thread, and credential id. The
+vault is intentionally channel-specific and is not a shared credential
+framework.
+
+When keychain-disabled test mode is active, writes return `false`, reads return
+`nil`, and deletes are no-ops that return `true`.
+
+## Diagnostics
+
+Channel diagnostics must redact raw credentials and reply tokens. Denials use
+specific reasons for sender, group, thread, write-disabled, expired, replayed,
+revoked, identity mismatch, disabled kill switch, and replay-store failure
+cases so operators can fix policy without seeing secrets.
+
+## Local State Assumption
+
+The nonce table and kill-switch state are local JSON files. They are intended to
+fail closed on read, write, or corruption errors, but they are not tamper-proof
+against a local actor with write access to Osaurus configuration and data
+directories.


### PR DESCRIPTION
## Summary

Adds a policy-only Agent Channel security foundation for future Discord, Slack, Telegram, and JSON channel adapters.

- models provider-neutral channel identities, groups, threads, senders, and trust levels
- evaluates sender, group, and thread allowlists with strictest-wins behavior
- adds scoped expiring reply tokens bound to channel identity and action
- persists replay nonces and a global remote/channel write kill switch
- stores channel credentials through channel-scoped Keychain accounts
- redacts credentials and reply tokens from diagnostics
- documents the security model and non-goals

This does not add adapter routing, inbox UI, remote command center, or computer-use triggers.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-channel-security swift test --package-path Packages/OsaurusCore --filter ChannelSecurityTests`

## Review Notes

- Independent model review found no blocking issues and called out expected foundation risks around future multi-process replay storage and integration enforcement.
- A compact security review flagged decoded identity normalization and decoded trust-level escalation risks. Both were fixed and covered by tests.

## Risk

The replay nonce store is process-local JSON for this foundation. Future multi-process channel receivers should move replay checks to SQLite compare-and-insert before sharing state across processes.