### PR TITLE
Add skill policy diagnostics

### DIFF
--- a/Packages/OsaurusCore/Models/Skill/SkillCapabilityPolicyDiagnostic.swift
+++ b/Packages/OsaurusCore/Models/Skill/SkillCapabilityPolicyDiagnostic.swift
@@ -1,0 +1,249 @@
+//
+//  SkillCapabilityPolicyDiagnostic.swift
+//  osaurus
+//
+//  Typed diagnostics for explaining skill availability in capability discovery.
+//
+
+import Foundation
+
+struct SkillSearchIndexSnapshot: Equatable, Sendable {
+    let vectorIndexInitialized: Bool
+    let vectorIndexAvailable: Bool
+    /// Skill ids known to the search index mapping. This is intentionally not
+    /// called "indexed": VecturaKit does not currently expose document listing.
+    let knownSkillIds: Set<UUID>
+
+    var knownSkillCount: Int { knownSkillIds.count }
+    var usesLexicalFallback: Bool { !vectorIndexAvailable }
+
+    static let unavailable = SkillSearchIndexSnapshot(
+        vectorIndexInitialized: false,
+        vectorIndexAvailable: false,
+        knownSkillIds: []
+    )
+}
+
+enum SkillCapabilitySource: String, Codable, CaseIterable, Sendable {
+    case builtIn = "built_in"
+    case standalone
+    case plugin
+
+    var displayLabel: String {
+        switch self {
+        case .builtIn:
+            return "Built-in"
+        case .standalone:
+            return "Standalone"
+        case .plugin:
+            return "Plugin"
+        }
+    }
+}
+
+enum SkillCapabilityState: String, Codable, CaseIterable, Sendable {
+    case loadable
+    case hidden
+    case disabled
+    case unavailable
+
+    var displayLabel: String {
+        switch self {
+        case .loadable:
+            return "Loadable"
+        case .hidden:
+            return "Hidden"
+        case .disabled:
+            return "Disabled"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+}
+
+enum SkillCapabilityPolicyReasonCode: String, Codable, CaseIterable, Sendable {
+    case loadableViaCapabilitiesLoad = "loadable_via_capabilities_load"
+    case globallyDisabled = "globally_disabled"
+    case allowedByAgentScope = "allowed_by_agent_scope"
+    case hiddenByAgentScope = "hidden_by_agent_scope"
+    case unscopedLegacyAgent = "unscoped_legacy_agent"
+    case configurationAgentUnsupported = "configuration_agent_unsupported"
+    case agentNotFound = "agent_not_found"
+}
+
+enum SkillCapabilitySearchReasonCode: String, Codable, CaseIterable, Sendable {
+    case searchable
+    case knownToSearchIndex = "known_to_search_index"
+    case lexicalFallback = "lexical_fallback"
+    case vectorIndexUnavailable = "vector_index_unavailable"
+    case notKnownToSearchIndex = "not_known_to_search_index"
+    case globallyDisabled = "globally_disabled"
+    case hiddenByAgentScope = "hidden_by_agent_scope"
+    case configurationAgentUnsupported = "configuration_agent_unsupported"
+    case agentNotFound = "agent_not_found"
+}
+
+struct SkillCapabilityPolicyDiagnostic: Equatable, Sendable {
+    struct Row: Equatable, Identifiable, Sendable {
+        var id: UUID { skillId }
+
+        let skillId: UUID
+        let skillName: String
+        let description: String
+        let source: SkillCapabilitySource
+        let state: SkillCapabilityState
+        let loadId: String
+        let pluginId: String?
+        let globallyEnabled: Bool
+        let agentAllowed: Bool
+        let agentScoped: Bool
+        let knownToSearchIndex: Bool
+        let searchableByCapabilitiesDiscover: Bool
+        let policyReasonCodes: [SkillCapabilityPolicyReasonCode]
+        let searchReasonCodes: [SkillCapabilitySearchReasonCode]
+        let instructionCharacters: Int
+
+        var compactSummary: String {
+            let policy = policyReasonCodes.map(\.rawValue).joined(separator: ",")
+            let search = searchReasonCodes.map(\.rawValue).joined(separator: ",")
+            return
+                "source=\(source.rawValue); state=\(state.rawValue); policy=\(policy); known_to_search_index=\(knownToSearchIndex); searchable=\(searchableByCapabilitiesDiscover); search=\(search)"
+        }
+    }
+
+    let agentId: UUID
+    let agentName: String
+    let toolMode: ToolSelectionMode
+    let agentScoped: Bool
+    let vectorIndexInitialized: Bool
+    let vectorIndexAvailable: Bool
+    let usingLexicalFallback: Bool
+    let knownSkillCount: Int
+    let totalSkillCount: Int
+    let rows: [Row]
+
+    var enabledSkillCount: Int {
+        rows.filter(\.globallyEnabled).count
+    }
+
+    var sourceCounts: [SkillCapabilitySource: Int] {
+        Dictionary(grouping: rows, by: \.source).mapValues(\.count)
+    }
+
+    var stateCounts: [SkillCapabilityState: Int] {
+        Dictionary(grouping: rows, by: \.state).mapValues(\.count)
+    }
+
+    func filteredRows(
+        query rawQuery: String = "",
+        source: SkillCapabilitySource? = nil,
+        state: SkillCapabilityState? = nil
+    ) -> [Row] {
+        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return rows.filter { row in
+            if let source, row.source != source { return false }
+            if let state, row.state != state { return false }
+            guard !query.isEmpty else { return true }
+            let haystack = [
+                row.skillName,
+                row.description,
+                row.source.displayLabel,
+                row.state.displayLabel,
+                row.loadId,
+                row.pluginId ?? "",
+                row.policyReasonCodes.map(\.rawValue).joined(separator: " "),
+                row.searchReasonCodes.map(\.rawValue).joined(separator: " "),
+            ].joined(separator: " ").lowercased()
+            return haystack.contains(query)
+        }
+    }
+
+    var textBlock: String {
+        guard !rows.isEmpty else { return "" }
+        var lines = [
+            "Skill policy diagnostics:",
+            "agent: \(agentName) (\(agentId.uuidString))",
+            "skills: \(enabledSkillCount) enabled / \(totalSkillCount) total, known_search_index_skills: \(knownSkillCount), vector_index_available: \(vectorIndexAvailable), vector_index_initialized: \(vectorIndexInitialized)",
+        ]
+        for row in rows {
+            lines.append("- \(row.loadId): \(row.compactSummary)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    func reporterSafeMarkdown(generatedAt: Date = Date(), rows selectedRows: [Row]? = nil) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let reportRows = (selectedRows ?? rows)
+            .sorted { lhs, rhs in
+                if lhs.source.rawValue == rhs.source.rawValue {
+                    return lhs.skillName.localizedCaseInsensitiveCompare(rhs.skillName) == .orderedAscending
+                }
+                return lhs.source.rawValue < rhs.source.rawValue
+            }
+        let reportStateCounts = Dictionary(grouping: reportRows, by: \.state).mapValues(\.count)
+        let reportSourceCounts = Dictionary(grouping: reportRows, by: \.source).mapValues(\.count)
+
+        var lines: [String] = [
+            "# Skill Policy Report",
+            "",
+            "- Generated: \(formatter.string(from: generatedAt))",
+            "- Agent: \(Self.escapeMarkdown(agentName)) (\(agentId.uuidString))",
+            "- Tool mode: \(toolMode.rawValue)",
+            "- Agent scope seeded: \(agentScoped)",
+            "- Skills: \(enabledSkillCount) enabled / \(totalSkillCount) total",
+            "- Known to search index: \(knownSkillCount)",
+            "- Vector index available: \(vectorIndexAvailable)",
+            "- Vector index initialized: \(vectorIndexInitialized)",
+            "- Rows in report: \(reportRows.count)",
+            "- Reporter-safe fields only: no instructions, references, assets, secrets, manifest paths, or runtime paths.",
+            "",
+            "## State Counts",
+        ]
+
+        for state in SkillCapabilityState.allCases {
+            lines.append("- \(state.displayLabel): \(reportStateCounts[state, default: 0])")
+        }
+
+        lines.append(contentsOf: [
+            "",
+            "## Source Counts",
+        ])
+
+        for source in SkillCapabilitySource.allCases {
+            let count = reportSourceCounts[source, default: 0]
+            if count > 0 {
+                lines.append("- \(source.displayLabel): \(count)")
+            }
+        }
+
+        lines.append(contentsOf: [
+            "",
+            "## Rows",
+            "",
+            "| Skill | Source | State | Load ID | Policy reasons | Search reasons | Enabled | Agent allowed | Known to search index | Searchable | Instruction chars |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: |",
+        ])
+
+        for row in reportRows {
+            lines.append(
+                "| \(Self.escapeMarkdown(row.skillName)) | \(row.source.rawValue) | \(row.state.rawValue) | \(Self.escapeMarkdown(row.loadId)) | \(Self.joinCodes(row.policyReasonCodes.map(\.rawValue))) | \(Self.joinCodes(row.searchReasonCodes.map(\.rawValue))) | \(row.globallyEnabled) | \(row.agentAllowed) | \(row.knownToSearchIndex) | \(row.searchableByCapabilitiesDiscover) | \(row.instructionCharacters) |"
+            )
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func joinCodes(_ codes: [String]) -> String {
+        guard !codes.isEmpty else { return "-" }
+        return escapeMarkdown(codes.joined(separator: ", "))
+    }
+
+    private static func escapeMarkdown(_ raw: String) -> String {
+        raw
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "|", with: "\\|")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+}

--- a/Packages/OsaurusCore/Services/Skill/SkillCapabilityPolicyService.swift
+++ b/Packages/OsaurusCore/Services/Skill/SkillCapabilityPolicyService.swift
@@ -1,0 +1,191 @@
+//
+//  SkillCapabilityPolicyService.swift
+//  osaurus
+//
+//  Read-only skill policy snapshots for the Skills management console.
+//
+
+import Foundation
+
+enum SkillCapabilityPolicyService {
+    struct Input: Sendable {
+        let agentId: UUID
+        let agentName: String
+        let agentExists: Bool
+        let isConfigurationAgent: Bool
+        let toolMode: ToolSelectionMode
+        let enabledSkillNames: Set<String>?
+        let skills: [Skill]
+        let indexSnapshot: SkillSearchIndexSnapshot
+
+        init(
+            agentId: UUID,
+            agentName: String,
+            agentExists: Bool = true,
+            isConfigurationAgent: Bool = false,
+            toolMode: ToolSelectionMode = .auto,
+            enabledSkillNames: Set<String>? = nil,
+            skills: [Skill],
+            indexSnapshot: SkillSearchIndexSnapshot = .unavailable
+        ) {
+            self.agentId = agentId
+            self.agentName = agentName
+            self.agentExists = agentExists
+            self.isConfigurationAgent = isConfigurationAgent
+            self.toolMode = toolMode
+            self.enabledSkillNames = enabledSkillNames
+            self.skills = skills
+            self.indexSnapshot = indexSnapshot
+        }
+    }
+
+    @MainActor
+    static func snapshot(agentId: UUID) async -> SkillCapabilityPolicyDiagnostic {
+        let manager = AgentManager.shared
+        let isConfigurationAgent = agentId == Agent.defaultId
+        let agent = manager.agent(for: agentId) ?? (isConfigurationAgent ? Agent.default : nil)
+        let skills = SkillManager.shared.skills
+        let indexSnapshot = await SkillSearchService.shared.indexSnapshot()
+        return build(
+            Input(
+                agentId: agentId,
+                agentName: agent?.name ?? "Unknown agent",
+                agentExists: agent != nil,
+                isConfigurationAgent: isConfigurationAgent,
+                toolMode: manager.effectiveToolSelectionMode(for: agentId),
+                enabledSkillNames: manager.effectiveEnabledSkillNames(for: agentId).map(Set.init),
+                skills: skills,
+                indexSnapshot: indexSnapshot
+            )
+        )
+    }
+
+    static func build(_ input: Input) -> SkillCapabilityPolicyDiagnostic {
+        let rows = input.skills
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            .map { row(for: $0, input: input) }
+
+        return SkillCapabilityPolicyDiagnostic(
+            agentId: input.agentId,
+            agentName: input.agentName,
+            toolMode: input.toolMode,
+            agentScoped: input.enabledSkillNames != nil,
+            vectorIndexInitialized: input.indexSnapshot.vectorIndexInitialized,
+            vectorIndexAvailable: input.indexSnapshot.vectorIndexAvailable,
+            usingLexicalFallback: input.indexSnapshot.usesLexicalFallback,
+            knownSkillCount: input.indexSnapshot.knownSkillCount,
+            totalSkillCount: input.skills.count,
+            rows: rows
+        )
+    }
+
+    private static func row(
+        for skill: Skill,
+        input: Input
+    ) -> SkillCapabilityPolicyDiagnostic.Row {
+        let source = source(for: skill)
+        let agentAllowedByScope = input.enabledSkillNames?.contains(skill.name) ?? true
+        let knownToSearchIndex =
+            input.indexSnapshot.vectorIndexAvailable
+            && input.indexSnapshot.knownSkillIds.contains(skill.id)
+
+        var policyReasons: [SkillCapabilityPolicyReasonCode] = []
+        var searchReasons: [SkillCapabilitySearchReasonCode] = []
+
+        func appendPolicy(_ reason: SkillCapabilityPolicyReasonCode) {
+            if !policyReasons.contains(reason) { policyReasons.append(reason) }
+        }
+        func appendSearch(_ reason: SkillCapabilitySearchReasonCode) {
+            if !searchReasons.contains(reason) { searchReasons.append(reason) }
+        }
+
+        let state: SkillCapabilityState
+        let agentAllowed: Bool
+        if !input.agentExists {
+            state = .unavailable
+            agentAllowed = false
+            appendPolicy(.agentNotFound)
+            appendSearch(.agentNotFound)
+        } else if input.isConfigurationAgent {
+            state = .hidden
+            agentAllowed = false
+            appendPolicy(.configurationAgentUnsupported)
+            appendSearch(.configurationAgentUnsupported)
+        } else if !skill.enabled {
+            state = .disabled
+            agentAllowed = agentAllowedByScope
+            appendPolicy(.globallyDisabled)
+            appendSearch(.globallyDisabled)
+        } else if !agentAllowedByScope {
+            state = .hidden
+            agentAllowed = false
+            appendPolicy(.hiddenByAgentScope)
+            appendSearch(.hiddenByAgentScope)
+        } else {
+            state = .loadable
+            agentAllowed = true
+            appendPolicy(.loadableViaCapabilitiesLoad)
+            if input.enabledSkillNames == nil {
+                appendPolicy(.unscopedLegacyAgent)
+            } else {
+                appendPolicy(.allowedByAgentScope)
+            }
+        }
+
+        let searchable: Bool
+        if state == .loadable {
+            if input.indexSnapshot.vectorIndexAvailable {
+                if knownToSearchIndex {
+                    appendSearch(.searchable)
+                    appendSearch(.knownToSearchIndex)
+                    searchable = true
+                } else {
+                    appendSearch(.notKnownToSearchIndex)
+                    searchable = false
+                }
+            } else {
+                appendSearch(.searchable)
+                appendSearch(.lexicalFallback)
+                appendSearch(.vectorIndexUnavailable)
+                searchable = true
+            }
+        } else {
+            searchable = false
+            if input.indexSnapshot.vectorIndexAvailable {
+                if knownToSearchIndex {
+                    appendSearch(.knownToSearchIndex)
+                } else {
+                    appendSearch(.notKnownToSearchIndex)
+                }
+            } else {
+                appendSearch(.vectorIndexUnavailable)
+            }
+        }
+
+        return SkillCapabilityPolicyDiagnostic.Row(
+            skillId: skill.id,
+            skillName: skill.name,
+            description: skill.description,
+            source: source,
+            state: state,
+            loadId: "skill/\(skill.name)",
+            pluginId: skill.pluginId,
+            globallyEnabled: skill.enabled,
+            agentAllowed: agentAllowed,
+            agentScoped: input.enabledSkillNames != nil,
+            knownToSearchIndex: knownToSearchIndex,
+            searchableByCapabilitiesDiscover: searchable,
+            policyReasonCodes: policyReasons,
+            searchReasonCodes: searchReasons,
+            instructionCharacters: skill.instructions.count
+        )
+    }
+
+    private static func source(for skill: Skill) -> SkillCapabilitySource {
+        if skill.isBuiltIn { return .builtIn }
+        if skill.pluginId != nil { return .plugin }
+        return .standalone
+    }
+}

--- a/Packages/OsaurusCore/Services/Skill/SkillSearchService.swift
+++ b/Packages/OsaurusCore/Services/Skill/SkillSearchService.swift
@@ -211,6 +211,14 @@ public actor SkillSearchService {
         return (accepted, diagnostic)
     }
 
+    func indexSnapshot() -> SkillSearchIndexSnapshot {
+        SkillSearchIndexSnapshot(
+            vectorIndexInitialized: isInitialized,
+            vectorIndexAvailable: vectorDB != nil,
+            knownSkillIds: Set(reverseIdMap.values)
+        )
+    }
+
     // MARK: - Rebuild
 
     public func rebuildIndex() async {

--- a/Packages/OsaurusCore/Tests/Skill/SkillCapabilityPolicyServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillCapabilityPolicyServiceTests.swift
@@ -1,0 +1,264 @@
+//
+//  SkillCapabilityPolicyServiceTests.swift
+//  osaurus
+//
+//  Focused tests for read-only skill capability policy/status diagnostics.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct SkillCapabilityPolicyServiceTests {
+
+    @Test func scopedEnabledSkillIsLoadableAndSearchableWhenKnownToSearchIndex() {
+        let skill = makeSkill(
+            name: "Research Helper",
+            description: "Structured research",
+            enabled: true
+        )
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Research Agent",
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .init(
+                    vectorIndexInitialized: true,
+                    vectorIndexAvailable: true,
+                    knownSkillIds: [skill.id]
+                )
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(diagnostic.agentScoped)
+        #expect(diagnostic.vectorIndexAvailable)
+        #expect(row.state == .loadable)
+        #expect(row.source == .standalone)
+        #expect(row.loadId == "skill/Research Helper")
+        #expect(row.agentAllowed)
+        #expect(row.knownToSearchIndex)
+        #expect(row.searchableByCapabilitiesDiscover)
+        #expect(row.policyReasonCodes == [.loadableViaCapabilitiesLoad, .allowedByAgentScope])
+        #expect(row.searchReasonCodes == [.searchable, .knownToSearchIndex])
+    }
+
+    @Test func disabledSkillExplainsGlobalDisableBeforeIndexingStatus() {
+        let skill = makeSkill(
+            name: "Disabled Skill",
+            enabled: false,
+            pluginId: "com.example.plugin"
+        )
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Agent",
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .init(
+                    vectorIndexInitialized: true,
+                    vectorIndexAvailable: true,
+                    knownSkillIds: [skill.id]
+                )
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(row.source == .plugin)
+        #expect(row.state == .disabled)
+        #expect(row.globallyEnabled == false)
+        #expect(row.agentAllowed)
+        #expect(row.searchableByCapabilitiesDiscover == false)
+        #expect(row.policyReasonCodes.contains(.globallyDisabled))
+        #expect(row.searchReasonCodes.contains(.globallyDisabled))
+        #expect(row.searchReasonCodes.contains(.knownToSearchIndex))
+    }
+
+    @Test func agentScopeHidesEnabledSkillOutsideGrant() {
+        let skill = makeSkill(name: "Hidden Skill", enabled: true)
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Agent",
+                enabledSkillNames: [],
+                skills: [skill],
+                indexSnapshot: .init(
+                    vectorIndexInitialized: true,
+                    vectorIndexAvailable: true,
+                    knownSkillIds: [skill.id]
+                )
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(row.state == .hidden)
+        #expect(row.agentAllowed == false)
+        #expect(row.searchableByCapabilitiesDiscover == false)
+        #expect(row.policyReasonCodes == [.hiddenByAgentScope])
+        #expect(row.searchReasonCodes.contains(.hiddenByAgentScope))
+        #expect(row.searchReasonCodes.contains(.knownToSearchIndex))
+    }
+
+    @Test func loadableSkillExplainsWhenVectorIndexDoesNotKnowIt() {
+        let skill = makeSkill(name: "Unindexed Skill", enabled: true)
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Agent",
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .init(
+                    vectorIndexInitialized: true,
+                    vectorIndexAvailable: true,
+                    knownSkillIds: []
+                )
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(row.state == .loadable)
+        #expect(row.knownToSearchIndex == false)
+        #expect(row.searchableByCapabilitiesDiscover == false)
+        #expect(row.searchReasonCodes == [.notKnownToSearchIndex])
+    }
+
+    @Test func unseededAgentReportsLegacyScopeAndLexicalFallback() {
+        let skill = makeSkill(name: "Legacy Skill", enabled: true)
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Legacy Agent",
+                enabledSkillNames: nil,
+                skills: [skill],
+                indexSnapshot: .unavailable
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(diagnostic.agentScoped == false)
+        #expect(diagnostic.usingLexicalFallback)
+        #expect(row.state == .loadable)
+        #expect(row.agentAllowed)
+        #expect(row.knownToSearchIndex == false)
+        #expect(row.searchableByCapabilitiesDiscover)
+        #expect(row.policyReasonCodes.contains(.unscopedLegacyAgent))
+        #expect(row.searchReasonCodes == [.searchable, .lexicalFallback, .vectorIndexUnavailable])
+    }
+
+    @Test func configurationAgentReportsSkillLoadingUnsupported() {
+        let skill = makeSkill(name: "Config Hidden", enabled: true)
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: Agent.defaultId,
+                agentName: "Osaurus",
+                isConfigurationAgent: true,
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .unavailable
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(row.state == .hidden)
+        #expect(row.agentAllowed == false)
+        #expect(row.searchableByCapabilitiesDiscover == false)
+        #expect(row.policyReasonCodes == [.configurationAgentUnsupported])
+        #expect(row.searchReasonCodes.contains(.configurationAgentUnsupported))
+    }
+
+    @Test func missingAgentReportsUnavailableForAllSkills() {
+        let skill = makeSkill(name: "Missing Agent Skill", enabled: true)
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Unknown agent",
+                agentExists: false,
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .unavailable
+            )
+        )
+
+        let row = diagnostic.rows[0]
+        #expect(row.state == .unavailable)
+        #expect(row.agentAllowed == false)
+        #expect(row.searchableByCapabilitiesDiscover == false)
+        #expect(row.policyReasonCodes == [.agentNotFound])
+        #expect(row.searchReasonCodes.contains(.agentNotFound))
+    }
+
+    @Test func reporterSafeMarkdownOmitsInstructionsAndPluginPaths() {
+        let skill = makeSkill(
+            name: "Reporter Skill",
+            description: "Short description",
+            instructions: "Never leak this instruction body.",
+            pluginId: "com.example.plugin"
+        )
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+                agentName: "Reporter Agent",
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .unavailable
+            )
+        )
+
+        let report = diagnostic.reporterSafeMarkdown(
+            generatedAt: Date(timeIntervalSince1970: 1_780_000_000)
+        )
+
+        #expect(report.contains("# Skill Policy Report"))
+        #expect(report.contains("Reporter Skill"))
+        #expect(report.contains("Reporter-safe fields only"))
+        #expect(!report.contains("Never leak this instruction body."))
+        #expect(!report.contains("SKILL.md"))
+        #expect(!report.contains("references/"))
+    }
+
+    @Test func reporterSafeMarkdownEscapesTableSpecialCharacters() {
+        let skill = makeSkill(
+            name: "Pipe | Skill\nName",
+            description: "Short description",
+            instructions: "instructions"
+        )
+        let diagnostic = SkillCapabilityPolicyService.build(
+            .init(
+                agentId: UUID(),
+                agentName: "Reporter | Agent",
+                enabledSkillNames: [skill.name],
+                skills: [skill],
+                indexSnapshot: .unavailable
+            )
+        )
+
+        let report = diagnostic.reporterSafeMarkdown()
+
+        #expect(report.contains("Pipe \\| Skill Name"))
+        #expect(report.contains("Reporter \\| Agent"))
+        #expect(!report.contains("Pipe | Skill\nName"))
+    }
+
+    private func makeSkill(
+        name: String,
+        description: String = "fixture",
+        instructions: String = "instructions",
+        enabled: Bool = true,
+        isBuiltIn: Bool = false,
+        pluginId: String? = nil
+    ) -> Skill {
+        Skill(
+            id: UUID(),
+            name: name,
+            description: description,
+            version: "1.0.0",
+            keywords: [],
+            enabled: enabled,
+            instructions: instructions,
+            isBuiltIn: isBuiltIn,
+            pluginId: pluginId
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Skill/SkillPolicyConsolePresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillPolicyConsolePresenterTests.swift
@@ -1,0 +1,119 @@
+//
+//  SkillPolicyConsolePresenterTests.swift
+//  osaurus
+//
+//  Tests for filtering and grouping in the Skills policy/status presenter.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct SkillPolicyConsolePresenterTests {
+
+    @Test func filtersByQuerySourceAndState() {
+        let diagnostic = makeDiagnostic(
+            rows: [
+                makeRow(name: "Research Helper", source: .standalone, state: .loadable),
+                makeRow(name: "Plugin Planner", source: .plugin, state: .hidden),
+                makeRow(name: "Built In Tutor", source: .builtIn, state: .disabled),
+            ]
+        )
+
+        let queryRows = SkillPolicyConsolePresenter.filteredRows(
+            diagnostic: diagnostic,
+            query: "plugin",
+            sourceFilter: .all,
+            stateFilter: .all
+        )
+        #expect(queryRows.map(\.skillName) == ["Plugin Planner"])
+
+        let pluginRows = SkillPolicyConsolePresenter.filteredRows(
+            diagnostic: diagnostic,
+            query: "",
+            sourceFilter: .plugin,
+            stateFilter: .all
+        )
+        #expect(pluginRows.map(\.skillName) == ["Plugin Planner"])
+
+        let hiddenRows = SkillPolicyConsolePresenter.filteredRows(
+            diagnostic: diagnostic,
+            query: "",
+            sourceFilter: .all,
+            stateFilter: .hidden
+        )
+        #expect(hiddenRows.map(\.skillName) == ["Plugin Planner"])
+    }
+
+    @Test func groupsRowsByStableSourceOrderAndSortsNames() {
+        let rows = [
+            makeRow(name: "Zulu Plugin", source: .plugin, state: .loadable),
+            makeRow(name: "Built In", source: .builtIn, state: .disabled),
+            makeRow(name: "Alpha Plugin", source: .plugin, state: .hidden),
+            makeRow(name: "Standalone", source: .standalone, state: .loadable),
+        ]
+
+        let groups = SkillPolicyConsolePresenter.groups(rows: rows)
+
+        #expect(groups.map(\.source) == [.builtIn, .standalone, .plugin])
+        #expect(groups[2].rows.map(\.skillName) == ["Alpha Plugin", "Zulu Plugin"])
+    }
+
+    @Test func stateCountUsesDiagnosticCounts() {
+        let diagnostic = makeDiagnostic(
+            rows: [
+                makeRow(name: "A", source: .standalone, state: .loadable),
+                makeRow(name: "B", source: .standalone, state: .loadable),
+                makeRow(name: "C", source: .plugin, state: .hidden),
+            ]
+        )
+
+        #expect(SkillPolicyConsolePresenter.stateCount(.loadable, diagnostic: diagnostic) == 2)
+        #expect(SkillPolicyConsolePresenter.stateCount(.hidden, diagnostic: diagnostic) == 1)
+        #expect(SkillPolicyConsolePresenter.stateCount(.disabled, diagnostic: diagnostic) == 0)
+    }
+
+    private func makeDiagnostic(
+        rows: [SkillCapabilityPolicyDiagnostic.Row]
+    ) -> SkillCapabilityPolicyDiagnostic {
+        SkillCapabilityPolicyDiagnostic(
+            agentId: UUID(),
+            agentName: "Agent",
+            toolMode: .auto,
+            agentScoped: true,
+            vectorIndexInitialized: true,
+            vectorIndexAvailable: true,
+            usingLexicalFallback: false,
+            knownSkillCount: rows.filter(\.knownToSearchIndex).count,
+            totalSkillCount: rows.count,
+            rows: rows
+        )
+    }
+
+    private func makeRow(
+        name: String,
+        source: SkillCapabilitySource,
+        state: SkillCapabilityState
+    ) -> SkillCapabilityPolicyDiagnostic.Row {
+        SkillCapabilityPolicyDiagnostic.Row(
+            skillId: UUID(),
+            skillName: name,
+            description: "\(name) description",
+            source: source,
+            state: state,
+            loadId: "skill/\(name)",
+            pluginId: source == .plugin ? "com.example.plugin" : nil,
+            globallyEnabled: state != .disabled,
+            agentAllowed: state == .loadable,
+            agentScoped: true,
+            knownToSearchIndex: true,
+            searchableByCapabilitiesDiscover: state == .loadable,
+            policyReasonCodes: state == .loadable ? [.loadableViaCapabilitiesLoad] : [.hiddenByAgentScope],
+            searchReasonCodes: state == .loadable
+                ? [.searchable, .knownToSearchIndex]
+                : [.hiddenByAgentScope, .knownToSearchIndex],
+            instructionCharacters: 12
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Skill/SkillPolicyConsolePresenter.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillPolicyConsolePresenter.swift
@@ -1,0 +1,140 @@
+//
+//  SkillPolicyConsolePresenter.swift
+//  osaurus
+//
+//  Pure view transforms for the Skills policy console.
+//
+
+import Foundation
+
+enum SkillPolicySourceFilter: String, CaseIterable, Identifiable {
+    case all
+    case builtIn
+    case standalone
+    case plugin
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All Sources"
+        case .builtIn:
+            return "Built-in"
+        case .standalone:
+            return "Standalone"
+        case .plugin:
+            return "Plugin"
+        }
+    }
+
+    var source: SkillCapabilitySource? {
+        switch self {
+        case .all:
+            return nil
+        case .builtIn:
+            return .builtIn
+        case .standalone:
+            return .standalone
+        case .plugin:
+            return .plugin
+        }
+    }
+}
+
+enum SkillPolicyStateFilter: String, CaseIterable, Identifiable {
+    case all
+    case loadable
+    case hidden
+    case disabled
+    case unavailable
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All States"
+        case .loadable:
+            return "Loadable"
+        case .hidden:
+            return "Hidden"
+        case .disabled:
+            return "Disabled"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+
+    var state: SkillCapabilityState? {
+        switch self {
+        case .all:
+            return nil
+        case .loadable:
+            return .loadable
+        case .hidden:
+            return .hidden
+        case .disabled:
+            return .disabled
+        case .unavailable:
+            return .unavailable
+        }
+    }
+
+    static func filter(for state: SkillCapabilityState) -> SkillPolicyStateFilter {
+        switch state {
+        case .loadable:
+            return .loadable
+        case .hidden:
+            return .hidden
+        case .disabled:
+            return .disabled
+        case .unavailable:
+            return .unavailable
+        }
+    }
+}
+
+enum SkillPolicyConsolePresenter {
+    struct Group: Identifiable, Equatable {
+        let source: SkillCapabilitySource
+        let rows: [SkillCapabilityPolicyDiagnostic.Row]
+
+        var id: SkillCapabilitySource { source }
+    }
+
+    static func filteredRows(
+        diagnostic: SkillCapabilityPolicyDiagnostic,
+        query: String,
+        sourceFilter: SkillPolicySourceFilter,
+        stateFilter: SkillPolicyStateFilter
+    ) -> [SkillCapabilityPolicyDiagnostic.Row] {
+        diagnostic.filteredRows(
+            query: query,
+            source: sourceFilter.source,
+            state: stateFilter.state
+        )
+    }
+
+    static func groups(
+        rows: [SkillCapabilityPolicyDiagnostic.Row]
+    ) -> [Group] {
+        let grouped = Dictionary(grouping: rows, by: \.source)
+        return SkillCapabilitySource.allCases.compactMap { source in
+            guard let sourceRows = grouped[source], !sourceRows.isEmpty else { return nil }
+            return Group(
+                source: source,
+                rows: sourceRows.sorted {
+                    $0.skillName.localizedCaseInsensitiveCompare($1.skillName) == .orderedAscending
+                }
+            )
+        }
+    }
+
+    static func stateCount(
+        _ state: SkillCapabilityState,
+        diagnostic: SkillCapabilityPolicyDiagnostic
+    ) -> Int {
+        diagnostic.stateCounts[state, default: 0]
+    }
+}


### PR DESCRIPTION
## Summary
- add reporter-safe skill capability diagnostics for agent scope, loadability, search visibility, and unavailable reasons
- expose a search-index snapshot so diagnostics can distinguish configured skills from skills known to the search index
- add a presenter that groups and filters diagnostics for a future capability/policy surface

## Validation
- `git diff --cached --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-skills-policy swift test --skip-update --scratch-path /Users/mmeding/Developer/Claude/Projects/osaurus/Packages/OsaurusCore/.build --package-path Packages/OsaurusCore --filter 'SkillCapabilityPolicyServiceTests|SkillPolicyConsolePresenterTests'`
- Review findings incorporated: avoided overclaiming vector index state, added missing-agent and not-known-to-search-index coverage, and escaped reporter output.

## Risk
- This is diagnostic infrastructure and presenter logic only; it does not change skill execution or permissions.
