### PR TITLE
Add OCR as a unified Subagent kind (ocr tool + per-agent Sub-agents tab)

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -760,6 +760,7 @@ extension AgentManager {
             computerUseEnabled: agent.settings.computerUseEnabled,
             spawnDelegationEnabled: agent.settings.spawnDelegationEnabled,
             imageEnabled: agent.settings.imageEnabled,
+            ocrEnabled: agent.settings.ocrEnabled,
             spawnableAgentNames: agent.settings.spawnableAgentNames
         )
     }

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -480,6 +480,10 @@ public struct AgentCapabilities: Sendable, Equatable {
     /// `spawnDelegationEnabled` so an agent can spawn without image (or vice
     /// versa).
     public var imageEnabled: Bool
+    /// OCR (`ocr`) exposed to the model — per-agent opt-in, split from
+    /// `imageEnabled` so an agent can OCR without image generation (or vice
+    /// versa).
+    public var ocrEnabled: Bool
     /// Personas this agent may launch via `spawn`. Empty → the `spawn` tool
     /// stays hidden (nothing to spawn). The Default agent ignores this and uses
     /// the global `SubagentConfiguration.spawnableAgentNames` pool instead.
@@ -496,6 +500,7 @@ public struct AgentCapabilities: Sendable, Equatable {
         computerUseEnabled: Bool = false,
         spawnDelegationEnabled: Bool = false,
         imageEnabled: Bool = false,
+        ocrEnabled: Bool = false,
         spawnableAgentNames: [String] = []
     ) {
         self.toolsEnabled = toolsEnabled
@@ -508,6 +513,7 @@ public struct AgentCapabilities: Sendable, Equatable {
         self.computerUseEnabled = computerUseEnabled
         self.spawnDelegationEnabled = spawnDelegationEnabled
         self.imageEnabled = imageEnabled
+        self.ocrEnabled = ocrEnabled
         self.spawnableAgentNames = spawnableAgentNames
     }
 }
@@ -764,6 +770,15 @@ public struct AgentSettings: Codable, Sendable, Equatable {
     /// image-edit model at run time). The Default agent uses the global
     /// `SubagentConfiguration.defaultImageEditModelId` instead.
     public var imageEditModelId: String?
+    /// Per-agent opt-in for the `ocr` tool (extract text from images via a local
+    /// OCR VLM). Default off; split from `imageEnabled` so an agent can enable
+    /// OCR independently. The Default agent ignores this and uses the global OCR
+    /// enable in `SubagentConfiguration`.
+    public var ocrEnabled: Bool
+    /// Per-agent OCR model bundle id (`nil` → resolve to the first ready
+    /// image-capable OCR model at run time). The Default agent uses the global
+    /// `SubagentConfiguration.defaultOcrModelId` instead.
+    public var ocrModelId: String?
     /// Per-agent permission policies for the delegation sub-agents (`spawn`,
     /// `image`), keyed by capability id. A kind absent from the map resolves to
     /// the safe `.ask` default. The Default agent uses the global
@@ -790,6 +805,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         spawnableAgentNames: [String] = [],
         imageGenerationModelId: String? = nil,
         imageEditModelId: String? = nil,
+        ocrEnabled: Bool = false,
+        ocrModelId: String? = nil,
         subagentPermissions: SubagentPermissionDefaults = SubagentPermissionDefaults(),
         subagentBudgets: SubagentBudgets = SubagentBudgets()
     ) {
@@ -809,6 +826,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         self.spawnableAgentNames = spawnableAgentNames
         self.imageGenerationModelId = imageGenerationModelId
         self.imageEditModelId = imageEditModelId
+        self.ocrEnabled = ocrEnabled
+        self.ocrModelId = ocrModelId
         self.subagentPermissions = subagentPermissions
         self.subagentBudgets = subagentBudgets
     }
@@ -866,6 +885,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         // `SubagentConfiguration`).
         imageGenerationModelId = try c.decodeIfPresent(String.self, forKey: .imageGenerationModelId)
         imageEditModelId = try c.decodeIfPresent(String.self, forKey: .imageEditModelId)
+        ocrEnabled = try c.decodeIfPresent(Bool.self, forKey: .ocrEnabled) ?? false
+        ocrModelId = try c.decodeIfPresent(String.self, forKey: .ocrModelId)
         subagentPermissions =
             (try? c.decodeIfPresent(SubagentPermissionDefaults.self, forKey: .subagentPermissions))
             ?? SubagentPermissionDefaults()
@@ -891,6 +912,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         case spawnableAgentNames
         case imageGenerationModelId
         case imageEditModelId
+        case ocrEnabled
+        case ocrModelId
         case subagentPermissions
         case subagentBudgets
         // Read-only legacy key — never encoded after migration.
@@ -915,6 +938,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         try c.encode(spawnableAgentNames, forKey: .spawnableAgentNames)
         try c.encodeIfPresent(imageGenerationModelId, forKey: .imageGenerationModelId)
         try c.encodeIfPresent(imageEditModelId, forKey: .imageEditModelId)
+        try c.encode(ocrEnabled, forKey: .ocrEnabled)
+        try c.encodeIfPresent(ocrModelId, forKey: .ocrModelId)
         try c.encode(subagentPermissions, forKey: .subagentPermissions)
         try c.encode(subagentBudgets, forKey: .subagentBudgets)
     }

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
@@ -175,6 +175,11 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     var imageDelegationEnabled: Bool
     var defaultImageGenerationModelId: String?
     var defaultImageEditModelId: String?
+    /// The DEFAULT / main-chat agent's `ocr` enable. Custom agents carry their
+    /// own `AgentSettings.ocrEnabled`; this governs the main chat only.
+    var ocrDelegationEnabled: Bool
+    /// The DEFAULT / main-chat agent's OCR model bundle id (`nil` → first ready).
+    var defaultOcrModelId: String?
     var imageJobLoadPolicy: SubagentImageLoadPolicy
     var permissionDefaults: SubagentPermissionDefaults
     var budgets: SubagentBudgets
@@ -190,6 +195,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         imageDelegationEnabled: Bool = false,
         defaultImageGenerationModelId: String? = nil,
         defaultImageEditModelId: String? = nil,
+        ocrDelegationEnabled: Bool = false,
+        defaultOcrModelId: String? = nil,
         imageJobLoadPolicy: SubagentImageLoadPolicy = .agentSingleResidency,
         permissionDefaults: SubagentPermissionDefaults = SubagentPermissionDefaults(),
         budgets: SubagentBudgets = SubagentBudgets(),
@@ -200,6 +207,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         self.imageDelegationEnabled = imageDelegationEnabled
         self.defaultImageGenerationModelId = defaultImageGenerationModelId
         self.defaultImageEditModelId = defaultImageEditModelId
+        self.ocrDelegationEnabled = ocrDelegationEnabled
+        self.defaultOcrModelId = defaultOcrModelId
         self.imageJobLoadPolicy = imageJobLoadPolicy
         self.permissionDefaults = permissionDefaults
         self.budgets = budgets.normalized
@@ -231,6 +240,12 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         imageDelegationEnabled
     }
 
+    /// Whether `ocr` is active for the DEFAULT / main chat (its OCR switch).
+    /// Custom agents gate on their own `AgentSettings.ocrEnabled`.
+    var ocrDelegationActive: Bool {
+        ocrDelegationEnabled
+    }
+
     /// Whether an agent-launched image job must evict resident chat models for
     /// the duration of the job (single-GPU-residency handoff). The other load
     /// policies keep the chat model resident. Single source for the image
@@ -246,6 +261,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             imageDelegationEnabled: imageDelegationEnabled,
             defaultImageGenerationModelId: Self.normalizedModelId(defaultImageGenerationModelId),
             defaultImageEditModelId: Self.normalizedModelId(defaultImageEditModelId),
+            ocrDelegationEnabled: ocrDelegationEnabled,
+            defaultOcrModelId: Self.normalizedModelId(defaultOcrModelId),
             imageJobLoadPolicy: imageJobLoadPolicy,
             permissionDefaults: permissionDefaults,
             budgets: budgets.normalized,
@@ -262,6 +279,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         case imageDelegationEnabled
         case defaultImageGenerationModelId
         case defaultImageEditModelId
+        case ocrDelegationEnabled
+        case defaultOcrModelId
         case imageJobLoadPolicy
         case permissionDefaults
         case budgets
@@ -280,6 +299,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
                 forKey: .defaultImageGenerationModelId
             ),
             defaultImageEditModelId: try container.decodeIfPresent(String.self, forKey: .defaultImageEditModelId),
+            ocrDelegationEnabled: try container.decodeIfPresent(Bool.self, forKey: .ocrDelegationEnabled) ?? false,
+            defaultOcrModelId: try container.decodeIfPresent(String.self, forKey: .defaultOcrModelId),
             // Enum fields use `(try? …) ?? default` so a single invalid/renamed
             // raw value falls back to its default instead of throwing — a throw
             // here would discard the ENTIRE delegation config (see the lenient

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -575,6 +575,12 @@ extension Array where Element == ModelPickerItem {
         filter(\.isImageEditDelegateCandidate)
     }
 
+    /// Models eligible as an `ocr` model — image-capable (VLM) models that can
+    /// read text from an image (DeepSeek-OCR / Unlimited-OCR and other VLMs).
+    var ocrDelegateCandidates: [ModelPickerItem] {
+        filter(\.isVLM)
+    }
+
     func subagentModelCandidate(
         id: String?,
         kind: SubagentModelKind

--- a/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
@@ -111,6 +111,10 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     /// unless the agent opted in (custom agents) / the global image switch is on
     /// (Default agent).
     public let imageEnabled: Bool
+    /// Per-agent opt-in for `ocr`. Enforced in `resolveTools` — stripped unless
+    /// the agent opted in (custom agents) / the global OCR switch is on (Default
+    /// agent).
+    public let ocrEnabled: Bool
     /// Personas this agent may launch via `spawn`. Drives the "is there anything
     /// to spawn?" half of the spawn visibility gate for custom agents.
     public let spawnableAgentNames: [String]
@@ -133,6 +137,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         computerUseEnabled: Bool = false,
         spawnDelegationEnabled: Bool = false,
         imageEnabled: Bool = false,
+        ocrEnabled: Bool = false,
         spawnableAgentNames: [String] = []
     ) {
         self.agentId = agentId
@@ -152,6 +157,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         self.computerUseEnabled = computerUseEnabled
         self.spawnDelegationEnabled = spawnDelegationEnabled
         self.imageEnabled = imageEnabled
+        self.ocrEnabled = ocrEnabled
         self.spawnableAgentNames = spawnableAgentNames
     }
 
@@ -193,6 +199,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
             computerUseEnabled: caps.computerUseEnabled,
             spawnDelegationEnabled: caps.spawnDelegationEnabled,
             imageEnabled: caps.imageEnabled,
+            ocrEnabled: caps.ocrEnabled,
             spawnableAgentNames: caps.spawnableAgentNames
         )
     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -684,6 +684,15 @@ public enum SystemPromptTemplates {
         - The job runs locally in the background and may briefly swap models; that is expected. Make the call and report the result when it returns.
         """
 
+    public static let ocrGuidance = """
+        ## OCR (image text extraction)
+
+        - You CAN read and extract text from images with the `ocr` tool. When the user provides one or more image file paths and asks you to read, transcribe, extract, recognize, or "OCR" the text in them, call `ocr` with `images` set to the path(s). Optionally pass a `prompt` to steer extraction (e.g. a grounding instruction); omit it to use the default.
+        - NEVER reply that you cannot read images or that you are "text-only" — you have this tool, so use it. Do not redirect the user to another app for text extraction.
+        - The tool returns the extracted text as a structured result. Use it to answer the user's request (quote, summarize, or process the text as asked).
+        - The job runs locally in the background and may briefly swap to the OCR model; that is expected. Make the call and report the result when it returns.
+        """
+
     // MARK: - Soul
 
     /// Renders the SOUL section — agent-authored, sandbox-only identity

--- a/Packages/OsaurusCore/Subagent/Kinds/OcrSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/OcrSubagentKind.swift
@@ -1,0 +1,333 @@
+//
+//  OcrSubagentKind.swift
+//  OsaurusCore — Subagent framework
+//
+//  The OCR sub-agent kind that serves the single `ocr` tool: extract text from
+//  one or more local images using a configured local OCR VLM (DeepSeek-OCR /
+//  Unlimited-OCR). Resolves the per-agent OCR model, seeds a bounded multimodal
+//  completion (image + grounding prompt) on that model through
+//  `AgentSubagentRunner`, and hands back the extracted text as a compact digest.
+//
+//  `modelSource = .dedicatedConfigured` (its own per-agent model, like `image`),
+//  but — unlike the image coordinator, which owns its residency internally — OCR
+//  runs the bounded VLM completion through the shared text runner, so it uses the
+//  host `ResidencyHandoff` (like `spawn`/text) to unload the resident chat model
+//  when the OCR model is a DIFFERENT local model (single GPU residency). The
+//  reject-before-evict policy gates (not enabled, permission denied, no model)
+//  are resolved up front so nothing is evicted before we know the run can run.
+//
+
+import Foundation
+
+/// Parsed, validated `ocr` tool arguments.
+struct OcrJobParams: Sendable {
+    /// One-to-four local image file paths to extract text from.
+    var imagePaths: [String]
+    /// Optional OCR model id; `nil` → use the per-agent configured default.
+    var model: String?
+    /// Optional extraction/grounding prompt; `nil` → the default grounding prompt.
+    var prompt: String?
+}
+
+final class OcrSubagentKind: SubagentKind, @unchecked Sendable {
+    let capability = SubagentCapabilityRegistry.ocr
+
+    private let params: OcrJobParams
+    private let argumentsJSON: String
+
+    /// Cap on the OCR text handed back to the parent.
+    private static let digestMaxChars = 16_000
+    /// Token cap for the OCR completion (text can be long for dense documents).
+    private static let ocrMaxTokens = 8_192
+    /// Max images per call.
+    static let maxImages = 4
+    /// Per-image byte ceiling (mirrors the image-edit source limit).
+    private static let maxImageBytes = 80 * 1024 * 1024
+    /// Default grounding prompt — DeepSeek-OCR / Unlimited-OCR emit clean output
+    /// for the grounding form (bare prompts can emit a leading EOS → empty).
+    private static let defaultPrompt = "<|grounding|>OCR this image."
+
+    // Resolved up front in `resolveModel`, read by permission/handoff/run.
+    private var residencyShouldUnload = false
+    private var residencyRequiredBytes: Int64 = 0
+    private var ramSafetyEnabled = false
+    private var handoffMaxElapsedSeconds = 120
+
+    init(params: OcrJobParams, argumentsJSON: String) {
+        self.params = params
+        self.argumentsJSON = argumentsJSON
+    }
+
+    var feedTitle: String {
+        let count = params.imagePaths.count
+        return "ocr: \(count) image\(count == 1 ? "" : "s")"
+    }
+
+    // MARK: - Model resolution (reject-before-evict)
+
+    func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel {
+        let config = SubagentConfigurationStore.snapshot()
+        // Per-agent OCR enable + model (no global master switch): Default / main
+        // chat → its own OCR switch + configured model; a custom agent → its own
+        // `ocrEnabled` toggle + per-agent model, resolved from the launching
+        // agent (`scope`).
+        let isDefault = scope.agentId == Agent.defaultId
+        let settings = await MainActor.run {
+            AgentManager.shared.agent(for: scope.agentId)?.settings
+        }
+        guard
+            SubagentToolVisibility.ocrAvailable(
+                isDefault: isDefault,
+                config: config,
+                perAgentEnabled: settings?.ocrEnabled ?? false
+            )
+        else {
+            throw SubagentError.denied("OCR is not enabled for this agent.")
+        }
+        if SubagentToolVisibility.effectivePermission(
+            capabilityId: capability.id,
+            isDefault: isDefault,
+            config: config,
+            settings: settings
+        ) == .deny {
+            throw SubagentError.denied("OCR is denied by this agent's permission settings.")
+        }
+
+        // Resolve the model: explicit request → per-agent configured default →
+        // a first-ready installed OCR model (name contains "ocr"). All must be
+        // an INSTALLED local bundle (OCR runs locally on the GPU).
+        let configured = SubagentToolVisibility.effectiveOcrModel(
+            isDefault: isDefault,
+            config: config,
+            settings: settings
+        )
+        let resolvedName = try Self.resolveModelName(
+            requested: params.model,
+            configured: configured
+        )
+
+        // Decide the residency handoff from ACTUAL GPU residency: if the OCR
+        // model is local and a DIFFERENT chat model is resident, unload it first
+        // so only one model touches the GPU at a time (avoids the MLX
+        // shared-command-stream SIGABRT). The handoff middleware runs the
+        // refuse-before-evict RAM preflight before any eviction.
+        let residentChatModels = await ModelRuntime.shared.cachedModelSummaries().map(\.name)
+        let otherResidentModels = residentChatModels.filter {
+            $0.caseInsensitiveCompare(resolvedName) != .orderedSame
+        }
+        if !otherResidentModels.isEmpty {
+            self.residencyShouldUnload = true
+            self.residencyRequiredBytes = ChatResidencyHandoff.estimatedChatModelBytes(named: resolvedName)
+            self.ramSafetyEnabled = config.ramSafetyPreflightEnabled
+            self.handoffMaxElapsedSeconds = SubagentToolVisibility.effectiveBudgets(
+                isDefault: isDefault,
+                config: config,
+                settings: settings
+            ).maxElapsedSeconds
+        }
+
+        return ResolvedModel(name: resolvedName, id: resolvedName, isLocal: true)
+    }
+
+    /// Resolve the OCR model name to an installed local bundle, or throw a
+    /// helpful `unavailable` error. Tries the explicit request, then the
+    /// per-agent configured default.
+    private static func resolveModelName(requested: String?, configured: String?) throws -> String {
+        for candidate in [requested, configured] {
+            guard let name = candidate?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty
+            else { continue }
+            guard ModelManager.findInstalledModel(named: name) != nil else {
+                throw SubagentError.unavailable(
+                    "OCR model '\(name)' is not installed. Pick an installed OCR model in the agent's Sub-agents tab."
+                )
+            }
+            return name
+        }
+        throw SubagentError.unavailable(
+            "No OCR model is configured. Install a local OCR model (e.g. DeepSeek-OCR / Unlimited-OCR) "
+                + "and select it in the agent's Sub-agents tab."
+        )
+    }
+
+    // MARK: - Permission
+
+    func permission(_ scope: SubagentScope, _ resolved: ResolvedModel) async -> SubagentDecision {
+        let config = SubagentConfigurationStore.snapshot()
+        let isDefault = scope.agentId == Agent.defaultId
+        let settings = await MainActor.run {
+            AgentManager.shared.agent(for: scope.agentId)?.settings
+        }
+        let policy = SubagentToolVisibility.effectivePermission(
+            capabilityId: capability.id,
+            isDefault: isDefault,
+            config: config,
+            settings: settings
+        )
+        switch policy {
+        case .deny:
+            return .denied("OCR is denied by this agent's permission settings.")
+        case .alwaysAllow:
+            return .allow
+        case .ask:
+            if ChatExecutionContext.autoApproveToolPrompts { return .allow }
+            let approvalJSON = SubagentApprovalArguments.enrichedJSON(
+                from: argumentsJSON,
+                values: ["resolved_model": resolved.name]
+            )
+            let approved = await ToolPermissionPromptService.requestApproval(
+                toolName: "ocr",
+                description: OcrTool.toolDescription,
+                argumentsJSON: approvalJSON
+            )
+            return approved ? .allow : .userDenied("User denied OCR.")
+        }
+    }
+
+    // MARK: - Residency handoff
+
+    func makeHandoff() -> SubagentHandoff {
+        guard residencyShouldUnload else { return PassthroughHandoff() }
+        let plan = ResidencyPlan(
+            shouldUnload: true,
+            requiredBytes: residencyRequiredBytes,
+            ramSafetyEnabled: ramSafetyEnabled,
+            maxElapsedSeconds: handoffMaxElapsedSeconds
+        )
+        return ResidencyHandoff.production { _ in plan }
+    }
+
+    // MARK: - Run
+
+    func run(
+        _ scope: SubagentScope,
+        _ resolved: ResolvedModel,
+        feed: SubagentFeed,
+        interrupt: InterruptToken
+    ) async throws -> SubagentResult {
+        feed.emitPhase("extracting", detail: resolved.name)
+
+        let images: [Data]
+        do {
+            images = try Self.loadImages(paths: params.imagePaths)
+        } catch let error as OcrInputError {
+            throw SubagentError.invalidArgs(
+                message: String(describing: error),
+                field: "images",
+                expected: "one to \(Self.maxImages) existing local image files under 80 MB each"
+            )
+        }
+
+        let prompt = (params.prompt?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? Self.defaultPrompt
+        let seed: [ChatMessage] = [
+            ChatMessage(
+                role: "system",
+                content:
+                    "You are an OCR engine. Transcribe the text in the user's image(s) exactly as it "
+                    + "appears, preserving line breaks and reading order. Output only the transcribed "
+                    + "text, with no commentary."
+            ),
+            ChatMessage(role: "user", text: prompt, imageData: images),
+        ]
+        let deadline = Date().addingTimeInterval(TimeInterval(handoffMaxElapsedSeconds))
+        let sessionId = "ocr-\(scope.toolCallId)-\(UUID().uuidString)"
+
+        let result = try await AgentSubagentRunner.run(
+            modelName: resolved.name,
+            seedMessages: seed,
+            maxTokens: Self.ocrMaxTokens,
+            maxIterations: 1,
+            deadline: deadline,
+            sessionId: sessionId,
+            isInterrupted: { interrupt.isInterrupted }
+        )
+
+        switch result.exit {
+        case .finalResponse, .endedBySurface:
+            let text = (result.digest ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else {
+                throw SubagentError.emptyExhausted(
+                    "OCR returned no text. The image may be blank, or the model may need a grounding prompt."
+                )
+            }
+            let capped =
+                text.count > Self.digestMaxChars
+                ? String(text.prefix(Self.digestMaxChars)) + "\n[text truncated]"
+                : text
+            let count = params.imagePaths.count
+            return SubagentResult(
+                payload: [
+                    "kind": "ocr_result",
+                    "model": resolved.name,
+                    "image_count": count,
+                    "text": capped,
+                    "summary": "Extracted text from \(count) image\(count == 1 ? "" : "s") with \(resolved.name).",
+                    "handoff": residencyShouldUnload,
+                ] as [String: Any],
+                summary: capped
+            )
+        case .cancelled:
+            throw SubagentError.timedOut("OCR hit its \(handoffMaxElapsedSeconds)s time budget.")
+        case .iterationCapReached:
+            throw SubagentError.iterationCap("OCR did not produce text within its turn budget.")
+        case .toolRejected:
+            throw SubagentError.toolRejected("OCR attempted unavailable child tool use.")
+        case .overBudget:
+            throw SubagentError.overBudget("OCR exceeded its context budget. Try fewer / smaller images.")
+        case .emptyResponseExhausted:
+            throw SubagentError.emptyExhausted(
+                "OCR returned empty output. The model may need a grounding prompt or a different OCR model."
+            )
+        }
+    }
+
+    // MARK: - Image loading
+
+    static func loadImages(paths: [String]) throws -> [Data] {
+        let trimmed =
+            paths
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !trimmed.isEmpty, trimmed.count <= maxImages else {
+            throw OcrInputError.invalidImageCount
+        }
+        return try trimmed.map { path in
+            // Accept an inline data URL directly (base64-encoded image bytes).
+            if path.hasPrefix("data:"), let comma = path.firstIndex(of: ","),
+                let data = Data(base64Encoded: String(path[path.index(after: comma)...]))
+            {
+                return data
+            }
+            let url =
+                URL(string: path).flatMap { $0.isFileURL ? $0 : nil }
+                ?? URL(fileURLWithPath: path)
+            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard values.isRegularFile == true else {
+                throw OcrInputError.notAFile(path)
+            }
+            if let size = values.fileSize, size > maxImageBytes {
+                throw OcrInputError.fileTooLarge(path)
+            }
+            return try Data(contentsOf: url)
+        }
+    }
+}
+
+/// Argument/IO validation failures for the `ocr` tool.
+enum OcrInputError: Error, CustomStringConvertible {
+    case invalidImageCount
+    case notAFile(String)
+    case fileTooLarge(String)
+
+    var description: String {
+        switch self {
+        case .invalidImageCount:
+            return "images must contain one to \(OcrSubagentKind.maxImages) image paths"
+        case .notAFile(let path):
+            return "image path is not a regular file: \(path)"
+        case .fileTooLarge(let path):
+            return "image exceeds the 80 MB limit: \(path)"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
@@ -52,6 +52,7 @@ public struct SubagentCapability: Sendable {
         case computerUse
         case spawn
         case image
+        case ocr
 
         /// The resolved per-agent flag for the `resolveTools` strip.
         public func enabled(in snapshot: AgentConfigSnapshot) -> Bool {
@@ -59,6 +60,7 @@ public struct SubagentCapability: Sendable {
             case .computerUse: return snapshot.computerUseEnabled
             case .spawn: return snapshot.spawnDelegationEnabled
             case .image: return snapshot.imageEnabled
+            case .ocr: return snapshot.ocrEnabled
             }
         }
 
@@ -68,6 +70,7 @@ public struct SubagentCapability: Sendable {
             case .computerUse: return settings.computerUseEnabled
             case .spawn: return settings.spawnDelegationEnabled
             case .image: return settings.imageEnabled
+            case .ocr: return settings.ocrEnabled
             }
         }
 
@@ -77,6 +80,7 @@ public struct SubagentCapability: Sendable {
             case .computerUse: settings.computerUseEnabled = value
             case .spawn: settings.spawnDelegationEnabled = value
             case .image: settings.imageEnabled = value
+            case .ocr: settings.ocrEnabled = value
             }
         }
     }
@@ -196,6 +200,26 @@ public enum SubagentCapabilityRegistry {
         guidanceLabelKey: "Image Generation"
     )
 
+    /// The OCR family — one `ocr` tool that extracts text from one or more
+    /// images using a configured local OCR VLM (DeepSeek-OCR / Unlimited-OCR).
+    /// `modelSource = .dedicatedConfigured` (its own per-agent model), but it
+    /// runs a bounded VLM completion through `AgentSubagentRunner` and unloads
+    /// the resident chat model via `ResidencyHandoff` when the OCR model is a
+    /// different local model. Off-by-default; each agent opts in from its
+    /// Sub-agents tab. The guidance renders when `ocr` resolves.
+    public static let ocr = SubagentCapability(
+        id: "ocr",
+        toolNames: ["ocr"],
+        gate: .delegation,
+        perAgentFlag: .ocr,
+        modelSource: .dedicatedConfigured,
+        displayLabel: "OCR",
+        iconName: "doc.text.viewfinder",
+        guidance: SystemPromptTemplates.ocrGuidance,
+        guidanceSectionId: "ocr",
+        guidanceLabelKey: "OCR"
+    )
+
     /// The reduction family — `sandbox_reduce` runs a read/search/exec-only
     /// child loop inside the sandbox and hands back only a digest. Gated by
     /// sandbox registration (NOT a per-agent / delegation toggle), so it never
@@ -209,12 +233,12 @@ public enum SubagentCapabilityRegistry {
         iconName: "doc.text.magnifyingglass"
     )
 
-    /// Every capability, in guidance-render order (computer_use, then image;
+    /// Every capability, in guidance-render order (computer_use, image, ocr;
     /// spawn / sandbox_reduce have no guidance and are skipped at render time).
-    public static let all: [SubagentCapability] = [computerUse, spawn, image, sandboxReduce]
+    public static let all: [SubagentCapability] = [computerUse, spawn, image, ocr, sandboxReduce]
 
-    /// The delegation-gated capabilities (spawn + image).
-    public static let delegationFamily: [SubagentCapability] = [spawn, image]
+    /// The delegation-gated capabilities (spawn + image + ocr).
+    public static let delegationFamily: [SubagentCapability] = [spawn, image, ocr]
 
     /// Distinct per-agent toggle flags, in registry order (computer_use, spawn,
     /// image). One entry per *toggle* (deduped, so a future kind that shares a
@@ -296,6 +320,17 @@ public enum SubagentToolVisibility {
         isDefault ? config.imageDelegationActive : perAgentEnabled
     }
 
+    /// Whether `ocr` is available for an agent. The Default / main chat is
+    /// governed by its own OCR switch (`ocrDelegationActive`); a custom agent by
+    /// its own toggle. There is no global master switch.
+    static func ocrAvailable(
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        perAgentEnabled: Bool
+    ) -> Bool {
+        isDefault ? config.ocrDelegationActive : perAgentEnabled
+    }
+
     /// Whether a specific `spawn` TARGET persona is reachable from a launching
     /// agent — the execution-time check the spawn kind enforces. Default / main
     /// chat uses its own pool; a custom agent its own allow-list.
@@ -335,6 +370,13 @@ public enum SubagentToolVisibility {
         ) {
             names.formUnion(SubagentCapabilityRegistry.image.toolNames)
         }
+        if ocrAvailable(
+            isDefault: isDefault,
+            config: config,
+            perAgentEnabled: snapshot.ocrEnabled
+        ) {
+            names.formUnion(SubagentCapabilityRegistry.ocr.toolNames)
+        }
         return names
     }
 
@@ -362,6 +404,18 @@ public enum SubagentToolVisibility {
             return isEdit ? config.defaultImageEditModelId : config.defaultImageGenerationModelId
         }
         return isEdit ? settings?.imageEditModelId : settings?.imageGenerationModelId
+    }
+
+    /// The effective OCR model id for an agent. Default / main chat uses the
+    /// global configured default; a custom agent uses its own per-agent model. A
+    /// `nil` result falls through to the run-time "first ready OCR model"
+    /// resolver, so an agent that enabled OCR without picking a model still works.
+    static func effectiveOcrModel(
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        settings: AgentSettings?
+    ) -> String? {
+        isDefault ? config.defaultOcrModelId : settings?.ocrModelId
     }
 
     /// The effective permission policy for a delegation capability. Default / main

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -208,7 +208,11 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             modelId: "scripted-browser-form",
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted)),
-            feed: ComputerUseFeed(toolCallId: "evidence-browser-form", goal: "Fill out the form"),
+            feed: SubagentFeed(
+                toolCallId: "evidence-browser-form",
+                kindId: "computer_use",
+                title: "Fill out the form"
+            ),
             interrupt: InterruptToken(),
             confirm: { preview in
                 await confirmationRecorder.record(preview)

--- a/Packages/OsaurusCore/Tests/Subagent/OcrToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/OcrToolTests.swift
@@ -1,0 +1,154 @@
+//
+//  OcrToolTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Model-free guardrail tests for the `ocr` sub-agent tool + its registry
+//  descriptor, mirroring `SpawnToolTests` / `SubagentCapabilityRegistryTests`.
+//  The full nested OCR run needs a live VLM (covered by the eval suite); these
+//  pin everything that must hold without one: the unified recursion guard,
+//  argument validation, the registry-timeout opt-out, the registry SSOT, the
+//  per-agent visibility/model resolvers, and the OCR config round-trips.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct OcrToolTests {
+
+    // MARK: - Tool entry contract
+
+    @Test func refusesRecursion() async throws {
+        // A running sub-agent of ANY kind blocks a nested `ocr` (the unified
+        // host guard, shared across the family).
+        let result = try await SubagentSession.$activeKindId.withValue("image") {
+            try await OcrTool().execute(argumentsJSON: #"{"images":["/tmp/a.png"]}"#)
+        }
+        #expect(ToolEnvelope.isError(result))
+        #expect(result.contains("cannot be called from inside"))
+    }
+
+    @Test func rejectsMissingImages() async throws {
+        let result = try await OcrTool().execute(argumentsJSON: #"{}"#)
+        #expect(ToolEnvelope.isError(result))
+        #expect(result.contains("images"))
+    }
+
+    @Test func rejectsMalformedArguments() async throws {
+        let result = try await OcrTool().execute(argumentsJSON: "not json")
+        #expect(ToolEnvelope.isError(result))
+    }
+
+    @Test func bypassesRegistryTimeout() {
+        #expect(OcrTool().bypassRegistryTimeout)
+    }
+
+    @Test func toolSchema() {
+        let tool = OcrTool()
+        #expect(tool.name == "ocr")
+        // `images` is the one required argument.
+        guard case .object(let root)? = tool.parameters,
+            case .array(let required)? = root["required"]
+        else {
+            Issue.record("ocr tool parameters missing required array")
+            return
+        }
+        #expect(required.contains(.string("images")))
+    }
+
+    // MARK: - Kind shape
+
+    @Test func kindShape() {
+        let kind = OcrSubagentKind(
+            params: OcrJobParams(imagePaths: ["/tmp/a.png"], model: nil, prompt: nil),
+            argumentsJSON: #"{"images":["/tmp/a.png"]}"#
+        )
+        #expect(kind.capability.id == "ocr")
+        #expect(kind.capability.toolNames == ["ocr"])
+        // OCR has its own configured model (like image), not the parent's.
+        #expect(kind.capability.modelSource == .dedicatedConfigured)
+        #expect(kind.feedTitle.contains("ocr"))
+    }
+
+    @Test func loadImagesRejectsTooMany() {
+        let many = (0..<(OcrSubagentKind.maxImages + 1)).map { "/tmp/\($0).png" }
+        #expect(throws: OcrInputError.self) {
+            _ = try OcrSubagentKind.loadImages(paths: many)
+        }
+    }
+
+    // MARK: - Registry SSOT
+
+    @Test func registryDescriptor() {
+        let ocr = SubagentCapabilityRegistry.ocr
+        #expect(ocr.id == "ocr")
+        #expect(ocr.toolNames == ["ocr"])
+        #expect(ocr.perAgentFlag == .ocr)
+        #expect(ocr.modelSource == .dedicatedConfigured)
+        #expect(ocr.displayLabel == "OCR")
+        #expect(!ocr.iconName.isEmpty)
+        #expect(ocr.guidance?.isEmpty == false)
+    }
+
+    @Test func registryLookupsResolveOcr() {
+        #expect(SubagentCapabilityRegistry.capability(forToolName: "ocr")?.id == "ocr")
+        #expect(SubagentCapabilityRegistry.capability(forKindId: "ocr")?.id == "ocr")
+        #expect(SubagentToolVisibility.delegationToolNames.contains("ocr"))
+        #expect(SubagentCapabilityRegistry.delegationFamily.contains { $0.id == "ocr" })
+    }
+
+    // MARK: - Per-agent visibility + model resolution
+
+    @Test func ocrAvailableDefaultVsCustom() {
+        let on = SubagentConfiguration(ocrDelegationEnabled: true)
+        let off = SubagentConfiguration(ocrDelegationEnabled: false)
+        // Default / main chat → its own OCR switch.
+        #expect(SubagentToolVisibility.ocrAvailable(isDefault: true, config: on, perAgentEnabled: false))
+        #expect(!SubagentToolVisibility.ocrAvailable(isDefault: true, config: off, perAgentEnabled: true))
+        // Custom agent → its own per-agent toggle (config switch is irrelevant).
+        #expect(SubagentToolVisibility.ocrAvailable(isDefault: false, config: off, perAgentEnabled: true))
+        #expect(!SubagentToolVisibility.ocrAvailable(isDefault: false, config: on, perAgentEnabled: false))
+    }
+
+    @Test func effectiveOcrModelDefaultVsCustom() {
+        let config = SubagentConfiguration(ocrDelegationEnabled: true, defaultOcrModelId: "global-ocr")
+        // Default / main chat → global configured default.
+        #expect(
+            SubagentToolVisibility.effectiveOcrModel(isDefault: true, config: config, settings: nil)
+                == "global-ocr"
+        )
+        // Custom agent → its own per-agent model.
+        var settings = AgentSettings.defaultDisabled
+        settings.ocrModelId = "agent-ocr"
+        #expect(
+            SubagentToolVisibility.effectiveOcrModel(isDefault: false, config: config, settings: settings)
+                == "agent-ocr"
+        )
+    }
+
+    // MARK: - Config round-trips
+
+    @Test func agentSettingsOcrRoundTrip() throws {
+        var settings = AgentSettings.defaultDisabled
+        settings.ocrEnabled = true
+        settings.ocrModelId = "deepseek-ocr"
+        let decoded = try JSONDecoder().decode(
+            AgentSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+        #expect(decoded.ocrEnabled)
+        #expect(decoded.ocrModelId == "deepseek-ocr")
+    }
+
+    @Test func subagentConfigurationOcrRoundTrip() throws {
+        let config = SubagentConfiguration(ocrDelegationEnabled: true, defaultOcrModelId: "unlimited-ocr")
+        let decoded = try JSONDecoder().decode(
+            SubagentConfiguration.self,
+            from: JSONEncoder().encode(config)
+        )
+        #expect(decoded.ocrDelegationEnabled)
+        #expect(decoded.defaultOcrModelId == "unlimited-ocr")
+        #expect(decoded.ocrDelegationActive)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentCapabilityRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentCapabilityRegistryTests.swift
@@ -159,7 +159,7 @@ struct SubagentCapabilityRegistryTests {
     @Test("the registry represents every shipped kind, including sandbox_reduce")
     func allRepresentsEveryKind() {
         let ids = Set(SubagentCapabilityRegistry.all.map(\.id))
-        #expect(ids == ["computer_use", "spawn", "image", "sandbox_reduce"])
+        #expect(ids == ["computer_use", "spawn", "image", "ocr", "sandbox_reduce"])
         // sandbox_reduce is display/guidance-only here — gated by sandbox
         // registration, not a per-agent or delegation toggle.
         #expect(SubagentCapabilityRegistry.sandboxReduce.perAgentFlag == nil)
@@ -197,7 +197,7 @@ struct SubagentCapabilityRegistryTests {
         // One card per *flag*: computer_use, spawn, and image are now each their
         // own per-agent toggle (image split out of the old shared spawn flag), so
         // the Sub-agents tab renders exactly three cards in registry order.
-        #expect(SubagentCapabilityRegistry.perAgentToggleFlags == [.computerUse, .spawn, .image])
+        #expect(SubagentCapabilityRegistry.perAgentToggleFlags == [.computerUse, .spawn, .image, .ocr])
     }
 
     /// Drift guard: the registry SSOT (consumed by both visibility surfaces)
@@ -211,10 +211,13 @@ struct SubagentCapabilityRegistryTests {
         #expect(SubagentToolVisibility.delegationToolNames == ToolRegistry.agentDelegationAllToolNames)
         #expect(ToolRegistry.agentDelegationSpawnToolNames == Set(SubagentCapabilityRegistry.spawn.toolNames))
         #expect(ToolRegistry.agentDelegationImageToolNames == Set(SubagentCapabilityRegistry.image.toolNames))
+        #expect(ToolRegistry.agentDelegationOcrToolNames == Set(SubagentCapabilityRegistry.ocr.toolNames))
         // The "all" set is exactly the union of the per-family sets.
         #expect(
             ToolRegistry.agentDelegationAllToolNames
-                == ToolRegistry.agentDelegationSpawnToolNames.union(ToolRegistry.agentDelegationImageToolNames)
+                == ToolRegistry.agentDelegationSpawnToolNames
+                .union(ToolRegistry.agentDelegationImageToolNames)
+                .union(ToolRegistry.agentDelegationOcrToolNames)
         )
     }
 

--- a/Packages/OsaurusCore/Tools/OcrTool.swift
+++ b/Packages/OsaurusCore/Tools/OcrTool.swift
@@ -1,0 +1,89 @@
+//
+//  OcrTool.swift
+//  osaurus
+//
+//  `ocr(images, model?, prompt?)` — extract text from one or more local images
+//  using a configured local OCR VLM (DeepSeek-OCR / Unlimited-OCR). Resolves the
+//  per-agent OCR model, runs a bounded multimodal completion on it (with the
+//  single-residency handoff when the OCR model displaces a resident chat model),
+//  and returns only the extracted text. Default OFF; each agent opts in from its
+//  Sub-agents tab. The shared host (`SubagentSession`) owns the recursion guard,
+//  live feed, permission verdict, residency handoff, and result normalization.
+//
+
+import Foundation
+
+public final class OcrTool: OsaurusTool, @unchecked Sendable {
+    public let name = "ocr"
+
+    public static let toolDescription =
+        "Extract text from one or more local images using your local OCR model. Pass one to four image "
+        + "file paths in `images`; the recognized text is returned as a structured result. Use when the "
+        + "user asks to read, transcribe, extract, or recognize text in images."
+
+    public var description: String { Self.toolDescription }
+
+    public let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "images": .object([
+                "type": .string("array"),
+                "items": .object(["type": .string("string")]),
+                "description": .string("One to four local image file paths to extract text from."),
+            ]),
+            "model": .object([
+                "type": .string("string"),
+                "description": .string("Optional OCR model id. Omit to use the configured default."),
+            ]),
+            "prompt": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Optional grounding/extraction instruction. Omit to use the default grounding prompt."
+                ),
+            ]),
+        ]),
+        "required": .array([.string("images")]),
+    ])
+
+    public var bypassRegistryTimeout: Bool { true }
+
+    public init() {}
+
+    public func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let imagesReq = requireStringArray(
+            args,
+            "images",
+            expected: "one to four image file paths",
+            tool: name
+        )
+        guard case .value(let rawPaths) = imagesReq else { return imagesReq.failureEnvelope ?? "" }
+        let imagePaths =
+            rawPaths
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let params = OcrJobParams(
+            imagePaths: imagePaths,
+            model: Self.optionalString(args["model"]),
+            prompt: Self.optionalString(args["prompt"])
+        )
+
+        // The shared host owns the recursion guard, live feed, permission
+        // verdict, residency handoff, compact-result normalization, and
+        // telemetry; the kind owns model resolution + the bounded OCR loop.
+        return await SubagentSession.run(
+            OcrSubagentKind(params: params, argumentsJSON: argumentsJSON),
+            tool: name
+        )
+    }
+
+    private static func optionalString(_ raw: Any?) -> String? {
+        guard let value = raw as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -207,6 +207,10 @@ final class ToolRegistry: ObservableObject {
             // defaults and low-RAM unload policy.
             SpawnTool(),
             ImageTool(),
+            // Native local OCR (one `ocr` tool; extracts text from images via a
+            // configured OCR VLM). Per-agent gated like image/spawn; the tool body
+            // resolves the OCR model + runs the single-residency handoff.
+            OcrTool(),
             // Agent DB feature (spec §6). The system prompt composer
             // gates these per-agent via `Agent.settings.dbEnabled`;
             // registering them as built-ins means agents that *do*
@@ -1439,7 +1443,11 @@ final class ToolRegistry: ObservableObject {
     static var agentDelegationImageToolNames: Set<String> {
         Set(SubagentCapabilityRegistry.image.toolNames)
     }
-    /// All agent-delegation tool names (spawn + image), derived from the
+    /// OCR-family tool names, derived from the capability registry.
+    static var agentDelegationOcrToolNames: Set<String> {
+        Set(SubagentCapabilityRegistry.ocr.toolNames)
+    }
+    /// All agent-delegation tool names (spawn + image + ocr), derived from the
     /// registry's delegation family. Used by the authoritative per-agent
     /// `spawnDelegationEnabled` gate in `SystemPromptComposer.resolveTools`.
     static var agentDelegationAllToolNames: Set<String> {

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -998,6 +998,7 @@ struct AgentDetailView: View {
     private var computerUseEnabled: Bool { subagentToggles[.computerUse] ?? false }
     private var spawnDelegationEnabled: Bool { subagentToggles[.spawn] ?? false }
     private var imageEnabled: Bool { subagentToggles[.image] ?? false }
+    private var ocrEnabled: Bool { subagentToggles[.ocr] ?? false }
     /// Per-agent `spawn` allow-list (which agents this agent may spawn).
     /// Mirrored from / into `AgentSettings.spawnableAgentNames`; empty hides the
     /// `spawn` tool. The Default agent uses the global pool instead.
@@ -1011,6 +1012,10 @@ struct AgentDetailView: View {
     /// agent uses `mainChatSubagentConfig` instead.
     @State private var imageGenerationModelId: String? = nil
     @State private var imageEditModelId: String? = nil
+    /// Per-agent OCR model bundle id. `nil` resolves to the first ready OCR model
+    /// at run time. Mirrored from / into `AgentSettings.ocrModelId`. The Default
+    /// agent uses `mainChatSubagentConfig.defaultOcrModelId` instead.
+    @State private var ocrModelId: String? = nil
     /// Per-agent delegation permissions (spawn / image) + spawn budgets. Mirrored
     /// from / into `AgentSettings`. The Default agent uses `mainChatSubagentConfig`.
     @State private var subagentPermissions: SubagentPermissionDefaults = SubagentPermissionDefaults()
@@ -3131,6 +3136,13 @@ struct AgentDetailView: View {
                     subtitle:
                         "Let the agent generate and edit images with a local model using the `image` tool."
                 )
+            case .ocr:
+                return PerAgentFeature(
+                    flag: .ocr,
+                    title: "OCR",
+                    subtitle:
+                        "Let the agent extract text from images with a local OCR model using the `ocr` tool."
+                )
             }
         }
     }
@@ -3313,6 +3325,14 @@ struct AgentDetailView: View {
                     saveMainChatSubagentConfig()
                 }
             )
+        case .ocr:
+            return Binding(
+                get: { mainChatSubagentConfig.ocrDelegationEnabled },
+                set: {
+                    mainChatSubagentConfig.ocrDelegationEnabled = $0
+                    saveMainChatSubagentConfig()
+                }
+            )
         case .spawn:
             return Binding(
                 get: { mainChatSpawnEnabled },
@@ -3364,6 +3384,30 @@ struct AgentDetailView: View {
             )
             subagentFootnote(
                 "Image load policy is a system setting in Settings → Sub-agents."
+            )
+        case .ocr:
+            ocrModelPickerRow
+            subagentPanelDivider
+            subagentPermissionRow(
+                for: SubagentCapabilityRegistry.ocr.id,
+                label: "Permission"
+            )
+            subagentFootnote(
+                "OCR runs a local image-capable model and may briefly unload the chat model."
+            )
+        }
+    }
+
+    /// OCR model picker for the OCR card. `nil` (Choose automatically) resolves
+    /// to the first ready OCR model at run time.
+    private var ocrModelPickerRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            AgentSheetSectionLabel("Model")
+            subagentModelPicker(
+                title: "OCR model",
+                selection: ocrModelSelection,
+                candidates: pickerItems.ocrDelegateCandidates,
+                currentId: currentOcrModelId
             )
         }
     }
@@ -3521,6 +3565,29 @@ struct AgentDetailView: View {
 
     private var currentImageEditModelId: String? {
         isDefaultAgent ? mainChatSubagentConfig.defaultImageEditModelId : imageEditModelId
+    }
+
+    private var ocrModelSelection: Binding<String> {
+        if isDefaultAgent {
+            return Binding(
+                get: { mainChatSubagentConfig.defaultOcrModelId ?? "" },
+                set: {
+                    mainChatSubagentConfig.defaultOcrModelId = normalizedModelSelection($0)
+                    saveMainChatSubagentConfig()
+                }
+            )
+        }
+        return Binding(
+            get: { ocrModelId ?? "" },
+            set: {
+                ocrModelId = normalizedModelSelection($0)
+                debouncedSave()
+            }
+        )
+    }
+
+    private var currentOcrModelId: String? {
+        isDefaultAgent ? mainChatSubagentConfig.defaultOcrModelId : ocrModelId
     }
 
     private func subagentPermissionBinding(for kindId: String) -> Binding<SubagentPermissionPolicy> {
@@ -5507,6 +5574,7 @@ struct AgentDetailView: View {
         spawnableAgentNames = agent.settings.spawnableAgentNames
         imageGenerationModelId = agent.settings.imageGenerationModelId
         imageEditModelId = agent.settings.imageEditModelId
+        ocrModelId = agent.settings.ocrModelId
         subagentPermissions = agent.settings.subagentPermissions
         subagentBudgets = agent.settings.subagentBudgets
         // The main chat (Default agent) binds its Sub-agents tab to the global
@@ -5734,6 +5802,8 @@ struct AgentDetailView: View {
                 // allow-list, which gates tool visibility).
                 imageGenerationModelId: imageGenerationModelId,
                 imageEditModelId: imageEditModelId,
+                ocrEnabled: ocrEnabled,
+                ocrModelId: ocrModelId,
                 subagentPermissions: subagentPermissions,
                 subagentBudgets: subagentBudgets
             ),


### PR DESCRIPTION
## Summary

Wires **OCR** into the unified Subagent framework (#1731) as a first-class capability, so it works the same way as image / spawn / text / computer-use: a per-agent toggle in the **Sub-agents** tab with its own model, permission, budget, system-prompt guidance, and single-residency model handoff.

Extends the framework following the new convention — no behavior change to existing kinds.

### What's added
- **`OcrSubagentKind`** (`Subagent/Kinds/OcrSubagentKind.swift`): `modelSource = .dedicatedConfigured`. Resolves the per-agent configured OCR VLM, runs a bounded multimodal completion (image + grounding prompt) on it via `AgentSubagentRunner`, and returns the extracted text. Uses `ResidencyHandoff` to unload the resident chat model when the local OCR model differs (single GPU residency); reject-before-evict gates resolved up front.
- **`OcrTool`** (`Tools/OcrTool.swift`): `ocr(images, model?, prompt?)` thin entry → `SubagentSession.run`.
- **Registry SSOT**: `ocr` descriptor + `PerAgentFlag.ocr` + `ocrAvailable` / `effectiveOcrModel`; included in `all` / `delegationFamily` / `visibleDelegationToolNames`; `ToolRegistry.agentDelegationOcrToolNames`.
- **Per-agent config cascade**: `AgentSettings.ocrEnabled`/`ocrModelId` → `AgentCapabilities` → `effectiveCapabilities` → `AgentConfigSnapshot.ocrEnabled`; default/main-chat `SubagentConfiguration.ocrDelegationEnabled`/`defaultOcrModelId`.
- **Surfacing**: `ToolRegistry` registration, `SystemPromptTemplates.ocrGuidance`, Sub-agents tab **OCR card + VLM-filtered model picker** (`ocrDelegateCandidates`).
- **Tests**: `OcrToolTests` (recursion guard, arg validation, registry SSOT, visibility/model resolvers, config round-trips) + updated registry assertions. **34/34 green** locally (OcrToolTests + SubagentCapabilityRegistryTests + ComputerUseEvidencePackTests).

No vmlx-swift repin: the DeepSeek-OCR / Unlimited-OCR engine is already in the pinned `9e0b60f`.

### Incidental main fix (separate commit)
`#1731` renamed `ComputerUseFeed → SubagentFeed` but left `ComputerUseEvidencePackTests` on the old type, so the `OsaurusCoreTests` target didn't compile on `main` (red CI for everyone). Second commit updates that one construction site to the new `SubagentFeed(toolCallId:kindId:title:)` API. Happy to split this into its own PR if preferred.

### Status
Draft — not for merge yet (release pending).

### Test plan
- [x] `swift build` (OsaurusCore) green
- [x] `OcrToolTests` + `SubagentCapabilityRegistryTests` + `ComputerUseEvidencePackTests` green (34/34)
- [ ] Manual: enable OCR on a custom agent's Sub-agents tab, pick a local OCR VLM, run `ocr` on an image