### PR TITLE
Fix Computer Use evidence feed migration

### DIFF
--- a/Packages/OsaurusCore/Services/Context/SubagentJobEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/SubagentJobEvaluator.swift
@@ -524,13 +524,13 @@ public enum SubagentJobEvaluator {
         )
         let started = Date()
         let envelope = await withEvalScope(toolCallId: toolCallId) {
-            await SubagentSession.run(kind, tool: "computer_use")
+            await SubagentSession.run(kind, tool: SubagentCapabilityRegistry.computerUse.primaryToolName)
         }
         let latency = Date().timeIntervalSince(started) * 1000
         return transcript(
             fromEnvelope: envelope,
-            tool: "computer_use",
-            kindId: "computer_use",
+            tool: SubagentCapabilityRegistry.computerUse.primaryToolName,
+            kindId: SubagentCapabilityRegistry.computerUse.id,
             toolCallId: toolCallId,
             latencyMs: latency
         )

--- a/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
@@ -259,7 +259,7 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
         case .done(let summary):
             return SubagentResult(
                 payload: [
-                    "kind": "computer_use",
+                    "kind": SubagentCapabilityRegistry.computerUse.id,
                     "model": model,
                     "summary": summary,
                     "steps": result.metrics.steps,

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -124,7 +124,7 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             modelId: "scripted",
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous)),
-            feed: SubagentFeed(toolCallId: "evidence-ax", kindId: "computer_use", title: "read the title field"),
+            feed: SubagentFeed(toolCallId: "evidence-ax", kindId: SubagentCapabilityRegistry.computerUse.id, title: "read the title field"),
             interrupt: InterruptToken(),
             confirm: { _ in true },
             limits: RunLimits(maxSteps: 2, wallClockSeconds: 30),

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -210,7 +210,7 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted)),
             feed: SubagentFeed(
                 toolCallId: "evidence-browser-form",
-                kindId: "computer_use",
+                kindId: SubagentCapabilityRegistry.computerUse.id,
                 title: "Fill out the form"
             ),
             interrupt: InterruptToken(),

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopActTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopActTests.swift
@@ -50,7 +50,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
 
         let out = await ComputerUseLoop.act(
             action: clickAction(),
@@ -95,7 +95,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
 
         _ = await ComputerUseLoop.act(
             action: clickAction(),
@@ -133,7 +133,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
 
         let out = await ComputerUseLoop.act(
             action: AgentAction(verb: .setValue, target: AgentTarget(mark: 13), text: "Jared"),
@@ -180,7 +180,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
 
         _ = await ComputerUseLoop.act(
             action: AgentAction(verb: .clear, target: AgentTarget(mark: 13)),
@@ -221,7 +221,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
 
         _ = await ComputerUseLoop.act(
             action: AgentAction(verb: .type, target: AgentTarget(mark: 13), text: "hi", replace: false),
@@ -262,7 +262,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
         let out = await ComputerUseLoop.act(
             action: action,
             element: makeElement(),
@@ -338,7 +338,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
         _ = await ComputerUseLoop.act(
             action: AgentAction(verb: .doubleClick, target: AgentTarget(mark: 13)),
             element: makeElement(),
@@ -377,7 +377,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "g")
 
         _ = await ComputerUseLoop.act(
             action: clickAction(),

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -61,7 +61,7 @@ final class ComputerUseLoopRunTests: XCTestCase {
             modelId: "test-model",
             driver: driver,
             gate: gate,
-            feed: SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "test goal"),
+            feed: SubagentFeed(toolCallId: "t", kindId: SubagentCapabilityRegistry.computerUse.id, title: "test goal"),
             interrupt: interrupt,
             confirm: confirm,
             limits: limits,

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentCapabilityRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentCapabilityRegistryTests.swift
@@ -262,6 +262,10 @@ struct SubagentCapabilityRegistryTests {
     @Test("capability descriptors expose the right primary tool + guidance shape")
     func capabilityShape() {
         #expect(SubagentCapabilityRegistry.computerUse.primaryToolName == "computer_use")
+        #expect(
+            SubagentCapabilityRegistry.displayLabel(forKindId: SubagentCapabilityRegistry.computerUse.id)
+                == "Computer Use"
+        )
         #expect(SubagentCapabilityRegistry.computerUse.guidance != nil)
         // Image generation + editing now share the single `image` tool.
         #expect(SubagentCapabilityRegistry.image.primaryToolName == "image")

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerComputerUseLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerComputerUseLoop.swift
@@ -44,7 +44,7 @@ extension EvalRunner {
         let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: preset))
         let feed = SubagentFeed(
             toolCallId: "eval-\(testCase.id)",
-            kindId: "computer_use",
+            kindId: SubagentCapabilityRegistry.computerUse.id,
             title: testCase.query
         )
         let interrupt = InterruptToken()

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ComputerUseLoopEvalTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ComputerUseLoopEvalTests.swift
@@ -40,7 +40,11 @@ struct ComputerUseLoopEvalTests {
             modelId: "scripted",
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous)),
-            feed: SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "deterministic eval"),
+            feed: SubagentFeed(
+                toolCallId: "t",
+                kindId: SubagentCapabilityRegistry.computerUse.id,
+                title: "deterministic eval"
+            ),
             interrupt: InterruptToken(),
             confirm: { _ in true },
             limits: RunLimits(maxSteps: maxSteps, wallClockSeconds: 30),

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SubagentEvalTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SubagentEvalTests.swift
@@ -230,13 +230,13 @@ struct SubagentEvalTests {
             ],
             maxSteps: 6
         )
-        #expect(transcript.tool == "computer_use")
+        #expect(transcript.tool == SubagentCapabilityRegistry.computerUse.primaryToolName)
         #expect(
             transcript.succeeded,
             "expected success; got \(transcript.envelopeKind) err=\(transcript.error ?? "-")"
         )
         #expect(transcript.envelopeKind == "success")
-        #expect(transcript.resultKind == "computer_use")
+        #expect(transcript.resultKind == SubagentCapabilityRegistry.computerUse.id)
         let values = await driver.finalValues()
         #expect(values["nightshift"] == "on")
         #expect(await driver.wasClicked("nightshift"))


### PR DESCRIPTION
## Summary
- align Computer Use evidence-feed fixtures and eval transcript construction with the subagent capability registry
- keep the Computer Use feed `kindId`, primary tool name, result payload kind, and display label anchored to the shared registry contract
- preserve existing tool-call IDs, goals, scripted runs, and eval scoring behavior

## Why
Computer Use feed and eval evidence should not depend on repeated string literals for the same capability. This keeps the evidence-pack tests, eval runner, and subagent transcript path aligned with the shared capability registry as the Computer Use stack evolves.

## Validation
- `git diff --check`
- `swiftlint lint <touched Swift files> --quiet` — exit 0; existing warnings remain in `SubagentJobEvaluator.swift`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-pr1733-core swift test --package-path Packages/OsaurusCore --filter 'ComputerUseEvidencePackTests|ComputerUseLoopActTests|ComputerUseLoopRunTests|SubagentCapabilityRegistryTests'` — 56 tests passed
- `swift test --package-path Packages/OsaurusEvals --filter 'ComputerUseLoopEvalTests|SubagentEvalTests'` — 27 tests passed
- GitHub CI is green
