### PR TITLE
Repin vmlx-swift b6eda04f — MLX Metal stream-map thread-safety (fixes concurrent-GPU EXC_BAD_ACCESS crashes)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86"
+        "revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86"
+        "revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         // Pinned to the merge of the writePNG main-actor hang fix on main.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "c976fcbd96f270ac55b6d69fad33284f89936d86"
+            revision: "b6eda04f4e471271778c64af5166ad3d9298afcf"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
-        #expect(packageResolved.contains(#""revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
-        #expect(workspaceResolved.contains(#""revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
-        #expect(appResolved.contains(#""revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86""#))
+        #expect(packageSwift.contains(#"revision: "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
+        #expect(packageResolved.contains(#""revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
+        #expect(workspaceResolved.contains(#""revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
+        #expect(appResolved.contains(#""revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -639,7 +639,7 @@ struct RuntimePolicySourceTests {
         // isolation, so the MLX eval() it triggers no longer blocks the main
         // thread during image generation (fixes the Sentry App Hanging report
         // in ZImage.performGenerate).
-        let expectedRuntimeHardenedRevision = "c976fcbd96f270ac55b6d69fad33284f89936d86"
+        let expectedRuntimeHardenedRevision = "b6eda04f4e471271778c64af5166ad3d9298afcf"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c976fcbd96f270ac55b6d69fad33284f89936d86"
+        "revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift to pick up **vmlx-swift #106** (mlx submodule `9dabb6c4`), which fixes the concurrent-GPU `EXC_BAD_ACCESS` crash family reported in Sentry (osaurus-inc / apple-macos), still live on 0.21.x.

## Root cause
Osaurus drives one MLX Metal device from multiple threads (generation + embedding/`capabilities_discover` + image-gen + model load/teardown). Two shared MLX maps were read + mutated with **no lock**, so a rehash on one thread corrupted a `find()` on another:
- **Scheduler** `default_streams_`/`streams_` → crash `mlx::core::default_stream → std::__hash_table::find` (biggest cluster, ~60 events).
- **metal::Device** `stream_map_` (`get_stream_` find vs `new_queue` emplace) → `Device::end_encoding` / `get_command_buffer` (live on 0.21.x).

The Device's kernel/library caches already had `kernel_mtx_`/`library_mtx_`; the stream maps were simply never given the same treatment.

## Fix (thread-safety at the source, not a serialization gate)
Dedicated mutex per map guarding **only** the find/emplace. `unordered_map` keeps element references stable across insert, so the returned `Stream`/`DeviceStream&` is used after the lock drops and per-stream GPU encoding (already serialized by `MetalGate`) is never under the lock → **no GPU serialization, no deadlock** — deliberately NOT the reverted blanket eval-gate (#92). The `MetalGate` admission logic and drain-before-release points were already sound; the maps were the gap.

## Verified live (dev app built from this mlx)
- **Compiles** (built the mlx C++ from this pin).
- Concurrent multi-model stress (3 rounds) — **no crash** (server alive), **no deadlock/hang** (10/10 same-model concurrent; post-stress request returns).
- **No regression** — qwen ("Paris"), Ornith ("Tokyo"), zaya (reasoning model, "PARIS").
- A rare race can't be proven absent by a short run; the mutex closing the map access is the by-construction proof — Sentry watch on the next release is the ultimate confirmation.

Files: `Package.swift` + 3 `Package.resolved` + 2 pin-assertion tests.