### PR TITLE
Add a standard per-agent model picker for chat-driven sub-agents

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -772,6 +772,14 @@ public struct AgentSettings: Codable, Sendable, Equatable {
     /// Per-agent budgets for `spawn` jobs (token / turn / wall-clock caps). The
     /// Default agent uses the global `SubagentConfiguration.budgets` instead.
     public var subagentBudgets: SubagentBudgets
+    /// Per-agent model override for subagent kinds, keyed by capability id
+    /// (`"computer_use"`, `"sandbox_reduce"`, `"spawn"`). An entry supersedes the
+    /// kind's default model source (the parent agent's model for computer_use /
+    /// sandbox_reduce; the chosen persona's model for spawn); an absent entry
+    /// means "inherit". Stored as a generic `[capabilityId: modelId]` map — like
+    /// `subagentPermissions` — so a new kind needs no new field. The Default
+    /// agent uses the global `SubagentConfiguration.subagentModelOverrides`.
+    public var subagentModelOverrides: [String: String]
 
     public init(
         dbEnabled: Bool,
@@ -791,7 +799,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         imageGenerationModelId: String? = nil,
         imageEditModelId: String? = nil,
         subagentPermissions: SubagentPermissionDefaults = SubagentPermissionDefaults(),
-        subagentBudgets: SubagentBudgets = SubagentBudgets()
+        subagentBudgets: SubagentBudgets = SubagentBudgets(),
+        subagentModelOverrides: [String: String] = [:]
     ) {
         self.dbEnabled = dbEnabled
         self.schedule = schedule
@@ -811,6 +820,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         self.imageEditModelId = imageEditModelId
         self.subagentPermissions = subagentPermissions
         self.subagentBudgets = subagentBudgets
+        self.subagentModelOverrides = subagentModelOverrides
     }
 
     public init(from decoder: Decoder) throws {
@@ -872,6 +882,27 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         subagentBudgets =
             (try? c.decodeIfPresent(SubagentBudgets.self, forKey: .subagentBudgets))
             ?? SubagentBudgets()
+        // Normalize on decode (trim values, drop blanks) so the per-agent stored
+        // shape matches the global `SubagentConfiguration.subagentModelOverrides`
+        // — a cleared picker round-trips as "no override", never an empty-string
+        // model id. The lenient `try?` keeps a malformed map from discarding the
+        // rest of the settings.
+        subagentModelOverrides = Self.normalizedModelOverrides(
+            (try? c.decodeIfPresent([String: String].self, forKey: .subagentModelOverrides)) ?? [:]
+        )
+    }
+
+    /// Trim values and drop blank entries so a cleared override (empty string)
+    /// round-trips as "no override" instead of an empty-string model id. Mirrors
+    /// `SubagentConfiguration.normalizedModelOverrides` so the per-agent and
+    /// global stored shapes agree.
+    private static func normalizedModelOverrides(_ value: [String: String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for (key, raw) in value {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { result[key] = trimmed }
+        }
+        return result
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -893,6 +924,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         case imageEditModelId
         case subagentPermissions
         case subagentBudgets
+        case subagentModelOverrides
         // Read-only legacy key — never encoded after migration.
         case generativeGreetings
     }
@@ -917,6 +949,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         try c.encodeIfPresent(imageEditModelId, forKey: .imageEditModelId)
         try c.encode(subagentPermissions, forKey: .subagentPermissions)
         try c.encode(subagentBudgets, forKey: .subagentBudgets)
+        try c.encode(subagentModelOverrides, forKey: .subagentModelOverrides)
     }
 
     /// Default settings for newly created agents (and for back-compat decoding of

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
@@ -183,6 +183,11 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     /// is freed, the job is rejected instead of unloading the orchestrator and
     /// failing to load the spawn model. See `ChatResidencyHandoff.memoryPreflight`.
     var ramSafetyPreflightEnabled: Bool
+    /// Per-capability model override for the DEFAULT / main-chat agent's subagent
+    /// kinds, keyed by capability id (`"spawn"`, `"sandbox_reduce"`). An entry
+    /// supersedes the kind's default model source; absent means "inherit". Custom
+    /// agents carry their own `AgentSettings.subagentModelOverrides`.
+    var subagentModelOverrides: [String: String]
 
     init(
         localTextDelegationEnabled: Bool = true,
@@ -193,7 +198,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         imageJobLoadPolicy: SubagentImageLoadPolicy = .agentSingleResidency,
         permissionDefaults: SubagentPermissionDefaults = SubagentPermissionDefaults(),
         budgets: SubagentBudgets = SubagentBudgets(),
-        ramSafetyPreflightEnabled: Bool = true
+        ramSafetyPreflightEnabled: Bool = true,
+        subagentModelOverrides: [String: String] = [:]
     ) {
         self.localTextDelegationEnabled = localTextDelegationEnabled
         self.spawnableAgentNames = spawnableAgentNames
@@ -204,6 +210,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         self.permissionDefaults = permissionDefaults
         self.budgets = budgets.normalized
         self.ramSafetyPreflightEnabled = ramSafetyPreflightEnabled
+        self.subagentModelOverrides = Self.normalizedModelOverrides(subagentModelOverrides)
     }
 
     static let `default` = SubagentConfiguration()
@@ -252,7 +259,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             // Preserve the user's RAM-safety choice across the save/load round-trip.
             // Omitting this dropped it back to the init default (`true`), making the
             // toggle un-disableable (the store runs `.normalized` on every save+load).
-            ramSafetyPreflightEnabled: ramSafetyPreflightEnabled
+            ramSafetyPreflightEnabled: ramSafetyPreflightEnabled,
+            subagentModelOverrides: subagentModelOverrides
         )
     }
 
@@ -266,6 +274,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         case permissionDefaults
         case budgets
         case ramSafetyPreflightEnabled
+        case subagentModelOverrides
     }
 
     init(from decoder: Decoder) throws {
@@ -298,7 +307,13 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             ramSafetyPreflightEnabled: try container.decodeIfPresent(
                 Bool.self,
                 forKey: .ramSafetyPreflightEnabled
-            ) ?? true
+            ) ?? true,
+            // Lenient: a malformed map must never discard the whole delegation
+            // config (same approach as `permissionDefaults`).
+            subagentModelOverrides: (try? container.decodeIfPresent(
+                [String: String].self,
+                forKey: .subagentModelOverrides
+            )) ?? [:]
         )
     }
 
@@ -306,5 +321,16 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Trim values and drop blank entries so a cleared picker (empty string)
+    /// round-trips as "no override" instead of an empty-string model id.
+    private static func normalizedModelOverrides(_ value: [String: String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for (key, raw) in value {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { result[key] = trimmed }
+        }
+        return result
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -575,6 +575,23 @@ extension Array where Element == ModelPickerItem {
         filter(\.isImageEditDelegateCandidate)
     }
 
+    /// Chat-capable candidates for the per-agent subagent model picker
+    /// (`computer_use` / `sandbox_reduce` / `spawn` override). Filters via
+    /// `isLikelyChatCapable` so embedding / image-only items are excluded.
+    var chatModelCandidates: [ModelPickerItem] {
+        filter(\.isLikelyChatCapable)
+    }
+
+    /// The chat candidate matching a stored subagent override id, or `nil` when
+    /// the id is unset/blank or no longer present (drives the picker's stale
+    /// "(unavailable)" tag).
+    func subagentChatModelCandidate(id: String?) -> ModelPickerItem? {
+        guard let id else { return nil }
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return chatModelCandidates.first { $0.id == trimmed }
+    }
+
     func subagentModelCandidate(
         id: String?,
         kind: SubagentModelKind

--- a/Packages/OsaurusCore/Services/Context/SubagentJobEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/SubagentJobEvaluator.swift
@@ -427,40 +427,39 @@ public enum SubagentJobEvaluator {
         name: String,
         _ body: @Sendable () async -> T
     ) async -> T {
-        let state:
-            (createdAgentId: UUID?, priorConfig: SubagentConfiguration, configChanged: Bool) =
-                await MainActor.run {
-                    let priorConfig = SubagentConfigurationStore.snapshot()
-                    var createdAgentId: UUID? = nil
-                    let exists = AgentManager.shared.agents.contains {
-                        $0.name.caseInsensitiveCompare(name) == .orderedSame
-                    }
-                    if !exists {
-                        let agent = Agent(
-                            id: UUID(),
-                            name: name,
-                            description: "Seeded by OsaurusEvals for the spawn lane; safe to delete.",
-                            systemPrompt:
-                                "You are a concise sub-agent. Answer the task directly and follow any "
-                                + "formatting instructions exactly. Do not add preamble or commentary."
-                        )
-                        AgentStore.save(agent)
-                        createdAgentId = agent.id
-                    }
-                    var updated = priorConfig
-                    if !priorConfig.isAgentSpawnable(name) {
-                        updated.spawnableAgentNames = priorConfig.spawnableAgentNames + [name]
-                    }
-                    // Enable the local handoff switch so a LOCAL run model can
-                    // spawn the local persona (the chat model unloads to make
-                    // room). Default is on; this only flips a host that disabled
-                    // it, and is restored afterward.
-                    updated.localTextDelegationEnabled = true
-                    let configChanged = updated != priorConfig
-                    if configChanged { SubagentConfigurationStore.save(updated) }
-                    if createdAgentId != nil { AgentManager.shared.refresh() }
-                    return (createdAgentId, priorConfig, configChanged)
+        let state: (createdAgentId: UUID?, priorConfig: SubagentConfiguration, configChanged: Bool) =
+            await MainActor.run {
+                let priorConfig = SubagentConfigurationStore.snapshot()
+                var createdAgentId: UUID? = nil
+                let exists = AgentManager.shared.agents.contains {
+                    $0.name.caseInsensitiveCompare(name) == .orderedSame
                 }
+                if !exists {
+                    let agent = Agent(
+                        id: UUID(),
+                        name: name,
+                        description: "Seeded by OsaurusEvals for the spawn lane; safe to delete.",
+                        systemPrompt:
+                            "You are a concise sub-agent. Answer the task directly and follow any "
+                            + "formatting instructions exactly. Do not add preamble or commentary."
+                    )
+                    AgentStore.save(agent)
+                    createdAgentId = agent.id
+                }
+                var updated = priorConfig
+                if !priorConfig.isAgentSpawnable(name) {
+                    updated.spawnableAgentNames = priorConfig.spawnableAgentNames + [name]
+                }
+                // Enable the local handoff switch so a LOCAL run model can
+                // spawn the local persona (the chat model unloads to make
+                // room). Default is on; this only flips a host that disabled
+                // it, and is restored afterward.
+                updated.localTextDelegationEnabled = true
+                let configChanged = updated != priorConfig
+                if configChanged { SubagentConfigurationStore.save(updated) }
+                if createdAgentId != nil { AgentManager.shared.refresh() }
+                return (createdAgentId, priorConfig, configChanged)
+            }
         let result = await body()
         await MainActor.run {
             if let id = state.createdAgentId {

--- a/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
@@ -12,8 +12,15 @@
 //    - The per-action `ComputerUseGate` + the `ComputerUsePromptQueue` confirm
 //      / cloud-vision consent overlay. The host permission is `.allow` — the
 //      real consent surface is the gate inside `run`, exactly as before.
-//    - `modelSource = .inheritsParent`: the loop drives the SAME model as the
-//      parent chat (no residency eviction; `makeHandoff()` stays passthrough).
+//
+//  `modelSource = .inheritsParent` is the DEFAULT source: the loop drives the
+//  parent chat model unless the agent set a per-agent `computer_use` model
+//  override (the standard model-pick axis). When the resolved model is a
+//  DIFFERENT local bundle than the resident chat model, `makeHandoff()` vends a
+//  `ResidencyHandoff` via the shared `SubagentResidency` layer (unload the chat
+//  model for the run, reload after); otherwise it stays passthrough. The vision
+//  posture is computed from the RESOLVED model so screenshot escalation tracks
+//  the chosen model.
 //
 
 import Foundation
@@ -77,6 +84,15 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
         let policySummary: String
     }
     private var config: RunConfig?
+    /// Residency plan resolved in `resolveModel` (reject-before-evict), run by
+    /// `makeHandoff()`. `.none` when no swap is needed (parent model, a remote
+    /// override, or the same local model already resident).
+    private var residencyPlan: ResidencyPlan = .none
+
+    /// Idle-wait budget (seconds) for the residency unload to wait for chat to
+    /// go idle before giving up. The loop itself is step-capped (`RunLimits`),
+    /// so this bounds only the pre-unload wait, not the run.
+    private static let residencyIdleWaitSeconds = 120
 
     init(goal: String, limits: RunLimits, evalHarness: ComputerUseEvalHarness? = nil) {
         self.goal = goal
@@ -94,32 +110,42 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
             return ResolvedModel(name: evalHarness.modelId, id: nil, isLocal: false)
         }
         let agentId = scope.agentId
-        // Resolve everything that lives on the main actor in one hop: the model,
-        // the agent's autonomy ceiling, a snapshot of the user policy, and the
-        // vision context (image support + local-vs-cloud posture + cloud-vision
-        // consent).
+        // One shared path for precedence (per-agent `computer_use` override →
+        // the parent agent's model), the availability fallback, and the live
+        // residency decision (reject-before-evict; a remote override / the
+        // inherited model needs no swap). The chat model is already idle here —
+        // the parent turn is awaiting this tool result. `evalModel` is nil: the
+        // eval harness is handled by the early-return above (it carries a
+        // driver/gate/vision, not just a model).
+        let resolved = try await SubagentModelResolution.resolve(
+            capabilityId: capability.id,
+            agentId: agentId,
+            evalModel: nil,
+            idleWaitSeconds: Self.residencyIdleWaitSeconds,
+            deniedMessage:
+                "Running Computer Use on a different local model requires \"Local Orchestrator "
+                + "Handoff\" enabled in Settings → Sub-agents (so the chat model can unload to "
+                + "make room).",
+            unavailableMessage:
+                "No model is selected for this agent, so Computer Use can't run. Pick a model first.",
+            defaultModel: { AgentManager.shared.effectiveModel(for: agentId) }
+        )
+        let modelId = resolved.model
+        // Snapshot the run rules from the RESOLVED model in a second main-actor
+        // hop: the agent's autonomy ceiling, a snapshot of the user policy, and
+        // the vision context (image support + local-vs-cloud posture +
+        // cloud-vision consent) so screenshot escalation tracks the chosen model.
         let snapshot = await MainActor.run {
-            () -> (model: String?, ceiling: AutonomyCeiling?, policy: AutonomyPolicy, vision: VisionContext) in
-            let model = AgentManager.shared.effectiveModel(for: agentId)
+            () -> (ceiling: AutonomyCeiling?, policy: AutonomyPolicy, vision: VisionContext) in
             let ceiling = AgentManager.shared.agent(for: agentId)?.settings.computerUseCeiling
             let policy = ComputerUsePolicyStore.load()
-            let vision: VisionContext
-            if let model, !model.isEmpty {
-                vision = VisionContext(
-                    modelAcceptsImages: ComputerUseTool.modelAcceptsImages(model),
-                    modelIsLocal: ModelManager.findInstalledModel(named: model) != nil,
-                    cloudConsent: CloudVisionConsent.shared.isGranted,
-                    cloudScrubMode: CloudVisionConsent.shared.scrubMode
-                )
-            } else {
-                vision = .none
-            }
-            return (model, ceiling, policy, vision)
-        }
-        guard let modelId = snapshot.model, !modelId.isEmpty else {
-            throw SubagentError.unavailable(
-                "No model is selected for this agent, so Computer Use can't run. Pick a model first."
+            let vision = VisionContext(
+                modelAcceptsImages: ComputerUseTool.modelAcceptsImages(modelId),
+                modelIsLocal: ModelManager.findInstalledModel(named: modelId) != nil,
+                cloudConsent: CloudVisionConsent.shared.isGranted,
+                cloudScrubMode: CloudVisionConsent.shared.scrubMode
             )
+            return (ceiling, policy, vision)
         }
         self.config = RunConfig(
             ceiling: snapshot.ceiling,
@@ -130,9 +156,12 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
                 ceiling: snapshot.ceiling
             )
         )
-        // Same-model kind: residency is irrelevant (no handoff), so `isLocal`
-        // is not consulted.
-        return ResolvedModel(name: modelId, id: nil, isLocal: false)
+        self.residencyPlan = resolved.decision.plan
+        return ResolvedModel(name: modelId, id: nil, isLocal: resolved.decision.isLocal)
+    }
+
+    func makeHandoff() -> SubagentHandoff {
+        SubagentResidency.handoff(for: residencyPlan)
     }
 
     /// `.allow` at the host level: the consent surface is the per-action gate

--- a/Packages/OsaurusCore/Subagent/Kinds/ImageSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ImageSubagentKind.swift
@@ -18,6 +18,17 @@
 //  coordinator stays the residency authority for images and the host only owns
 //  the guard, feed, result, and telemetry.
 //
+//  Model divergence (deliberate): `image` is the ONE kind that does NOT use the
+//  standard per-agent model picker. Its capability sets
+//  `supportsModelOverride = false`, so it is NOT a `SubagentModelResolution`
+//  client and AgentsView does not render the shared override row for it. Instead
+//  it owns a dedicated model system — separate gen vs edit ids
+//  (`imageGenerationModelId` / `imageEditModelId`), resolved via
+//  `SubagentToolVisibility.effectiveImageModel`, with their own readiness +
+//  "first ready" fallback and the coordinator-owned residency above. The
+//  chat-driven kinds (computer_use, spawn, sandbox_reduce) instead share
+//  `subagentModelOverrides` → `effectiveSubagentModel` → `SubagentModelResolution`.
+//
 
 import Combine
 import Foundation

--- a/Packages/OsaurusCore/Subagent/Kinds/SandboxReduceKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/SandboxReduceKind.swift
@@ -7,8 +7,12 @@
 //  hands back ONLY a short digest (raw tool output never crosses into the
 //  parent context). Runs on the SAME shared runner (`AgentSubagentRunner`) and
 //  host (`SubagentSession`) as `spawn`, so the recursion guard, live feed, and
-//  compact-result contract are shared. `modelSource = .inheritsParent` (same
-//  model as the parent) so no residency eviction (`makeHandoff()` passthrough).
+//  compact-result contract are shared. `modelSource = .inheritsParent` is the
+//  DEFAULT source (the parent agent's model); a per-agent `sandbox_reduce` model
+//  override (the standard model-pick axis) supersedes it. When the resolved
+//  model is a DIFFERENT local bundle than the resident chat model, `makeHandoff()`
+//  vends a `ResidencyHandoff` via the shared `SubagentResidency` layer; otherwise
+//  it stays passthrough.
 //
 //  Guardrails preserved from the standalone tool: the read/search/exec
 //  allowlist (enforced in the executor as defense in depth), the child loop's
@@ -31,9 +35,11 @@ final class SandboxReduceKind: SubagentKind, @unchecked Sendable {
     /// agent's model via `AgentManager.effectiveModel`.
     private let modelOverride: String?
 
-    /// Resolved in `resolveModel`, read by `run`.
-    private var modelId: String = ""
+    /// The child tool allow-list resolved in `resolveModel`, read by `run`.
     private var toolSpecs: [Tool] = []
+    /// Residency plan resolved in `resolveModel` (reject-before-evict), run by
+    /// `makeHandoff()`. `.none` when no swap is needed.
+    private var residencyPlan: ResidencyPlan = .none
 
     init(
         agentId: String,
@@ -56,19 +62,11 @@ final class SandboxReduceKind: SubagentKind, @unchecked Sendable {
 
     func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel {
         let agentUUID = UUID(uuidString: agentId)
-        let override = modelOverride
-        let (model, specs): (String?, [Tool]) = await MainActor.run {
-            let model =
-                override
-                ?? agentUUID.flatMap { AgentManager.shared.effectiveModel(for: $0) }
-                ?? ChatConfigurationStore.load().defaultModel
-            let specs = ToolRegistry.shared.specs(forTools: SandboxReduceTool.childToolAllowlist)
-            return (model, specs)
-        }
-        guard let model, !model.isEmpty else {
-            throw SubagentError.unavailable(
-                "No model is configured for this agent, so the reduction subagent cannot run."
-            )
+        // Resolve the child tool allow-list before touching the model so an
+        // infra gap (container still starting) fails fast, before any residency
+        // planning.
+        let specs: [Tool] = await MainActor.run {
+            ToolRegistry.shared.specs(forTools: SandboxReduceTool.childToolAllowlist)
         }
         guard !specs.isEmpty else {
             throw SubagentError.executionFailed(
@@ -78,15 +76,39 @@ final class SandboxReduceKind: SubagentKind, @unchecked Sendable {
                 retryable: true
             )
         }
-        self.modelId = model
         self.toolSpecs = specs
-        // Same-model kind: residency is irrelevant (no handoff), so `isLocal`
-        // is not consulted.
-        return ResolvedModel(name: model, id: nil, isLocal: false)
+
+        // One shared path for precedence (eval seam → per-agent `sandbox_reduce`
+        // override → the parent agent's model → the global chat default), the
+        // availability fallback, and the live residency decision
+        // (reject-before-evict; a remote override / the inherited model needs no
+        // swap, the eval seam stays passthrough).
+        let resolved = try await SubagentModelResolution.resolve(
+            capabilityId: capability.id,
+            agentId: agentUUID,
+            evalModel: modelOverride,
+            idleWaitSeconds: Int(SandboxReduceTool.wallClockSeconds),
+            deniedMessage:
+                "Running the reduction subagent on a different local model requires \"Local "
+                + "Orchestrator Handoff\" enabled in Settings → Sub-agents (so the chat model "
+                + "can unload to make room).",
+            unavailableMessage:
+                "No model is configured for this agent, so the reduction subagent cannot run.",
+            defaultModel: {
+                agentUUID.flatMap { AgentManager.shared.effectiveModel(for: $0) }
+                    ?? ChatConfigurationStore.load().defaultModel
+            }
+        )
+        self.residencyPlan = resolved.decision.plan
+        return ResolvedModel(name: resolved.model, id: nil, isLocal: resolved.decision.isLocal)
     }
 
     func permission(_ scope: SubagentScope, _ resolved: ResolvedModel) async -> SubagentDecision {
         .allow
+    }
+
+    func makeHandoff() -> SubagentHandoff {
+        SubagentResidency.handoff(for: residencyPlan)
     }
 
     func run(
@@ -173,6 +195,7 @@ final class SandboxReduceKind: SubagentKind, @unchecked Sendable {
             return SubagentResult(
                 payload: [
                     "kind": "digest",
+                    "model": resolved.name,
                     "digest": capped,
                     "iterations": result.iterations,
                 ] as [String: Any],

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -37,10 +37,9 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
     private var personaId: UUID?
     private var systemPrompt: String = ""
     private var budgets = SubagentBudgets()
-    private var residencyShouldUnload = false
-    private var residencyRequiredBytes: Int64 = 0
-    private var ramSafetyEnabled = false
-    private var handoffMaxElapsedSeconds = 120
+    /// The residency plan resolved at `resolveModel` time (reject-before-evict),
+    /// consumed by `makeHandoff()`. `.none` when no swap is needed.
+    private var residencyPlan: ResidencyPlan = .none
 
     init(agentName: String, input: String, modelOverride: String? = nil) {
         self.agentName = agentName
@@ -96,17 +95,6 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         guard let persona else {
             throw SubagentError.unavailable("Agent '\(agentName)' not found.")
         }
-        let modelName: String?
-        if let modelOverride {
-            modelName = modelOverride
-        } else {
-            modelName = await MainActor.run {
-                AgentManager.shared.effectiveModel(for: persona.id)
-            }
-        }
-        guard let modelName, !modelName.isEmpty else {
-            throw SubagentError.unavailable("Agent '\(agentName)' has no model configured.")
-        }
 
         self.personaName = persona.name
         self.personaId = persona.id
@@ -117,31 +105,26 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
             settings: settings
         )
 
-        // Decide the residency handoff from ACTUAL GPU residency (not a
-        // best-effort orchestrator name lookup): if the spawn model is local
-        // and ANY other chat model is resident, unload it first so only one
-        // model touches the GPU at a time (avoids the MLX shared-command-stream
-        // SIGABRT). Reject-before-evict: require the handoff to be enabled here,
-        // before anything is unloaded.
-        let isLocalModel = ModelManager.findInstalledModel(named: modelName) != nil
-        let residentChatModels = await ModelRuntime.shared.cachedModelSummaries().map(\.name)
-        let otherResidentModels = residentChatModels.filter {
-            $0.caseInsensitiveCompare(modelName) != .orderedSame
-        }
-        if isLocalModel && !otherResidentModels.isEmpty {
-            guard config.localOrchestratorTextHandoffActive else {
-                throw SubagentError.denied(
-                    "Spawning a different local agent requires \"Local Orchestrator Handoff\" enabled "
-                        + "in Settings → Sub-agents (so the chat model can unload to make room)."
-                )
-            }
-            self.residencyShouldUnload = true
-            self.residencyRequiredBytes = ChatResidencyHandoff.estimatedChatModelBytes(named: modelName)
-            self.ramSafetyEnabled = config.ramSafetyPreflightEnabled
-            self.handoffMaxElapsedSeconds = self.budgets.maxElapsedSeconds
-        }
+        // One shared path for precedence (eval seam → per-agent `spawn` override
+        // → the persona's own model), the availability fallback, and the live
+        // residency decision (reject-before-evict). The override is read from
+        // the LAUNCHING agent (`scope.agentId`); the default is the persona's
+        // configured model.
+        let personaId = persona.id
+        let resolved = try await SubagentModelResolution.resolve(
+            capabilityId: capability.id,
+            agentId: scope.agentId,
+            evalModel: modelOverride,
+            idleWaitSeconds: self.budgets.maxElapsedSeconds,
+            deniedMessage:
+                "Spawning a different local agent requires \"Local Orchestrator Handoff\" enabled "
+                + "in Settings → Sub-agents (so the chat model can unload to make room).",
+            unavailableMessage: "Agent '\(agentName)' has no model configured.",
+            defaultModel: { AgentManager.shared.effectiveModel(for: personaId) }
+        )
+        self.residencyPlan = resolved.decision.plan
 
-        return ResolvedModel(name: modelName, id: nil, isLocal: isLocalModel)
+        return ResolvedModel(name: resolved.model, id: nil, isLocal: resolved.decision.isLocal)
     }
 
     func permission(_ scope: SubagentScope, _ resolved: ResolvedModel) async -> SubagentDecision {
@@ -151,14 +134,7 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
     }
 
     func makeHandoff() -> SubagentHandoff {
-        guard residencyShouldUnload else { return PassthroughHandoff() }
-        let plan = ResidencyPlan(
-            shouldUnload: true,
-            requiredBytes: residencyRequiredBytes,
-            ramSafetyEnabled: ramSafetyEnabled,
-            maxElapsedSeconds: handoffMaxElapsedSeconds
-        )
-        return ResidencyHandoff.production { _ in plan }
+        SubagentResidency.handoff(for: residencyPlan)
     }
 
     func run(
@@ -206,7 +182,7 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
                     "summary": capped,
                     "iterations": result.iterations,
                     "elapsed_seconds": elapsed,
-                    "handoff": residencyShouldUnload,
+                    "handoff": residencyPlan.shouldUnload,
                 ] as [String: Any],
                 summary: capped
             )

--- a/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
@@ -111,6 +111,15 @@ public struct SubagentCapability: Sendable {
     public let perAgentFlag: PerAgentFlag?
     /// How this kind gets its model (drives docs + the future model-pick axis).
     public let modelSource: ModelSource
+    /// Whether this kind exposes the standard per-agent model-override picker
+    /// (`subagentModelOverrides` → `effectiveSubagentModel` → the shared
+    /// `SubagentModelResolution` layer). True for the chat-driven kinds
+    /// (computer_use, spawn, sandbox_reduce). False for `image`, which owns its
+    /// own dedicated gen/edit model system (`effectiveImageModel`) and renders
+    /// its own pickers — see the `image` registration below. AgentsView renders
+    /// the override row for any capability with this set, so a new chat-driven
+    /// kind gets a picker by only flipping this flag.
+    public let supportsModelOverride: Bool
     /// Human label for the live-feed header + collapsed tool chip.
     public let displayLabel: String
     /// SF Symbol for the live feed + tool chip.
@@ -130,6 +139,7 @@ public struct SubagentCapability: Sendable {
         gate: Gate,
         perAgentFlag: PerAgentFlag? = nil,
         modelSource: ModelSource = .inheritsParent,
+        supportsModelOverride: Bool = false,
         displayLabel: String? = nil,
         iconName: String = "sparkles",
         guidance: String? = nil,
@@ -141,6 +151,7 @@ public struct SubagentCapability: Sendable {
         self.gate = gate
         self.perAgentFlag = perAgentFlag
         self.modelSource = modelSource
+        self.supportsModelOverride = supportsModelOverride
         self.displayLabel = displayLabel ?? id
         self.iconName = iconName
         self.guidance = guidance
@@ -160,6 +171,7 @@ public enum SubagentCapabilityRegistry {
         gate: .perAgent,
         perAgentFlag: .computerUse,
         modelSource: .inheritsParent,
+        supportsModelOverride: true,
         displayLabel: "Computer Use",
         iconName: "cursorarrow.rays",
         guidance: SystemPromptTemplates.computerUseGuidance,
@@ -177,18 +189,25 @@ public enum SubagentCapabilityRegistry {
         gate: .delegation,
         perAgentFlag: .spawn,
         modelSource: .persona,
+        supportsModelOverride: true,
         displayLabel: "Subagent",
         iconName: "person.2.fill"
     )
 
     /// The image family — one `image` tool that both generates and edits
     /// (`source_paths` → edit). The guidance renders when `image` resolves.
+    /// `supportsModelOverride = false` is deliberate: `image` owns its own model
+    /// system (separate gen/edit defaults via `effectiveImageModel`, its own
+    /// readiness + "first ready" fallback, and coordinator-owned residency), so
+    /// it is NOT a `SubagentModelResolution` client and keeps its dedicated
+    /// gen/edit pickers instead of the shared per-agent override row.
     public static let image = SubagentCapability(
         id: "image",
         toolNames: ["image"],
         gate: .delegation,
         perAgentFlag: .image,
         modelSource: .dedicatedConfigured,
+        supportsModelOverride: false,
         displayLabel: "Image",
         iconName: "photo",
         guidance: SystemPromptTemplates.imageGenerationGuidance,
@@ -205,6 +224,7 @@ public enum SubagentCapabilityRegistry {
         toolNames: ["sandbox_reduce"],
         gate: .sandboxExec,
         modelSource: .inheritsParent,
+        supportsModelOverride: true,
         displayLabel: "Investigation",
         iconName: "doc.text.magnifyingglass"
     )
@@ -233,6 +253,15 @@ public enum SubagentCapabilityRegistry {
     /// The descriptor for a kind id (`SubagentFeed.kindId` / `capability.id`).
     public static func capability(forKindId id: String) -> SubagentCapability? {
         all.first { $0.id == id }
+    }
+
+    /// The descriptor bound to a per-agent toggle flag — lets the AgentsView
+    /// Sub-agents tab render the standard model-override row generically
+    /// (`supportsModelOverride`) instead of hand-wiring it per kind.
+    public static func capability(forPerAgentFlag flag: SubagentCapability.PerAgentFlag)
+        -> SubagentCapability?
+    {
+        all.first { $0.perAgentFlag == flag }
     }
 
     /// The descriptor that gates a given tool name.
@@ -362,6 +391,26 @@ public enum SubagentToolVisibility {
             return isEdit ? config.defaultImageEditModelId : config.defaultImageGenerationModelId
         }
         return isEdit ? settings?.imageEditModelId : settings?.imageGenerationModelId
+    }
+
+    /// The effective per-run model override for a subagent capability, or `nil`
+    /// to inherit the kind's default model source (the parent agent's model for
+    /// computer_use / sandbox_reduce; the chosen persona's model for spawn). The
+    /// Default / main chat reads the global override map; a custom agent its own.
+    /// A blank stored value resolves to `nil` (inherit). This is the standard
+    /// model-pick axis every chat-driven kind reads the same way.
+    static func effectiveSubagentModel(
+        capabilityId: String,
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        settings: AgentSettings?
+    ) -> String? {
+        let raw =
+            isDefault
+            ? config.subagentModelOverrides[capabilityId]
+            : settings?.subagentModelOverrides[capabilityId]
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed?.isEmpty ?? true) ? nil : trimmed
     }
 
     /// The effective permission policy for a delegation capability. Default / main

--- a/Packages/OsaurusCore/Subagent/SubagentModelResolution.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentModelResolution.swift
@@ -1,0 +1,136 @@
+//
+//  SubagentModelResolution.swift
+//  OsaurusCore — Subagent framework
+//
+//  The one model-resolution path the chat-driven sub-agent kinds (spawn,
+//  computer_use, sandbox_reduce) share. Each kind previously repeated the same
+//  three steps inline: look up the per-agent model override, fall back to the
+//  kind's default model source, then run the live `SubagentResidency` decision
+//  and stash the plan for `makeHandoff()`. This folds that into one precedence
+//  (`pickModel`) + one availability gate (`availableOverride`) + one live
+//  `resolve`, so a new chat-driven kind gets the whole behaviour for free and
+//  the three kinds can never drift on precedence, the availability fallback, or
+//  the eval-bypasses-residency invariant.
+//
+//  Image is deliberately NOT a client: it owns its own model system
+//  (`imageGenerationModelId` / `imageEditModelId`, `effectiveImageModel`, the
+//  gen/edit split + readiness, coordinator-owned residency) and sets
+//  `SubagentCapability.supportsModelOverride = false`. Every kind that DOES set
+//  `supportsModelOverride = true` resolves through here.
+//
+
+import Foundation
+
+/// The shared model-resolution layer for chat-driven sub-agent kinds. Stateless
+/// and split into a pure precedence step (`pickModel`), a `@MainActor`
+/// availability gate (`availableOverride`), and a live `resolve` wrapper that
+/// folds in `SubagentResidency`. The pure pieces unit-test with no GPU / no
+/// MainActor.
+enum SubagentModelResolution {
+    /// The resolved run model plus the residency decision its `makeHandoff()`
+    /// will run. Bundled so a kind stores one value and returns one model.
+    struct Resolved: Sendable {
+        let model: String
+        let decision: SubagentResidencyDecision
+    }
+
+    /// Pure model precedence: the eval seam (forced run model) wins, then an
+    /// AVAILABLE per-agent override, then the kind's default model source.
+    /// Empty / whitespace-only entries are treated as absent so a blank stored
+    /// value transparently inherits. No dependencies, so the precedence is
+    /// unit-testable on its own.
+    static func pickModel(
+        evalModel: String?,
+        availableOverride: String?,
+        defaultModel: String?
+    ) -> String? {
+        trimmedNonEmpty(evalModel)
+            ?? trimmedNonEmpty(availableOverride)
+            ?? trimmedNonEmpty(defaultModel)
+    }
+
+    /// Trim a model id and treat empty / whitespace-only as absent (`nil`), so a
+    /// blank stored value transparently inherits at every precedence slot.
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+
+    /// The stored override id IF it is still usable, else `nil` so the caller
+    /// falls back to the kind default instead of hard-failing on a model that
+    /// was deleted or whose provider disconnected. Local installs are
+    /// authoritative (the picker cache may not list every bundle); a remote id
+    /// is checked against `ModelPickerItemCache`, which mirrors connected
+    /// providers. A cold cache can't disprove availability, so the id is
+    /// trusted rather than silently dropped.
+    @MainActor
+    static func availableOverride(_ id: String?) -> String? {
+        guard let trimmed = trimmedNonEmpty(id) else { return nil }
+        if ModelManager.findInstalledModel(named: trimmed) != nil { return trimmed }
+        guard ModelPickerItemCache.shared.isLoaded else { return trimmed }
+        return ModelPickerItemCache.shared.items.contains { $0.id == trimmed } ? trimmed : nil
+    }
+
+    /// Live resolution for a chat-driven kind.
+    ///
+    /// - Eval seam: when `evalModel` is set the run model is forced and the
+    ///   residency decision is the passthrough `(isLocal: false, plan: .none)` —
+    ///   the uniform eval-bypasses-residency invariant, so a deterministic lane
+    ///   never depends on live GPU residency.
+    /// - Otherwise: resolves the launching agent's `settings`, reads the
+    ///   per-agent `effectiveSubagentModel` override, drops it through
+    ///   `availableOverride`, falls back to `defaultModel()`, then runs the
+    ///   shared `SubagentResidency.resolve` (reject-before-evict).
+    ///
+    /// `agentId` is the launching agent whose override map + settings are read
+    /// (spawn/computer_use pass `scope.agentId`; sandbox_reduce its own agent
+    /// id). `defaultModel` is the kind's default model source, evaluated on the
+    /// main actor only when no usable override is present.
+    static func resolve(
+        capabilityId: String,
+        agentId: UUID?,
+        evalModel: String?,
+        idleWaitSeconds: Int,
+        deniedMessage: String,
+        unavailableMessage: String,
+        defaultModel: @escaping @Sendable @MainActor () -> String?
+    ) async throws -> Resolved {
+        // Eval seam: force the model, keep residency passthrough.
+        if let forced = trimmedNonEmpty(evalModel) {
+            return Resolved(
+                model: forced,
+                decision: SubagentResidencyDecision(isLocal: false, plan: .none)
+            )
+        }
+
+        let config = SubagentConfigurationStore.snapshot()
+        let isDefault = agentId == Agent.defaultId
+        let model: String? = await MainActor.run {
+            let settings = agentId.flatMap { AgentManager.shared.agent(for: $0)?.settings }
+            let override = SubagentToolVisibility.effectiveSubagentModel(
+                capabilityId: capabilityId,
+                isDefault: isDefault,
+                config: config,
+                settings: settings
+            )
+            return pickModel(
+                evalModel: nil,
+                availableOverride: availableOverride(override),
+                defaultModel: defaultModel()
+            )
+        }
+        guard let model, !model.isEmpty else {
+            throw SubagentError.unavailable(unavailableMessage)
+        }
+
+        let decision = try await SubagentResidency.resolve(
+            modelName: model,
+            config: config,
+            idleWaitSeconds: idleWaitSeconds,
+            deniedMessage: deniedMessage
+        )
+        return Resolved(model: model, decision: decision)
+    }
+}

--- a/Packages/OsaurusCore/Subagent/SubagentResidency.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentResidency.swift
@@ -1,0 +1,101 @@
+//
+//  SubagentResidency.swift
+//  OsaurusCore — Subagent framework
+//
+//  The shared model-residency layer for the chat-driven sub-agent kinds
+//  (spawn, computer_use, sandbox_reduce). When a kind resolves a model that is
+//  a DIFFERENT local bundle than the resident orchestrator, single-GPU
+//  residency requires unloading the chat model for the run and reloading it
+//  after — exactly the flow `spawn` (`TextSubagentKind`) pioneered. This
+//  generalizes that decision so every kind reads it once instead of
+//  re-deriving the live-residency check + reject-before-evict gate inline.
+//
+//  The decision is split into a pure `decidePlan` (no `ModelRuntime` /
+//  `ModelManager`, so it unit-tests with no GPU) and a live `resolve` wrapper
+//  the kinds call. `handoff(for:)` maps a resolved plan onto the host's
+//  `SubagentHandoff` middleware (a real `ResidencyHandoff` when it unloads,
+//  otherwise the passthrough default).
+//
+
+import Foundation
+
+/// The residency outcome a kind resolves up front (reject-before-evict): the
+/// `isLocal` flag for its `ResolvedModel` plus the `ResidencyPlan` the
+/// `makeHandoff()` middleware runs (or `.none` for no swap).
+struct SubagentResidencyDecision: Sendable {
+    /// True when the resolved model is an installed local bundle (so the host's
+    /// handoff middleware may need single-GPU-residency eviction).
+    let isLocal: Bool
+    /// The per-run residency plan. `.none` means run in place (remote model,
+    /// same as the resident orchestrator, or nothing else resident).
+    let plan: ResidencyPlan
+}
+
+enum SubagentResidency {
+    /// Pure residency decision — no `ModelRuntime` / `ModelManager`, so the
+    /// control flow (remote ⇒ none, same ⇒ none, different-local + handoff-off ⇒
+    /// denied, different-local + handoff-on ⇒ unload) is unit-testable with no
+    /// GPU. `residentChatModels` is the live set of resident chat-model names;
+    /// the caller resolves it (empty when the model isn't local).
+    static func decidePlan(
+        isLocal: Bool,
+        modelName: String,
+        residentChatModels: [String],
+        handoffEnabled: Bool,
+        ramSafetyEnabled: Bool,
+        requiredBytes: Int64,
+        idleWaitSeconds: Int,
+        deniedMessage: String
+    ) throws -> ResidencyPlan {
+        // A remote/router model never touches local GPU residency.
+        guard isLocal else { return .none }
+        // Only a DIFFERENT resident chat model forces a swap; the same model
+        // already resident is reused in place.
+        let otherResidentModels = residentChatModels.filter {
+            $0.caseInsensitiveCompare(modelName) != .orderedSame
+        }
+        guard !otherResidentModels.isEmpty else { return .none }
+        // Reject BEFORE evicting: if the handoff is disabled, fail cleanly so
+        // nothing is unloaded.
+        guard handoffEnabled else { throw SubagentError.denied(deniedMessage) }
+        return ResidencyPlan(
+            shouldUnload: true,
+            requiredBytes: requiredBytes,
+            ramSafetyEnabled: ramSafetyEnabled,
+            maxElapsedSeconds: idleWaitSeconds
+        )
+    }
+
+    /// Live residency decision for a resolved model name. Reads the installed
+    /// bundle (`ModelManager`) + the resident chat models (`ModelRuntime`) and
+    /// feeds them to `decidePlan`. Throws `SubagentError.denied` when a
+    /// different local model would require the handoff but it is disabled.
+    static func resolve(
+        modelName: String,
+        config: SubagentConfiguration,
+        idleWaitSeconds: Int,
+        deniedMessage: String
+    ) async throws -> SubagentResidencyDecision {
+        let isLocal = ModelManager.findInstalledModel(named: modelName) != nil
+        let residentChatModels =
+            isLocal ? await ModelRuntime.shared.cachedModelSummaries().map(\.name) : []
+        let plan = try decidePlan(
+            isLocal: isLocal,
+            modelName: modelName,
+            residentChatModels: residentChatModels,
+            handoffEnabled: config.localOrchestratorTextHandoffActive,
+            ramSafetyEnabled: config.ramSafetyPreflightEnabled,
+            requiredBytes: isLocal
+                ? ChatResidencyHandoff.estimatedChatModelBytes(named: modelName) : 0,
+            idleWaitSeconds: idleWaitSeconds,
+            deniedMessage: deniedMessage
+        )
+        return SubagentResidencyDecision(isLocal: isLocal, plan: plan)
+    }
+
+    /// Map a resolved plan onto the host handoff middleware: a real
+    /// `ResidencyHandoff` when it unloads, otherwise the passthrough default.
+    static func handoff(for plan: ResidencyPlan) -> SubagentHandoff {
+        plan.shouldUnload ? ResidencyHandoff.production { _ in plan } : PassthroughHandoff()
+    }
+}

--- a/Packages/OsaurusCore/Tests/Agent/AgentSettingsCodableTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentSettingsCodableTests.swift
@@ -66,6 +66,59 @@ struct AgentSettingsCodableTests {
         #expect(decoded.imageEditModelId == nil)
     }
 
+    @Test("the per-agent subagent model overrides round-trip")
+    func roundTripsModelOverrides() throws {
+        var settings = AgentSettings.defaultDisabled
+        settings.subagentModelOverrides = [
+            SubagentCapabilityRegistry.computerUse.id: "vision-model",
+            SubagentCapabilityRegistry.sandboxReduce.id: "reducer-model",
+            SubagentCapabilityRegistry.spawn.id: "spawn-model",
+        ]
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AgentSettings.self, from: data)
+
+        #expect(
+            decoded.subagentModelOverrides[SubagentCapabilityRegistry.computerUse.id]
+                == "vision-model"
+        )
+        #expect(
+            decoded.subagentModelOverrides[SubagentCapabilityRegistry.sandboxReduce.id]
+                == "reducer-model"
+        )
+        #expect(
+            decoded.subagentModelOverrides[SubagentCapabilityRegistry.spawn.id] == "spawn-model"
+        )
+    }
+
+    @Test("legacy JSON without subagentModelOverrides decodes to an empty map")
+    func backCompatModelOverrides() throws {
+        // An older agent file that predates the per-capability model override.
+        let json = #"{"dbEnabled":false,"computerUseEnabled":true}"#
+        let decoded = try JSONDecoder().decode(AgentSettings.self, from: Data(json.utf8))
+
+        #expect(decoded.subagentModelOverrides.isEmpty)
+    }
+
+    @Test("a blank / whitespace model override entry is dropped on decode")
+    func blankModelOverrideDroppedOnDecode() throws {
+        // A cleared picker an older build may have persisted as "" (or a stray
+        // whitespace value) must decode as "no override" so the per-agent stored
+        // shape matches the global SubagentConfiguration normalization — never an
+        // empty-string model id that would later resolve to a bogus override.
+        let json = #"""
+            {"dbEnabled":false,"subagentModelOverrides":{"computer_use":"   ","spawn":"real-model","sandbox_reduce":""}}
+            """#
+        let decoded = try JSONDecoder().decode(AgentSettings.self, from: Data(json.utf8))
+
+        #expect(decoded.subagentModelOverrides[SubagentCapabilityRegistry.computerUse.id] == nil)
+        #expect(decoded.subagentModelOverrides[SubagentCapabilityRegistry.sandboxReduce.id] == nil)
+        #expect(
+            decoded.subagentModelOverrides[SubagentCapabilityRegistry.spawn.id] == "real-model"
+        )
+        #expect(decoded.subagentModelOverrides.count == 1)
+    }
+
     @Test("legacy JSON without the new keys decodes to safe defaults")
     func backCompatDefaults() throws {
         // An older agent file that predates per-agent image / permission / budget.

--- a/Packages/OsaurusCore/Tests/AgentDelegation/SubagentConfigurationTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/SubagentConfigurationTests.swift
@@ -148,4 +148,33 @@ struct SubagentConfigurationTests {
         #expect(config.normalized.anyAgentSpawnable)
         #expect(config.normalized.isAgentSpawnable("researcher"))  // case-insensitive
     }
+
+    @Test("subagent model overrides round-trip and drop blank entries")
+    func modelOverridesRoundTripAndNormalize() throws {
+        // `init` normalizes: it trims values and drops blank entries so a cleared
+        // picker (empty string) round-trips as "no override", not an empty id.
+        let config = SubagentConfiguration(
+            subagentModelOverrides: [
+                "spawn": "spawn-model",
+                "sandbox_reduce": "  reducer-model  ",
+                "computer_use": "   ",
+            ]
+        )
+        #expect(config.subagentModelOverrides["spawn"] == "spawn-model")
+        #expect(config.subagentModelOverrides["sandbox_reduce"] == "reducer-model")
+        #expect(config.subagentModelOverrides["computer_use"] == nil)
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(SubagentConfiguration.self, from: data)
+        #expect(decoded.subagentModelOverrides["spawn"] == "spawn-model")
+        #expect(decoded.subagentModelOverrides["sandbox_reduce"] == "reducer-model")
+        #expect(decoded.subagentModelOverrides["computer_use"] == nil)
+    }
+
+    @Test("legacy config without subagentModelOverrides decodes to an empty map")
+    func backCompatModelOverridesEmpty() throws {
+        let data = Data(#"{"localTextDelegationEnabled":true}"#.utf8)
+        let decoded = try JSONDecoder().decode(SubagentConfiguration.self, from: data)
+        #expect(decoded.subagentModelOverrides.isEmpty)
+    }
 }

--- a/Packages/OsaurusCore/Tests/AgentDelegation/SubagentModelOverrideResolverTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/SubagentModelOverrideResolverTests.swift
@@ -1,0 +1,109 @@
+//
+//  SubagentModelOverrideResolverTests.swift
+//  OsaurusCoreTests — Agent delegation
+//
+//  Pins the single resolver every chat-driven kind reads for its per-run model
+//  override: `SubagentToolVisibility.effectiveSubagentModel`. The Default / main
+//  chat reads the global override map; a custom agent reads its own; a blank or
+//  absent value resolves to `nil` (inherit the kind's default model source).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Subagent model override resolver")
+struct SubagentModelOverrideResolverTests {
+
+    @Test("a custom agent reads its own per-agent override map")
+    func customAgentReadsSettings() {
+        var settings = AgentSettings.defaultDisabled
+        settings.subagentModelOverrides = ["computer_use": "vision-model"]
+
+        let model = SubagentToolVisibility.effectiveSubagentModel(
+            capabilityId: "computer_use",
+            isDefault: false,
+            config: .default,
+            settings: settings
+        )
+        #expect(model == "vision-model")
+    }
+
+    @Test("the main chat reads the global override map")
+    func mainChatReadsGlobalConfig() {
+        let config = SubagentConfiguration(subagentModelOverrides: ["spawn": "global-model"])
+
+        let model = SubagentToolVisibility.effectiveSubagentModel(
+            capabilityId: "spawn",
+            isDefault: true,
+            config: config,
+            settings: nil
+        )
+        #expect(model == "global-model")
+    }
+
+    @Test("an absent or blank override resolves to nil (inherit)")
+    func absentOrBlankIsNil() {
+        // Absent entirely.
+        #expect(
+            SubagentToolVisibility.effectiveSubagentModel(
+                capabilityId: "sandbox_reduce",
+                isDefault: false,
+                config: .default,
+                settings: AgentSettings.defaultDisabled
+            ) == nil
+        )
+
+        // Blank value — `AgentSettings` does not normalize its map, so the
+        // resolver must trim and treat whitespace as "inherit".
+        var settings = AgentSettings.defaultDisabled
+        settings.subagentModelOverrides = ["sandbox_reduce": "   "]
+        #expect(
+            SubagentToolVisibility.effectiveSubagentModel(
+                capabilityId: "sandbox_reduce",
+                isDefault: false,
+                config: .default,
+                settings: settings
+            ) == nil
+        )
+    }
+
+    @Test("custom and main-chat override maps are isolated")
+    func customAndDefaultAreIsolated() {
+        let config = SubagentConfiguration(subagentModelOverrides: ["spawn": "global-only"])
+        var settings = AgentSettings.defaultDisabled
+        settings.subagentModelOverrides = ["spawn": "agent-only"]
+
+        // A custom agent ignores the global map.
+        #expect(
+            SubagentToolVisibility.effectiveSubagentModel(
+                capabilityId: "spawn",
+                isDefault: false,
+                config: config,
+                settings: settings
+            ) == "agent-only"
+        )
+        // The Default agent ignores per-agent settings.
+        #expect(
+            SubagentToolVisibility.effectiveSubagentModel(
+                capabilityId: "spawn",
+                isDefault: true,
+                config: config,
+                settings: settings
+            ) == "global-only"
+        )
+    }
+
+    @Test("a nil settings (no agent context) resolves to nil for a custom lookup")
+    func nilSettingsIsNil() {
+        #expect(
+            SubagentToolVisibility.effectiveSubagentModel(
+                capabilityId: "computer_use",
+                isDefault: false,
+                config: .default,
+                settings: nil
+            ) == nil
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -209,7 +209,10 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted)),
             feed: SubagentFeed(
-                toolCallId: "evidence-browser-form", kindId: "computer_use", title: "Fill out the form"),
+                toolCallId: "evidence-browser-form",
+                kindId: "computer_use",
+                title: "Fill out the form"
+            ),
             interrupt: InterruptToken(),
             confirm: { preview in
                 await confirmationRecorder.record(preview)

--- a/Packages/OsaurusCore/Tests/Model/SubagentModelPickerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/SubagentModelPickerTests.swift
@@ -51,6 +51,42 @@ struct SubagentModelPickerTests {
         #expect(items.subagentModelCandidate(id: nil, kind: .imageEdit) == nil)
     }
 
+    @Test("chat candidates include local/remote chat and exclude image/embedding")
+    func chatCandidatesFilterByCapability() {
+        let items: [ModelPickerItem] = [
+            ModelPickerItem(id: "local-chat", displayName: "Local Chat", source: .local),
+            ModelPickerItem(
+                id: "embedder",
+                displayName: "Embedder",
+                source: .local,
+                isEmbedding: true
+            ),
+            imageModel(id: "flux", textToImage: true),
+            ModelPickerItem(
+                id: "remote-chat",
+                displayName: "Remote Chat",
+                source: .remote(providerName: "P", providerId: UUID())
+            ),
+        ]
+
+        #expect(Set(items.chatModelCandidates.map(\.id)) == ["local-chat", "remote-chat"])
+    }
+
+    @Test("subagentChatModelCandidate matches a stored chat id, else nil")
+    func chatCandidateLookup() {
+        let items: [ModelPickerItem] = [
+            ModelPickerItem(id: "local-chat", displayName: "Local Chat", source: .local),
+            imageModel(id: "flux", textToImage: true),
+        ]
+
+        #expect(items.subagentChatModelCandidate(id: "local-chat")?.id == "local-chat")
+        // An image model is not a chat candidate, so the lookup misses.
+        #expect(items.subagentChatModelCandidate(id: "flux") == nil)
+        #expect(items.subagentChatModelCandidate(id: "   ") == nil)
+        #expect(items.subagentChatModelCandidate(id: nil) == nil)
+        #expect(items.subagentChatModelCandidate(id: "missing") == nil)
+    }
+
     private func imageModel(
         id: String,
         ready: Bool = true,

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentCapabilityRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentCapabilityRegistryTests.swift
@@ -184,6 +184,28 @@ struct SubagentCapabilityRegistryTests {
         #expect(SubagentCapabilityRegistry.sandboxReduce.modelSource == .inheritsParent)
     }
 
+    @Test("supportsModelOverride is true for the chat-driven kinds and false for image")
+    func supportsModelOverrideFlag() {
+        // The chat-driven kinds share the standard per-agent model picker
+        // (`subagentModelOverrides` → `effectiveSubagentModel` →
+        // `SubagentModelResolution`).
+        #expect(SubagentCapabilityRegistry.computerUse.supportsModelOverride)
+        #expect(SubagentCapabilityRegistry.spawn.supportsModelOverride)
+        #expect(SubagentCapabilityRegistry.sandboxReduce.supportsModelOverride)
+        // image owns its own dedicated gen/edit model system → no shared row.
+        #expect(!SubagentCapabilityRegistry.image.supportsModelOverride)
+    }
+
+    @Test("capability(forPerAgentFlag:) maps each toggle flag to its descriptor")
+    func capabilityForPerAgentFlag() {
+        #expect(
+            SubagentCapabilityRegistry.capability(forPerAgentFlag: .computerUse)?.id
+                == "computer_use"
+        )
+        #expect(SubagentCapabilityRegistry.capability(forPerAgentFlag: .spawn)?.id == "spawn")
+        #expect(SubagentCapabilityRegistry.capability(forPerAgentFlag: .image)?.id == "image")
+    }
+
     @Test("every descriptor carries a display label + icon for the feed and chip")
     func displayAndIconArePopulated() {
         for capability in SubagentCapabilityRegistry.all {

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentModelResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentModelResolutionTests.swift
@@ -1,0 +1,170 @@
+//
+//  SubagentModelResolutionTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Coverage for the shared model-resolution layer every chat-driven kind
+//  (spawn / computer_use / sandbox_reduce) routes through. The pure
+//  `pickModel` precedence (eval seam → available override → default, with
+//  blanks treated as absent) and the `availableOverride` trimming are
+//  GPU-free; two `resolve` cases pin the eval-bypasses-residency invariant and
+//  the no-override → default fallback that the kind suites previously couldn't
+//  reach without a live agent.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Subagent model resolution")
+struct SubagentModelResolutionTests {
+
+    // MARK: - pickModel precedence
+
+    @Test("the eval seam wins over an available override and the default")
+    func evalSeamWins() {
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: "eval",
+                availableOverride: "override",
+                defaultModel: "default"
+            ) == "eval"
+        )
+    }
+
+    @Test("an available override wins over the default when there is no eval seam")
+    func availableOverrideWins() {
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: nil,
+                availableOverride: "override",
+                defaultModel: "default"
+            ) == "override"
+        )
+    }
+
+    @Test("an unavailable override (nil) falls back to the default model")
+    func unavailableOverrideFallsBackToDefault() {
+        // `availableOverride` returns nil when the stored id is gone; the
+        // precedence then transparently inherits the kind's default source.
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: nil,
+                availableOverride: nil,
+                defaultModel: "default"
+            ) == "default"
+        )
+    }
+
+    @Test("everything nil resolves to nil (caller throws unavailable)")
+    func allNilIsNil() {
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: nil,
+                availableOverride: nil,
+                defaultModel: nil
+            ) == nil
+        )
+    }
+
+    @Test("blank / whitespace entries are treated as absent at every slot")
+    func blanksAreAbsent() {
+        // A blank eval seam falls through to the override…
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: "   ",
+                availableOverride: "override",
+                defaultModel: "default"
+            ) == "override"
+        )
+        // …a blank override falls through to the default…
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: nil,
+                availableOverride: "\n\t ",
+                defaultModel: "default"
+            ) == "default"
+        )
+        // …and an all-blank set resolves to nil. The winning value is returned
+        // trimmed.
+        #expect(
+            SubagentModelResolution.pickModel(
+                evalModel: "  ",
+                availableOverride: "  ",
+                defaultModel: "  padded-model  "
+            ) == "padded-model"
+        )
+    }
+
+    // MARK: - availableOverride trimming
+
+    @MainActor
+    @Test("availableOverride treats nil / empty / whitespace ids as no override")
+    func availableOverrideRejectsBlanks() {
+        #expect(SubagentModelResolution.availableOverride(nil) == nil)
+        #expect(SubagentModelResolution.availableOverride("") == nil)
+        #expect(SubagentModelResolution.availableOverride("   \n ") == nil)
+    }
+
+    // MARK: - resolve invariants
+
+    @Test("the eval seam forces the model and bypasses residency entirely")
+    func resolveEvalBypassesResidency() async throws {
+        let resolved = try await SubagentModelResolution.resolve(
+            capabilityId: SubagentCapabilityRegistry.spawn.id,
+            agentId: nil,
+            evalModel: "eval/forced-model",
+            idleWaitSeconds: 30,
+            deniedMessage: "denied",
+            unavailableMessage: "unavailable",
+            defaultModel: { "must-not-be-used" }
+        )
+        #expect(resolved.model == "eval/forced-model")
+        // Uniform invariant: eval never depends on live GPU residency.
+        #expect(resolved.decision.isLocal == false)
+        #expect(resolved.decision.plan.shouldUnload == false)
+    }
+
+    @Test("with no override an unknown agent uses the default model; a remote default needs no swap")
+    func resolveFallsBackToDefault() async throws {
+        // `agentId: nil` → no settings, so no per-agent override regardless of
+        // global config; the default closure supplies the model. A remote-looking
+        // default is not an installed local bundle, so residency stays in place.
+        let resolved = try await SubagentModelResolution.resolve(
+            capabilityId: SubagentCapabilityRegistry.computerUse.id,
+            agentId: nil,
+            evalModel: nil,
+            idleWaitSeconds: 30,
+            deniedMessage: "denied",
+            unavailableMessage: "unavailable",
+            defaultModel: { "remote/frontier-model" }
+        )
+        #expect(resolved.model == "remote/frontier-model")
+        #expect(resolved.decision.isLocal == false)
+        #expect(resolved.decision.plan.shouldUnload == false)
+    }
+
+    @Test("no resolvable model throws the kind's unavailable message")
+    func resolveThrowsWhenNoModel() async {
+        do {
+            _ = try await SubagentModelResolution.resolve(
+                capabilityId: SubagentCapabilityRegistry.computerUse.id,
+                agentId: nil,
+                evalModel: nil,
+                idleWaitSeconds: 30,
+                deniedMessage: "denied",
+                unavailableMessage: "no model here",
+                defaultModel: { nil }
+            )
+            Issue.record("expected an unavailable error")
+        } catch let error as SubagentError {
+            guard case .unavailable(let message) = error else {
+                Issue.record("expected .unavailable, got \(error)")
+                return
+            }
+            #expect(message == "no model here")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentResidencyTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentResidencyTests.swift
@@ -1,0 +1,129 @@
+//
+//  SubagentResidencyTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Model-free coverage of the shared residency DECISION (`SubagentResidency`)
+//  that every chat-driven kind (spawn / computer_use / sandbox_reduce) uses to
+//  decide whether running its resolved model must unload the resident chat
+//  model. The middleware itself is covered by `ResidencyHandoffTests`; here we
+//  pin the pure `decidePlan` control flow and the `handoff(for:)` mapping.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Subagent residency decision")
+struct SubagentResidencyTests {
+    private let denied = "handoff disabled"
+
+    @Test("a remote model never touches local residency")
+    func remoteModelNeedsNoSwap() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: false,
+            modelName: "remote/model",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: 123,
+            idleWaitSeconds: 60,
+            deniedMessage: denied
+        )
+        #expect(plan.shouldUnload == false)
+    }
+
+    @Test("the same local model already resident runs in place")
+    func sameLocalRunsInPlace() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-a",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: false,
+            requiredBytes: 0,
+            idleWaitSeconds: 60,
+            deniedMessage: denied
+        )
+        #expect(plan.shouldUnload == false)
+    }
+
+    @Test("the same model in a different case is treated as resident (no swap)")
+    func sameLocalCaseInsensitive() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "Local-A",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: false,
+            requiredBytes: 0,
+            idleWaitSeconds: 60,
+            deniedMessage: denied
+        )
+        #expect(plan.shouldUnload == false)
+    }
+
+    @Test("nothing else resident means nothing to evict")
+    func nothingResidentNeedsNoSwap() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: [],
+            handoffEnabled: false,  // irrelevant — nothing to evict
+            ramSafetyEnabled: true,
+            requiredBytes: 4096,
+            idleWaitSeconds: 90,
+            deniedMessage: denied
+        )
+        #expect(plan.shouldUnload == false)
+    }
+
+    @Test("a different local model with the handoff enabled unloads, carrying the plan")
+    func differentLocalUnloads() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: 4096,
+            idleWaitSeconds: 90,
+            deniedMessage: denied
+        )
+        #expect(plan.shouldUnload == true)
+        #expect(plan.requiredBytes == 4096)
+        #expect(plan.ramSafetyEnabled == true)
+        #expect(plan.maxElapsedSeconds == 90)
+    }
+
+    @Test("a different local model with the handoff disabled is rejected BEFORE evict")
+    func differentLocalHandoffDisabledThrows() {
+        do {
+            _ = try SubagentResidency.decidePlan(
+                isLocal: true,
+                modelName: "local-b",
+                residentChatModels: ["local-a"],
+                handoffEnabled: false,
+                ramSafetyEnabled: true,
+                requiredBytes: 4096,
+                idleWaitSeconds: 90,
+                deniedMessage: denied
+            )
+            Issue.record("expected a denied error")
+        } catch let error as SubagentError {
+            guard case .denied(let message) = error else {
+                Issue.record("expected .denied, got \(error)")
+                return
+            }
+            #expect(message == denied)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test("handoff(for:) maps an unload plan to a residency handoff, else passthrough")
+    func handoffMapping() {
+        #expect(SubagentResidency.handoff(for: ResidencyPlan(shouldUnload: true)) is ResidencyHandoff)
+        #expect(SubagentResidency.handoff(for: .none) is PassthroughHandoff)
+    }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1015,6 +1015,11 @@ struct AgentDetailView: View {
     /// from / into `AgentSettings`. The Default agent uses `mainChatSubagentConfig`.
     @State private var subagentPermissions: SubagentPermissionDefaults = SubagentPermissionDefaults()
     @State private var subagentBudgets: SubagentBudgets = SubagentBudgets()
+    /// Per-agent subagent model overrides keyed by capability id (computer_use /
+    /// sandbox_reduce / spawn). Empty/absent = inherit the kind's default model.
+    /// Mirrored from / into `AgentSettings.subagentModelOverrides`; the Default
+    /// agent uses `mainChatSubagentConfig.subagentModelOverrides`.
+    @State private var subagentModelOverrides: [String: String] = [:]
     /// The Default / main-chat agent's sub-agent config, loaded from / saved to
     /// the global store. The built-in agent is in-memory (`AgentManager.update`
     /// refuses it), so its spawn/image config lives in `SubagentConfiguration`;
@@ -3173,11 +3178,62 @@ struct AgentDetailView: View {
                         )
                         if isOn.wrappedValue {
                             subagentConfigPanel {
+                                // The standard model-override row is rendered from
+                                // the registry flag (`supportsModelOverride`), so a
+                                // new chat-driven kind gets the picker for free —
+                                // the kind-specific config follows it.
+                                if let capability = SubagentCapabilityRegistry.capability(
+                                    forPerAgentFlag: feature.flag
+                                ), capability.supportsModelOverride {
+                                    subagentModelOverrideRow(capability)
+                                    subagentPanelDivider
+                                }
                                 subagentInlineConfig(for: feature.flag)
                             }
                         }
                     }
                 }
+                if sandboxReduceModelPickerVisible {
+                    sandboxReduceCard
+                }
+            }
+        }
+    }
+
+    /// The reduction subagent (`sandbox_reduce`) has no per-agent enable toggle —
+    /// it is gated by the agent's sandbox (autonomous exec). Surface its model
+    /// picker whenever the sandbox is on, so it shares the standard model-pick
+    /// axis with the toggle-backed kinds.
+    private var sandboxReduceModelPickerVisible: Bool {
+        SubagentCapabilityRegistry.sandboxReduce.supportsModelOverride
+            && agentManager.effectiveAutonomousExec(for: agent.id)?.enabled == true
+    }
+
+    /// A non-toggle "Investigation" card for `sandbox_reduce`: an info header
+    /// (it's always available while the sandbox is on) plus the standard model
+    /// override picker. Binds to `AgentSettings` (custom) or the global store
+    /// (main chat) via `subagentModelOverrideRow`.
+    private var sandboxReduceCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Investigation", bundle: .module)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    Text(
+                        "The reduction subagent reads, searches, and runs commands in this agent's sandbox, then returns only a digest. Available whenever the sandbox is on.",
+                        bundle: .module
+                    )
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 12)
+            }
+            .padding(10)
+            .background(roundedSurface(fill: theme.inputBackground, stroke: theme.inputBorder))
+            subagentConfigPanel {
+                subagentModelOverrideRow(SubagentCapabilityRegistry.sandboxReduce)
             }
         }
     }
@@ -3348,11 +3404,16 @@ struct AgentDetailView: View {
     private func subagentInlineConfig(for flag: SubagentCapability.PerAgentFlag) -> some View {
         switch flag {
         case .computerUse:
+            // The model-override row is rendered generically above (registry
+            // `supportsModelOverride`); this arm holds only computer-use-specific
+            // config.
             computerUseCeilingRow
             subagentFootnote(
                 "Requires Accessibility permission. Grant it and review status in Settings > Computer Use."
             )
         case .spawn:
+            // The model-override row is rendered generically above (registry
+            // `supportsModelOverride`).
             spawnableAgentsPicker
             subagentPanelDivider
             subagentPermissionRow(
@@ -3414,11 +3475,12 @@ struct AgentDetailView: View {
         title: LocalizedStringKey,
         selection: Binding<String>,
         candidates: [ModelPickerItem],
-        currentId: String?
+        currentId: String?,
+        emptyLabel: LocalizedStringKey = "Choose automatically"
     ) -> some View {
         subagentControlRow(title) {
             Picker("", selection: selection) {
-                Text("Choose automatically", bundle: .module).tag("")
+                Text(emptyLabel, bundle: .module).tag("")
                 if let currentId,
                     !currentId.isEmpty,
                     !candidates.contains(where: { $0.id == currentId })
@@ -3432,6 +3494,57 @@ struct AgentDetailView: View {
             .labelsHidden()
             .frame(maxWidth: 220, alignment: .trailing)
         }
+    }
+
+    /// The standard per-capability model-override picker for any chat-driven
+    /// kind that sets `supportsModelOverride` (computer_use / sandbox_reduce /
+    /// spawn). Empty selection = inherit the kind's default model source; the
+    /// empty-tag label is derived from the kind's `modelSource` ("Use persona's
+    /// model" for spawn, else "Inherit parent model") so the row needs no
+    /// per-kind copy. Lists chat-capable candidates; a stale stored id shows an
+    /// "(unavailable)" tag. Binds per-agent (custom) or to the global store
+    /// (main chat) via `subagentModelOverrideBinding`.
+    private func subagentModelOverrideRow(_ capability: SubagentCapability) -> some View {
+        let inheritLabel: LocalizedStringKey =
+            capability.modelSource == .persona ? "Use persona's model" : "Inherit parent model"
+        let selection = subagentModelOverrideBinding(for: capability.id)
+        return subagentModelPicker(
+            title: "Model",
+            selection: selection,
+            candidates: pickerItems.chatModelCandidates,
+            currentId: normalizedModelSelection(selection.wrappedValue),
+            emptyLabel: inheritLabel
+        )
+    }
+
+    /// Two-way binding into a capability's model override. Empty string clears
+    /// the override (inherit). Custom agents write `subagentModelOverrides`
+    /// (debounced agent save); the main chat writes the global store.
+    private func subagentModelOverrideBinding(for kindId: String) -> Binding<String> {
+        if isDefaultAgent {
+            return Binding(
+                get: { mainChatSubagentConfig.subagentModelOverrides[kindId] ?? "" },
+                set: { newValue in
+                    if let trimmed = normalizedModelSelection(newValue) {
+                        mainChatSubagentConfig.subagentModelOverrides[kindId] = trimmed
+                    } else {
+                        mainChatSubagentConfig.subagentModelOverrides.removeValue(forKey: kindId)
+                    }
+                    saveMainChatSubagentConfig()
+                }
+            )
+        }
+        return Binding(
+            get: { subagentModelOverrides[kindId] ?? "" },
+            set: { newValue in
+                if let trimmed = normalizedModelSelection(newValue) {
+                    subagentModelOverrides[kindId] = trimmed
+                } else {
+                    subagentModelOverrides.removeValue(forKey: kindId)
+                }
+                debouncedSave()
+            }
+        )
     }
 
     /// Segmented Ask / Deny / Always permission picker for a delegation kind,
@@ -5507,6 +5620,7 @@ struct AgentDetailView: View {
         imageEditModelId = agent.settings.imageEditModelId
         subagentPermissions = agent.settings.subagentPermissions
         subagentBudgets = agent.settings.subagentBudgets
+        subagentModelOverrides = agent.settings.subagentModelOverrides
         // The main chat (Default agent) binds its Sub-agents tab to the global
         // store; load it and derive the UI-only spawn-enable from a non-empty pool.
         mainChatSubagentConfig = SubagentConfigurationStore.snapshot()
@@ -5733,7 +5847,8 @@ struct AgentDetailView: View {
                 imageGenerationModelId: imageGenerationModelId,
                 imageEditModelId: imageEditModelId,
                 subagentPermissions: subagentPermissions,
-                subagentBudgets: subagentBudgets
+                subagentBudgets: subagentBudgets,
+                subagentModelOverrides: subagentModelOverrides
             ),
             order: current.order
         )

--- a/docs/SUBAGENT_PORTABLE_DESIGN.md
+++ b/docs/SUBAGENT_PORTABLE_DESIGN.md
@@ -34,13 +34,47 @@ configurable primitive. Almost everything needed already exists.
 > **`modelSource`** axis — `.dedicatedConfigured` (image: own configured default +
 > coordinator-owned residency), `.persona` (spawn: a chosen persona's local/remote
 > model; the kind runs the residency handoff), `.inheritsParent` (computer_use /
-> sandbox_reduce: reuse the parent model, no swap) — that documents the local-vs-remote
+> sandbox_reduce: the parent model is the DEFAULT) — that documents the local-vs-remote
 > model axis a future dedicated model-backed kind (e.g. an AppleScript generator)
 > drops into. The vestigial `needsHandoff` protocol field is gone: intent is expressed
 > by `modelSource`, and the actual swap is whether the kind overrides `makeHandoff()`
-> (default `PassthroughHandoff`). **Add-a-kind recipe:** (1) add a `SubagentCapability`
-> to the registry's `all`, (2) write the `SubagentKind` conformer that returns it, (3)
-> add a thin tool that builds the kind and calls `SubagentSession.run`. Per-kind
+> (default `PassthroughHandoff`).
+>
+> **Standard model picker + shared residency (2026-06-27).** `modelSource` is the
+> kind's **default** source only; picking the model a sub-agent runs on is now a
+> standard, override-aware axis. A per-capability override map —
+> `subagentModelOverrides[capabilityId]` on `AgentSettings` (custom) /
+> `SubagentConfiguration` (main chat), read by the single resolver
+> `SubagentToolVisibility.effectiveSubagentModel(...)` — supersedes the default for
+> `computer_use`, `sandbox_reduce`, and `spawn`. The three chat-driven kinds share
+> ONE resolution path, **`Subagent/SubagentModelResolution.swift`**, instead of
+> repeating the lookup/fallback/residency block: a pure
+> `pickModel(eval, availableOverride, default)` (precedence eval seam > available
+> override > kind default, blanks-as-absent, unit-testable), a
+> `@MainActor availableOverride(_:)` that **falls back to the default** when the
+> stored override is no longer installed / not in `ModelPickerItemCache` (cold cache
+> ⇒ trust the id) so a deleted model never hard-fails, and a live `resolve(...)`
+> that enforces the **eval-bypasses-residency invariant** (eval seam ⇒
+> `(isLocal:false, plan:.none)`, so deterministic lanes never depend on live GPU
+> residency) then delegates the swap to `Subagent/SubagentResidency.swift`. That
+> residency layer — a pure `decidePlan(...)` (no GPU, unit-testable) + a live
+> `resolve(...)` wrapper — implements "different local model than the resident chat
+> model ⇒ unload/reload, reject-before-evict when the handoff is off." So the
+> **resolved** model (not the static `modelSource`) drives the handoff:
+> `computer_use` / `sandbox_reduce` keep `.inheritsParent` (preserving the registry
+> assertions) yet vend a real `ResidencyHandoff` when an override selects a different
+> local model. The picker is **registry-driven** via
+> `SubagentCapability.supportsModelOverride` (true for `computer_use` / `spawn` /
+> `sandbox_reduce`): AgentsView renders the standard override row for any capability
+> with the flag set, with the empty-tag label derived from `modelSource`. `image`
+> sets `supportsModelOverride = false` and is **deliberately divergent** — it owns
+> its own model system (separate gen/edit ids via `effectiveImageModel`, readiness +
+> "first ready" fallback, coordinator-owned residency) and is NOT a
+> `SubagentModelResolution` client. **Add-a-kind recipe:** (1) add a
+> `SubagentCapability` to the registry's `all` (set `supportsModelOverride = true`
+> for a chat-driven kind to get the picker for free), (2) write the `SubagentKind`
+> conformer that returns it and resolves through `SubagentModelResolution.resolve`,
+> (3) add a thin tool that builds the kind and calls `SubagentSession.run`. Per-kind
 > permission lives in `SubagentPermissionDefaults`, now a `[kindId: policy]` map keyed
 > by `capability.id` (legacy top-level `spawn`/`image` keys migrate on decode), so a
 > new permissioned kind needs no new config field — it reads/writes its own id.

--- a/docs/SUBAGENT_TEAM_SPEC.md
+++ b/docs/SUBAGENT_TEAM_SPEC.md
@@ -23,6 +23,46 @@ This file is the spec + wiring contract for the current build.
 > default→global / custom→`AgentSettings`). The in-prompt first-use image-model picker is
 > gone (model lives in the tab). §2/§4/§6 below reflect this.
 
+> **Standard sub-agent model picker (2026-06-27).** Picking the model a sub-agent
+> runs on is now a **standard axis** of the framework, not a per-kind special case.
+> A per-capability override — `subagentModelOverrides[capabilityId]` on
+> `AgentSettings` (custom agents) / `SubagentConfiguration` (main chat), a
+> `[capabilityId: modelId]` map mirroring `subagentPermissions` — supersedes the
+> kind's default model source. One resolver reads it:
+> `SubagentToolVisibility.effectiveSubagentModel(capabilityId:isDefault:config:settings:)`
+> (blank/absent → inherit). Scope: `computer_use` + `sandbox_reduce` get new
+> pickers; `spawn` gets an optional override that supersedes the persona's model;
+> `image` keeps its own gen/edit pickers.
+>
+> **Hardening (2026-06-27).** The three chat-driven kinds now share ONE
+> resolution path, `Subagent/SubagentModelResolution.swift`, instead of repeating
+> the lookup/fallback/residency block inline:
+> - **Precedence** (`pickModel`, pure): eval seam > an *available* per-agent
+>   override > the kind default; blank/whitespace entries are treated as absent.
+> - **Availability fallback** (`availableOverride`, `@MainActor`): a stored
+>   override that is no longer installed locally / not in the
+>   `ModelPickerItemCache` resolves to `nil` so the kind inherits its default
+>   instead of hard-failing on a deleted model (a cold cache trusts the id).
+> - **Eval-bypasses-residency invariant**: when the eval seam forces a model the
+>   decision is always `(isLocal: false, plan: .none)`, so a deterministic lane
+>   never depends on live GPU residency.
+> - **Residency**: it then calls the shared residency layer
+>   (`Subagent/SubagentResidency.swift`) — when the resolved model is a DIFFERENT
+>   local bundle than the resident chat model it unloads/reloads exactly like
+>   `spawn` (reject-before-evict if Local Orchestrator Handoff is off).
+>
+> The picker is **registry-driven**: `SubagentCapability.supportsModelOverride`
+> (true for `computer_use` / `spawn` / `sandbox_reduce`; false for `image`) makes
+> AgentsView render the standard override row automatically, with the empty-tag
+> label derived from `modelSource` ("Use persona's model" for `spawn`, else
+> "Inherit parent model"). A new chat-driven kind gets a picker by only flipping
+> the flag. `image` sets it false because it owns its own model system (separate
+> gen/edit ids via `effectiveImageModel`, readiness + "first ready" fallback,
+> coordinator-owned residency) and is NOT a `SubagentModelResolution` client.
+> Pickers live in each agent's **Sub-agents** tab (`sandbox_reduce` via a
+> non-toggle "Investigation" panel shown when the sandbox is on). §1's table + the
+> `modelSource` note below reflect this.
+
 > **No master switch + no Spawn tab (2026-06-26, supersedes every "master switch /
 > `agentDelegationEnabled` / global enable / Settings → Spawn tab" reference below,
 > including §2's gate #1 and §4's `agentDelegationExcludedToolNames`).** The global
@@ -52,19 +92,23 @@ result → defer-cleanup):
 
 | Kind | Tool | Runner | Returns | `modelSource` → handoff |
 |------|------|--------|---------|--------------------------|
-| `TextSubagentKind` | `spawn` | `AgentSubagentRunner` → `AgentToolLoop` on a persona's model | text digest | `.persona` — a local persona model unloads/reloads the local orchestrator (the kind's `makeHandoff()` vends a `ResidencyHandoff`) |
+| `TextSubagentKind` | `spawn` | `AgentSubagentRunner` → `AgentToolLoop` on a persona's model | text digest | `.persona` default (+ optional `spawn` override); a DIFFERENT local model unloads/reloads the local orchestrator via the shared `SubagentResidency` layer |
 | `ImageSubagentKind` | `image` | `NativeImageJobCoordinator` → `ImageGenerationService` (vMLXFlux); `source_paths` ⇒ edit | artifact | `.dedicatedConfigured` — the coordinator owns image-model residency (kind keeps the passthrough default) |
-| `ComputerUseKind` | `computer_use` | `ComputerUseLoop` (+ per-action confirm gate) | summary | `.inheritsParent` — no swap (passthrough) |
-| `SandboxReduceKind` | `sandbox_reduce` | `AgentToolLoop` with a read/search/exec allowlist | digest | `.inheritsParent` — no swap (passthrough) |
+| `ComputerUseKind` | `computer_use` | `ComputerUseLoop` (+ per-action confirm gate) | summary | `.inheritsParent` default (+ optional `computer_use` override); a DIFFERENT local model unloads/reloads via the shared `SubagentResidency` layer |
+| `SandboxReduceKind` | `sandbox_reduce` | `AgentToolLoop` with a read/search/exec allowlist | digest | `.inheritsParent` default (+ optional `sandbox_reduce` override); a DIFFERENT local model unloads/reloads via the shared `SubagentResidency` layer |
 | privacy loop · code exec · browser · … | — | their own kind | their result | future |
 
-> **`modelSource` axis.** A kind declares how it resolves the model it runs:
-> `.dedicatedConfigured` (own configured default + coordinator-owned residency),
-> `.persona` (a chosen persona's local/remote model; the kind runs the residency
-> handoff), or `.inheritsParent` (reuses the parent agent's model, no residency
-> change). It documents the local-vs-remote axis a future dedicated model-backed
-> kind (e.g. an AppleScript generator) slots into, and matches whether the kind
-> overrides `makeHandoff()`.
+> **`modelSource` axis (the DEFAULT source, not the final model).** A kind declares
+> how it DEFAULTS to sourcing its model: `.dedicatedConfigured` (own configured
+> default + coordinator-owned residency), `.persona` (a chosen persona's
+> local/remote model), or `.inheritsParent` (reuses the parent agent's model). It
+> documents the local-vs-remote axis a future dedicated model-backed kind (e.g. an
+> AppleScript generator) slots into. The **resolved** model is now override-aware
+> (`effectiveSubagentModel` > the `modelSource` default), and the handoff is driven
+> by that resolved model through the shared `SubagentResidency` layer — NOT by the
+> static `modelSource`. So `computer_use` / `sandbox_reduce` keep `.inheritsParent`
+> (their default, preserving the registry assertions) yet now vend a
+> `ResidencyHandoff` when an override picks a different local model.
 
 Reuse, don't reinvent: `AgentToolLoop` (`Services/Chat/AgentToolLoop.swift`),
 `sandbox_reduce` (`docs/REDUCTION_SUBAGENT.md`), Computer Use Subagent (PR #1578).
@@ -143,21 +187,47 @@ restore-on-failure (orchestrator never left unloaded).
   descriptor are one value. (`needsHandoff` is gone — intent is the descriptor's
   `modelSource`, and the actual swap is whether the kind overrides `makeHandoff()`.)
 - **`Subagent/ResidencyHandoff.swift`** — the optional handoff middleware
-  (`SubagentHandoff`); only model-swapping kinds override `makeHandoff()` to vend a
-  real `ResidencyHandoff` (today `spawn`, via its `.persona` model source). It builds
-  on `Services/AgentDelegation/ChatResidencyHandoff.swift` (wait-idle → unload
-  resident chat models → memoryPreflight → reload). Kinds that keep the
-  `PassthroughHandoff` default (`computer_use`, `sandbox_reduce`, and `image` —
-  whose coordinator owns its own residency) skip it.
+  (`SubagentHandoff`); model-swapping kinds override `makeHandoff()` to vend a real
+  `ResidencyHandoff`. Today every chat-driven kind (`spawn`, `computer_use`,
+  `sandbox_reduce`) can, because the model is override-aware. It builds on
+  `Services/AgentDelegation/ChatResidencyHandoff.swift` (wait-idle → unload resident
+  chat models → memoryPreflight → reload). A kind vends `PassthroughHandoff` when no
+  swap is needed (parent/persona model, a remote override, or the same local model
+  already resident); `image` keeps the passthrough default (its coordinator owns
+  image-model residency).
+- **`Subagent/SubagentResidency.swift`** — the **shared residency decision** every
+  chat-driven kind uses (extracted from `TextSubagentKind`'s old inline block). A
+  pure `decidePlan(...)` (no `ModelRuntime`/`ModelManager`, so unit-testable with no
+  GPU) encodes the control flow — remote ⇒ none, same-as-resident ⇒ none,
+  different-local + handoff-off ⇒ `throw .denied` (reject-before-evict), different-
+  local + handoff-on ⇒ unload plan — and a live `resolve(...)` wrapper reads the
+  installed bundle + resident chat models and feeds it. `handoff(for:)` maps the
+  resolved plan onto the middleware (a real `ResidencyHandoff` or `PassthroughHandoff`).
+- **`Subagent/SubagentModelResolution.swift`** — the **shared model-resolution
+  path** for the chat-driven kinds (`spawn`, `computer_use`, `sandbox_reduce`), so
+  they no longer repeat the override-lookup → default → residency block inline. A
+  pure `pickModel(eval, availableOverride, default)` (eval > available override >
+  default, blanks-as-absent; unit-testable), a `@MainActor availableOverride(_:)`
+  that drops a stored override that's no longer installed / not in
+  `ModelPickerItemCache` (cold cache ⇒ trust the id) so a deleted model gracefully
+  inherits the default, and a live `resolve(...)` that folds in the per-agent
+  override + the **eval-bypasses-residency** invariant (eval seam ⇒
+  `(isLocal:false, plan:.none)`) then calls `SubagentResidency.resolve`. Returns
+  `(model, decision)`; the kind stores `decision.plan` for `makeHandoff()`. `image`
+  is NOT a client (own model system).
 - **`Subagent/SubagentFeed.swift`** — `SubagentFeed` / `SubagentActivityEvent` /
   `SubagentFeedRegistry` / `SubagentInterruptCenter`: one live progress + interrupt
   surface for all kinds (text spawn included). `NativeToolCallGroupView` binds it.
 - **`Subagent/SubagentCapabilityRegistry.swift`** — the per-kind `SubagentCapability`
   descriptor (SSOT): `id` + `toolNames` + `gate` (+ `perAgentFlag`) + `modelSource` +
-  `displayLabel`/`iconName` + `guidance*`. Drives `resolveTools`/`ToolRegistry`
-  gating, the AgentsView per-agent toggle, the feed header + tool chip, and the
-  prompt guidance loop, plus the `SubagentToolVisibility` resolver shared by the
-  composer and the HTTP surface.
+  `supportsModelOverride` + `displayLabel`/`iconName` + `guidance*`. Drives
+  `resolveTools`/`ToolRegistry` gating, the AgentsView per-agent toggle + the
+  registry-driven model-override row (`supportsModelOverride`; `capability(forPerAgentFlag:)`
+  maps a toggle to its descriptor), the feed header + tool chip, and the prompt
+  guidance loop, plus the `SubagentToolVisibility` resolver shared by the composer
+  and the HTTP surface. `supportsModelOverride` is true for `computer_use` / `spawn`
+  / `sandbox_reduce` and false for `image` (which owns its own gen/edit model
+  system, so it is not a `SubagentModelResolution` client).
 
 ### Dispatch / runners
 - **`Tools/SpawnTool.swift`** — the `spawn(agent, input)` tool → `TextSubagentKind`.
@@ -167,8 +237,9 @@ restore-on-failure (orchestrator never left unloaded).
   prompt/model/tools → compact envelope. Used by `TextSubagentKind` (`local_delegate`
   is gone — its body lived here and is now spawn's only path).
 - **`Tools/SandboxReduceTool.swift`** — the `sandbox_reduce` tool → `SandboxReduceKind`
-  (read/search/exec allowlist on `AgentToolLoop`, `modelSource = .inheritsParent` →
-  passthrough handoff).
+  (read/search/exec allowlist on `AgentToolLoop`, `modelSource = .inheritsParent`
+  default + optional `sandbox_reduce` override → shared `SubagentResidency` handoff;
+  the eval `modelOverride` seam keeps the prior passthrough).
 - `Services/Chat/AgentToolLoop.swift` — the bounded loop driver (reused).
 
 ### Image kind (engine-specific, same handoff/progress)
@@ -182,9 +253,11 @@ restore-on-failure (orchestrator never left unloaded).
 
 ### Computer-use kind
 - `ComputerUse/Tool/ComputerUseTool.swift` + `ComputerUse/Loop/ComputerUseLoop.swift`
-  → `ComputerUseKind` (`modelSource = .inheritsParent` → passthrough handoff, host
-  permission `.auto`; keeps its own per-action confirm gate). Adopts the shared
-  feed/registry + compact-result contract.
+  → `ComputerUseKind` (`modelSource = .inheritsParent` default + optional
+  `computer_use` override → shared `SubagentResidency` handoff; the `VisionContext`
+  is recomputed from the RESOLVED model so screenshot escalation tracks the chosen
+  model; host permission `.auto`; keeps its own per-action confirm gate). Adopts the
+  shared feed/registry + compact-result contract.
 
 ### Personas / config / runtime (reused, existing)
 - `Models/Agent/Agent.swift` + `Managers/AgentManager.swift` — persona name/model
@@ -194,7 +267,9 @@ restore-on-failure (orchestrator never left unloaded).
   `imageEnabled` (image is its own per-agent toggle, no longer riding the spawn flag),
   and — added 2026-06-26 — `imageGenerationModelId` / `imageEditModelId` (`String?`),
   `subagentPermissions` (`SubagentPermissionDefaults`), and `subagentBudgets`
-  (`SubagentBudgets`). `effectiveCapabilities(for:)` carries `imageEnabled` +
+  (`SubagentBudgets`); added 2026-06-27 — `subagentModelOverrides`
+  (`[capabilityId: modelId]`, the per-capability model picker, mirroring
+  `subagentPermissions`). `effectiveCapabilities(for:)` carries `imageEnabled` +
   `spawnableAgentNames` through to the snapshot the visibility resolvers read; the model /
   permission / budget fields are read live at the kind via the effective-settings
   resolvers (below).
@@ -204,16 +279,19 @@ restore-on-failure (orchestrator never left unloaded).
   main-chat** values: default image gen/edit models, per-kind permission
   (`SubagentPermissionDefaults` is a `[kindId: policy]` map keyed by `capability.id`,
   ask/deny/always — a kind absent from the map defaults to `.ask`, so a new permissioned
-  kind needs no new struct field), budgets, `imageDelegationEnabled`, and
-  `spawnableAgentNames` (the main chat's pool). These also back the REST `/v1/images`
+  kind needs no new struct field), budgets, `imageDelegationEnabled`,
+  `spawnableAgentNames` (the main chat's pool), and — added 2026-06-27 —
+  `subagentModelOverrides` (the main chat's `[capabilityId: modelId]` map, used by
+  `spawn`; normalized to drop blanks). These also back the REST `/v1/images`
   default. Custom agents override the model / permission / budget values from their own
   `AgentSettings`. Persists to `agent-delegation.json`; broadcasts
   `.subagentConfigurationChanged`.
 - `Subagent/SubagentCapabilityRegistry.swift` — `SubagentToolVisibility` also hosts the
   pure **effective-settings resolvers** (`effectiveImageModel` / `effectivePermission` /
-  `effectiveBudgets`): **Default → global `SubagentConfiguration`; custom →
-  `AgentSettings`** (nil image model → first-ready fallback; missing permission → `.ask`).
-  Each kind reads these so the Default-vs-custom branch lives in one tested place.
+  `effectiveBudgets` / `effectiveSubagentModel`): **Default → global
+  `SubagentConfiguration`; custom → `AgentSettings`** (nil image model → first-ready
+  fallback; missing permission → `.ask`; blank/absent model override → inherit). Each
+  kind reads these so the Default-vs-custom branch lives in one tested place.
 - `Services/ModelRuntime.swift` — load/unload/`preload`/`cachedModelSummaries`, the
   model-fit refusal; `Services/ModelRuntime/MetalGate.swift` — GPU owner-keyed gate.
 
@@ -224,10 +302,19 @@ restore-on-failure (orchestrator never left unloaded).
   tool-name sets are DERIVED from `SubagentCapabilityRegistry` (no hand-maintained list).
 - `Views/Agent/AgentsView.swift` — per-agent sub-agent controls live in the dedicated
   **`DetailTab.subagents`** ("Sub-agents") tab, rendered registry-driven (one card per
-  `SubagentCapabilityRegistry.perAgentToggleFlags` entry: `computer_use` →
-  autonomy-ceiling, `spawn` → per-agent spawnable checklist + permission picker + budget
-  steppers, `image` → gen/edit model pickers + permission picker) with each card's config
-  in an inline DisclosureGroup. The tab is **shown for the Default agent too** (2026-06-26):
+  `SubagentCapabilityRegistry.perAgentToggleFlags` entry: `computer_use` → autonomy
+  ceiling, `spawn` → per-agent spawnable checklist + permission picker + budget steppers,
+  `image` → gen/edit model pickers + permission picker) with each card's config in an
+  inline panel. The standard model-override row is rendered **generically** above each
+  card's kind-specific config whenever its descriptor sets `supportsModelOverride`
+  (resolved via `capability(forPerAgentFlag:)`), so the per-kind arms no longer hand-wire
+  it — a new chat-driven kind gets the picker for free. One
+  `subagentModelOverrideRow(_ capability:)` draws it (chat candidates from
+  `pickerItems.chatModelCandidates`; the empty-tag label is derived from `modelSource` —
+  "Use persona's model" for `spawn`, else "Inherit parent model"). `sandbox_reduce` has
+  no per-agent toggle, so it gets a non-toggle "Investigation" panel reusing the same row,
+  shown when the agent's sandbox (`effectiveAutonomousExec`) is on AND
+  `sandboxReduce.supportsModelOverride`. The tab is **shown for the Default agent too** (2026-06-26):
   it renders only the Spawn + Image cards (no `computer_use`), bound to the global
   `SubagentConfiguration` via `SubagentConfigurationStore` (the main chat's settings still
   live there). Custom-agent cards write `AgentSettings` via `debouncedSave()`; the main
@@ -267,8 +354,11 @@ denoise step counter (k/N). Re-entrancy: a subprocess cannot `spawn`.
   `resolveModel` / `permission` / `run` (override `makeHandoff()` only if it swaps
   models) + one thin tool that builds the kind and calls `SubagentSession.run`. The
   host gives you scope ids, recursion guard, feed/interrupt, the (optional) handoff,
-  and the compact-result envelope for free. A dedicated model-backed kind (e.g. an
-  AppleScript generator on a local or remote model) is exactly this recipe with
-  `modelSource = .dedicatedConfigured` or `.persona`. Do NOT add recursive agents,
-  helper LLMs, or shell workers inside a kind — it is normal Swift service code
-  driving one bounded job.
+  and the compact-result envelope for free. A chat-driven kind also gets the standard
+  per-agent model picker for free by setting `supportsModelOverride = true` and
+  resolving through `SubagentModelResolution.resolve(...)` (precedence + availability
+  fallback + the eval-bypasses-residency invariant + the shared residency handoff); a
+  dedicated model-backed kind (e.g. an AppleScript generator on a local or remote model)
+  is exactly this recipe with `modelSource = .dedicatedConfigured` or `.persona`. Do NOT
+  add recursive agents, helper LLMs, or shell workers inside a kind — it is normal Swift
+  service code driving one bounded job.


### PR DESCRIPTION
## Summary

Picking the model a sub-agent runs on is now a standard axis of the sub-agent framework. Previously `computer_use` and `sandbox_reduce` were locked to the parent agent's model and `spawn` to the persona's model. Each agent can now choose a per-capability run model from its **Sub-agents** tab, with a graceful fallback to the kind's default when no override is set.

The three chat-driven kinds (`computer_use`, `spawn`, `sandbox_reduce`) share one resolution + residency path instead of repeating it inline:

- **`SubagentModelResolution`** — pure precedence (eval seam > an *available* per-agent override > the kind default, blanks treated as absent), a `@MainActor` availability gate that inherits the default when a stored override is no longer installed / disconnected (cold cache trusts the id), and the uniform **eval-bypasses-residency** invariant.
- **`SubagentResidency`** — the single unload/reload handoff decision (reject-before-evict) when the resolved model is a *different* local bundle than the resident chat model.

The picker is **registry-driven**: `SubagentCapability.supportsModelOverride` makes `AgentsView` render the override row automatically (empty-tag label derived from `modelSource`), so a new chat-driven kind gets a picker by only flipping the flag. `image` opts out (`supportsModelOverride = false`) — it deliberately keeps its own dedicated gen/edit model system. Also reaches parity on the override maps (decode normalization/round-trip) and adds the `model` field to the `sandbox_reduce` digest.

No behavior change when no override is set.

## Changes

- [x] Behavior change
- [x] UI change (Sub-agents tab model pickers)
- [x] Refactor / chore
- [x] Tests
- [x] Docs

## Test Plan

- `make test` (keychain-disabled per `AGENTS.md`):
  ```
  OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test \
    swift test --package-path Packages/OsaurusCore --filter \
    'SubagentModelResolutionTests|SubagentCapabilityRegistryTests|AgentSettingsCodableTests|SubagentConfigurationTests|SubagentResidencyTests|SubagentModelOverrideResolverTests|SubagentModelPickerTests|SpawnToolTests|SubagentJobEvaluatorSeedTests|SandboxReduceToolTests'
  ```
  All green. New coverage: `pickModel` precedence + availability fallback, the eval-bypasses-residency invariant, `supportsModelOverride` per kind, and a blank override entry dropped on decode.
- `swift build --package-path Packages/OsaurusCore` — clean.
- Manual: open an agent's Sub-agents tab, set a `computer_use` / `spawn` / `sandbox_reduce` model, confirm a different local model triggers the orchestrator handoff and an unset/blank pick inherits the default.

## Screenshots

UI adds a "Model" row (chat-capable candidates; "Inherit parent model" / "Use persona's model" empty tag) to each chat-driven sub-agent card plus a non-toggle "Investigation" panel for `sandbox_reduce`. Will attach before/after on request.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+ (validated via `swift build` + `swift test`; not run through the full Xcode app build)

Made with [Cursor](https://cursor.com)