### PR TITLE
Add same-turn MCP schema activation proof

### DIFF
--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -342,9 +342,10 @@ public enum AgentLoopEvaluator {
             additionalToolNames: []
         )
         let systemPrompt = composed.prompt
-        // Frozen for the whole run (deferred-schema policy, production
-        // parity): `capabilities_load` never patches the request schema.
-        let toolSpecs = composed.tools
+        // Each agent-loop iteration is a fresh provider request. A successful
+        // `capabilities_load` may merge validated schemas into this array so
+        // the next request in the same run can call the loaded tool.
+        var toolSpecs = composed.tools
 
         // Shared loop budget wiring (same as chat/HTTP/plugin) with a
         // run-scoped sticky watermark.
@@ -358,7 +359,7 @@ public enum AgentLoopEvaluator {
             maxTokens
             ?? ChatConfigurationStore.load().maxTokens
             ?? 2_048
-        let budgetManager = AgentLoopBudget.makeBudgetManager(
+        var budgetManager = AgentLoopBudget.makeBudgetManager(
             contextWindow: contextWindow,
             systemPromptChars: systemPrompt.count,
             toolTokens: composed.toolTokens,
@@ -388,7 +389,7 @@ public enum AgentLoopEvaluator {
         var firstStepPrefillTps: Double?
         var sawAnyModelStep = false
         // Deterministic context-cost accounting, accumulated per model step
-        // from the exact composed prompt + frozen tool schema. Unlike the
+        // from the exact composed prompt + active tool schema. Unlike the
         // runtime-only decode/completion counters above, this does not depend
         // on a streaming stats hint, so it is populated for remote frontier
         // runs too — the optimization loop's provider-independent "tokens per
@@ -419,7 +420,7 @@ public enum AgentLoopEvaluator {
                 iterations: iterations,
                 exit: exit,
                 systemPrompt: systemPrompt,
-                toolSchemaNames: composed.tools.map { $0.function.name },
+                toolSchemaNames: toolSpecs.map { $0.function.name },
                 loopDurationMs: loopMs,
                 notices: noticesSeen,
                 compacted: watermark.hasCompacted,
@@ -452,6 +453,10 @@ public enum AgentLoopEvaluator {
                 tool_choice: toolSpecs.isEmpty ? nil : .auto,
                 session_id: sessionId
             )
+        }
+
+        func activeToolTokens() -> Int {
+            ToolRegistry.shared.totalEstimatedTokens(for: toolSpecs)
         }
 
         /// Append the assistant turn carrying this step's tool calls.
@@ -527,15 +532,20 @@ public enum AgentLoopEvaluator {
         ) async -> AgentLoopToolExecution {
             var result = rawResult
             let isError = ToolEnvelope.isError(result)
-            // Deferred-schema policy (production parity): drain the load
-            // buffer — tools loaded via `capabilities_load` are callable
-            // immediately through the registry — but the request schema
-            // stays FROZEN for the whole run; the model is told via the
-            // result note instead of a mid-run `<tools>` rewrite.
             if inv.toolName == "capabilities_load" {
                 let drained = await CapabilityLoadBuffer.shared.drain()
                 if !drained.isEmpty, !isError {
-                    result += AgentToolLoop.deferredSchemaNotice
+                    let activation = await AgentToolLoop.activateCapabilitySchemas(
+                        loadedTools: drained,
+                        currentTools: toolSpecs,
+                        mode: .sameTurnNextRequest
+                    )
+                    toolSpecs = activation.tools
+                    budgetManager.reserve(.tools, tokens: activeToolTokens())
+                    result = AgentToolLoop.annotateCapabilityLoadResult(
+                        result,
+                        activation: activation.report
+                    )
                 }
             }
             history.append(
@@ -599,12 +609,12 @@ public enum AgentLoopEvaluator {
             },
             modelStep: { effective, _ in
                 // Context-cost accounting: estimate the INPUT tokens for THIS
-                // step (the exact messages the loop composed + the run's
-                // frozen tool schema) before the model call. Deterministic and
+                // step (the exact messages the loop composed + the active tool
+                // schema) before the model call. Deterministic and
                 // provider-independent, so it is captured even when the run
                 // surfaces no runtime stats hint (remote / non-streaming).
                 let stepInputTokens =
-                    ContextBudgetManager.estimateTokens(for: effective) + composed.toolTokens
+                    ContextBudgetManager.estimateTokens(for: effective) + activeToolTokens()
                 promptTokensTotal += stepInputTokens
                 peakContextTokens = max(peakContextTokens, stepInputTokens)
                 modelStepCount += 1

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -91,6 +91,27 @@ private func loopTestTool(_ name: String) -> Tool {
     )
 }
 
+private func loopMCPProviderTool(_ name: String) -> Tool {
+    Tool(
+        type: "function",
+        function: ToolFunction(
+            name: name,
+            description: "Remote provider tool \(name)",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Search query"),
+                    ]),
+                ]),
+                "required": .array([.string("query")]),
+                "additionalProperties": .bool(false),
+            ])
+        )
+    )
+}
+
 private func parsedJSONObject(_ json: String) throws -> [String: Any] {
     let data = try #require(json.data(using: .utf8))
     return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -203,6 +224,69 @@ struct AgentToolLoopTests {
         #expect(activation["status"] as? String == "activated_for_same_turn_next_request")
         #expect(activation["schema_visible_on_next_agent_loop_request"] as? Bool == true)
         #expect((activation["activated_tool_names"] as? [String]) == ["miyo_search"])
+        #expect(!loadResult.contains(AgentToolLoop.deferredSchemaNotice))
+    }
+
+    @Test func capabilitiesLoadActivatesBufferedMCPProviderSchemaForSameTurnUse() async throws {
+        let providerTool = loopMCPProviderTool("mcp_provider_search")
+        var activeTools = [loopTestTool("capabilities_load")]
+        var schemaNamesSeen: [[String]] = []
+        var loadResult = ""
+
+        _ = await CapabilityLoadBuffer.shared.drain()
+
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("capabilities_load", #"{"ids":["tool/mcp_provider_search"]}"#)]),
+            .toolCalls([inv("mcp_provider_search", #"{"query":"same turn"}"#)]),
+            .finalResponse,
+        ])
+        var hooks = surface.makeHooks()
+        hooks.buildMessages = { notices in
+            surface.builtNotices.append(notices)
+            schemaNamesSeen.append(activeTools.map { $0.function.name })
+            return AgentLoopIterationInput(messages: [ChatMessage(role: "user", content: "task")])
+        }
+        hooks.executeTool = { inv, callId in
+            surface.executedCalls.append((inv.toolName, inv.jsonArguments, callId))
+            if inv.toolName == "capabilities_load" {
+                if let diagnostic = await CapabilityLoadBuffer.shared.add(providerTool) {
+                    Issue.record("Provider tool schema should buffer cleanly: \(diagnostic.message)")
+                }
+                let drained = await CapabilityLoadBuffer.shared.drain()
+                let activation = AgentToolLoop.activateCapabilitySchemas(
+                    loadedTools: drained,
+                    currentTools: activeTools,
+                    mode: .sameTurnNextRequest
+                )
+                activeTools = activation.tools
+                loadResult = AgentToolLoop.annotateCapabilityLoadResult(
+                    ToolEnvelope.success(tool: inv.toolName, text: "Tool 'mcp_provider_search' loaded."),
+                    activation: activation.report
+                )
+                return AgentLoopToolExecution(result: loadResult)
+            }
+            return AgentLoopToolExecution(result: ToolEnvelope.success(tool: inv.toolName, text: "ran"))
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 4),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result.exit == .finalResponse)
+        #expect(surface.executedCalls.map(\.name) == ["capabilities_load", "mcp_provider_search"])
+        #expect(schemaNamesSeen.first == ["capabilities_load"])
+        #expect(schemaNamesSeen.dropFirst().first?.contains("mcp_provider_search") == true)
+
+        let envelope = try parsedJSONObject(loadResult)
+        let payload = try #require(envelope["result"] as? [String: Any])
+        let activation = try #require(payload["activation"] as? [String: Any])
+        let continuation = try #require(activation["continuation"] as? [String: Any])
+        #expect(activation["status"] as? String == "activated_for_same_turn_next_request")
+        #expect(activation["schema_visible_on_next_agent_loop_request"] as? Bool == true)
+        #expect((activation["activated_tool_names"] as? [String]) == ["mcp_provider_search"])
+        #expect(continuation["required"] as? Bool == false)
         #expect(!loadResult.contains(AgentToolLoop.deferredSchemaNotice))
     }
 


### PR DESCRIPTION
## Summary
- activate MCP provider tool schemas immediately after a successful `capabilities_load` result so the next same-turn request can use the newly loaded tool
- update prompt-budget accounting when same-turn schemas are added dynamically
- add a focused proof for buffered MCP provider schema activation

## Validation
- `git diff --cached --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-mcp-same-turn swift test --skip-update --scratch-path /Users/mmeding/Developer/Claude/Projects/osaurus/Packages/OsaurusCore/.build --package-path Packages/OsaurusCore --filter AgentToolLoopTests/capabilitiesLoadActivatesBufferedMCPProviderSchemaForSameTurnUse`
- Review findings incorporated: live tool-token accounting now reflects dynamically activated schemas.

## Draft gate
- This touches agent-loop behavior and needs local/frontier eval evidence before it should be marked ready for review.
