### PR TITLE
Add tool result grounding evals

### DIFF
--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -29,6 +29,7 @@ Packages/OsaurusEvals/
     StreamingHint/      — StreamingToolHint encode/decode round-trips
     Subagent/           — SubagentSession host: scripted model-free + live spawn/image/computer_use/sandbox_reduce
     ToolEnvelope/       — ToolEnvelope.{success,failure} JSON shape
+    ToolResultGrounding/ — transcript fixtures checking final-answer grounding against tool results
 ```
 
 A "suite" is just a directory of `*.json` case files. Add a new case by dropping a JSON file in — no Swift edit required.

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -393,6 +393,11 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// `maximum` rules from regressing.
         public let schema: SchemaExpectations?
         public let toolEnvelope: ToolEnvelopeExpectations?
+        /// Transcript-grounding expectation for `domain == "tool_result_grounding"`.
+        /// Pure-data: replays a frozen tool-call/result/final-answer transcript
+        /// and scores whether the final answer is grounded in the named tool
+        /// result rather than tool-call arguments.
+        public let toolResultGrounding: ToolResultGroundingExpectations?
         public let streamingHint: StreamingHintExpectations?
         public let prefixHash: PrefixHashExpectations?
         public let argumentCoercion: ArgumentCoercionExpectations?
@@ -462,6 +467,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         public init(
             schema: SchemaExpectations? = nil,
             toolEnvelope: ToolEnvelopeExpectations? = nil,
+            toolResultGrounding: ToolResultGroundingExpectations? = nil,
             streamingHint: StreamingHintExpectations? = nil,
             prefixHash: PrefixHashExpectations? = nil,
             argumentCoercion: ArgumentCoercionExpectations? = nil,
@@ -478,6 +484,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         ) {
             self.schema = schema
             self.toolEnvelope = toolEnvelope
+            self.toolResultGrounding = toolResultGrounding
             self.streamingHint = streamingHint
             self.prefixHash = prefixHash
             self.argumentCoercion = argumentCoercion
@@ -491,6 +498,83 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.defaultAgent = defaultAgent
             self.screenContext = screenContext
             self.subagent = subagent
+        }
+    }
+
+    /// Expectation for `domain == "tool_result_grounding"` cases. The runner
+    /// does not call a model. It scores a committed transcript fixture so proof
+    /// artifacts can state: a tool was called, a result was returned, the final
+    /// answer happened after that result, and specific answer fragments came
+    /// from the result payload rather than from call arguments.
+    public struct ToolResultGroundingExpectations: Sendable, Codable {
+        public let events: [Event]
+        public let assertions: [Assertion]
+        /// Default true: the scored assistant answer must appear after at least
+        /// one tool result. Set false only for negative/unit fixtures.
+        public let requireFinalAfterToolResults: Bool?
+        /// Default true: every tool result must match a prior tool call by id.
+        public let requireMatchedResults: Bool?
+
+        public init(
+            events: [Event],
+            assertions: [Assertion],
+            requireFinalAfterToolResults: Bool? = nil,
+            requireMatchedResults: Bool? = nil
+        ) {
+            self.events = events
+            self.assertions = assertions
+            self.requireFinalAfterToolResults = requireFinalAfterToolResults
+            self.requireMatchedResults = requireMatchedResults
+        }
+
+        public struct Event: Sendable, Codable {
+            public let kind: String
+            public let callId: String?
+            public let tool: String?
+            public let arguments: String?
+            public let content: String?
+
+            public init(
+                kind: String,
+                callId: String? = nil,
+                tool: String? = nil,
+                arguments: String? = nil,
+                content: String? = nil
+            ) {
+                self.kind = kind
+                self.callId = callId
+                self.tool = tool
+                self.arguments = arguments
+                self.content = content
+            }
+        }
+
+        public struct Assertion: Sendable, Codable {
+            /// The tool result that grounds this assertion.
+            public let callId: String
+            /// Every fragment must appear in the final answer and in the named
+            /// result payload. This makes "answer copied from arguments" fail.
+            public let answerMustContain: [String]?
+            /// Every fragment must be absent from the final answer.
+            public let answerMustNotContain: [String]?
+            /// Every fragment must appear in the named result payload.
+            public let resultMustContain: [String]?
+            /// Every fragment must be absent from the original tool arguments.
+            public let argumentsMustNotContain: [String]?
+
+            public init(
+                callId: String,
+                answerMustContain: [String]? = nil,
+                answerMustNotContain: [String]? = nil,
+                resultMustContain: [String]? = nil,
+                argumentsMustNotContain: [String]? = nil
+            ) {
+                self.callId = callId
+                self.answerMustContain = answerMustContain
+                self.answerMustNotContain = answerMustNotContain
+                self.resultMustContain = resultMustContain
+                self.argumentsMustNotContain = argumentsMustNotContain
+            }
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -271,6 +271,8 @@ public enum EvalRunner {
             return runSchemaCase(testCase, modelId: modelId)
         case "tool_envelope":
             return runToolEnvelopeCase(testCase, modelId: modelId)
+        case "tool_result_grounding":
+            return runToolResultGroundingCase(testCase, modelId: modelId)
         case "streaming_hint":
             return runStreamingHintCase(testCase, modelId: modelId)
         case "prefix_hash":

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerToolResultGrounding.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerToolResultGrounding.swift
@@ -1,0 +1,225 @@
+//
+//  EvalRunnerToolResultGrounding.swift
+//  OsaurusEvalsKit
+//
+//  Pure-data scoring for frozen tool-call/result transcripts. This lane
+//  gives runtime-proof artifacts a deterministic way to show that the final
+//  answer used the tool result payload, not stale prompt text or call args.
+//
+
+import Foundation
+
+extension EvalRunner {
+    static func runToolResultGroundingCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let exp = testCase.expect.toolResultGrounding else {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .errored,
+                notes: ["missing `expect.toolResultGrounding`"],
+                modelId: modelId
+            )
+        }
+
+        let parsed = parseToolResultGroundingEvents(exp.events)
+        if !parsed.errors.isEmpty {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .errored,
+                notes: parsed.errors,
+                modelId: modelId
+            )
+        }
+
+        var notes: [String] = []
+        let requireMatchedResults = exp.requireMatchedResults ?? true
+        if requireMatchedResults {
+            for result in parsed.results.values.sorted(by: { $0.index < $1.index }) {
+                guard let call = parsed.calls[result.callId] else {
+                    notes.append("tool result \(result.callId) has no prior matching tool call")
+                    continue
+                }
+                if result.index < call.index {
+                    notes.append("tool result \(result.callId) appears before its matching tool call")
+                }
+                if let resultTool = result.tool, resultTool != call.tool {
+                    notes.append(
+                        "tool result \(result.callId) tool mismatch: call \(call.tool), result \(resultTool)"
+                    )
+                }
+            }
+        }
+
+        guard let final = parsed.finalAssistant else {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .failed,
+                notes: notes + ["no final assistant message to score"],
+                modelId: modelId
+            )
+        }
+
+        if exp.requireFinalAfterToolResults ?? true {
+            let anyPriorResult = parsed.results.values.contains { $0.index < final.index }
+            if !anyPriorResult {
+                notes.append("final answer appeared before any tool result")
+            }
+        }
+
+        for assertion in exp.assertions {
+            guard let result = parsed.results[assertion.callId] else {
+                notes.append("assertion references missing tool result \(assertion.callId)")
+                continue
+            }
+            let call = parsed.calls[assertion.callId]
+            if result.index > final.index {
+                notes.append("asserted tool result \(assertion.callId) appears after the final answer")
+            }
+
+            for fragment in assertion.resultMustContain ?? [] {
+                if !result.content.contains(fragment) {
+                    notes.append("result \(assertion.callId) missing required fragment `\(fragment)`")
+                }
+            }
+            for fragment in assertion.answerMustContain ?? [] {
+                if !final.content.contains(fragment) {
+                    notes.append("final answer missing required fragment `\(fragment)`")
+                }
+                if !result.content.contains(fragment) {
+                    notes.append(
+                        "required answer fragment `\(fragment)` is not present in result \(assertion.callId)"
+                    )
+                }
+                if call?.arguments?.contains(fragment) == true {
+                    notes.append(
+                        "required answer fragment `\(fragment)` was already present in tool call \(assertion.callId) arguments"
+                    )
+                }
+            }
+            for fragment in assertion.answerMustNotContain ?? [] {
+                if final.content.contains(fragment) {
+                    notes.append("final answer contains forbidden fragment `\(fragment)`")
+                }
+            }
+            for fragment in assertion.argumentsMustNotContain ?? [] {
+                if call?.arguments?.contains(fragment) == true {
+                    notes.append("tool call \(assertion.callId) arguments contain forbidden fragment `\(fragment)`")
+                }
+            }
+        }
+
+        let passed = notes.isEmpty
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: passed ? .passed : .failed,
+            notes: passed
+                ? ["grounded \(exp.assertions.count) assertion(s) across \(parsed.results.count) tool result(s)"]
+                : notes,
+            modelId: modelId
+        )
+    }
+
+    private static func parseToolResultGroundingEvents(
+        _ events: [EvalCase.ToolResultGroundingExpectations.Event]
+    ) -> GroundingParse {
+        var calls: [String: GroundingCall] = [:]
+        var results: [String: GroundingResult] = [:]
+        var finalAssistant: GroundingAssistant?
+        var errors: [String] = []
+
+        for (index, event) in events.enumerated() {
+            switch normalizedGroundingKind(event.kind) {
+            case "toolcall":
+                guard let callId = nonEmpty(event.callId), let tool = nonEmpty(event.tool) else {
+                    errors.append("event \(index) toolCall needs non-empty callId and tool")
+                    continue
+                }
+                if calls[callId] != nil {
+                    errors.append("event \(index) duplicates toolCall id \(callId)")
+                    continue
+                }
+                calls[callId] = GroundingCall(
+                    callId: callId,
+                    tool: tool,
+                    arguments: event.arguments,
+                    index: index
+                )
+            case "toolresult":
+                guard let callId = nonEmpty(event.callId), let content = event.content else {
+                    errors.append("event \(index) toolResult needs non-empty callId and content")
+                    continue
+                }
+                if results[callId] != nil {
+                    errors.append("event \(index) duplicates toolResult id \(callId)")
+                    continue
+                }
+                results[callId] = GroundingResult(
+                    callId: callId,
+                    tool: event.tool,
+                    content: content,
+                    index: index
+                )
+            case "assistant":
+                guard let content = event.content else {
+                    errors.append("event \(index) assistant needs content")
+                    continue
+                }
+                finalAssistant = GroundingAssistant(content: content, index: index)
+            default:
+                errors.append("event \(index) has unknown kind `\(event.kind)`")
+            }
+        }
+
+        return GroundingParse(
+            calls: calls,
+            results: results,
+            finalAssistant: finalAssistant,
+            errors: errors
+        )
+    }
+
+    private static func normalizedGroundingKind(_ raw: String) -> String {
+        raw.lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+    }
+
+    private static func nonEmpty(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return raw
+    }
+
+    private struct GroundingParse {
+        var calls: [String: GroundingCall]
+        var results: [String: GroundingResult]
+        var finalAssistant: GroundingAssistant?
+        var errors: [String]
+    }
+
+    private struct GroundingCall {
+        var callId: String
+        var tool: String
+        var arguments: String?
+        var index: Int
+    }
+
+    private struct GroundingResult {
+        var callId: String
+        var tool: String?
+        var content: String
+        var index: Int
+    }
+
+    private struct GroundingAssistant {
+        var content: String
+        var index: Int
+    }
+}

--- a/Packages/OsaurusEvals/Suites/ToolResultGrounding/README.md
+++ b/Packages/OsaurusEvals/Suites/ToolResultGrounding/README.md
@@ -1,0 +1,36 @@
+# ToolResultGrounding suite
+
+Pure-data transcript checks for model/tool reliability artifacts. Each case
+freezes a tool-call/result/final-answer sequence and asserts that the final
+answer uses fragments from the named tool result, not tool-call arguments.
+
+This suite does not call a model and does not touch UI. It is meant to make
+runtime proof rows reviewable after a live run has produced a transcript-shaped
+artifact.
+
+## Running
+
+```bash
+swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+  --suite Packages/OsaurusEvals/Suites/ToolResultGrounding \
+  --model auto
+```
+
+`--model` is ignored by the scorer; `auto` keeps local configuration unchanged.
+
+## Case schema
+
+Use `expect.toolResultGrounding.events` to list `toolCall`, `toolResult`, and
+`assistant` events in transcript order. Use `assertions` to bind a final-answer
+fragment to the result `callId` it must come from.
+
+Important fields:
+
+- `answerMustContain`: fragments that must appear in the final answer and in
+  the named tool result, and must not already appear in the matching tool-call
+  arguments.
+- `answerMustNotContain`: stale or fabricated fragments that must stay out of
+  the final answer.
+- `resultMustContain`: fragments that must be present in the tool result.
+- `argumentsMustNotContain`: fragments that must not have been available in the
+  original tool-call arguments.

--- a/Packages/OsaurusEvals/Suites/ToolResultGrounding/latest-result-wins.json
+++ b/Packages/OsaurusEvals/Suites/ToolResultGrounding/latest-result-wins.json
@@ -1,0 +1,50 @@
+{
+  "id": "tool_result_grounding.latest-result-wins",
+  "domain": "tool_result_grounding",
+  "label": "tool result grounding: latest result beats stale earlier data",
+  "query": "Read the status twice and report the current release gate.",
+  "fixtures": {},
+  "expect": {
+    "toolResultGrounding": {
+      "events": [
+        {
+          "kind": "toolCall",
+          "callId": "read-previous",
+          "tool": "file_read",
+          "arguments": "{\"path\":\"status.txt\"}"
+        },
+        {
+          "kind": "toolResult",
+          "callId": "read-previous",
+          "tool": "file_read",
+          "content": "release gate: green-17\n"
+        },
+        {
+          "kind": "toolCall",
+          "callId": "read-latest",
+          "tool": "file_read",
+          "arguments": "{\"path\":\"status.txt\",\"fresh\":true}"
+        },
+        {
+          "kind": "toolResult",
+          "callId": "read-latest",
+          "tool": "file_read",
+          "content": "release gate: amber-42\n"
+        },
+        {
+          "kind": "assistant",
+          "content": "The current release gate is amber-42."
+        }
+      ],
+      "assertions": [
+        {
+          "callId": "read-latest",
+          "answerMustContain": ["amber-42"],
+          "answerMustNotContain": ["green-17"],
+          "resultMustContain": ["release gate: amber-42"],
+          "argumentsMustNotContain": ["amber-42"]
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ToolResultGrounding/result-continuation.json
+++ b/Packages/OsaurusEvals/Suites/ToolResultGrounding/result-continuation.json
@@ -1,0 +1,37 @@
+{
+  "id": "tool_result_grounding.result-continuation",
+  "domain": "tool_result_grounding",
+  "label": "tool result grounding: final answer continues from executed result",
+  "query": "Summarize the blocker counts after running the project report tool.",
+  "fixtures": {},
+  "expect": {
+    "toolResultGrounding": {
+      "events": [
+        {
+          "kind": "toolCall",
+          "callId": "report-1",
+          "tool": "project_status",
+          "arguments": "{\"scope\":\"release\",\"format\":\"summary\"}"
+        },
+        {
+          "kind": "toolResult",
+          "callId": "report-1",
+          "tool": "project_status",
+          "content": "{\"ok\":true,\"summary\":\"3 blocked, 2 ready\",\"owner\":\"runtime\"}"
+        },
+        {
+          "kind": "assistant",
+          "content": "The release report shows 3 blocked, 2 ready."
+        }
+      ],
+      "assertions": [
+        {
+          "callId": "report-1",
+          "answerMustContain": ["3 blocked, 2 ready"],
+          "resultMustContain": ["\"summary\":\"3 blocked, 2 ready\""],
+          "argumentsMustNotContain": ["3 blocked", "2 ready"]
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolResultGroundingTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolResultGroundingTests.swift
@@ -1,0 +1,220 @@
+//
+//  ToolResultGroundingTests.swift
+//  OsaurusEvalsKitTests
+//
+//  Model-free coverage for transcript fixtures that prove final answers are
+//  grounded in tool results rather than stale prompt text or call arguments.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+@MainActor
+struct ToolResultGroundingTests {
+    private typealias Grounding = EvalCase.ToolResultGroundingExpectations
+    private typealias Event = EvalCase.ToolResultGroundingExpectations.Event
+    private typealias Assertion = EvalCase.ToolResultGroundingExpectations.Assertion
+
+    @Test func groundedTranscriptPasses() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read", arguments: "{\"path\":\"state.txt\"}"),
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                    Event(kind: "assistant", content: "The current state is ready-9."),
+                ],
+                assertions: [
+                    Assertion(
+                        callId: "call-1",
+                        answerMustContain: ["ready-9"],
+                        resultMustContain: ["state: ready-9"],
+                        argumentsMustNotContain: ["ready-9"]
+                    )
+                ]
+            )
+        )
+
+        #expect(report.outcome == .passed, "notes: \(report.notes)")
+    }
+
+    @Test func staleFinalAnswerFails() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read", arguments: "{\"path\":\"state.txt\"}"),
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                    Event(kind: "assistant", content: "The current state is stale-4."),
+                ],
+                assertions: [
+                    Assertion(
+                        callId: "call-1",
+                        answerMustContain: ["ready-9"],
+                        answerMustNotContain: ["stale-4"],
+                        resultMustContain: ["state: ready-9"]
+                    )
+                ]
+            )
+        )
+
+        #expect(report.outcome == .failed)
+        #expect(report.notes.contains { $0.contains("missing required fragment") })
+        #expect(report.notes.contains { $0.contains("forbidden fragment") })
+    }
+
+    @Test func answerFragmentCopiedFromArgumentsFails() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(
+                        kind: "toolCall",
+                        callId: "call-1",
+                        tool: "file_read",
+                        arguments: "{\"path\":\"state.txt\",\"expected\":\"ready-9\"}"
+                    ),
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                    Event(kind: "assistant", content: "The current state is ready-9."),
+                ],
+                assertions: [
+                    Assertion(callId: "call-1", answerMustContain: ["ready-9"])
+                ]
+            )
+        )
+
+        #expect(report.outcome == .failed)
+        #expect(report.notes.contains { $0.contains("already present in tool call") })
+    }
+
+    @Test func unmatchedToolResultFails() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                    Event(kind: "assistant", content: "The current state is ready-9."),
+                ],
+                assertions: [
+                    Assertion(callId: "call-1", answerMustContain: ["ready-9"])
+                ]
+            )
+        )
+
+        #expect(report.outcome == .failed)
+        #expect(report.notes.contains { $0.contains("no prior matching tool call") })
+    }
+
+    @Test func finalBeforeResultFails() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "assistant", content: "The current state is ready-9."),
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read", arguments: "{\"path\":\"state.txt\"}"),
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                ],
+                assertions: [
+                    Assertion(callId: "call-1", answerMustContain: ["ready-9"])
+                ]
+            )
+        )
+
+        #expect(report.outcome == .failed)
+        #expect(report.notes.contains { $0.contains("before any tool result") })
+    }
+
+    @Test func assertedResultAfterFinalFails() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolCall", callId: "older", tool: "file_read", arguments: "{\"path\":\"old.txt\"}"),
+                    Event(kind: "toolResult", callId: "older", tool: "file_read", content: "state: old-1\n"),
+                    Event(kind: "assistant", content: "The current state is ready-9."),
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read", arguments: "{\"path\":\"state.txt\"}"),
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                ],
+                assertions: [
+                    Assertion(callId: "call-1", answerMustContain: ["ready-9"])
+                ]
+            )
+        )
+
+        #expect(report.outcome == .failed)
+        #expect(report.notes.contains { $0.contains("appears after the final answer") })
+    }
+
+    @Test func resultBeforeCallFails() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolResult", callId: "call-1", tool: "file_read", content: "state: ready-9\n"),
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read", arguments: "{\"path\":\"state.txt\"}"),
+                    Event(kind: "assistant", content: "The current state is ready-9."),
+                ],
+                assertions: [
+                    Assertion(callId: "call-1", answerMustContain: ["ready-9"])
+                ]
+            )
+        )
+
+        #expect(report.outcome == .failed)
+        #expect(report.notes.contains { $0.contains("appears before its matching tool call") })
+    }
+
+    @Test func malformedEventErrors() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolCall", callId: nil, tool: "file_read"),
+                    Event(kind: "assistant", content: "No result."),
+                ],
+                assertions: []
+            )
+        )
+
+        #expect(report.outcome == .errored)
+        #expect(report.notes.contains { $0.contains("toolCall needs") })
+    }
+
+    @Test func duplicateCallIdErrors() {
+        let report = score(
+            Grounding(
+                events: [
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read"),
+                    Event(kind: "toolCall", callId: "call-1", tool: "file_read"),
+                    Event(kind: "assistant", content: "No result."),
+                ],
+                assertions: []
+            )
+        )
+
+        #expect(report.outcome == .errored)
+        #expect(report.notes.contains { $0.contains("duplicates toolCall id") })
+    }
+
+    @Test func suiteDecodesAndPasses() throws {
+        let suiteDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // OsaurusEvalsKitTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // OsaurusEvals
+            .appendingPathComponent("Suites/ToolResultGrounding", isDirectory: true)
+
+        let suite = try EvalSuite.load(from: suiteDir)
+        #expect(suite.decodeFailures.isEmpty, "decode failures: \(suite.decodeFailures)")
+        #expect(suite.cases.count == 2)
+        for testCase in suite.cases {
+            #expect(testCase.domain == "tool_result_grounding")
+            let report = EvalRunner.runToolResultGroundingCase(testCase, modelId: "fixture")
+            #expect(report.outcome == .passed, "\(testCase.id) notes: \(report.notes)")
+        }
+    }
+
+    private func score(_ expectation: Grounding) -> EvalCaseReport {
+        let testCase = EvalCase(
+            id: "tool_result_grounding.test",
+            domain: "tool_result_grounding",
+            query: "q",
+            fixtures: .init(),
+            expect: .init(toolResultGrounding: expectation)
+        )
+        return EvalRunner.runToolResultGroundingCase(testCase, modelId: "fixture")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a model-free `tool_result_grounding` eval domain for frozen tool-call/result/final-answer transcripts.
- Adds fixture cases checking that final answers use tool result payloads instead of stale earlier tool results or tool-call arguments.
- Tightens transcript scoring for matching call/result order, duplicate call IDs, asserted-result ordering, and answer fragments copied from arguments.
- Documents the suite so runtime proof artifacts can attach deterministic grounding evidence after a live run produces a transcript-shaped artifact.

## Validation
- `swiftc -parse Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerToolResultGrounding.swift Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolResultGroundingTests.swift`
- `python3 -m json.tool Packages/OsaurusEvals/Suites/ToolResultGrounding/latest-result-wins.json`
- `python3 -m json.tool Packages/OsaurusEvals/Suites/ToolResultGrounding/result-continuation.json`
- `git diff --check`
- GitHub CI: test-core, test-cli, swiftlint, shellcheck, and release drafter are green on `d07557fb`.

## Notes
- Local focused `swift test --package-path Packages/OsaurusEvals --filter ToolResultGroundingTests` was attempted, but local SwiftPM dependency checkout stalled before tests ran on external MLX submodules. GitHub CI completed the full required test lane successfully.