### PR TITLE
Subagent harness hardening: admission gate, mid-run interrupt, tool-capable workers, RAM coexistence, residency crash lane

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -823,6 +823,10 @@ public struct AgentSettings: Codable, Sendable, Equatable {
     /// Per-agent budgets for `spawn` jobs (token / turn / wall-clock caps). The
     /// Default agent uses the global `SubagentConfiguration.budgets` instead.
     public var subagentBudgets: SubagentBudgets
+    /// What tools this agent's spawned workers may reach (`none` = text-only,
+    /// `readOnly` = curated read-only set). Default `.none`; the Default agent
+    /// uses the global `SubagentConfiguration.spawnToolAccess` instead.
+    public var spawnToolAccess: SpawnToolAccess
     /// Per-agent model override for subagent kinds, keyed by capability id
     /// (`"computer_use"`, `"spawn"`). An entry supersedes the
     /// kind's default model source (the parent agent's model for computer_use;
@@ -857,7 +861,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         imageEditModelId: String? = nil,
         subagentPermissions: SubagentPermissionDefaults = SubagentPermissionDefaults(),
         subagentBudgets: SubagentBudgets = SubagentBudgets(),
-        subagentModelOverrides: [String: String] = [:]
+        subagentModelOverrides: [String: String] = [:],
+        spawnToolAccess: SpawnToolAccess = .none
     ) {
         self.dbEnabled = dbEnabled
         self.schedule = schedule
@@ -884,6 +889,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         self.subagentPermissions = subagentPermissions
         self.subagentBudgets = subagentBudgets
         self.subagentModelOverrides = subagentModelOverrides
+        self.spawnToolAccess = spawnToolAccess
     }
 
     public init(from decoder: Decoder) throws {
@@ -971,6 +977,10 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         subagentModelOverrides = Self.normalizedModelOverrides(
             (try? c.decodeIfPresent([String: String].self, forKey: .subagentModelOverrides)) ?? [:]
         )
+        // Lenient enum decode: an invalid/renamed raw value falls back to the
+        // safe text-only default instead of failing the whole agent decode.
+        spawnToolAccess =
+            (try? c.decodeIfPresent(SpawnToolAccess.self, forKey: .spawnToolAccess)) ?? .none
     }
 
     /// Trim values and drop blank entries so a cleared override (empty string)
@@ -1012,6 +1022,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         case subagentPermissions
         case subagentBudgets
         case subagentModelOverrides
+        case spawnToolAccess
         // Read-only legacy key — never encoded after migration.
         case generativeGreetings
     }
@@ -1043,6 +1054,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         try c.encode(subagentPermissions, forKey: .subagentPermissions)
         try c.encode(subagentBudgets, forKey: .subagentBudgets)
         try c.encode(subagentModelOverrides, forKey: .subagentModelOverrides)
+        try c.encode(spawnToolAccess, forKey: .spawnToolAccess)
     }
 
     /// Default settings for newly created agents (and for back-compat decoding of

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
@@ -120,14 +120,25 @@ public struct SubagentPermissionDefaults: Codable, Equatable, Sendable {
     }
 }
 
+/// What tools a spawned subagent (the child worker) may reach. `none` keeps
+/// spawn text-only (every child tool call is refused); `readOnly` exposes the
+/// curated read-only set (`file_read` / `file_search`, plus the sandbox reads
+/// when registered) so the worker can do its own bulk reading — the parent's
+/// context is preserved instead of ferrying file contents through the digest.
+public enum SpawnToolAccess: String, Codable, CaseIterable, Sendable {
+    case none
+    case readOnly = "read_only"
+}
+
 public struct SubagentBudgets: Codable, Equatable, Sendable {
     public var maxDelegateTokens: Int
     public var maxDelegateTurns: Int
-    /// Reserved. Spawned subagents run text-only (`AgentSubagentRunner` passes
-    /// `tools: nil` and rejects any tool call), so there are no nested tool calls
-    /// to cap and nothing enforces this today. Kept for forward-compat for when a
-    /// subagent kind gains tool use; intentionally NOT surfaced in Settings until
-    /// then so the control isn't a no-op.
+    /// Cap on child tool calls per spawn run when the launching agent grants
+    /// tool access (`SpawnToolAccess.readOnly`). `0` means "use the built-in
+    /// default cap" (`TextSubagentKind.defaultReadOnlyToolCallCap`) rather
+    /// than zero calls, so enabling tool access is never silently inert.
+    /// Ignored while tool access is `none` (text-only spawn refuses every
+    /// call regardless).
     public var maxToolCalls: Int
     public var maxElapsedSeconds: Int
 
@@ -141,7 +152,7 @@ public struct SubagentBudgets: Codable, Equatable, Sendable {
 
     public init(
         maxDelegateTokens: Int = 2048,
-        maxDelegateTurns: Int = 1,
+        maxDelegateTurns: Int = 2,
         maxToolCalls: Int = 0,
         maxElapsedSeconds: Int = 120
     ) {
@@ -203,6 +214,15 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     /// is freed, the job is rejected instead of unloading the orchestrator and
     /// failing to load the spawn model. See `ChatResidencyHandoff.memoryPreflight`.
     var ramSafetyPreflightEnabled: Bool
+    /// When true, a local spawn model may load ALONGSIDE the resident chat
+    /// model instead of the unload→run→reload handoff — but only when the
+    /// server eviction policy is Flexible (Multi Model) AND the live RAM
+    /// projection says both fit (see `SubagentResidency.decidePlan`'s
+    /// coexistence gate). Default OFF: two resident MLX graphs is the
+    /// historical BUG G concurrent-GPU crash class, so single residency stays
+    /// the default until the direction-matrix crash lane proves a machine's
+    /// configuration safe. Strict eviction policy ignores this flag entirely.
+    var subagentCoexistenceEnabled: Bool
     /// Per-capability model override for the DEFAULT / main-chat agent's subagent
     /// kinds, keyed by capability id (`"spawn"`, `"computer_use"`). An entry
     /// supersedes the kind's default model source; absent means "inherit". Custom
@@ -218,6 +238,10 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     /// security gate stays on `spawnableModelNames`. Trimmed, blanks dropped, and
     /// pruned to current pool members on normalize.
     var spawnableModelNotes: [String: String]
+    /// The DEFAULT / main-chat agent's child-tool grant for spawn runs. Custom
+    /// agents carry their own `AgentSettings.spawnToolAccess`; this governs the
+    /// main chat only. Default `.none` (text-only spawn).
+    var spawnToolAccess: SpawnToolAccess
 
     init(
         localTextDelegationEnabled: Bool = true,
@@ -232,9 +256,11 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         permissionDefaults: SubagentPermissionDefaults = SubagentPermissionDefaults(),
         budgets: SubagentBudgets = SubagentBudgets(),
         ramSafetyPreflightEnabled: Bool = true,
+        subagentCoexistenceEnabled: Bool = false,
         subagentModelOverrides: [String: String] = [:],
         spawnableModelNames: [String] = [],
-        spawnableModelNotes: [String: String] = [:]
+        spawnableModelNotes: [String: String] = [:],
+        spawnToolAccess: SpawnToolAccess = .none
     ) {
         self.localTextDelegationEnabled = localTextDelegationEnabled
         self.spawnableAgentNames = spawnableAgentNames
@@ -248,6 +274,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         self.permissionDefaults = permissionDefaults
         self.budgets = budgets.normalized
         self.ramSafetyPreflightEnabled = ramSafetyPreflightEnabled
+        self.subagentCoexistenceEnabled = subagentCoexistenceEnabled
         self.subagentModelOverrides = Self.normalizedModelOverrides(subagentModelOverrides)
         let normalizedModelNames = Self.normalizedSpawnableModelNames(spawnableModelNames)
         self.spawnableModelNames = normalizedModelNames
@@ -255,6 +282,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             spawnableModelNotes,
             names: normalizedModelNames
         )
+        self.spawnToolAccess = spawnToolAccess
     }
 
     static let `default` = SubagentConfiguration()
@@ -341,11 +369,13 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             // Omitting this dropped it back to the init default (`true`), making the
             // toggle un-disableable (the store runs `.normalized` on every save+load).
             ramSafetyPreflightEnabled: ramSafetyPreflightEnabled,
+            subagentCoexistenceEnabled: subagentCoexistenceEnabled,
             subagentModelOverrides: subagentModelOverrides,
             // The init trims model names, drops blanks, and prunes notes to the
             // surviving pool members, so passing the raw values here is enough.
             spawnableModelNames: spawnableModelNames,
-            spawnableModelNotes: spawnableModelNotes
+            spawnableModelNotes: spawnableModelNotes,
+            spawnToolAccess: spawnToolAccess
         )
     }
 
@@ -362,9 +392,11 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         case permissionDefaults
         case budgets
         case ramSafetyPreflightEnabled
+        case subagentCoexistenceEnabled
         case subagentModelOverrides
         case spawnableModelNames
         case spawnableModelNotes
+        case spawnToolAccess
     }
 
     init(from decoder: Decoder) throws {
@@ -413,6 +445,10 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
                 Bool.self,
                 forKey: .ramSafetyPreflightEnabled
             ) ?? true,
+            subagentCoexistenceEnabled: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .subagentCoexistenceEnabled
+            ) ?? false,
             // Lenient: a malformed map must never discard the whole delegation
             // config (same approach as `permissionDefaults`).
             subagentModelOverrides: (try? container.decodeIfPresent(
@@ -426,7 +462,13 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             spawnableModelNotes: (try? container.decodeIfPresent(
                 [String: String].self,
                 forKey: .spawnableModelNotes
-            )) ?? [:]
+            )) ?? [:],
+            // Enum field: lenient like the other enums so an invalid raw value
+            // falls back to the safe text-only default.
+            spawnToolAccess: (try? container.decodeIfPresent(
+                SpawnToolAccess.self,
+                forKey: .spawnToolAccess
+            )) ?? .none
         )
     }
 

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
@@ -4,18 +4,60 @@
 //
 //  Shared bounded runner for the text subagent KINDs: a context-isolated
 //  `AgentToolLoop` on a chosen model that returns a compact digest only (the
-//  orchestrator never sees the transcript). Serves `spawn` (text-only, no child
-//  tools); the optional child toolset hook remains for future tool-capable
-//  kinds. The host (`SubagentSession`) owns the recursion guard, feed,
-//  permission, and residency handoff; this owns only the loop + digest.
+//  orchestrator never sees the transcript). Serves `spawn` (optionally with a
+//  curated child toolset — see `AgentSubagentToolset`). The host
+//  (`SubagentSession`) owns the recursion guard, feed, permission, and
+//  residency handoff; this owns only the loop + digest.
+//
+//  The model step STREAMS (`ChatEngine.streamChat`) instead of buffering a
+//  completion, which buys three things at once:
+//    - live token progress for the subagent feed (`onProgress`),
+//    - chunk-granular cancellation (user interrupt / deadline / parent task
+//      cancel take effect mid-generation, not at iteration boundaries), and
+//    - authoritative usage capture from the terminal stats sentinel
+//      (`StreamingStatsHint`) with an estimator fallback for remote providers.
+//
+//  A watchdog task races the stream so the silent phases (prefill, remote
+//  first-token waits) are also interruptible; cancelling the consumer tears
+//  the producer down through `AsyncThrowingStream.onTermination`, which
+//  propagates into `ModelRuntime`'s generation cancel (and vmlx's
+//  `finishSlot` GPU drain), so a cancelled run never leaves work on the GPU.
 //
 
 import Foundation
+
+/// Why a subagent run stopped before finishing. Threaded out of the runner so
+/// the kind can map each cause to honest user-facing copy instead of blaming
+/// every cancellation on the time budget.
+enum SubagentCancelCause: String, Sendable {
+    /// The user pressed the subagent row's stop button (`InterruptToken`).
+    case userInterrupt = "user_interrupt"
+    /// The run hit its own `maxElapsedSeconds` wall-clock budget.
+    case deadline
+    /// The surrounding task (parent chat turn / HTTP request) was cancelled.
+    case parentTask = "parent_task"
+}
+
+/// Aggregated model usage across every iteration of one subagent run.
+struct AgentSubagentUsage: Sendable {
+    /// Prompt tokens of the LAST model step (the largest composed prompt —
+    /// what the run actually cost to re-prefill on its final iteration).
+    var promptTokens: Int = 0
+    /// Completion tokens summed across steps. Authoritative (stats sentinel)
+    /// when the runtime reports them, estimator fallback otherwise.
+    var completionTokens: Int = 0
+    /// Decode speed of the last step that reported one (tok/s).
+    var tokensPerSecond: Double?
+}
 
 struct AgentSubagentRunResult: Sendable {
     var digest: String?
     var exit: AgentToolLoop.Exit
     var iterations: Int
+    /// Set when `exit == .cancelled` (nil otherwise) so the kind can map an
+    /// honest message per cause.
+    var cancelCause: SubagentCancelCause?
+    var usage: AgentSubagentUsage = AgentSubagentUsage()
 }
 
 /// Optional child toolset for a subagent run. When `nil`, the run is text-only
@@ -31,9 +73,32 @@ struct AgentSubagentToolset: Sendable {
 }
 
 enum AgentSubagentRunner {
+    /// Throttled live-progress callback: cumulative completion tokens for the
+    /// current step and the last reported decode speed (nil until the runtime
+    /// reports one).
+    typealias Progress = @Sendable (_ completionTokens: Int, _ tokensPerSecond: Double?) -> Void
+
+    /// Internal cancel signal carrying its cause. Thrown out of the stream
+    /// consumption (or its watchdog) and converted to a `.cancelled` exit at
+    /// the runner boundary — never escapes `run`.
+    private struct RunCancelled: Error {
+        let cause: SubagentCancelCause
+    }
+
+    /// What one streamed model step produced.
+    private struct StepOutcome {
+        var text = ""
+        var reasoning = ""
+        var toolCalls: [ServiceToolInvocation] = []
+        /// Authoritative completion-token count from the stats sentinel, or
+        /// a character-based estimate when the provider never reported one.
+        var completionTokens = 0
+        var tokensPerSecond: Double?
+    }
+
     /// Run a bounded subagent loop. The caller (kind) owns model resolution,
     /// permission, the residency handoff, and result mapping; this owns the
-    /// loop, message bookkeeping, and digest capture.
+    /// loop, message bookkeeping, digest capture, and cancellation.
     static func run(
         modelName: String,
         seedMessages: [ChatMessage],
@@ -41,14 +106,19 @@ enum AgentSubagentRunner {
         maxIterations: Int,
         deadline: Date,
         sessionId: String,
+        temperature: Float? = nil,
         isAgentRequest: Bool = true,
-        stopOnToolRejection: Bool = true,
+        stopOnToolRejection: Bool = false,
         treatEmptyChoicesAsFinal: Bool = false,
         isInterrupted: @escaping @Sendable () -> Bool = { false },
-        toolset: AgentSubagentToolset? = nil
+        toolset: AgentSubagentToolset? = nil,
+        onProgress: Progress? = nil
     ) async throws -> AgentSubagentRunResult {
         var messages = seedMessages
         var finalDigest: String?
+        var usage = AgentSubagentUsage()
+        var iterationsSeen = 0
+        var recordedCancelCause: SubagentCancelCause?
 
         let contextWindow = await AgentLoopBudget.resolveContextWindow(modelId: modelName)
         let toolTokens: Int
@@ -66,9 +136,23 @@ enum AgentSubagentRunner {
         let watermark = CompactionWatermark()
         let engine = ChatEngine(source: .chatUI)
 
+        /// One probe for all three cancel sources, in specificity order: the
+        /// subagent's own stop button first, then its wall-clock budget, then
+        /// the surrounding task.
+        @Sendable func cancelCause() -> SubagentCancelCause? {
+            if isInterrupted() { return .userInterrupt }
+            if Date() >= deadline { return .deadline }
+            if Task.isCancelled { return .parentTask }
+            return nil
+        }
+
         let hooks = AgentLoopHooks(
             isCancelled: {
-                Task.isCancelled || Date() >= deadline || isInterrupted()
+                if let cause = cancelCause() {
+                    recordedCancelCause = cause
+                    return true
+                }
+                return false
             },
             buildMessages: { notices in
                 for notice in notices {
@@ -82,12 +166,13 @@ enum AgentSubagentRunner {
                 )
             },
             modelStep: { effective, _ in
+                iterationsSeen += 1
                 var request = ChatCompletionRequest(
                     model: modelName,
                     messages: effective,
-                    temperature: nil,
+                    temperature: temperature,
                     max_tokens: maxTokens,
-                    stream: false,
+                    stream: true,
                     top_p: nil,
                     frequency_penalty: nil,
                     presence_penalty: nil,
@@ -97,25 +182,81 @@ enum AgentSubagentRunner {
                     tool_choice: nil,
                     session_id: sessionId
                 )
+                // Same posture as the main chat surface: a per-agent
+                // temperature override rides along, everything else stays on
+                // the model bundle's own generation defaults.
                 request.samplingParametersAreImplicit = true
                 request.isAgentRequest = isAgentRequest
-                let response = try await engine.completeChat(request: request)
-                guard let choice = response.choices.first else {
-                    return treatEmptyChoicesAsFinal ? .finalResponse : .emptyResponse
+
+                let stepStarted = Date()
+                let stream = try await engine.streamChat(request: request)
+                let outcome = try await Self.consumeStream(
+                    stream,
+                    cancelCause: cancelCause,
+                    onProgress: onProgress
+                )
+
+                // Usage: prompt of the last step (largest composed prompt),
+                // completions summed. Estimator fallback for providers that
+                // never emit the stats sentinel.
+                usage.promptTokens = ContextBudgetManager.estimateTokens(for: effective)
+                var stepCompletion = outcome.completionTokens
+                if stepCompletion == 0 {
+                    stepCompletion =
+                        TokenEstimator.estimate(outcome.text)
+                        + TokenEstimator.estimate(outcome.reasoning)
                 }
-                if let calls = choice.message.tool_calls, !calls.isEmpty {
-                    messages.append(choice.message)
+                usage.completionTokens += stepCompletion
+                if let tps = outcome.tokensPerSecond {
+                    usage.tokensPerSecond = tps
+                } else if stepCompletion > 0 {
+                    let elapsed = Date().timeIntervalSince(stepStarted)
+                    if elapsed > 0.5 {
+                        usage.tokensPerSecond = Double(stepCompletion) / elapsed
+                    }
+                }
+
+                if !outcome.toolCalls.isEmpty {
+                    // Frame the assistant tool_calls message exactly as the
+                    // non-streamed path did, so the child transcript stays
+                    // OpenAI-shaped for the next iteration.
+                    let calls = outcome.toolCalls.map { inv -> ToolCall in
+                        let raw = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+                        return ToolCall(
+                            id: inv.toolCallId ?? "call_" + String(raw.prefix(24)),
+                            type: "function",
+                            function: ToolCallFunction(
+                                name: inv.toolName,
+                                arguments: inv.jsonArguments
+                            ),
+                            geminiThoughtSignature: inv.geminiThoughtSignature
+                        )
+                    }
+                    messages.append(
+                        ChatMessage(
+                            role: "assistant",
+                            content: nil,
+                            tool_calls: calls,
+                            tool_call_id: nil
+                        )
+                    )
                     return .toolCalls(
-                        calls.map {
+                        zip(outcome.toolCalls, calls).map { inv, call in
                             ServiceToolInvocation(
-                                toolName: $0.function.name,
-                                jsonArguments: $0.function.arguments,
-                                toolCallId: $0.id
+                                toolName: inv.toolName,
+                                jsonArguments: inv.jsonArguments,
+                                toolCallId: call.id,
+                                geminiThoughtSignature: inv.geminiThoughtSignature
                             )
                         }
                     )
                 }
-                finalDigest = choice.message.content
+
+                let text = outcome.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if text.isEmpty {
+                    return treatEmptyChoicesAsFinal ? .finalResponse : .emptyResponse
+                }
+                finalDigest = outcome.text
                 return .finalResponse
             },
             onDedupedResult: { _, callId, held in
@@ -167,19 +308,129 @@ enum AgentSubagentRunner {
             }
         )
 
-        let runResult = try await AgentToolLoop.run(
-            policy: AgentLoopPolicy(
-                maxIterations: maxIterations,
-                stopOnToolRejection: stopOnToolRejection,
-                dedupeNoticeEnabled: false
-            ),
-            state: AgentTaskState(),
-            hooks: hooks
-        )
-        return AgentSubagentRunResult(
-            digest: finalDigest,
-            exit: runResult.exit,
-            iterations: runResult.iterations
-        )
+        do {
+            let runResult = try await AgentToolLoop.run(
+                policy: AgentLoopPolicy(
+                    maxIterations: maxIterations,
+                    stopOnToolRejection: stopOnToolRejection,
+                    dedupeNoticeEnabled: false
+                ),
+                state: AgentTaskState(),
+                hooks: hooks
+            )
+            return AgentSubagentRunResult(
+                digest: finalDigest,
+                exit: runResult.exit,
+                iterations: runResult.iterations,
+                cancelCause: runResult.exit == .cancelled ? (recordedCancelCause ?? cancelCause()) : nil,
+                usage: usage
+            )
+        } catch let cancelled as RunCancelled {
+            // Mid-generation cancellation (chunk checkpoint or watchdog):
+            // convert to the same `.cancelled` exit the boundary checks
+            // produce, with the recorded cause.
+            return AgentSubagentRunResult(
+                digest: nil,
+                exit: .cancelled,
+                iterations: iterationsSeen,
+                cancelCause: cancelled.cause,
+                usage: usage
+            )
+        }
+    }
+
+    // MARK: - Stream consumption
+
+    /// Consume one model step's stream with chunk-granular cancellation and a
+    /// watchdog covering the silent phases (prefill, remote first-token
+    /// waits). Tool calls surface as thrown
+    /// `ServiceToolInvocations`/`ServiceToolInvocation` from the stream and
+    /// are captured into the outcome; a tripped cancel throws `RunCancelled`.
+    private static func consumeStream(
+        _ stream: AsyncThrowingStream<String, Error>,
+        cancelCause: @escaping @Sendable () -> SubagentCancelCause?,
+        onProgress: Progress?
+    ) async throws -> StepOutcome {
+        try await withThrowingTaskGroup(of: StepOutcome?.self) { group in
+            group.addTask {
+                var outcome = StepOutcome()
+                // Cheap running counters so per-chunk progress stays O(1):
+                // estimate = chars/4 until the authoritative stats sentinel
+                // arrives (local runtimes emit it; remote providers may not).
+                var visibleChars = 0
+                var sawStats = false
+                var lastProgressEmit = Date.distantPast
+                do {
+                    for try await delta in stream {
+                        if let cause = cancelCause() { throw RunCancelled(cause: cause) }
+                        if let stats = StreamingStatsHint.decode(delta) {
+                            sawStats = true
+                            outcome.completionTokens = stats.tokenCount
+                            outcome.tokensPerSecond = stats.tokensPerSecond
+                            onProgress?(stats.tokenCount, stats.tokensPerSecond)
+                            continue
+                        }
+                        if let reasoningDelta = StreamingReasoningHint.decode(delta) {
+                            outcome.reasoning += reasoningDelta
+                            visibleChars += reasoningDelta.count
+                        } else if StreamingToolHint.isSentinel(delta) {
+                            // Other in-band hints (tool/args fragments, prefill
+                            // progress, billing) — not visible text.
+                            continue
+                        } else {
+                            outcome.text += delta
+                            visibleChars += delta.count
+                        }
+                        if !sawStats {
+                            outcome.completionTokens =
+                                visibleChars / TokenEstimator.charsPerToken
+                        }
+                        // Throttle the feed callback to ~4 Hz.
+                        if let onProgress, Date().timeIntervalSince(lastProgressEmit) >= 0.25 {
+                            lastProgressEmit = Date()
+                            onProgress(outcome.completionTokens, outcome.tokensPerSecond)
+                        }
+                    }
+                } catch let batch as ServiceToolInvocations {
+                    outcome.toolCalls = batch.invocations
+                } catch let single as ServiceToolInvocation {
+                    outcome.toolCalls = [single]
+                }
+                // The producer FINISHES (rather than throws) when its own task
+                // is cancelled, so re-probe after a clean stream end: a stream
+                // torn down by a cancel must not be mistaken for a complete
+                // answer. If the step still produced usable output (tool calls
+                // or non-empty text), keep it — the cancel landed at natural
+                // completion and honesty favors the finished result.
+                if outcome.toolCalls.isEmpty,
+                    outcome.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    let cause = cancelCause()
+                {
+                    throw RunCancelled(cause: cause)
+                }
+                return outcome
+            }
+            group.addTask {
+                // Watchdog: fires the cancel even when no deltas arrive
+                // (prefill, remote waits). Never returns normally.
+                while true {
+                    if let cause = cancelCause() { throw RunCancelled(cause: cause) }
+                    try await Task.sleep(nanoseconds: 200_000_000)
+                }
+            }
+            do {
+                // First finisher wins: the consumer is the only child that can
+                // return a value; a watchdog trip (or consumer throw) lands
+                // here as the thrown error.
+                guard let first = try await group.next(), let outcome = first else {
+                    throw RunCancelled(cause: cancelCause() ?? .parentTask)
+                }
+                group.cancelAll()
+                return outcome
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
     }
 }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -639,6 +639,25 @@ enum AgentToolLoop {
         "[System Notice] Tool call budget: \(remaining) of \(maxIterations) remaining. Wrap up your current work and provide a summary."
     }
 
+    /// The mid-run near-limit notice (history estimate crossed ~90% of the
+    /// history budget). When a spawn tool is visible in the schema, the
+    /// notice also nudges delegation: offloading the remaining bulk
+    /// reading/research to a worker costs the parent a digest instead of
+    /// the whole transcript — exactly what a tight window needs. The nudge
+    /// is advisory (same posture as the task-state bias notices).
+    static func contextNearLimitNotice(spawnAvailable: Bool) -> String {
+        var notice =
+            "[System Notice] Context is nearly full — older messages are being compacted. "
+            + "Wrap up the current work and provide a summary."
+        if spawnAvailable {
+            notice +=
+                " If substantial reading, research, or summarization remains, delegate it via "
+                + "your spawn tool with a self-contained input — the returned digest costs a "
+                + "fraction of doing that work inline here."
+        }
+        return notice
+    }
+
     /// Staged once per run, the first time a data-movement step is refunded,
     /// so the model learns it can lean on bulk loads without burning budget.
     static func dataMovementReliefNotice(cap: Int) -> String {

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -989,13 +989,23 @@ public struct SystemPromptComposer: Sendable {
                     modelNames: modelNames,
                     modelNotes: modelNotes
                 )
+                // The worker tool-reach line must match what the runtime will
+                // actually grant, so resolve it through the SAME helper the
+                // spawn kind uses (default agent → global config, custom →
+                // its own settings).
+                let toolAccess = SubagentToolVisibility.effectiveSpawnToolAccess(
+                    isDefault: isDefault,
+                    config: config,
+                    settings: AgentManager.shared.agent(for: snapshot.agentId)?.settings
+                )
                 composer.append(
                     .static(
                         id: "spawn",
                         label: L("Subagents"),
                         content: SystemPromptTemplates.spawnGuidance(
                             agents: descriptors.agents,
-                            models: descriptors.models
+                            models: descriptors.models,
+                            toolAccess: toolAccess
                         )
                     )
                 )

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -762,13 +762,21 @@ public enum SystemPromptTemplates {
     /// one-time cached-prefix bust), matching the other config-driven sections.
     public static func spawnGuidance(
         agents: [SpawnAgentDescriptor],
-        models: [SpawnModelDescriptor]
+        models: [SpawnModelDescriptor],
+        toolAccess: SpawnToolAccess = .none
     ) -> String {
         var lines: [String] = ["## Delegating subtasks (spawn)", ""]
         lines.append(
-            "- You can hand a bounded, self-contained subtask to another worker and get back ONLY a "
-                + "compact result digest (not its transcript). Use it to offload focused "
-                + "text/coding/analysis work; keep the orchestration and the final answer to the user here."
+            "- You can hand a bounded, self-contained subtask to a worker and get back ONLY a "
+                + "compact result digest — the worker's transcript never enters this conversation, "
+                + "so delegating context-heavy work costs you a digest instead of everything the "
+                + "worker read and produced."
+        )
+        lines.append(
+            "- Offload work that would bloat this context: bulk reading + summarization, research "
+                + "and extraction over long material, log/error triage, first drafts. Prefer a "
+                + "small/local worker for that kind of work when one is listed; keep orchestration "
+                + "and the final answer to the user here."
         )
         if !agents.isEmpty {
             lines.append(
@@ -784,10 +792,28 @@ public enum SystemPromptTemplates {
             )
             for model in models { lines.append("  - " + modelLine(model)) }
         }
+        switch toolAccess {
+        case .readOnly:
+            lines.append(
+                "- Workers CAN read files themselves (read-only: file_read / file_search, plus "
+                    + "sandbox reads when available) within a per-run call budget — so you can "
+                    + "delegate \"read these files and report X\" with exact paths in `input` "
+                    + "instead of pasting file contents."
+            )
+        case .none:
+            lines.append(
+                "- Workers are text-only (no tools) — paste ALL material the task needs directly "
+                    + "into `input`; the worker cannot read files or fetch anything itself."
+            )
+        }
         lines.append(
             "- `input` must be the COMPLETE task as a self-contained prompt — the worker sees only that, "
                 + "not this conversation. Pick the target whose description or note best fits the task; "
                 + "if none clearly fits, just do it yourself rather than guessing."
+        )
+        lines.append(
+            "- Spawns of remote/cloud targets may run in parallel (several spawn calls in one turn); "
+                + "spawns of local targets run one at a time — a second local spawn waits for the GPU."
         )
         return lines.joined(separator: "\n")
     }

--- a/Packages/OsaurusCore/Services/Context/SubagentJobEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/SubagentJobEvaluator.swift
@@ -75,6 +75,31 @@ public struct SubagentJobTranscript: Sendable, Codable {
     public let error: String?
     /// Wall-clock milliseconds for the host run.
     public let latencyMs: Double
+    /// Worker usage from the spawn payload (`prompt_tokens` /
+    /// `completion_tokens` / `total_tokens` / `tokens_per_second`), when the
+    /// run reported it. Numbers normalized to Double for one Codable shape.
+    public let usage: [String: Double]?
+    /// Context-saved accounting from the spawn payload (`worker_tokens` /
+    /// `digest_tokens` / `context_saved_tokens`) — the measurable "what did
+    /// delegation save the parent" record.
+    public let contextAccounting: [String: Int]?
+    /// Residency phase durations (seconds) recorded by the host from the
+    /// feed timeline (`unloading_chat_models`, `restoring_chat_models`,
+    /// `waiting for local GPU`, `coexisting`, …) — the handoff-latency proof.
+    public let residencyPhases: [String: Double]?
+    /// Post-run cache counters (`prefix_hits` / `disk_l2_hits` / …) captured
+    /// for local runs — the resume prefix-hit / L2 mitigation signal.
+    public let postRunCache: [String: Int]?
+    /// Parallel-batch lane only: peak concurrent `run()` bodies observed.
+    public let maxConcurrent: Int?
+    /// Parallel-batch lane only: how many of the batch's runs completed
+    /// (success envelopes).
+    public let runsCompleted: Int?
+    /// Residency lane only: whether the local orchestrator was verified
+    /// GPU-resident again AFTER the run (before the lane's cleanup) — the
+    /// "restore verified resident" proof. `nil` when the case had no local
+    /// orchestrator to restore (`ensureResident: false`) or the run failed.
+    public let restoredResident: Bool?
 
     public init(
         tool: String,
@@ -91,7 +116,14 @@ public struct SubagentJobTranscript: Sendable, Codable {
         handoffWrapped: Bool? = nil,
         nestedRefused: Bool? = nil,
         error: String? = nil,
-        latencyMs: Double
+        latencyMs: Double,
+        usage: [String: Double]? = nil,
+        contextAccounting: [String: Int]? = nil,
+        residencyPhases: [String: Double]? = nil,
+        postRunCache: [String: Int]? = nil,
+        maxConcurrent: Int? = nil,
+        runsCompleted: Int? = nil,
+        restoredResident: Bool? = nil
     ) {
         self.tool = tool
         self.kindId = kindId
@@ -108,6 +140,13 @@ public struct SubagentJobTranscript: Sendable, Codable {
         self.nestedRefused = nestedRefused
         self.error = error
         self.latencyMs = latencyMs
+        self.usage = usage
+        self.contextAccounting = contextAccounting
+        self.residencyPhases = residencyPhases
+        self.postRunCache = postRunCache
+        self.maxConcurrent = maxConcurrent
+        self.runsCompleted = runsCompleted
+        self.restoredResident = restoredResident
     }
 }
 
@@ -178,6 +217,25 @@ public struct ScriptedSubagentSpec: Sendable {
     public var resultKind: String
     /// Resolved model name the scripted kind returns.
     public var modelName: String
+    /// Resolve as a REMOTE model (`isLocal: false`), so the host's default
+    /// admission class is `.remote` — the parallel fan-out lane.
+    public var remote: Bool
+    /// Hold `run()` open for this long (polling the interrupt token every
+    /// ~20 ms), so an external interrupt or a sibling batch run can land
+    /// mid-run. An interrupt observed during the wait throws the honest
+    /// user-stop error (mirrors `TextSubagentKind`'s cancel mapping).
+    public var runDelayMs: Int
+    /// Attach canned `usage` + `context` accounting to the success payload so
+    /// the transcript/scoring plumbing for the live spawn fields is testable
+    /// deterministically (this is the model-free TEST kind, not production).
+    public var includeUsageAccounting: Bool
+    /// Parallel-batch rendezvous: hold `run()` open until this many sibling
+    /// runs have ENTERED the shared overlap probe (bounded wait), so a
+    /// fan-out lane observes true overlap deterministically instead of
+    /// depending on sleep timing. `0` = off. Only meaningful with a probe;
+    /// never set it for a serialized (exclusive) batch — the later runs can't
+    /// enter until the earlier ones exit, so the wait would just time out.
+    public var rendezvousArrivals: Int
 
     public init(
         kindId: String = "scripted",
@@ -189,7 +247,11 @@ public struct ScriptedSubagentSpec: Sendable {
         phases: [String] = ["running"],
         summary: String = "scripted digest",
         resultKind: String = "scripted_result",
-        modelName: String = "scripted-model"
+        modelName: String = "scripted-model",
+        remote: Bool = false,
+        runDelayMs: Int = 0,
+        includeUsageAccounting: Bool = false,
+        rendezvousArrivals: Int = 0
     ) {
         self.kindId = kindId
         self.needsHandoff = needsHandoff
@@ -201,6 +263,10 @@ public struct ScriptedSubagentSpec: Sendable {
         self.summary = summary
         self.resultKind = resultKind
         self.modelName = modelName
+        self.remote = remote
+        self.runDelayMs = runDelayMs
+        self.includeUsageAccounting = includeUsageAccounting
+        self.rendezvousArrivals = rendezvousArrivals
     }
 }
 
@@ -213,13 +279,23 @@ public enum SubagentJobEvaluator {
     /// the envelope + feed + handoff/recursion observations. No tokens, no
     /// model, CI-safe — this is the deterministic seam the whole subagent
     /// family rides on.
-    public static func runScripted(_ spec: ScriptedSubagentSpec) async -> SubagentJobTranscript {
+    ///
+    /// `interruptAfterMs` trips the run's `InterruptToken` through the REAL
+    /// `SubagentInterruptCenter` (the feed row's stop-button path) after the
+    /// delay — pair with `spec.runDelayMs` so the run is still open when the
+    /// interrupt lands (the deterministic interrupt-mid-run lane).
+    public static func runScripted(
+        _ spec: ScriptedSubagentSpec,
+        interruptAfterMs: Int? = nil
+    ) async -> SubagentJobTranscript {
         let kind = ScriptedSubagentKind(spec: spec)
         let toolCallId = freshToolCallId()
         let started = Date()
+        let stopper = scheduleInterrupt(afterMs: interruptAfterMs, toolCallId: toolCallId)
         let envelope = await withEvalScope(toolCallId: toolCallId) {
             await SubagentSession.run(kind, tool: spec.kindId)
         }
+        stopper?.cancel()
         let latency = Date().timeIntervalSince(started) * 1000
         return transcript(
             fromEnvelope: envelope,
@@ -234,6 +310,77 @@ public enum SubagentJobEvaluator {
             // branch). `needsHandoff: true` reads `true` (the wrap branch).
             handoffWrapped: kind.handoffWrapped,
             nestedRefused: spec.recurse ? kind.nestedRefused : nil
+        )
+    }
+
+    /// Run `count` copies of the scripted spec CONCURRENTLY through the host —
+    /// the parallel-batch lane. Every run gets its own tool-call id + feed
+    /// (like a real parallel tool batch), and all share one overlap probe, so
+    /// the transcript reports the substantive observation: `maxConcurrent`
+    /// (did the admission gate serialize the local-exclusive runs, or fan the
+    /// remote runs out) and `runsCompleted` (nobody deadlocked or refused).
+    /// The combined transcript takes envelope/summary from the FIRST FAILURE
+    /// when one exists (so expectations catch it), else from the first run.
+    public static func runScriptedParallelBatch(
+        _ spec: ScriptedSubagentSpec,
+        count: Int
+    ) async -> SubagentJobTranscript {
+        let runs = max(2, count)
+        let probe = SubagentOverlapProbe()
+        let started = Date()
+
+        let results: [SubagentJobTranscript] = await withTaskGroup(
+            of: (Int, SubagentJobTranscript).self
+        ) { group in
+            for index in 0 ..< runs {
+                group.addTask {
+                    let kind = ScriptedSubagentKind(spec: spec, overlapProbe: probe)
+                    let toolCallId = freshToolCallId()
+                    let envelope = await withEvalScope(toolCallId: toolCallId) {
+                        await SubagentSession.run(kind, tool: spec.kindId)
+                    }
+                    return (
+                        index,
+                        transcript(
+                            fromEnvelope: envelope,
+                            tool: spec.kindId,
+                            kindId: spec.kindId,
+                            toolCallId: toolCallId,
+                            latencyMs: 0
+                        )
+                    )
+                }
+            }
+            var collected: [(Int, SubagentJobTranscript)] = []
+            for await item in group { collected.append(item) }
+            return collected.sorted { $0.0 < $1.0 }.map { $0.1 }
+        }
+
+        let latency = Date().timeIntervalSince(started) * 1000
+        let completed = results.filter(\.succeeded).count
+        let primary = results.first { !$0.succeeded } ?? results[0]
+        return SubagentJobTranscript(
+            tool: primary.tool,
+            kindId: primary.kindId,
+            succeeded: completed == runs,
+            envelopeKind: primary.envelopeKind,
+            resultKind: primary.resultKind,
+            mode: primary.mode,
+            model: primary.model,
+            summary: primary.summary,
+            imageCount: nil,
+            feedEventKinds: primary.feedEventKinds,
+            feedPhases: primary.feedPhases,
+            handoffWrapped: nil,
+            nestedRefused: nil,
+            error: primary.error,
+            latencyMs: latency,
+            usage: primary.usage,
+            contextAccounting: primary.contextAccounting,
+            residencyPhases: primary.residencyPhases,
+            postRunCache: primary.postRunCache,
+            maxConcurrent: probe.maxConcurrent,
+            runsCompleted: completed
         )
     }
 
@@ -252,14 +399,17 @@ public enum SubagentJobEvaluator {
     public static func runSpawn(
         agent: String,
         input: String,
-        modelId: String? = nil
+        modelId: String? = nil,
+        interruptAfterMs: Int? = nil
     ) async -> SubagentJobTranscript {
         let toolCallId = freshToolCallId()
         let kind = TextSubagentKind(agentName: agent, input: input, modelOverride: modelId)
         let started = Date()
+        let stopper = scheduleInterrupt(afterMs: interruptAfterMs, toolCallId: toolCallId)
         let envelope = await withEvalScope(toolCallId: toolCallId) {
             await SubagentSession.run(kind, tool: "spawn_agent")
         }
+        stopper?.cancel()
         let latency = Date().timeIntervalSince(started) * 1000
         return transcript(
             fromEnvelope: envelope,
@@ -279,14 +429,17 @@ public enum SubagentJobEvaluator {
     /// (unseeded id) surface a `rejected` envelope so the runner skips vs. fails.
     public static func runSpawnModel(
         model: String,
-        input: String
+        input: String,
+        interruptAfterMs: Int? = nil
     ) async -> SubagentJobTranscript {
         let toolCallId = freshToolCallId()
         let kind = TextSubagentKind(model: model, input: input, modelOverride: model)
         let started = Date()
+        let stopper = scheduleInterrupt(afterMs: interruptAfterMs, toolCallId: toolCallId)
         let envelope = await withEvalScope(toolCallId: toolCallId) {
             await SubagentSession.run(kind, tool: "spawn_model")
         }
+        stopper?.cancel()
         let latency = Date().timeIntervalSince(started) * 1000
         return transcript(
             fromEnvelope: envelope,
@@ -429,6 +582,22 @@ public enum SubagentJobEvaluator {
         let payload = (ToolEnvelope.successPayload(envelope) as? [String: Any]) ?? [:]
         let handoffFlag = payload["handoff"] as? Bool
 
+        // Restore-verified-resident: after a successful run with a LOCAL
+        // orchestrator, the orchestrator must be back in the live resident set
+        // (the restore leg actually reloaded it — or, for in-place directions,
+        // never dropped it). Checked BEFORE the clean-slate below tears it down.
+        // The runtime caches models under the canonical installed short name
+        // (lowercased repo folder), not the case file's `owner/Repo` string,
+        // so canonicalize before comparing.
+        var restoredResident: Bool?
+        if ensureResident && orchestratorLocal && ToolEnvelope.isSuccess(envelope) {
+            let canonical = ModelManager.findInstalledModel(named: orchestrator)?.name ?? orchestrator
+            let resident = await ModelRuntime.shared.cachedModelSummaries().map(\.name)
+            restoredResident = resident.contains {
+                $0.caseInsensitiveCompare(canonical) == .orderedSame
+            }
+        }
+
         // Restore config + core model, then drop the (reloaded) orchestrator so
         // the next case starts from a clean resident set.
         await MainActor.run {
@@ -446,7 +615,8 @@ public enum SubagentJobEvaluator {
             kindId: "spawn",
             toolCallId: toolCallId,
             latencyMs: latency,
-            handoffWrapped: handoffFlag
+            handoffWrapped: handoffFlag,
+            restoredResident: restoredResident
         )
     }
 
@@ -616,8 +786,13 @@ public enum SubagentJobEvaluator {
     /// snapshotted and restored, leaving a developer's real config untouched.
     /// `SubagentConfigurationStore` is nonisolated, but this hops to the main
     /// actor to match `withSpawnableAgent`'s ordering against `AgentManager`.
+    ///
+    /// `toolAccess` (when non-nil) also sets the Default agent's global
+    /// `spawnToolAccess` for the run — the tool-capable spawn lane (the child
+    /// sees the curated read-only toolset instead of running text-only).
     public static func withSpawnableModel<T: Sendable>(
         id: String,
+        toolAccess: SpawnToolAccess? = nil,
         _ body: @Sendable () async -> T
     ) async -> T {
         let state: (priorConfig: SubagentConfiguration, configChanged: Bool) = await MainActor.run {
@@ -627,6 +802,7 @@ public enum SubagentJobEvaluator {
                 updated.spawnableModelNames = priorConfig.spawnableModelNames + [id]
             }
             updated.localTextDelegationEnabled = true
+            if let toolAccess { updated.spawnToolAccess = toolAccess }
             let configChanged = updated != priorConfig
             if configChanged { SubagentConfigurationStore.save(updated) }
             return (priorConfig, configChanged)
@@ -641,6 +817,22 @@ public enum SubagentJobEvaluator {
     }
 
     // MARK: - Shared plumbing
+
+    /// Schedule an interrupt through the REAL `SubagentInterruptCenter` (the
+    /// feed row's stop-button path) after `afterMs`. Retries until the run's
+    /// token is actually registered (a slow host may still be resolving when
+    /// the delay elapses), so the stop can't be silently missed. Returns the
+    /// task so the caller cancels it when the run finishes first. `nil` = no-op.
+    private static func scheduleInterrupt(afterMs: Int?, toolCallId: String) -> Task<Void, Never>? {
+        guard let afterMs, afterMs > 0 else { return nil }
+        return Task {
+            try? await Task.sleep(nanoseconds: UInt64(afterMs) * 1_000_000)
+            while !Task.isCancelled {
+                if SubagentInterruptCenter.shared.interrupt(toolCallId) { return }
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+    }
 
     /// Bind the chat execution context the host resolves its scope from, plus
     /// headless auto-approval so `.ask`-gated kinds (image) don't block on a
@@ -673,7 +865,8 @@ public enum SubagentJobEvaluator {
         toolCallId: String,
         latencyMs: Double,
         handoffWrapped: Bool? = nil,
-        nestedRefused: Bool? = nil
+        nestedRefused: Bool? = nil,
+        restoredResident: Bool? = nil
     ) -> SubagentJobTranscript {
         let succeeded = ToolEnvelope.isSuccess(envelope)
         let payload = (ToolEnvelope.successPayload(envelope) as? [String: Any]) ?? [:]
@@ -695,6 +888,15 @@ public enum SubagentJobEvaluator {
         let envelopeKind = succeeded ? "success" : (failureKind(envelope) ?? "execution_error")
         let error = succeeded ? nil : ToolEnvelope.failureMessage(envelope)
 
+        // Usage / context-saved / residency telemetry from the payload, when
+        // the run recorded them (spawn success payloads + the host's
+        // residency object). All numeric maps, normalized for Codable.
+        let usage = numberMap(payload["usage"])
+        let contextAccounting = intMap(payload["context"])
+        let residency = payload["residency"] as? [String: Any]
+        let residencyPhases = numberMap(residency?["phases"])
+        let postRunCache = intMap(residency?["post_run_cache"])
+
         return SubagentJobTranscript(
             tool: tool,
             kindId: kindId,
@@ -710,8 +912,33 @@ public enum SubagentJobEvaluator {
             handoffWrapped: handoffWrapped,
             nestedRefused: nestedRefused,
             error: error,
-            latencyMs: latencyMs
+            latencyMs: latencyMs,
+            usage: usage,
+            contextAccounting: contextAccounting,
+            residencyPhases: residencyPhases,
+            postRunCache: postRunCache,
+            restoredResident: restoredResident
         )
+    }
+
+    /// `[String: any number]` → `[String: Double]` (nil when absent/empty).
+    private static func numberMap(_ value: Any?) -> [String: Double]? {
+        guard let dict = value as? [String: Any] else { return nil }
+        var result: [String: Double] = [:]
+        for (key, raw) in dict {
+            if let number = raw as? NSNumber { result[key] = number.doubleValue }
+        }
+        return result.isEmpty ? nil : result
+    }
+
+    /// `[String: any number]` → `[String: Int]` (nil when absent/empty).
+    private static func intMap(_ value: Any?) -> [String: Int]? {
+        guard let dict = value as? [String: Any] else { return nil }
+        var result: [String: Int] = [:]
+        for (key, raw) in dict {
+            if let number = raw as? NSNumber { result[key] = number.intValue }
+        }
+        return result.isEmpty ? nil : result
     }
 
     /// The failure envelope's `kind` discriminator, or `nil` if `envelope`
@@ -749,8 +976,11 @@ final class ScriptedSubagentKind: SubagentKind, @unchecked Sendable {
     private let spec: ScriptedSubagentSpec
     private let recordingHandoff = RecordingSubagentHandoff()
     private let nestedBox = NestedResultBox()
+    /// Optional shared overlap probe for the parallel-batch lane (enter/exit
+    /// around `run`, so peak concurrency across sibling runs is observable).
+    private let overlapProbe: SubagentOverlapProbe?
 
-    init(spec: ScriptedSubagentSpec) {
+    init(spec: ScriptedSubagentSpec, overlapProbe: SubagentOverlapProbe? = nil) {
         self.spec = spec
         self.capability = SubagentCapability(
             id: spec.kindId,
@@ -758,6 +988,7 @@ final class ScriptedSubagentKind: SubagentKind, @unchecked Sendable {
             gate: .sandboxExec
         )
         self.needsHandoff = spec.needsHandoff
+        self.overlapProbe = overlapProbe
     }
 
     /// Whether the residency-handoff middleware wrapped the run.
@@ -773,7 +1004,16 @@ final class ScriptedSubagentKind: SubagentKind, @unchecked Sendable {
 
     func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel {
         if let failure = spec.resolveFailure { throw failure.error(context: "resolve") }
-        return ResolvedModel(name: spec.modelName, id: spec.modelName, isLocal: true)
+        return ResolvedModel(name: spec.modelName, id: spec.modelName, isLocal: !spec.remote)
+    }
+
+    /// A handoff-opted scripted kind models the local residency swap, so it
+    /// admits as `.localExclusive` (a parallel batch of two serializes —
+    /// the batch-race lane). Otherwise the protocol default applies (local
+    /// in-place / remote fan-out from `spec.remote`).
+    func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+        if needsHandoff { return .localExclusive }
+        return resolved.isLocal ? .localInPlace : .remote
     }
 
     func permission(_ scope: SubagentScope, _ resolved: ResolvedModel) async -> SubagentDecision {
@@ -790,7 +1030,20 @@ final class ScriptedSubagentKind: SubagentKind, @unchecked Sendable {
         feed: SubagentFeed,
         interrupt: InterruptToken
     ) async throws -> SubagentResult {
+        overlapProbe?.enter()
+        defer { overlapProbe?.exit() }
         for phase in spec.phases { feed.emitPhase(phase, detail: resolved.name) }
+
+        // Fan-out rendezvous: wait (bounded) until every sibling has entered,
+        // so overlap is observed by construction, not by sleep timing.
+        // Arrivals are monotonic, so a sibling that already exited still counts.
+        if spec.rendezvousArrivals > 0, let probe = overlapProbe {
+            let deadline = Date().addingTimeInterval(3)
+            while probe.arrivals < spec.rendezvousArrivals, Date() < deadline {
+                if interrupt.isInterrupted { break }
+                try? await Task.sleep(nanoseconds: 5_000_000)
+            }
+        }
 
         if spec.recurse {
             // A running subagent must not be able to start another: drive a
@@ -804,16 +1057,86 @@ final class ScriptedSubagentKind: SubagentKind, @unchecked Sendable {
                 && (SubagentJobEvaluator.failureKind(nested) == "rejected")
         }
 
+        // Hold the run open, polling the interrupt token — the deterministic
+        // interrupt-mid-run lane (feed stop button → InterruptCenter → token
+        // → honest user-stop error), plus the overlap window for the
+        // parallel-batch lane. Mirrors `TextSubagentKind`'s cancel mapping.
+        if spec.runDelayMs > 0 {
+            let deadline = Date().addingTimeInterval(Double(spec.runDelayMs) / 1000)
+            while Date() < deadline {
+                if interrupt.isInterrupted {
+                    throw SubagentError.userDenied(
+                        "Scripted subagent was stopped by the user."
+                    )
+                }
+                try? await Task.sleep(nanoseconds: 20_000_000)
+            }
+            if interrupt.isInterrupted {
+                throw SubagentError.userDenied("Scripted subagent was stopped by the user.")
+            }
+        }
+
         if let failure = spec.runFailure { throw failure.error(context: "run") }
 
-        return SubagentResult(
-            payload: [
-                "kind": spec.resultKind,
-                "model": resolved.name,
-                "summary": spec.summary,
-            ] as [String: Any],
-            summary: spec.summary
-        )
+        var payload: [String: Any] = [
+            "kind": spec.resultKind,
+            "model": resolved.name,
+            "summary": spec.summary,
+        ]
+        if spec.includeUsageAccounting {
+            // Canned numbers exercising the SAME payload keys the live spawn
+            // path emits, so the transcript + scoring plumbing is CI-testable.
+            payload["usage"] =
+                [
+                    "prompt_tokens": 120,
+                    "completion_tokens": 40,
+                    "total_tokens": 160,
+                    "tokens_per_second": 42.5,
+                ] as [String: Any]
+            payload["context"] = [
+                "worker_tokens": 160,
+                "digest_tokens": 12,
+                "context_saved_tokens": 148,
+            ]
+        }
+        return SubagentResult(payload: payload, summary: spec.summary)
+    }
+}
+
+/// Shared enter/exit concurrency probe for the parallel-batch lane: sibling
+/// scripted runs report peak overlap of their `run()` bodies, which is the
+/// substantive "did the admission gate serialize / fan out" observation.
+public final class SubagentOverlapProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var active = 0
+    private var peak = 0
+    private var entries = 0
+
+    public init() {}
+
+    public var maxConcurrent: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return peak
+    }
+    /// Total number of runs that ENTERED (monotonic — rendezvous-safe).
+    public var arrivals: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries
+    }
+
+    func enter() {
+        lock.lock()
+        active += 1
+        peak = max(peak, active)
+        entries += 1
+        lock.unlock()
+    }
+    func exit() {
+        lock.lock()
+        active -= 1
+        lock.unlock()
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -773,7 +773,11 @@ public actor ModelRuntime {
         return min(byModel, bySystem)
     }
 
-    private static func flexibleResidentBudgetBytes() -> Int64 {
+    /// Flexible-mode resident-weights soft cap. Also read by
+    /// `SubagentResidency`'s coexistence gate, which must stay under it —
+    /// loading past this triggers `unloadForFlexibleResidentBudget`'s own
+    /// eviction, which would evict the orchestrator with no restore lease.
+    static func flexibleResidentBudgetBytes() -> Int64 {
         let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
         return Int64(Double(ProcessInfo.processInfo.physicalMemory) * thresholds.soft)
     }

--- a/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
@@ -125,6 +125,10 @@ final class AppleScriptKind: SubagentKind, @unchecked Sendable {
         SubagentResidency.handoff(for: residencyPlan)
     }
 
+    func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+        SubagentResidency.admissionClass(isLocal: resolved.isLocal, plan: residencyPlan)
+    }
+
     /// `.allow` at the host level: the consent surface is the per-script
     /// execution-mode gate inside `run` (confirm-each / auto-run-with-warning),
     /// not a per-call approval card.

--- a/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
@@ -164,6 +164,10 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
         SubagentResidency.handoff(for: residencyPlan)
     }
 
+    func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+        SubagentResidency.admissionClass(isLocal: resolved.isLocal, plan: residencyPlan)
+    }
+
     /// `.allow` at the host level: the consent surface is the per-action gate
     /// (`ComputerUseGate` + confirm overlay) wired inside `run`, not a per-call
     /// approval card. Accessibility preflight stays on the tool's

--- a/Packages/OsaurusCore/Subagent/Kinds/ImageSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ImageSubagentKind.swift
@@ -57,6 +57,11 @@ final class ImageSubagentKind: SubagentKind, @unchecked Sendable {
 
     private let params: ImageJobParams
     private let argumentsJSON: String
+    /// Load policy snapshotted in `resolveModel`, read by `admissionClass`:
+    /// `.agentSingleResidency` unloads chat models inside the coordinator, so
+    /// the run must hold the GPU exclusively even though the host handoff
+    /// stays passthrough (the coordinator is the residency authority).
+    private var loadPolicy: SubagentImageLoadPolicy = .agentSingleResidency
 
     init(params: ImageJobParams, argumentsJSON: String) {
         self.params = params
@@ -96,6 +101,7 @@ final class ImageSubagentKind: SubagentKind, @unchecked Sendable {
             )
         }
         let modelKind: SubagentModelKind = params.isEdit ? .imageEdit : .imageGeneration
+        self.loadPolicy = config.imageJobLoadPolicy
         let configured = SubagentToolVisibility.effectiveImageModel(
             isEdit: params.isEdit,
             isDefault: isDefault,
@@ -114,6 +120,14 @@ final class ImageSubagentKind: SubagentKind, @unchecked Sendable {
         } catch {
             throw SubagentError.unavailable(String(describing: error))
         }
+    }
+
+    /// The image model is always a local MLX graph; under `.agentSingleResidency`
+    /// the coordinator additionally unloads/restores chat models, which is a
+    /// full residency handoff — exclusive. Other policies keep the image model
+    /// alongside (in-place local).
+    func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+        loadPolicy == .agentSingleResidency ? .localExclusive : .localInPlace
     }
 
     // MARK: - Permission

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -52,11 +52,29 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
     /// Cap on the digest handed back to the parent.
     private static let digestMaxChars = 8_000
 
+    /// Curated read-only child toolset (host reads + sandbox reads).
+    /// `specs(forTools:)` silently drops whichever aren't registered right
+    /// now, so the child only ever sees live tools.
+    static let readOnlyChildToolNames = [
+        "file_read", "file_search",
+        "sandbox_read_file", "sandbox_search_files",
+    ]
+
+    /// Tool-call cap applied when the launching agent grants `readOnly`
+    /// access but its `maxToolCalls` budget is 0 (the "use default" marker) —
+    /// so enabling tool access is never silently inert.
+    static let defaultReadOnlyToolCallCap = 8
+
     // Resolved up front in `resolveModel`, read by permission/handoff/run.
     private var resolvedAgentName: String = ""
     private var resolvedAgentId: UUID?
     private var systemPrompt: String = ""
     private var budgets = SubagentBudgets()
+    /// The launching agent's child-tool grant (`none` = text-only).
+    private var toolAccess: SpawnToolAccess = .none
+    /// The target agent's user-set temperature override (agent mode only;
+    /// `nil` keeps the model bundle's own generation defaults).
+    private var temperature: Float?
     /// The residency plan resolved at `resolveModel` time (reject-before-evict),
     /// consumed by `makeHandoff()`. `.none` when no swap is needed.
     private var residencyPlan: ResidencyPlan = .none
@@ -125,6 +143,11 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
             config: config,
             settings: settings
         )
+        self.toolAccess = SubagentToolVisibility.effectiveSpawnToolAccess(
+            isDefault: isDefault,
+            config: config,
+            settings: settings
+        )
 
         switch target {
         case .agent(let agentName):
@@ -183,6 +206,12 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         self.resolvedAgentName = agent.name
         self.resolvedAgentId = agent.id
         self.systemPrompt = agent.systemPrompt
+        // The target agent's own sampling override rides along (a user-set
+        // value, consistent with "defaults come from the model bundle unless
+        // the user explicitly overrides").
+        self.temperature = await MainActor.run {
+            AgentManager.shared.effectiveTemperature(for: agent.id)
+        }
 
         // One shared path for precedence (eval seam → per-agent `spawn` override
         // → the target agent's own model), the availability fallback, and the live
@@ -262,6 +291,10 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         SubagentResidency.handoff(for: residencyPlan)
     }
 
+    func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+        SubagentResidency.admissionClass(isLocal: resolved.isLocal, plan: residencyPlan)
+    }
+
     func run(
         _ scope: SubagentScope,
         _ resolved: ResolvedModel,
@@ -274,6 +307,11 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         let started = Date()
         let seed = seedMessages(systemPrompt: systemPrompt, input: input)
         let sessionId = "spawn-\((resolvedAgentId ?? UUID()).uuidString)-\(UUID().uuidString)"
+        let toolset = await Self.makeToolset(
+            access: toolAccess,
+            maxToolCalls: budgets.maxToolCalls,
+            feed: feed
+        )
 
         let result = try await AgentSubagentRunner.run(
             modelName: resolved.name,
@@ -282,7 +320,18 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
             maxIterations: budgets.maxDelegateTurns,
             deadline: deadline,
             sessionId: sessionId,
-            isInterrupted: { interrupt.isInterrupted }
+            temperature: temperature,
+            isInterrupted: { interrupt.isInterrupted },
+            toolset: toolset,
+            onProgress: { [feed] tokens, tokensPerSecond in
+                // Live "generating" row: coalesced in place by the feed, so
+                // long generations show advancing tokens + tok/s.
+                var detail = "\(tokens) tokens"
+                if let tokensPerSecond {
+                    detail += String(format: " · %.1f tok/s", tokensPerSecond)
+                }
+                feed.emitProgress("generating", step: tokens, detail: detail)
+            }
         )
         let elapsed = Date().timeIntervalSince(started)
 
@@ -310,10 +359,33 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
                 "handoff": residencyPlan.shouldUnload,
             ]
             if case .agent = target { payload["agent"] = resolvedAgentName }
+
+            // Usage + context-saved accounting: what the worker consumed vs
+            // what the digest costs the parent — the measurable "context
+            // saved" per delegation.
+            let usage = result.usage
+            var usageDict: [String: Any] = [
+                "prompt_tokens": usage.promptTokens,
+                "completion_tokens": usage.completionTokens,
+                "total_tokens": usage.promptTokens + usage.completionTokens,
+            ]
+            if let tps = usage.tokensPerSecond {
+                usageDict["tokens_per_second"] = (tps * 10).rounded() / 10
+            }
+            payload["usage"] = usageDict
+            let workerTokens = usage.promptTokens + usage.completionTokens
+            let digestTokens = TokenEstimator.estimate(capped)
+            payload["context"] = [
+                "worker_tokens": workerTokens,
+                "digest_tokens": digestTokens,
+                "context_saved_tokens": max(0, workerTokens - digestTokens),
+            ]
             return SubagentResult(payload: payload, summary: capped)
         case .cancelled:
-            throw SubagentError.timedOut(
-                "Subagent '\(targetLabel)' hit its \(budgets.maxElapsedSeconds)s time budget."
+            throw Self.cancelError(
+                cause: result.cancelCause,
+                label: targetLabel,
+                maxElapsedSeconds: budgets.maxElapsedSeconds
             )
         case .iterationCapReached:
             throw SubagentError.iterationCap(
@@ -334,6 +406,117 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         }
     }
 
+    /// Honest exit mapping for a `.cancelled` runner exit: the three cancel
+    /// causes get DISTINCT copy (a user stop is not a "time budget" failure).
+    /// Pure — unit-testable without a live runner.
+    static func cancelError(
+        cause: SubagentCancelCause?,
+        label: String,
+        maxElapsedSeconds: Int
+    ) -> SubagentError {
+        switch cause {
+        case .userInterrupt:
+            return .userDenied("Subagent '\(label)' was stopped by the user.")
+        case .parentTask:
+            return .executionFailed(
+                message: "Subagent '\(label)' was cancelled with the parent run.",
+                retryable: false
+            )
+        case .deadline, .none:
+            return .timedOut(
+                "Subagent '\(label)' hit its \(maxElapsedSeconds)s time budget."
+            )
+        }
+    }
+
+    /// Build the child's curated read-only toolset when the launching agent
+    /// granted access; `nil` keeps the run text-only. The closure enforces the
+    /// allowlist and the per-run tool-call cap, dispatches through the shared
+    /// `ToolRegistry` (its permission gate + schema preflight included), and
+    /// narrates each call to the live feed.
+    ///
+    /// `specs` / `dispatch` are injection seams for unit tests (production
+    /// passes nil → live registry lookup + registry dispatch).
+    static func makeToolset(
+        access: SpawnToolAccess,
+        maxToolCalls: Int,
+        feed: SubagentFeed?,
+        specs specsOverride: [Tool]? = nil,
+        dispatch: (@Sendable (ServiceToolInvocation) async -> String)? = nil
+    ) async -> AgentSubagentToolset? {
+        guard access == .readOnly else { return nil }
+        let specs: [Tool]
+        if let specsOverride {
+            specs = specsOverride
+        } else {
+            specs = await MainActor.run {
+                ToolRegistry.shared.specs(forTools: readOnlyChildToolNames)
+            }
+        }
+        guard !specs.isEmpty else { return nil }
+        let allowed = Set(specs.map { $0.function.name })
+        let cap = maxToolCalls > 0 ? maxToolCalls : defaultReadOnlyToolCallCap
+        let counter = ToolCallCounter()
+        let dispatchCall: @Sendable (ServiceToolInvocation) async -> String =
+            dispatch
+            ?? { invocation in
+                do {
+                    return try await ToolRegistry.shared.execute(
+                        name: invocation.toolName,
+                        argumentsJSON: invocation.jsonArguments
+                    )
+                } catch {
+                    return ToolEnvelope.fromError(error, tool: invocation.toolName)
+                }
+            }
+        return AgentSubagentToolset(
+            specs: specs,
+            execute: { [weak feed] invocation in
+                guard allowed.contains(invocation.toolName) else {
+                    return ToolEnvelope.failure(
+                        kind: .rejected,
+                        message:
+                            "Tool '\(invocation.toolName)' is not available inside this subagent. "
+                            + "Available: \(allowed.sorted().joined(separator: ", ")).",
+                        tool: invocation.toolName,
+                        retryable: false
+                    )
+                }
+                let used = counter.increment()
+                guard used <= cap else {
+                    return ToolEnvelope.failure(
+                        kind: .rejected,
+                        message:
+                            "Tool-call budget (\(cap)) exhausted for this subagent run. "
+                            + "Produce your final answer from what you already have.",
+                        tool: invocation.toolName,
+                        retryable: false
+                    )
+                }
+                feed?.emit(
+                    SubagentActivityEvent(
+                        step: used,
+                        kind: .act,
+                        title: invocation.toolName,
+                        detail: Self.toolCallDetail(invocation)
+                    )
+                )
+                return await dispatchCall(invocation)
+            }
+        )
+    }
+
+    /// Compact one-line feed detail for a child tool call: the `path` /
+    /// `query` argument when present, else nothing (never the raw JSON).
+    private static func toolCallDetail(_ invocation: ServiceToolInvocation) -> String? {
+        guard let data = invocation.jsonArguments.data(using: .utf8),
+            let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return nil }
+        let value = (obj["path"] ?? obj["query"] ?? obj["pattern"]) as? String
+        guard let value, !value.isEmpty else { return nil }
+        return value.count > 80 ? String(value.prefix(80)) + "…" : value
+    }
+
     /// Shared "not spawnable" denial copy for both targets, so the agent and
     /// model messages can't drift. `kind` is the capitalized noun ("Agent" /
     /// "Model"); the tab pointer differs for the main chat vs a custom agent.
@@ -349,5 +532,20 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         if !sys.isEmpty { msgs.append(ChatMessage(role: "system", content: sys)) }
         msgs.append(ChatMessage(role: "user", content: input))
         return msgs
+    }
+}
+
+/// Thread-safe per-run tool-call counter for the child toolset closure
+/// (parallel batches may execute two child calls concurrently).
+private final class ToolCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    /// Increment and return the new total.
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
     }
 }

--- a/Packages/OsaurusCore/Subagent/ResidencyHandoff.swift
+++ b/Packages/OsaurusCore/Subagent/ResidencyHandoff.swift
@@ -42,17 +42,27 @@ struct ResidencyPlan: Sendable {
     var ramSafetyEnabled: Bool
     /// Idle-wait budget (seconds) before the unload gives up on chat going idle.
     var maxElapsedSeconds: Int
+    /// RAM-aware coexistence: a DIFFERENT local model loads alongside the
+    /// resident orchestrator (no unload, no restore) because the projection
+    /// said both fit under the flexible eviction policy. The handoff still
+    /// waits for local chat generation to go idle before the run — the drain
+    /// keeps "two resident graphs" from becoming "two GENERATING graphs"
+    /// (the BUG G crash class) at run start; process-wide exclusivity for the
+    /// run itself comes from the admission class.
+    var coexists: Bool
 
     init(
         shouldUnload: Bool,
         requiredBytes: Int64 = 0,
         ramSafetyEnabled: Bool = false,
-        maxElapsedSeconds: Int = 300
+        maxElapsedSeconds: Int = 300,
+        coexists: Bool = false
     ) {
         self.shouldUnload = shouldUnload
         self.requiredBytes = requiredBytes
         self.ramSafetyEnabled = ramSafetyEnabled
         self.maxElapsedSeconds = maxElapsedSeconds
+        self.coexists = coexists
     }
 
     /// A plan that performs no residency change.
@@ -146,5 +156,49 @@ struct ResidencyHandoff: SubagentHandoff {
             _ = await restore(lease, emit)
             throw error
         }
+    }
+}
+
+/// Coexistence handoff: the subagent model loads ALONGSIDE the resident
+/// orchestrator (flexible eviction policy + RAM projection passed), so there
+/// is nothing to unload or restore. The one residency obligation kept from the
+/// single-residency flow is the idle drain: local chat generation must be idle
+/// before the run starts, so a second MLX graph never begins producing while
+/// another graph is mid-generation (the BUG G crash class). `waitForIdle` is
+/// injectable for tests; `.production` wires it to `InferenceLoadCoordinator`.
+struct CoexistenceHandoff: SubagentHandoff {
+    typealias WaitForIdle = @Sendable (_ timeoutMs: Int) async -> Bool
+
+    let maxElapsedSeconds: Int
+    let waitForIdle: WaitForIdle
+
+    static func production(maxElapsedSeconds: Int) -> CoexistenceHandoff {
+        CoexistenceHandoff(
+            maxElapsedSeconds: maxElapsedSeconds,
+            waitForIdle: { timeoutMs in
+                await InferenceLoadCoordinator.shared.waitForChatIdle(timeoutMs: timeoutMs)
+            }
+        )
+    }
+
+    func around(
+        scope: SubagentScope,
+        resolved: ResolvedModel,
+        feed: SubagentFeed,
+        run body: () async throws -> SubagentResult
+    ) async throws -> SubagentResult {
+        // Same wait bounds as the unload path (15s floor, 300s ceiling).
+        let waitMs = max(15, min(maxElapsedSeconds, 300)) * 1000
+        feed.emitPhase(
+            "coexisting",
+            detail: "keeping the chat model loaded; waiting for local generation to go idle"
+        )
+        let wentIdle = await waitForIdle(waitMs)
+        guard wentIdle else {
+            throw SubagentError.unavailable(
+                "Local chat generation did not become idle before the coexistence run."
+            )
+        }
+        return try await body()
     }
 }

--- a/Packages/OsaurusCore/Subagent/SubagentAdmission.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentAdmission.swift
@@ -1,0 +1,147 @@
+//
+//  SubagentAdmission.swift
+//  OsaurusCore — Subagent framework
+//
+//  Process-wide admission control for subagent runs. The TaskLocal recursion
+//  guard in `SubagentSession` only protects one task tree; a parallel tool
+//  batch (or chat + HTTP surfaces racing) can start two subagent runs
+//  CONCURRENTLY. Two concurrent local runs are exactly the historical
+//  concurrent-GPU crash class (BUG G: MLX async tails racing the next Metal
+//  producer), and two concurrent residency handoffs can strand the
+//  orchestrator (A unloads chat → B snapshots "nothing resident" → A restores
+//  while B loads).
+//
+//  Rules, by residency class:
+//    - `.remote`         — no local GPU involvement; always admitted, any
+//                          number run concurrently (parallel remote fan-out).
+//    - `.localInPlace`   — drives a local model with no unload (same-model
+//                          computer_use, coexistence spawns); admitted unless
+//                          an exclusive run holds the GPU.
+//    - `.localExclusive` — performs a residency handoff (unload → run →
+//                          restore) or otherwise owns the GPU alone; admitted
+//                          only when NO other local run is active.
+//
+//  Blocked runs WAIT (bounded) rather than refuse: a parallel batch of two
+//  local spawns serializes here — second run starts when the first releases —
+//  which matches what the model expects from issuing two tool calls. The wait
+//  is polled so cancellation of the waiting task exits promptly; on timeout
+//  the caller returns a typed retryable envelope instead of crashing into a
+//  concurrent handoff.
+//
+
+import Foundation
+
+/// Residency class of one subagent run, derived by the kind AFTER model
+/// resolution (so it reflects the live residency plan, not static config).
+public enum SubagentAdmissionClass: String, Sendable {
+    /// Remote/router model — no local GPU residency involvement.
+    case remote
+    /// Local model driven in place (no unload of resident chat models).
+    case localInPlace = "local_in_place"
+    /// Local run that unloads/loads models (residency handoff) and must own
+    /// the GPU exclusively.
+    case localExclusive = "local_exclusive"
+}
+
+/// Process-wide gate that serializes local subagent runs while letting remote
+/// runs fan out. An actor: admission checks and counter updates are atomic;
+/// waiting is a poll loop so the actor is never held across a suspension.
+public actor SubagentAdmission {
+    public static let shared = SubagentAdmission()
+
+    /// How long a blocked run waits for the GPU before returning the typed
+    /// busy envelope. Generous: a local handoff (unload + run + restore) on
+    /// big bundles legitimately takes minutes.
+    public static let defaultWaitTimeoutSeconds: TimeInterval = 300
+
+    private var exclusiveActive = 0
+    private var inPlaceActive = 0
+    private var remoteActive = 0
+
+    /// Test seam: poll interval for blocked waiters.
+    private let pollNanoseconds: UInt64
+
+    public init(pollNanoseconds: UInt64 = 100_000_000) {
+        self.pollNanoseconds = pollNanoseconds
+    }
+
+    /// Outcome of an admission attempt.
+    public enum Outcome: Sendable, Equatable {
+        case admitted
+        /// Wait budget elapsed while another local run held the GPU.
+        case timedOut(activeDescription: String)
+        /// The waiting task itself was cancelled.
+        case cancelled
+    }
+
+    /// Admit a run of `admissionClass`, waiting (bounded) while conflicting
+    /// runs hold the GPU. `onWait` fires once, only if the run actually has
+    /// to queue (feed "waiting" row). Every `.admitted` return MUST be paired
+    /// with exactly one `release(_:)`.
+    public func admit(
+        _ admissionClass: SubagentAdmissionClass,
+        timeoutSeconds: TimeInterval = SubagentAdmission.defaultWaitTimeoutSeconds,
+        onWait: (@Sendable (_ activeDescription: String) -> Void)? = nil
+    ) async -> Outcome {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var signaledWait = false
+        while !canAdmit(admissionClass) {
+            if !signaledWait {
+                signaledWait = true
+                onWait?(activeDescription)
+            }
+            if Task.isCancelled { return .cancelled }
+            if Date() >= deadline { return .timedOut(activeDescription: activeDescription) }
+            // Suspending releases the actor so concurrent release()/admit()
+            // proceed; wake-up order between multiple waiters is unfair but
+            // the population is tiny (one tool batch).
+            try? await Task.sleep(nanoseconds: pollNanoseconds)
+        }
+        take(admissionClass)
+        return .admitted
+    }
+
+    /// Release a previously admitted run.
+    public func release(_ admissionClass: SubagentAdmissionClass) {
+        switch admissionClass {
+        case .remote: remoteActive = max(0, remoteActive - 1)
+        case .localInPlace: inPlaceActive = max(0, inPlaceActive - 1)
+        case .localExclusive: exclusiveActive = max(0, exclusiveActive - 1)
+        }
+    }
+
+    /// Live counters (tests + diagnostics).
+    public func snapshot() -> (exclusive: Int, inPlace: Int, remote: Int) {
+        (exclusiveActive, inPlaceActive, remoteActive)
+    }
+
+    // MARK: - Internals
+
+    private func canAdmit(_ admissionClass: SubagentAdmissionClass) -> Bool {
+        switch admissionClass {
+        case .remote:
+            // Remote never touches the local GPU; even an exclusive handoff
+            // in flight is irrelevant.
+            return true
+        case .localInPlace:
+            return exclusiveActive == 0
+        case .localExclusive:
+            return exclusiveActive == 0 && inPlaceActive == 0
+        }
+    }
+
+    private func take(_ admissionClass: SubagentAdmissionClass) {
+        switch admissionClass {
+        case .remote: remoteActive += 1
+        case .localInPlace: inPlaceActive += 1
+        case .localExclusive: exclusiveActive += 1
+        }
+    }
+
+    private var activeDescription: String {
+        var parts: [String] = []
+        if exclusiveActive > 0 { parts.append("\(exclusiveActive) local handoff") }
+        if inPlaceActive > 0 { parts.append("\(inPlaceActive) local run") }
+        return parts.isEmpty ? "another subagent" : parts.joined(separator: " + ")
+    }
+}

--- a/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
@@ -612,4 +612,15 @@ public enum SubagentToolVisibility {
         let budgets = isDefault ? config.budgets : (settings?.subagentBudgets ?? SubagentBudgets())
         return budgets.normalized
     }
+
+    /// The effective child-tool grant for spawn runs launched by an agent.
+    /// Default / main chat uses the global setting; a custom agent uses its
+    /// own. Missing settings resolve to the safe text-only `.none`.
+    static func effectiveSpawnToolAccess(
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        settings: AgentSettings?
+    ) -> SpawnToolAccess {
+        isDefault ? config.spawnToolAccess : (settings?.spawnToolAccess ?? .none)
+    }
 }

--- a/Packages/OsaurusCore/Subagent/SubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentKind.swift
@@ -51,6 +51,12 @@ public protocol SubagentKind: Sendable {
     /// `ResidencyHandoff` configured with their per-run plan (the kind owns the
     /// policy + size source, so the middleware stays generic).
     func makeHandoff() -> SubagentHandoff
+
+    /// The run's residency class for process-wide admission
+    /// (`SubagentAdmission`): remote runs fan out concurrently, local
+    /// handoffs are exclusive. Called after `resolveModel`, so kinds derive it
+    /// from their live residency plan.
+    func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass
 }
 
 extension SubagentKind {
@@ -58,6 +64,13 @@ extension SubagentKind {
 
     /// Default: no residency change. Model-swapping kinds override.
     public func makeHandoff() -> SubagentHandoff { PassthroughHandoff() }
+
+    /// Default: a local model runs in place; a remote model doesn't touch the
+    /// GPU. Kinds whose plan unloads resident models override to
+    /// `.localExclusive`.
+    public func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+        resolved.isLocal ? .localInPlace : .remote
+    }
 }
 
 // MARK: - Optional handoff middleware

--- a/Packages/OsaurusCore/Subagent/SubagentResidency.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentResidency.swift
@@ -31,12 +31,61 @@ struct SubagentResidencyDecision: Sendable {
     let plan: ResidencyPlan
 }
 
+/// Live RAM numbers for the coexistence gate in `decidePlan`, resolved by the
+/// `resolve` wrapper so the decision itself stays a pure function. `.disabled`
+/// (allowed == false) preserves the single-residency default.
+struct SubagentCoexistence: Sendable {
+    /// User opt-in AND flexible eviction policy. Strict policy must pass
+    /// false: the runtime itself strict-evicts any other resident model on
+    /// load, which would silently evict the orchestrator with NO restore lease.
+    var allowed: Bool
+    /// Reclaimable physical memory right now (free + inactive + purgeable),
+    /// WITHOUT counting resident chat models — they stay loaded.
+    var availableBytes: Int64
+    /// Sum of resident chat-model weight bytes (they remain resident).
+    var residentBytes: Int64
+    /// The runtime's flexible-mode resident-weights soft cap
+    /// (`ModelRuntime.flexibleResidentBudgetBytes`). Loading past it triggers
+    /// the runtime's own budget eviction — which would evict the orchestrator
+    /// without a restore lease — so the gate must stay under it. `0` = no cap.
+    var flexibleBudgetBytes: Int64
+
+    static let disabled = SubagentCoexistence(
+        allowed: false,
+        availableBytes: 0,
+        residentBytes: 0,
+        flexibleBudgetBytes: 0
+    )
+
+    /// Same footprint model as `ChatResidencyHandoff.memoryPreflight`: weights
+    /// inflate ~1.3x once resident (KV + activations + framework overhead)…
+    static let residencyInflation = 1.3
+    /// …plus fixed headroom kept for the OS/app.
+    static let headroomBytes: Int64 = 3 * 1024 * 1024 * 1024
+
+    /// Whether a subagent model of `requiredBytes` (on-disk weights) fits
+    /// alongside the resident models. Unknown size (`<= 0`) never fits — the
+    /// gate must be able to prove the projection, not assume it.
+    func fits(requiredBytes: Int64) -> Bool {
+        guard allowed, requiredBytes > 0 else { return false }
+        let needed = Int64(Double(requiredBytes) * Self.residencyInflation) + Self.headroomBytes
+        guard availableBytes >= needed else { return false }
+        // Mirror the runtime's flexible-budget eviction check (raw weights,
+        // uninflated — same terms `unloadForFlexibleResidentBudget` compares).
+        if flexibleBudgetBytes > 0, residentBytes + requiredBytes > flexibleBudgetBytes {
+            return false
+        }
+        return true
+    }
+}
+
 enum SubagentResidency {
     /// Pure residency decision — no `ModelRuntime` / `ModelManager`, so the
     /// control flow (remote ⇒ none, same ⇒ none, different-local + handoff-off ⇒
-    /// denied, different-local + handoff-on ⇒ unload) is unit-testable with no
-    /// GPU. `residentChatModels` is the live set of resident chat-model names;
-    /// the caller resolves it (empty when the model isn't local).
+    /// denied, different-local + coexistence-fits ⇒ coexist, different-local +
+    /// handoff-on ⇒ unload) is unit-testable with no GPU. `residentChatModels`
+    /// is the live set of resident chat-model names; the caller resolves it
+    /// (empty when the model isn't local).
     static func decidePlan(
         isLocal: Bool,
         modelName: String,
@@ -45,7 +94,8 @@ enum SubagentResidency {
         ramSafetyEnabled: Bool,
         requiredBytes: Int64,
         idleWaitSeconds: Int,
-        deniedMessage: String
+        deniedMessage: String,
+        coexistence: SubagentCoexistence = .disabled
     ) throws -> ResidencyPlan {
         // A remote/router model never touches local GPU residency.
         guard isLocal else { return .none }
@@ -55,6 +105,20 @@ enum SubagentResidency {
             $0.caseInsensitiveCompare(modelName) != .orderedSame
         }
         guard !otherResidentModels.isEmpty else { return .none }
+        // RAM-aware coexistence: both models fit (flexible policy, projection
+        // proven) → skip the 10–60s unload+reload round-trip and run alongside.
+        // Checked before the handoff-enabled gate on purpose: coexistence does
+        // not unload the orchestrator, which is exactly what that toggle
+        // protects. Tight RAM or unknown size falls through to the handoff.
+        if coexistence.fits(requiredBytes: requiredBytes) {
+            return ResidencyPlan(
+                shouldUnload: false,
+                requiredBytes: requiredBytes,
+                ramSafetyEnabled: ramSafetyEnabled,
+                maxElapsedSeconds: idleWaitSeconds,
+                coexists: true
+            )
+        }
         // Reject BEFORE evicting: if the handoff is disabled, fail cleanly so
         // nothing is unloaded.
         guard handoffEnabled else { throw SubagentError.denied(deniedMessage) }
@@ -88,12 +152,30 @@ enum SubagentResidency {
         // spawning the SAME model the user is chatting with runs in place
         // instead of needlessly unloading + reloading the identical bundle.
         let canonicalName = installed?.name ?? modelName
-        let residentChatModels: [String] =
-            isLocal
-            ? await ModelRuntime.shared.cachedModelSummaries().map {
-                ModelManager.findInstalledModel(named: $0.name)?.name ?? $0.name
+        let residentSummaries =
+            isLocal ? await ModelRuntime.shared.cachedModelSummaries() : []
+        let residentChatModels: [String] = residentSummaries.map {
+            ModelManager.findInstalledModel(named: $0.name)?.name ?? $0.name
+        }
+        // Coexistence gate inputs (live numbers; the decision itself is pure).
+        // Only meaningful when the user opted in AND the server eviction policy
+        // is Flexible — under Strict the runtime itself evicts any other
+        // resident model on load, which would strand the orchestrator with no
+        // restore lease, so Strict always keeps the single-residency handoff.
+        let coexistence: SubagentCoexistence
+        if isLocal, config.subagentCoexistenceEnabled {
+            let policy = await MainActor.run {
+                ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
             }
-            : []
+            coexistence = SubagentCoexistence(
+                allowed: policy == .manualMultiModel,
+                availableBytes: ChatResidencyHandoff.availableMemoryBytes(),
+                residentBytes: residentSummaries.reduce(Int64(0)) { $0 + $1.bytes },
+                flexibleBudgetBytes: ModelRuntime.flexibleResidentBudgetBytes()
+            )
+        } else {
+            coexistence = .disabled
+        }
         let plan = try decidePlan(
             isLocal: isLocal,
             modelName: canonicalName,
@@ -108,14 +190,31 @@ enum SubagentResidency {
             requiredBytes: isLocal
                 ? ChatResidencyHandoff.estimatedChatModelBytes(named: modelName) : 0,
             idleWaitSeconds: idleWaitSeconds,
-            deniedMessage: deniedMessage
+            deniedMessage: deniedMessage,
+            coexistence: coexistence
         )
         return SubagentResidencyDecision(isLocal: isLocal, plan: plan)
     }
 
     /// Map a resolved plan onto the host handoff middleware: a real
-    /// `ResidencyHandoff` when it unloads, otherwise the passthrough default.
+    /// `ResidencyHandoff` when it unloads, the idle-drain `CoexistenceHandoff`
+    /// when both models stay resident, otherwise the passthrough default.
     static func handoff(for plan: ResidencyPlan) -> SubagentHandoff {
-        plan.shouldUnload ? ResidencyHandoff.production { _ in plan } : PassthroughHandoff()
+        if plan.shouldUnload { return ResidencyHandoff.production { _ in plan } }
+        if plan.coexists {
+            return CoexistenceHandoff.production(maxElapsedSeconds: plan.maxElapsedSeconds)
+        }
+        return PassthroughHandoff()
+    }
+
+    /// Map a resolved plan onto the process-wide admission class
+    /// (`SubagentAdmission`): a plan that unloads resident models owns the GPU
+    /// exclusively; a coexistence run ALSO admits exclusively (two resident
+    /// graphs must never both generate — the run may share residency but not
+    /// the GPU's producer slot); a local run without a swap shares with other
+    /// in-place runs; remote never contends.
+    static func admissionClass(isLocal: Bool, plan: ResidencyPlan) -> SubagentAdmissionClass {
+        if plan.shouldUnload || plan.coexists { return .localExclusive }
+        return isLocal ? .localInPlace : .remote
     }
 }

--- a/Packages/OsaurusCore/Subagent/SubagentSession.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentSession.swift
@@ -7,7 +7,8 @@
 //  share ONE lifecycle:
 //
 //    recursion guard → scope ids → resolve model (reject-before-evict)
-//      → permission → register feed + interrupt → [optional handoff]
+//      → permission → register feed + interrupt → process-wide admission
+//      (local runs serialize, remote fan out) → [optional handoff]
 //      → run kind → normalize to a compact ToolEnvelope → defer cleanup
 //      → telemetry
 //
@@ -25,9 +26,29 @@ private let subagentLog = Logger(subsystem: "ai.osaurus", category: "Subagent")
 /// hook so the host stays dependency-free; richer `FeatureTelemetry` rows are
 /// emitted by individual kinds where they already exist (computer_use).
 enum SubagentTelemetry {
-    static func record(kindId: String, success: Bool, elapsed: TimeInterval) {
+    static func record(
+        kindId: String,
+        success: Bool,
+        elapsed: TimeInterval,
+        usage: [String: Any]? = nil,
+        phases: [(phase: String, seconds: Double)] = []
+    ) {
+        var extra = ""
+        if let usage {
+            let prompt = usage["prompt_tokens"] as? Int ?? 0
+            let completion = usage["completion_tokens"] as? Int ?? 0
+            extra += " promptTokens=\(prompt) completionTokens=\(completion)"
+            if let tps = usage["tokens_per_second"] as? Double {
+                extra += String(format: " tokPerSec=%.1f", tps)
+            }
+        }
+        if !phases.isEmpty {
+            let joined = phases.map { String(format: "%@=%.2fs", $0.phase, $0.seconds) }
+                .joined(separator: " ")
+            extra += " phases[\(joined)]"
+        }
         subagentLog.info(
-            "subagent run kind=\(kindId, privacy: .public) success=\(success, privacy: .public) elapsed=\(elapsed, format: .fixed(precision: 2), privacy: .public)s"
+            "subagent run kind=\(kindId, privacy: .public) success=\(success, privacy: .public) elapsed=\(elapsed, format: .fixed(precision: 2), privacy: .public)s\(extra, privacy: .public)"
         )
     }
 }
@@ -101,37 +122,158 @@ public enum SubagentSession {
             SubagentFeedRegistry.shared.unregister(toolCallId: scope.toolCallId)
         }
 
+        // 5. Process-wide admission: the TaskLocal guard above only covers one
+        //    task tree; a parallel tool batch can reach here CONCURRENTLY.
+        //    Local runs serialize (a queued run waits — visible in the feed);
+        //    remote runs fan out. This is what makes two spawns in one batch
+        //    safe instead of a concurrent-GPU handoff race.
+        let admissionClass = kind.admissionClass(resolved)
+        let admission = await SubagentAdmission.shared.admit(
+            admissionClass,
+            onWait: { [feed] active in
+                feed.emitPhase("waiting for local GPU", detail: active)
+            }
+        )
+        switch admission {
+        case .admitted:
+            break
+        case .timedOut(let active):
+            let message =
+                "\(tool) is waiting on \(active) that did not finish in time. "
+                + "Retry when the running subagent completes."
+            feed.finish(success: false, summary: message)
+            return ToolEnvelope.failure(
+                kind: .unavailable,
+                message: message,
+                tool: tool,
+                retryable: true
+            )
+        case .cancelled:
+            let message = "Run cancelled while waiting for another subagent to finish."
+            feed.finish(success: false, summary: message)
+            return ToolEnvelope.failure(
+                kind: .executionError,
+                message: message,
+                tool: tool,
+                retryable: false
+            )
+        }
+
         let effectiveHandoff = handoff ?? kind.makeHandoff()
         let started = Date()
 
-        // 5. Run under the recursion guard, wrapped by the optional handoff.
+        // 6. Run under the recursion guard, wrapped by the optional handoff.
+        //    The admission slot is held for the WHOLE wrapped run (handoff
+        //    included) and released on every exit path below.
         do {
+            // Post-run cache counters must be captured INSIDE the handoff wrap
+            // (after the kind's run, BEFORE the restore leg): restoring the
+            // orchestrator can evict the subagent model under a single-model
+            // policy, shutting down its engine and losing the counters.
+            let cacheCapture = PostRunCacheCapture()
             let result = try await SubagentSession.$activeKindId.withValue(kind.capability.id) {
                 try await effectiveHandoff.around(
                     scope: scope,
                     resolved: resolved,
                     feed: feed
                 ) {
-                    try await kind.run(scope, resolved, feed: feed, interrupt: interrupt)
+                    let r = try await kind.run(scope, resolved, feed: feed, interrupt: interrupt)
+                    if resolved.isLocal {
+                        cacheCapture.value = await ModelRuntime.batchDiagnosticsSnapshot()
+                    }
+                    return r
                 }
             }
+            await SubagentAdmission.shared.release(admissionClass)
+
+            // Residency telemetry: phase durations derived from the feed's own
+            // event timeline (the handoff emits its phases there), plus the
+            // post-run cache counters for local runs (prefix/L2 state at run
+            // end — the resume prefix-hit / L2 disk-cache mitigation signal).
+            var payload = result.payload
+            var residency: [String: Any] = [:]
+            let phases = Self.residencyPhaseTimings(
+                events: feed.currentEvents(),
+                endedAt: Date()
+            )
+            if !phases.isEmpty {
+                residency["phases"] = Dictionary(
+                    uniqueKeysWithValues: phases.map { ($0.phase, ($0.seconds * 100).rounded() / 100) }
+                )
+                residency["phase_order"] = phases.map(\.phase)
+                let summary = phases.map { String(format: "%@ %.1fs", $0.phase, $0.seconds) }
+                    .joined(separator: " · ")
+                feed.emit(
+                    SubagentActivityEvent(kind: .narrate, title: "handoff timings", detail: summary)
+                )
+            }
+            if let snapshot = cacheCapture.value {
+                residency["post_run_cache"] = [
+                    "prefix_hits": snapshot.prefixHits,
+                    "prefix_misses": snapshot.prefixMisses,
+                    "disk_l2_hits": snapshot.diskL2Hits,
+                    "disk_l2_misses": snapshot.diskL2Misses,
+                    "disk_l2_stores": snapshot.diskL2Stores,
+                ]
+            }
+            if !residency.isEmpty {
+                payload["residency"] = residency
+            }
+
             feed.finish(success: true, summary: result.summary ?? "")
             SubagentTelemetry.record(
                 kindId: kind.capability.id,
                 success: true,
-                elapsed: Date().timeIntervalSince(started)
+                elapsed: Date().timeIntervalSince(started),
+                usage: payload["usage"] as? [String: Any],
+                phases: phases
             )
-            return ToolEnvelope.success(tool: tool, result: result.payload)
+            return ToolEnvelope.success(tool: tool, result: payload)
         } catch {
+            await SubagentAdmission.shared.release(admissionClass)
             let env = envelope(for: error, tool: tool)
             feed.finish(success: false, summary: ToolEnvelope.failureMessage(env))
             SubagentTelemetry.record(
                 kindId: kind.capability.id,
                 success: false,
-                elapsed: Date().timeIntervalSince(started)
+                elapsed: Date().timeIntervalSince(started),
+                phases: Self.residencyPhaseTimings(
+                    events: feed.currentEvents(),
+                    endedAt: Date()
+                )
             )
             return env
         }
+    }
+
+    /// Residency-relevant phase titles whose durations are worth reporting:
+    /// the admission queue wait, the single-residency handoff legs, and the
+    /// coexistence idle drain. `running`/`generating` and kind-specific
+    /// phases are excluded — the payload already carries `elapsed_seconds`.
+    static let timedPhaseTitles: Set<String> = [
+        "waiting for local GPU",
+        "waiting_for_chat_idle",
+        "unloading_chat_models",
+        "restoring_chat_models",
+        "restoring_chat_models_retry",
+        "coexisting",
+    ]
+
+    /// Derive phase durations from a feed's event timeline: a timed phase
+    /// lasts until the NEXT event of any kind (or `endedAt` for the last
+    /// event). Pure — unit-testable with synthetic events.
+    static func residencyPhaseTimings(
+        events: [SubagentActivityEvent],
+        endedAt: Date
+    ) -> [(phase: String, seconds: Double)] {
+        var timings: [(phase: String, seconds: Double)] = []
+        for (index, event) in events.enumerated() {
+            guard event.kind == .phase, timedPhaseTitles.contains(event.title) else { continue }
+            let end = index + 1 < events.count ? events[index + 1].timestamp : endedAt
+            let seconds = max(0, end.timeIntervalSince(event.timestamp))
+            timings.append((phase: event.title, seconds: seconds))
+        }
+        return timings
     }
 
     /// Map a thrown error to the canonical failure envelope. `SubagentError`
@@ -141,4 +283,11 @@ public enum SubagentSession {
         if let se = error as? SubagentError { return se.envelope(tool: tool) }
         return ToolEnvelope.fromError(error, tool: tool)
     }
+}
+
+/// Reference box carrying the run-end cache snapshot out of the handoff
+/// closure (written once inside the wrap, read after it returns — a
+/// happens-before ordering, so a plain box is sufficient).
+private final class PostRunCacheCapture: @unchecked Sendable {
+    var value: BatchDiagnosticsSnapshot?
 }

--- a/Packages/OsaurusCore/Tests/AgentDelegation/SubagentConfigurationTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/SubagentConfigurationTests.swift
@@ -24,7 +24,9 @@ struct SubagentConfigurationTests {
         #expect(config.permissionDefaults.policy(for: "spawn") == .ask)
         #expect(config.permissionDefaults.policy(for: "image") == .ask)
         #expect(config.budgets.maxDelegateTokens == 2048)
-        #expect(config.budgets.maxDelegateTurns == 1)
+        // 2 turns so a first tool-refusal envelope (text-only spawn) still
+        // leaves the model one turn to produce its digest.
+        #expect(config.budgets.maxDelegateTurns == 2)
         #expect(config.budgets.maxToolCalls == 0)
         #expect(config.budgets.maxElapsedSeconds == 120)
     }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -215,6 +215,17 @@ struct AgentToolLoopTests {
         #expect(surface.executedCalls.count == max)
     }
 
+    @Test func nearLimitNoticeAddsDelegationNudgeOnlyWhenSpawnVisible() {
+        let plain = AgentToolLoop.contextNearLimitNotice(spawnAvailable: false)
+        #expect(plain.contains("Context is nearly full"))
+        #expect(!plain.contains("spawn"))
+
+        let nudged = AgentToolLoop.contextNearLimitNotice(spawnAvailable: true)
+        #expect(nudged.contains("Context is nearly full"))
+        #expect(nudged.contains("spawn tool"))
+        #expect(nudged.contains("self-contained input"))
+    }
+
     @Test func budgetWarningStagedAtThreshold() async throws {
         // maxIterations 5, threshold 3: after iteration 2 remaining == 3,
         // so iterations 3, 4, 5 must each see the warning notice.

--- a/Packages/OsaurusCore/Tests/Chat/SpawnGuidanceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SpawnGuidanceTests.swift
@@ -135,6 +135,42 @@ struct SpawnGuidanceTests {
         #expect(!agentsOnly.contains("`spawn_model(input, model)`"))
     }
 
+    // MARK: - Renderer: tool reach + parallelism policy
+
+    @Test("tool-reach line tracks the launching agent's SpawnToolAccess")
+    func toolReachLineTracksAccess() {
+        let textOnly = SystemPromptTemplates.spawnGuidance(
+            agents: [agent("helper")],
+            models: [],
+            toolAccess: SpawnToolAccess.none
+        )
+        #expect(textOnly.contains("Workers are text-only"))
+        #expect(!textOnly.contains("Workers CAN read files"))
+
+        let readOnly = SystemPromptTemplates.spawnGuidance(
+            agents: [agent("helper")],
+            models: [],
+            toolAccess: .readOnly
+        )
+        #expect(readOnly.contains("Workers CAN read files"))
+        #expect(readOnly.contains("file_read"))
+        #expect(!readOnly.contains("Workers are text-only"))
+    }
+
+    @Test("context-offload framing, self-contained input rule, and the parallel policy are always present")
+    func coreRulesAlwaysPresent() {
+        let text = SystemPromptTemplates.spawnGuidance(
+            agents: [agent("helper")],
+            models: []
+        )
+        #expect(text.contains("compact result digest"))
+        #expect(text.contains("bulk reading + summarization"))
+        #expect(text.contains("COMPLETE task as a self-contained prompt"))
+        #expect(text.contains("not this conversation"))
+        #expect(text.contains("may run in parallel"))
+        #expect(text.contains("local targets run one at a time"))
+    }
+
     @Test("a note is only rendered when present (no dangling em-dash for note-less models)")
     func noteOnlyRendersWhenPresent() {
         let text = SystemPromptTemplates.spawnGuidance(

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnToolsetTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnToolsetTests.swift
@@ -1,0 +1,203 @@
+//
+//  SpawnToolsetTests.swift
+//  OsaurusCoreTests
+//
+//  Unit coverage for the spawn child toolset (Phase 2 context offload):
+//  the `SpawnToolAccess` gate, the allowlist refusal, and the per-run
+//  `maxToolCalls` cap — using the injection seams so no live ToolRegistry
+//  or model is needed.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SpawnToolsetTests {
+    private func spec(_ name: String) -> Tool {
+        Tool(
+            type: "function",
+            function: ToolFunction(name: name, description: nil, parameters: nil)
+        )
+    }
+
+    private func invocation(_ name: String) -> ServiceToolInvocation {
+        ServiceToolInvocation(toolName: name, jsonArguments: "{}")
+    }
+
+    @Test("access none yields no toolset (text-only run)")
+    func noneYieldsNil() async {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: SpawnToolAccess.none,
+            maxToolCalls: 4,
+            feed: nil,
+            specs: [spec("file_read")],
+            dispatch: { _ in "unreachable" }
+        )
+        #expect(toolset == nil)
+    }
+
+    @Test("readOnly with no registered tools yields no toolset")
+    func emptySpecsYieldNil() async {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: .readOnly,
+            maxToolCalls: 4,
+            feed: nil,
+            specs: [],
+            dispatch: { _ in "unreachable" }
+        )
+        #expect(toolset == nil)
+    }
+
+    @Test("allowed tool dispatches; non-allowlisted tool is refused")
+    func allowlistEnforced() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: .readOnly,
+            maxToolCalls: 4,
+            feed: nil,
+            specs: [spec("file_read"), spec("file_search")],
+            dispatch: { inv in "ran:\(inv.toolName)" }
+        )
+        let set = try #require(toolset)
+        #expect(set.specs.count == 2)
+
+        let ok = await set.execute(invocation("file_read"))
+        #expect(ok == "ran:file_read")
+
+        let refused = await set.execute(invocation("delete_everything"))
+        #expect(ToolEnvelope.isError(refused))
+        #expect(ToolEnvelope.failureMessage(refused).contains("not available inside this subagent"))
+    }
+
+    @Test("maxToolCalls cap refuses further calls with budget copy")
+    func toolCallCapEnforced() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: .readOnly,
+            maxToolCalls: 2,
+            feed: nil,
+            specs: [spec("file_read")],
+            dispatch: { _ in "ok" }
+        )
+        let set = try #require(toolset)
+
+        let first = await set.execute(invocation("file_read"))
+        let second = await set.execute(invocation("file_read"))
+        let third = await set.execute(invocation("file_read"))
+        #expect(first == "ok")
+        #expect(second == "ok")
+        #expect(ToolEnvelope.isError(third))
+        #expect(ToolEnvelope.failureMessage(third).contains("Tool-call budget (2) exhausted"))
+    }
+
+    @Test("maxToolCalls 0 falls back to the default read-only cap")
+    func zeroCapUsesDefault() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: .readOnly,
+            maxToolCalls: 0,
+            feed: nil,
+            specs: [spec("file_read")],
+            dispatch: { _ in "ok" }
+        )
+        let set = try #require(toolset)
+
+        var successes = 0
+        for _ in 0 ..< (TextSubagentKind.defaultReadOnlyToolCallCap + 1) {
+            let result = await set.execute(invocation("file_read"))
+            if result == "ok" { successes += 1 }
+        }
+        #expect(successes == TextSubagentKind.defaultReadOnlyToolCallCap)
+    }
+
+    @Test("refused non-allowlisted call does not consume the cap")
+    func refusalDoesNotBurnBudget() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: .readOnly,
+            maxToolCalls: 1,
+            feed: nil,
+            specs: [spec("file_read")],
+            dispatch: { _ in "ok" }
+        )
+        let set = try #require(toolset)
+
+        _ = await set.execute(invocation("not_allowed"))
+        let allowed = await set.execute(invocation("file_read"))
+        #expect(allowed == "ok")
+    }
+
+    @Test("cancel-reason mapping: user stop / parent cancel / deadline get distinct honest copy")
+    func cancelReasonMapping() {
+        // User stop → user_denied with "stopped by the user" (NOT a timeout).
+        let userStop = TextSubagentKind.cancelError(
+            cause: .userInterrupt,
+            label: "worker",
+            maxElapsedSeconds: 120
+        )
+        guard case .userDenied(let userMessage) = userStop else {
+            Issue.record("user interrupt mapped to \(userStop), expected .userDenied")
+            return
+        }
+        #expect(userMessage.contains("stopped by the user"))
+        #expect(!userMessage.contains("time budget"))
+
+        // Parent task cancel → execution failure tied to the parent run.
+        let parent = TextSubagentKind.cancelError(
+            cause: .parentTask,
+            label: "worker",
+            maxElapsedSeconds: 120
+        )
+        guard case .executionFailed(let parentMessage, let retryable) = parent else {
+            Issue.record("parent cancel mapped to \(parent), expected .executionFailed")
+            return
+        }
+        #expect(parentMessage.contains("cancelled with the parent run"))
+        #expect(retryable == false)
+
+        // Deadline (and the unknown-cause fallback) → the time-budget copy.
+        for cause in [SubagentCancelCause.deadline, nil] {
+            let deadline = TextSubagentKind.cancelError(
+                cause: cause,
+                label: "worker",
+                maxElapsedSeconds: 120
+            )
+            guard case .timedOut(let deadlineMessage) = deadline else {
+                Issue.record("\(String(describing: cause)) mapped to \(deadline), expected .timedOut")
+                return
+            }
+            #expect(deadlineMessage.contains("120s time budget"))
+        }
+    }
+
+    @Test("effectiveSpawnToolAccess: default agent uses global, custom uses settings")
+    func effectiveAccessResolution() {
+        var config = SubagentConfiguration()
+        config.spawnToolAccess = .readOnly
+        var settings = AgentSettings.defaultDisabled
+        settings.spawnToolAccess = SpawnToolAccess.none
+
+        // Default agent → global config value.
+        #expect(
+            SubagentToolVisibility.effectiveSpawnToolAccess(
+                isDefault: true,
+                config: config,
+                settings: settings
+            ) == .readOnly
+        )
+        // Custom agent → its own settings, not the global.
+        #expect(
+            SubagentToolVisibility.effectiveSpawnToolAccess(
+                isDefault: false,
+                config: config,
+                settings: settings
+            ) == SpawnToolAccess.none
+        )
+        // Missing settings → safe text-only default.
+        #expect(
+            SubagentToolVisibility.effectiveSpawnToolAccess(
+                isDefault: false,
+                config: config,
+                settings: nil
+            ) == SpawnToolAccess.none
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionTests.swift
@@ -1,0 +1,309 @@
+//
+//  SubagentAdmissionTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Unit coverage of the process-wide admission gate that serializes local
+//  subagent runs (the parallel-batch handoff race fix) while letting remote
+//  runs fan out. Uses a private instance with a fast poll so the tests are
+//  deterministic and quick; one session-level test proves two exclusive runs
+//  never overlap end to end through `SubagentSession.run`.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("SubagentAdmission")
+struct SubagentAdmissionTests {
+
+    private func makeGate() -> SubagentAdmission {
+        SubagentAdmission(pollNanoseconds: 2_000_000)  // 2 ms poll for tests
+    }
+
+    @Test("remote admits concurrently, even while an exclusive run is active")
+    func remoteAlwaysAdmits() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localExclusive) == .admitted)
+        #expect(await gate.admit(.remote) == .admitted)
+        #expect(await gate.admit(.remote) == .admitted)
+        let counts = await gate.snapshot()
+        #expect(counts.exclusive == 1)
+        #expect(counts.remote == 2)
+        await gate.release(.remote)
+        await gate.release(.remote)
+        await gate.release(.localExclusive)
+    }
+
+    @Test("in-place runs coexist with each other")
+    func inPlaceCoexists() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localInPlace) == .admitted)
+        #expect(await gate.admit(.localInPlace) == .admitted)
+        let counts = await gate.snapshot()
+        #expect(counts.inPlace == 2)
+        await gate.release(.localInPlace)
+        await gate.release(.localInPlace)
+    }
+
+    @Test("a second exclusive run queues until the first releases")
+    func exclusiveSerializes() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localExclusive) == .admitted)
+
+        let waited = WaitFlag()
+        let second = Task {
+            await gate.admit(
+                .localExclusive,
+                timeoutSeconds: 5,
+                onWait: { _ in waited.set() }
+            )
+        }
+        // Give the second admit time to hit the wait loop, then release.
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        await gate.release(.localExclusive)
+
+        let outcome = await second.value
+        #expect(outcome == .admitted)
+        #expect(waited.isSet)
+        await gate.release(.localExclusive)
+        let counts = await gate.snapshot()
+        #expect(counts.exclusive == 0)
+    }
+
+    @Test("an exclusive run waits for in-place runs to drain")
+    func exclusiveWaitsForInPlace() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localInPlace) == .admitted)
+        let second = Task {
+            await gate.admit(.localExclusive, timeoutSeconds: 5)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        await gate.release(.localInPlace)
+        #expect(await second.value == .admitted)
+        await gate.release(.localExclusive)
+    }
+
+    @Test("an in-place run is blocked only by an exclusive run")
+    func inPlaceBlockedByExclusive() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localExclusive) == .admitted)
+        let second = Task {
+            await gate.admit(.localInPlace, timeoutSeconds: 5)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        await gate.release(.localExclusive)
+        #expect(await second.value == .admitted)
+        await gate.release(.localInPlace)
+    }
+
+    @Test("a blocked run times out with the active-run description")
+    func timeout() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localExclusive) == .admitted)
+        let outcome = await gate.admit(.localExclusive, timeoutSeconds: 0.05)
+        guard case .timedOut(let active) = outcome else {
+            Issue.record("expected .timedOut, got \(outcome)")
+            return
+        }
+        #expect(active.contains("local handoff"))
+        await gate.release(.localExclusive)
+    }
+
+    @Test("cancelling a waiting task returns .cancelled without taking a slot")
+    func cancelledWaiter() async {
+        let gate = makeGate()
+        #expect(await gate.admit(.localExclusive) == .admitted)
+        let waiter = Task {
+            await gate.admit(.localExclusive, timeoutSeconds: 30)
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        waiter.cancel()
+        #expect(await waiter.value == .cancelled)
+        let counts = await gate.snapshot()
+        #expect(counts.exclusive == 1)
+        await gate.release(.localExclusive)
+    }
+
+    @Test("release clamps at zero (defensive against double-release)")
+    func releaseClamps() async {
+        let gate = makeGate()
+        await gate.release(.localExclusive)
+        let counts = await gate.snapshot()
+        #expect(counts.exclusive == 0)
+        #expect(await gate.admit(.localExclusive) == .admitted)
+        await gate.release(.localExclusive)
+    }
+
+    // MARK: - Plan → class mapping
+
+    @Test("residency plan maps onto the admission class")
+    func planMapping() {
+        let unloadPlan = ResidencyPlan(shouldUnload: true)
+        #expect(
+            SubagentResidency.admissionClass(isLocal: true, plan: unloadPlan) == .localExclusive
+        )
+        #expect(SubagentResidency.admissionClass(isLocal: true, plan: .none) == .localInPlace)
+        #expect(SubagentResidency.admissionClass(isLocal: false, plan: .none) == .remote)
+    }
+}
+
+// MARK: - Session-level serialization
+
+@Suite("SubagentSession admission")
+struct SubagentSessionAdmissionTests {
+
+    /// A kind that reports `.localExclusive` and records run overlap.
+    private final class ExclusiveKind: SubagentKind, @unchecked Sendable {
+        let capability = SubagentCapability(
+            id: "exclusive-scripted",
+            toolNames: ["exclusive-scripted"],
+            gate: .sandboxExec
+        )
+        let tracker: OverlapTracker
+
+        init(tracker: OverlapTracker) { self.tracker = tracker }
+
+        func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel {
+            ResolvedModel(name: "scripted-local", id: "scripted-local", isLocal: true)
+        }
+        func permission(_ scope: SubagentScope, _ resolved: ResolvedModel) async -> SubagentDecision {
+            .allow
+        }
+        func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+            .localExclusive
+        }
+        func run(
+            _ scope: SubagentScope,
+            _ resolved: ResolvedModel,
+            feed: SubagentFeed,
+            interrupt: InterruptToken
+        ) async throws -> SubagentResult {
+            tracker.enter()
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            tracker.exit()
+            return SubagentResult(payload: ["kind": "scripted", "summary": "done"])
+        }
+    }
+
+    @Test("two concurrent exclusive runs never overlap through the host")
+    func exclusiveRunsSerializeThroughSession() async {
+        let tracker = OverlapTracker()
+        let a = ExclusiveKind(tracker: tracker)
+        let b = ExclusiveKind(tracker: tracker)
+        async let first = SubagentSession.run(a, tool: "exclusive-scripted")
+        async let second = SubagentSession.run(b, tool: "exclusive-scripted")
+        let envelopes = await [first, second]
+        #expect(envelopes.allSatisfy { ToolEnvelope.isSuccess($0) })
+        #expect(tracker.maxConcurrent == 1)
+        #expect(tracker.totalRuns == 2)
+    }
+
+    /// A kind that reports `.remote` and holds inside `run` until BOTH runs
+    /// are in flight (rendezvous), proving remote spawns fan out in parallel.
+    /// If remote runs were wrongly serialized, the first would hold its slot
+    /// while waiting for a second that can never start — the rendezvous times
+    /// out and `maxConcurrent` stays 1.
+    private final class RemoteKind: SubagentKind, @unchecked Sendable {
+        let capability = SubagentCapability(
+            id: "remote-scripted",
+            toolNames: ["remote-scripted"],
+            gate: .sandboxExec
+        )
+        let tracker: OverlapTracker
+
+        init(tracker: OverlapTracker) { self.tracker = tracker }
+
+        func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel {
+            ResolvedModel(name: "scripted-remote", isLocal: false)
+        }
+        func permission(_ scope: SubagentScope, _ resolved: ResolvedModel) async -> SubagentDecision {
+            .allow
+        }
+        func admissionClass(_ resolved: ResolvedModel) -> SubagentAdmissionClass {
+            .remote
+        }
+        func run(
+            _ scope: SubagentScope,
+            _ resolved: ResolvedModel,
+            feed: SubagentFeed,
+            interrupt: InterruptToken
+        ) async throws -> SubagentResult {
+            tracker.enter()
+            defer { tracker.exit() }
+            // Rendezvous on ARRIVALS (monotonic), not the live count — the
+            // sibling may already have exited by the time this run polls.
+            let deadline = Date().addingTimeInterval(2)
+            while tracker.totalRuns < 2, Date() < deadline {
+                try? await Task.sleep(nanoseconds: 2_000_000)
+            }
+            return SubagentResult(payload: ["kind": "scripted", "summary": "done"])
+        }
+    }
+
+    @Test("two concurrent remote runs overlap through the host (parallel fan-out)")
+    func remoteRunsFanOutThroughSession() async {
+        let tracker = OverlapTracker()
+        let a = RemoteKind(tracker: tracker)
+        let b = RemoteKind(tracker: tracker)
+        async let first = SubagentSession.run(a, tool: "remote-scripted")
+        async let second = SubagentSession.run(b, tool: "remote-scripted")
+        let envelopes = await [first, second]
+        #expect(envelopes.allSatisfy { ToolEnvelope.isSuccess($0) })
+        #expect(tracker.maxConcurrent == 2)
+        #expect(tracker.totalRuns == 2)
+    }
+}
+
+// MARK: - Test helpers
+
+private final class WaitFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return flag
+    }
+    func set() {
+        lock.lock()
+        flag = true
+        lock.unlock()
+    }
+}
+
+private final class OverlapTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var active = 0
+    private var _maxConcurrent = 0
+    private var _totalRuns = 0
+
+    var currentActive: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return active
+    }
+    var maxConcurrent: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _maxConcurrent
+    }
+    var totalRuns: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _totalRuns
+    }
+
+    func enter() {
+        lock.lock()
+        active += 1
+        _maxConcurrent = max(_maxConcurrent, active)
+        _totalRuns += 1
+        lock.unlock()
+    }
+    func exit() {
+        lock.lock()
+        active -= 1
+        lock.unlock()
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentResidencyTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentResidencyTests.swift
@@ -125,6 +125,220 @@ struct SubagentResidencyTests {
     func handoffMapping() {
         #expect(SubagentResidency.handoff(for: ResidencyPlan(shouldUnload: true)) is ResidencyHandoff)
         #expect(SubagentResidency.handoff(for: .none) is PassthroughHandoff)
+        #expect(
+            SubagentResidency.handoff(
+                for: ResidencyPlan(shouldUnload: false, coexists: true)
+            ) is CoexistenceHandoff
+        )
+    }
+
+    // MARK: - RAM-aware coexistence gate
+
+    /// 10 GB model, plenty of reclaimable RAM, well under the flexible cap.
+    private func roomyCoexistence(allowed: Bool = true) -> SubagentCoexistence {
+        SubagentCoexistence(
+            allowed: allowed,
+            availableBytes: 64 * 1_073_741_824,
+            residentBytes: 8 * 1_073_741_824,
+            flexibleBudgetBytes: 96 * 1_073_741_824
+        )
+    }
+
+    private let tenGB: Int64 = 10 * 1_073_741_824
+
+    @Test("coexistence: both fit under flexible policy → run alongside, no unload")
+    func coexistenceFitsRunsAlongside() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: roomyCoexistence()
+        )
+        #expect(plan.shouldUnload == false)
+        #expect(plan.coexists == true)
+        #expect(plan.maxElapsedSeconds == 90)
+    }
+
+    @Test("coexistence disabled (default) keeps the single-residency handoff")
+    func coexistenceDisabledKeepsHandoff() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: .disabled
+        )
+        #expect(plan.shouldUnload == true)
+        #expect(plan.coexists == false)
+    }
+
+    @Test("coexistence: tight reclaimable RAM falls back to the handoff")
+    func coexistenceTightRAMFallsBack() throws {
+        var inputs = roomyCoexistence()
+        // 10 GB * 1.3 + 3 GB headroom = 16 GB needed; only 12 GB available.
+        inputs.availableBytes = 12 * 1_073_741_824
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: inputs
+        )
+        #expect(plan.shouldUnload == true)
+        #expect(plan.coexists == false)
+    }
+
+    @Test("coexistence: exceeding the flexible resident budget falls back (runtime would evict)")
+    func coexistenceOverFlexibleBudgetFallsBack() throws {
+        var inputs = roomyCoexistence()
+        // resident 8 GB + incoming 10 GB > 16 GB cap → the runtime's own
+        // budget eviction would evict the orchestrator with no restore lease.
+        inputs.flexibleBudgetBytes = 16 * 1_073_741_824
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: inputs
+        )
+        #expect(plan.shouldUnload == true)
+        #expect(plan.coexists == false)
+    }
+
+    @Test("coexistence: unknown model size cannot prove the fit → handoff")
+    func coexistenceUnknownSizeFallsBack() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: 0,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: roomyCoexistence()
+        )
+        #expect(plan.shouldUnload == true)
+        #expect(plan.coexists == false)
+    }
+
+    @Test("coexistence applies even with the handoff toggle OFF (nothing is unloaded)")
+    func coexistenceBypassesHandoffToggle() throws {
+        let plan = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-b",
+            residentChatModels: ["local-a"],
+            handoffEnabled: false,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: roomyCoexistence()
+        )
+        #expect(plan.shouldUnload == false)
+        #expect(plan.coexists == true)
+    }
+
+    @Test("coexistence never fires for same-model or remote targets")
+    func coexistenceIrrelevantForSameOrRemote() throws {
+        let same = try SubagentResidency.decidePlan(
+            isLocal: true,
+            modelName: "local-a",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: roomyCoexistence()
+        )
+        #expect(same.coexists == false)
+
+        let remote = try SubagentResidency.decidePlan(
+            isLocal: false,
+            modelName: "xai/grok-4.3",
+            residentChatModels: ["local-a"],
+            handoffEnabled: true,
+            ramSafetyEnabled: true,
+            requiredBytes: tenGB,
+            idleWaitSeconds: 90,
+            deniedMessage: denied,
+            coexistence: roomyCoexistence()
+        )
+        #expect(remote.coexists == false)
+    }
+
+    @Test("admission class: coexist and unload plans are exclusive; in-place shares; remote never contends")
+    func admissionClassMapping() {
+        #expect(
+            SubagentResidency.admissionClass(
+                isLocal: true,
+                plan: ResidencyPlan(shouldUnload: true)
+            ) == .localExclusive
+        )
+        #expect(
+            SubagentResidency.admissionClass(
+                isLocal: true,
+                plan: ResidencyPlan(shouldUnload: false, coexists: true)
+            ) == .localExclusive
+        )
+        #expect(
+            SubagentResidency.admissionClass(isLocal: true, plan: .none) == .localInPlace
+        )
+        #expect(
+            SubagentResidency.admissionClass(isLocal: false, plan: .none) == .remote
+        )
+    }
+
+    @Test("coexistence handoff: waits for idle then runs; a busy GPU refuses the run")
+    func coexistenceHandoffIdleGate() async throws {
+        let scope = SubagentScope(
+            sessionId: "coexist-test",
+            toolCallId: "call-1",
+            agentId: UUID()
+        )
+        let resolved = ResolvedModel(name: "local-b", isLocal: true)
+        let feed = SubagentFeed(toolCallId: "call-1", kindId: "spawn", title: "test")
+
+        let ranBody = CoexistenceProbe()
+        let idle = CoexistenceHandoff(maxElapsedSeconds: 30, waitForIdle: { _ in true })
+        let result = try await idle.around(scope: scope, resolved: resolved, feed: feed) {
+            ranBody.mark()
+            return SubagentResult(payload: ["ok": true], summary: "done")
+        }
+        #expect(result.summary == "done")
+        #expect(ranBody.wasMarked)
+
+        let busy = CoexistenceHandoff(maxElapsedSeconds: 30, waitForIdle: { _ in false })
+        do {
+            _ = try await busy.around(scope: scope, resolved: resolved, feed: feed) {
+                Issue.record("body must not run when the idle wait fails")
+                return SubagentResult(payload: [:], summary: "")
+            }
+            Issue.record("expected an unavailable error")
+        } catch let error as SubagentError {
+            guard case .unavailable = error else {
+                Issue.record("expected .unavailable, got \(error)")
+                return
+            }
+        }
     }
 
     // MARK: - Named four-direction proof
@@ -235,5 +449,21 @@ struct SubagentResidencyTests {
             deniedMessage: denied
         )
         #expect(plan.shouldUnload == false)
+    }
+}
+
+/// Tiny thread-safe flag for the handoff body probe.
+private final class CoexistenceProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var marked = false
+    func mark() {
+        lock.lock()
+        defer { lock.unlock() }
+        marked = true
+    }
+    var wasMarked: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return marked
     }
 }

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentSessionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentSessionTests.swift
@@ -171,6 +171,82 @@ struct SubagentSessionTests {
         _ = await SubagentSession.run(kind, tool: "scripted")
         #expect(observedBox.value == "live")
     }
+
+    @Test("residency phase timings derive from the feed timeline (handoff legs only)")
+    func residencyPhaseTimingDerivation() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        func event(
+            _ title: String,
+            at offset: TimeInterval,
+            kind: SubagentActivityEvent.Kind = .phase
+        ) -> SubagentActivityEvent {
+            SubagentActivityEvent(
+                timestamp: t0.addingTimeInterval(offset),
+                kind: kind,
+                title: title
+            )
+        }
+        let events = [
+            event("waiting_for_chat_idle", at: 0),
+            event("unloading_chat_models", at: 1.5),
+            event("running", at: 4.5),
+            event("generating", at: 5.0, kind: .progress),
+            event("restoring_chat_models", at: 20.0),
+        ]
+        let timings = SubagentSession.residencyPhaseTimings(
+            events: events,
+            endedAt: t0.addingTimeInterval(28.0)
+        )
+        #expect(
+            timings.map(\.phase) == [
+                "waiting_for_chat_idle", "unloading_chat_models", "restoring_chat_models",
+            ]
+        )
+        #expect(abs(timings[0].seconds - 1.5) < 0.001)
+        #expect(abs(timings[1].seconds - 3.0) < 0.001)
+        // The final restore leg runs until the run's end timestamp.
+        #expect(abs(timings[2].seconds - 8.0) < 0.001)
+        // Kind-specific phases ("running") and progress rows are not timed.
+        #expect(!timings.contains { $0.phase == "running" })
+    }
+
+    @Test("a handoff-wrapped run reports residency phases in its payload")
+    func residencyPayloadFromScriptedHandoff() async {
+        let kind = ScriptedKind(needsHandoff: true)
+        // A handoff that emits the real phase titles around the body.
+        let handoff = PhaseEmittingHandoff()
+        let envelope = await SubagentSession.run(kind, tool: "scripted", handoff: handoff)
+        #expect(ToolEnvelope.isSuccess(envelope))
+        let payload = ToolEnvelope.successPayload(envelope) as? [String: Any]
+        let residency = payload?["residency"] as? [String: Any]
+        let phases = residency?["phases"] as? [String: Any]
+        #expect(phases?.keys.contains("waiting_for_chat_idle") == true)
+        #expect(phases?.keys.contains("unloading_chat_models") == true)
+        #expect(phases?.keys.contains("restoring_chat_models") == true)
+        let order = residency?["phase_order"] as? [String]
+        #expect(
+            order == [
+                "waiting_for_chat_idle", "unloading_chat_models", "restoring_chat_models",
+            ]
+        )
+    }
+}
+
+/// Handoff that emits the production phase titles around the body, so the
+/// session's payload derivation sees a realistic timeline without ModelRuntime.
+private struct PhaseEmittingHandoff: SubagentHandoff {
+    func around(
+        scope: SubagentScope,
+        resolved: ResolvedModel,
+        feed: SubagentFeed,
+        run body: () async throws -> SubagentResult
+    ) async throws -> SubagentResult {
+        feed.emitPhase("waiting_for_chat_idle", detail: nil)
+        feed.emitPhase("unloading_chat_models", detail: "local-a")
+        let result = try await body()
+        feed.emitPhase("restoring_chat_models", detail: "local-a")
+        return result
+    }
 }
 
 /// Tiny reference box so escaping `@Sendable` closures can hand a value back.

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1075,6 +1075,7 @@ struct AgentDetailView: View {
     /// from / into `AgentSettings`.
     @State private var subagentPermissions: SubagentPermissionDefaults = SubagentPermissionDefaults()
     @State private var subagentBudgets: SubagentBudgets = SubagentBudgets()
+    @State private var spawnToolAccess: SpawnToolAccess = .none
     /// Per-agent subagent model overrides keyed by capability id (computer_use /
     /// spawn). Empty/absent = inherit the kind's default model.
     /// Mirrored from / into `AgentSettings.subagentModelOverrides`.
@@ -3434,6 +3435,8 @@ struct AgentDetailView: View {
                 label: "Permission"
             )
             subagentPanelDivider
+            spawnToolAccessRow
+            subagentPanelDivider
             subagentBudgetRows
             subagentFootnote(
                 "Local handoff and RAM-safety for spawn jobs are system settings in Settings → Subagents."
@@ -3758,6 +3761,35 @@ struct AgentDetailView: View {
             get: { subagentBudgets[keyPath: keyPath] },
             set: {
                 subagentBudgets[keyPath: keyPath] = $0
+                debouncedSave()
+            }
+        )
+    }
+
+    /// Worker tool grant for spawned subagents: text-only (default) or the
+    /// curated read-only file set. What "read-only" reaches is enforced in
+    /// `TextSubagentKind.makeToolset`, not here.
+    private var spawnToolAccessRow: some View {
+        subagentControlRow(
+            "Worker tools",
+            subtitle:
+                "Let spawned workers read files themselves (file_read / file_search) so bulk reading stays out of this agent's context."
+        ) {
+            Picker("", selection: spawnToolAccessSelection) {
+                Text("Text-only", bundle: .module).tag(SpawnToolAccess.none)
+                Text("Read-only files", bundle: .module).tag(SpawnToolAccess.readOnly)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: 160)
+        }
+    }
+
+    private var spawnToolAccessSelection: Binding<SpawnToolAccess> {
+        Binding(
+            get: { spawnToolAccess },
+            set: {
+                spawnToolAccess = $0
                 debouncedSave()
             }
         )
@@ -6062,6 +6094,7 @@ struct AgentDetailView: View {
         subagentPermissions = agent.settings.subagentPermissions
         subagentBudgets = agent.settings.subagentBudgets
         subagentModelOverrides = agent.settings.subagentModelOverrides
+        spawnToolAccess = agent.settings.spawnToolAccess
         // Snapshot the global subagent config for the spawn-handoff warning.
         globalSubagentConfig = SubagentConfigurationStore.snapshot()
         hostWorkspacePath = agent.hostWorkspacePath
@@ -6287,7 +6320,8 @@ struct AgentDetailView: View {
                 imageEditModelId: imageEditModelId,
                 subagentPermissions: subagentPermissions,
                 subagentBudgets: subagentBudgets,
-                subagentModelOverrides: subagentModelOverrides
+                subagentModelOverrides: subagentModelOverrides,
+                spawnToolAccess: spawnToolAccess
             ),
             order: current.order
         )

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4122,9 +4122,20 @@ final class ChatSession: ObservableObject {
                                 historyTokens >= Int(Double(historyBudget) * 0.9)
                             {
                                 tokenBudgetNoticeFired = true
+                                // Delegation nudge rides along when a spawn tool
+                                // is actually in this run's frozen schema: a
+                                // tight window is exactly when offloading bulk
+                                // reading to a worker pays for itself.
+                                let spawnVisible = toolSpecs.contains {
+                                    $0.function.name == SubagentCapabilityRegistry.spawnAgentToolName
+                                        || $0.function.name
+                                            == SubagentCapabilityRegistry.spawnModelToolName
+                                }
                                 msgs = AgentLoopBudget.appendingTransientNotices(
                                     [
-                                        "[System Notice] Context is nearly full — older messages are being compacted. Wrap up the current work and provide a summary."
+                                        AgentToolLoop.contextNearLimitNotice(
+                                            spawnAvailable: spawnVisible
+                                        )
                                     ],
                                     to: msgs
                                 )

--- a/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
@@ -41,6 +41,13 @@ struct SubagentSettingsSection: View {
                                 "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper.",
                             isOn: $configuration.ramSafetyPreflightEnabled
                         )
+
+                        SettingsToggle(
+                            title: "Keep Chat Model Loaded (Coexistence)",
+                            description:
+                                "Experimental: when the server eviction policy is Flexible (Multi Model) and memory projections say both fit, load the helper model alongside the chat model instead of unloading and reloading it — skipping the swap round-trip on high-RAM Macs. Tight RAM or the Strict policy always falls back to the normal handoff.",
+                            isOn: $configuration.subagentCoexistenceEnabled
+                        )
                     }
                 }
             }

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -1846,6 +1846,31 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         public let recurse: Bool?
         /// Lifecycle phases the scripted kind emits onto the feed.
         public let phases: [String]?
+        /// Scripted lane: run this many copies CONCURRENTLY through the host
+        /// (one parallel tool batch). ≥2 selects the parallel-batch path; the
+        /// transcript then reports `maxConcurrent` + `runsCompleted`. Pair
+        /// with `needsHandoff` (local-exclusive → must serialize) or `remote`
+        /// (fan-out → must overlap).
+        public let parallel: Int?
+        /// Scripted lane: resolve as a REMOTE model (`isLocal: false`) so the
+        /// admission class is `.remote` — the parallel fan-out input.
+        public let remote: Bool?
+        /// Scripted lane: hold `run()` open this long (polling the interrupt
+        /// token every ~20 ms) so interrupts / sibling overlap can land.
+        public let runDelayMs: Int?
+        /// Scripted parallel lane: rendezvous — each run waits (bounded) until
+        /// ALL siblings have entered, so fan-out overlap is observed by
+        /// construction. Only set for concurrent-capable classes (`remote`);
+        /// a serialized batch would just burn the bounded wait.
+        public let rendezvous: Bool?
+        /// Scripted lane: attach canned `usage` + `context` accounting to the
+        /// success payload — deterministic CI coverage for the usage /
+        /// context-saved scoring plumbing the live spawn lanes ride.
+        public let includeUsageAccounting: Bool?
+        /// Scripted + live spawn lanes: trip the run's stop button (the real
+        /// `SubagentInterruptCenter` path) after this many milliseconds — the
+        /// interrupt-mid-generation lane. Expect `user_denied` + "stopped".
+        public let interruptAfterMs: Int?
 
         // --- live spawn lane inputs ---
         /// Spawnable agent name for the `spawn` lane.
@@ -1868,6 +1893,11 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// rejected") that must NOT be seeded. `input` is the task; `model` (when
         /// set) pins the target id, otherwise the run model is used.
         public let seedSpawnableModel: Bool?
+        /// Tool-capable spawn lane: grant the child this tool reach for the
+        /// run (`"readOnly"` → curated read-only toolset; nil/`"none"` →
+        /// text-only). Applied with the seeding snapshot/restore, so a
+        /// developer's real config is untouched.
+        public let seedSpawnToolAccess: String?
 
         // --- live spawn_model_residency lane inputs ---
         /// The chat/core ORCHESTRATOR model the residency decision is made
@@ -1885,6 +1915,27 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// `false` for a remote orchestrator (nothing local to make resident).
         /// nil → false.
         public let ensureResident: Bool?
+        /// Residency matrix lane: repeat the FULL production run this many
+        /// times back-to-back (rapid unload/reload cycles — the crash-safety
+        /// stressor). Every cycle must satisfy the per-cycle checks. nil → 1.
+        public let cycles: Int?
+        /// Residency matrix lane: a distinctive token appended to the input
+        /// with an instruction to echo it verbatim. EVERY cycle's digest must
+        /// contain it — the sentinel context-recall proof across the handoff.
+        public let sentinel: String?
+
+        // --- residency matrix expectations ---
+        /// Assert no NEW osaurus-related crash reports (`.ips`/`.crash` under
+        /// ~/Library/Logs/DiagnosticReports) appeared during the case — the
+        /// before/after crash-count gate from the manual proof campaigns.
+        public let expectNoNewCrashReports: Bool?
+        /// Assert the local orchestrator is verified GPU-resident again after
+        /// EVERY cycle (restore actually happened / in-place never dropped it).
+        /// Only meaningful with `ensureResident: true`.
+        public let expectRestoredResident: Bool?
+        /// Assert no raw parser/template/tool markers (`<think>`, `<|`,
+        /// `<tool_call>`, `<start_of_turn>`, …) leak into any cycle's digest.
+        public let expectNoMarkerLeaks: Bool?
 
         // --- live image lane inputs ---
         /// Prompt for the `image` lane (also the edit instruction).
@@ -1947,6 +1998,34 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         public let expectImageMode: String?
         /// Image lane: minimum number of images on success.
         public let minImages: Int?
+        /// Parallel-batch lane: exact peak overlap of run bodies. `1` pins
+        /// serialization (two local handoffs never overlap — the batch-race
+        /// guard); `2` pins remote fan-out (both actually ran concurrently).
+        public let expectMaxConcurrent: Int?
+        /// Parallel-batch lane: exact number of runs that must succeed (the
+        /// queued run completes rather than being refused or deadlocking).
+        public let expectRunsCompleted: Int?
+        /// Assert worker usage was recorded: `prompt_tokens` +
+        /// `completion_tokens` present and > 0 (per the proof rule that a
+        /// generation row without token accounting is not a pass).
+        public let expectUsageRecorded: Bool?
+        /// Assert context-saved accounting is present (`worker_tokens` > 0,
+        /// `digest_tokens` > 0, `context_saved_tokens` recorded) — the
+        /// measurable "delegation saved the parent context" row.
+        public let expectContextAccounting: Bool?
+        /// Minimum `context_saved_tokens` the delegation must have saved.
+        public let minContextSavedTokens: Int?
+        /// Residency phase names that must appear in the recorded phase
+        /// timings (e.g. `unloading_chat_models`, `restoring_chat_models`) —
+        /// the handoff-latency telemetry proof.
+        public let expectResidencyPhases: [String]?
+        /// Per-phase duration ceilings (seconds) on the recorded residency
+        /// phase timings — MicroPerf-style latency assertions. A phase listed
+        /// here must be present AND under its ceiling.
+        public let maxPhaseSeconds: [String: Double]?
+        /// Assert the post-run cache counters were captured for a local run
+        /// (`prefix_hits` / `disk_l2_*`) — the resume prefix-hit signal.
+        public let expectPostRunCache: Bool?
 
         public init(
             lane: String,
@@ -1956,13 +2035,25 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             runFailure: String? = nil,
             recurse: Bool? = nil,
             phases: [String]? = nil,
+            parallel: Int? = nil,
+            remote: Bool? = nil,
+            runDelayMs: Int? = nil,
+            rendezvous: Bool? = nil,
+            includeUsageAccounting: Bool? = nil,
+            interruptAfterMs: Int? = nil,
             agent: String? = nil,
             input: String? = nil,
             seedSpawnableAgent: Bool? = nil,
             seedSpawnableModel: Bool? = nil,
+            seedSpawnToolAccess: String? = nil,
             orchestrator: String? = nil,
             handoffEnabled: Bool? = nil,
             ensureResident: Bool? = nil,
+            cycles: Int? = nil,
+            sentinel: String? = nil,
+            expectNoNewCrashReports: Bool? = nil,
+            expectRestoredResident: Bool? = nil,
+            expectNoMarkerLeaks: Bool? = nil,
             prompt: String? = nil,
             sourcePaths: [String]? = nil,
             model: String? = nil,
@@ -1984,7 +2075,15 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             expectHandoffWrapped: Bool? = nil,
             expectNestedRefused: Bool? = nil,
             expectImageMode: String? = nil,
-            minImages: Int? = nil
+            minImages: Int? = nil,
+            expectMaxConcurrent: Int? = nil,
+            expectRunsCompleted: Int? = nil,
+            expectUsageRecorded: Bool? = nil,
+            expectContextAccounting: Bool? = nil,
+            minContextSavedTokens: Int? = nil,
+            expectResidencyPhases: [String]? = nil,
+            maxPhaseSeconds: [String: Double]? = nil,
+            expectPostRunCache: Bool? = nil
         ) {
             self.lane = lane
             self.needsHandoff = needsHandoff
@@ -1993,13 +2092,25 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.runFailure = runFailure
             self.recurse = recurse
             self.phases = phases
+            self.parallel = parallel
+            self.remote = remote
+            self.runDelayMs = runDelayMs
+            self.rendezvous = rendezvous
+            self.includeUsageAccounting = includeUsageAccounting
+            self.interruptAfterMs = interruptAfterMs
             self.agent = agent
             self.input = input
             self.seedSpawnableAgent = seedSpawnableAgent
             self.seedSpawnableModel = seedSpawnableModel
+            self.seedSpawnToolAccess = seedSpawnToolAccess
             self.orchestrator = orchestrator
             self.handoffEnabled = handoffEnabled
             self.ensureResident = ensureResident
+            self.cycles = cycles
+            self.sentinel = sentinel
+            self.expectNoNewCrashReports = expectNoNewCrashReports
+            self.expectRestoredResident = expectRestoredResident
+            self.expectNoMarkerLeaks = expectNoMarkerLeaks
             self.prompt = prompt
             self.sourcePaths = sourcePaths
             self.model = model
@@ -2022,6 +2133,14 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.expectNestedRefused = expectNestedRefused
             self.expectImageMode = expectImageMode
             self.minImages = minImages
+            self.expectMaxConcurrent = expectMaxConcurrent
+            self.expectRunsCompleted = expectRunsCompleted
+            self.expectUsageRecorded = expectUsageRecorded
+            self.expectContextAccounting = expectContextAccounting
+            self.minContextSavedTokens = minContextSavedTokens
+            self.expectResidencyPhases = expectResidencyPhases
+            self.maxPhaseSeconds = maxPhaseSeconds
+            self.expectPostRunCache = expectPostRunCache
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerSubagent.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerSubagent.swift
@@ -97,6 +97,7 @@ extension EvalRunner {
             return scriptedSpecError(testCase, label: label, modelId: modelId, field: "runFailure", raw: raw)
         }
 
+        let parallel = exp.parallel ?? 1
         let spec = ScriptedSubagentSpec(
             kindId: "scripted",
             needsHandoff: exp.needsHandoff ?? false,
@@ -104,9 +105,24 @@ extension EvalRunner {
             resolveFailure: exp.resolveFailure.flatMap(ScriptedSubagentSpec.Failure.init(rawValue:)),
             runFailure: exp.runFailure.flatMap(ScriptedSubagentSpec.Failure.init(rawValue:)),
             recurse: exp.recurse ?? false,
-            phases: exp.phases ?? ["running"]
+            phases: exp.phases ?? ["running"],
+            remote: exp.remote ?? false,
+            runDelayMs: exp.runDelayMs ?? 0,
+            includeUsageAccounting: exp.includeUsageAccounting ?? false,
+            rendezvousArrivals: (exp.rendezvous ?? false) ? max(2, parallel) : 0
         )
-        let transcript = await SubagentJobEvaluator.runScripted(spec)
+        // `parallel ≥ 2` drives the parallel-batch path (one batch, N
+        // concurrent host runs, shared overlap probe); otherwise one run,
+        // optionally stopped mid-run through the real interrupt center.
+        let transcript: SubagentJobTranscript
+        if parallel >= 2 {
+            transcript = await SubagentJobEvaluator.runScriptedParallelBatch(spec, count: parallel)
+        } else {
+            transcript = await SubagentJobEvaluator.runScripted(
+                spec,
+                interruptAfterMs: exp.interruptAfterMs
+            )
+        }
         let (passed, notes) = score(transcript, against: exp)
         return EvalCaseReport(
             id: testCase.id,
@@ -142,16 +158,23 @@ extension EvalRunner {
         // its own pinned model), making `spawn` a real cross-model column.
         // Positive cases opt into agent seeding (so they RUN anywhere across
         // models); negative guards (not-spawnable) must NOT be seeded.
+        let interruptAfterMs = exp.interruptAfterMs
         let transcript: SubagentJobTranscript
         if exp.seedSpawnableAgent == true {
             transcript = await SubagentJobEvaluator.withSpawnableAgent(name: agent) {
-                await SubagentJobEvaluator.runSpawn(agent: agent, input: input, modelId: modelId)
+                await SubagentJobEvaluator.runSpawn(
+                    agent: agent,
+                    input: input,
+                    modelId: modelId,
+                    interruptAfterMs: interruptAfterMs
+                )
             }
         } else {
             transcript = await SubagentJobEvaluator.runSpawn(
                 agent: agent,
                 input: input,
-                modelId: modelId
+                modelId: modelId,
+                interruptAfterMs: interruptAfterMs
             )
         }
         return finishLive(testCase, exp: exp, transcript: transcript, lane: "spawn", modelId: modelId, label: label)
@@ -181,13 +204,35 @@ extension EvalRunner {
         // spawnable pool (so they RUN anywhere); negative guards (not-spawnable)
         // must NOT be seeded.
         let target = exp.model ?? modelId
+        let interruptAfterMs = exp.interruptAfterMs
         let transcript: SubagentJobTranscript
         if exp.seedSpawnableModel == true {
-            transcript = await SubagentJobEvaluator.withSpawnableModel(id: target) {
-                await SubagentJobEvaluator.runSpawnModel(model: target, input: input)
+            // `seedSpawnToolAccess: "readOnly"` additionally grants the child
+            // the curated read-only toolset for the run (tool-capable lane).
+            // Accept the friendly camelCase spelling and the stored raw value.
+            let toolAccess: SpawnToolAccess? = exp.seedSpawnToolAccess.flatMap {
+                switch $0 {
+                case "readOnly", "read_only": return .readOnly
+                case "none": return SpawnToolAccess.none
+                default: return SpawnToolAccess(rawValue: $0)
+                }
+            }
+            transcript = await SubagentJobEvaluator.withSpawnableModel(
+                id: target,
+                toolAccess: toolAccess
+            ) {
+                await SubagentJobEvaluator.runSpawnModel(
+                    model: target,
+                    input: input,
+                    interruptAfterMs: interruptAfterMs
+                )
             }
         } else {
-            transcript = await SubagentJobEvaluator.runSpawnModel(model: target, input: input)
+            transcript = await SubagentJobEvaluator.runSpawnModel(
+                model: target,
+                input: input,
+                interruptAfterMs: interruptAfterMs
+            )
         }
         return finishLive(
             testCase,
@@ -235,20 +280,175 @@ extension EvalRunner {
                 modelId: modelId
             )
         }
-        let transcript = await SubagentJobEvaluator.runSpawnModelResidency(
-            orchestrator: orchestrator,
-            target: target,
-            handoffEnabled: exp.handoffEnabled ?? true,
-            ensureResident: exp.ensureResident ?? false,
-            input: input
-        )
-        return finishLive(
-            testCase,
-            exp: exp,
-            transcript: transcript,
-            lane: "spawn_model_residency",
+
+        // Matrix-lane extensions over the single-shot direction case: repeated
+        // rapid cycles, sentinel context-recall, marker-leak and
+        // restore-verified checks per cycle, and a before/after crash-report
+        // count around the whole case.
+        let cycles = max(1, exp.cycles ?? 1)
+        let effectiveInput = composedInput(input, sentinel: exp.sentinel)
+        let crashBaseline: Set<String>? =
+            (exp.expectNoNewCrashReports == true) ? crashReportSnapshot() : nil
+
+        var cycleNotes: [String] = []
+        var cyclesPassed = true
+        var lastTranscript: SubagentJobTranscript?
+
+        for cycle in 1 ... cycles {
+            let transcript = await SubagentJobEvaluator.runSpawnModelResidency(
+                orchestrator: orchestrator,
+                target: target,
+                handoffEnabled: exp.handoffEnabled ?? true,
+                ensureResident: exp.ensureResident ?? false,
+                input: effectiveInput
+            )
+
+            // Availability-skip: when the FIRST cycle can't run on this host
+            // (model not installed / remote not routable) and the case didn't
+            // expect that envelope, the whole case reads "didn't apply".
+            let availabilitySkipKinds: Set<String> = ["rejected", "unavailable", "user_denied"]
+            if cycle == 1,
+                !transcript.succeeded,
+                availabilitySkipKinds.contains(transcript.envelopeKind),
+                exp.expectEnvelopeKind != transcript.envelopeKind
+            {
+                return .terminal(
+                    id: testCase.id,
+                    label: label,
+                    domain: testCase.domain,
+                    outcome: .skipped,
+                    notes: [
+                        "live spawn_model_residency lane unavailable on this host: "
+                            + (transcript.error ?? transcript.envelopeKind)
+                    ],
+                    modelId: modelId
+                )
+            }
+
+            // Per-cycle checks (multi-cycle cases must hold EVERY cycle; the
+            // standard matchers run once against the last transcript below).
+            func cycleCheck(_ ok: Bool, _ pass: String, _ fail: String) {
+                cyclesPassed = cyclesPassed && ok
+                cycleNotes.append(ok ? "cycle \(cycle): \(pass)" : "cycle \(cycle): \(fail)")
+            }
+            if cycles > 1 || exp.sentinel != nil || exp.expectNoMarkerLeaks == true
+                || exp.expectRestoredResident == true
+            {
+                if let wantSuccess = exp.expectSuccess {
+                    cycleCheck(
+                        transcript.succeeded == wantSuccess,
+                        "success \(transcript.succeeded)",
+                        "expected success=\(wantSuccess), got \(transcript.succeeded) "
+                            + "(\(transcript.envelopeKind): \(transcript.error ?? "-"))"
+                    )
+                }
+            }
+            if let sentinel = exp.sentinel {
+                cycleCheck(
+                    transcript.summary.localizedCaseInsensitiveContains(sentinel),
+                    "sentinel '\(sentinel)' recalled",
+                    "sentinel '\(sentinel)' MISSING from digest (got: \(transcript.summary.prefix(120)))"
+                )
+            }
+            if exp.expectNoMarkerLeaks == true {
+                let leaks = markerLeaks(in: transcript.summary)
+                cycleCheck(
+                    leaks.isEmpty,
+                    "no marker leaks",
+                    "raw markers leaked into the digest: \(leaks)"
+                )
+            }
+            if exp.expectRestoredResident == true {
+                cycleCheck(
+                    transcript.restoredResident == true,
+                    "orchestrator restored resident",
+                    "orchestrator NOT verified resident after the run "
+                        + "(restoredResident=\(String(describing: transcript.restoredResident)))"
+                )
+            }
+            lastTranscript = transcript
+        }
+
+        guard let final = lastTranscript else {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .errored,
+                notes: ["residency matrix lane produced no transcript"],
+                modelId: modelId
+            )
+        }
+
+        // Standard matchers against the last cycle's transcript.
+        var (passed, notes) = score(final, against: exp)
+        passed = passed && cyclesPassed
+        notes.append(contentsOf: cycleNotes)
+        if cycles > 1 { notes.append("cycles: \(cycles) rapid cycles completed") }
+
+        // Crash-report gate: zero NEW osaurus-related reports across the case.
+        if let baseline = crashBaseline {
+            let fresh = crashReportSnapshot().subtracting(baseline)
+            if fresh.isEmpty {
+                notes.append("crash reports: none new")
+            } else {
+                passed = false
+                notes.append("NEW crash reports appeared: \(fresh.sorted().joined(separator: ", "))")
+            }
+        }
+
+        return EvalCaseReport(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            query: testCase.query,
+            outcome: passed ? .passed : .failed,
+            notes: notes,
             modelId: modelId,
-            label: label
+            latencyMs: final.latencyMs
+        )
+    }
+
+    /// Compose the effective residency-lane input: the case input plus the
+    /// sentinel echo instruction, so recall across the handoff is assertable.
+    nonisolated static func composedInput(_ input: String, sentinel: String?) -> String {
+        guard let sentinel, !sentinel.isEmpty else { return input }
+        return input + " Include the exact token \"\(sentinel)\" verbatim in your reply."
+    }
+
+    /// Raw parser/template/tool markers that must never reach a digest a
+    /// parent agent consumes. Curated from the chat-template families the
+    /// runtime hosts (think tags, ChatML/Gemma turn markers, tool-call tags,
+    /// llama instruction markers).
+    nonisolated static let leakMarkers: [String] = [
+        "<think>", "</think>",
+        "<|",
+        "<tool_call>", "</tool_call>", "[TOOL_CALLS]",
+        "<start_of_turn>", "<end_of_turn>",
+        "[/INST]", "<<SYS>>",
+    ]
+
+    /// The subset of `leakMarkers` present in `text` (empty = clean).
+    nonisolated static func markerLeaks(in text: String) -> [String] {
+        leakMarkers.filter { text.contains($0) }
+    }
+
+    /// Names of osaurus-related crash reports currently on disk
+    /// (`~/Library/Logs/DiagnosticReports/*.ips|*.crash` whose filename
+    /// mentions osaurus, case-insensitive). Compared before/after a matrix
+    /// case to assert zero new reports — the crash-count gate.
+    nonisolated static func crashReportSnapshot() -> Set<String> {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/DiagnosticReports")
+        guard
+            let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path)
+        else { return [] }
+        return Set(
+            names.filter { name in
+                let lower = name.lowercased()
+                return (lower.hasSuffix(".ips") || lower.hasSuffix(".crash"))
+                    && lower.contains("osaurus")
+            }
         )
     }
 
@@ -545,6 +745,81 @@ extension EvalRunner {
                 fail: "images \(t.imageCount ?? 0) < \(minImages)"
             )
         }
+        if let want = exp.expectMaxConcurrent {
+            check(
+                t.maxConcurrent == want,
+                pass: "maxConcurrent ok: \(want)",
+                fail: "maxConcurrent \(t.maxConcurrent.map(String.init) ?? "nil") != \(want)"
+            )
+        }
+        if let want = exp.expectRunsCompleted {
+            check(
+                t.runsCompleted == want,
+                pass: "runsCompleted ok: \(want)",
+                fail: "runsCompleted \(t.runsCompleted.map(String.init) ?? "nil") != \(want)"
+            )
+        }
+        if exp.expectUsageRecorded == true {
+            let prompt = t.usage?["prompt_tokens"] ?? 0
+            let completion = t.usage?["completion_tokens"] ?? 0
+            check(
+                prompt > 0 && completion > 0,
+                pass: "usage ok: prompt=\(Int(prompt)) completion=\(Int(completion))",
+                fail: "usage missing/zero: prompt=\(Int(prompt)) completion=\(Int(completion))"
+            )
+        }
+        if exp.expectContextAccounting == true {
+            let worker = t.contextAccounting?["worker_tokens"] ?? 0
+            let digest = t.contextAccounting?["digest_tokens"] ?? 0
+            let recorded = t.contextAccounting?["context_saved_tokens"] != nil
+            check(
+                worker > 0 && digest > 0 && recorded,
+                pass: "context accounting ok: worker=\(worker) digest=\(digest)",
+                fail:
+                    "context accounting missing: worker=\(worker) digest=\(digest) "
+                    + "saved_recorded=\(recorded)"
+            )
+        }
+        if let minSaved = exp.minContextSavedTokens {
+            let saved = t.contextAccounting?["context_saved_tokens"] ?? -1
+            check(
+                saved >= minSaved,
+                pass: "context saved ok: \(saved) ≥ \(minSaved)",
+                fail: "context saved \(saved) < \(minSaved)"
+            )
+        }
+        if let requiredPhases = exp.expectResidencyPhases, !requiredPhases.isEmpty {
+            let recorded = t.residencyPhases ?? [:]
+            let missing = requiredPhases.filter { recorded[$0] == nil }
+            check(
+                missing.isEmpty,
+                pass: "residency phases ok: \(requiredPhases)",
+                fail:
+                    "residency phases missing \(missing) "
+                    + "(recorded: \(recorded.keys.sorted()))"
+            )
+        }
+        if let ceilings = exp.maxPhaseSeconds, !ceilings.isEmpty {
+            let recorded = t.residencyPhases ?? [:]
+            for (phase, ceiling) in ceilings.sorted(by: { $0.key < $1.key }) {
+                guard let seconds = recorded[phase] else {
+                    check(false, pass: "", fail: "phase '\(phase)' not recorded (ceiling \(ceiling)s)")
+                    continue
+                }
+                check(
+                    seconds <= ceiling,
+                    pass: String(format: "phase %@ ok: %.2fs ≤ %.0fs", phase, seconds, ceiling),
+                    fail: String(format: "phase %@ %.2fs > ceiling %.0fs", phase, seconds, ceiling)
+                )
+            }
+        }
+        if exp.expectPostRunCache == true {
+            check(
+                t.postRunCache != nil,
+                pass: "post-run cache counters captured",
+                fail: "post-run cache counters missing (local run should capture prefix/L2 stats)"
+            )
+        }
 
         notes.append(
             "transcript: tool=\(t.tool) envelope=\(t.envelopeKind) "
@@ -552,6 +827,26 @@ extension EvalRunner {
                 + "phases=[\(t.feedPhases.joined(separator: ","))] "
                 + "latencyMs=\(Int(t.latencyMs))"
         )
+        if let usage = t.usage, !usage.isEmpty {
+            let tps = usage["tokens_per_second"].map { String(format: " tok/s=%.1f", $0) } ?? ""
+            notes.append(
+                "usage: prompt=\(Int(usage["prompt_tokens"] ?? 0)) "
+                    + "completion=\(Int(usage["completion_tokens"] ?? 0))\(tps)"
+            )
+        }
+        if let context = t.contextAccounting, !context.isEmpty {
+            notes.append(
+                "context: worker=\(context["worker_tokens"] ?? 0) "
+                    + "digest=\(context["digest_tokens"] ?? 0) "
+                    + "saved=\(context["context_saved_tokens"] ?? 0)"
+            )
+        }
+        if let phases = t.residencyPhases, !phases.isEmpty {
+            let joined = phases.sorted(by: { $0.key < $1.key })
+                .map { String(format: "%@=%.2fs", $0.key, $0.value) }
+                .joined(separator: " ")
+            notes.append("residency: \(joined)")
+        }
         return (passed, notes)
     }
 

--- a/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-local-local-diff.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-local-local-diff.json
@@ -1,0 +1,29 @@
+{
+  "id": "subagent.residency-matrix-local-local-diff",
+  "domain": "subagent",
+  "label": "Subagent • matrix: local→local (different) × rapid swap cycles, crash-free + restore verified",
+  "query": "Rapid repeated unload→run→reload swaps between two different local models.",
+  "notes": "LIVE RESIDENCY MATRIX (crash lane, RAM-real, machine-specific) — THE delicate direction: 2 rapid production cycles of the full residency swap (unload resident Qwen orchestrator → run the different local Gemma target → reload Qwen), the exact MLX unload/load churn behind the historical BUG G crash class (async GPU tails racing the next Metal producer). Asserts per cycle: handoffWrapped=true (the swap really happened), sentinel recall across the handoff, a coherent digest with no raw parser/template markers, and the orchestrator VERIFIED resident again after restore; plus zero NEW osaurus crash reports (.ips before/after) across the case. Run with FILTER=residency-matrix; SKIPS when either local model isn't installed.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model_residency",
+      "orchestrator": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+      "model": "OsaurusAI/gemma-4-E4B-it-4bit",
+      "handoffEnabled": true,
+      "ensureResident": true,
+      "cycles": 2,
+      "sentinel": "papaya-window-88",
+      "input": "Reply with one short sentence confirming you received this task.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectHandoffWrapped": true,
+      "expectResidencyPhases": ["unloading_chat_models", "restoring_chat_models"],
+      "expectNoNewCrashReports": true,
+      "expectRestoredResident": true,
+      "expectNoMarkerLeaks": true,
+      "expectUsageRecorded": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-local-local-same.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-local-local-same.json
@@ -1,0 +1,28 @@
+{
+  "id": "subagent.residency-matrix-local-local-same",
+  "domain": "subagent",
+  "label": "Subagent • matrix: local→local (same) × rapid cycles, crash-free + sentinel recall",
+  "query": "Rapid repeated spawns of the SAME local model as the resident orchestrator.",
+  "notes": "LIVE RESIDENCY MATRIX (crash lane, machine-specific) — extends residency-dir-local-local-same from decision-proof to CRASH-proof: 2 rapid production cycles of run-in-place (no unload), asserting per cycle a coherent digest with the sentinel token recalled across the boundary, no raw parser/template markers in the digest, and the orchestrator still verified GPU-resident; plus zero NEW osaurus crash reports (.ips before/after) across the whole case — the 2026-06 manual campaign turned into a rerunnable lane. Run with FILTER=residency-matrix; SKIPS when the model isn't installed.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model_residency",
+      "orchestrator": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+      "model": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+      "handoffEnabled": true,
+      "ensureResident": true,
+      "cycles": 2,
+      "sentinel": "papaya-window-88",
+      "input": "Reply with one short sentence confirming you received this task.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectHandoffWrapped": false,
+      "expectNoNewCrashReports": true,
+      "expectRestoredResident": true,
+      "expectNoMarkerLeaks": true,
+      "expectUsageRecorded": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-local-remote.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-local-remote.json
@@ -1,0 +1,27 @@
+{
+  "id": "subagent.residency-matrix-local-remote",
+  "domain": "subagent",
+  "label": "Subagent • matrix: local→remote × rapid cycles, orchestrator stays resident",
+  "query": "Rapid repeated remote spawns while a local orchestrator is GPU-resident.",
+  "notes": "LIVE RESIDENCY MATRIX (crash lane) — local orchestrator, REMOTE target: 2 rapid production cycles that must never touch the local GPU (handoffWrapped=false), with the resident orchestrator VERIFIED still loaded after every cycle (no needless eviction), sentinel recall through the remote worker, no raw markers in the digest, and zero NEW osaurus crash reports across the case. Requires the remote provider connected — run with a remote --model (e.g. MODEL=xai/grok-4.3) + XAI_API_KEY; SKIPS when the local orchestrator isn't installed or the remote target isn't routable. Run with FILTER=residency-matrix.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model_residency",
+      "orchestrator": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+      "model": "xai/grok-4.3",
+      "handoffEnabled": true,
+      "ensureResident": true,
+      "cycles": 2,
+      "sentinel": "papaya-window-88",
+      "input": "Reply with one short sentence confirming you received this task.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectHandoffWrapped": false,
+      "expectNoNewCrashReports": true,
+      "expectRestoredResident": true,
+      "expectNoMarkerLeaks": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-remote-local.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-remote-local.json
@@ -1,0 +1,27 @@
+{
+  "id": "subagent.residency-matrix-remote-local",
+  "domain": "subagent",
+  "label": "Subagent • matrix: remote→local × rapid cycles, load in place crash-free",
+  "query": "Rapid repeated local spawns under a remote orchestrator (nothing resident).",
+  "notes": "LIVE RESIDENCY MATRIX (crash lane) — REMOTE orchestrator, LOCAL target: nothing local is resident to evict, so 2 rapid production cycles load and run the local target in place (handoffWrapped=false). This is repeated cold load→generate→teardown churn on the local GPU — the load/unload half of the BUG G class without the swap. Asserts sentinel recall, no raw markers in the digest, and zero NEW osaurus crash reports across the case. Needs NO remote key (the remote orchestrator never generates — only the local target runs); SKIPS when the local target isn't installed. Run with FILTER=residency-matrix.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model_residency",
+      "orchestrator": "xai/grok-4.3",
+      "model": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+      "handoffEnabled": true,
+      "ensureResident": false,
+      "cycles": 2,
+      "sentinel": "papaya-window-88",
+      "input": "Reply with one short sentence confirming you received this task.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectHandoffWrapped": false,
+      "expectNoNewCrashReports": true,
+      "expectNoMarkerLeaks": true,
+      "expectUsageRecorded": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-remote-remote.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/residency-matrix-remote-remote.json
@@ -1,0 +1,26 @@
+{
+  "id": "subagent.residency-matrix-remote-remote",
+  "domain": "subagent",
+  "label": "Subagent • matrix: remote→remote × rapid cycles, no residency involved",
+  "query": "Rapid repeated remote spawns under a remote orchestrator.",
+  "notes": "LIVE RESIDENCY MATRIX (crash lane) — both sides REMOTE: no local residency in play at all, so 2 rapid production cycles run in place (handoffWrapped=false) and are safe to parallelize in production (the .remote admission class). Asserts sentinel recall, no raw markers in the digest, and zero NEW osaurus crash reports across the case. Requires the remote provider connected — run with a remote --model (e.g. MODEL=xai/grok-4.3) + XAI_API_KEY; SKIPS when the remote target isn't routable. Run with FILTER=residency-matrix.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model_residency",
+      "orchestrator": "xai/grok-4.3",
+      "model": "xai/grok-4.3",
+      "handoffEnabled": true,
+      "ensureResident": false,
+      "cycles": 2,
+      "sentinel": "papaya-window-88",
+      "input": "Reply with one short sentence confirming you received this task.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectHandoffWrapped": false,
+      "expectNoNewCrashReports": true,
+      "expectNoMarkerLeaks": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/residency-phase-telemetry.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/residency-phase-telemetry.json
@@ -1,0 +1,29 @@
+{
+  "id": "subagent.residency-phase-telemetry",
+  "domain": "subagent",
+  "label": "Subagent • residency handoff records phase timings + post-run cache",
+  "query": "A real local→local handoff must record how long each residency leg took.",
+  "notes": "LIVE RESIDENCY (RAM-real, machine-specific) — the HANDOFF-LATENCY TELEMETRY case, extending residency-dir-local-local-diff-on from decision-proof to timing-proof. The production unload → run → restore must surface per-phase durations (unloading_chat_models, restoring_chat_models) in the payload's residency object, each under a generous MicroPerf-style ceiling (unload ≤ 120 s, restore ≤ 300 s — regression tripwires, not tight machine gates), plus the post-run prefix/L2 cache counters local runs capture (the resume prefix-hit / L2 disk-cache mitigation signal from SUBAGENT_PORTABLE_DESIGN §8.2). Id is `residency-*` so it stays OUT of FILTER=spawn; run with FILTER=residency-. SKIPS when either local model isn't installed.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model_residency",
+      "orchestrator": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
+      "model": "OsaurusAI/gemma-4-E4B-it-4bit",
+      "handoffEnabled": true,
+      "ensureResident": true,
+      "input": "Reply with a single short sentence confirming you received this task.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectHandoffWrapped": true,
+      "expectResidencyPhases": ["unloading_chat_models", "restoring_chat_models"],
+      "maxPhaseSeconds": {
+        "unloading_chat_models": 120,
+        "restoring_chat_models": 300
+      },
+      "expectPostRunCache": true,
+      "expectUsageRecorded": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/scripted-interrupt-mid-run.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/scripted-interrupt-mid-run.json
@@ -1,0 +1,20 @@
+{
+  "id": "subagent.scripted-interrupt-mid-run",
+  "domain": "subagent",
+  "label": "Subagent • interrupt mid-run -> honest user-stop envelope",
+  "query": "The user presses the subagent row's stop button while the run is in flight.",
+  "notes": "Model-free. THE INTERRUPT LANE, deterministically: the scripted run holds itself open for 5 s while the evaluator trips the run's InterruptToken through the REAL SubagentInterruptCenter after ~150 ms (the exact stop-button path). The kind must observe the token mid-run and map it to the HONEST user-stop error — a `user_denied` envelope whose copy says stopped, NOT a `timeout` blaming the time budget (the historical dishonest mapping). Also proves interruption takes effect promptly (the case completes in well under the 5 s run window).",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "scripted",
+      "decision": "allow",
+      "phases": ["running"],
+      "runDelayMs": 5000,
+      "interruptAfterMs": 150,
+      "expectSuccess": false,
+      "expectEnvelopeKind": "user_denied",
+      "summaryContains": ["stopped"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/scripted-parallel-batch-exclusive.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/scripted-parallel-batch-exclusive.json
@@ -1,0 +1,21 @@
+{
+  "id": "subagent.scripted-parallel-batch-exclusive",
+  "domain": "subagent",
+  "label": "Subagent • parallel batch: two local handoffs serialize, both complete",
+  "query": "One tool batch starts two local-handoff subagents concurrently.",
+  "notes": "Model-free. THE BATCH-RACE GUARD: two scripted kinds that model the local residency handoff (needsHandoff → .localExclusive admission) are started CONCURRENTLY through the real host, like a parallel tool batch. The process-wide SubagentAdmission gate must serialize them — peak overlap of the run bodies is exactly 1 — while the queued run WAITS and then completes (runsCompleted 2, success envelopes for both). A failure here is the historical concurrent-GPU handoff race (BUG G class) resurfacing.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "scripted",
+      "decision": "allow",
+      "needsHandoff": true,
+      "parallel": 2,
+      "runDelayMs": 150,
+      "phases": ["running"],
+      "expectSuccess": true,
+      "expectMaxConcurrent": 1,
+      "expectRunsCompleted": 2
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/scripted-parallel-batch-remote.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/scripted-parallel-batch-remote.json
@@ -1,0 +1,22 @@
+{
+  "id": "subagent.scripted-parallel-batch-remote",
+  "domain": "subagent",
+  "label": "Subagent • parallel batch: two remote spawns fan out concurrently",
+  "query": "One tool batch starts two remote-model subagents concurrently.",
+  "notes": "Model-free. THE REMOTE FAN-OUT PROOF: two scripted kinds that resolve as REMOTE (.remote admission — no local GPU involvement) start concurrently through the real host and must actually OVERLAP (peak concurrency 2), not serialize. The rendezvous knob makes each run wait (bounded) until both have entered, so overlap is observed by construction instead of sleep timing. Pins the parallel-remote admission policy documented in the spawn guidance.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "scripted",
+      "decision": "allow",
+      "remote": true,
+      "parallel": 2,
+      "rendezvous": true,
+      "runDelayMs": 50,
+      "phases": ["running"],
+      "expectSuccess": true,
+      "expectMaxConcurrent": 2,
+      "expectRunsCompleted": 2
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/scripted-usage-accounting.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/scripted-usage-accounting.json
@@ -1,0 +1,20 @@
+{
+  "id": "subagent.scripted-usage-accounting",
+  "domain": "subagent",
+  "label": "Subagent • usage + context-saved accounting flows into the transcript",
+  "query": "A scripted run reports worker usage and context-saved accounting.",
+  "notes": "Model-free. Pins the TELEMETRY PLUMBING the live spawn lanes ride: a success payload carrying `usage` (prompt/completion/tok/s) and `context` (worker_tokens / digest_tokens / context_saved_tokens) must surface in the transcript and satisfy the usage + context-saved matchers. A regression here means live context-offload accounting silently vanishes from payloads, reports, and telemetry.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "scripted",
+      "decision": "allow",
+      "phases": ["running"],
+      "includeUsageAccounting": true,
+      "expectSuccess": true,
+      "expectUsageRecorded": true,
+      "expectContextAccounting": true,
+      "minContextSavedTokens": 100
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/spawn-model-live-interrupt.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/spawn-model-live-interrupt.json
@@ -1,0 +1,19 @@
+{
+  "id": "subagent.spawn-model-live-interrupt",
+  "domain": "subagent",
+  "label": "Subagent • live interrupt mid-generation -> honest user-stop",
+  "query": "Stop a live spawned generation mid-flight via the feed's stop button path.",
+  "notes": "LIVE. Interrupt-mid-GENERATION: spawns the run model on a long task, then trips the run's InterruptToken through the real SubagentInterruptCenter after ~1.5 s — while the model is prefilling or decoding. The streaming runner's chunk checkpoints / watchdog must cancel the in-flight generation promptly and the kind must map the cause honestly: `user_denied` + \"stopped by the user\" copy, never a `timeout` blaming the budget. Because the case EXPECTS the user_denied envelope, it scores normally (the availability-skip rule only skips UNEXPECTED rejected/unavailable/user_denied envelopes, e.g. on a host where the model can't run).",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model",
+      "seedSpawnableModel": true,
+      "input": "Count from 1 to 2000, one number per line, no commentary. Do not stop early.",
+      "interruptAfterMs": 1500,
+      "expectSuccess": false,
+      "expectEnvelopeKind": "user_denied",
+      "summaryContains": ["stopped by the user"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Subagent/spawn-model-live-tool-lane.json
+++ b/Packages/OsaurusEvals/Suites/Subagent/spawn-model-live-tool-lane.json
@@ -1,0 +1,21 @@
+{
+  "id": "subagent.spawn-model-live-tool-lane",
+  "domain": "subagent",
+  "label": "Subagent • live tool-capable spawn with context-saved accounting",
+  "query": "Spawn a tool-capable worker and verify usage + context-saved accounting.",
+  "notes": "LIVE. THE CONTEXT-OFFLOAD LANE: seeds the run model as spawnable AND grants the child the curated read-only toolset (seedSpawnToolAccess readOnly — the per-agent SpawnToolAccess wiring) for the run. The worker digests inline material; success must carry REAL usage (prompt/completion tokens — a generation row without token accounting is not a pass) and the context-saved accounting object (worker_tokens vs digest_tokens), making \"what did delegation save the parent\" measurable per run. Tool USE itself is model-discretionary (the material is inline), so scoring pins the accounting contract, not the model's tool whims; SpawnToolsetTests pin allowlist/cap enforcement deterministically.",
+  "fixtures": {},
+  "expect": {
+    "subagent": {
+      "lane": "spawn_model",
+      "seedSpawnableModel": true,
+      "seedSpawnToolAccess": "readOnly",
+      "input": "Summarize the following incident report in exactly two sentences. Report: At 09:12 the API gateway began returning 502s for 8% of requests. The cause was a routing table update that removed the healthy upstream pool for the EU region. Rollback completed at 09:41 and error rates returned to baseline by 09:44. A postmortem action item was filed to add canary validation for routing changes.",
+      "expectSuccess": true,
+      "expectEnvelopeKind": "success",
+      "expectResultKind": "spawn_result",
+      "expectUsageRecorded": true,
+      "expectContextAccounting": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SubagentEvalTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SubagentEvalTests.swift
@@ -162,6 +162,156 @@ struct SubagentEvalTests {
         #expect(report.outcome == .errored, "notes: \(report.notes)")
     }
 
+    // MARK: - Parallel batch (batch-race + remote fan-out lanes)
+
+    /// Two concurrent LOCAL-HANDOFF runs in one batch must serialize through
+    /// the process-wide admission gate (peak overlap 1) and BOTH complete —
+    /// the batch-race guard, scored end-to-end through the runner.
+    @Test func parallelExclusiveBatchSerializesAndCompletes() async {
+        let report = await scoreScripted(
+            Sub(
+                lane: "scripted",
+                needsHandoff: true,
+                decision: "allow",
+                phases: ["running"],
+                parallel: 2,
+                runDelayMs: 120,
+                expectSuccess: true,
+                expectMaxConcurrent: 1,
+                expectRunsCompleted: 2
+            )
+        )
+        #expect(report.outcome == .passed, "notes: \(report.notes)")
+    }
+
+    /// Two concurrent REMOTE runs must actually overlap (peak concurrency 2)
+    /// — the parallel fan-out policy, observed via the rendezvous knob.
+    @Test func parallelRemoteBatchFansOut() async {
+        let report = await scoreScripted(
+            Sub(
+                lane: "scripted",
+                decision: "allow",
+                phases: ["running"],
+                parallel: 2,
+                remote: true,
+                runDelayMs: 40,
+                rendezvous: true,
+                expectSuccess: true,
+                expectMaxConcurrent: 2,
+                expectRunsCompleted: 2
+            )
+        )
+        #expect(report.outcome == .passed, "notes: \(report.notes)")
+    }
+
+    // MARK: - Interrupt mid-run (honest user-stop mapping)
+
+    /// Tripping the run's InterruptToken through the real interrupt center
+    /// mid-run must surface the HONEST user-stop envelope (`user_denied`,
+    /// "stopped" copy) — never a timeout blaming the budget — and must take
+    /// effect promptly (well before the 5 s run window elapses).
+    @Test func interruptMidRunMapsToUserDenied() async {
+        let started = Date()
+        let report = await scoreScripted(
+            Sub(
+                lane: "scripted",
+                decision: "allow",
+                phases: ["running"],
+                runDelayMs: 5000,
+                interruptAfterMs: 100,
+                expectSuccess: false,
+                expectEnvelopeKind: "user_denied",
+                summaryContains: ["stopped"]
+            )
+        )
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(report.outcome == .passed, "notes: \(report.notes)")
+        #expect(elapsed < 4, "interrupt should land promptly; took \(elapsed)s")
+    }
+
+    // MARK: - Usage + context-saved accounting plumbing
+
+    /// A payload carrying `usage` + `context` must satisfy the usage and
+    /// context-saved matchers — the plumbing the live spawn lanes ride.
+    @Test func usageAndContextAccountingScores() async {
+        let report = await scoreScripted(
+            Sub(
+                lane: "scripted",
+                decision: "allow",
+                phases: ["running"],
+                includeUsageAccounting: true,
+                expectSuccess: true,
+                expectUsageRecorded: true,
+                expectContextAccounting: true,
+                minContextSavedTokens: 100
+            )
+        )
+        #expect(report.outcome == .passed, "notes: \(report.notes)")
+    }
+
+    /// The usage matcher must FAIL a run that recorded no usage (a
+    /// generation row without token accounting is not a pass).
+    @Test func usageMatcherFailsWithoutAccounting() async {
+        let report = await scoreScripted(
+            Sub(
+                lane: "scripted",
+                decision: "allow",
+                phases: ["running"],
+                expectSuccess: true,
+                expectUsageRecorded: true
+            )
+        )
+        #expect(report.outcome == .failed, "notes: \(report.notes)")
+    }
+
+    /// Residency-phase matchers must fail when the run recorded no phase
+    /// timings (passthrough run), so a telemetry case can't silently pass.
+    @Test func residencyPhaseMatcherFailsWithoutTimings() async {
+        let report = await scoreScripted(
+            Sub(
+                lane: "scripted",
+                decision: "allow",
+                phases: ["running"],
+                expectSuccess: true,
+                expectResidencyPhases: ["unloading_chat_models"]
+            )
+        )
+        #expect(report.outcome == .failed, "notes: \(report.notes)")
+    }
+
+    // MARK: - Residency matrix lane helpers (model-free)
+
+    /// The marker-leak detector must flag every hosted template family's raw
+    /// markers and stay quiet on clean prose (including the sentinel token).
+    @Test func markerLeakDetection() {
+        #expect(EvalRunner.markerLeaks(in: "Task received. ZEBRA-7431 confirmed.").isEmpty)
+        #expect(EvalRunner.markerLeaks(in: "ok <think>hidden</think>") == ["<think>", "</think>"])
+        #expect(EvalRunner.markerLeaks(in: "<|im_start|>assistant") == ["<|"])
+        #expect(EvalRunner.markerLeaks(in: "<start_of_turn>model hi") == ["<start_of_turn>"])
+        #expect(EvalRunner.markerLeaks(in: "<tool_call>{}</tool_call>").contains("<tool_call>"))
+        #expect(EvalRunner.markerLeaks(in: "text [/INST] more") == ["[/INST]"])
+    }
+
+    /// Sentinel composition appends the verbatim-echo instruction exactly
+    /// once and leaves sentinel-free inputs untouched.
+    @Test func sentinelInputComposition() {
+        let plain = EvalRunner.composedInput("Do the task.", sentinel: nil)
+        #expect(plain == "Do the task.")
+        let composed = EvalRunner.composedInput("Do the task.", sentinel: "ZEBRA-7431")
+        #expect(composed.hasPrefix("Do the task."))
+        #expect(composed.contains("\"ZEBRA-7431\""))
+        #expect(composed.contains("verbatim"))
+    }
+
+    /// The crash-report snapshot is a stable, non-throwing filename set
+    /// (contents are machine state; two immediate scans must agree).
+    @Test func crashReportSnapshotIsStable() {
+        let first = EvalRunner.crashReportSnapshot()
+        let second = EvalRunner.crashReportSnapshot()
+        #expect(first == second)
+        #expect(first.allSatisfy { $0.lowercased().contains("osaurus") })
+    }
+
     @Test func unknownLaneErrors() async {
         let report = await scoreScripted(Sub(lane: "teleport"))
         #expect(report.outcome == .errored, "notes: \(report.notes)")
@@ -174,7 +324,11 @@ struct SubagentEvalTests {
         #expect(t.succeeded)
         #expect(t.envelopeKind == "success")
         #expect(t.resultKind == "scripted_result")
-        #expect(t.feedPhases == ["running"])
+        // Parallel-running tests share the process-wide admission gate, so
+        // the host may legitimately prepend a "waiting for local GPU" queue
+        // phase; the kind's own phase must still be present and terminal.
+        #expect(t.feedPhases.last == "running")
+        #expect(t.feedPhases.allSatisfy { $0 == "running" || $0 == "waiting for local GPU" })
         #expect(t.summary == "scripted digest")
         #expect(t.feedEventKinds.contains("phase"))
     }
@@ -193,6 +347,26 @@ struct SubagentEvalTests {
         )
         #expect(t.succeeded)
         #expect(t.handoffWrapped == true)
+    }
+
+    @Test func facadeParallelBatchTranscriptShape() async {
+        let t = await SubagentJobEvaluator.runScriptedParallelBatch(
+            ScriptedSubagentSpec(needsHandoff: true, runDelayMs: 80),
+            count: 2
+        )
+        #expect(t.succeeded)
+        #expect(t.maxConcurrent == 1)
+        #expect(t.runsCompleted == 2)
+    }
+
+    @Test func facadeUsageAccountingTranscript() async {
+        let t = await SubagentJobEvaluator.runScripted(
+            ScriptedSubagentSpec(includeUsageAccounting: true)
+        )
+        #expect(t.succeeded)
+        #expect((t.usage?["prompt_tokens"] ?? 0) > 0)
+        #expect((t.usage?["completion_tokens"] ?? 0) > 0)
+        #expect((t.contextAccounting?["context_saved_tokens"] ?? 0) > 0)
     }
 
     // MARK: - computer_use lane (scripted driver, model-free)


### PR DESCRIPTION
## Summary

Hardens the subagent harness end-to-end — correctness first, then the Mac-native capability/performance work:

- **Process-wide admission gate** (`SubagentAdmission` actor): local runs serialize (a queued run waits, visible in the feed), remote spawns fan out concurrently. Fixes the parallel-batch race where two local handoffs could interleave unload/restore and strand the orchestrator (the historical BUG G concurrent-GPU crash class).
- **Real mid-generation interruption**: the spawn inner step now streams (`ChatEngine.streamChat`) with per-chunk cancel checkpoints plus a watchdog covering silent phases (prefill, remote first-token waits). User stop / deadline / parent-task cancel map to distinct, honest error copy instead of blaming everything on the time budget.
- **Tool-capable workers (context offload)**: opt-in per agent (`SpawnToolAccess`, default text-only), a curated read-only toolset (`file_read` / `file_search` / sandbox reads) dispatched through the shared `ToolRegistry` with a per-run call cap. Spawn payloads now report usage plus context-saved accounting (worker tokens vs digest tokens), and the near-limit notice nudges delegation when a spawn tool is visible.
- **RAM-aware coexistence** (opt-in, default OFF): under the Flexible eviction policy, when the live RAM projection says both models fit, the spawn model loads alongside the resident chat model — skipping the 10–60s unload/reload round-trip. Coexistence runs still admit exclusively and drain chat to idle first, so two resident graphs never both generate.
- **Residency + usage telemetry**: handoff phase durations (idle-wait / unload / restore / coexist), live tok/s progress into the subagent feed, and post-run prefix/L2 cache counters captured before the restore leg.
- **Live direction-matrix crash lane**: the `spawn_model_residency` eval lane gains repeated rapid cycles, sentinel context-recall, marker-leak scanning, restore-verified-resident, and before/after crash-report counting. Five new suite cases cover all four orchestrator⇄target directions × same/diff model.
- Smaller fixes from the audit: `stopOnToolRejection: false` + default `maxDelegateTurns` 1→2 (a refused first tool attempt no longer kills the run), the target agent's temperature override now rides through `spawn_agent`, and spawn guidance rewritten around context offload with the worker tool-reach and parallel policy stated.

## Changes

- [x] Behavior change
- [x] UI change (Agents → Subagents worker-tools picker; Settings → Subagents coexistence toggle)
- [x] Tests

## Test Plan

- `swift test --package-path Packages/OsaurusCore` — subagent/chat suites: 111 tests pass (admission serialization/fan-out, coexistence decide-plan matrix, cancel-cause mapping, toolset allowlist + call caps, phase-timing derivation, guidance content).
- `swift test --package-path Packages/OsaurusEvals` — 157 tests pass (parallel-batch lanes, interrupt lane, usage/context scoring, matrix helpers, suite decode guard).
- Live: `make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/Subagent` with `XAI_API_KEY` set — 47 cases: 45 passed, 2 skipped (image lanes, no image model configured), 0 failed. Models: `mlx-community/Qwen3.5-4B-OptiQ-4bit` (orchestrator), `OsaurusAI/gemma-4-E4B-it-4bit` (local target), `xai/grok-4.3` (remote).
- Live matrix lane (`FILTER=residency-matrix`): all 5 directions pass — 2 rapid cycles each, sentinel recalled, no marker leaks, orchestrator restore-verified, zero new crash reports. The delicate local→local different-model swap: unload 0.04s, restore 4.4s, 23.4 tok/s, peak RAM 7.1 GB.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I verified build on macOS with Xcode 16.4+