### PR TITLE
triage and fix sentry app hangs and crashes

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
@@ -52,6 +52,17 @@ public struct ScreenContextDistiller: Sendable {
         self.maxItemChars = maxItemChars
     }
 
+    /// Area (width * height) of a rectangle reported by the accessibility API,
+    /// clamped so the multiply can't overflow `Int` and trap. AX can return
+    /// absurd or garbage dimensions for off-screen or misreporting elements, and
+    /// the raw `w * h` (and the downstream `area * 100` comparison) would crash
+    /// on overflow. Clamping each side keeps the value well within `Int` while
+    /// preserving the relative ordering these areas are used for.
+    private static func clampedArea(_ w: Int, _ h: Int) -> Int {
+        let side = 1_000_000
+        return min(max(0, w), side) * min(max(0, h), side)
+    }
+
     /// Osaurus's own identity, used to exclude it from the "what you're doing"
     /// signal (it's usually frontmost when the user hits send).
     private struct SelfIdentity {
@@ -343,7 +354,7 @@ public struct ScreenContextDistiller: Sendable {
     /// largest window when none is flagged focused.
     private func focusedWindowSummary(in snapshot: CUSnapshot) -> CUWindowSummary? {
         snapshot.windows.first(where: { $0.focused })
-            ?? snapshot.windows.max(by: { (max(0, $0.w) * max(0, $0.h)) < (max(0, $1.w) * max(0, $1.h)) })
+            ?? snapshot.windows.max(by: { Self.clampedArea($0.w, $0.h) < Self.clampedArea($1.w, $1.h) })
     }
 
     /// True when the elements already contain a text area carrying real content,
@@ -394,7 +405,7 @@ public struct ScreenContextDistiller: Sendable {
         let largest =
             elements
             .filter { $0.role.lowercased() == "textarea" }
-            .max(by: { (max(0, $0.w) * max(0, $0.h)) < (max(0, $1.w) * max(0, $1.h)) })
+            .max(by: { Self.clampedArea($0.w, $0.h) < Self.clampedArea($1.w, $1.h) })
         guard let largest, let viewing = cleaned(largest.value, limit: maxViewingChars) else {
             return focused
         }
@@ -436,7 +447,7 @@ public struct ScreenContextDistiller: Sendable {
                 .map(dedupKey)
         )
 
-        let windowArea = focusedWindow.map { max(0, $0.w) * max(0, $0.h) } ?? 0
+        let windowArea = focusedWindow.map { Self.clampedArea($0.w, $0.h) } ?? 0
 
         // Rank candidates so genuine content leads: the main editor/body first,
         // then headings, then body text, then filled inputs — lower tiers only
@@ -498,7 +509,7 @@ public struct ScreenContextDistiller: Sendable {
         windowArea: Int
     ) -> (text: String, rank: ContentRank, weight: Int)? {
         let label = cleaned(element.label, limit: maxItemChars)
-        let area = max(0, element.w) * max(0, element.h)
+        let area = Self.clampedArea(element.w, element.h)
         // "Large" = occupies a meaningful fraction of the focused window, the
         // signature of a document/editor body vs. a sidebar label.
         let isLarge = windowArea > 0 && area * 100 >= windowArea * 12

--- a/Packages/OsaurusCore/Identity/RevocationStore.swift
+++ b/Packages/OsaurusCore/Identity/RevocationStore.swift
@@ -85,7 +85,8 @@ public final class RevocationStore: @unchecked Sendable {
             counterThresholds: counterThresholds
         )
         guard let data = try? JSONEncoder().encode(model) else { return }
-        Keychain.write(service: Self.keychainService, account: Self.keychainAccount, data: data)
+        Keychain.writeInBackground(
+            service: Self.keychainService, account: Self.keychainAccount, data: data)
     }
 
     private func load() {

--- a/Packages/OsaurusCore/Identity/WhitelistStore.swift
+++ b/Packages/OsaurusCore/Identity/WhitelistStore.swift
@@ -107,7 +107,8 @@ public final class WhitelistStore: @unchecked Sendable {
             agents: agentAddresses.mapValues { Array($0) }
         )
         guard let data = try? JSONEncoder().encode(model) else { return }
-        Keychain.write(service: Self.keychainService, account: Self.keychainAccount, data: data)
+        Keychain.writeInBackground(
+            service: Self.keychainService, account: Self.keychainAccount, data: data)
     }
 
     private func load() {

--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -589,7 +589,7 @@ public final class BackgroundTaskManager: ObservableObject {
             return false
         }
 
-        let globalLimit = ToastConfigurationStore.load().maxConcurrentTasks
+        let globalLimit = ToastManager.shared.configuration.maxConcurrentTasks
         let activeTasks = backgroundTasks.values.filter { $0.status.isActive }
 
         guard activeTasks.count < globalLimit else {

--- a/Packages/OsaurusCore/ObjCSupport/OsaurusExceptionCatcher.m
+++ b/Packages/OsaurusCore/ObjCSupport/OsaurusExceptionCatcher.m
@@ -1,0 +1,15 @@
+//
+//  OsaurusExceptionCatcher.m
+//  osaurus
+//
+
+#import "OsaurusObjCSupport.h"
+
+NSException *_Nullable osr_catch_exception(void(NS_NOESCAPE ^block)(void)) {
+    @try {
+        block();
+        return nil;
+    } @catch (NSException *exception) {
+        return exception;
+    }
+}

--- a/Packages/OsaurusCore/ObjCSupport/include/OsaurusObjCSupport.h
+++ b/Packages/OsaurusCore/ObjCSupport/include/OsaurusObjCSupport.h
@@ -1,0 +1,23 @@
+//
+//  OsaurusObjCSupport.h
+//  osaurus
+//
+//  Small Objective-C shim for the handful of framework calls that can raise
+//  an NSException that Swift cannot `catch`.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runs `block` inside an Objective-C `@try`/`@catch`. Returns `nil` when the
+/// block completes normally, or the caught `NSException` when one is raised.
+///
+/// Swift's `do`/`catch` only handles `Error`, not Objective-C `NSException`, so
+/// an exception thrown by a framework call (e.g. AppKit's non-thread-safe
+/// `NSPasteboard` type-cache mutation racing another access) otherwise
+/// terminates the process. Wrapping such a call in this helper lets the Swift
+/// caller treat it as a recoverable failure instead of a crash.
+NSException *_Nullable osr_catch_exception(void(NS_NOESCAPE ^_Nonnull block)(void));
+
+NS_ASSUME_NONNULL_END

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -156,10 +156,19 @@ let package = Package(
                 .linkedFramework("Security")
             ]
         ),
+        // Objective-C shim for framework calls that raise an NSException Swift
+        // cannot `catch` (see `osr_catch_exception`). Kept in its own target
+        // because a SwiftPM target cannot mix Swift and Objective-C sources.
+        .target(
+            name: "OsaurusObjCSupport",
+            path: "ObjCSupport",
+            publicHeadersPath: "include"
+        ),
         .target(
             name: "OsaurusCore",
             dependencies: [
                 "OsaurusSQLCipher",
+                "OsaurusObjCSupport",
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
@@ -192,7 +201,7 @@ let package = Package(
                 .product(name: "Sentry", package: "sentry-cocoa"),
             ],
             path: ".",
-            exclude: ["Tests", "SQLCipher"],
+            exclude: ["Tests", "SQLCipher", "ObjCSupport"],
             resources: [.process("Resources")],
             swiftSettings: [
                 // `SystemLanguageModel.contextSize` only exists in the macOS 26.4+

--- a/Packages/OsaurusCore/Services/Context/ClipboardService.swift
+++ b/Packages/OsaurusCore/Services/Context/ClipboardService.swift
@@ -8,6 +8,7 @@
 import AppKit
 import Combine
 import Foundation
+import OsaurusObjCSupport
 
 /// Service for monitoring the macOS pasteboard and capturing selections from other apps
 @MainActor
@@ -64,13 +65,28 @@ public final class ClipboardService: ObservableObject {
         label: "com.dinoki.osaurus.clipboard.pasteboard"
     )
 
-    /// Runs `work` against the shared pasteboard on the serial pasteboard queue.
+    /// Runs `work` against the shared pasteboard on the serial pasteboard queue,
+    /// returning `nil` when the read raises. The serial queue only orders *our*
+    /// pasteboard access; `NSPasteboard.general` is a process-wide singleton that
+    /// other subsystems (e.g. the Cmd+V paste handler on the main thread) touch
+    /// concurrently, and AppKit's non-thread-safe type cache can throw an
+    /// `NSRangeException` mid-read. Catching it here degrades a poll to a no-op
+    /// instead of terminating the app on an exception Swift can't `catch`.
     nonisolated private static func onPasteboardQueue<T: Sendable>(
         _ work: @escaping @Sendable (NSPasteboard) -> T
-    ) async -> T {
+    ) async -> T? {
         await withCheckedContinuation { continuation in
             pasteboardQueue.async {
-                continuation.resume(returning: work(NSPasteboard.general))
+                var result: T?
+                let raised = osr_catch_exception {
+                    result = work(NSPasteboard.general)
+                }
+                if let raised {
+                    print("[ClipboardService] Pasteboard read raised \(raised.name.rawValue); skipping")
+                    continuation.resume(returning: nil)
+                } else {
+                    continuation.resume(returning: result)
+                }
             }
         }
     }
@@ -128,13 +144,13 @@ public final class ClipboardService: ObservableObject {
         // (never `readObjects(forClasses:)`), which are safe to call off the main actor.
         // They run on the shared serial pasteboard queue so they never overlap another
         // pasteboard access and corrupt its internal type cache.
-        let changeCount = await Self.onPasteboardQueue { $0.changeCount }
+        guard let changeCount = await Self.onPasteboardQueue({ $0.changeCount }) else { return }
         guard changeCount != knownChangeCount else { return }
 
         print("[ClipboardService] Pasteboard change detected. Count: \(changeCount) (was \(knownChangeCount))")
         lastChangeCount = changeCount
 
-        let detected = await Self.onPasteboardQueue { Self.detectContent(in: $0) }
+        let detected = await Self.onPasteboardQueue { Self.detectContent(in: $0) } ?? nil
         guard let content = detected else {
             print("[ClipboardService] Change detected but no meaningful content found on pasteboard.")
             return
@@ -206,7 +222,7 @@ public final class ClipboardService: ObservableObject {
     /// Attempt to grab the current selection from the active application
     /// by simulating Cmd+C and waiting for the pasteboard to update.
     public func grabSelection() async -> String? {
-        let startChangeCount = await Self.onPasteboardQueue { $0.changeCount }
+        guard let startChangeCount = await Self.onPasteboardQueue({ $0.changeCount }) else { return nil }
         print("[ClipboardService] Starting grabSelection. Current changeCount: \(startChangeCount)")
 
         // 1. simulate Cmd+C
@@ -222,7 +238,7 @@ public final class ClipboardService: ObservableObject {
         print("[ClipboardService] Waiting for pasteboard update...")
         for i in 0 ..< 10 {
             try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms
-            let currentChangeCount = await Self.onPasteboardQueue { $0.changeCount }
+            guard let currentChangeCount = await Self.onPasteboardQueue({ $0.changeCount }) else { continue }
             if currentChangeCount != startChangeCount {
                 print(
                     "[ClipboardService] Pasteboard update detected at iteration \(i+1). New count: \(currentChangeCount)"

--- a/Packages/OsaurusCore/Services/Keychain/Keychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/Keychain.swift
@@ -22,6 +22,14 @@ import Security
 /// Callers apply their own `KeychainQueryHelpers.disablesKeychainForProcess`
 /// short-circuit before calling these methods.
 enum Keychain {
+    /// Serial queue for fire-and-forget writes. `SecItemAdd`/`SecItemUpdate`
+    /// are synchronous and can block for seconds under iCloud-keychain or
+    /// first-unlock contention; running them here keeps that I/O off the main
+    /// thread (a recurring app-hang source). Serial so concurrent writes to the
+    /// same item don't race.
+    private static let writeQueue = DispatchQueue(
+        label: "com.dinoki.osaurus.keychain.write", qos: .utility)
+
     private static func baseQuery(service: String, account: String) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
@@ -56,6 +64,23 @@ enum Keychain {
         var add = base
         add.merge(attributes) { _, new in new }
         return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Fire-and-forget variant of `write` that runs the blocking SecItem call
+    /// off the caller's thread. Use when the authoritative value is held in
+    /// memory and the write result isn't needed synchronously, so the caller
+    /// never blocks the main thread on Security-framework I/O. `data` is
+    /// captured at call time, so callers can encode their snapshot first and
+    /// return immediately.
+    static func writeInBackground(
+        service: String,
+        account: String,
+        data: Data,
+        accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) {
+        writeQueue.async {
+            _ = write(service: service, account: account, data: data, accessible: accessible)
+        }
     }
 
     /// Read (`service`, `account`). Returns `nil` when the item is absent or

--- a/Packages/OsaurusCore/Views/Credits/CreditsTopUpSheet.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsTopUpSheet.swift
@@ -306,7 +306,10 @@ struct CreditsTopUpSheet: View {
             // so the user can see why and retry.
             return
         }
-        NSWorkspace.shared.open(url)
+        // Launching the browser blocks on an XPC round-trip to LaunchServices
+        // that can stall for seconds, so hand the URL off the main actor. The
+        // sheet dismisses immediately; the open completes in the background.
+        Task.detached { NSWorkspace.shared.open(url) }
         dismiss()
     }
 }


### PR DESCRIPTION
## Summary
- Triaged the unresolved app-hang and crash issues in Sentry across several passes
- Moved the identity revocation and whitelist keychain writes off the main thread through a new fire-and-forget background write, since the blocking keychain calls were tripping the app-hang watchdog under icloud contention
- Stopped reading the toast configuration from disk on every background-task dispatch, reading the in-memory copy instead so the dispatch hot path no longer touches the filesystem on the main thread
- Moved the checkout url launch off the main thread so the credits top-up flow no longer blocks on the launch-services round trip
- Clamped accessibility element dimensions before multiplying so screen-context sampling no longer traps on integer overflow
- Caught the appkit exception raised during pasteboard reads so a cross-thread pasteboard race degrades to a skipped poll instead of crashing the app
- Archived the app-hang and crash issues that had no actionable first-party frames (pure SwiftUI, CoreText, swift-runtime, dyld internals, MLX and Metal library frames, plus single-event UI noise)
- Resolved four image-generation app-hang issues whose main-thread compute path is already off the main thread in the current tree
