### PR TITLE
Fix native image generation echoing artifact JSON instead of confirming

### DIFF
--- a/Packages/OsaurusCore/Tests/AgentDelegation/NativeImageToolArtifactBridgeTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/NativeImageToolArtifactBridgeTests.swift
@@ -81,6 +81,83 @@ struct NativeImageToolArtifactBridgeTests {
         }
     }
 
+    /// Pins the decoupling the chat loop relies on: the model-facing tool
+    /// result stays the compact `toolPayload` (marker-free, no host paths) so a
+    /// small quantized model confirms briefly instead of echoing the artifact
+    /// metadata JSON, while the card-facing string is the enriched
+    /// SHARED_ARTIFACT block. If these two ever collapse back into one string,
+    /// the `enriched != resultText` guard in `postProcessToolResult` would stop
+    /// firing and the model would again see the metadata block.
+    @Test
+    func modelFacingResultStaysCompact_whileCardResultIsEnriched() async throws {
+        try await Self.runLocked { tmp in
+            let generatedDir = tmp.appendingPathComponent("generated", isDirectory: true)
+            try FileManager.default.createDirectory(at: generatedDir, withIntermediateDirectories: true)
+            let generated = generatedDir.appendingPathComponent("cow.png")
+            let bytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+            try bytes.write(to: generated)
+
+            // The compact payload is exactly what the model keeps as the `.tool`
+            // message after the fix — only the card override is enriched.
+            let modelFacingResult = ToolEnvelope.success(
+                tool: "image",
+                result: [
+                    "kind": "native_image_generation_job",
+                    "mode": "generate",
+                    "job_id": "job-cow",
+                    "model": "Z-Image-Turbo-mflux-4bit",
+                    "status": "completed",
+                    "already_displayed": true,
+                    "display_note":
+                        "The image is already shown to the user in the chat; do NOT call share_artifact for it.",
+                    "images": [
+                        [
+                            "path": generated.path,
+                            "url": generated.absoluteString,
+                            "seed": 11,
+                        ]
+                    ],
+                ] as [String: Any]
+            )
+
+            let outcome = NativeImageToolArtifactBridge.processFirstImageArtifact(
+                toolName: "image",
+                toolResult: modelFacingResult,
+                contextId: "chat-cow"
+            )
+
+            switch try #require(outcome) {
+            case .success(let processed):
+                let cardFacingResult = ToolEnvelope.success(
+                    tool: "image",
+                    text: processed.enrichedToolResult
+                )
+
+                // The marker token without the trailing newline survives JSON
+                // string-encoding (the `\n` does not), so match on it directly.
+                let markerToken = "---SHARED_ARTIFACT_START---"
+
+                // Divergence is the whole fix: the chat loop must not overwrite
+                // the model result with the card block.
+                #expect(modelFacingResult != cardFacingResult)
+
+                // Model-facing result is marker-free, host-path-free, and is NOT
+                // parseable as an artifact — so it can't be echoed as one.
+                #expect(modelFacingResult.contains(markerToken) == false)
+                #expect(modelFacingResult.contains("host_path") == false)
+                #expect(SharedArtifact.fromEnrichedToolResult(modelFacingResult) == nil)
+
+                // Card-facing result is the enriched artifact block and still
+                // rebuilds into a renderable artifact.
+                #expect(cardFacingResult.contains(markerToken))
+                #expect(cardFacingResult.contains("host_path"))
+                #expect(SharedArtifact.fromEnrichedToolResult(cardFacingResult)?.filename == "cow.png")
+            case .failure(let reason):
+                Issue.record("expected success, got failure: \(reason)")
+            }
+        }
+    }
+
     @Test
     func nonImageToolResult_isIgnored() {
         let outcome = NativeImageToolArtifactBridge.processFirstImageArtifact(

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3607,6 +3607,12 @@ final class ChatSession: ObservableObject {
 
                     ttftTrace?.mark("pre_ttft_done")
 
+                    // Per-call card override for native image results: the model
+                    // keeps the compact `toolPayload` (a small quantized model
+                    // parrots the enriched metadata JSON as its answer), while the
+                    // artifact card needs the enriched SHARED_ARTIFACT block.
+                    var nativeImageCardOverrides: [String: String] = [:]
+
                     // Build the matching tool-result turn for a call. Every
                     // assistant `tool_use` MUST be paired with a tool turn
                     // before the loop yields control — Anthropic's Messages
@@ -3630,7 +3636,9 @@ final class ChatSession: ObservableObject {
                                 turn.role == .assistant
                                     && (turn.toolCalls?.contains { $0.id == callId } ?? false)
                             }) ?? assistantTurn
-                        owner.setToolResult(result, for: callId)
+                        // Card uses the override when present (native image);
+                        // every other tool falls back to the model-facing result.
+                        owner.setToolResult(nativeImageCardOverrides[callId] ?? result, for: callId)
                         let toolTurn = ChatTurn(role: .tool, content: result)
                         toolTurn.toolCallId = callId
                         return toolTurn
@@ -3789,12 +3797,19 @@ final class ChatSession: ObservableObject {
                                 await PluginManager.shared.notifyArtifactHandlers(artifact: artifact)
                             }
                         } else if NativeImageToolArtifactBridge.isNativeImageTool(inv.toolName) {
-                            resultText = await self.processNativeImageToolResult(
+                            // Enrich for the artifact card only; the model keeps
+                            // the compact `toolPayload` in `resultText`. The bridge
+                            // returns its input unchanged on failure, so a changed
+                            // string means success — route it to the card.
+                            let enriched = await self.processNativeImageToolResult(
                                 toolName: inv.toolName,
                                 toolResult: resultText
                             )
-                            if let artifact = SharedArtifact.fromEnrichedToolResult(resultText) {
-                                await PluginManager.shared.notifyArtifactHandlers(artifact: artifact)
+                            if enriched != resultText {
+                                nativeImageCardOverrides[callId] = enriched
+                                if let artifact = SharedArtifact.fromEnrichedToolResult(enriched) {
+                                    await PluginManager.shared.notifyArtifactHandlers(artifact: artifact)
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Summary

- After a local image generation, small quantized models (e.g. Gemma 4 12B QAT MXFP4) were parroting the enriched `SHARED_ARTIFACT` metadata block back as their final answer, so the user saw a raw JSON object instead of a short natural-language confirmation.
- Root cause: the chat loop (`ChatView.swift`) overwrote the model-facing tool result with the same enriched block it builds for the artifact card. This change decouples the two — the model keeps the compact `toolPayload` (marker-free, no host paths) while the enriched block is routed to the card only, via a per-call override map in the run scope.
- Other tools are unaffected (they fall back to the model-facing result), and the HTTP API path already retained the compact payload.

## Test plan

- [x] `NativeImageToolArtifactBridgeTests.modelFacingResultStaysCompact_whileCardResultIsEnriched` — pins that the model-facing result stays compact and unparseable as an artifact, while the card-facing result remains the enriched, renderable `SHARED_ARTIFACT` block.
- [x] Existing `imageGenerateResult_copiesFirstImageIntoChatArtifactStore` card-rendering test stays green.
- [ ] Live: rerun the cow prompt on `gemma-4-12B-it-qat-MXFP4` and confirm the artifact card renders and the final turn is a natural confirmation (no JSON echo); record token/s.

Made with [Cursor](https://cursor.com)