### PR TITLE
Add redacted provider request diagnostics

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -293,6 +293,7 @@ public final class RemoteProviderManager: ObservableObject {
         var state = providerStates[providerId] ?? RemoteProviderState(providerId: providerId)
         state.isConnecting = true
         state.lastError = nil
+        state.lastReplayDiagnostics = nil
         providerStates[providerId] = state
 
         do {
@@ -354,6 +355,7 @@ public final class RemoteProviderManager: ObservableObject {
             state.discoveredModels = models
             state.lastConnectedAt = Date()
             state.lastError = nil
+            state.lastReplayDiagnostics = nil
             providerStates[providerId] = state
 
             print("[Osaurus] Remote Provider '\(provider.name)': Connected with \(models.count) models")
@@ -367,6 +369,7 @@ public final class RemoteProviderManager: ObservableObject {
             state.isConnecting = false
             state.isConnected = false
             state.lastError = errorMessage
+            state.lastReplayDiagnostics = (error as? RemoteProviderServiceError)?.replayDiagnostics
             state.discoveredModels = []
             providerStates[providerId] = state
 
@@ -558,7 +561,8 @@ public final class RemoteProviderManager: ObservableObject {
             switch serviceError {
             case .invalidResponse:
                 return true
-            case .invalidURL, .notConnected, .requestFailed, .streamingError, .noModelsAvailable:
+            case .invalidURL, .notConnected, .requestFailed, .requestFailedWithDiagnostics,
+                .streamingError, .noModelsAvailable:
                 return false
             }
         }
@@ -908,25 +912,53 @@ public final class RemoteProviderManager: ObservableObject {
 
         do {
             let (data, response): (Data, URLResponse)
-            if let override = testConnectionTransportOverride {
-                (data, response) = try await override(request)
-            } else {
-                (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
+            do {
+                if let override = testConnectionTransportOverride {
+                    (data, response) = try await override(request)
+                } else {
+                    (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
+                }
+            } catch {
+                let diagnostics = ProviderReplayDiagnosticBundle(
+                    phase: "test_model_discovery",
+                    request: request,
+                    transportError: error,
+                    configuredSecretHeaderKeys: tempProvider.secretHeaderKeys
+                )
+                throw RemoteProviderServiceError.requestFailedWithDiagnostics(
+                    "Network error: \(ProviderDiagnosticRedactor.safe(error.localizedDescription, maxLength: 240))",
+                    diagnostics
+                )
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 print("[Osaurus] Test Connection: Invalid response type")
-                throw RemoteProviderError.connectionFailed("Invalid response")
+                let diagnostics = ProviderReplayDiagnosticBundle(
+                    phase: "test_model_discovery",
+                    request: request,
+                    configuredSecretHeaderKeys: tempProvider.secretHeaderKeys
+                )
+                throw RemoteProviderServiceError.invalidResponse.attachingReplayDiagnostics(diagnostics)
             }
 
             print("[Osaurus] Test Connection: HTTP \(httpResponse.statusCode)")
+            let diagnostics = ProviderReplayDiagnosticBundle(
+                phase: "test_model_discovery",
+                request: request,
+                response: httpResponse,
+                responseData: data,
+                configuredSecretHeaderKeys: tempProvider.secretHeaderKeys
+            )
 
             // Parse models response based on provider type
             if providerType == .gemini {
                 if httpResponse.statusCode >= 400 {
                     let errorMessage = extractErrorMessage(from: data, statusCode: httpResponse.statusCode)
                     print("[Osaurus] Test Connection: Error response: \(errorMessage)")
-                    throw RemoteProviderError.connectionFailed(errorMessage)
+                    throw RemoteProviderServiceError.requestFailedWithDiagnostics(
+                        ProviderDiagnosticRedactor.safe(errorMessage, maxLength: 500),
+                        diagnostics
+                    )
                 }
 
                 let modelsResponse = try JSONDecoder().decode(GeminiModelsResponse.self, from: data)
@@ -939,14 +971,26 @@ public final class RemoteProviderManager: ObservableObject {
                 print("[Osaurus] Test Connection (Gemini): Success - found \(models.count) models")
                 return models
             } else {
-                let models = try RemoteProviderService.decodeOpenAICompatibleModelsResponse(
-                    data: data,
-                    statusCode: httpResponse.statusCode,
-                    provider: tempProvider
-                )
+                let models: [String]
+                do {
+                    models = try RemoteProviderService.decodeOpenAICompatibleModelsResponse(
+                        data: data,
+                        statusCode: httpResponse.statusCode,
+                        provider: tempProvider
+                    )
+                } catch let error as RemoteProviderServiceError {
+                    throw error.attachingReplayDiagnostics(diagnostics)
+                } catch {
+                    throw RemoteProviderServiceError.requestFailedWithDiagnostics(
+                        "Invalid /models response: \(ProviderDiagnosticRedactor.safe(error.localizedDescription, maxLength: 240))",
+                        diagnostics
+                    )
+                }
                 print("[Osaurus] Test Connection: Success - found \(models.count) models")
                 return models
             }
+        } catch let error as RemoteProviderServiceError {
+            throw error
         } catch let error as RemoteProviderError {
             throw error
         } catch {

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -38,7 +38,9 @@ enum RemoteProviderHeaderRedactor {
     private static let exactSensitiveHeaderNames: Set<String> = [
         "authorization",
         "api-key",
+        "cookie",
         "proxy-authorization",
+        "set-cookie",
         "x-api-key",
         "x-goog-api-key",
     ]
@@ -452,6 +454,7 @@ public struct RemoteProviderState: Sendable {
     public var isConnected: Bool
     public var isConnecting: Bool
     public var lastError: String?
+    public var lastReplayDiagnostics: ProviderReplayDiagnosticBundle?
     public var discoveredModels: [String]
     public var lastConnectedAt: Date?
 
@@ -460,6 +463,7 @@ public struct RemoteProviderState: Sendable {
         self.isConnected = false
         self.isConnecting = false
         self.lastError = nil
+        self.lastReplayDiagnostics = nil
         self.discoveredModels = []
         self.lastConnectedAt = nil
     }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -21316,6 +21316,28 @@
         }
       }
     },
+    "Copy diagnostics and include this redacted request/response evidence with the report." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kopiere die Diagnosedaten und füge diesen geschwärzten Anfrage-/Antwortnachweis in den Bericht ein."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "진단 정보를 복사하고 이 수정된 요청/응답 증거를 보고서에 포함하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "复制诊断信息，并在报告中包含这份已遮盖的请求/响应证据。"
+          }
+        }
+      }
+    },
     "Copy Image" : {
       "localizations" : {
         "de" : {
@@ -70120,6 +70142,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请求格式"
+          }
+        }
+      }
+    },
+    "Request evidence" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anfragenachweis"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "요청 증거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "请求证据"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -104,6 +104,9 @@ public enum ProviderNetworkDiagnostics {
         ) {
             rows.append(oauthContext)
         }
+        if let replay = remoteReplayDiagnosticsRow(state: state) {
+            rows.append(replay)
+        }
         rows.append(
             contentsOf: [
                 remoteModelDiscoveryRow(provider: provider),
@@ -398,6 +401,18 @@ public enum ProviderNetworkDiagnostics {
         )
     }
 
+    private static func remoteReplayDiagnosticsRow(state: RemoteProviderState?) -> ProviderDiagnosticRow? {
+        guard let diagnostics = state?.lastReplayDiagnostics else { return nil }
+        return ProviderDiagnosticRow(
+            id: "request-evidence",
+            title: L("Request evidence"),
+            value: diagnostics.summary,
+            severity: .warning,
+            detail: diagnostics.pasteboardText,
+            action: L("Copy diagnostics and include this redacted request/response evidence with the report.")
+        )
+    }
+
     private static func remoteRequestFormatRow(provider: RemoteProvider) -> ProviderDiagnosticRow {
         ProviderDiagnosticRow(
             id: "format",
@@ -677,6 +692,6 @@ public enum ProviderNetworkDiagnostics {
     }
 
     private static func safeDiagnostic(_ raw: String) -> String {
-        OpenAICodexOAuthService.safeDiagnosticFragment(raw, maxLength: 280)
+        ProviderDiagnosticRedactor.safe(raw, maxLength: 280)
     }
 }

--- a/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
@@ -1,0 +1,258 @@
+//
+//  ProviderReplayDiagnostics.swift
+//  osaurus
+//
+//  Redacted request/response evidence for provider connectivity failures.
+//
+
+import Foundation
+
+public struct ProviderReplayDiagnosticHeader: Sendable, Equatable {
+    public let name: String
+    public let value: String
+}
+
+public struct ProviderReplayDiagnosticRequest: Sendable, Equatable {
+    public let method: String
+    public let url: String
+    public let timeout: TimeInterval
+    public let headers: [ProviderReplayDiagnosticHeader]
+    public let body: String?
+}
+
+public struct ProviderReplayDiagnosticResponse: Sendable, Equatable {
+    public let statusCode: Int
+    public let url: String
+    public let headers: [ProviderReplayDiagnosticHeader]
+    public let body: String?
+}
+
+public struct ProviderReplayDiagnosticBundle: Sendable, Equatable {
+    public let phase: String
+    public let request: ProviderReplayDiagnosticRequest
+    public let response: ProviderReplayDiagnosticResponse?
+    public let transportError: String?
+
+    public init(
+        phase: String,
+        request: URLRequest,
+        response: HTTPURLResponse? = nil,
+        responseData: Data? = nil,
+        transportError: Error? = nil,
+        configuredSecretHeaderKeys: [String] = []
+    ) {
+        self.phase = ProviderDiagnosticRedactor.safe(phase, maxLength: 120)
+        self.request = ProviderReplayDiagnosticRequest(
+            method: request.httpMethod ?? "GET",
+            url: ProviderDiagnosticRedactor.redactedURLString(request.url),
+            timeout: request.timeoutInterval,
+            headers: ProviderDiagnosticRedactor.redactedHeaderList(
+                request.allHTTPHeaderFields ?? [:],
+                configuredSecretHeaderKeys: configuredSecretHeaderKeys
+            ),
+            body: ProviderDiagnosticRedactor.redactedBodyExcerpt(request.httpBody)
+        )
+        self.response = response.map { httpResponse in
+            ProviderReplayDiagnosticResponse(
+                statusCode: httpResponse.statusCode,
+                url: ProviderDiagnosticRedactor.redactedURLString(httpResponse.url),
+                headers: ProviderDiagnosticRedactor.redactedHeaderList(
+                    httpResponse.allHeaderFields.reduce(into: [String: String]()) { result, pair in
+                        guard let name = pair.key as? String else { return }
+                        result[name] = String(describing: pair.value)
+                    },
+                    configuredSecretHeaderKeys: configuredSecretHeaderKeys
+                ),
+                body: ProviderDiagnosticRedactor.redactedBodyExcerpt(responseData)
+            )
+        }
+        self.transportError = transportError.map {
+            ProviderDiagnosticRedactor.safe($0.localizedDescription, maxLength: 500)
+        }
+    }
+
+    public var summary: String {
+        if let response {
+            return "\(request.method) \(request.url) -> HTTP \(response.statusCode)"
+        }
+        if transportError != nil {
+            return "\(request.method) \(request.url) -> transport error"
+        }
+        return "\(request.method) \(request.url)"
+    }
+
+    public var pasteboardText: String {
+        var lines = [
+            "Provider request evidence:",
+            "phase: \(phase)",
+            "request: \(request.method) \(request.url)",
+            "request_timeout_seconds: \(formatSeconds(request.timeout))",
+            "request_headers: \(formatHeaders(request.headers))",
+        ]
+        if let body = request.body {
+            lines.append("request_body: \(body)")
+        }
+        if let response {
+            lines.append("response: HTTP \(response.statusCode) \(response.url)")
+            lines.append("response_headers: \(formatHeaders(response.headers))")
+            if let body = response.body {
+                lines.append("response_body: \(body)")
+            }
+        }
+        if let transportError {
+            lines.append("transport_error: \(transportError)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func formatSeconds(_ value: TimeInterval) -> String {
+        if value.isFinite {
+            return String(format: "%.1f", value)
+        }
+        return "unbounded"
+    }
+
+    private func formatHeaders(_ headers: [ProviderReplayDiagnosticHeader]) -> String {
+        guard !headers.isEmpty else { return "none" }
+        return headers
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+    }
+}
+
+enum ProviderDiagnosticRedactor {
+    private static let sensitiveFieldNames: Set<String> = [
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "client_secret",
+        "code",
+        "code_verifier",
+        "id_token",
+        "key",
+        "password",
+        "refresh_token",
+        "secret",
+        "token",
+        "verifier",
+    ]
+
+    static func redactedURLString(_ url: URL?) -> String {
+        guard let url else { return "unknown" }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return safe(url.absoluteString, maxLength: 700)
+        }
+
+        if components.user?.isEmpty == false {
+            components.user = "***"
+        }
+        if components.password?.isEmpty == false {
+            components.password = "***"
+        }
+        if let queryItems = components.queryItems {
+            components.queryItems = queryItems.map { item in
+                guard isSensitiveFieldName(item.name) else { return item }
+                return URLQueryItem(name: item.name, value: "***")
+            }
+        }
+
+        return safe(components.url?.absoluteString ?? url.absoluteString, maxLength: 700)
+    }
+
+    static func redactedHeaderList(
+        _ headers: [String: String],
+        configuredSecretHeaderKeys: [String] = []
+    ) -> [ProviderReplayDiagnosticHeader] {
+        headers
+            .map { name, value in
+                let redacted = RemoteProviderHeaderRedactor.valueForLogging(
+                    headerName: name,
+                    value: value,
+                    configuredSecretHeaderKeys: configuredSecretHeaderKeys
+                )
+                return ProviderReplayDiagnosticHeader(
+                    name: safe(name, maxLength: 120),
+                    value: redacted == RemoteProviderHeaderRedactor.redactedValue
+                        ? redacted
+                        : safe(redacted, maxLength: 300)
+                )
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    static func redactedBodyExcerpt(_ data: Data?, maxBytes: Int = 1600) -> String? {
+        guard let data, !data.isEmpty else { return nil }
+        let excerptData = Data(data.prefix(maxBytes))
+        let raw =
+            String(data: excerptData, encoding: .utf8)
+            ?? excerptData.map { String(format: "%02x", $0) }.joined()
+        let suffix = data.count > maxBytes ? " ... [truncated \(data.count - maxBytes) bytes]" : ""
+        return safe(raw, maxLength: maxBytes) + suffix
+    }
+
+    static func safe(_ raw: String, maxLength: Int = 700) -> String {
+        var value = raw
+        let replacements: [(pattern: String, template: String)] = [
+            (#"(?i)\b(authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?[^\s,;}]+\"?"#, "$1=***"),
+            (#"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+"#, "$1 ***"),
+            (
+                #"(?i)\"(access_token|refresh_token|id_token|code_verifier|code|verifier|client_secret|api_key|apikey|password|secret|token|key)\"\s*:\s*\"[^\"]*\""#,
+                #""$1":"***""#
+            ),
+            (
+                #"(?i)\b(access_token|refresh_token|id_token|code_verifier|code|verifier|client_secret|api_key|apikey|password|secret|token|key)\s*=\s*([^&\s,;}]+)"#,
+                "$1=***"
+            ),
+            (#"(?i)\b(api[-_]?key|x[-_]?api[-_]?key|x[-_]?goog[-_]?api[-_]?key|password|secret|token|client_secret)\s*:\s*([^\s,;}]+)"#, "$1=***"),
+            (#"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"#, "jwt=***"),
+            (#"\bsk-[A-Za-z0-9._-]{8,}\b"#, "sk-***"),
+            (#"\bosk-[A-Za-z0-9._-]{8,}\b"#, "osk-***"),
+        ]
+
+        for replacement in replacements {
+            value = replaceMatches(
+                in: value,
+                pattern: replacement.pattern,
+                template: replacement.template
+            )
+        }
+
+        value = value
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        while value.contains("  ") {
+            value = value.replacingOccurrences(of: "  ", with: " ")
+        }
+        guard !value.isEmpty else { return "No details returned" }
+        guard value.count > maxLength else { return value }
+        return String(value.prefix(maxLength)) + "..."
+    }
+
+    private static func isSensitiveFieldName(_ name: String) -> Bool {
+        let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return false }
+        if sensitiveFieldNames.contains(normalized) {
+            return true
+        }
+        return normalized.contains("token")
+            || normalized.contains("secret")
+            || normalized.contains("password")
+            || normalized.contains("api_key")
+            || normalized.contains("apikey")
+    }
+
+    private static func replaceMatches(
+        in value: String,
+        pattern: String,
+        template: String
+    ) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return value }
+        let range = NSRange(value.startIndex..., in: value)
+        return regex.stringByReplacingMatches(in: value, range: range, withTemplate: template)
+    }
+}

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -19,6 +19,7 @@ public enum RemoteProviderServiceError: LocalizedError {
     case invalidURL
     case notConnected
     case requestFailed(String)
+    case requestFailedWithDiagnostics(String, ProviderReplayDiagnosticBundle)
     case invalidResponse
     case streamingError(String)
     case noModelsAvailable
@@ -30,7 +31,11 @@ public enum RemoteProviderServiceError: LocalizedError {
         case .notConnected:
             return L("Provider is not connected")
         case .requestFailed(let message):
-            return L("Request failed: \(message)")
+            return L("Request failed: \(ProviderDiagnosticRedactor.safe(message, maxLength: 500))")
+        case .requestFailedWithDiagnostics(let message, let diagnostics):
+            return L(
+                "Request failed: \(ProviderDiagnosticRedactor.safe(message, maxLength: 500)). Redacted request evidence: \(diagnostics.summary)"
+            )
         case .invalidResponse:
             return L("Invalid response from provider")
         case .streamingError(let message):
@@ -44,6 +49,27 @@ public enum RemoteProviderServiceError: LocalizedError {
         guard case .streamingError(let message) = self else { return false }
         return message.contains("mid-argument")
             || message.contains("arguments were complete")
+    }
+
+    public var replayDiagnostics: ProviderReplayDiagnosticBundle? {
+        guard case .requestFailedWithDiagnostics(_, let diagnostics) = self else { return nil }
+        return diagnostics
+    }
+
+    func attachingReplayDiagnostics(_ diagnostics: ProviderReplayDiagnosticBundle) -> RemoteProviderServiceError {
+        switch self {
+        case .requestFailed(let message):
+            return .requestFailedWithDiagnostics(
+                ProviderDiagnosticRedactor.safe(message, maxLength: 500),
+                diagnostics
+            )
+        case .invalidResponse:
+            return .requestFailedWithDiagnostics("Invalid response from provider", diagnostics)
+        case .requestFailedWithDiagnostics:
+            return self
+        case .invalidURL, .notConnected, .streamingError, .noModelsAvailable:
+            return self
+        }
     }
 }
 
@@ -4246,17 +4272,53 @@ extension RemoteProviderService {
             timeout: provider.timeout
         )
 
-        let (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw RemoteProviderServiceError.invalidResponse
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
+        } catch {
+            let diagnostics = ProviderReplayDiagnosticBundle(
+                phase: "model_discovery",
+                request: request,
+                transportError: error,
+                configuredSecretHeaderKeys: provider.secretHeaderKeys
+            )
+            throw RemoteProviderServiceError.requestFailedWithDiagnostics(
+                "Network error: \(ProviderDiagnosticRedactor.safe(error.localizedDescription, maxLength: 240))",
+                diagnostics
+            )
         }
 
-        return try decodeOpenAICompatibleModelsResponse(
-            data: data,
-            statusCode: httpResponse.statusCode,
-            provider: provider
+        guard let httpResponse = response as? HTTPURLResponse else {
+            let diagnostics = ProviderReplayDiagnosticBundle(
+                phase: "model_discovery",
+                request: request,
+                configuredSecretHeaderKeys: provider.secretHeaderKeys
+            )
+            throw RemoteProviderServiceError.invalidResponse.attachingReplayDiagnostics(diagnostics)
+        }
+
+        let diagnostics = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: request,
+            response: httpResponse,
+            responseData: data,
+            configuredSecretHeaderKeys: provider.secretHeaderKeys
         )
+        do {
+            return try decodeOpenAICompatibleModelsResponse(
+                data: data,
+                statusCode: httpResponse.statusCode,
+                provider: provider
+            )
+        } catch let error as RemoteProviderServiceError {
+            throw error.attachingReplayDiagnostics(diagnostics)
+        } catch {
+            throw RemoteProviderServiceError.requestFailedWithDiagnostics(
+                "Invalid /models response: \(ProviderDiagnosticRedactor.safe(error.localizedDescription, maxLength: 240))",
+                diagnostics
+            )
+        }
     }
 
     static func decodeOpenAICompatibleModelsResponse(

--- a/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
@@ -102,7 +102,10 @@ struct RemoteProviderManagerConnectivityCenterTests {
     @Test func testConnectionUsesManualModelsWhenModelsEndpointIsMissing() async throws {
         try await RemoteProviderTestLock.shared.run {
             let manager = RemoteProviderManager.shared
-            defer { manager._testRemoveProviders(ids: []) }
+            defer {
+                manager.testConnectionTransportOverride = nil
+                manager._testRemoveProviders(ids: [])
+            }
 
             manager.testConnectionTransportOverride = { request in
                 #expect(request.url?.absoluteString == "https://api.example.test/v1/models")
@@ -132,9 +135,12 @@ struct RemoteProviderManagerConnectivityCenterTests {
     }
 
     @Test func testConnectionStillFailsWithoutManualModelsOnServerError() async throws {
-        try await RemoteProviderTestLock.shared.run {
+        await RemoteProviderTestLock.shared.run {
             let manager = RemoteProviderManager.shared
-            defer { manager._testRemoveProviders(ids: []) }
+            defer {
+                manager.testConnectionTransportOverride = nil
+                manager._testRemoveProviders(ids: [])
+            }
 
             manager.testConnectionTransportOverride = { request in
                 let response = HTTPURLResponse(
@@ -146,8 +152,8 @@ struct RemoteProviderManagerConnectivityCenterTests {
                 return (Data(#"{"error":{"message":"boom"}}"#.utf8), response)
             }
 
-            await #expect(throws: RemoteProviderError.self) {
-                try await manager.testConnection(
+            do {
+                _ = try await manager.testConnection(
                     host: "api.example.test",
                     providerProtocol: .https,
                     port: nil,
@@ -158,6 +164,17 @@ struct RemoteProviderManagerConnectivityCenterTests {
                     headers: [:],
                     manualModelIds: ["local-chat"]
                 )
+                Issue.record("Expected server error to fail instead of falling back to manual models.")
+            } catch let error as RemoteProviderServiceError {
+                guard case .requestFailedWithDiagnostics(let message, let diagnostics) = error else {
+                    Issue.record("Expected replay diagnostics, got \(error).")
+                    return
+                }
+                #expect(message.contains("boom"))
+                #expect(diagnostics.phase == "test_model_discovery")
+                #expect(diagnostics.response?.statusCode == 500)
+            } catch {
+                Issue.record("Expected RemoteProviderServiceError, got \(error).")
             }
         }
     }

--- a/Packages/OsaurusCore/Tests/Provider/ProviderReplayDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderReplayDiagnosticsTests.swift
@@ -1,0 +1,166 @@
+//
+//  ProviderReplayDiagnosticsTests.swift
+//  osaurusTests
+//
+//  Security coverage for provider request/response replay diagnostics.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Provider replay diagnostics")
+struct ProviderReplayDiagnosticsTests {
+    @Test func bundleRedactsRequestAndResponseSecrets() throws {
+        let url = try #require(
+            URL(
+                string:
+                    "https://user:password@api.example.test/v1/models?api_key=sk-query-secret-12345&token=query-token&safe=1"
+            )
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 12
+        request.setValue("Bearer sk-request-header-12345", forHTTPHeaderField: "Authorization")
+        request.setValue("visible", forHTTPHeaderField: "X-Debug")
+        request.setValue("custom-secret", forHTTPHeaderField: "X-Custom-Provider-Secret")
+        request.httpBody = Data(
+            #"{"api_key":"sk-body-secret-12345","access_token":"body-access","messages":[{"content":"hello"}]}"#.utf8
+        )
+
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/json",
+                    "Set-Cookie": "session=response-cookie-secret",
+                ]
+            )
+        )
+        let body = Data(
+            #"{"error":{"message":"bad key sk-response-secret-12345","refresh_token":"response-refresh","token":"response-token"}}"#.utf8
+        )
+
+        let bundle = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: request,
+            response: response,
+            responseData: body,
+            configuredSecretHeaderKeys: ["X-Custom-Provider-Secret"]
+        )
+        let copied = bundle.pasteboardText
+
+        #expect(copied.contains("request: POST https://***:***@api.example.test/v1/models"))
+        #expect(copied.contains("safe=1"))
+        #expect(copied.contains("api_key=***"))
+        #expect(copied.contains("token=***"))
+        #expect(copied.contains("Authorization=***"))
+        #expect(copied.contains("X-Custom-Provider-Secret=***"))
+        #expect(copied.contains("X-Debug=visible"))
+        #expect(copied.contains(#""api_key":"***""#))
+        #expect(copied.contains(#""access_token":"***""#))
+        #expect(copied.contains(#""refresh_token":"***""#))
+        #expect(copied.contains(#""token":"***""#))
+        #expect(copied.contains("sk-***"))
+        #expect(copied.contains("Set-Cookie=***"))
+
+        for secret in [
+            "password",
+            "sk-query-secret-12345",
+            "query-token",
+            "sk-request-header-12345",
+            "custom-secret",
+            "sk-body-secret-12345",
+            "body-access",
+            "response-cookie-secret",
+            "sk-response-secret-12345",
+            "response-refresh",
+            "response-token",
+        ] {
+            #expect(!copied.contains(secret))
+        }
+    }
+
+    @Test func providerDiagnosticsCopyIncludesRedactedReplayEvidence() throws {
+        let provider = RemoteProvider(
+            name: "Local API",
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 8000,
+            basePath: "/api/v1",
+            authType: .apiKey,
+            providerType: .openaiLegacy
+        )
+        let url = try #require(URL(string: "http://127.0.0.1:8000/api/v1/models?access_token=url-secret"))
+        var request = URLRequest(url: url)
+        request.setValue("Bearer sk-report-secret-12345", forHTTPHeaderField: "Authorization")
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )
+        )
+        let diagnostics = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: request,
+            response: response,
+            responseData: Data(#"{"error":{"message":"invalid api_key=sk-report-body-12345"}}"#.utf8)
+        )
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = "HTTP 401 unauthorized"
+        state.lastReplayDiagnostics = diagnostics
+
+        let report = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: state,
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+
+        let row = try #require(report.rows.first { $0.id == "request-evidence" })
+        let copied = report.pasteboardText
+        #expect(row.severity == .warning)
+        #expect(copied.contains("Provider request evidence:"))
+        #expect(copied.contains("GET http://127.0.0.1:8000/api/v1/models?access_token=***"))
+        #expect(!copied.contains("url-secret"))
+        #expect(!copied.contains("sk-report-secret-12345"))
+        #expect(!copied.contains("sk-report-body-12345"))
+    }
+
+    @Test func replayEvidenceKeepsBodyExcerptsOnOneLine() throws {
+        let url = try #require(URL(string: "https://api.example.test/v1/models"))
+        var request = URLRequest(url: url)
+        request.httpBody = Data("line1\nAuthorization: Bearer sk-body-line-secret\nline3".utf8)
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        )
+
+        let bundle = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: request,
+            response: response,
+            responseData: Data("error\nrequest_headers: Authorization=Bearer sk-response-line-secret".utf8)
+        )
+
+        let copied = bundle.pasteboardText
+        #expect(copied.contains("request_body: line1 Authorization=*** line3"))
+        #expect(copied.contains("response_body: error request_headers: Authorization=***"))
+        #expect(!copied.contains("sk-body-line-secret"))
+        #expect(!copied.contains("sk-response-line-secret"))
+        #expect(!copied.contains("\nAuthorization:"))
+        let lines = copied.split(separator: "\n").map(String.init)
+        #expect(lines.filter { $0.hasPrefix("request_headers:") }.count == 1)
+        #expect(lines.filter { $0.hasPrefix("response_body:") }.count == 1)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderHeaderRedactorTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderHeaderRedactorTests.swift
@@ -12,7 +12,10 @@ import Testing
 @Suite("RemoteProviderHeaderRedactor")
 struct RemoteProviderHeaderRedactorTests {
     @Test func redactsBuiltInProviderCredentialHeaders() {
-        for header in ["Authorization", "x-api-key", "x-goog-api-key", "api-key", "Proxy-Authorization"] {
+        for header in [
+            "Authorization", "x-api-key", "x-goog-api-key", "api-key",
+            "Proxy-Authorization", "Cookie", "Set-Cookie",
+        ] {
             #expect(
                 RemoteProviderHeaderRedactor.valueForLogging(headerName: header, value: "super-secret")
                     == RemoteProviderHeaderRedactor.redactedValue

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerTestConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerTestConnectionTests.swift
@@ -14,7 +14,10 @@ struct RemoteProviderManagerTestConnectionTests {
     @Test func testConnectionUsesManualModelsWhenModelsEndpointIsMissing() async throws {
         try await RemoteProviderTestLock.shared.run {
             let manager = RemoteProviderManager.shared
-            defer { manager._testRemoveProviders(ids: []) }
+            defer {
+                manager.testConnectionTransportOverride = nil
+                manager._testRemoveProviders(ids: [])
+            }
 
             manager.testConnectionTransportOverride = { request in
                 #expect(request.url?.absoluteString == "https://api.example.test/v1/models")
@@ -40,6 +43,77 @@ struct RemoteProviderManagerTestConnectionTests {
             )
 
             #expect(models == ["direct-chat"])
+        }
+    }
+
+    @Test func testConnectionFailureCarriesRedactedReplayDiagnostics() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            defer {
+                manager.testConnectionTransportOverride = nil
+                manager._testRemoveProviders(ids: [])
+            }
+
+            manager.testConnectionTransportOverride = { request in
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-test-request-secret-12345")
+                #expect(request.value(forHTTPHeaderField: "X-Provider-Token") == "request-token-secret")
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: [
+                        "Content-Type": "application/json",
+                        "Set-Cookie": "session=response-cookie-secret",
+                    ]
+                )!
+                return (
+                    Data(
+                        #"{"error":{"message":"invalid api key sk-response-secret-12345","access_token":"response-access-token"}}"#
+                            .utf8
+                    ),
+                    response
+                )
+            }
+
+            do {
+                _ = try await manager.testConnection(
+                    host: "api.example.test",
+                    providerProtocol: .https,
+                    port: nil,
+                    basePath: "/v1",
+                    authType: .apiKey,
+                    providerType: .openaiLegacy,
+                    apiKey: "sk-test-request-secret-12345",
+                    headers: ["X-Provider-Token": "request-token-secret"],
+                    manualModelIds: []
+                )
+                Issue.record("Expected test connection to fail.")
+            } catch let error as RemoteProviderServiceError {
+                let diagnostics = try #require(error.replayDiagnostics)
+                let copied = diagnostics.pasteboardText
+
+                #expect(copied.contains("Provider request evidence:"))
+                #expect(copied.contains("request: GET https://api.example.test/v1/models"))
+                #expect(copied.contains("response: HTTP 401 https://api.example.test/v1/models"))
+                #expect(copied.contains("Authorization=***"))
+                #expect(copied.contains("X-Provider-Token=***"))
+                #expect(copied.contains("Set-Cookie=***"))
+                #expect(copied.contains(#""access_token":"***""#))
+                #expect(copied.contains("sk-***"))
+
+                for secret in [
+                    "sk-test-request-secret-12345",
+                    "request-token-secret",
+                    "response-cookie-secret",
+                    "sk-response-secret-12345",
+                    "response-access-token",
+                ] {
+                    #expect(!copied.contains(secret))
+                    #expect(!error.localizedDescription.contains(secret))
+                }
+            } catch {
+                Issue.record("Expected RemoteProviderServiceError, got \(error).")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a redacted provider replay diagnostic bundle for failed provider requests and test-connection failures
- surface method, URL, status, elapsed time, headers, and bounded body excerpts without leaking configured secrets
- include copyable one-line evidence in provider network diagnostics so users can share failure context safely

## Validation
- `git diff --cached --check`
- `bash scripts/i18n/check.sh`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-provider-replay swift test --skip-update --scratch-path /Users/mmeding/Developer/Claude/Projects/osaurus/Packages/OsaurusCore/.build --package-path Packages/OsaurusCore --filter 'ProviderReplayDiagnosticsTests|RemoteProviderManagerTestConnectionTests|RemoteProviderHeaderRedactorTests'`
- Review findings incorporated: newline/tab sanitization, line-injection coverage, cookie header redaction, and localization catalog entries.

## Risk
- Diagnostics include only bounded and redacted evidence; credential-bearing header names are redacted before copy/export.
