### PR TITLE
Fix concurrent-GPU crash on sub-agent residency handoff (unload: drain before free)

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -559,6 +559,17 @@ public actor ModelRuntime {
 
         modelCache[name]?.container.disableCaching()
 
+        // Drain the GPU BEFORE releasing the weight arrays. The lease/idle
+        // drains above stop new work and wait for request leases, but a chat
+        // turn's last compute command buffer (e.g. `Gemma4.prepare`) can still
+        // be queued on the shared Metal stream. Freeing the weights first and
+        // synchronizing only afterwards (below) lets that queued buffer execute
+        // against already-freed weights — observed SIGSEGV in
+        // `Gemma4.prepare → metal::Device::end_encoding` when the OCR/spawn
+        // residency handoff loads the sub-agent model on top of it. Draining
+        // here forces the buffer to complete while its weights are still valid.
+        Stream.gpu.synchronize()
+
         autoreleasepool {
             _ = modelCache.removeValue(forKey: name)
         }


### PR DESCRIPTION
## Fix: concurrent-GPU crash on the sub-agent residency handoff

`7f04086c` — one-line drain in `ModelRuntime.unload`, plus the why and the live proof.

### Symptom
Rare, non-deterministic crash when a chat driver model hands off to a sub-agent executor (OCR / spawn / image residency swap). Two manifestations, same family:
- `SIGSEGV / EXC_BAD_ACCESS` → `Gemma4.prepare → mlx::core::metal::Device::end_encoding`
- `SIGABRT / MTLReportFailure` (CommandEncoder-race assertion)

### Root cause (osaurus-side)
`ModelRuntime.unload(name:)` freed the chat model's weight arrays (`modelCache.removeValue`) and only `Stream.gpu.synchronize()`d **after** the free. The lease/idle drains above stop new work and wait for request *leases*, but a chat turn's last **compute** command buffer (`Gemma4.prepare`) can still be queued on the shared Metal stream. Freeing first and synchronizing afterwards forces that queued buffer to execute against **already-freed weights**; the OCR/spawn handoff then loads the sub-agent model on the same stream, widening the window.

### Fix
One `Stream.gpu.synchronize()` **before** the free, so the queued buffer completes while its weights are still valid. No widened `MetalGate` / no new lock — that is what deadlocked the prior comprehensive attempt; this is the *same* synchronize already used post-free, on the unloading thread that owns the buffers.

### Not an engine change
The BatchEngine `finishSlot` GPU drain (`vmlx-swift 107c467b`) is **already on `vmlx-origin/main` `9e0b60f`** (the SHA this PR pins) — verified via `git show`. The earlier "missing finishSlot drain" reading came from analyzing the *stale local* `main` (`21ab8b76`, an ancestor of `9e0b60f`); landing it would be a no-op. This residual is purely the osaurus unload free-then-drain ordering (#91/#92/#93), pre-existing and independent of the OCR work.

### Proof (live, identical concurrent stress)
Aggressive concurrent OCR-handoff stress (parallel `/health` + chat contention during forced gemma-4-e2b → zaya1-vl-8b OCR handoffs):

| Build | Result |
|---|---|
| Unfixed (`9e0b60f`) | **CRASHED at iter 1–2** — 2 crash reports (SIGSEGV `Gemma4.prepare` + SIGABRT `MTLReportFailure`) |
| Fixed | **12/12 alive, 0 crashes**, no new crash report, app responsive (no deadlock) |

Sequential (non-concurrent) stress was 20/20 clean on both — the race only opens under concurrent runtime contention, which is why it was a rare field crash.