### PR TITLE
fix continuing and exporting conversations after the encryption update

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionsManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionsManager.swift
@@ -33,14 +33,23 @@ final class ChatSessionsManager: ObservableObject {
         // key rotation, `ChatSessionStore` deferred the DB open rather than
         // parking the launch main thread, leaving `sessions` empty. Reload
         // once the rotation settles. Armed only when the initial load came
-        // back empty (the sole case a deferral matters), and never under
-        // tests — a rotation in an unrelated suite must not trigger a stray
-        // cross-suite DB reload on the main actor (see RuntimeEnvironment
-        // .isUnderTests for the prior contactsd main-actor-stall incident).
-        if sessions.isEmpty, !RuntimeEnvironment.isUnderTests {
+        // back empty, and never under tests — a rotation in an unrelated suite
+        // must not trigger a stray cross-suite DB reload on the main actor (see
+        // RuntimeEnvironment.isUnderTests for the prior contactsd
+        // main-actor-stall incident).
+        //
+        // The same rotation-complete signal also drains any turn writes that
+        // `ChatSessionStore` had to defer while the DB was closed (#1737), so
+        // arm the observer whenever the initial open could have been deferred —
+        // not only when the list came back empty. Still never under tests, to
+        // avoid a stray cross-suite DB reload on the main actor.
+        if !RuntimeEnvironment.isUnderTests {
             NotificationCenter.default.publisher(for: StorageMutationGate.didFinishMutatingNotification)
                 .receive(on: DispatchQueue.main)
-                .sink { [weak self] _ in self?.refresh() }
+                .sink { [weak self] _ in
+                    ChatSessionStore.flushPendingSaves()
+                    self?.refresh()
+                }
                 .store(in: &cancellables)
         }
     }

--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -216,5 +216,17 @@ enum ChatSessionStore {
             pendingSaves.removeAll()
             ChatHistoryDatabase.shared.close()
         }
+
+        /// Mark the store as already open so save/load skip `ensureOpen()`'s
+        /// Keychain-gated path. Pair with `ChatHistoryDatabase.shared.openInMemory()`.
+        static func _markStorageOpenForTesting() { didOpen = true }
+
+        /// Seed the deferred-save queue as if a save had been dropped while the
+        /// DB was closed, so `flushPendingSaves()` can be exercised directly.
+        static func _enqueuePendingSaveForTesting(_ session: ChatSessionData) {
+            pendingSaves[session.id] = session
+        }
+
+        static var _pendingSaveCountForTesting: Int { pendingSaves.count }
     #endif
 }

--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -23,7 +23,20 @@ enum ChatSessionStore {
     static func load(id: UUID) -> ChatSessionData? {
         ensureOpen()
         guard let session = ChatHistoryDatabase.shared.loadSession(id: id) else { return nil }
-        return recoverTranscriptTurnsIfNeeded(session)
+        let recovered = recoverTranscriptTurnsIfNeeded(session)
+        // When turns were re-derived from the Memory transcript (the #1737
+        // orphaned-conversation case), persist them back once so later
+        // loads/exports read full rows instead of re-deriving every time.
+        // Best-effort and only when the DB is already open — never force a
+        // Keychain touch on the load path.
+        if session.turns.isEmpty, !recovered.turns.isEmpty, didOpen {
+            do {
+                try ChatHistoryDatabase.shared.saveSession(recovered)
+            } catch {
+                print("[ChatSessionStore] Failed to heal recovered turns for \(id): \(error)")
+            }
+        }
+        return recovered
     }
 
     /// Save a session (creates or updates)
@@ -155,8 +168,9 @@ enum ChatSessionStore {
             guard !recoveredTurns.isEmpty else { return session }
 
             var recovered = session
-            // Read-only compatibility fallback. Do not write these turns back to
-            // chat-history here; recovery should not mutate storage during load.
+            // Pure transform — write-back is the caller's job (`load` heals the
+            // chat-history row once when the DB is open) so this stays usable
+            // from read-only/non-open contexts without mutating storage.
             recovered.turns = recoveredTurns
             return recovered
         } catch {

--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -29,10 +29,44 @@ enum ChatSessionStore {
     /// Save a session (creates or updates)
     static func save(_ session: ChatSessionData) {
         ensureOpen()
+        // When the chat-history DB is deferred (storage key not yet resident or
+        // a key rotation is in flight), `ensureOpen()` leaves `didOpen` false.
+        // Writing now throws `.notOpen` and silently drops the turns — the
+        // #1737 regression where finished conversations couldn't be continued or
+        // exported. Queue instead and re-flush once storage becomes ready.
+        guard didOpen else {
+            pendingSaves[session.id] = session
+            return
+        }
         do {
             try ChatHistoryDatabase.shared.saveSession(session)
         } catch {
             print("[ChatSessionStore] Failed to save session \(session.id): \(error)")
+        }
+    }
+
+    /// Sessions whose writes were deferred because the chat-history DB wasn't
+    /// open yet. Keyed by id so repeated saves of the same session collapse to
+    /// the latest snapshot. Drained by `flushPendingSaves()`.
+    private static var pendingSaves: [UUID: ChatSessionData] = [:]
+
+    /// Re-attempt any saves that were deferred while the chat-history DB was
+    /// closed. Call when storage becomes ready (e.g. on the rotation-complete
+    /// notification). No-op when nothing is pending or the DB is still deferred.
+    static func flushPendingSaves() {
+        guard !pendingSaves.isEmpty else { return }
+        ensureOpen()
+        guard didOpen else { return }
+        let drained = pendingSaves
+        pendingSaves.removeAll()
+        for (id, session) in drained {
+            do {
+                try ChatHistoryDatabase.shared.saveSession(session)
+            } catch {
+                print("[ChatSessionStore] Failed to flush deferred save \(id): \(error)")
+                // Keep it queued for the next readiness signal.
+                pendingSaves[id] = session
+            }
         }
     }
 
@@ -165,6 +199,7 @@ enum ChatSessionStore {
     #if DEBUG
         static func _resetForTesting() {
             didOpen = false
+            pendingSaves.removeAll()
             ChatHistoryDatabase.shared.close()
         }
     #endif

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
@@ -1,0 +1,78 @@
+//
+//  ChatSessionStoreDeferredSaveTests.swift
+//  osaurus
+//
+//  Regression coverage for #1737: turn writes that were deferred while the
+//  chat-history DB was closed must be re-flushed (not dropped), and loading an
+//  orphaned conversation must heal its turns back onto disk.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite(.serialized)
+struct ChatSessionStoreDeferredSaveTests {
+    private func withOpenStores(
+        memory: Bool = false,
+        _ body: () throws -> Void
+    ) throws {
+        try ChatHistoryDatabase.shared.openInMemory()
+        if memory { try MemoryDatabase.shared.openInMemory() }
+        ChatSessionStore._markStorageOpenForTesting()
+        defer {
+            ChatSessionStore._resetForTesting()
+            if memory { MemoryDatabase.shared.close() }
+        }
+        try body()
+    }
+
+    @Test func flushPersistsQueuedSavesToDatabase() throws {
+        try withOpenStores {
+            let session = ChatSessionData(
+                id: UUID(),
+                title: "Deferred chat",
+                turns: [
+                    ChatTurnData(role: .user, content: "queued question"),
+                    ChatTurnData(role: .assistant, content: "queued answer"),
+                ]
+            )
+            ChatSessionStore._enqueuePendingSaveForTesting(session)
+            #expect(ChatSessionStore._pendingSaveCountForTesting == 1)
+
+            ChatSessionStore.flushPendingSaves()
+
+            #expect(ChatSessionStore._pendingSaveCountForTesting == 0)
+            let loaded = ChatHistoryDatabase.shared.loadSession(id: session.id)
+            #expect(loaded?.turns.map(\.content) == ["queued question", "queued answer"])
+        }
+    }
+
+    @Test func loadHealsOrphanedTurnsBackToDisk() throws {
+        try withOpenStores(memory: true) {
+            let sessionId = UUID(uuidString: "44444444-5555-6666-7777-888888888888")!
+            // Metadata row exists, but turns were lost (the #1737 state).
+            try ChatHistoryDatabase.shared.saveSession(
+                ChatSessionData(id: sessionId, title: "Orphaned chat", turns: [])
+            )
+            try MemoryDatabase.shared.insertTranscriptTurn(
+                agentId: Agent.defaultId.uuidString,
+                conversationId: sessionId.uuidString,
+                chunkIndex: 0,
+                role: "user",
+                content: "are my turns gone?",
+                tokenCount: 4
+            )
+
+            let loaded = ChatSessionStore.load(id: sessionId)
+            #expect(loaded?.turns.map(\.content) == ["are my turns gone?"])
+
+            // The heal should have written the recovered turns back, so a raw
+            // DB read (no transcript fallback) now sees them too.
+            let healed = ChatHistoryDatabase.shared.loadSession(id: sessionId)
+            #expect(healed?.turns.map(\.content) == ["are my turns gone?"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

addresses #1737

- fixed a regression where finished conversations could not be continued or exported after updating, showing only the title on export
- stopped silently dropping chat history writes when storage was deferred during the at-rest encryption migration or a key rotation
- queued those writes and re-flushed them once storage became ready instead of losing the turns
- repaired conversations already orphaned by the update by recovering their turns from the memory transcript and persisting them back on next open
- added tests covering the deferred-save flush and the orphaned conversation heal

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
