### PR TITLE
Fix chat history loss from non-idempotent schema migrations

### DIFF
--- a/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
@@ -44,8 +44,6 @@ public enum ChatHistoryDatabaseError: Error, LocalizedError {
 public final class ChatHistoryDatabase: @unchecked Sendable {
     public static let shared = ChatHistoryDatabase()
 
-    private static let schemaVersion = 4
-
     private var db: OpaquePointer?
     private let queue = DispatchQueue(label: "ai.osaurus.chatHistory.database")
     private let stmtCache = PreparedStatementCache(capacity: 64)
@@ -65,7 +63,27 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             guard db == nil else { return }
             OsaurusPaths.ensureExistsSilent(OsaurusPaths.chatHistory())
             try openConnection()
-            try runMigrations()
+            do {
+                try runMigrations()
+            } catch {
+                // Don't leave a live, half-migrated connection: `db` is set by
+                // `openConnection()`, and a non-nil `db` makes every later
+                // `open()` no-op-succeed (`guard db == nil`), running the app
+                // against a schema missing columns its SQL expects. Close it,
+                // record the failure so it surfaces in `/health` + the recovery
+                // UI, and rethrow so `StorageRecoveryService` can retry/reset.
+                stmtCache.clear()
+                if let connection = db {
+                    sqlite3_close(connection)
+                    db = nil
+                }
+                PersistenceHealth.shared.recordDatabaseOpenFailure(
+                    subsystem: StorageRecoveryService.Store.chatHistory.rawValue,
+                    error: error,
+                    path: OsaurusPaths.chatHistoryDatabaseFile().path
+                )
+                throw error
+            }
         }
         OsaurusDatabaseHandle.register(maintenanceHandle)
     }
@@ -177,6 +195,34 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         try executeRaw("PRAGMA user_version = \(v)")
     }
 
+    /// Whether `table` currently has `column`. Cheap `PRAGMA table_info`
+    /// scan, mirroring `MemoryDatabase`'s idempotent-migration helper.
+    private func tableHasColumn(_ table: String, _ column: String) -> Bool {
+        var found = false
+        try? executeRaw("PRAGMA table_info(\(table))") { stmt in
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                if String(cString: sqlite3_column_text(stmt, 1)) == column {
+                    found = true
+                    break
+                }
+            }
+        }
+        return found
+    }
+
+    /// Idempotent `ALTER TABLE <table> ADD COLUMN <column> <type>`, run only
+    /// when `column` is absent (`type` carries the SQL type + any
+    /// constraints, e.g. `TEXT NOT NULL DEFAULT ''`). Re-running a migration
+    /// step on a DB that already has the column — e.g. a store whose
+    /// `user_version` is stuck behind columns a prior build (or the
+    /// encryption-convergence rebuild) already added — is then a no-op
+    /// instead of a fatal `duplicate column name` error that aborts `open()`
+    /// and renders the whole chat history unreadable and unwritable.
+    private func addColumnIfMissing(_ table: String, _ column: String, _ type: String) throws {
+        guard !tableHasColumn(table, column) else { return }
+        try executeRaw("ALTER TABLE \(table) ADD COLUMN \(column) \(type)")
+    }
+
     private func migrateToV1() throws {
         try executeRaw(
             """
@@ -228,7 +274,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// win for the post-stream `save()` path that previously ran
     /// `DELETE all + INSERT all`).
     private func migrateToV2() throws {
-        try executeRaw("ALTER TABLE turns ADD COLUMN content_hash TEXT NOT NULL DEFAULT ''")
+        try addColumnIfMissing("turns", "content_hash", "TEXT NOT NULL DEFAULT ''")
         try setSchemaVersion(2)
     }
 
@@ -236,7 +282,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// conversations under an opt-in "Archived" filter without deleting
     /// them.
     private func migrateToV3() throws {
-        try executeRaw("ALTER TABLE sessions ADD COLUMN archived INTEGER NOT NULL DEFAULT 0")
+        try addColumnIfMissing("sessions", "archived", "INTEGER NOT NULL DEFAULT 0")
         try setSchemaVersion(3)
     }
 
@@ -247,7 +293,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// would require parsing every turn's attachments + toolCalls JSON
     /// in Swift, which we avoid here to keep the migration cheap.
     private func migrateToV4() throws {
-        try executeRaw("ALTER TABLE sessions ADD COLUMN capabilities TEXT NOT NULL DEFAULT ''")
+        try addColumnIfMissing("sessions", "capabilities", "TEXT NOT NULL DEFAULT ''")
         try setSchemaVersion(4)
     }
 
@@ -257,10 +303,10 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// behavior. `created_at` and `completed_at` are stored as REAL
     /// (timeIntervalSince1970), consistent with the session timestamps.
     private func migrateToV5() throws {
-        try executeRaw("ALTER TABLE turns ADD COLUMN created_at REAL")
-        try executeRaw("ALTER TABLE turns ADD COLUMN completed_at REAL")
-        try executeRaw("ALTER TABLE turns ADD COLUMN generation_token_count INTEGER")
-        try executeRaw("ALTER TABLE turns ADD COLUMN time_to_first_token REAL")
+        try addColumnIfMissing("turns", "created_at", "REAL")
+        try addColumnIfMissing("turns", "completed_at", "REAL")
+        try addColumnIfMissing("turns", "generation_token_count", "INTEGER")
+        try addColumnIfMissing("turns", "time_to_first_token", "REAL")
         try setSchemaVersion(5)
     }
 
@@ -268,14 +314,14 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// chat UI can show "· 1.2s" next to each completed tool call after reload.
     /// Nullable; legacy turns just surface no durations.
     private func migrateToV6() throws {
-        try executeRaw("ALTER TABLE turns ADD COLUMN tool_call_durations TEXT")
+        try addColumnIfMissing("turns", "tool_call_durations", "TEXT")
         try setSchemaVersion(6)
     }
 
     /// v7: add `thinking_duration` (REAL seconds) so the thinking block can show
     /// "Thought for 30s" after reload. Nullable; legacy turns surface nothing.
     private func migrateToV7() throws {
-        try executeRaw("ALTER TABLE turns ADD COLUMN thinking_duration REAL")
+        try addColumnIfMissing("turns", "thinking_duration", "REAL")
         try setSchemaVersion(7)
     }
 
@@ -284,7 +330,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// shows a billed-but-empty turn and its "you were charged" notice rather
     /// than a silent gap. Nullable; metadata only (no prompt/response text).
     private func migrateToV8() throws {
-        try executeRaw("ALTER TABLE turns ADD COLUMN router_billing TEXT")
+        try addColumnIfMissing("turns", "router_billing", "TEXT")
         try setSchemaVersion(8)
     }
 
@@ -1062,7 +1108,12 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
 
     static func bindText(_ stmt: OpaquePointer, index: Int, value: String?) {
         if let value {
-            sqlite3_bind_text(stmt, Int32(index), value, -1, SQLITE_TRANSIENT)
+            // Bind with an explicit UTF-8 byte length instead of -1
+            // (NUL-terminated). Document-extracted text (e.g. from a PDF) can
+            // contain embedded NUL bytes; with -1 SQLite truncates the value
+            // at the first NUL, silently dropping the rest of the content.
+            // SQLITE_TRANSIENT makes SQLite copy the bytes during the call.
+            sqlite3_bind_text(stmt, Int32(index), value, Int32(value.utf8.count), SQLITE_TRANSIENT)
         } else {
             sqlite3_bind_null(stmt, Int32(index))
         }

--- a/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
@@ -1,0 +1,361 @@
+//
+//  ChatHistoryMigrationRepairTests.swift
+//  osaurusTests
+//
+//  Regression coverage for the chat-history schema-migration repair.
+//
+//  Field reports surfaced stores stuck at `user_version = 1` whose columns
+//  had already been added by a prior build (or reset by the encryption
+//  convergence rebuild), missing only the newest column. With the old
+//  non-idempotent migrations, `open()` re-ran `migrateToV2` and threw
+//  `duplicate column name: content_hash`, never reaching the v8
+//  `router_billing` ALTER. Because `selectTurnsSQL` / `insertTurnSQL`
+//  reference `router_billing`, every `loadSession` then returned nil
+//  (existing chats opened empty) and every `saveSession` threw (new chats
+//  vanished on restart) — the "all my history is gone" symptom.
+//
+//  These tests pin the reproduced failure state and the partial variants,
+//  asserting the now-idempotent migrations self-heal on the next `open()`:
+//  columns that already exist are skipped, the missing ones are added, the
+//  schema version reconciles to the latest, and existing + new data round
+//  trips.
+//
+
+import CryptoKit
+import Foundation
+import OsaurusSQLCipher
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ChatHistoryMigrationRepairTests {
+
+    // MARK: - Production v1 CREATE TABLE shapes
+
+    private static let createSessionsV1 = """
+        CREATE TABLE sessions (
+            id                   TEXT PRIMARY KEY,
+            title                TEXT NOT NULL,
+            created_at           REAL NOT NULL,
+            updated_at           REAL NOT NULL,
+            selected_model       TEXT,
+            agent_id             TEXT,
+            source               TEXT NOT NULL DEFAULT 'chat',
+            source_plugin_id     TEXT,
+            external_session_key TEXT,
+            dispatch_task_id     TEXT,
+            turn_count           INTEGER NOT NULL DEFAULT 0
+        )
+        """
+
+    private static let createTurnsV1 = """
+        CREATE TABLE turns (
+            id            TEXT PRIMARY KEY,
+            session_id    TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            seq           INTEGER NOT NULL,
+            role          TEXT NOT NULL,
+            content       TEXT,
+            attachments   TEXT,
+            tool_calls    TEXT,
+            tool_call_id  TEXT,
+            tool_results  TEXT,
+            thinking      TEXT NOT NULL DEFAULT ''
+        )
+        """
+
+    // Per-version ALTERs mirroring `migrateToVN`, used to assemble
+    // partially-migrated fixtures.
+    private static let alterV2 = ["ALTER TABLE turns ADD COLUMN content_hash TEXT NOT NULL DEFAULT ''"]
+    private static let alterV3 = ["ALTER TABLE sessions ADD COLUMN archived INTEGER NOT NULL DEFAULT 0"]
+    private static let alterV4 = ["ALTER TABLE sessions ADD COLUMN capabilities TEXT NOT NULL DEFAULT ''"]
+    private static let alterV5 = [
+        "ALTER TABLE turns ADD COLUMN created_at REAL",
+        "ALTER TABLE turns ADD COLUMN completed_at REAL",
+        "ALTER TABLE turns ADD COLUMN generation_token_count INTEGER",
+        "ALTER TABLE turns ADD COLUMN time_to_first_token REAL",
+    ]
+    private static let alterV6 = ["ALTER TABLE turns ADD COLUMN tool_call_durations TEXT"]
+    private static let alterV7 = ["ALTER TABLE turns ADD COLUMN thinking_duration REAL"]
+    private static let alterV8 = ["ALTER TABLE turns ADD COLUMN router_billing TEXT"]
+
+    // MARK: - Reporter-exact: v1 stuck, every column except v8 router_billing
+
+    /// The exact reproduced failure state: `user_version = 1`, all columns
+    /// through v7 present, only `router_billing` missing. Opening must NOT
+    /// throw, must add `router_billing`, must reconcile the version to 8,
+    /// must return the pre-existing turns (not nil), and a fresh save must
+    /// round-trip.
+    @Test
+    func stuckV1MissingRouterBillingHealsAndPreservesHistory() async throws {
+        try await runWithPlaintextRoot {
+            let sid = UUID()
+            let userTurn = UUID()
+            let assistantTurn = UUID()
+
+            var statements = [Self.createSessionsV1]
+            statements += Self.alterV3 + Self.alterV4
+            statements.append(Self.createTurnsV1)
+            statements += Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7
+            statements += [
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
+                VALUES ('\(sid.uuidString)', 'Reporter chat', 1000, 2000, 'chat', 2, 0, '')
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content)
+                VALUES ('\(userTurn.uuidString)', '\(sid.uuidString)', 0, 'user', 'hello from before the upgrade')
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content)
+                VALUES ('\(assistantTurn.uuidString)', '\(sid.uuidString)', 1, 'assistant', 'hi, I remember our chat')
+                """,
+                "PRAGMA user_version = 1",
+            ]
+            try self.seedChatHistoryDB(statements)
+
+            let db = ChatHistoryDatabase()
+            try db.open()  // must not throw on the duplicate-column ALTER
+            defer { db.close() }
+
+            #expect(self.diskUserVersion() == 8)
+            #expect(self.diskColumns(table: "turns").contains("router_billing"))
+
+            let loaded = db.loadSession(id: sid)
+            #expect(loaded != nil)
+            #expect(loaded?.turns.count == 2)
+            #expect(loaded?.turns.first?.role == .user)
+            #expect(loaded?.turns.first?.content == "hello from before the upgrade")
+            #expect(loaded?.turns.last?.role == .assistant)
+
+            let newId = UUID()
+            let newSession = ChatSessionData(
+                id: newId,
+                title: "New chat after repair",
+                turns: [ChatTurnData(role: .user, content: "fresh turn after repair")]
+            )
+            try db.saveSession(newSession)
+            let reloaded = db.loadSession(id: newId)
+            #expect(reloaded?.turns.count == 1)
+            #expect(reloaded?.turns.first?.content == "fresh turn after repair")
+        }
+    }
+
+    // MARK: - v1 stuck, every v2-v8 column already present
+
+    /// A store whose `user_version` is stuck at 1 but already carries every
+    /// column (including v8). Every migration ALTER must be skipped, the
+    /// version reconciled to 8, and data must still load + save.
+    @Test
+    func stuckV1WithAllColumnsPresentOpensCleanly() async throws {
+        try await runWithPlaintextRoot {
+            let sid = UUID()
+
+            var statements = [Self.createSessionsV1]
+            statements += Self.alterV3 + Self.alterV4
+            statements.append(Self.createTurnsV1)
+            statements += Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7 + Self.alterV8
+            statements += [
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
+                VALUES ('\(sid.uuidString)', 'All columns', 1000, 2000, 'chat', 1, 0, '')
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content)
+                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'already fully columned')
+                """,
+                "PRAGMA user_version = 1",
+            ]
+            try self.seedChatHistoryDB(statements)
+
+            let db = ChatHistoryDatabase()
+            try db.open()
+            defer { db.close() }
+
+            #expect(self.diskUserVersion() == 8)
+            let loaded = db.loadSession(id: sid)
+            #expect(loaded?.turns.count == 1)
+            #expect(loaded?.turns.first?.content == "already fully columned")
+
+            let newId = UUID()
+            try db.saveSession(
+                ChatSessionData(
+                    id: newId,
+                    title: "Save works",
+                    turns: [ChatTurnData(role: .assistant, content: "ok")]
+                )
+            )
+            #expect(db.loadSession(id: newId)?.turns.count == 1)
+        }
+    }
+
+    // MARK: - v1 stuck, missing the earlier v3/v4 session columns
+
+    /// A store stalled before the v3/v4 session columns: `content_hash`
+    /// present but `archived`/`capabilities` missing. Here it is the
+    /// metadata path (`loadAllMetadata` / `saveSession`) that breaks
+    /// pre-fix. Opening must add the columns, reconcile to 8, and both the
+    /// sidebar metadata query and saves must succeed.
+    @Test
+    func stuckV1MissingArchivedAndCapabilitiesHeals() async throws {
+        try await runWithPlaintextRoot {
+            let sid = UUID()
+
+            var statements = [Self.createSessionsV1, Self.createTurnsV1]
+            statements += Self.alterV2  // content_hash only; no archived/capabilities, no v5-v8
+            statements += [
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count)
+                VALUES ('\(sid.uuidString)', 'Legacy partial', 1000, 2000, 'chat', 1)
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content)
+                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'partial migration row')
+                """,
+                "PRAGMA user_version = 1",
+            ]
+            try self.seedChatHistoryDB(statements)
+
+            let db = ChatHistoryDatabase()
+            try db.open()
+            defer { db.close() }
+
+            #expect(self.diskUserVersion() == 8)
+            #expect(self.diskColumns(table: "sessions").contains("archived"))
+            #expect(self.diskColumns(table: "sessions").contains("capabilities"))
+
+            // Sidebar metadata query (references archived/capabilities) works.
+            let metadata = db.loadAllMetadata()
+            #expect(metadata.contains { $0.id == sid })
+            // Full load + new save both succeed.
+            #expect(db.loadSession(id: sid)?.turns.count == 1)
+            let newId = UUID()
+            try db.saveSession(
+                ChatSessionData(id: newId, title: "post-heal", turns: [ChatTurnData(role: .user, content: "hi")])
+            )
+            #expect(db.loadSession(id: newId)?.turns.count == 1)
+        }
+    }
+
+    // MARK: - Fresh database
+
+    /// Guard against migration regressions: a brand-new (empty) database
+    /// migrates 0 -> 8 cleanly and round-trips a session.
+    @Test
+    func freshDatabaseMigratesToLatestAndRoundTrips() async throws {
+        try await runWithPlaintextRoot {
+            let db = ChatHistoryDatabase()
+            try db.open()
+            defer { db.close() }
+
+            #expect(self.diskUserVersion() == 8)
+
+            let id = UUID()
+            try db.saveSession(
+                ChatSessionData(
+                    id: id,
+                    title: "Fresh",
+                    turns: [
+                        ChatTurnData(role: .user, content: "q"),
+                        ChatTurnData(role: .assistant, content: "a"),
+                    ]
+                )
+            )
+            #expect(db.loadSession(id: id)?.turns.count == 2)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Run `body` with an isolated temp root in plaintext storage posture,
+    /// matching the reporter's `mode = plaintext` so a pre-seeded plaintext
+    /// file opens via detection without touching the Keychain.
+    private func runWithPlaintextRoot(_ body: @Sendable () throws -> Void) async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-chat-migration-tests-\(UUID().uuidString)"
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = nil
+                StorageEncryptionPolicy.shared.invalidateCache()
+                StorageKeyManager.shared.wipeCache()
+                try? FileManager.default.removeItem(at: root)
+            }
+            try StorageEncryptionPolicy.shared.setDesiredMode(.plaintext)
+            StorageKeyManager.shared.wipeCache()
+            try body()
+        }
+    }
+
+    /// Create the chat-history DB file (plaintext) at the overridden path
+    /// and run the given raw SQL statements in order.
+    private func seedChatHistoryDB(_ statements: [String]) throws {
+        let path = OsaurusPaths.chatHistoryDatabaseFile().path
+        let parent = URL(fileURLWithPath: path).deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let conn = try EncryptedSQLiteOpener.open(path: path, key: nil)
+        defer { sqlite3_close(conn) }
+        for sql in statements {
+            try exec(conn, sql)
+        }
+    }
+
+    private func exec(_ conn: OpaquePointer, _ sql: String) throws {
+        var err: UnsafeMutablePointer<CChar>?
+        let rc = sqlite3_exec(conn, sql, nil, nil, &err)
+        if rc != SQLITE_OK {
+            let msg = err.map { String(cString: $0) } ?? "?"
+            sqlite3_free(err)
+            throw NSError(
+                domain: "ChatHistoryMigrationRepairTests",
+                code: Int(rc),
+                userInfo: [NSLocalizedDescriptionKey: msg]
+            )
+        }
+    }
+
+    /// Run `body` against an independent read-only connection to the on-disk
+    /// chat-history file, returning `fallback` if it can't be opened. WAL mode
+    /// is a persistent property of the file, so this second connection reads
+    /// the committed migration result while the primary handle is still open.
+    private func withDiskConnection<T>(_ fallback: T, _ body: (OpaquePointer) -> T) -> T {
+        guard
+            let conn = try? EncryptedSQLiteOpener.open(
+                path: OsaurusPaths.chatHistoryDatabaseFile().path,
+                key: nil,
+                applyPerfPragmas: false,
+                applyForeignKeys: false
+            )
+        else { return fallback }
+        defer { sqlite3_close(conn) }
+        return body(conn)
+    }
+
+    /// Read `PRAGMA user_version` from disk.
+    private func diskUserVersion() -> Int {
+        withDiskConnection(-1) { conn in
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(conn, "PRAGMA user_version", -1, &stmt, nil) == SQLITE_OK else { return -1 }
+            defer { sqlite3_finalize(stmt) }
+            return sqlite3_step(stmt) == SQLITE_ROW ? Int(sqlite3_column_int(stmt, 0)) : -1
+        }
+    }
+
+    /// The column names currently on `table`, read from disk.
+    private func diskColumns(table: String) -> Set<String> {
+        withDiskConnection([]) { conn in
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(conn, "PRAGMA table_info(\(table))", -1, &stmt, nil) == SQLITE_OK else { return [] }
+            defer { sqlite3_finalize(stmt) }
+            var columns: Set<String> = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                if let c = sqlite3_column_text(stmt, 1) {
+                    columns.insert(String(cString: c))
+                }
+            }
+            return columns
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A user reported that all of their chat history disappeared (and that a new chat started with a PDF didn't persist). Root cause was a non-idempotent SQLite schema migration, not anything PDF-specific.

A chat-history store whose `PRAGMA user_version` was stuck at `1` while the later columns were already present (e.g. after the encryption-convergence rebuild) re-ran the v2+ `ALTER TABLE ... ADD COLUMN` statements on `open()`. The `duplicate column name` error aborted `runMigrations()` **before** reaching the v8 `router_billing` ALTER. Because `selectTurnsSQL` / `insertTurnSQL` reference `router_billing`:

- `loadSession` threw and returned `nil` → existing chats opened to an empty state, and
- `saveSession` threw → new chats vanished on restart.

That combination is exactly the "old chats are visible in the sidebar but open empty, and new chats don't persist" symptom from the field report (reporter snapshot: `mode=plaintext`, `user_version=1`, every column through v7 present, only `router_billing` missing).

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [x] Refactor / chore
- [x] Tests
- [ ] Docs

Details:
- **Idempotent migrations.** New `addColumnIfMissing(table, column, type)` helper (backed by a `tableHasColumn` `PRAGMA table_info` check) so every `migrateToV2..V8` step adds a column only when absent. Re-running a step on a partially-migrated schema is now a no-op instead of fatal, so a stuck `user_version` self-heals on the next `open()` and reconciles to the latest version.
- **Hardened `open()`.** If `runMigrations()` throws, we now clear the statement cache, close the half-migrated connection, record a `PersistenceHealth` database-open failure (surfaces in `/health` + the recovery UI), and rethrow — so `StorageRecoveryService` can retry/reset instead of silently leaving a live handle on a broken schema (a non-nil `db` would make every later `open()` no-op-succeed).
- **`bindText` NUL fix.** Bind with an explicit UTF-8 byte length instead of `-1`, so document-extracted text (e.g. from a PDF) containing embedded NUL bytes isn't truncated at the first NUL.
- **Dead code.** Removed the unused `schemaVersion = 4` constant (`latestSchemaVersion = 8` is the real source of truth).
- **Regression tests.** `ChatHistoryMigrationRepairTests` pins the reporter-exact stuck state plus partial-migration variants, asserting open() self-heals, the version reconciles to 8, and pre-existing + new data round-trip.

## Test Plan

```bash
OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test \
  swift test --package-path Packages/OsaurusCore \
  --filter 'ChatHistoryMigrationRepairTests|ChatHistoryDatabaseTests|IncrementalSaveSessionTests|AttachmentSpilloverTests'
```

- New migration-repair suite (4 tests) passes, including the reporter-exact `user_version=1` / missing-`router_billing` case.
- Related storage suites (17 tests: incremental save, attachment spillover, core DB round-trips) stay green after the `addColumnIfMissing` refactor and the `bindText` change.
- No model/runtime behavior involved; storage-only change.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+

Made with [Cursor](https://cursor.com)