### PR TITLE
Recover chat continuation from transcript fallback

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -22,7 +22,8 @@ enum ChatSessionStore {
     /// Load a specific session by ID
     static func load(id: UUID) -> ChatSessionData? {
         ensureOpen()
-        return ChatHistoryDatabase.shared.loadSession(id: id)
+        guard let session = ChatHistoryDatabase.shared.loadSession(id: id) else { return nil }
+        return recoverTranscriptTurnsIfNeeded(session)
     }
 
     /// Save a session (creates or updates)
@@ -101,6 +102,64 @@ enum ChatSessionStore {
             print("[ChatSessionStore] Failed to open chat-history database: \(error)")
             return
         }
+    }
+
+    static func recoverTranscriptTurnsIfNeeded(
+        _ session: ChatSessionData,
+        memoryDatabase: MemoryDatabase = .shared
+    ) -> ChatSessionData {
+        guard session.turns.isEmpty else { return session }
+        // Keep launch/load paths non-invasive: transcript fallback never opens
+        // Memory on behalf of chat history, because that may touch Keychain.
+        guard memoryDatabase.isOpen else { return session }
+
+        do {
+            let transcript = try memoryDatabase.loadTranscriptForConversation(
+                conversationId: session.id.uuidString
+            )
+            let recoveredTurns = transcript.compactMap(chatTurnData(from:))
+            guard !recoveredTurns.isEmpty else { return session }
+
+            var recovered = session
+            // Read-only compatibility fallback. Do not write these turns back to
+            // chat-history here; recovery should not mutate storage during load.
+            recovered.turns = recoveredTurns
+            return recovered
+        } catch {
+            print("[ChatSessionStore] Transcript recovery failed for session \(session.id): \(error)")
+            return session
+        }
+    }
+
+    private static func chatTurnData(from transcriptTurn: TranscriptTurn) -> ChatTurnData? {
+        let trimmedContent = transcriptTurn.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedContent.isEmpty else { return nil }
+        guard let role = MessageRole(rawValue: transcriptTurn.role) else { return nil }
+
+        return ChatTurnData(
+            role: role,
+            content: transcriptTurn.content,
+            createdAt: transcriptDate(from: transcriptTurn.createdAt)
+        )
+    }
+
+    private static func transcriptDate(from raw: String) -> Date? {
+        guard !raw.isEmpty else { return nil }
+
+        let iso8601Formatter = ISO8601DateFormatter()
+        if let date = iso8601Formatter.date(from: raw) {
+            return date
+        }
+        iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso8601Formatter.date(from: raw) {
+            return date
+        }
+
+        let sqliteFormatter = DateFormatter()
+        sqliteFormatter.locale = Locale(identifier: "en_US_POSIX")
+        sqliteFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        sqliteFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return sqliteFormatter.date(from: raw)
     }
 
     #if DEBUG

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreTranscriptRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreTranscriptRecoveryTests.swift
@@ -1,0 +1,136 @@
+//
+//  ChatSessionStoreTranscriptRecoveryTests.swift
+//  osaurus
+//
+//  Regression coverage for recovering chat-history sessions whose turn rows
+//  are missing while Memory still has transcript turns for the same session.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ChatSessionStoreTranscriptRecoveryTests {
+    @Test func emptySessionHydratesTurnsFromMemoryTranscript() throws {
+        let db = MemoryDatabase()
+        try db.openInMemory()
+        defer { db.close() }
+
+        let sessionId = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        let agentId = UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!
+        try db.insertTranscriptTurn(
+            agentId: agentId.uuidString,
+            conversationId: sessionId.uuidString,
+            chunkIndex: 1,
+            role: "assistant",
+            content: "Yes, from the transcript fallback.",
+            tokenCount: 6,
+            title: "Recovered chat",
+            createdAt: "2026-06-28 12:00:05"
+        )
+        try db.insertTranscriptTurn(
+            agentId: agentId.uuidString,
+            conversationId: sessionId.uuidString,
+            chunkIndex: 0,
+            role: "user",
+            content: "Can you recover this?",
+            tokenCount: 4,
+            title: "Recovered chat",
+            createdAt: "2026-06-28T12:00:00.123Z"
+        )
+
+        let session = ChatSessionData(
+            id: sessionId,
+            title: "Recovered chat",
+            turns: [],
+            agentId: agentId
+        )
+
+        let recovered = ChatSessionStore.recoverTranscriptTurnsIfNeeded(
+            session,
+            memoryDatabase: db
+        )
+
+        #expect(recovered.turns.map(\.role) == [.user, .assistant])
+        #expect(recovered.turns.map(\.content) == [
+            "Can you recover this?",
+            "Yes, from the transcript fallback.",
+        ])
+        #expect(recovered.turns[0].createdAt != nil)
+        #expect(recovered.turns[1].createdAt != nil)
+    }
+
+    @Test func transcriptRecoveryDoesNotOpenClosedMemoryDatabase() throws {
+        let db = MemoryDatabase()
+        let session = ChatSessionData(id: UUID(), turns: [])
+
+        let recovered = ChatSessionStore.recoverTranscriptTurnsIfNeeded(
+            session,
+            memoryDatabase: db
+        )
+
+        #expect(recovered.turns.isEmpty)
+        #expect(!db.isOpen)
+    }
+
+    @Test func existingChatHistoryTurnsWinOverTranscriptFallback() throws {
+        let db = MemoryDatabase()
+        try db.openInMemory()
+        defer { db.close() }
+
+        let sessionId = UUID(uuidString: "22222222-3333-4444-5555-666666666666")!
+        try db.insertTranscriptTurn(
+            agentId: Agent.defaultId.uuidString,
+            conversationId: sessionId.uuidString,
+            chunkIndex: 0,
+            role: "user",
+            content: "transcript should not replace this",
+            tokenCount: 5
+        )
+
+        let existingTurn = ChatTurnData(role: .user, content: "chat history wins")
+        let session = ChatSessionData(id: sessionId, turns: [existingTurn])
+
+        let recovered = ChatSessionStore.recoverTranscriptTurnsIfNeeded(
+            session,
+            memoryDatabase: db
+        )
+
+        #expect(recovered.turns.map(\.content) == ["chat history wins"])
+    }
+
+    @Test func transcriptRecoverySkipsBlankAndUnknownRoles() throws {
+        let db = MemoryDatabase()
+        try db.openInMemory()
+        defer { db.close() }
+
+        let sessionId = UUID(uuidString: "33333333-4444-5555-6666-777777777777")!
+        try db.insertTranscriptTurn(
+            agentId: Agent.defaultId.uuidString,
+            conversationId: sessionId.uuidString,
+            chunkIndex: 0,
+            role: "developer",
+            content: "unsupported role",
+            tokenCount: 2
+        )
+        try db.insertTranscriptTurn(
+            agentId: Agent.defaultId.uuidString,
+            conversationId: sessionId.uuidString,
+            chunkIndex: 1,
+            role: "assistant",
+            content: "   ",
+            tokenCount: 0
+        )
+
+        let session = ChatSessionData(id: sessionId, turns: [])
+
+        let recovered = ChatSessionStore.recoverTranscriptTurnsIfNeeded(
+            session,
+            memoryDatabase: db
+        )
+
+        #expect(recovered.turns.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- recover empty chat-history sessions from already-open Memory transcript rows when chat history has no turns
- keep recovery read-only: it does not open Memory storage, touch Keychain, or backfill chat history during load
- parse fractional ISO timestamps, preserve transcript ordering, and skip blank or unknown roles

## Validation
- `git diff --cached --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-chat-recovery swift test --skip-update --scratch-path /Users/mmeding/Developer/Claude/Projects/osaurus/Packages/OsaurusCore/.build --package-path Packages/OsaurusCore --filter ChatSessionStoreTranscriptRecoveryTests`
- Review findings incorporated: read-only fallback comment, closed-database coverage, ordering coverage, and fractional-date coverage.

## Risk
- Recovery only applies when Memory storage is already open; closed storage intentionally returns the original session.
