### PR TITLE
Repin vmlx-swift: deterministic RMSNorm shift + Mistral VLM full-resolution images

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
+        "revision" : "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
+        "revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf"
+        "revision" : "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
+        "revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
+        "revision" : "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3d353c9f22a847703f9ddfad1f85f5c920283733c064f55a84964eebb49a203",
+  "originHash" : "785a98ab5e9fcb21e8612a325228d51adac584eaecbc14cf3d7d7998eb9f8865",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
+        "revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
+        "revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf"
+        "revision" : "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -33,11 +33,12 @@ let package = Package(
         // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift fix,
         // the full order-dependent-load sweep (#108, no more ~7.5% degenerate
         // loads), the Mistral3 VLM fix that honors the bundle's longest_edge
-        // instead of clamping images to 336px, and the stop-string fix (#109)
-        // that stops post-stop text leaking into responses.
+        // instead of clamping images to 336px, the stop-string fix (#109) that
+        // stops post-stop text leaking into responses, and the Mistral
+        // bare-JSON-array tool-call recovery (#110) for VL-history turns.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
+            revision: "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -30,12 +30,14 @@ let package = Package(
         // MLXLMCommon, MLXLLM, MLXVLM, Tokenizers, Jinja, cache, parser,
         // MTP, and media-runtime surfaces Osaurus previously pulled from
         // separate MLX, inference, tokenizer, template, and transformer pins.
-        // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift + the full order-dependent-load sweep (#108)
-        // fix (no more ~7.5% degenerate loads) and the Mistral3 VLM fix that
-        // honors the bundle's longest_edge instead of clamping images to 336px.
+        // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift fix,
+        // the full order-dependent-load sweep (#108, no more ~7.5% degenerate
+        // loads), the Mistral3 VLM fix that honors the bundle's longest_edge
+        // instead of clamping images to 336px, and the stop-string fix (#109)
+        // that stops post-stop text leaking into responses.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
+            revision: "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -30,10 +30,12 @@ let package = Package(
         // MLXLMCommon, MLXLLM, MLXVLM, Tokenizers, Jinja, cache, parser,
         // MTP, and media-runtime surfaces Osaurus previously pulled from
         // separate MLX, inference, tokenizer, template, and transformer pins.
-        // Pinned to the merge of the writePNG main-actor hang fix on main.
+        // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift
+        // fix (no more ~7.5% degenerate loads) and the Mistral3 VLM fix that
+        // honors the bundle's longest_edge instead of clamping images to 336px.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b6eda04f4e471271778c64af5166ad3d9298afcf"
+            revision: "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -30,12 +30,12 @@ let package = Package(
         // MLXLMCommon, MLXLLM, MLXVLM, Tokenizers, Jinja, cache, parser,
         // MTP, and media-runtime surfaces Osaurus previously pulled from
         // separate MLX, inference, tokenizer, template, and transformer pins.
-        // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift
+        // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift + the full order-dependent-load sweep (#108)
         // fix (no more ~7.5% degenerate loads) and the Mistral3 VLM fix that
         // honors the bundle's longest_edge instead of clamping images to 336px.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
+            revision: "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
-        #expect(packageResolved.contains(#""revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
-        #expect(workspaceResolved.contains(#""revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
-        #expect(appResolved.contains(#""revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
+        #expect(packageSwift.contains(#"revision: "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
+        #expect(packageResolved.contains(#""revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
+        #expect(workspaceResolved.contains(#""revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
+        #expect(appResolved.contains(#""revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
-        #expect(packageResolved.contains(#""revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
-        #expect(workspaceResolved.contains(#""revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
-        #expect(appResolved.contains(#""revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf""#))
+        #expect(packageSwift.contains(#"revision: "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
+        #expect(packageResolved.contains(#""revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
+        #expect(workspaceResolved.contains(#""revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
+        #expect(appResolved.contains(#""revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -639,7 +639,16 @@ struct RuntimePolicySourceTests {
         // isolation, so the MLX eval() it triggers no longer blocks the main
         // thread during image generation (fixes the Sentry App Hanging report
         // in ZImage.performGenerate).
-        let expectedRuntimeHardenedRevision = "b6eda04f4e471271778c64af5166ad3d9298afcf"
+        // plus the deterministic-load checkpoint: the shared RMSNorm
+        // convention resolver (vmlx-swift#102) and the full
+        // order-dependent-load sweep (vmlx-swift#108) that remove every
+        // per-process-random Dictionary/Set-order load decision (no more
+        // ~7.5% "degenerates until reload" loads), the Mistral3 VLM fix
+        // (vmlx-swift#107) that honors the bundle's longest_edge instead of
+        // crushing images to 336px, and the stop-string fix (vmlx-swift#109)
+        // that discards post-stop buffers at end-of-stream so text after a
+        // matched stop string can no longer leak into responses.
+        let expectedRuntimeHardenedRevision = "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -648,7 +648,7 @@ struct RuntimePolicySourceTests {
         // crushing images to 336px, and the stop-string fix (vmlx-swift#109)
         // that discards post-stop buffers at end-of-stream so text after a
         // matched stop string can no longer leak into responses.
-        let expectedRuntimeHardenedRevision = "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
+        let expectedRuntimeHardenedRevision = "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
+        "revision" : "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
+        "revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b6eda04f4e471271778c64af5166ad3d9298afcf"
+        "revision" : "b6f5cd31e266387b9b5f1015866fffad9b775ec0"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3515555eb6e86cc5d124f2b6bb4694d7df43b608"
+        "revision" : "6f154490e1dbaf0d10f396da77ca6a752d0f20a1"
       }
     },
     {


### PR DESCRIPTION
Bumps the `vmlx-swift` pin `b6eda04f` → `b6f5cd31`, shipping two field-reported fixes.

### 1. Probabilistic degenerate loads (critical)
Some models degenerated into garbage on ~7.5% of loads and stayed broken until reloaded. Root cause: qwen3.5's `(1 + weight)` RMSNorm-shift decision was read from the **first** norm weight in *randomized* `Dictionary` iteration order — and a handful of norms legitimately have mean > 0.5, so whenever the random first pick was one of those, the shift was skipped for the whole model. Now resolved **order-independently per bundle** (majority vote over probe norms), with any explicit safetensors-metadata / `config.json` `norm_convention` declaration taking precedence. Shared `NormConventionResolver` so other `(1+weight)` architectures can adopt it.
_(vmlx-swift #102)_

### 2. Mistral VLM empty / garbled responses on detailed images
Plain vision-language chat (e.g. "read this note") returned garbled or **empty** ("I wasn't able to generate a response") output on handwriting, dense documents, small text, or screenshots — while Gemma/Qwen read the same image fine. Root cause: `Mistral3VLMProcessor` hard-clamped every image's longest edge to `patch_size*24 = 336px`, ignoring the bundle's declared `longest_edge` (1540). The Pixtral/Mistral3 vision tower is variable-resolution (its 2D RoPE grid is precomputed for the full `image_size/patch_size` grid), so this was pure, unnecessary detail loss. Now honors `longest_edge`. Covers all mistral3-family VL bundles (they share one processor).
_(vmlx-swift #107)_

**Verification:** vmlx changes build clean; Mistral VL fix proven live on `Mistral-Small-3.1-24B` — a handwritten note that transcribed as garbage at 336px ("Daddy, darling … feel quite fine") is read verbatim at 1540px ("Dear diary … I felt quite cheerful"). osaurus build against the new pin verified locally.

No osaurus source changes — dependency revision bump only; neither vmlx fix alters public API.