### PR TITLE
Make local↔image model handoffs crash-free and seamless

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -10,6 +10,7 @@ import Darwin
 import Foundation
 import MLXLLM
 import SwiftUI
+import os
 
 extension Notification.Name {
     /// Posted when local model list changes (download completed, model deleted)
@@ -44,6 +45,12 @@ enum ModelListTab: String, CaseIterable, AnimatedTabItem {
 @MainActor
 final class ModelManager: NSObject, ObservableObject {
     static let shared = ModelManager()
+
+    /// Diagnostics logger usable from the `nonisolated static` discovery paths.
+    nonisolated static let discoveryLog = Logger(
+        subsystem: "com.dinoki.osaurus",
+        category: "ModelManager.discovery"
+    )
 
     let downloadService = ModelDownloadService.shared
 
@@ -1668,6 +1675,18 @@ extension ModelManager {
         if let cached = cachedLocalModels {
             localModelsCacheCondition.unlock()
             return mergeExternalModels(into: cached)
+        }
+
+        // Cache miss: the call below parks on `localModelsCacheCondition.wait`
+        // (up to `localModelsScanWaitLimit`, ~10s) for the background scan. On
+        // the main thread that is a user-visible hang/beachball — UI and hot
+        // paths (chat greeting, residency planning) must call
+        // `discoverLocalModelsOffMain()` instead. Surface a regression loudly
+        // rather than letting it silently beachball; behavior is unchanged.
+        if Thread.isMainThread {
+            Self.discoveryLog.error(
+                "discoverLocalModels() called on the MAIN THREAD with a cold cache — it may block up to \(localModelsScanWaitLimitOverrideForTests ?? localModelsScanWaitLimit, privacy: .public)s. Use discoverLocalModelsOffMain() from UI/handoff paths."
+            )
         }
 
         if localModelsScanInFlight {

--- a/Packages/OsaurusCore/Managers/Model/SpeechModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/SpeechModelManager.swift
@@ -174,7 +174,11 @@ public final class SpeechModelManager: ObservableObject {
 
         downloadStates[model.id] = .downloading(progress: 0.0)
 
-        let task = Task { [weak self] in
+        // Pin the download consumer to the main actor: it resumes after an
+        // `await` on FluidAudio's downloader (off-main) and then mutates the
+        // @Published `downloadStates` — an un-annotated Task would write them
+        // off-main ("Updating ObservedObject from background threads").
+        let task = Task { @MainActor [weak self] in
             guard let self else { return }
 
             do {

--- a/Packages/OsaurusCore/Managers/SpeechService.swift
+++ b/Packages/OsaurusCore/Managers/SpeechService.swift
@@ -1302,7 +1302,11 @@ public final class SpeechService: ObservableObject {
 
     private func startWorkerProcessing() {
         guard let worker = transcriptionWorker else { return }
-        Task {
+        // `TranscriptionWorker` is a separate actor whose AsyncStream resumes on
+        // the cooperative pool, so consume it on the main actor — otherwise these
+        // @Published writes land off-main ("Updating ObservedObject from
+        // background threads will cause undefined behavior").
+        Task { @MainActor in
             print("[SpeechService] Starting to consume worker updates")
             for await update in await worker.start() {
                 switch update {

--- a/Packages/OsaurusCore/Models/Theme/Theme.swift
+++ b/Packages/OsaurusCore/Models/Theme/Theme.swift
@@ -806,6 +806,17 @@ public class ThemeManager: ObservableObject {
     }
 
     @objc private func systemAppearanceChanged() {
+        // `DistributedNotificationCenter` delivers this selector on an arbitrary
+        // thread, so hop to the main actor before touching any @Published theme
+        // state. Mutating it on the delivery thread is the "Updating
+        // ObservedObject<ThemeManager> from background threads will cause
+        // undefined behavior" hazard observed in the crash log.
+        Task { @MainActor [weak self] in
+            self?.applySystemAppearanceChange()
+        }
+    }
+
+    private func applySystemAppearanceChange() {
         // Only update if we're following system appearance and no user-selected theme is active
         guard appearanceMode == .system, activeCustomTheme == nil else { return }
 

--- a/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
@@ -53,6 +53,7 @@ enum ChatResidencyHandoff {
     enum HandoffError: Error, CustomStringConvertible {
         case chatBusy
         case insufficientMemory(neededGB: Double, availableGB: Double)
+        case restoreFailed(models: [String])
         var description: String {
             switch self {
             case .chatBusy:
@@ -64,6 +65,10 @@ enum ChatResidencyHandoff {
                     neededGB,
                     availableGB
                 )
+            case let .restoreFailed(models):
+                return
+                    "failed to reload the chat model(s) after the subagent job (the orchestrator may need to be re-selected): "
+                    + models.joined(separator: ", ")
             }
         }
     }
@@ -185,11 +190,56 @@ enum ChatResidencyHandoff {
     ) async throws -> [String] {
         guard !lease.isEmpty else { return [] }
         onPhase("restoring_chat_models", lease.unloadedModelNames.joined(separator: ", "))
+
+        // Surface the reload in the chat input's "Loading Model…" indicator.
+        // `preload` bypasses `generateEventStream` (which is what normally bumps
+        // this counter), so without this the post-job restore looks like a
+        // frozen, empty chat while the orchestrator weights reload. Balanced by
+        // the `defer` across every exit (success, retry, throw).
+        InferenceProgressManager.shared.modelLoadWillStartAsync()
+        defer { InferenceProgressManager.shared.modelLoadDidFinishAsync() }
+
         var restored: [String] = []
+        var failures: [String] = []
         for name in lease.unloadedModelNames {
-            try await ModelRuntime.shared.preload(name: name)
-            restored.append(name)
+            if await reloadAndVerify(name) {
+                restored.append(name)
+                continue
+            }
+            // One retry before giving up: a transient reload failure (the GPU
+            // still settling behind the just-released image/teardown lane, or a
+            // racing evict) must not strand the orchestrator unloaded with no
+            // resident model and only a log to show for it.
+            onPhase("restoring_chat_models_retry", name)
+            if await reloadAndVerify(name) {
+                restored.append(name)
+            } else {
+                failures.append(name)
+            }
+        }
+
+        guard failures.isEmpty else {
+            onPhase("restore_failed", failures.joined(separator: ", "))
+            throw HandoffError.restoreFailed(models: failures)
         }
         return restored
+    }
+
+    /// Preload `name` and confirm it is actually resident afterwards. A bare
+    /// `preload` that throws — or silently loads nothing — would otherwise be
+    /// reported as a successful restore while the chat window has no model
+    /// loaded. Returns `true` only when the model is in the live runtime cache
+    /// after the load. Never throws: callers branch on the Bool and retry.
+    private static func reloadAndVerify(_ name: String) async -> Bool {
+        do {
+            try await ModelRuntime.shared.preload(name: name)
+        } catch {
+            logger.error(
+                "Orchestrator restore: preload threw for \(name, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+        let resident = await ModelRuntime.shared.cachedModelSummaries().map(\.name)
+        return resident.contains(name)
     }
 }

--- a/Packages/OsaurusCore/Services/AgentDelegation/NativeImageJobCoordinator.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/NativeImageJobCoordinator.swift
@@ -491,7 +491,7 @@ actor NativeImageJobCoordinator {
                 record(NativeImageJobProgress(jobID: jobID, phase: .unloading, model: model))
                 await imageService.unload()
             }
-            let restoredChatModels = try await self.restoreChatResidencyIfNeeded(
+            let restoredChatModels = await self.restoreChatResidencyIfNeeded(
                 lease: chatLease,
                 jobID: jobID,
                 record: record
@@ -514,7 +514,7 @@ actor NativeImageJobCoordinator {
                 await imageService.unload()
             }
             if !chatLease.unloadedModelNames.isEmpty {
-                _ = try? await self.restoreChatResidencyIfNeeded(
+                _ = await self.restoreChatResidencyIfNeeded(
                     lease: chatLease,
                     jobID: jobID,
                     record: record
@@ -565,11 +565,17 @@ actor NativeImageJobCoordinator {
         return lease
     }
 
+    /// Best-effort restore: the image has already been produced and written to
+    /// disk by the time this runs, so a reload hiccup must NOT fail the job and
+    /// lose the user's image. `restoreBestEffort` already retries + verifies
+    /// residency and logs a persistent failure; if the orchestrator still isn't
+    /// resident, the next chat turn reloads it on demand (cold load through the
+    /// gated `loadContainer`). Returns the names actually restored.
     private func restoreChatResidencyIfNeeded(
         lease: ChatResidencyLease,
         jobID: String,
         record: (NativeImageJobProgress) -> Void
-    ) async throws -> [String] {
+    ) async -> [String] {
         guard !lease.unloadedModelNames.isEmpty else { return [] }
         record(
             NativeImageJobProgress(
@@ -578,7 +584,7 @@ actor NativeImageJobCoordinator {
                 message: lease.unloadedModelNames.joined(separator: ", ")
             )
         )
-        return try await ChatResidencyHandoff.restore(lease)
+        return await ChatResidencyHandoff.restoreBestEffort(lease)
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -557,6 +557,16 @@ public actor ModelRuntime {
             await cancelAndDrainLoadingTasks([(name, record)])
         }
 
+        // Serialize the GPU teardown against every other Metal producer via the
+        // exclusive teardown gate. Acquired here — AFTER the lease/idle drains
+        // above, so we never hold the gate while waiting for in-flight requests
+        // — and released only after the final synchronize below, so "teardown
+        // gate released" provably means "this model's GPU work is idle",
+        // symmetric with the load and image lanes. Without it the next admitted
+        // producer (a model load, image job, or embedder) starts the moment this
+        // function returns and races the async buffer frees/fences the weight
+        // release enqueues — the chat→image handoff `Gather::eval_gpu` abort.
+        await MetalGate.shared.enterModelTeardown(model: name)
         modelCache[name]?.container.disableCaching()
 
         // Drain the GPU BEFORE releasing the weight arrays. The lease/idle
@@ -588,6 +598,7 @@ public actor ModelRuntime {
         Stream.gpu.synchronize()
         Memory.clearCache()
         Stream.gpu.synchronize()
+        await MetalGate.shared.exitModelTeardown(model: name)
     }
 
     /// Evict `other` for the strict-single-model policy WITHOUT cancelling an
@@ -682,6 +693,12 @@ public actor ModelRuntime {
             return
         }
 
+        // Normal (non-quit) teardown serializes against other GPU producers via
+        // the teardown gate, symmetric with `unload(name:)`. The quit path
+        // deliberately skips it: `cancelAllGenerations` already shut every engine
+        // down, and blocking on a wedged gate holder must never hang the quit
+        // chain (the stuck-lease guard above already chose to let the OS reclaim).
+        if !quit { await MetalGate.shared.enterModelTeardown(model: "all-models") }
         for holder in modelCache.values {
             holder.container.disableCaching()
         }
@@ -701,6 +718,7 @@ public actor ModelRuntime {
         Memory.cacheLimit = mlxCacheLimit()
         Stream.gpu.synchronize()
         Memory.clearCache()
+        if !quit { await MetalGate.shared.exitModelTeardown(model: "all-models") }
     }
 
     /// Invalidates the cached RuntimeConfig so the next request reads fresh values.

--- a/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
@@ -56,10 +56,26 @@ public actor ImageGenerationService {
     /// pressure handoffs. Manual image-panel flows may choose to keep the
     /// engine warm and skip this through `SubagentImageLoadPolicy`.
     public func unload() async {
-        if let engine {
-            await engine.unload()
+        guard let engine else {
+            loadedDirectoryName = nil
+            return
         }
+        // Image-model teardown is a GPU producer (freeing the FLUX weights
+        // enqueues Metal allocator frees/fences). Hold the exclusive image lane
+        // across it and drain the device before releasing — symmetric with the
+        // `drive()` exit barrier and the `ModelRuntime` teardown gate. The agent
+        // image job calls this the instant generation finishes, immediately
+        // before the chat-model `restore` (`ModelRuntime.preload` →
+        // `enterModelLoad`); without the gate that reload starts while these
+        // frees are still settling and races them on the shared Metal command
+        // queue (the `MTLReleaseAssertionFailure` / `Gather::eval_gpu` class).
+        await MetalGate.shared.enterImageGeneration()
+        await engine.unload()
         loadedDirectoryName = nil
+        MLXCacheIOLock.withSerializedMLXCacheIO {
+            Memory.clearCache()
+        }
+        await MetalGate.shared.exitImageGeneration()
     }
 
     // MARK: - Model store root

--- a/Packages/OsaurusCore/Services/ModelRuntime/MetalGate.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MetalGate.swift
@@ -140,6 +140,26 @@ public actor MetalGate {
         release("load:\(model)")
     }
 
+    // MARK: - Model teardown (weight free + GPU drain) — exclusive
+
+    /// Unloading a model is a GPU producer too: freeing the weight arrays
+    /// enqueues allocator frees + fences and the `Stream.gpu.synchronize` /
+    /// `Memory.clearCache` drains submit/settle device work. Like a load it must
+    /// not overlap any other producer — otherwise the next producer (a model
+    /// load, image job, or embedder) admitted the instant `unload` returns races
+    /// this model's still-in-flight teardown buffers on the shared Metal command
+    /// queue (observed as the chat→image handoff `Gather::eval_gpu` /
+    /// `computeCommandEncoderWithDispatchType:` abort). A distinct owner from
+    /// `load:` keeps teardown vs load distinguishable in telemetry; both are
+    /// mutually exclusive against every other owner.
+    public func enterModelTeardown(model: String) async {
+        await acquire("unload:\(model)", shared: false)
+    }
+
+    public func exitModelTeardown(model: String) {
+        release("unload:\(model)")
+    }
+
     // MARK: - Image generation (vMLXFlux engine) — exclusive
 
     /// The native image engine (vMLXFlux) is a second MLX graph on the same Metal

--- a/Packages/OsaurusCore/Services/Voice/VADService.swift
+++ b/Packages/OsaurusCore/Services/Voice/VADService.swift
@@ -194,8 +194,18 @@ public final class VADService: ObservableObject {
     // MARK: - Private Methods
 
     private func setupObservers() {
-        // Observe configuration changes
+        // Observe configuration changes.
+        //
+        // Every sink below delivers on the main run loop before mutating this
+        // @MainActor object's @Published state. `SpeechService` publishes some
+        // of these (`currentTranscription`, `confirmedTranscription`,
+        // `audioLevel`, `isRecording`) from its transcription worker — a
+        // separate actor whose stream resumes off the main thread — so without
+        // `.receive(on: RunLoop.main)` the writes are the "Updating
+        // ObservedObject<VADService> from background threads" undefined behavior
+        // seen in the crash log.
         NotificationCenter.default.publisher(for: .voiceConfigurationChanged)
+            .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.loadConfiguration()
             }
@@ -203,12 +213,14 @@ public final class VADService: ObservableObject {
 
         // Observe transcription changes from SpeechService
         speechService.$currentTranscription
+            .receive(on: RunLoop.main)
             .sink { [weak self] transcription in
                 self?.handleTranscription(transcription, isConfirmed: false)
             }
             .store(in: &cancellables)
 
         speechService.$confirmedTranscription
+            .receive(on: RunLoop.main)
             .sink { [weak self] transcription in
                 self?.handleTranscription(transcription, isConfirmed: true)
             }
@@ -216,6 +228,7 @@ public final class VADService: ObservableObject {
 
         // Observe audio level
         speechService.$audioLevel
+            .receive(on: RunLoop.main)
             .sink { [weak self] level in
                 guard let self = self, self.state == .listening else { return }
                 self.audioLevel = level
@@ -225,6 +238,7 @@ public final class VADService: ObservableObject {
         // Observe recording state - auto-restart if stopped unexpectedly
         speechService.$isRecording
             .dropFirst()  // Ignore initial value
+            .receive(on: RunLoop.main)
             .sink { [weak self] isRecording in
                 guard let self = self else { return }
 

--- a/Packages/OsaurusCore/Tests/AgentDelegation/ChatResidencyHandoffRestoreTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/ChatResidencyHandoffRestoreTests.swift
@@ -1,0 +1,90 @@
+//
+//  ChatResidencyHandoffRestoreTests.swift
+//  osaurus
+//
+//  Restore-path robustness for the chat↔(image/spawn) handoff. The post-job
+//  reload now verifies the model is actually resident, retries once, throws a
+//  typed `restoreFailed` on a persistent miss, and the best-effort wrapper
+//  swallows that failure so an already-produced image is never lost. These
+//  exercise the real `ModelRuntime.preload` failure path (an unresolvable
+//  model name fast-throws "Installed model not found" before any GPU work), so
+//  no model load or Metal device is required.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ChatResidencyHandoffRestoreTests {
+
+    /// A name `ModelManager.findInstalledModel` can never resolve, so `preload`
+    /// fast-throws before touching the GPU — driving the restore failure +
+    /// single-retry path deterministically.
+    private static let unresolvable =
+        "__osaurus_nonexistent_restore_test_model_4f9a__"
+
+    @Test("empty lease restore is a no-op and touches nothing")
+    func emptyLeaseIsNoOp() async throws {
+        let restored = try await ChatResidencyHandoff.restore(.empty)
+        #expect(restored.isEmpty)
+    }
+
+    @Test("restore throws restoreFailed when a model can't be made resident")
+    func restoreThrowsRestoreFailedOnPersistentMiss() async {
+        let lease = ChatResidencyLease(unloadedModelNames: [Self.unresolvable])
+        var captured: ChatResidencyHandoff.HandoffError?
+        do {
+            _ = try await ChatResidencyHandoff.restore(lease)
+            Issue.record("restore should have thrown for an unresolvable model")
+        } catch let error as ChatResidencyHandoff.HandoffError {
+            captured = error
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
+        guard case .restoreFailed(let models)? = captured else {
+            Issue.record("expected .restoreFailed, got \(String(describing: captured))")
+            return
+        }
+        #expect(models == [Self.unresolvable])
+    }
+
+    @Test("restore surfaces a retry attempt and a restore_failed phase before throwing")
+    func restoreEmitsRetryAndFailurePhases() async {
+        let lease = ChatResidencyLease(unloadedModelNames: [Self.unresolvable])
+        let phases = PhaseLog()
+        _ = try? await ChatResidencyHandoff.restore(lease) { phase, _ in
+            phases.add(phase)
+        }
+        let recorded = phases.value
+        // The single retry is attempted, and a terminal failure phase is
+        // surfaced so the chat shows a recoverable error instead of a silent,
+        // model-less window.
+        #expect(recorded.contains("restoring_chat_models_retry"))
+        #expect(recorded.contains("restore_failed"))
+    }
+
+    @Test("restoreBestEffort swallows a persistent failure so the image is never lost")
+    func bestEffortSwallowsPersistentFailure() async {
+        let lease = ChatResidencyLease(unloadedModelNames: [Self.unresolvable])
+        let restored = await ChatResidencyHandoff.restoreBestEffort(lease)
+        #expect(restored.isEmpty)
+    }
+}
+
+/// Thread-safe ordered capture for the restore `onPhase` callback.
+private final class PhaseLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var phases: [String] = []
+    func add(_ phase: String) {
+        lock.lock()
+        phases.append(phase)
+        lock.unlock()
+    }
+    var value: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return phases
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentDelegation/NativeImageJobCoordinatorTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/NativeImageJobCoordinatorTests.swift
@@ -153,6 +153,26 @@ struct NativeImageJobCoordinatorTests {
         )
     }
 
+    @Test("post-job chat restore is best-effort so a produced image is never lost")
+    func restoreWiringIsBestEffort() throws {
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // AgentDelegation/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+        let coordinator = try String(
+            contentsOf: coreRoot.appendingPathComponent(
+                "Services/AgentDelegation/NativeImageJobCoordinator.swift"
+            ),
+            encoding: .utf8
+        )
+        // The image is generated and written to disk BEFORE the chat-model
+        // restore runs, so a reload hiccup must not throw and discard the user's
+        // image. Pin the best-effort wiring (and the absence of the throwing
+        // variant) so a future refactor can't silently reintroduce the loss.
+        #expect(coordinator.contains("await ChatResidencyHandoff.restoreBestEffort(lease)"))
+        #expect(!coordinator.contains("try await ChatResidencyHandoff.restore(lease)"))
+    }
+
     @Test func progressDictionaryIncludesChatToolContext() throws {
         let turnID = UUID()
         let progress = NativeImageJobProgress(

--- a/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
@@ -13,6 +13,14 @@ import Testing
 
 @testable import OsaurusCore
 
+/// Ordered, actor-isolated event log used to prove exclusion deterministically:
+/// a blocked waiter cannot record its "acquired" event until the current holder
+/// records its "released" event first.
+private actor GateOrderRecorder {
+    private(set) var events: [String] = []
+    func record(_ event: String) { events.append(event) }
+}
+
 @Suite(.serialized)
 struct MetalGateTests {
 
@@ -46,5 +54,115 @@ struct MetalGateTests {
         // cleanly when nothing else holds the GPU.
         await MetalGate.shared.enterModelLoad(model: "qwen3.5-4b")
         await MetalGate.shared.exitModelLoad(model: "qwen3.5-4b")
+    }
+
+    // MARK: - Model teardown (unload) owner — exclusive against every producer
+
+    @Test func modelTeardownProceedsWhenIdle() async {
+        // Unload teardown is exclusive; it acquires and releases cleanly when
+        // nothing else holds the GPU.
+        await MetalGate.shared.enterModelTeardown(model: "qwen3.5-4b")
+        await MetalGate.shared.exitModelTeardown(model: "qwen3.5-4b")
+    }
+
+    @Test func teardownWaitsForImageGenerationToRelease() async {
+        // The chat→image handoff race: a model unload must not run its GPU
+        // teardown while the image lane holds the device. Prove the teardown
+        // cannot acquire until image generation releases.
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterImageGeneration()
+        let waiter = Task {
+            await MetalGate.shared.enterModelTeardown(model: "chat-model")
+            await rec.record("teardown-acquired")
+            await MetalGate.shared.exitModelTeardown(model: "chat-model")
+        }
+        // Let the waiter run and block on the exclusive image owner.
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("image-released")
+        await MetalGate.shared.exitImageGeneration()
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["image-released", "teardown-acquired"])
+    }
+
+    @Test func teardownWaitsForModelLoadToRelease() async {
+        // A teardown must not overlap a model load on the shared device.
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterModelLoad(model: "incoming-model")
+        let waiter = Task {
+            await MetalGate.shared.enterModelTeardown(model: "outgoing-model")
+            await rec.record("teardown-acquired")
+            await MetalGate.shared.exitModelTeardown(model: "outgoing-model")
+        }
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("load-released")
+        await MetalGate.shared.exitModelLoad(model: "incoming-model")
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["load-released", "teardown-acquired"])
+    }
+
+    @Test func generationWaitsForTeardownToRelease() async {
+        // The restore side: a chat-model reload's generation must not start
+        // while a previous model's teardown is still draining the device.
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterModelTeardown(model: "old-model")
+        let waiter = Task {
+            await MetalGate.shared.enterGeneration(model: "new-model")
+            await rec.record("gen-acquired")
+            await MetalGate.shared.exitGeneration(model: "new-model")
+        }
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("teardown-released")
+        await MetalGate.shared.exitModelTeardown(model: "old-model")
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["teardown-released", "gen-acquired"])
+    }
+
+    // MARK: - Source contract: the unload teardown is actually gate-bracketed
+
+    @Test func unloadTeardownIsGateBracketedInSource() throws {
+        // The GPU teardown section itself can't be unit-run (no Metal in CI), so
+        // pin the wiring textually: the teardown owner exists and is exclusive,
+        // `ModelRuntime.unload` brackets its teardown with it, and the post-job
+        // image unload is wrapped in the exclusive image lane (the symmetric
+        // restore-side fix). Mirrors `ImageGenerationBridgeContractTests`.
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Service/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+
+        let gate = try String(
+            contentsOf: coreRoot.appendingPathComponent("Services/ModelRuntime/MetalGate.swift"),
+            encoding: .utf8
+        )
+        let runtime = try String(
+            contentsOf: coreRoot.appendingPathComponent("Services/ModelRuntime.swift"),
+            encoding: .utf8
+        )
+        let imageService = try String(
+            contentsOf: coreRoot.appendingPathComponent(
+                "Services/ModelRuntime/ImageGenerationService.swift"
+            ),
+            encoding: .utf8
+        )
+
+        // Exclusive teardown owner.
+        #expect(gate.contains("public func enterModelTeardown(model: String) async"))
+        #expect(gate.contains("public func exitModelTeardown(model: String)"))
+        #expect(gate.contains(#"acquire("unload:\(model)", shared: false)"#))
+
+        // ModelRuntime.unload brackets its GPU teardown with the gate.
+        #expect(runtime.contains("await MetalGate.shared.enterModelTeardown(model: name)"))
+        #expect(runtime.contains("await MetalGate.shared.exitModelTeardown(model: name)"))
+
+        // The post-job image unload frees FLUX weights under the exclusive image
+        // lane (engine.unload immediately follows entering the gate).
+        #expect(
+            imageService.contains(
+                "await MetalGate.shared.enterImageGeneration()\n        await engine.unload()"
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary

Local→image (and all model) handoffs could crash with a Metal abort and showed a beachball mid-handoff. Root cause: **model unload was an ungated GPU producer**. `ModelRuntime.unload` / `clearAll` and `ImageGenerationService.unload` freed weights and drained the device without holding `MetalGate`, so the next producer (a model load, image job, or embedder) was admitted the instant unload returned and raced the still-in-flight teardown buffers on the shared Metal command queue — the chat→image `Gather::eval_gpu` / `computeCommandEncoderWithDispatchType:` abort. Separately, several `@Published` mutations landed off the main thread, and a cold-cache model scan could block the main thread.

## Changes

**GPU teardown serialization (the crash)**
- New exclusive `enterModelTeardown`/`exitModelTeardown` owner on `MetalGate`, symmetric to model load.
- Bracket the GPU teardown in `ModelRuntime.unload` and `clearAll` (non-quit path) and in `ImageGenerationService.unload`, draining the device before releasing the gate so "gate released" provably means "this model's GPU work is idle". The quit path deliberately skips the gate so a wedged holder can't hang shutdown.

**Off-main `@Published` fixes (the beachball)**
- Hop to the main actor before mutating `@Published` state delivered on arbitrary threads: `ThemeManager.systemAppearanceChanged` (DistributedNotificationCenter), the `VADService` Combine sinks (`.receive(on: RunLoop.main)`), and the `SpeechService` / `SpeechModelManager` consumer tasks (`@MainActor`).
- Log (don't crash) when `ModelManager.discoverLocalModels()` runs on the main thread with a cold cache, so a UI-thread beachball regression is diagnosable.

**Seamless restore**
- `ChatResidencyHandoff.restore` now verifies the model is actually resident, retries once, surfaces the reload in the "Loading Model…" indicator, and throws a typed `restoreFailed` instead of silently leaving a model-less chat.
- The image job restores best-effort (`restoreBestEffort`) so a reload hiccup never discards an already-produced image.

## Test plan

- [x] Targeted unit suites pass (25/25): `MetalGateTests`, `ChatResidencyHandoffRestoreTests`, `NativeImageJobCoordinatorTests`.
  - MetalGate: teardown is mutually exclusive vs image-generation and model-load; a reload's generation waits for a prior teardown to release; source-contract test that the teardown sections are gate-bracketed.
  - Restore: verify/retry/typed-failure/best-effort behavior; coordinator best-effort wiring.
- [x] Live evals on local MLX (`mlx-community/Qwen3.5-4B-OptiQ-4bit`):
  - `subagent.residency-dir-local-local-diff-on` (local→local unload→restore) — pass.
  - `subagent.image-generate-live` (chat→image→restore with `Z-Image-Turbo-mflux-4bit`, `agent_single_residency`) — pass; transcript phases `waiting for chat idle → unloading chat models → loading model → generating → unloading image model → restoring chat models`, valid PNG produced, **no Metal abort signatures**.
- [ ] CI green.