### PR TITLE
Unify the model-download tabs on a shared ModelListRow

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Views/PrivacyView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/PrivacyView.swift
@@ -242,20 +242,17 @@ struct PrivacyView: View {
                 onOpenProviders: { ManagementStateManager.shared.selectedTab = .providers }
             )
         case .model:
-            VStack(alignment: .leading, spacing: 24) {
-                SettingsSection(title: L("Detection Models"), icon: "cube.box.fill") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(
-                            "Choose the on-device model that powers AI detection. Pattern rules in the Rules tab work without any model.",
-                            bundle: .module
-                        )
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.tertiaryText)
-                        .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: 16) {
+                Text(
+                    "Choose the on-device model that powers AI detection. Pattern rules in the Rules tab work without any model.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 4)
 
-                        PrivacyModelSelector(configuration: $configuration, save: save)
-                    }
-                }
+                PrivacyModelSelector(configuration: $configuration, save: save, layout: .sections)
             }
         }
     }
@@ -359,51 +356,115 @@ private enum PrivacyTab: String, CaseIterable, AnimatedTabItem {
     }
 }
 
-// MARK: - Model selector (radio cards, shared by Overview + Models tabs)
+// MARK: - Model selector (shared by Overview + Models tabs)
 
-/// Radio-style chooser between the available on-device detection models.
-/// Self-contained: reads/writes `configuration.aiDetectionBackend` and
-/// drives each model's download/manage lifecycle through its manager
-/// singleton, so both the Overview and Models tabs can render the same
-/// control with just a configuration binding.
+/// Chooser between the available on-device detection models, rendered on the
+/// shared `ModelListRow`. Self-contained: reads/writes
+/// `configuration.aiDetectionBackend` and drives each model's download/manage
+/// lifecycle through its manager singleton. The Overview tab renders the rows
+/// flat (`.flat`); the Models tab groups them into Installed / Available
+/// sections (`.sections`) to match the Voice and Images tabs.
 private struct PrivacyModelSelector: View {
+    enum Layout { case flat, sections }
+
     @Environment(\.theme) private var theme
+    @Environment(\.openURL) private var openURL
     @Binding var configuration: PrivacyFilterConfiguration
     let save: () -> Void
+    var layout: Layout = .flat
 
     @ObservedObject private var downloader = PrivacyFilterModelDownloader.shared
     @ObservedObject private var rampart = RampartModelManager.shared
     @State private var pendingRemoval: PrivacyAIBackend?
 
+    /// Rampart first (the lightweight default suggestion), then OpenAI.
+    private let backends: [PrivacyAIBackend] = [.rampart, .openai]
+
+    private var installedBackends: [PrivacyAIBackend] { backends.filter(isInstalled) }
+    private var availableBackends: [PrivacyAIBackend] { backends.filter { !isInstalled($0) } }
+
     var body: some View {
-        VStack(spacing: 10) {
-            card(.rampart)
-            card(.openai)
-        }
-        .confirmationDialog(
-            Text("Remove model?", bundle: .module),
-            isPresented: Binding(
-                get: { pendingRemoval != nil },
-                set: { if !$0 { pendingRemoval = nil } }
-            ),
-            titleVisibility: .visible
-        ) {
-            Button(role: .destructive) {
-                if let backend = pendingRemoval { remove(backend) }
-                pendingRemoval = nil
-            } label: {
-                Text("Remove Model", bundle: .module)
+        content
+            .confirmationDialog(
+                Text("Remove model?", bundle: .module),
+                isPresented: Binding(
+                    get: { pendingRemoval != nil },
+                    set: { if !$0 { pendingRemoval = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button(role: .destructive) {
+                    if let backend = pendingRemoval { remove(backend) }
+                    pendingRemoval = nil
+                } label: {
+                    Text("Remove Model", bundle: .module)
+                }
+                Button(role: .cancel) { pendingRemoval = nil } label: {
+                    Text("Cancel", bundle: .module)
+                }
+            } message: {
+                Text(
+                    "This deletes the on-disk model. Detection for it stops until you re-download.",
+                    bundle: .module
+                )
             }
-            Button(role: .cancel) { pendingRemoval = nil } label: {
-                Text("Cancel", bundle: .module)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch layout {
+        case .flat:
+            VStack(spacing: 8) {
+                ForEach(backends, id: \.self) { row($0) }
             }
-        } message: {
-            Text(
-                "This deletes the on-disk model. Detection for it stops until you re-download.",
-                bundle: .module
-            )
+        case .sections:
+            VStack(alignment: .leading, spacing: 24) {
+                if !installedBackends.isEmpty {
+                    SettingsSection(title: "Installed", icon: "checkmark.seal.fill") {
+                        VStack(spacing: 8) {
+                            ForEach(installedBackends, id: \.self) { row($0) }
+                        }
+                    }
+                }
+                if !availableBackends.isEmpty {
+                    SettingsSection(title: "Available", icon: "square.and.arrow.down") {
+                        VStack(spacing: 8) {
+                            ForEach(availableBackends, id: \.self) { row($0) }
+                        }
+                    }
+                }
+            }
         }
     }
+
+    // MARK: Row
+
+    private func row(_ backend: PrivacyAIBackend) -> ModelListRow {
+        let info = meta(backend)
+        let installed = isInstalled(backend)
+        let active = installed && configuration.aiDetectionBackend == backend
+        return ModelListRow(
+            title: info.name,
+            subtitle: "\(info.size) · \(info.summary)",
+            leading: leading(backend, installed: installed),
+            isDefault: active,
+            status: status(backend),
+            primary: primaryAction(backend, installed: installed, active: active),
+            menuItems: menuItems(backend, installed: installed),
+            onViewHuggingFace: { openHuggingFace(repoId(backend)) },
+            onCancel: cancelAction(backend)
+        )
+    }
+
+    private func leading(_ backend: PrivacyAIBackend, installed: Bool) -> ModelListRow.Leading {
+        if installed { return .init(icon: "checkmark.seal.fill", tint: theme.successColor) }
+        if case .failed = status(backend) {
+            return .init(icon: "exclamationmark.triangle.fill", tint: theme.warningColor)
+        }
+        return .init(icon: "cube.box.fill", tint: theme.accentColor)
+    }
+
+    // MARK: Metadata
 
     private func meta(_ backend: PrivacyAIBackend) -> (name: String, size: String, summary: String) {
         switch backend {
@@ -422,6 +483,13 @@ private struct PrivacyModelSelector: View {
         }
     }
 
+    private func repoId(_ backend: PrivacyAIBackend) -> String {
+        switch backend {
+        case .openai: return PrivacyFilterModelDownloader.repoId
+        case .rampart: return RampartModelManager.repoId
+        }
+    }
+
     private func isInstalled(_ backend: PrivacyAIBackend) -> Bool {
         switch backend {
         case .openai:
@@ -433,153 +501,95 @@ private struct PrivacyModelSelector: View {
         }
     }
 
-    @ViewBuilder
-    private func card(_ backend: PrivacyAIBackend) -> some View {
-        let selected = configuration.aiDetectionBackend == backend
-        let info = meta(backend)
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 10) {
-                Image(systemName: selected ? "largecircle.fill.circle" : "circle")
-                    .font(.system(size: 16))
-                    .foregroundColor(selected ? theme.accentColor : theme.tertiaryText)
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        Text(verbatim: info.name)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(theme.primaryText)
-                        Text(verbatim: info.size)
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(theme.secondaryText)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 1)
-                            .background(theme.tertiaryBackground, in: Capsule())
-                        if isInstalled(backend) {
-                            HStack(spacing: 3) {
-                                Image(systemName: "checkmark.seal.fill").font(.system(size: 9))
-                                Text("Installed", bundle: .module).font(.system(size: 10, weight: .medium))
-                            }
-                            .foregroundColor(theme.successColor)
-                        }
-                    }
-                    Text(verbatim: info.summary)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.tertiaryText)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer()
+    // MARK: Status mapping
+
+    private func status(_ backend: PrivacyAIBackend) -> ModelListRow.Status {
+        switch backend {
+        case .openai:
+            switch downloader.state {
+            case .idle: return .idle
+            case .enumerating: return .inProgress(progress: nil, detail: L("Preparing…"))
+            case let .downloading(_, _, _, done, total):
+                let progress = total > 0 ? Double(done) / Double(total) : nil
+                return .inProgress(progress: progress, detail: nil)
+            case .verifying: return .inProgress(progress: nil, detail: L("Verifying…"))
+            case .ready: return .ready
+            case .failed(let message): return .failed(message)
             }
-            HStack { Spacer(); controls(backend) }
+        case .rampart:
+            switch rampart.state {
+            case .idle:
+                return RampartModelManager.bundleExists() ? .ready : .idle
+            case .downloading(let progress):
+                return .inProgress(progress: progress, detail: nil)
+            case .ready: return .ready
+            case .failed(let message): return .failed(message)
+            }
         }
-        .padding(12)
-        .background(theme.cardBackground, in: RoundedRectangle(cornerRadius: 10))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(
-                    selected ? theme.accentColor : theme.cardBorder,
-                    lineWidth: selected ? 1.5 : 1
-                )
-        )
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if configuration.aiDetectionBackend != backend {
+    }
+
+    // MARK: Actions
+
+    private func primaryAction(_ backend: PrivacyAIBackend, installed: Bool, active: Bool)
+        -> ModelListRow.Action?
+    {
+        if installed {
+            // The active model shows the Default badge; other installed models
+            // offer Set as Default. The active one needs no primary action.
+            guard !active else { return nil }
+            return ModelListRow.Action(title: "Set as Default", icon: "checkmark.circle") {
                 configuration.aiDetectionBackend = backend
                 save()
             }
         }
+        // Not installed: Install, or Retry after a failed attempt.
+        if case .failed = status(backend) {
+            return ModelListRow.Action(title: "Retry", icon: "arrow.clockwise") {
+                startDownload(backend)
+            }
+        }
+        return ModelListRow.Action(title: "Install", icon: "arrow.down.circle") {
+            startDownload(backend)
+        }
     }
 
-    @ViewBuilder
-    private func controls(_ backend: PrivacyAIBackend) -> some View {
+    private func menuItems(_ backend: PrivacyAIBackend, installed: Bool) -> [ModelListRow.Action] {
+        guard installed else { return [] }
+        var items: [ModelListRow.Action] = []
+        // Re-verify recomputes the OpenAI bundle manifest; Rampart has no
+        // verify step, so it only offers Remove.
+        if backend == .openai {
+            items.append(
+                ModelListRow.Action(title: "Re-verify", icon: "arrow.clockwise") {
+                    downloader.reverify()
+                }
+            )
+        }
+        items.append(
+            ModelListRow.Action(title: "Remove", icon: "trash", role: .destructive) {
+                pendingRemoval = backend
+            }
+        )
+        return items
+    }
+
+    private func startDownload(_ backend: PrivacyAIBackend) {
         switch backend {
-        case .openai: openAIControls
-        case .rampart: rampartControls
+        case .openai: PrivacyFilterModelDownloader.shared.startDownload()
+        case .rampart: RampartModelManager.shared.startDownload()
         }
     }
 
-    private func actionLabel(_ icon: String, _ text: String) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: icon)
-            Text(verbatim: text)
+    private func cancelAction(_ backend: PrivacyAIBackend) -> () -> Void {
+        switch backend {
+        case .openai: return { downloader.cancel() }
+        case .rampart: return { rampart.cancel() }
         }
     }
 
-    @ViewBuilder
-    private var openAIControls: some View {
-        switch downloader.state {
-        case .ready:
-            HStack(spacing: 6) {
-                Button(action: downloader.reverify) {
-                    actionLabel("arrow.clockwise", L("Re-verify"))
-                }
-                .buttonStyle(SettingsButtonStyle())
-                Button(role: .destructive) { pendingRemoval = .openai } label: {
-                    actionLabel("trash", L("Remove"))
-                }
-                .buttonStyle(SettingsButtonStyle(isDestructive: true))
-            }
-        case .idle, .failed:
-            Button(action: { PrivacyFilterModelDownloader.shared.startDownload() }) {
-                actionLabel("arrow.down.circle", L("Install"))
-            }
-            .buttonStyle(SettingsButtonStyle())
-        default:
-            HStack(spacing: 6) {
-                ProgressView().controlSize(.small)
-                Text(verbatim: openAIProgressText)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.tertiaryText)
-                Button(action: downloader.cancel) { Text("Cancel", bundle: .module) }
-                    .buttonStyle(SettingsButtonStyle())
-            }
-        }
-    }
-
-    private var openAIProgressText: String {
-        switch downloader.state {
-        case let .downloading(_, _, _, done, total):
-            return total > 0 ? "\(Int(Double(done) / Double(total) * 100))%" : "…"
-        case .verifying:
-            return L("Verifying…")
-        default:
-            return L("Preparing…")
-        }
-    }
-
-    @ViewBuilder
-    private var rampartControls: some View {
-        switch rampart.state {
-        case .ready:
-            Button(role: .destructive) { pendingRemoval = .rampart } label: {
-                actionLabel("trash", L("Remove"))
-            }
-            .buttonStyle(SettingsButtonStyle(isDestructive: true))
-        case .downloading(let progress):
-            HStack(spacing: 6) {
-                ProgressView().controlSize(.small)
-                Text(verbatim: "\(Int(progress * 100))%")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.tertiaryText)
-                Button(action: rampart.cancel) { Text("Cancel", bundle: .module) }
-                    .buttonStyle(SettingsButtonStyle())
-            }
-        case .failed:
-            Button(action: { RampartModelManager.shared.startDownload() }) {
-                actionLabel("arrow.clockwise", L("Retry"))
-            }
-            .buttonStyle(SettingsButtonStyle())
-        case .idle:
-            if RampartModelManager.bundleExists() {
-                Button(role: .destructive) { pendingRemoval = .rampart } label: {
-                    actionLabel("trash", L("Remove"))
-                }
-                .buttonStyle(SettingsButtonStyle(isDestructive: true))
-            } else {
-                Button(action: { RampartModelManager.shared.startDownload() }) {
-                    actionLabel("arrow.down.circle", L("Install"))
-                }
-                .buttonStyle(SettingsButtonStyle())
-            }
-        }
+    private func openHuggingFace(_ repoId: String) {
+        guard let url = URL(string: "https://huggingface.co/\(repoId)") else { return }
+        openURL(url)
     }
 
     private func remove(_ backend: PrivacyAIBackend) {

--- a/Packages/OsaurusCore/Views/Model/ImageModelsDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ImageModelsDownloadView.swift
@@ -102,14 +102,15 @@ struct ImageModelsDownloadView: View {
         SettingsSection(title: "Installed", icon: "checkmark.seal.fill") {
             VStack(spacing: 8) {
                 ForEach(installed) { model in
-                    ImageModelRow(
+                    ModelListRow(
                         title: model.info.displayName,
                         subtitle: installedSubtitle(model.info),
                         leading: leadingStyle(for: model.info),
-                        kindLabel: kindLabel(model.info.kind),
-                        quantLabel: quantText(bits: model.info.quantizationBits, id: model.info.id),
-                        state: state(model.id),
-                        metrics: downloads.metrics[model.id],
+                        badges: badges(
+                            kind: kindLabel(model.info.kind),
+                            quant: quantText(bits: model.info.quantizationBits, id: model.info.id)
+                        ),
+                        status: rowStatus(model.id),
                         primary: installedPrimaryAction(model),
                         menuItems: installedMenuItems(model),
                         onViewHuggingFace: huggingFaceAction(model.repoId),
@@ -124,15 +125,13 @@ struct ImageModelsDownloadView: View {
         SettingsSection(title: "Available", icon: "square.and.arrow.down") {
             VStack(spacing: 8) {
                 ForEach(availableEntries) { entry in
-                    ImageModelRow(
+                    ModelListRow(
                         title: entry.displayName,
                         subtitle: availableSubtitle(entry),
-                        leading: ImageModelRow.Leading(icon: "photo", tint: theme.accentColor),
-                        kindLabel: nil,
-                        quantLabel: quantText(bits: nil, id: entry.repoId),
-                        state: state(entry.id),
-                        metrics: downloads.metrics[entry.id],
-                        primary: ImageModelRow.Action(title: "Download", icon: "arrow.down.circle") {
+                        leading: ModelListRow.Leading(icon: "photo", tint: theme.accentColor),
+                        badges: badges(kind: nil, quant: quantText(bits: nil, id: entry.repoId)),
+                        status: rowStatus(entry.id),
+                        primary: ModelListRow.Action(title: "Download", icon: "arrow.down.circle") {
                             downloads.download(entry)
                         },
                         onViewHuggingFace: huggingFaceAction(entry.repoId),
@@ -173,12 +172,12 @@ struct ImageModelsDownloadView: View {
 
     // MARK: - Row models
 
-    private func installedPrimaryAction(_ model: InstalledModel) -> ImageModelRow.Action? {
+    private func installedPrimaryAction(_ model: InstalledModel) -> ModelListRow.Action? {
         let info = model.info
         // Ready + runnable kind → prominent Generate/Edit (opens the manual panel).
         if info.ready, info.kind == "imageGen" || info.kind == "imageEdit" {
             let isEdit = info.kind == "imageEdit"
-            return ImageModelRow.Action(
+            return ModelListRow.Action(
                 title: isEdit ? "Edit" : "Generate",
                 icon: isEdit ? "wand.and.stars" : "sparkles",
                 role: .primary
@@ -189,33 +188,60 @@ struct ImageModelsDownloadView: View {
         // Not ready → surface Re-download as the primary fix (when the source repo
         // is known); otherwise the only action is delete, left to the menu.
         if !info.ready, let repo = model.repoId {
-            return ImageModelRow.Action(title: "Re-download", icon: "arrow.clockwise") {
+            return ModelListRow.Action(title: "Re-download", icon: "arrow.clockwise") {
                 downloads.download(repoId: repo, displayName: info.displayName)
             }
         }
         return nil
     }
 
-    private func installedMenuItems(_ model: InstalledModel) -> [ImageModelRow.Action] {
+    private func installedMenuItems(_ model: InstalledModel) -> [ModelListRow.Action] {
         let info = model.info
-        var items: [ImageModelRow.Action] = []
+        var items: [ModelListRow.Action] = []
         // Re-download for ready models lives in the menu (not-ready exposes it as
         // the primary action instead, so it isn't duplicated).
         if info.ready, let repo = model.repoId {
             items.append(
-                ImageModelRow.Action(title: "Re-download", icon: "arrow.clockwise") {
+                ModelListRow.Action(title: "Re-download", icon: "arrow.clockwise") {
                     downloads.download(repoId: repo, displayName: info.displayName)
                 }
             )
         }
-        // "View on Hugging Face" now lives inline as an always-visible link
-        // button (see ImageModelRow), so the overflow menu keeps only the
-        // heavier actions: Re-download (for ready bundles) and Delete.
+        // "View on Hugging Face" lives inline as an always-visible link button
+        // (see ModelListRow), so the overflow menu keeps only the heavier
+        // actions: Re-download (for ready bundles) and Delete.
         items.append(
-            ImageModelRow.Action(title: "Delete", icon: "trash", role: .destructive) {
+            ModelListRow.Action(title: "Delete", icon: "trash", role: .destructive) {
                 downloads.delete(info.id)
             }
         )
+        return items
+    }
+
+    /// Map the shared `DownloadState` (+ live metrics) onto the row's
+    /// presentation status. Paused mirrors downloading here since the image
+    /// tab exposes Cancel (not Resume) while a transfer is staged.
+    private func rowStatus(_ id: String) -> ModelListRow.Status {
+        switch state(id) {
+        case .notStarted:
+            return .idle
+        case .downloading(let progress):
+            return .inProgress(progress: progress, detail: downloads.metrics[id]?.formattedLine)
+        case .paused(let progress):
+            return .inProgress(progress: progress, detail: downloads.metrics[id]?.formattedLine)
+        case .completed:
+            return .ready
+        case .failed(let error):
+            return .failed(error)
+        }
+    }
+
+    /// Build the row's leading badges from the optional capability (kind) and
+    /// quantization labels. Both are already localized / formatted by callers.
+    private func badges(kind: String?, quant: String?) -> [ModelBadge.Item] {
+        var items: [ModelBadge.Item] = []
+        if let kind { items.append(ModelBadge.Item(text: kind, style: .accent)) }
+        if let quant { items.append(ModelBadge.Item(text: quant, style: .neutral)) }
         return items
     }
 
@@ -244,10 +270,10 @@ struct ImageModelsDownloadView: View {
         return parts.isEmpty ? L("Not downloaded yet") : parts.joined(separator: " · ")
     }
 
-    private func leadingStyle(for info: ImageModelInfo) -> ImageModelRow.Leading {
+    private func leadingStyle(for info: ImageModelInfo) -> ModelListRow.Leading {
         info.ready
-            ? ImageModelRow.Leading(icon: "checkmark.seal.fill", tint: theme.successColor)
-            : ImageModelRow.Leading(icon: "exclamationmark.triangle.fill", tint: theme.warningColor)
+            ? ModelListRow.Leading(icon: "checkmark.seal.fill", tint: theme.successColor)
+            : ModelListRow.Leading(icon: "exclamationmark.triangle.fill", tint: theme.warningColor)
     }
 
     /// A short capability pill for non-default image kinds; plain generation
@@ -306,238 +332,5 @@ struct ImageModelsDownloadView: View {
         if lower.contains("6bit") || lower.contains("6-bit") { return "6-bit" }
         if lower.contains("4bit") || lower.contains("4-bit") { return "4-bit" }
         return nil
-    }
-}
-
-// MARK: - Image Model Row
-
-/// One clean list row for an image bundle, on the shared 10pt input-card chrome
-/// (the same surface `SettingsToggle` and the Privacy rows use). The row is
-/// static like the Privacy rows; inline controls surface the primary action
-/// (Download / Generate / Edit / Re-download / Cancel), live download progress,
-/// an always-visible "View on Hugging Face" link, and an overflow menu for the
-/// remaining heavier actions (Re-download / Delete) when present.
-private struct ImageModelRow: View {
-    @Environment(\.theme) private var theme
-
-    struct Leading {
-        let icon: String
-        let tint: Color
-    }
-
-    enum ActionRole { case normal, primary, destructive }
-
-    struct Action: Identifiable {
-        let id = UUID()
-        let title: String
-        let icon: String
-        var role: ActionRole = .normal
-        let handler: () -> Void
-    }
-
-    let title: String
-    let subtitle: String
-    let leading: Leading
-    var kindLabel: String? = nil
-    var quantLabel: String? = nil
-    let state: DownloadState
-    let metrics: ModelDownloadService.DownloadMetrics?
-    var primary: Action? = nil
-    var menuItems: [Action] = []
-    /// Always-visible inline "View on Hugging Face" link (when the source repo
-    /// is known). Pulled out of the overflow menu so it stays reachable while a
-    /// download is in flight and isn't the lone item behind a 3-dot affordance.
-    var onViewHuggingFace: (() -> Void)? = nil
-    let onCancel: () -> Void
-
-    private var isActive: Bool {
-        switch state {
-        case .downloading, .paused: return true
-        default: return false
-        }
-    }
-
-    var body: some View {
-        HStack(spacing: 12) {
-            leadingIcon
-
-            VStack(alignment: .leading, spacing: 4) {
-                titleRow
-                if isActive {
-                    progressRow
-                } else {
-                    Text(verbatim: subtitle)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.secondaryText)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-
-            Spacer(minLength: 12)
-
-            trailing
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(theme.inputBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(theme.inputBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    // MARK: Pieces
-
-    private var leadingIcon: some View {
-        Image(systemName: leading.icon)
-            .font(.system(size: 14, weight: .semibold))
-            .foregroundColor(leading.tint)
-            .frame(width: 32, height: 32)
-            .background(RoundedRectangle(cornerRadius: 8).fill(leading.tint.opacity(0.12)))
-    }
-
-    private var titleRow: some View {
-        HStack(spacing: 6) {
-            Text(verbatim: title)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(theme.primaryText)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            if let kindLabel { pill(kindLabel, tint: theme.accentColor) }
-            if let quantLabel { pill(quantLabel, tint: theme.secondaryText) }
-        }
-    }
-
-    private func pill(_ text: String, tint: Color) -> some View {
-        Text(verbatim: text)
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundColor(tint)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(Capsule().fill(tint.opacity(0.12)))
-            .overlay(Capsule().stroke(tint.opacity(0.22), lineWidth: 0.5))
-    }
-
-    private var progressRow: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 2).fill(theme.tertiaryBackground)
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(theme.accentColor)
-                        .frame(width: max(0, geo.size.width * progressValue))
-                        .animation(.easeOut(duration: 0.3), value: progressValue)
-                }
-            }
-            .frame(height: 4)
-
-            HStack(spacing: 6) {
-                Text(verbatim: "\(Int(progressValue * 100))%")
-                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                    .foregroundColor(theme.secondaryText)
-                if let line = metrics?.formattedLine {
-                    Text(verbatim: "·").foregroundColor(theme.tertiaryText)
-                    Text(verbatim: line)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundColor(theme.tertiaryText)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-            }
-        }
-    }
-
-    private var progressValue: Double {
-        switch state {
-        case .downloading(let p), .paused(let p): return p
-        default: return 0
-        }
-    }
-
-    private var trailing: some View {
-        // The Hugging Face link is rendered first in both states so it never
-        // disappears mid-download. Active downloads then show Cancel; idle rows
-        // show the primary action plus an overflow menu only when real items
-        // remain (Installed: Re-download / Delete).
-        HStack(spacing: 8) {
-            if let onViewHuggingFace {
-                huggingFaceButton(onViewHuggingFace)
-            }
-
-            if isActive {
-                Button(action: onCancel) {
-                    Text("Cancel", bundle: .module)
-                }
-                .buttonStyle(SettingsButtonStyle())
-            } else {
-                if let primary {
-                    Button(action: primary.handler) {
-                        HStack(spacing: 4) {
-                            Image(systemName: primary.icon)
-                            Text(LocalizedStringKey(primary.title), bundle: .module)
-                        }
-                    }
-                    .buttonStyle(
-                        SettingsButtonStyle(
-                            isPrimary: primary.role == .primary,
-                            isDestructive: primary.role == .destructive
-                        )
-                    )
-                }
-                if !menuItems.isEmpty { overflowMenu }
-            }
-        }
-    }
-
-    /// Compact link button (Hugging Face mark) sharing the overflow menu's
-    /// chrome so the two trailing controls read as one family.
-    private func huggingFaceButton(_ action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            controlChrome {
-                Text(verbatim: "🤗")
-                    .font(.system(size: 13))
-            }
-            .contentShape(RoundedRectangle(cornerRadius: 8))
-        }
-        .buttonStyle(.plain)
-        .localizedHelp("View on Hugging Face")
-    }
-
-    private var overflowMenu: some View {
-        Menu {
-            ForEach(menuItems) { item in
-                Button(role: item.role == .destructive ? .destructive : nil, action: item.handler) {
-                    Label {
-                        Text(LocalizedStringKey(item.title), bundle: .module)
-                    } icon: {
-                        Image(systemName: item.icon)
-                    }
-                }
-            }
-        } label: {
-            controlChrome {
-                Image(systemName: "ellipsis")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(theme.secondaryText)
-            }
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-    }
-
-    /// Shared 28x28 rounded-square chrome for the trailing icon controls
-    /// (Hugging Face link + overflow menu) so they read as one family.
-    private func controlChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-        content()
-            .frame(width: 28, height: 28)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.tertiaryBackground)
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.inputBorder, lineWidth: 1))
-            )
     }
 }

--- a/Packages/OsaurusCore/Views/Model/ModelListRow.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelListRow.swift
@@ -210,7 +210,7 @@ struct ModelListRow: View {
             } else {
                 HStack(spacing: 6) {
                     ProgressView().controlSize(.small)
-                    Text(verbatim: detail ?? L("Working…"))
+                    Text(verbatim: detail ?? L("Loading…"))
                         .font(.system(size: 11))
                         .foregroundColor(theme.tertiaryText)
                 }

--- a/Packages/OsaurusCore/Views/Model/ModelListRow.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelListRow.swift
@@ -1,0 +1,305 @@
+//
+//  ModelListRow.swift
+//  osaurus
+//
+//  The single, shared list row used by every feature "Models" tab (Voice,
+//  Privacy, Images — and the future Computer Use tab). Generalized from the
+//  Image tab's row so each downloadable-model surface renders identically:
+//  a 32pt leading icon, a title with badges, a subtitle or live download
+//  progress, an always-visible "View on Hugging Face" link, a primary action
+//  (Download / Install / Set as Default / Generate / …), and an overflow menu
+//  for the heavier actions (Delete / Remove / Re-verify / Re-download).
+//
+//  Sits on the shared 10pt input-card chrome (the same surface `SettingsToggle`
+//  uses) and is grouped by callers under `SettingsSection` "Installed" /
+//  "Available". Presentation-only: each feature maps its own download manager
+//  state into `ModelListRow.Status` and supplies the actions, so the row stays
+//  decoupled from any specific download service.
+//
+
+import SwiftUI
+
+// MARK: - Model Badge
+
+/// The one pill used by every model row — replaces the previously divergent
+/// per-tab capsules ("EN", "Default", "Installed", quant chips, kind chips).
+/// Callers pass already-localized text (mirroring the rest of the row), so the
+/// label renders verbatim.
+struct ModelBadge: View {
+    @Environment(\.theme) private var theme
+
+    enum Style { case neutral, accent, success, warning }
+
+    struct Item {
+        let text: String
+        var icon: String? = nil
+        var style: Style = .neutral
+    }
+
+    let item: Item
+
+    private var tint: Color {
+        switch item.style {
+        case .neutral: return theme.secondaryText
+        case .accent: return theme.accentColor
+        case .success: return theme.successColor
+        case .warning: return theme.warningColor
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            if let icon = item.icon {
+                Image(systemName: icon)
+                    .font(.system(size: 9, weight: .semibold))
+            }
+            Text(verbatim: item.text)
+                .font(.system(size: 10, weight: .semibold))
+        }
+        .foregroundColor(tint)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Capsule().fill(tint.opacity(0.12)))
+        .overlay(Capsule().stroke(tint.opacity(0.22), lineWidth: 0.5))
+    }
+}
+
+// MARK: - Model List Row
+
+struct ModelListRow: View {
+    @Environment(\.theme) private var theme
+
+    struct Leading {
+        let icon: String
+        let tint: Color
+    }
+
+    enum ActionRole { case normal, primary, destructive }
+
+    struct Action: Identifiable {
+        let id = UUID()
+        let title: String
+        let icon: String
+        var role: ActionRole = .normal
+        let handler: () -> Void
+    }
+
+    /// Normalized download lifecycle. `inProgress(progress: nil, …)` renders an
+    /// indeterminate spinner + detail (for phases like verify/enumerate that
+    /// have no fraction); a non-nil progress renders the linear bar + percent.
+    enum Status {
+        case idle
+        case inProgress(progress: Double?, detail: String?)
+        case ready
+        case failed(String)
+    }
+
+    let title: String
+    let subtitle: String
+    let leading: Leading
+    var badges: [ModelBadge.Item] = []
+    /// When true the row shows a success "Default" badge and an accent border —
+    /// the single, unified "this model is the active choice" treatment shared
+    /// by every Models tab.
+    var isDefault: Bool = false
+    let status: Status
+    var primary: Action? = nil
+    var menuItems: [Action] = []
+    /// Always-visible inline "View on Hugging Face" link (when the source repo
+    /// is known). Pulled out of the overflow menu so it stays reachable while a
+    /// download is in flight and isn't the lone item behind a 3-dot affordance.
+    var onViewHuggingFace: (() -> Void)? = nil
+    var onCancel: (() -> Void)? = nil
+
+    private var isActive: Bool {
+        if case .inProgress = status { return true }
+        return false
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            leadingIcon
+
+            VStack(alignment: .leading, spacing: 4) {
+                titleRow
+                if isActive {
+                    progressRow
+                } else {
+                    Text(verbatim: subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer(minLength: 12)
+
+            trailing
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.inputBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(
+                            isDefault ? theme.accentColor : theme.inputBorder,
+                            lineWidth: isDefault ? 1.5 : 1
+                        )
+                )
+        )
+    }
+
+    // MARK: Pieces
+
+    private var leadingIcon: some View {
+        Image(systemName: leading.icon)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundColor(leading.tint)
+            .frame(width: 32, height: 32)
+            .background(RoundedRectangle(cornerRadius: 8).fill(leading.tint.opacity(0.12)))
+    }
+
+    private var titleRow: some View {
+        HStack(spacing: 6) {
+            Text(verbatim: title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if isDefault {
+                ModelBadge(item: ModelBadge.Item(text: L("Default"), style: .success))
+            }
+            ForEach(badges.indices, id: \.self) { index in
+                ModelBadge(item: badges[index])
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var progressRow: some View {
+        if case let .inProgress(progress, detail) = status {
+            if let progress {
+                VStack(alignment: .leading, spacing: 4) {
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 2).fill(theme.tertiaryBackground)
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(theme.accentColor)
+                                .frame(width: max(0, geo.size.width * progress))
+                                .animation(.easeOut(duration: 0.3), value: progress)
+                        }
+                    }
+                    .frame(height: 4)
+
+                    HStack(spacing: 6) {
+                        Text(verbatim: "\(Int(progress * 100))%")
+                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                            .foregroundColor(theme.secondaryText)
+                        if let detail {
+                            Text(verbatim: "·").foregroundColor(theme.tertiaryText)
+                            Text(verbatim: detail)
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundColor(theme.tertiaryText)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
+                    }
+                }
+            } else {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text(verbatim: detail ?? L("Working…"))
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            }
+        }
+    }
+
+    private var trailing: some View {
+        // The Hugging Face link renders first in both states so it never
+        // disappears mid-download. Active downloads then show Cancel; idle rows
+        // show the primary action plus an overflow menu only when items remain.
+        HStack(spacing: 8) {
+            if let onViewHuggingFace {
+                huggingFaceButton(onViewHuggingFace)
+            }
+
+            if isActive {
+                if let onCancel {
+                    Button(action: onCancel) {
+                        Text("Cancel", bundle: .module)
+                    }
+                    .buttonStyle(SettingsButtonStyle())
+                }
+            } else {
+                if let primary {
+                    Button(action: primary.handler) {
+                        HStack(spacing: 4) {
+                            Image(systemName: primary.icon)
+                            Text(LocalizedStringKey(primary.title), bundle: .module)
+                        }
+                    }
+                    .buttonStyle(
+                        SettingsButtonStyle(
+                            isPrimary: primary.role == .primary,
+                            isDestructive: primary.role == .destructive
+                        )
+                    )
+                }
+                if !menuItems.isEmpty { overflowMenu }
+            }
+        }
+    }
+
+    /// Compact link button (Hugging Face mark) sharing the overflow menu's
+    /// chrome so the two trailing controls read as one family.
+    private func huggingFaceButton(_ action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            controlChrome {
+                Text(verbatim: "🤗")
+                    .font(.system(size: 13))
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .localizedHelp("View on Hugging Face")
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            ForEach(menuItems) { item in
+                Button(role: item.role == .destructive ? .destructive : nil, action: item.handler) {
+                    Label {
+                        Text(LocalizedStringKey(item.title), bundle: .module)
+                    } icon: {
+                        Image(systemName: item.icon)
+                    }
+                }
+            }
+        } label: {
+            controlChrome {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    /// Shared 28x28 rounded-square chrome for the trailing icon controls
+    /// (Hugging Face link + overflow menu) so they read as one family.
+    private func controlChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .frame(width: 28, height: 28)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(theme.tertiaryBackground)
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.inputBorder, lineWidth: 1))
+            )
+    }
+}

--- a/Packages/OsaurusCore/Views/Voice/VoiceView.swift
+++ b/Packages/OsaurusCore/Views/Voice/VoiceView.swift
@@ -204,35 +204,47 @@ private struct VoiceHeaderStatusIndicator: View {
 // MARK: - Voice Models Tab
 
 private struct VoiceModelsTab: View {
-    @Environment(\.theme) private var theme
     @ObservedObject private var modelManager = SpeechModelManager.shared
 
-    /// All available speech models as a single flat list, recommended first so
-    /// the default model stays on top. The list is short enough that the old
-    /// search field + Recommended/All-Models section split were just noise.
-    /// Recomputed off `objectWillChange` rather than per body render so the
+    /// Curated speech models, recommended first so the default stays on top.
+    /// Recomputed off `objectWillChange` (not per body render) so the
     /// high-frequency download-progress publishes don't re-walk it each frame.
     @State private var orderedModels: [SpeechModel] = []
 
+    private func isInstalled(_ model: SpeechModel) -> Bool {
+        modelManager.effectiveDownloadState(for: model) == .completed
+    }
+
+    private var installed: [SpeechModel] { orderedModels.filter(isInstalled) }
+    private var available: [SpeechModel] { orderedModels.filter { !isInstalled($0) } }
+
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
+            VStack(alignment: .leading, spacing: 24) {
                 // Legacy WhisperKit cleanup banner
                 if modelManager.legacyWhisperModelsExist {
                     LegacyWhisperBanner()
-                        .padding(.horizontal, 24)
                 }
 
-                VStack(spacing: 12) {
-                    ForEach(orderedModels) { model in
-                        SpeechModelRow(model: model)
+                if !installed.isEmpty {
+                    SettingsSection(title: "Installed", icon: "checkmark.seal.fill") {
+                        VStack(spacing: 8) {
+                            ForEach(installed) { SpeechModelListRow(model: $0) }
+                        }
                     }
                 }
-                .padding(.horizontal, 24)
 
-                Spacer(minLength: 24)
+                if !available.isEmpty {
+                    SettingsSection(title: "Available", icon: "square.and.arrow.down") {
+                        VStack(spacing: 8) {
+                            ForEach(available) { SpeechModelListRow(model: $0) }
+                        }
+                    }
+                }
             }
-            .padding(.top, 16)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 24)
+            .frame(maxWidth: .infinity, alignment: .top)
         }
         .onAppear { refreshModels() }
         .onReceive(modelManager.objectWillChange) { _ in
@@ -313,195 +325,82 @@ private struct LegacyWhisperBanner: View {
 
 // MARK: - Speech Model Row
 
-private struct SpeechModelRow: View {
-    @Environment(\.theme) private var theme
+/// Adapts a Parakeet `SpeechModel` onto the shared `ModelListRow`: maps the
+/// speech-specific download state into the row's status, surfaces the EN /
+/// Default badges, and wires Download / Retry / Set as Default / Delete.
+private struct SpeechModelListRow: View {
     @ObservedObject private var modelManager = SpeechModelManager.shared
+    @Environment(\.theme) private var theme
 
     let model: SpeechModel
-
-    @State private var isHovering = false
 
     private var downloadState: SpeechDownloadState {
         modelManager.effectiveDownloadState(for: model)
     }
 
-    private var isSelected: Bool {
-        modelManager.selectedModelId == model.id
-    }
+    private var isCompleted: Bool { downloadState == .completed }
+    private var isSelected: Bool { modelManager.selectedModelId == model.id }
 
     var body: some View {
-        HStack(spacing: 16) {
-            // Icon
-            ZStack {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(iconBackground)
-                Image(systemName: iconName)
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundColor(iconColor)
-            }
-            .frame(width: 48, height: 48)
-
-            // Info
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 8) {
-                    Text(model.name)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(theme.primaryText)
-
-                    if model.isEnglishOnly {
-                        Text("EN", bundle: .module)
-                            .font(.system(size: 9, weight: .bold))
-                            .foregroundColor(theme.secondaryText)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .background(Capsule().fill(theme.tertiaryBackground))
-                    }
-
-                    if isSelected {
-                        Text("Default", bundle: .module)
-                            .font(.system(size: 9, weight: .bold))
-                            .foregroundColor(theme.successColor)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .background(Capsule().fill(theme.successColor.opacity(0.1)))
-                    }
-                }
-
-                Text(model.description)
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.secondaryText)
-                    .lineLimit(1)
-
-                Text(model.size)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.tertiaryText)
-            }
-
-            Spacer()
-
-            // Actions
-            actionButton
-        }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 14)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14)
-                        .stroke(
-                            isSelected ? theme.successColor.opacity(0.3) : theme.cardBorder,
-                            lineWidth: 1
-                        )
-                )
+        ModelListRow(
+            title: model.name,
+            subtitle: "\(model.description) · \(model.size)",
+            leading: leading,
+            badges: model.isEnglishOnly ? [ModelBadge.Item(text: L("EN"), style: .neutral)] : [],
+            isDefault: isSelected && isCompleted,
+            status: status,
+            primary: primaryAction,
+            menuItems: menuItems,
+            onCancel: { modelManager.cancelDownload(model.id) }
         )
-        .scaleEffect(isHovering ? 1.005 : 1)
-        .animation(.easeOut(duration: 0.15), value: isHovering)
-        .onHover { hovering in
-            isHovering = hovering
+    }
+
+    private var leading: ModelListRow.Leading {
+        switch downloadState {
+        case .completed: return .init(icon: "waveform", tint: theme.successColor)
+        case .downloading: return .init(icon: "arrow.down.circle", tint: theme.accentColor)
+        case .failed: return .init(icon: "exclamationmark.triangle", tint: theme.errorColor)
+        case .notStarted: return .init(icon: "waveform.circle", tint: theme.secondaryText)
         }
     }
 
-    private var iconName: String {
+    private var status: ModelListRow.Status {
         switch downloadState {
-        case .completed: return "waveform"
-        case .downloading: return "arrow.down.circle"
-        case .failed: return "exclamationmark.triangle"
-        default: return "waveform.circle"
+        case .notStarted: return .idle
+        case .downloading(let progress): return .inProgress(progress: progress, detail: nil)
+        case .completed: return .ready
+        case .failed(let error): return .failed(error)
         }
     }
 
-    private var iconColor: Color {
+    private var primaryAction: ModelListRow.Action? {
         switch downloadState {
-        case .completed: return theme.successColor
-        case .downloading: return theme.accentColor
-        case .failed: return theme.errorColor
-        default: return theme.secondaryText
-        }
-    }
-
-    private var iconBackground: Color {
-        switch downloadState {
-        case .completed: return theme.successColor.opacity(0.15)
-        case .downloading: return theme.accentColor.opacity(0.15)
-        case .failed: return theme.errorColor.opacity(0.15)
-        default: return theme.tertiaryBackground
-        }
-    }
-
-    @ViewBuilder
-    private var actionButton: some View {
-        switch downloadState {
-        case .notStarted, .failed:
-            Button(action: { modelManager.downloadModel(model) }) {
-                Text("Download", bundle: .module)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(theme.isDark ? theme.primaryBackground : .white)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(theme.accentColor)
-                    )
+        case .notStarted:
+            return ModelListRow.Action(title: "Download", icon: "arrow.down.circle") {
+                modelManager.downloadModel(model)
             }
-            .buttonStyle(PlainButtonStyle())
-
-        case .downloading(let progress):
-            HStack(spacing: 12) {
-                // Progress indicator
-                ZStack {
-                    Circle()
-                        .stroke(theme.tertiaryBackground, lineWidth: 3)
-                    Circle()
-                        .trim(from: 0, to: progress)
-                        .stroke(theme.accentColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                        .rotationEffect(.degrees(-90))
-                        .animation(.easeOut(duration: 0.3), value: progress)
-                }
-                .frame(width: 28, height: 28)
-
-                Text("\(Int(progress * 100))%", bundle: .module)
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(theme.secondaryText)
-                    .frame(width: 40)
-
-                Button(action: { modelManager.cancelDownload(model.id) }) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(theme.tertiaryText)
-                }
-                .buttonStyle(PlainButtonStyle())
+        case .failed:
+            return ModelListRow.Action(title: "Retry", icon: "arrow.clockwise") {
+                modelManager.downloadModel(model)
             }
-
         case .completed:
-            HStack(spacing: 8) {
-                if !isSelected {
-                    Button(action: { modelManager.setDefaultModel(model.id) }) {
-                        Text("Set Default", bundle: .module)
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(theme.accentColor)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .stroke(theme.accentColor, lineWidth: 1)
-                            )
-                    }
-                    .buttonStyle(PlainButtonStyle())
+            return isSelected
+                ? nil
+                : ModelListRow.Action(title: "Set as Default", icon: "checkmark.circle") {
+                    modelManager.setDefaultModel(model.id)
                 }
-
-                Button(action: { Task { await modelManager.deleteModel(model) } }) {
-                    Image(systemName: "trash")
-                        .font(.system(size: 14))
-                        .foregroundColor(theme.tertiaryText)
-                        .padding(8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(theme.tertiaryBackground)
-                        )
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
+        case .downloading:
+            return nil
         }
+    }
+
+    private var menuItems: [ModelListRow.Action] {
+        guard isCompleted else { return [] }
+        return [
+            ModelListRow.Action(title: "Delete", icon: "trash", role: .destructive) {
+                modelManager.deleteModel(model)
+            }
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary

The Voice, Privacy, and Images "Models" tabs each rendered their downloadable-model lists with a bespoke row — different icon chrome, badges, progress indicators, action layouts, and even different selection metaphors (Privacy used radio cards; Voice/Images used a "Default" badge). This unifies them.

- **New shared components** (`Packages/OsaurusCore/Views/Model/ModelListRow.swift`): `ModelListRow` + `ModelBadge`, generalized from the Images row. Every model surface now renders identically — 32pt leading icon, title with badges, subtitle or live download progress, an always-visible "View on Hugging Face" link, a primary action (Download / Install / Set as Default / …), and an overflow menu for heavier actions (Delete / Remove / Re-verify).
- **Presentation-only row**: each feature maps its own download-manager state into `ModelListRow.Status` (idle / inProgress / ready / failed), with indeterminate progress for Privacy's enumerate & verify phases, so the row stays decoupled from any specific download service.
- **Images** (`ImageModelsDownloadView.swift`): deleted the private `ImageModelRow`; maps `DownloadState` → `Status` and kind/quant → badges. Visuals unchanged (this was the baseline).
- **Voice** (`VoiceView.swift`): replaced the flat `SpeechModelRow` list with `SettingsSection` Installed / Available groups + `ModelListRow`; EN / Default badges; Download / Retry / Set as Default / Delete + Cancel. Legacy Whisper banner retained.
- **Privacy** (`PrivacyView.swift`): rewrote `PrivacyModelSelector` onto `ModelListRow`. Dropped the radio cards in favor of the shared "Default" badge + "Set as Default" metaphor. Models tab groups rows into Installed / Available (`.sections`); Overview renders them flat (`.flat`). Added Hugging Face links and an overflow Re-verify / Remove with the existing removal confirmation.

Net: `611 insertions(+), 604 deletions(-)` across 4 files — mostly deleting three duplicated row implementations.

## Test plan

- [ ] `make app` builds clean (Release) — verified locally, exit 0.
- [ ] **Images → Models**: Installed/Available sections, download progress, HF link, kind/quant badges, and overflow actions match pre-refactor visuals.
- [ ] **Voice → Models**: Installed/Available grouping; EN + Default badges; Download → progress → Cancel; Set as Default; Delete; legacy Whisper banner still shows.
- [ ] **Privacy → Models**: Rampart/OpenAI grouped Installed/Available; Install → indeterminate enumerate/verify → ready; Default badge + Set as Default switches the active backend; Re-verify / Remove (with confirmation) work.
- [ ] **Privacy → Overview**: same rows render flat and selection stays in sync with the Models tab.