### PR TITLE
Improve image generation: responsive cancel, live timer/estimate, dynamic OsaurusAI catalog

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -15081,6 +15081,28 @@
         }
       }
     },
+    "Cancelling…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird abgebrochen…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在取消…"
+          }
+        }
+      }
+    },
     "Cannot access file" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -16571,6 +16593,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "检查中"
+          }
+        }
+      }
+    },
+    "Checking Hugging Face for more models…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hugging Face wird nach weiteren Modellen durchsucht…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hugging Face에서 더 많은 모델을 확인하는 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在 Hugging Face 上查找更多模型…"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/HuggingFaceService.swift
+++ b/Packages/OsaurusCore/Services/HuggingFaceService.swift
@@ -524,6 +524,69 @@ actor HuggingFaceService {
         }
     }
 
+    // MARK: - Org / author model listing
+
+    /// One row from the `/api/models?author=…` listing endpoint. Lightweight
+    /// (no file sizes — the listing endpoint omits them); callers resolve
+    /// sizes lazily via the tree API when needed.
+    struct OrgModelListing: Sendable {
+        let id: String
+        let pipelineTag: String?
+        let tags: [String]
+        let downloads: Int?
+        let lastModified: String?
+    }
+
+    private struct OrgModelRow: Decodable {
+        let id: String
+        let pipeline_tag: String?
+        let tags: [String]?
+        let downloads: Int?
+        let lastModified: String?
+    }
+
+    /// List public models published by an HF org/author, sorted by downloads
+    /// (most-popular first). Returns `[]` on any failure (network, non-2xx,
+    /// decode) so callers can treat it as "nothing found". `full=1` includes
+    /// `pipeline_tag` + `tags`, which callers use to classify repos (image vs
+    /// LLM).
+    func fetchModels(author: String, limit: Int = 200) async -> [OrgModelListing] {
+        let trimmed = author.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        var comps = URLComponents()
+        comps.scheme = "https"
+        comps.host = "huggingface.co"
+        comps.path = "/api/models"
+        comps.queryItems = [
+            URLQueryItem(name: "author", value: trimmed),
+            URLQueryItem(name: "full", value: "1"),
+            URLQueryItem(name: "sort", value: "downloads"),
+            URLQueryItem(name: "limit", value: String(limit)),
+        ]
+        guard let url = comps.url else { return [] }
+
+        var req = URLRequest(url: url)
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            let (data, response) = try await GlobalProxySettings.sharedSession().data(for: req)
+            guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
+                return []
+            }
+            let rows = try JSONDecoder().decode([OrgModelRow].self, from: data)
+            return rows.map {
+                OrgModelListing(
+                    id: $0.id,
+                    pipelineTag: $0.pipeline_tag,
+                    tags: $0.tags ?? [],
+                    downloads: $0.downloads,
+                    lastModified: $0.lastModified
+                )
+            }
+        } catch {
+            return []
+        }
+    }
+
     /// Extract license identifier from HF tags
     private func extractLicenseFromTags(_ tags: [String]) -> String? {
         // HF tags often include license: prefix

--- a/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
@@ -295,6 +295,10 @@ public actor ImageGenerationService {
                         continuation.yield(.loadingModel(model: requestedModel))
                         try await self.ensureLoaded(requestedModel, expected: kind)
                     }
+                    // Honor a cancel that arrived during the (uninterruptible)
+                    // weight load so generation never starts. The gate-drain
+                    // tail below still runs on every path.
+                    if cancelRequested() { cancelled = true }
                     let engine = self.ensureEngine()
                     let outputDir = OsaurusPaths.generatedImages()
                     OsaurusPaths.ensureExistsSilent(outputDir)

--- a/Packages/OsaurusCore/Services/ModelRuntime/ImageModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ImageModelDownloadService.swift
@@ -42,24 +42,20 @@ final class ImageModelDownloadService: ObservableObject {
 
     @Published private(set) var states: [String: DownloadState] = [:]
     @Published private(set) var metrics: [String: ModelDownloadService.DownloadMetrics] = [:]
+    /// Image bundles published under the OsaurusAI HF org, fetched at runtime.
+    /// This is the sole source for the Available list — empty until
+    /// `refreshCatalog()` succeeds, and left untouched on a fetch failure so a
+    /// previously-loaded listing keeps showing. Users can still stage any other
+    /// mflux bundle by pasting its repo id via the UI's Import field.
+    @Published private(set) var fetchedCatalog: [ImageModelDownload] = []
+    /// True while the OsaurusAI org listing fetch is in flight.
+    @Published private(set) var isLoadingCatalog = false
 
-    /// Curated, known-public mirrors. Most users will paste a repo id via the
-    /// UI's custom field instead — any mflux bundle works as long as its repo
-    /// name carries a recognizable family token (z-image, flux1-schnell,
-    /// qwen-image, ideogram, …). Seeded with the Ideogram mirrors named in the
-    /// vMLX integration spec; extend as more public mflux repos are verified.
-    static let catalog: [ImageModelDownload] = [
-        ImageModelDownload(
-            repoId: "cocktailpeanut/ideogram-4-fp8",
-            displayName: "Ideogram 4 (fp8)",
-            note: "Strong typography renderer."
-        ),
-        ImageModelDownload(
-            repoId: "cocktailpeanut/ideogram-4-nf4",
-            displayName: "Ideogram 4 (NF4)",
-            note: "4-bit; smaller footprint."
-        ),
-    ]
+    /// HF org whose published image bundles populate the Available list.
+    static let osaurusOrgAuthor = "OsaurusAI"
+    /// HF `pipeline_tag` values that denote a runnable on-device image bundle
+    /// (excludes `image-text-to-text` VLMs/LLMs published in the same org).
+    private static let imagePipelineTags: Set<String> = ["text-to-image", "image-to-image"]
 
     /// File patterns to stage. Matched against each file's name across all
     /// subdirectories, so nested `transformer/*.safetensors` etc. are included.
@@ -97,7 +93,7 @@ final class ImageModelDownloadService: ObservableObject {
     }
 
     /// Source HF repo a staged bundle was downloaded from. Reads the hidden
-    /// marker; falls back to a curated catalog entry with the same id. `nil`
+    /// marker; falls back to a fetched-catalog entry with the same id. `nil`
     /// when neither is known (e.g. an old imported bundle), in which case
     /// re-download is unavailable and only delete is offered.
     func sourceRepoId(for id: String) -> String? {
@@ -108,7 +104,7 @@ final class ImageModelDownloadService: ObservableObject {
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty { return trimmed }
         }
-        return Self.catalog.first { $0.id == id }?.repoId
+        return fetchedCatalog.first { $0.id == id }?.repoId
     }
 
     /// Delete a staged bundle from disk, cancel any in-flight download, and
@@ -172,6 +168,38 @@ final class ImageModelDownloadService: ObservableObject {
 
     func download(_ entry: ImageModelDownload) {
         download(repoId: entry.repoId, displayName: entry.displayName)
+    }
+
+    /// Fetch the OsaurusAI org listing from Hugging Face and refresh
+    /// `fetchedCatalog` with its image bundles (text-to-image / image-to-image
+    /// pipelines). Best-effort: a failed or empty fetch leaves any
+    /// previously-loaded listing intact rather than blanking the list.
+    func refreshCatalog() async {
+        isLoadingCatalog = true
+        defer { isLoadingCatalog = false }
+        let rows = await HuggingFaceService.shared.fetchModels(author: Self.osaurusOrgAuthor)
+        guard !rows.isEmpty else { return }
+        let entries =
+            rows
+            .filter { Self.imagePipelineTags.contains(($0.pipelineTag ?? "").lowercased()) }
+            .map(Self.makeCatalogEntry(from:))
+        // Listing is already sorted by downloads (most popular first).
+        fetchedCatalog = entries
+    }
+
+    /// Map an HF org listing row to a downloadable catalog entry. The display
+    /// name is the repo's last path component (the quant pill in the row is
+    /// derived from the repo id separately).
+    private static func makeCatalogEntry(
+        from row: HuggingFaceService.OrgModelListing
+    ) -> ImageModelDownload {
+        let isEdit = (row.pipelineTag ?? "").lowercased() == "image-to-image"
+        let tail = row.id.split(separator: "/").last.map(String.init) ?? row.id
+        return ImageModelDownload(
+            repoId: row.id,
+            displayName: tail,
+            note: isEdit ? "Image edit · mflux" : "Text-to-image · mflux"
+        )
     }
 
     /// Start downloading any HuggingFace mflux repo into the image models root.

--- a/Packages/OsaurusCore/Views/Model/ImageGenerationPanelView.swift
+++ b/Packages/OsaurusCore/Views/Model/ImageGenerationPanelView.swift
@@ -33,9 +33,25 @@ final class ImageGenerationPanelModel: ObservableObject {
     @Published var phase: Phase = .idle
     @Published var resultURL: URL?
     @Published var resultSeed: UInt64?
+    /// `true` between a user Cancel press and the terminal event that resolves
+    /// the job. The actual weight load inside vMLXFlux is not interruptible, so
+    /// this drives immediate UI feedback while the soft cancel settles.
+    @Published var isCancelling = false
+    /// Live elapsed wall-clock for the current job (Generate press → finish),
+    /// updated ~10x/sec while busy so the panel can show a running timer.
+    @Published var elapsed: TimeInterval = 0
+    /// Final elapsed of the most recent finished job (any outcome), for the
+    /// "Done in Xs" readout.
+    @Published private(set) var lastDuration: TimeInterval?
+    /// Estimate carried over from the last *successful* run with the same
+    /// model + size + mode, shown before/while the next run finishes.
+    @Published private(set) var estimate: TimeInterval?
 
     private var job: Task<Void, Never>?
     private let jobID = UUID().uuidString
+    private var startDate: Date?
+    private var timerTask: Task<Void, Never>?
+    private var durationKey: String?
 
     var isBusy: Bool {
         switch phase {
@@ -45,14 +61,20 @@ final class ImageGenerationPanelModel: ObservableObject {
     }
 
     func generate(_ params: ImageGenerationParameters) {
+        durationKey = ImageGenerationDurationStore.key(
+            model: params.model, width: params.width, height: params.height, isEdit: false)
         start { await ImageGenerationService.shared.generate(params, jobID: self.jobID) }
     }
 
     func edit(_ params: ImageEditParameters) {
+        durationKey = ImageGenerationDurationStore.key(
+            model: params.model, width: params.width, height: params.height, isEdit: true)
         start { await ImageGenerationService.shared.edit(params, jobID: self.jobID) }
     }
 
     func cancel() {
+        guard isBusy, !isCancelling else { return }
+        isCancelling = true
         Task { await ImageGenerationService.shared.cancel(jobID: jobID) }
     }
 
@@ -62,7 +84,11 @@ final class ImageGenerationPanelModel: ObservableObject {
         job?.cancel()
         resultURL = nil
         resultSeed = nil
+        isCancelling = false
+        lastDuration = nil
+        estimate = durationKey.flatMap { ImageGenerationDurationStore.lastDuration(for: $0) }
         phase = .loadingModel("")
+        startTiming()
         job = Task { [weak self] in
             guard let self else { return }
             do {
@@ -71,9 +97,17 @@ final class ImageGenerationPanelModel: ObservableObject {
                     await self.apply(event)
                 }
             } catch is CancellationError {
-                await MainActor.run { self.phase = .cancelled }
+                await MainActor.run {
+                    self.isCancelling = false
+                    self.finishTiming(persist: false)
+                    self.phase = .cancelled
+                }
             } catch {
-                await MainActor.run { self.phase = .failed(String(describing: error)) }
+                await MainActor.run {
+                    self.isCancelling = false
+                    self.finishTiming(persist: false)
+                    self.phase = .failed(String(describing: error))
+                }
             }
         }
     }
@@ -91,12 +125,70 @@ final class ImageGenerationPanelModel: ObservableObject {
                 resultURL = first.url
                 resultSeed = first.seed
             }
+            isCancelling = false
+            finishTiming(persist: true)
             phase = .done
         case .failed(let message, _):
+            isCancelling = false
+            finishTiming(persist: false)
             phase = .failed(message)
         case .cancelled:
+            isCancelling = false
+            finishTiming(persist: false)
             phase = .cancelled
         }
+    }
+
+    private func startTiming() {
+        startDate = Date()
+        elapsed = 0
+        timerTask?.cancel()
+        timerTask = Task { [weak self] in
+            while let self, self.isBusy {
+                self.elapsed = Date().timeIntervalSince(self.startDate ?? Date())
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+        }
+    }
+
+    /// Stop the timer, freeze the final elapsed, and (on success) persist it as
+    /// the estimate for the next run with the same key.
+    private func finishTiming(persist: Bool) {
+        timerTask?.cancel()
+        timerTask = nil
+        guard let start = startDate else { return }
+        let total = Date().timeIntervalSince(start)
+        startDate = nil
+        elapsed = total
+        lastDuration = total
+        if persist, let key = durationKey {
+            ImageGenerationDurationStore.record(total, for: key)
+            estimate = total
+        }
+    }
+}
+
+/// Persists the most recent successful end-to-end duration (Generate press →
+/// finished image) per model + size + mode, so the panel can offer a rough
+/// "~Xs" estimate before the next run. Backed by a plist dictionary in
+/// `UserDefaults`.
+enum ImageGenerationDurationStore {
+    private static let defaultsKey = "osaurus.imageGeneration.lastDurations"
+
+    static func key(model: String, width: Int?, height: Int?, isEdit: Bool) -> String {
+        let size = (width != nil && height != nil) ? "\(width!)x\(height!)" : "auto"
+        return "\(model)|\(size)|\(isEdit ? "edit" : "gen")"
+    }
+
+    static func lastDuration(for key: String) -> TimeInterval? {
+        (UserDefaults.standard.dictionary(forKey: defaultsKey) as? [String: Double])?[key]
+    }
+
+    static func record(_ duration: TimeInterval, for key: String) {
+        guard duration.isFinite, duration > 0 else { return }
+        var dict = (UserDefaults.standard.dictionary(forKey: defaultsKey) as? [String: Double]) ?? [:]
+        dict[key] = duration
+        UserDefaults.standard.set(dict, forKey: defaultsKey)
     }
 }
 
@@ -273,28 +365,62 @@ struct ImageGenerationPanelView: View {
 
     private var statusCard: some View {
         Group {
-            switch model.phase {
-            case .idle:
-                EmptyView()
-            case .loadingModel(let m):
-                statusRow(spinner: true, text: m.isEmpty ? L("Loading model…") : "Loading \(m)…")
-            case .running(let step, let total, let eta):
-                VStack(alignment: .leading, spacing: 6) {
-                    statusRow(
-                        spinner: true,
-                        text: "Step \(step)/\(total)" + (eta.map { String(format: " · ~%.0fs", $0) } ?? "")
-                    )
-                    ProgressView(value: Double(step), total: Double(max(total, 1)))
-                        .tint(theme.accentColor)
+            if model.isCancelling {
+                statusRow(
+                    spinner: true,
+                    text: L("Cancelling…") + " · " + Self.formatDuration(model.elapsed),
+                    color: theme.warningColor
+                )
+            } else {
+                switch model.phase {
+                case .idle:
+                    EmptyView()
+                case .loadingModel(let m):
+                    let base = m.isEmpty ? L("Loading model…") : "Loading \(m)…"
+                    statusRow(spinner: true, text: base + busyTimingSuffix)
+                case .running(let step, let total, let eta):
+                    VStack(alignment: .leading, spacing: 6) {
+                        statusRow(
+                            spinner: true,
+                            text: "Step \(step)/\(total)"
+                                + (eta.map { String(format: " · ~%.0fs", $0) } ?? "")
+                                + " · " + Self.formatDuration(model.elapsed)
+                        )
+                        ProgressView(value: Double(step), total: Double(max(total, 1)))
+                            .tint(theme.accentColor)
+                    }
+                case .done:
+                    let text = model.lastDuration.map {
+                        L("Done") + " · " + Self.formatDuration($0)
+                    } ?? L("Done")
+                    statusRow(spinner: false, text: text, color: theme.successColor)
+                case .failed(let message):
+                    statusRow(spinner: false, text: message, color: theme.errorColor)
+                case .cancelled:
+                    statusRow(spinner: false, text: L("Cancelled"), color: theme.warningColor)
                 }
-            case .done:
-                statusRow(spinner: false, text: L("Done"), color: theme.successColor)
-            case .failed(let message):
-                statusRow(spinner: false, text: message, color: theme.errorColor)
-            case .cancelled:
-                statusRow(spinner: false, text: L("Cancelled"), color: theme.warningColor)
             }
         }
+    }
+
+    /// " · 12.3s" plus " / ~25s" when a prior-run estimate is known.
+    private var busyTimingSuffix: String {
+        var suffix = " · " + Self.formatDuration(model.elapsed)
+        if let estimate = model.estimate {
+            suffix += " / " + Self.formatEstimate(estimate)
+        }
+        return suffix
+    }
+
+    private static func formatDuration(_ t: TimeInterval) -> String {
+        if t < 60 { return String(format: "%.1fs", t) }
+        return String(format: "%dm %02ds", Int(t) / 60, Int(t) % 60)
+    }
+
+    private static func formatEstimate(_ t: TimeInterval) -> String {
+        let r = t.rounded()
+        if r < 60 { return String(format: "~%.0fs", r) }
+        return String(format: "~%dm %02ds", Int(r) / 60, Int(r) % 60)
     }
 
     private func resultCard(_ url: URL) -> some View {
@@ -342,7 +468,11 @@ struct ImageGenerationPanelView: View {
             }
             .buttonStyle(PlainButtonStyle())
             Spacer()
-            if model.isBusy {
+            if model.isCancelling {
+                Text("Cancelling…", bundle: .module)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+            } else if model.isBusy {
                 Button(action: { model.cancel() }) {
                     Text("Cancel", bundle: .module)
                         .font(.system(size: 13, weight: .medium))

--- a/Packages/OsaurusCore/Views/Model/ImageModelsDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ImageModelsDownloadView.swift
@@ -44,9 +44,9 @@ struct ImageModelsDownloadView: View {
 
     private var installedIds: Set<String> { Set(installed.map(\.id)) }
 
-    /// Curated catalog entries not yet on disk.
+    /// OsaurusAI org image bundles (fetched from HF) not yet on disk.
     private var availableEntries: [ImageModelDownload] {
-        ImageModelDownloadService.catalog.filter { !installedIds.contains($0.id) }
+        downloads.fetchedCatalog.filter { !installedIds.contains($0.id) }
     }
 
     // MARK: - Body
@@ -54,18 +54,24 @@ struct ImageModelsDownloadView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                if installed.isEmpty && availableEntries.isEmpty {
+                if installed.isEmpty && availableEntries.isEmpty && !downloads.isLoadingCatalog {
                     emptyState
                 } else {
                     if !installed.isEmpty { installedSection }
-                    if !availableEntries.isEmpty { availableSection }
+                    if !availableEntries.isEmpty || downloads.isLoadingCatalog { availableSection }
                 }
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 24)
             .frame(maxWidth: .infinity, alignment: .top)
         }
-        .task { await refreshInstalled() }
+        .task {
+            // Start the org fetch and the local scan together so the loading
+            // state engages immediately (no empty-state flash before the list).
+            async let installedRefresh: Void = refreshInstalled()
+            async let catalogRefresh: Void = downloads.refreshCatalog()
+            _ = await (installedRefresh, catalogRefresh)
+        }
         .onReceive(NotificationCenter.default.publisher(for: .localModelsChanged)) { _ in
             Task { await refreshInstalled() }
         }
@@ -128,8 +134,20 @@ struct ImageModelsDownloadView: View {
                         onCancel: { downloads.cancel(entry.id) }
                     )
                 }
+                if downloads.isLoadingCatalog { catalogLoadingRow }
             }
         }
+    }
+
+    private var catalogLoadingRow: some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text("Checking Hugging Face for more models…", bundle: .module)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+            Spacer()
+        }
+        .padding(12)
     }
 
     private var emptyState: some View {


### PR DESCRIPTION
## Summary

Three related improvements to the manual image-generation panel and the image-model catalog:

- **Responsive cancel.** Pressing Cancel now flips the panel into an immediate, disabled "Cancelling…" state (footer + status row with live elapsed) instead of appearing stuck. Because the vMLXFlux weight load is not interruptible, the request is a *soft* cancel: `ImageGenerationService` re-checks `cancelRequested()` right after the load completes, so a cancel issued mid-load is honored before any generation starts, and the Metal gate-drain tail still runs on every path.
- **Live timer + persisted estimate.** The panel shows a running wall-clock timer (Generate press → finish) and, on success, persists the end-to-end duration per `model + size + mode` in `UserDefaults` (`ImageGenerationDurationStore`). The next matching run shows a `~Xs` estimate alongside the live time, and finished runs show `Done · Xs`.
- **Dynamic OsaurusAI catalog.** The Available list is now fetched at runtime from the `OsaurusAI` Hugging Face org (`/api/models?author=…&full=1`, sorted by downloads) and filtered to image pipelines (`text-to-image` / `image-to-image`), replacing the hardcoded Ideogram seed. Manual repo-id import still works, and a failed/offline fetch leaves any previously-loaded listing intact rather than blanking the list.

New strings ("Cancelling…", "Checking Hugging Face for more models…") include de/ko/zh-Hans translations.

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` — clean
- [x] Targeted suites pass: `NativeImageJobCoordinatorTests`, `Image generation bridge contract` (13 tests, 2 suites)
- [ ] Manual: open the image panel, press Cancel during model load → UI shows "Cancelling…" immediately and no image is produced
- [ ] Manual: run a generation twice with the same model/size → second run shows a `~Xs` estimate; `Done · Xs` after finish
- [ ] Manual: open Image Models → "Available" shows OsaurusAI org bundles (loading row while fetching); offline keeps the last listing / Import field

Made with [Cursor](https://cursor.com)