### PR TITLE
Repin vmlx-swift to c976fcbd — Ornith prefill counter advances (vmlx #105)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5b8371b428f205bd7a4e91df901bfefefb71dfda"
+        "revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5b8371b428f205bd7a4e91df901bfefefb71dfda"
+        "revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         // Pinned to the merge of the writePNG main-actor hang fix on main.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5b8371b428f205bd7a4e91df901bfefefb71dfda"
+            revision: "c976fcbd96f270ac55b6d69fad33284f89936d86"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "5b8371b428f205bd7a4e91df901bfefefb71dfda""#))
-        #expect(packageResolved.contains(#""revision" : "5b8371b428f205bd7a4e91df901bfefefb71dfda""#))
-        #expect(workspaceResolved.contains(#""revision" : "5b8371b428f205bd7a4e91df901bfefefb71dfda""#))
-        #expect(appResolved.contains(#""revision" : "5b8371b428f205bd7a4e91df901bfefefb71dfda""#))
+        #expect(packageSwift.contains(#"revision: "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
+        #expect(packageResolved.contains(#""revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
+        #expect(workspaceResolved.contains(#""revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
+        #expect(appResolved.contains(#""revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -639,7 +639,7 @@ struct RuntimePolicySourceTests {
         // isolation, so the MLX eval() it triggers no longer blocks the main
         // thread during image generation (fixes the Sentry App Hanging report
         // in ZImage.performGenerate).
-        let expectedRuntimeHardenedRevision = "5b8371b428f205bd7a4e91df901bfefefb71dfda"
+        let expectedRuntimeHardenedRevision = "c976fcbd96f270ac55b6d69fad33284f89936d86"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5b8371b428f205bd7a4e91df901bfefefb71dfda"
+        "revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86"
       }
     },
     {


### PR DESCRIPTION
Repins the vmlx-swift dependency `5b8371b4 → c976fcbd` to pick up **vmlx-swift #105**.

## What #105 fixes
VLM `Qwen35.prepare()` ran the whole prompt through one forward returning `.logits` — no `PrefillProgress` frames — so osaurus showed a **frozen `Prefill 0/N`** counter for long hybrid (Ornith / qwen3_5) prompts. It now chunks the **text-only** prefill in `windowSize` (512) steps and reports `reportCompletedUnits` per chunk (mirrors Gemma4). Image/video prefill stays single-shot (mrope needs the full grid). Numerically identical — positions + causal mask are rebuilt from `cache.offset` (same invariant as decode), chunks pass `mask: nil`.

## Files
`Package.swift` + 3 `Package.resolved` (pin) + 2 pin-assertion tests (`ImageGenerationBridgeContractTests`, `RuntimePolicySourceTests`).

## Live proof (dev app built on this exact pin)
Re-confirming on the shipping pin (not a local override); matrix posted as a comment.