### PR TITLE
Disconnect must not evict the BatchEngine (cold-load hangup crashed the server)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "822888f6f79079c5683676a13b1ac084dd798908"
+        "revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
+        "revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
+        "revision" : "822888f6f79079c5683676a13b1ac084dd798908"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "822888f6f79079c5683676a13b1ac084dd798908"
+        "revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
+        "revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
+        "revision" : "822888f6f79079c5683676a13b1ac084dd798908"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -33,12 +33,13 @@ let package = Package(
         // Pinned to vmlx main with the deterministic qwen3.5 RMSNorm-shift fix,
         // the full order-dependent-load sweep (#108, no more ~7.5% degenerate
         // loads), the Mistral3 VLM fix that honors the bundle's longest_edge
-        // instead of clamping images to 336px, the stop-string fix (#109) that
-        // stops post-stop text leaking into responses, and the Mistral
-        // bare-JSON-array tool-call recovery (#110) for VL-history turns.
+        // instead of clamping images to 336px, the stop-string fix (#109), the
+        // Mistral bare-JSON-array tool-call recovery (#110), and chunk-level
+        // prefill cancellation (#111) so a dropped request stops encoding
+        // GPU work within one chunk instead of holding it to end of prompt.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
+            revision: "822888f6f79079c5683676a13b1ac084dd798908"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -35,12 +35,13 @@ let package = Package(
         // loads), the Mistral3 VLM fix that honors the bundle's longest_edge
         // instead of clamping images to 336px, the stop-string fix (#109), the
         // Mistral bare-JSON-array tool-call recovery (#110), chunk-level
-        // prefill cancellation (#111), and shutdown-drains-producers (#112)
-        // so engine teardown returns only after its producers are off the
-        // shared GPU command queue (cold-load disconnect crash).
+        // prefill cancellation (#111), shutdown-drains-producers (#112), and
+        // serialized disk-restore evals (#113) — together closing the
+        // client-disconnect crash train (engine teardown returns only after
+        // producers are off the GPU; restores can't race input tokenization).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
+            revision: "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,12 +34,13 @@ let package = Package(
         // the full order-dependent-load sweep (#108, no more ~7.5% degenerate
         // loads), the Mistral3 VLM fix that honors the bundle's longest_edge
         // instead of clamping images to 336px, the stop-string fix (#109), the
-        // Mistral bare-JSON-array tool-call recovery (#110), and chunk-level
-        // prefill cancellation (#111) so a dropped request stops encoding
-        // GPU work within one chunk instead of holding it to end of prompt.
+        // Mistral bare-JSON-array tool-call recovery (#110), chunk-level
+        // prefill cancellation (#111), and shutdown-drains-producers (#112)
+        // so engine teardown returns only after its producers are off the
+        // shared GPU command queue (cold-load disconnect crash).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "822888f6f79079c5683676a13b1ac084dd798908"
+            revision: "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -442,11 +442,23 @@ public actor ModelRuntime {
     }
 
     /// Cancel the active decode for `name` without evicting the loaded
-    /// container. HTTP non-streaming callers use this when the client drops
-    /// before any response body can be written; otherwise the server can keep
-    /// decoding for a request nobody is still reading.
+    /// container OR its `BatchEngine`. Every disconnect hook (streaming and
+    /// non-streaming) routes here when the client drops; otherwise the server
+    /// can keep decoding for a request nobody is still reading.
+    ///
+    /// This must NOT call `Registry.shutdownEngine`: shutting the engine down
+    /// also removes it from the registry, so the next request builds a fresh
+    /// `BatchEngine` on the same `ModelContainer`. If the dropped request was
+    /// still prefilling, its producer keeps encoding until the next chunk
+    /// boundary (prefill cancellation is chunk-granular, vmlx #111) — and two
+    /// engines' producers on one container race on the shared GPU command
+    /// queue and abort the process ("A command encoder is already encoding to
+    /// this command buffer"; 100%-reproducible via disconnect during a
+    /// cold-load prefill + immediate retry). Cancelling the wrapper task is
+    /// sufficient: it terminates the vmlx stream, which cancels the producer,
+    /// while the engine's solo-path guard keeps follow-up requests queued on
+    /// the SAME engine until the producer has actually returned.
     func cancelGeneration(name: String) async {
-        await MLXBatchAdapter.Registry.shared.shutdownEngine(for: name)
         await cancelActiveGeneration(for: name)
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
-        #expect(packageResolved.contains(#""revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
-        #expect(workspaceResolved.contains(#""revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
-        #expect(appResolved.contains(#""revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
+        #expect(packageSwift.contains(#"revision: "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
+        #expect(packageResolved.contains(#""revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
+        #expect(workspaceResolved.contains(#""revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
+        #expect(appResolved.contains(#""revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
-        #expect(packageResolved.contains(#""revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
-        #expect(workspaceResolved.contains(#""revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
-        #expect(appResolved.contains(#""revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3""#))
+        #expect(packageSwift.contains(#"revision: "822888f6f79079c5683676a13b1ac084dd798908""#))
+        #expect(packageResolved.contains(#""revision" : "822888f6f79079c5683676a13b1ac084dd798908""#))
+        #expect(workspaceResolved.contains(#""revision" : "822888f6f79079c5683676a13b1ac084dd798908""#))
+        #expect(appResolved.contains(#""revision" : "822888f6f79079c5683676a13b1ac084dd798908""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "822888f6f79079c5683676a13b1ac084dd798908""#))
-        #expect(packageResolved.contains(#""revision" : "822888f6f79079c5683676a13b1ac084dd798908""#))
-        #expect(workspaceResolved.contains(#""revision" : "822888f6f79079c5683676a13b1ac084dd798908""#))
-        #expect(appResolved.contains(#""revision" : "822888f6f79079c5683676a13b1ac084dd798908""#))
+        #expect(packageSwift.contains(#"revision: "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
+        #expect(packageResolved.contains(#""revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
+        #expect(workspaceResolved.contains(#""revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
+        #expect(appResolved.contains(#""revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -648,7 +648,7 @@ struct RuntimePolicySourceTests {
         // crushing images to 336px, and the stop-string fix (vmlx-swift#109)
         // that discards post-stop buffers at end-of-stream so text after a
         // matched stop string can no longer leak into responses.
-        let expectedRuntimeHardenedRevision = "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
+        let expectedRuntimeHardenedRevision = "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -648,7 +648,7 @@ struct RuntimePolicySourceTests {
         // crushing images to 336px, and the stop-string fix (vmlx-swift#109)
         // that discards post-stop buffers at end-of-stream so text after a
         // matched stop string can no longer leak into responses.
-        let expectedRuntimeHardenedRevision = "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
+        let expectedRuntimeHardenedRevision = "822888f6f79079c5683676a13b1ac084dd798908"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -648,7 +648,7 @@ struct RuntimePolicySourceTests {
         // crushing images to 336px, and the stop-string fix (vmlx-swift#109)
         // that discards post-stop buffers at end-of-stream so text after a
         // matched stop string can no longer leak into responses.
-        let expectedRuntimeHardenedRevision = "822888f6f79079c5683676a13b1ac084dd798908"
+        let expectedRuntimeHardenedRevision = "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "822888f6f79079c5683676a13b1ac084dd798908"
+        "revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "634d11d3a9489cc09ffbf33ae1235d9aaf6b9821"
+        "revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5b4eb5bcbc099e73986f13cc4560e5c2f355d4e3"
+        "revision" : "822888f6f79079c5683676a13b1ac084dd798908"
       }
     },
     {


### PR DESCRIPTION
## Problem

Any client that disconnected while its request was still **prefilling** could kill the whole server with the next request. 100%-reproducible:

1. fresh server → streaming chat that cold-loads the model
2. hard socket close (~463 bytes in, mid-prefill)
3. immediate second request → **SIGABRT**, crash report shows two threads both inside `BatchEngine.startSoloFastPath → TokenIterator.prepare → asyncEval`:

```
AGX...CommandBuffer tryCoalescingPreviousComputeCommandEncoderWithConfig:
failed assertion 'A command encoder is already encoding to this command buffer'
```

This matches the production Sentry cluster on the same assertion (APPLE-MACOS-33 / APPLE-MACOS-D6).

## Root cause

Every disconnect hook routes to `ModelRuntime.cancelGeneration`, which called `Registry.shutdownEngine(for:)` — that both shuts down **and removes** the engine from the registry. The dropped request's prefill producer is not stopped by that (prefill had no cancellation points in vmlx), so it keeps encoding GPU work; the follow-up request then builds a **fresh `BatchEngine` on the same `ModelContainer`** and starts its own prefill. Two producers on the shared GPU command queue → Metal encoder assertion → abort. This is exactly the scenario the Registry's own single-flight comment warns about.

Warm-model disconnects never crashed because decode checks `Task.isCancelled` between tokens — the orphan exits within one token. Prefill was the wide-open window.

## Fix (two layers)

- **This repo**: `cancelGeneration` no longer touches the registry — it cancels the wrapper task (which terminates the vmlx stream and cancels the producer) and leaves the engine registered. The engine's solo-path guard then queues follow-up requests on the **same** engine until the producer has actually returned. No rebuild, no concurrent producers.
- **vmlx #111** (pin advanced to `822888f6`): chunk-level `Task.checkCancellation()` in all five chunked-prefill loops, so the orphan producer exits within one ~512-token chunk instead of encoding the rest of the prompt for a dead request. Unit-tested engine-side (cancelled prepare encodes zero chunks; live tasks bit-identical).

Either layer alone prevents the crash; together they also stop wasting GPU on dead requests and keep TTFT for the retry low.

## Proof

Live proof on the dev-built app follows in a comment: the deterministic repro before/after, warm-disconnect control, and a post-fix coherence check.