### PR TITLE
Cut per-turn prompt cost: remote prompt caching + local KV prefix reuse + measured text trims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,23 @@ unrelated "wants to use your confidential information" prompts:
 ```bash
 OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
 OSAURUS_TEST_ROOT=/tmp/osaurus-test \
+OSU_MODELS_DIR=/tmp/osaurus-test-models \
 make test
 ```
 
 In that mode, Keychain wrappers should return nil / no-op on reads, writes,
 and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
 `SecItemUpdate` / `SecItemDelete` against the login Keychain.
+
+`OSU_MODELS_DIR` (pointed at an empty dir) matters on machines with real
+models in `~/MLXModels`: dispatch-style tests start real `ChatSession.send`
+turns, and without the override they resolve the user's installed models and
+try to load them inside the SwiftPM harness — which has no Metal kernels and
+dies with `MLX/MLXArray.swift precondition failed`. With the override those
+sends fail fast with `modelUnavailable`, matching CI behavior. Keychain-gated
+suites (e.g. `PluginAgentScopingTests`) still fail by design under
+`OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`; run those without the flag when you
+need real Keychain proof.
 
 ## Model Runtime Non-Negotiables
 

--- a/Packages/OsaurusCore/Models/API/AnthropicAPI.swift
+++ b/Packages/OsaurusCore/Models/API/AnthropicAPI.swift
@@ -23,6 +23,23 @@ struct AnthropicMessagesRequest: Codable, Sendable {
     let tools: [AnthropicTool]?
     let tool_choice: AnthropicToolChoice?
     let metadata: AnthropicMetadata?
+    /// Top-level automatic prompt caching ("cache_control": {"type": "ephemeral"}).
+    /// Anthropic places the cache breakpoint on the last cacheable block and
+    /// moves it forward as the conversation grows — cache reads bill at 0.1x
+    /// input price. Optional + default nil so the server-side Anthropic-compat
+    /// decode path and existing construction sites are unaffected; the
+    /// synthesized Codable omits the key when nil.
+    var cache_control: AnthropicCacheControl? = nil
+}
+
+/// `{"type": "ephemeral"}` cache-control marker. Only "ephemeral" exists in
+/// the API today (5-minute TTL, refreshed on each hit).
+struct AnthropicCacheControl: Codable, Sendable {
+    let type: String
+
+    init(type: String = "ephemeral") {
+        self.type = type
+    }
 }
 
 /// System content can be a string or array of content blocks
@@ -433,6 +450,12 @@ enum AnthropicResponseContentBlock: Codable, Sendable {
 struct AnthropicUsage: Codable, Sendable {
     let input_tokens: Int
     let output_tokens: Int
+    /// Prompt-caching split reported by Anthropic when `cache_control` is in
+    /// play: tokens written to the cache this request (billed 1.25x) and
+    /// tokens read from it (billed 0.1x). Optional — absent on the
+    /// server-side compat writer and on providers that don't cache.
+    var cache_creation_input_tokens: Int? = nil
+    var cache_read_input_tokens: Int? = nil
 
     init(inputTokens: Int, outputTokens: Int) {
         self.input_tokens = inputTokens

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -186,6 +186,17 @@ final class ChatTurn: ObservableObject, Identifiable {
     var reasoningEncrypted: String? = nil
     /// For role==.tool messages, associates this result with the originating call id
     var toolCallId: String? = nil
+    /// Frozen memory / screen-context block this USER turn was originally
+    /// sent with, INCLUDING the trailing separator (see
+    /// `SystemPromptComposer.composeInjectedUserPrefix`). Recorded once at
+    /// send time and replayed verbatim by `turnToMessage` on every later
+    /// request, so the wire bytes for this turn never change after it has
+    /// been part of a token stream — required for paged-KV prefix reuse
+    /// across turns. Never rendered in the UI (the bubble shows `content`);
+    /// persisted so a reloaded session still matches the disk-backed L2
+    /// prefix cache. Nil on assistant/tool turns and on turns sent before
+    /// this field existed.
+    var injectedContextPrefix: String? = nil
     /// Convenience map for UI to show tool results grouped under the assistant turn
     @Published var toolResults: [String: String] = [:]
     /// Wall-clock duration (seconds) each tool call took to finish, keyed by call
@@ -470,6 +481,7 @@ extension ChatTurn {
         let toolCalls: [ToolCall]?
         let toolResults: [String: String]?
         let toolCallId: String?
+        var injectedContextPrefix: String? = nil
     }
 
     /// Converts this turn to a persistable representation
@@ -481,7 +493,8 @@ extension ChatTurn {
             thinking: thinkingIsEmpty ? nil : thinking,
             toolCalls: toolCalls,
             toolResults: toolResults.isEmpty ? nil : toolResults,
-            toolCallId: toolCallId
+            toolCallId: toolCallId,
+            injectedContextPrefix: injectedContextPrefix
         )
     }
 
@@ -502,6 +515,7 @@ extension ChatTurn {
             turn.toolResults = toolResults
         }
         turn.toolCallId = p.toolCallId
+        turn.injectedContextPrefix = p.injectedContextPrefix
 
         return turn
     }

--- a/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
@@ -45,6 +45,12 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
     /// assistant turn. Metadata only - no prompt/response text. Nil for local
     /// models and non-router providers.
     public var routerBilling: RouterBillingSummary?
+    /// Frozen memory / screen-context block this user turn was sent with
+    /// (see `ChatTurn.injectedContextPrefix`). Persisted so a reloaded
+    /// session replays the exact wire bytes of every past turn and the
+    /// disk-backed prefix cache can still hit. Nil for non-user turns and
+    /// legacy sessions.
+    public var injectedContextPrefix: String?
 
     public init(
         id: UUID = UUID(),
@@ -64,7 +70,8 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         timeToFirstToken: TimeInterval? = nil,
         reasoningItemId: String? = nil,
         reasoningEncrypted: String? = nil,
-        routerBilling: RouterBillingSummary? = nil
+        routerBilling: RouterBillingSummary? = nil,
+        injectedContextPrefix: String? = nil
     ) {
         self.id = id
         self.role = role
@@ -84,6 +91,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         self.reasoningItemId = reasoningItemId
         self.reasoningEncrypted = reasoningEncrypted
         self.routerBilling = routerBilling
+        self.injectedContextPrefix = injectedContextPrefix
     }
 
     // Backward-compatible decoder: migrates old `attachedImages` into unified `attachments`
@@ -106,6 +114,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         reasoningItemId = try container.decodeIfPresent(String.self, forKey: .reasoningItemId)
         reasoningEncrypted = try container.decodeIfPresent(String.self, forKey: .reasoningEncrypted)
         routerBilling = try container.decodeIfPresent(RouterBillingSummary.self, forKey: .routerBilling)
+        injectedContextPrefix = try container.decodeIfPresent(String.self, forKey: .injectedContextPrefix)
 
         if let unified = try container.decodeIfPresent([Attachment].self, forKey: .attachments) {
             attachments = unified
@@ -140,6 +149,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         try container.encodeIfPresent(reasoningItemId, forKey: .reasoningItemId)
         try container.encodeIfPresent(reasoningEncrypted, forKey: .reasoningEncrypted)
         try container.encodeIfPresent(routerBilling, forKey: .routerBilling)
+        try container.encodeIfPresent(injectedContextPrefix, forKey: .injectedContextPrefix)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -151,6 +161,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         case createdAt, completedAt, generationTokenCount, timeToFirstToken
         case reasoningItemId, reasoningEncrypted
         case routerBilling
+        case injectedContextPrefix
     }
 }
 
@@ -178,6 +189,7 @@ extension ChatTurnData {
         self.reasoningItemId = turn.reasoningItemId
         self.reasoningEncrypted = turn.reasoningEncrypted
         self.routerBilling = turn.routerBilling
+        self.injectedContextPrefix = turn.injectedContextPrefix
     }
 }
 
@@ -204,5 +216,6 @@ extension ChatTurn {
         self.reasoningItemId = data.reasoningItemId
         self.reasoningEncrypted = data.reasoningEncrypted
         self.routerBilling = data.routerBilling
+        self.injectedContextPrefix = data.injectedContextPrefix
     }
 }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2854,7 +2854,29 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         if !composed.prompt.isEmpty {
             SystemPromptComposer.injectSystemContent(composed.prompt, into: &enriched.messages)
         }
-        SystemPromptComposer.injectMemoryPrefix(composed.memorySection, into: &enriched.messages)
+        // Session-stable memory injection: when the caller supplies a
+        // session_id, previously injected prefixes are replayed onto the
+        // matching history user messages (the client resends CLEAN history,
+        // so without this the prior turn's injected bytes vanish and the
+        // paged-KV prefix diverges at that message — re-prefilling the whole
+        // last exchange). Without a session_id there is no cross-request
+        // identity, so it falls back to plain latest-message injection.
+        if let sid = request.session_id, !sid.isEmpty {
+            let frozen = await SessionToolStateStore.shared.frozenUserPrefixes(sid)
+            if let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
+                memorySection: composed.memorySection,
+                frozen: frozen,
+                into: &enriched.messages
+            ) {
+                await SessionToolStateStore.shared.recordUserPrefix(
+                    sid,
+                    key: recorded.key,
+                    prefix: recorded.prefix
+                )
+            }
+        } else {
+            SystemPromptComposer.injectMemoryPrefix(composed.memorySection, into: &enriched.messages)
+        }
         // Agent-run / HTTP orchestrators must get the active Subagent
         // tools as callable SCHEMAS too. `composeChatContext` only surfaces the
         // built-in image tools as a prompt-hint capability (not the schema), so

--- a/Packages/OsaurusCore/Services/Chat/ModelFamilyGuidance.swift
+++ b/Packages/OsaurusCore/Services/Chat/ModelFamilyGuidance.swift
@@ -20,8 +20,9 @@
 //      unguided model paired with the always-on prohibition sections
 //      reads as net-restrictive (refuses more) and, when it does act
 //      with no fitting tool, fabricates. The default block is the
-//      smallest counterweight that keeps it obedient without encouraging
-//      tool enumeration (it explicitly says "only call tools that exist").
+//      smallest counterweight that keeps it obedient; the anti-invention
+//      guardrail is owned by `SystemPromptTemplates.groundingDirective`,
+//      which co-fires for every tool-enabled chat with a non-empty schema.
 //
 //  Each family gets a tightly-targeted block; the default block is kept
 //  minimal so it does not inflate every prompt the way a full universal
@@ -142,20 +143,17 @@ enum ModelFamilyGuidance {
         return compact ? compactGuidance(for: resolved) : guidance(for: resolved)
     }
 
-    // MARK: - Shared lines
-
-    /// One-line tool-grounding rule shared across the family blocks. The
-    /// full statement (live-data grounding, manifest-vs-schema, discover
-    /// before denying) lives once in `SystemPromptTemplates.groundingDirective`,
-    /// which always co-fires with a family block; this compact reminder keeps
-    /// the anti-fabrication guardrail visible inside each family's own block
-    /// without re-printing the whole paragraph four times. Wording preserves
-    /// the substrings the obedience tests pin ("Only call tools that exist in
-    /// your schema", "never invent a tool name").
-    static let toolGroundingLine =
-        "Only call tools that exist in your schema. If a capability seems missing, run `capabilities_discover` before saying it's unavailable; never invent a tool name, and never deny a capability named in the Enabled capabilities list."
-
     // MARK: - Family blocks
+    //
+    // None of the blocks restate the tool-grounding rule ("only call tools
+    // that exist in your schema / never invent a tool name / never deny a
+    // listed capability"). That statement is owned by
+    // `SystemPromptTemplates.groundingDirective`, which co-fires with every
+    // family block that has a non-empty tool schema — and, unlike a shared
+    // line here, it picks the schema-correct variant (the tool-name-free
+    // base when `capabilities_discover` isn't resolvable). Re-stating it
+    // here both duplicated ~40 tokens per prompt and named tools that some
+    // schemas (Default agent, manual mode) cannot call.
 
     /// GPT / Codex / o-series: persistence + verification + act-don't-ask.
     /// The XML-tag shape matters — these models were trained to weight
@@ -227,7 +225,6 @@ enum ModelFamilyGuidance {
     static let googleGeminiGuidance = """
         ## Operational directives
 
-        - \(toolGroundingLine)
         - Act, don't narrate. When the next step is a tool call, emit it in \
         this response — don't describe what you would do.
         - Parallel tool calls when independent: batch reads and searches in \
@@ -248,7 +245,6 @@ enum ModelFamilyGuidance {
     static let googleGemmaGuidance = """
         ## Operational directives
 
-        - \(toolGroundingLine)
         - **Don't enumerate tools.** Never list or describe your available \
         tools in your reply, and never mention a name that isn't in your schema.
         - **Verify before you act.** Read the file or list the directory first \
@@ -269,8 +265,8 @@ enum ModelFamilyGuidance {
     static let googleGemmaGuidanceCompact = """
         ## Operational directives
 
-        - \(toolGroundingLine)
-        - Never list or describe your tools in a reply.
+        - Never list or describe your tools in a reply, and never mention a \
+        name that isn't in your schema.
         - Be concise — a few sentences, not paragraphs.
         - Verify before you act: read the file or list the directory first \
         when a path is involved; never guess at contents.
@@ -287,7 +283,6 @@ enum ModelFamilyGuidance {
     static let glmQwenGuidance = """
         ## Reminders
 
-        - \(toolGroundingLine)
         - Prefer one rich shell invocation over many small calls when the \
         steps are mechanical.
         - Keep going until the task is done. After a tool returns, take \
@@ -315,7 +310,6 @@ enum ModelFamilyGuidance {
         - After a tool result, continue with the next concrete tool call when \
         more evidence is needed. Only answer in prose once the requested work \
         is actually grounded or complete.
-        - \(toolGroundingLine)
         """
 
     /// LFM2 / Liquid: small-active MoE that hedges and refuses when it sees
@@ -336,7 +330,6 @@ enum ModelFamilyGuidance {
         web pages, current state), don't decline — fetch it yourself with \
         sandbox_exec (e.g. curl) or run capabilities_discover first. Treating a \
         missing purpose-built tool as a dead end is an error.
-        - \(toolGroundingLine)
         - For local, reversible work (reading, editing a file, running a test), \
         just proceed. Ask a clarifying question only when guessing wrong would \
         change the result.
@@ -346,16 +339,16 @@ enum ModelFamilyGuidance {
 
     /// Default block for unrecognised families (Apple Foundation and any
     /// future model). The smallest obedience counterweight that offsets the
-    /// always-on prohibition sections without encouraging tool enumeration:
-    /// the "only call tools that exist" line is what keeps an unguided model
-    /// from listing or inventing tool names. Live-data/anti-fabrication is
-    /// owned by `SystemPromptTemplates.groundingDirective` (always co-fires),
-    /// so it is intentionally not repeated here.
+    /// always-on prohibition sections without encouraging tool enumeration —
+    /// "a listed tool" keeps the framing anchored to the schema. Live-data /
+    /// anti-invention rules ("never invent a tool name", capability claims
+    /// need backing) are owned by `SystemPromptTemplates.groundingDirective`,
+    /// which co-fires whenever the request carries a tool schema, so they are
+    /// intentionally not repeated here.
     static let defaultGuidance = """
         ## Reminders
 
         - Use a listed tool when it improves correctness or grounds a claim. \
         Don't decline a request you have the tools to satisfy.
-        - \(toolGroundingLine)
         """
 }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2374,6 +2374,116 @@ public struct SystemPromptComposer: Sendable {
         )
     }
 
+    /// Render the memory + screen-context block exactly as the per-turn
+    /// injectors (`injectMemoryPrefix` + `injectScreenContextPrefix`) would
+    /// prepend it to a non-empty user message, INCLUDING the trailing
+    /// separator — so `prefix + originalContent` reproduces the legacy
+    /// injected bytes. Callers freeze this string per user turn (chat) or
+    /// per session ledger entry (HTTP/plugin) so that once a turn has been
+    /// sent with an injected prefix, every later request replays the same
+    /// bytes and the paged KV cache can reuse the whole prior exchange.
+    /// Returns nil when both inputs are nil/blank.
+    static func composeInjectedUserPrefix(
+        memorySection: String?,
+        screenContext: String?
+    ) -> String? {
+        var prefix = ""
+        if let memorySection {
+            let trimmed = memorySection.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { prefix = "[Memory]\n\(trimmed)\n[/Memory]\n\n" }
+        }
+        if let screenContext {
+            let trimmed = screenContext.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { prefix = "\(trimmed)\n\n" + prefix }
+        }
+        return prefix.isEmpty ? nil : prefix
+    }
+
+    /// Session-stable memory injection for surfaces whose history is owned
+    /// by the CALLER (HTTP `/agents/{id}/run`, plugin host): the client
+    /// resends clean history each request, so a prefix injected into the
+    /// latest user message on request N silently vanishes from request
+    /// N+1's history and the local paged-KV prefix diverges at that message
+    /// (the whole last exchange re-prefills). This helper makes the
+    /// injected bytes sticky:
+    ///   1. re-applies previously recorded prefixes (`frozen`, keyed by
+    ///      content-hash + occurrence of the ORIGINAL user message) to
+    ///      matching history user messages, and
+    ///   2. injects this request's `memorySection` into the latest user
+    ///      message — unless that message already has a recorded prefix
+    ///      (identical retry), in which case the recorded bytes win.
+    /// Returns the (key, prefix) recorded for the latest user message so
+    /// the caller can persist it into the session ledger; nil when nothing
+    /// new was injected. Multimodal (`contentParts`) messages are skipped,
+    /// matching `injectMemoryPrefix`.
+    static func applyFrozenMemoryPrefixes(
+        memorySection: String?,
+        frozen: [String: String],
+        into messages: inout [ChatMessage]
+    ) -> (key: String, prefix: String)? {
+        guard let lastUserIdx = messages.lastIndex(where: { $0.role == "user" }) else { return nil }
+        let keys = frozenPrefixKeys(for: messages)
+
+        func prepend(_ prefix: String, at idx: Int) {
+            let existing = messages[idx]
+            guard existing.contentParts == nil else { return }
+            messages[idx] = ChatMessage(
+                role: existing.role,
+                content: prefix + (existing.content ?? ""),
+                tool_calls: existing.tool_calls,
+                tool_call_id: existing.tool_call_id
+            )
+        }
+
+        // History user messages: replay the exact bytes they were sent with.
+        for (idx, key) in keys where idx != lastUserIdx {
+            if let prefix = frozen[key] { prepend(prefix, at: idx) }
+        }
+
+        guard let lastKey = keys[lastUserIdx] else { return nil }
+        if let recorded = frozen[lastKey] {
+            // Identical retry of the same latest message — byte stability
+            // beats fresher memory.
+            prepend(recorded, at: lastUserIdx)
+            return nil
+        }
+        guard messages[lastUserIdx].contentParts == nil,
+            let prefix = composeInjectedUserPrefix(
+                memorySection: memorySection,
+                screenContext: nil
+            )
+        else { return nil }
+        prepend(prefix, at: lastUserIdx)
+        return (key: lastKey, prefix: prefix)
+    }
+
+    /// Stable ledger keys for every user message in the array:
+    /// FNV-1a hash of the ORIGINAL content plus an occurrence ordinal, so
+    /// duplicate texts ("yes", "continue") map to distinct entries while
+    /// remaining deterministic for a client that resends identical history.
+    private static func frozenPrefixKeys(for messages: [ChatMessage]) -> [Int: String] {
+        var occurrence: [String: Int] = [:]
+        var keys: [Int: String] = [:]
+        for (idx, msg) in messages.enumerated() where msg.role == "user" {
+            let hash = fnv1aHex(msg.content ?? "")
+            let ordinal = occurrence[hash, default: 0]
+            occurrence[hash] = ordinal + 1
+            keys[idx] = "\(hash)#\(ordinal)"
+        }
+        return keys
+    }
+
+    /// Deterministic FNV-1a 64-bit over UTF-8 bytes (matches the hashing
+    /// style used by `CompactionWatermark` for message identities).
+    private static func fnv1aHex(_ text: String) -> String {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0100_0000_01b3
+        }
+        return String(hash, radix: 16)
+    }
+
     /// Prepend a frozen screen-context block (already rendered by
     /// `ScreenContextSnapshot.render()`, tags and all) to the latest user
     /// message. Placed on the user turn — not the system prompt — for two

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -73,16 +73,24 @@ public enum SystemPromptTemplates {
     /// Compact agent-loop cheat-sheet for small-context / small local models
     /// (`prefersCompactPrompt`). Same four tools and the load-bearing rules
     /// (always answer in plain text, OPTIONAL 3+ step todo, OPTIONAL complete
-    /// that only closes a todo alongside the answer, one-question clarify,
-    /// file-exists artifact), one line each.
+    /// that only closes a todo alongside the answer, last-resort one-question
+    /// clarify with the anti-punt rule, file-exists artifact), one line each.
+    ///
+    /// The clarify line keeps the false-clarify discipline from the W4 eval
+    /// fixes compressed, not dropped: "fully specified is not ambiguous" +
+    /// the user-asks escape hatch must survive because the compact bootstrap
+    /// skeleton truncates the ClarifyTool description to its first sentence,
+    /// so this bullet is the only place a small model sees the anti-punt
+    /// rule. Argument constraints (option limits, ≥30-char summary) live in
+    /// the constraint-preserving tool schemas and are not restated here.
     public static let agentLoopGuidanceCompact = """
         ## Agent loop
 
-        - Always answer the user in plain text; that plain-text reply ends the turn.
-        - `todo(markdown)` — OPTIONAL checklist for multi-step (3+) work; re-send it with each box checked as you finish. Skip single-step or direct questions.
-        - `complete(summary)` — OPTIONAL: only to close a `todo`, in the SAME message as your answer; a short WHAT+HOW status, not the answer. No vague placeholders.
-        - `clarify(question)` — last resort, NOT for big or multi-step tasks. If the request is fully specified, just do the work. Ask one concrete question only when a required input is missing or contradictory and no sensible default exists (or the user explicitly asks you to); otherwise assume a reasonable default, proceed, and note it.
-        - `share_artifact(path | content+filename)` — the only way the user sees a file/image/report; the file MUST exist first. Sandbox: save under home, not `/tmp`.
+        - Answer the user in plain text; that reply ends the turn.
+        - `todo(markdown)` — OPTIONAL, 3+ step work only: create first, re-send with each box checked. Skip single-step work.
+        - `complete(summary)` — OPTIONAL, only closes a `todo`: short WHAT+HOW status in the SAME message as your answer, not the answer.
+        - `clarify(question)` — last resort; a fully specified task is not ambiguous, just do it. Ask ONE question only when the user asks or a required input is missing/contradictory with no sensible default.
+        - `share_artifact(path | content+filename)` — the only way the user sees a file/image; it MUST exist first. Sandbox: save under home, not `/tmp`.
         """
 
     // MARK: - Grounding
@@ -475,8 +483,8 @@ public enum SystemPromptTemplates {
             : verboseBlocks(groups)
 
         // The "never deny a listed capability" rule is owned by
-        // `toolGroundingLine` / `groundingDirective` (which co-fire whenever
-        // this section renders), so the intro doesn't restate it. Compact
+        // `groundingDirective` (which co-fires whenever this section
+        // renders), so the intro doesn't restate it. Compact
         // mode (small-context models) also drops the worked example — the
         // ids themselves are what stop a small model from denying a
         // capability, and the example's tokens crowd an 8K window.

--- a/Packages/OsaurusCore/Services/Context/SessionToolState.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolState.swift
@@ -47,19 +47,31 @@ struct SessionToolState: Sendable {
     /// and keeps the cached prefix byte-stable. `nil` means "no snapshot yet"
     /// (or no SOUL content) — the next compose reads it fresh.
     var frozenSoul: String?
+    /// Frozen per-user-message memory prefixes for surfaces whose history is
+    /// client-owned (HTTP `/agents/{id}/run`, plugin host). Keyed by
+    /// content-hash + occurrence of the ORIGINAL user message (see
+    /// `SystemPromptComposer.applyFrozenMemoryPrefixes`); the value is the
+    /// exact prefix bytes injected when that message was the latest. Later
+    /// requests replay the prefix onto the matching history message so the
+    /// wire bytes stay monotonic and the paged KV cache reuses the prior
+    /// exchange. The chat surface doesn't use this — it freezes prefixes
+    /// directly on its own `ChatTurn`s.
+    var frozenUserPrefixes: [String: String] = [:]
 
     init(
         loadedToolNames: LoadedTools = [],
         initialAlwaysLoadedNames: LoadedTools? = nil,
         sessionFingerprint: String? = nil,
         frozenManifest: String? = nil,
-        frozenSoul: String? = nil
+        frozenSoul: String? = nil,
+        frozenUserPrefixes: [String: String] = [:]
     ) {
         self.loadedToolNames = loadedToolNames
         self.initialAlwaysLoadedNames = initialAlwaysLoadedNames
         self.sessionFingerprint = sessionFingerprint
         self.frozenManifest = frozenManifest
         self.frozenSoul = frozenSoul
+        self.frozenUserPrefixes = frozenUserPrefixes
     }
 
     /// Canonical fingerprint string for a (mode, toolSelectionMode) pair.

--- a/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
@@ -31,7 +31,86 @@ actor SessionToolStateStore {
     /// per send so we can audit whether KV reuse is actually happening.
     private var lastSendCacheHint: [String: (turn: Int, hint: String)] = [:]
 
+    /// Per-session per-message fingerprint of the most recent send's
+    /// conversation (hash + estimated tokens per message). The next send
+    /// diffs against it to report how many conversation tokens the paged KV
+    /// cache could reuse vs how many re-prefill — the conversation-level
+    /// counterpart of the static-prefix `cacheHint` match.
+    private var lastConversationSend: [String: ConversationFingerprint] = [:]
+
     private init() {}
+
+    // MARK: - Conversation reuse accounting (pure helpers)
+
+    /// Message-level fingerprint of an outbound conversation: a stable
+    /// content hash and an estimated token count per message.
+    struct ConversationFingerprint: Sendable {
+        let hashes: [String]
+        let tokens: [Int]
+
+        init(messages: [ChatMessage]) {
+            var hashes: [String] = []
+            var tokens: [Int] = []
+            hashes.reserveCapacity(messages.count)
+            tokens.reserveCapacity(messages.count)
+            for msg in messages {
+                hashes.append(SessionToolStateStore.messageIdentityHash(msg))
+                tokens.append(ContextBudgetManager.estimateTokens(forMessage: msg))
+            }
+            self.hashes = hashes
+            self.tokens = tokens
+        }
+    }
+
+    /// Estimated (reused, reprefilled) conversation tokens for a send,
+    /// given the previous send's fingerprint. KV reuse is a CONTIGUOUS
+    /// byte-prefix property, so reuse counts only the leading run of
+    /// messages whose identity matches the previous send — and only when
+    /// the static system+tools prefix ahead of them was itself stable
+    /// (`staticPrefixMatched`); a static-prefix change re-prefills the
+    /// entire stream regardless of conversation overlap.
+    static func conversationReuse(
+        previous: ConversationFingerprint?,
+        current: ConversationFingerprint,
+        staticPrefixMatched: Bool
+    ) -> (reusedTokens: Int, reprefilledTokens: Int, reusedMessages: Int) {
+        let total = current.tokens.reduce(0, +)
+        guard staticPrefixMatched, let previous else {
+            return (0, total, 0)
+        }
+        var matching = 0
+        let limit = min(previous.hashes.count, current.hashes.count)
+        while matching < limit, previous.hashes[matching] == current.hashes[matching] {
+            matching += 1
+        }
+        let reused = current.tokens.prefix(matching).reduce(0, +)
+        return (reused, total - reused, matching)
+    }
+
+    /// Stable identity hash for one message: role, content bytes, tool
+    /// linkage, and tool-call payloads (FNV-1a, mirroring
+    /// `CompactionWatermark`'s identity style).
+    static func messageIdentityHash(_ msg: ChatMessage) -> String {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        func fold(_ text: String) {
+            for byte in text.utf8 {
+                hash ^= UInt64(byte)
+                hash = hash &* 0x0000_0100_0000_01b3
+            }
+            // Field separator so ("ab","c") never collides with ("a","bc").
+            hash ^= 0x1F
+            hash = hash &* 0x0000_0100_0000_01b3
+        }
+        fold(msg.role)
+        fold(msg.content ?? "")
+        fold(msg.tool_call_id ?? "")
+        for call in msg.tool_calls ?? [] {
+            fold(call.id)
+            fold(call.function.name)
+            fold(call.function.arguments)
+        }
+        return String(hash, radix: 16)
+    }
 
     // MARK: - Reads
 
@@ -87,6 +166,7 @@ actor SessionToolStateStore {
         if recorded == liveFingerprint { return false }
         states.removeValue(forKey: sessionId)
         lastSendCacheHint.removeValue(forKey: sessionId)
+        lastConversationSend.removeValue(forKey: sessionId)
         return true
     }
 
@@ -109,17 +189,47 @@ actor SessionToolStateStore {
         states[sessionId] = entry
     }
 
+    // MARK: - Frozen user-message prefixes (HTTP / plugin paths)
+
+    /// The session's frozen per-user-message memory prefixes (empty when
+    /// none recorded). See `SessionToolState.frozenUserPrefixes`.
+    func frozenUserPrefixes(_ sessionId: String) -> [String: String] {
+        states[sessionId]?.frozenUserPrefixes ?? [:]
+    }
+
+    /// Record the prefix injected into a user message so later requests in
+    /// the same session replay the exact bytes. Creates the entry if the
+    /// session hasn't composed yet (the injection can run before
+    /// `setInitial`).
+    func recordUserPrefix(_ sessionId: String, key: String, prefix: String) {
+        var entry = states[sessionId] ?? SessionToolState()
+        entry.frozenUserPrefixes[key] = prefix
+        states[sessionId] = entry
+    }
+
     // MARK: - Cache fingerprint
 
     /// Record this send's cache-hint, emit a one-line `[Cache]` log entry,
     /// and stamp the matching TTFT trace fields. Lives on the store so the
     /// turn counter + previous-hint comparison sit next to the state they
     /// describe instead of being duplicated at every call site.
+    ///
+    /// When `conversation` is supplied (the full outbound message array;
+    /// leading system messages are excluded here), the store also diffs it
+    /// against the previous send's per-message fingerprint and logs
+    /// conversation-level reuse: how many history tokens the paged KV cache
+    /// can reuse (contiguous matching prefix) vs how many re-prefill. This
+    /// is the regression tripwire for cross-turn byte divergence — before
+    /// the frozen-turn-prefix fix, the last exchange re-prefilled every
+    /// turn and this line would have shown it immediately. The computed
+    /// stats are returned for tests / callers that want them.
+    @discardableResult
     func recordSend(
         sessionId: String,
         cacheHint: String,
-        trace: TTFTTrace?
-    ) {
+        trace: TTFTTrace?,
+        conversation: [ChatMessage]? = nil
+    ) -> (reusedTokens: Int, reprefilledTokens: Int, reusedMessages: Int)? {
         let prev = lastSendCacheHint[sessionId]
         let turn = (prev?.turn ?? 0) + 1
         lastSendCacheHint[sessionId] = (turn: turn, hint: cacheHint)
@@ -137,6 +247,27 @@ actor SessionToolStateStore {
         trace?.set("cacheHint", cacheHint)
         trace?.set("cacheTurn", turn)
         trace?.set("cacheHintMatched", matchStr == "true" ? "1" : (matchStr == "n/a" ? "n/a" : "0"))
+
+        guard let conversation else { return nil }
+        // The static system+tools prefix is accounted by the hint above;
+        // the conversation diff starts after it. A first send (no previous
+        // hint) counts everything as prefill, matching a cold cache.
+        let nonSystem = conversation.filter { $0.role != "system" }
+        let fingerprint = ConversationFingerprint(messages: nonSystem)
+        let reuse = Self.conversationReuse(
+            previous: lastConversationSend[sessionId],
+            current: fingerprint,
+            staticPrefixMatched: matchStr == "true"
+        )
+        lastConversationSend[sessionId] = fingerprint
+        debugLog(
+            "[Cache] conv turn=\(turn) reused≈\(reuse.reusedTokens)t "
+                + "reprefill≈\(reuse.reprefilledTokens)t "
+                + "msgs=\(reuse.reusedMessages)/\(nonSystem.count)"
+        )
+        trace?.set("convReusedTokens", reuse.reusedTokens)
+        trace?.set("convReprefilledTokens", reuse.reprefilledTokens)
+        return reuse
     }
 
     // MARK: - Invalidation
@@ -146,6 +277,7 @@ actor SessionToolStateStore {
     func invalidate(_ sessionId: String) {
         states.removeValue(forKey: sessionId)
         lastSendCacheHint.removeValue(forKey: sessionId)
+        lastConversationSend.removeValue(forKey: sessionId)
     }
 
     /// Drop every cached session entry. Used when a process-wide signal
@@ -161,11 +293,13 @@ actor SessionToolStateStore {
     func invalidateAll() {
         states.removeAll()
         lastSendCacheHint.removeAll()
+        lastConversationSend.removeAll()
     }
 
     /// Reset everything (test helper).
     func reset() {
         states.removeAll()
         lastSendCacheHint.removeAll()
+        lastConversationSend.removeAll()
     }
 }

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -753,6 +753,9 @@ final class PluginHostContext: @unchecked Sendable {
     private struct EnrichedInference {
         var request: ChatCompletionRequest
         let tools: [Tool]?
+        /// (key, prefix) for the memory block injected into this request's
+        /// latest user message, when the session ledger should record it.
+        var recordedUserPrefix: (key: String, prefix: String)? = nil
     }
 
     /// Fully prepared inference state ready for the agentic loop.
@@ -809,7 +812,34 @@ final class PluginHostContext: @unchecked Sendable {
             sessionId: request.session_id
         )
         let execMode = agentCtx?.executionMode ?? .none
-        var enriched = enrichRequest(request, context: agentCtx, options: options)
+        // Session-stable memory injection (parity with the chat surface's
+        // frozen turn prefixes): fetch previously recorded per-user-message
+        // prefixes so `enrichRequest` replays the exact bytes earlier
+        // requests were sent with, and record the prefix newly injected into
+        // this request's latest user message for the NEXT request. Without
+        // this, plugin history resent clean each call diverges from the
+        // prior wire bytes and re-prefills the last exchange.
+        let frozenPrefixes: [String: String]
+        if let sid = request.session_id, !sid.isEmpty {
+            frozenPrefixes = await SessionToolStateStore.shared.frozenUserPrefixes(sid)
+        } else {
+            frozenPrefixes = [:]
+        }
+        var enriched = enrichRequest(
+            request,
+            context: agentCtx,
+            options: options,
+            frozenUserPrefixes: frozenPrefixes
+        )
+        if let sid = request.session_id, !sid.isEmpty,
+            let recorded = enriched.recordedUserPrefix
+        {
+            await SessionToolStateStore.shared.recordUserPrefix(
+                sid,
+                key: recorded.key,
+                prefix: recorded.prefix
+            )
+        }
         if let pid = pluginId {
             let instructions: String? = await MainActor.run {
                 PluginInstructionsResolver.instructions(pluginId: pid, agentId: agentCtx?.agentId)
@@ -961,7 +991,8 @@ final class PluginHostContext: @unchecked Sendable {
     private static func enrichRequest(
         _ request: ChatCompletionRequest,
         context: AgentContext?,
-        options: InferenceOptions
+        options: InferenceOptions,
+        frozenUserPrefixes: [String: String] = [:]
     ) -> EnrichedInference {
         guard let ctx = context else {
             return EnrichedInference(request: request, tools: request.tools)
@@ -977,7 +1008,17 @@ final class PluginHostContext: @unchecked Sendable {
 
         var messages = request.messages
         SystemPromptComposer.injectSystemContent(ctx.systemPrompt, into: &messages)
-        SystemPromptComposer.injectMemoryPrefix(ctx.memorySection, into: &messages)
+        // Byte-stable memory injection: replay prefixes recorded on earlier
+        // requests of this session onto matching history messages, then
+        // inject this request's memory into the latest user message (see
+        // SystemPromptComposer.applyFrozenMemoryPrefixes). The recorded pair
+        // rides back on EnrichedInference so `prepareInference` can persist
+        // it into the session ledger.
+        let recordedUserPrefix = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: ctx.memorySection,
+            frozen: frozenUserPrefixes,
+            into: &messages
+        )
 
         let effectiveTools: [Tool]?
         if let explicit = request.tools, !explicit.isEmpty {
@@ -1007,7 +1048,11 @@ final class PluginHostContext: @unchecked Sendable {
         enrichedWithRuntimeOptions.enable_thinking = request.enable_thinking
         enrichedWithRuntimeOptions.reasoning_effort = request.reasoning_effort
         enrichedWithRuntimeOptions.modelOptions = request.modelOptions
-        return EnrichedInference(request: enrichedWithRuntimeOptions, tools: effectiveTools)
+        return EnrichedInference(
+            request: enrichedWithRuntimeOptions,
+            tools: effectiveTools,
+            recordedUserPrefix: recordedUserPrefix
+        )
     }
 
     private static func iterationRequest(

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1436,6 +1436,20 @@ public actor RemoteProviderService: ToolCapableService {
         }
     }
 
+    /// Whether the target accepts OpenAI's `prompt_cache_key` body field —
+    /// a session-scoped routing hint that improves upstream prompt-cache hit
+    /// rates for multi-turn conversations (OpenAI already auto-caches
+    /// >=1024-token prefixes; the key routes same-session requests to the
+    /// same cache shard). Gated to genuine OpenAI hosts only: third-party
+    /// OpenAI-compat schemas can be strict about unknown fields (the same
+    /// reason `idempotency_key` is router-only), and Gemini/Anthropic have
+    /// their own caching (implicit / `cache_control`).
+    static func supportsPromptCacheKey(providerType: RemoteProviderType, host: String) -> Bool {
+        guard providerType == .openaiLegacy else { return false }
+        let normalizedHost = host.lowercased()
+        return normalizedHost == "api.openai.com" || normalizedHost.hasSuffix(".openai.com")
+    }
+
     static func remoteChatMaxTokens(
         providerType: RemoteProviderType,
         parameters: GenerationParameters
@@ -1541,6 +1555,20 @@ public actor RemoteProviderService: ToolCapableService {
         }
 
         switch event.type {
+        case "message_start":
+            // Prompt-caching telemetry: `message_start` carries the request's
+            // usage split. Log the cache read/write counts so the win from the
+            // top-level `cache_control` in `toAnthropicRequest()` is observable
+            // per turn (cache reads bill 0.1x input; writes 1.25x).
+            if let startEvent = try? JSONDecoder().decode(MessageStartEvent.self, from: jsonData) {
+                let usage = startEvent.message.usage
+                debugLog(
+                    "[Cache][Anthropic] input=\(usage.input_tokens)"
+                        + " cacheRead=\(usage.cache_read_input_tokens ?? 0)"
+                        + " cacheWrite=\(usage.cache_creation_input_tokens ?? 0)"
+                )
+            }
+
         case "content_block_delta":
             guard let deltaEvent = try? JSONDecoder().decode(ContentBlockDeltaEvent.self, from: jsonData)
             else { return .continue }
@@ -2384,6 +2412,16 @@ public actor RemoteProviderService: ToolCapableService {
         if stream, Self.requestsStreamUsageOptions(providerType: provider.providerType) {
             request.streamOptions = StreamOptions(include_usage: true)
         }
+        // Session-scoped prompt-cache routing hint for genuine OpenAI hosts.
+        // The chat surface already threads a stable per-conversation
+        // `session_id`; scoping the key to it keeps one conversation's turns
+        // on one cache shard without coupling unrelated sessions.
+        if !isAgentRun,
+            let sessionId = parameters.sessionId, !sessionId.isEmpty,
+            Self.supportsPromptCacheKey(providerType: provider.providerType, host: provider.host)
+        {
+            request.promptCacheKey = "osaurus-session-\(sessionId)"
+        }
         request.runAsRemoteAgent = parameters.runAsRemoteAgent
         return request
     }
@@ -3082,6 +3120,13 @@ public actor RemoteProviderService: ToolCapableService {
         switch providerType {
         case .anthropic:
             let response = try JSONDecoder().decode(AnthropicMessagesResponse.self, from: data)
+            // Same prompt-caching telemetry as the streaming `message_start`
+            // handler, for the non-streaming path.
+            debugLog(
+                "[Cache][Anthropic] input=\(response.usage.input_tokens)"
+                    + " cacheRead=\(response.usage.cache_read_input_tokens ?? 0)"
+                    + " cacheWrite=\(response.usage.cache_creation_input_tokens ?? 0)"
+            )
             var textContent = ""
             var toolCalls: [ToolCall] = []
 
@@ -3395,6 +3440,13 @@ struct RemoteChatRequest: Encodable {
     /// wire bytes (the non-streaming path and Anthropic/Gemini/Responses, which
     /// build their own bodies, never set it).
     var streamOptions: StreamOptions? = nil
+    /// OpenAI `prompt_cache_key`: session-scoped routing hint that improves
+    /// upstream prompt-cache hit rates (OpenAI auto-caches >=1024-token
+    /// prefixes; the key routes same-session requests to the same cache
+    /// shard). Set (in `buildChatRequest`) only for genuine OpenAI hosts (see
+    /// `supportsPromptCacheKey`) so strict third-party OpenAI-compat schemas
+    /// never see an unknown field. Encoded only when non-nil.
+    var promptCacheKey: String? = nil
     /// Local-only routing marker (Mode 2). When true, `buildURLRequest` targets
     /// the peer's `/agents/{address}/run` endpoint instead of
     /// `/chat/completions`. Intentionally absent from `CodingKeys` so it never
@@ -3411,6 +3463,7 @@ struct RemoteChatRequest: Encodable {
         case idempotencyKey = "idempotency_key"
         case veniceParameters = "venice_parameters"
         case streamOptions = "stream_options"
+        case promptCacheKey = "prompt_cache_key"
     }
 
     func encode(to encoder: Encoder) throws {
@@ -3461,6 +3514,7 @@ struct RemoteChatRequest: Encodable {
         try container.encodeIfPresent(idempotencyKey, forKey: .idempotencyKey)
         try container.encodeIfPresent(veniceParameters, forKey: .veniceParameters)
         try container.encodeIfPresent(streamOptions, forKey: .streamOptions)
+        try container.encodeIfPresent(promptCacheKey, forKey: .promptCacheKey)
         // `modelOptions` is intentionally not in `CodingKeys` — it stays
         // in-process for model-specific feature flags.
     }
@@ -3650,7 +3704,16 @@ struct RemoteChatRequest: Encodable {
             stop_sequences: stop,
             tools: anthropicTools,
             tool_choice: anthropicToolChoice,
-            metadata: nil
+            metadata: nil,
+            // Top-level automatic prompt caching: Anthropic puts the cache
+            // breakpoint on the last cacheable block and advances it as the
+            // conversation grows, so multi-turn sessions re-read the whole
+            // prefix at 0.1x input price instead of re-paying full rate every
+            // turn. Safe to send unconditionally — the canonical JSON encoder
+            // already guarantees byte-stable prefixes across turns, and
+            // requests below the model's minimum cacheable length are simply
+            // processed uncached.
+            cache_control: AnthropicCacheControl()
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ConversationReuseTelemetryTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ConversationReuseTelemetryTests.swift
@@ -1,0 +1,244 @@
+//
+//  ConversationReuseTelemetryTests.swift
+//  osaurusTests
+//
+//  Coverage for the conversation-level KV-reuse telemetry in
+//  `SessionToolStateStore`: the per-send diff that reports how many
+//  history tokens the paged KV cache can reuse (contiguous matching
+//  message prefix vs the previous send) and how many re-prefill. This is
+//  the observable counterpart of the frozen-turn-prefix fix — a cross-turn
+//  byte divergence shows up here as a truncated reuse run.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Conversation reuse telemetry")
+struct ConversationReuseTelemetryTests {
+
+    private func fingerprint(_ messages: [ChatMessage]) -> SessionToolStateStore.ConversationFingerprint {
+        SessionToolStateStore.ConversationFingerprint(messages: messages)
+    }
+
+    // MARK: - messageIdentityHash
+
+    @Test func identityHash_isStableForEqualMessages() {
+        let a = ChatMessage(role: "user", content: "hello")
+        let b = ChatMessage(role: "user", content: "hello")
+        #expect(
+            SessionToolStateStore.messageIdentityHash(a)
+                == SessionToolStateStore.messageIdentityHash(b)
+        )
+    }
+
+    @Test func identityHash_distinguishesRoleContentAndToolLinkage() {
+        let base = ChatMessage(role: "user", content: "hello")
+        let differentRole = ChatMessage(role: "assistant", content: "hello")
+        let differentContent = ChatMessage(role: "user", content: "hello!")
+        let toolLinked = ChatMessage(
+            role: "tool",
+            content: "hello",
+            tool_calls: nil,
+            tool_call_id: "call_1"
+        )
+        let hashes = [base, differentRole, differentContent, toolLinked]
+            .map(SessionToolStateStore.messageIdentityHash)
+        #expect(Set(hashes).count == hashes.count)
+    }
+
+    /// Field boundaries must be separated: ("ab","c") vs ("a","bc") style
+    /// concatenation collisions would fake a match across role/content.
+    @Test func identityHash_doesNotCollideAcrossFieldBoundaries() {
+        let a = ChatMessage(role: "user", content: "xy")
+        let b = ChatMessage(role: "userx", content: "y")
+        #expect(
+            SessionToolStateStore.messageIdentityHash(a)
+                != SessionToolStateStore.messageIdentityHash(b)
+        )
+    }
+
+    @Test func identityHash_coversToolCallPayloads() {
+        let call1 = ChatMessage(
+            role: "assistant",
+            content: nil,
+            tool_calls: [
+                ToolCall(
+                    id: "c1",
+                    type: "function",
+                    function: ToolCallFunction(name: "search", arguments: "{\"q\":\"a\"}")
+                )
+            ],
+            tool_call_id: nil
+        )
+        let call2 = ChatMessage(
+            role: "assistant",
+            content: nil,
+            tool_calls: [
+                ToolCall(
+                    id: "c1",
+                    type: "function",
+                    function: ToolCallFunction(name: "search", arguments: "{\"q\":\"b\"}")
+                )
+            ],
+            tool_call_id: nil
+        )
+        #expect(
+            SessionToolStateStore.messageIdentityHash(call1)
+                != SessionToolStateStore.messageIdentityHash(call2)
+        )
+    }
+
+    // MARK: - conversationReuse
+
+    /// First send of a session: everything is prefill (cold cache).
+    @Test func reuse_firstSendCountsEverythingAsPrefill() {
+        let current = fingerprint([
+            ChatMessage(role: "user", content: "hello there"),
+            ChatMessage(role: "assistant", content: "hi!"),
+        ])
+        let result = SessionToolStateStore.conversationReuse(
+            previous: nil,
+            current: current,
+            staticPrefixMatched: true
+        )
+        #expect(result.reusedTokens == 0)
+        #expect(result.reusedMessages == 0)
+        #expect(result.reprefilledTokens == current.tokens.reduce(0, +))
+    }
+
+    /// Append-only growth (the frozen-prefix contract): every previous
+    /// message matches, so only the new tail re-prefills.
+    @Test func reuse_appendOnlyGrowthReusesWholePreviousTranscript() {
+        let turn1: [ChatMessage] = [
+            ChatMessage(role: "user", content: "[Memory]\nfact\n[/Memory]\n\nfirst question")
+        ]
+        let turn2 =
+            turn1 + [
+                ChatMessage(role: "assistant", content: "first answer"),
+                ChatMessage(role: "user", content: "second question"),
+            ]
+        let prev = fingerprint(turn1)
+        let current = fingerprint(turn2)
+        let result = SessionToolStateStore.conversationReuse(
+            previous: prev,
+            current: current,
+            staticPrefixMatched: true
+        )
+        #expect(result.reusedMessages == 1)
+        #expect(result.reusedTokens == current.tokens[0])
+        #expect(result.reprefilledTokens == current.tokens[1] + current.tokens[2])
+    }
+
+    /// The legacy injection divergence: turn 2 renders the previous user
+    /// message with different bytes (its memory prefix vanished). Reuse
+    /// stops at index 0 — the exact re-prefill the telemetry must surface.
+    @Test func reuse_byteDivergenceAtHistoryMessageTruncatesReuse() {
+        let turn1: [ChatMessage] = [
+            ChatMessage(role: "user", content: "[Memory]\nfact\n[/Memory]\n\nfirst question")
+        ]
+        let turn2: [ChatMessage] = [
+            ChatMessage(role: "user", content: "first question"),  // prefix vanished
+            ChatMessage(role: "assistant", content: "first answer"),
+            ChatMessage(role: "user", content: "[Memory]\nnew\n[/Memory]\n\nsecond question"),
+        ]
+        let result = SessionToolStateStore.conversationReuse(
+            previous: fingerprint(turn1),
+            current: fingerprint(turn2),
+            staticPrefixMatched: true
+        )
+        #expect(result.reusedMessages == 0)
+        #expect(result.reusedTokens == 0)
+        #expect(result.reprefilledTokens == fingerprint(turn2).tokens.reduce(0, +))
+    }
+
+    /// Reuse is a contiguous-prefix property: a divergence in the middle
+    /// ends the run even if later messages match again.
+    @Test func reuse_stopsAtFirstDivergenceEvenIfTailMatches() {
+        let prev = fingerprint([
+            ChatMessage(role: "user", content: "q1"),
+            ChatMessage(role: "assistant", content: "a1"),
+            ChatMessage(role: "user", content: "q2"),
+        ])
+        let current = fingerprint([
+            ChatMessage(role: "user", content: "q1"),
+            ChatMessage(role: "assistant", content: "a1 EDITED"),
+            ChatMessage(role: "user", content: "q2"),
+        ])
+        let result = SessionToolStateStore.conversationReuse(
+            previous: prev,
+            current: current,
+            staticPrefixMatched: true
+        )
+        #expect(result.reusedMessages == 1)
+        #expect(result.reusedTokens == current.tokens[0])
+    }
+
+    /// A static system+tools prefix change re-prefills the whole stream —
+    /// conversation overlap cannot be reused past a rewritten prefix.
+    @Test func reuse_staticPrefixMismatchZeroesReuse() {
+        let messages = [ChatMessage(role: "user", content: "same bytes")]
+        let result = SessionToolStateStore.conversationReuse(
+            previous: fingerprint(messages),
+            current: fingerprint(messages),
+            staticPrefixMatched: false
+        )
+        #expect(result.reusedTokens == 0)
+        #expect(result.reusedMessages == 0)
+        #expect(result.reprefilledTokens == fingerprint(messages).tokens.reduce(0, +))
+    }
+
+    // MARK: - recordSend integration (actor state across two turns)
+
+    /// Two-turn flow through the real store entry point: turn 1 is all
+    /// prefill; turn 2 with identical hint + append-only conversation
+    /// reuses turn 1's whole transcript (leading system message excluded —
+    /// it belongs to the static-prefix row). Uses a unique session id so
+    /// parallel tests can't interfere; invalidation clears the fingerprint.
+    @Test func recordSend_twoTurnFlowReportsAppendOnlyReuse() async {
+        let sid = "conv-reuse-\(UUID().uuidString)"
+        let system = ChatMessage(role: "system", content: "static prefix")
+        let u1 = ChatMessage(role: "user", content: "[Memory]\nf\n[/Memory]\n\nq1")
+        let turn1: [ChatMessage] = [system, u1]
+
+        let first = await SessionToolStateStore.shared.recordSend(
+            sessionId: sid,
+            cacheHint: "hint-A",
+            trace: nil,
+            conversation: turn1
+        )
+        #expect(first?.reusedTokens == 0)
+        #expect(first?.reusedMessages == 0)
+
+        let turn2 =
+            turn1 + [
+                ChatMessage(role: "assistant", content: "a1"),
+                ChatMessage(role: "user", content: "q2"),
+            ]
+        let second = await SessionToolStateStore.shared.recordSend(
+            sessionId: sid,
+            cacheHint: "hint-A",
+            trace: nil,
+            conversation: turn2
+        )
+        // Turn 1's user message (the only non-system message) is reused in
+        // full; only the new exchange re-prefills.
+        #expect(second?.reusedMessages == 1)
+        #expect(second?.reusedTokens == ContextBudgetManager.estimateTokens(forMessage: u1))
+        #expect((second?.reprefilledTokens ?? 0) > 0)
+
+        // A hint flip (static prefix rewrite) zeroes conversation reuse
+        // even with identical history bytes.
+        let third = await SessionToolStateStore.shared.recordSend(
+            sessionId: sid,
+            cacheHint: "hint-B",
+            trace: nil,
+            conversation: turn2
+        )
+        #expect(third?.reusedTokens == 0)
+        #expect(third?.reusedMessages == 0)
+
+        await SessionToolStateStore.shared.invalidate(sid)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ModelFamilyGuidanceObedienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelFamilyGuidanceObedienceTests.swift
@@ -22,8 +22,13 @@ struct ModelFamilyGuidanceObedienceTests {
         #expect(ModelFamilyGuidance.family(for: "OsaurusAI/LFM2.5-8B-A1B-MXFP8") == .lfm2)
         let guidance = ModelFamilyGuidance.guidance(forModelId: "OsaurusAI/LFM2.5-8B-A1B-MXFP8")
         #expect(guidance == ModelFamilyGuidance.lfm2Guidance)
-        // Anti-hallucination guardrail must ride along with the obedience push.
-        #expect(guidance?.contains("Only call tools that exist in your schema") == true)
+        // The fetch-it-yourself action bullet is the block's reason to exist —
+        // LFM2 reads the grounding directive's caution half and skips its
+        // action half, so the imperative must stay in the family block even
+        // though the anti-invention rule itself was deduped into
+        // `groundingDirective` (see toolGroundingRuleIsOwnedByGroundingDirective).
+        #expect(guidance?.contains("fetch it yourself") == true)
+        #expect(guidance?.contains("do not decline") == true)
     }
 
     @Test("unrecognised families fall back to the default obedience block, not nil")
@@ -58,12 +63,8 @@ struct ModelFamilyGuidanceObedienceTests {
         }
         // The frontier block must not carry the local-Gemma brevity clamp.
         #expect(!ModelFamilyGuidance.googleGeminiGuidance.contains("Be concise"))
-        // Anti-hallucination guardrail still rides along.
-        #expect(
-            ModelFamilyGuidance.googleGeminiGuidance.contains(
-                "Only call tools that exist in your schema"
-            )
-        )
+        // The act-don't-narrate push is the block's core directive.
+        #expect(ModelFamilyGuidance.googleGeminiGuidance.contains("Act, don't narrate"))
     }
 
     @Test("o-series markers match on token boundaries only")
@@ -109,12 +110,64 @@ struct ModelFamilyGuidanceObedienceTests {
     func defaultBlockGuardsAgainstEnumeration() {
         // The whole reason `.other` historically returned nil was the fear
         // of a universal addendum encouraging tool listing. The default
-        // block must explicitly bound that risk.
+        // block bounds that risk by anchoring to "a listed tool" — the
+        // anti-invention rule itself lives in `groundingDirective` (below).
+        #expect(ModelFamilyGuidance.defaultGuidance.contains("a listed tool"))
+        #expect(!ModelFamilyGuidance.defaultGuidance.contains("list your tools"))
+    }
+
+    /// Pins the dedupe: the tool-grounding rule ("never invent a tool name",
+    /// capability claims need backing) is stated once, by
+    /// `SystemPromptTemplates.groundingDirective` — which co-fires with every
+    /// family block whenever the request carries a non-empty tool schema —
+    /// and is NOT restated inside the family blocks. Before this change every
+    /// family block except GPT/Codex carried a ~40-token copy, so prompts
+    /// paid for the rule two or three times.
+    @Test("tool-grounding rule is owned by groundingDirective, not family blocks")
+    func toolGroundingRuleIsOwnedByGroundingDirective() {
+        // Both grounding variants carry the anti-invention rule…
+        #expect(SystemPromptTemplates.groundingDirectiveFull.contains("never invent a tool name"))
+        #expect(SystemPromptTemplates.groundingDirectiveBase.contains("never invent a tool name"))
         #expect(
-            ModelFamilyGuidance.defaultGuidance.contains(
-                "Only call tools that exist in your schema"
+            SystemPromptTemplates.groundingDirectiveFullCompact.contains("never invent a tool name")
+        )
+        // …and the discovery-aware variants own the capability-claim rule.
+        #expect(SystemPromptTemplates.groundingDirectiveFull.contains("Enabled capabilities list"))
+
+        // No family block restates it.
+        let allBlocks: [(String, String)] = [
+            ("gptCodex", ModelFamilyGuidance.gptCodexGuidance),
+            ("gptCodexCompact", ModelFamilyGuidance.gptCodexGuidanceCompact),
+            ("gemma", ModelFamilyGuidance.googleGemmaGuidance),
+            ("gemmaCompact", ModelFamilyGuidance.googleGemmaGuidanceCompact),
+            ("gemini", ModelFamilyGuidance.googleGeminiGuidance),
+            ("glmQwen", ModelFamilyGuidance.glmQwenGuidance),
+            ("deepSeek", ModelFamilyGuidance.deepSeekGuidance),
+            ("lfm2", ModelFamilyGuidance.lfm2Guidance),
+            ("default", ModelFamilyGuidance.defaultGuidance),
+        ]
+        for (label, block) in allBlocks {
+            #expect(
+                !block.contains("Only call tools that exist in your schema"),
+                "\(label) restates the deduped tool-grounding rule"
+            )
+            #expect(
+                !block.contains("never deny a capability named in the Enabled capabilities list"),
+                "\(label) restates the deduped capability-claim rule"
+            )
+        }
+
+        // Gemma keeps its own anti-enumeration line (a different, observed
+        // failure mode: listing fictional tool names in its reply).
+        #expect(
+            ModelFamilyGuidance.googleGemmaGuidance.contains(
+                "never mention a name that isn't in your schema"
             )
         )
-        #expect(ModelFamilyGuidance.defaultGuidance.contains("never invent a tool name"))
+        #expect(
+            ModelFamilyGuidance.googleGemmaGuidanceCompact.contains(
+                "never mention a name that isn't in your schema"
+            )
+        )
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
@@ -1,0 +1,235 @@
+//
+//  PromptTokenTableTests.swift
+//
+//  Phase-0 measurement baseline for the system-prompt efficiency work: a
+//  per-section token table (full vs compact variant) over every template
+//  the composer can render, plus a live compose that prints the real
+//  `PromptManifest` breakdown and always-loaded tool-schema cost.
+//
+//  The printed tables are the deliverable — they anchor before/after
+//  comparisons for prompt trims. The assertions are deliberately loose
+//  (compact never exceeds full; totals are non-zero) so the suite
+//  documents cost without pinning every number twice (the hard ceilings
+//  live in TotalPromptBudgetTests / SandboxSectionTokenAuditTests).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct PromptTokenTableTests {
+
+    /// One row of the audit table: a section label plus its full and
+    /// compact renderings (compact == full when no variant exists).
+    private struct Row {
+        let label: String
+        let full: String
+        let compact: String
+
+        init(_ label: String, full: String, compact: String? = nil) {
+            self.label = label
+            self.full = full
+            self.compact = compact ?? full
+        }
+
+        var fullTokens: Int { TokenEstimator.estimate(full) }
+        var compactTokens: Int { TokenEstimator.estimate(compact) }
+    }
+
+    private func sectionRows() -> [Row] {
+        [
+            Row("platformIdentity", full: SystemPromptTemplates.platformIdentity),
+            Row("defaultPersona", full: SystemPromptTemplates.defaultPersona),
+            Row(
+                "agentLoopGuidance",
+                full: SystemPromptTemplates.agentLoopGuidance,
+                compact: SystemPromptTemplates.agentLoopGuidanceCompact
+            ),
+            Row(
+                "grounding(discovery)",
+                full: SystemPromptTemplates.groundingDirectiveFull,
+                compact: SystemPromptTemplates.groundingDirectiveFullCompact
+            ),
+            Row("grounding(base)", full: SystemPromptTemplates.groundingDirectiveBase),
+            Row(
+                "discoveryNudge(sandbox,+plugins)",
+                full: SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: true),
+                compact: SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+                    canCreatePlugins: true,
+                    compact: true
+                )
+            ),
+            Row(
+                "discoveryNudge(sandbox,-plugins)",
+                full: SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: false),
+                compact: SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+                    canCreatePlugins: false,
+                    compact: true
+                )
+            ),
+            Row("discoveryNudge(non-sandbox)", full: SystemPromptTemplates.capabilityDiscoveryNudge),
+            Row(
+                "secretHandling",
+                full: SystemPromptTemplates.secretHandlingGuidance,
+                compact: SystemPromptTemplates.secretHandlingGuidanceCompact
+            ),
+            Row(
+                "selfImprovement(+plugins)",
+                full: SystemPromptTemplates.selfImprovementGuidance(canCreatePlugins: true),
+                compact: SystemPromptTemplates.selfImprovementGuidance(
+                    canCreatePlugins: true,
+                    compact: true
+                )
+            ),
+            Row(
+                "codeStyle",
+                full: SystemPromptTemplates.codeStyleGuidance,
+                compact: SystemPromptTemplates.codeStyleGuidanceCompact
+            ),
+            Row(
+                "riskAware",
+                full: SystemPromptTemplates.riskAwareGuidance,
+                compact: SystemPromptTemplates.riskAwareGuidanceCompact
+            ),
+            Row("computerUse", full: SystemPromptTemplates.computerUseGuidance),
+            Row(
+                "imageGeneration",
+                full: SystemPromptTemplates.imageGenerationGuidance,
+                compact: SystemPromptTemplates.imageGenerationGuidanceCompact
+            ),
+            Row(
+                "appleScript",
+                full: SystemPromptTemplates.appleScriptGuidance,
+                compact: SystemPromptTemplates.appleScriptGuidanceCompact
+            ),
+            Row(
+                "sandbox(section)",
+                full: SystemPromptTemplates.sandbox(
+                    home: "/home/agent-abcdef123456",
+                    hostReadCombined: false,
+                    backgroundEnabled: true
+                ),
+                compact: SystemPromptTemplates.sandbox(
+                    home: "/home/agent-abcdef123456",
+                    hostReadCombined: false,
+                    backgroundEnabled: true,
+                    compact: true
+                )
+            ),
+            Row("skillsGovernToolGroups", full: SystemPromptTemplates.skillsGovernToolGroups),
+            Row(
+                "pluginCreator",
+                full: PluginCreatorGate.section(
+                    instructions: SystemPromptTemplates.pluginCreatorInstructions
+                )
+            ),
+            Row(
+                "family(gptCodex)",
+                full: ModelFamilyGuidance.gptCodexGuidance,
+                compact: ModelFamilyGuidance.gptCodexGuidanceCompact
+            ),
+            Row(
+                "family(gemma)",
+                full: ModelFamilyGuidance.googleGemmaGuidance,
+                compact: ModelFamilyGuidance.googleGemmaGuidanceCompact
+            ),
+            Row("family(gemini)", full: ModelFamilyGuidance.googleGeminiGuidance),
+            Row("family(glm/qwen)", full: ModelFamilyGuidance.glmQwenGuidance),
+            Row("family(deepseek)", full: ModelFamilyGuidance.deepSeekGuidance),
+            Row("family(lfm2)", full: ModelFamilyGuidance.lfm2Guidance),
+            Row("family(default)", full: ModelFamilyGuidance.defaultGuidance),
+        ]
+    }
+
+    private func tableLine(_ label: String, _ full: Int, _ compact: Int) -> String {
+        let name = label.padding(toLength: 34, withPad: " ", startingAt: 0)
+        let f = String(format: "%8d", full)
+        let c = String(format: "%8d", compact)
+        let saved = String(format: "%8d", full - compact)
+        return "  \(name)\(f)\(c)\(saved)"
+    }
+
+    @Test("per-section token table (full vs compact)")
+    func printSectionTokenTable() {
+        let rows = sectionRows()
+        var lines: [String] = []
+        lines.append("[PromptTokenTable] per-section tokens (TokenEstimator)")
+        lines.append(
+            "  " + "section".padding(toLength: 34, withPad: " ", startingAt: 0)
+                + "    full compact   saved"
+        )
+        var fullTotal = 0
+        var compactTotal = 0
+        for row in rows {
+            fullTotal += row.fullTokens
+            compactTotal += row.compactTokens
+            lines.append(tableLine(row.label, row.fullTokens, row.compactTokens))
+        }
+        lines.append(tableLine("TOTAL (all rows)", fullTotal, compactTotal))
+        print(lines.joined(separator: "\n"))
+
+        for row in rows {
+            #expect(row.fullTokens > 0, "\(row.label) rendered empty")
+            #expect(
+                row.compactTokens <= row.fullTokens,
+                "\(row.label): compact (\(row.compactTokens)) exceeds full (\(row.fullTokens))"
+            )
+        }
+    }
+
+    /// Live sandbox compose: print the real `PromptManifest` section table
+    /// and the always-loaded tool-schema cost. Mirrors the harness in
+    /// `TotalPromptBudgetTests` (Storage → Sandbox → catalog lock order,
+    /// baseline-filtered schema) so the numbers are deterministic.
+    @Test("live sandbox compose manifest + tool schema table")
+    func printLiveComposeTable() async {
+        await SandboxTestLock.runWithStoragePaths {
+            await DynamicCatalogTestLock.shared.run {
+                let config = AutonomousExecConfig(enabled: true, pluginCreate: true)
+                let agent = Agent(
+                    name: "TokenTableAgent",
+                    systemPrompt: "Test identity",
+                    agentAddress: "test-token-table-\(UUID().uuidString)",
+                    autonomousExec: config
+                )
+                AgentManager.shared.add(agent)
+                BuiltinSandboxTools.register(
+                    agentId: agent.id.uuidString,
+                    agentName: agent.name,
+                    config: config
+                )
+
+                let ctx = await SystemPromptComposer.composeChatContext(
+                    agentId: agent.id,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "qwen3-8b"
+                )
+
+                let expectedNames = ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+                    .union(SystemPromptComposer.agentLoopToolNames)
+                    .union(["capabilities_discover", "capabilities_load"])
+                let baseline = ctx.tools.filter { expectedNames.contains($0.function.name) }
+                let toolTokens = ToolRegistry.shared.totalEstimatedTokens(for: baseline)
+
+                print("[PromptTokenTable] live sandbox compose (model: qwen3-8b)")
+                print(ctx.manifest.debugDescription)
+                print(
+                    "  Tool schema:         \(String(format: "%5d", toolTokens)) "
+                        + "(\(baseline.count) baseline tools of \(ctx.tools.count) resolved)"
+                )
+                print(
+                    "  Prompt + tools:      \(String(format: "%5d", ctx.manifest.totalEstimatedTokens + toolTokens))"
+                )
+
+                ToolRegistry.shared.unregisterAllSandboxTools()
+                _ = await AgentManager.shared.delete(id: agent.id)
+
+                #expect(ctx.manifest.totalEstimatedTokens > 0)
+                #expect(toolTokens > 0)
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/SandboxSectionTokenAuditTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SandboxSectionTokenAuditTests.swift
@@ -188,12 +188,28 @@ struct SandboxSectionTokenAuditTests {
         #expect(SystemPromptTemplates.secretHandlingGuidanceCompact.contains("sandbox_secret_set"))
         #expect(SystemPromptTemplates.secretHandlingGuidanceCompact.contains("env var"))
 
-        // Agent loop: compact keeps all four tools.
+        // Agent loop: compact keeps all four tools AND is a real reduction —
+        // the 2026-06 version was only ~6% smaller than full, which paid the
+        // maintenance cost of a second variant for no prefill win. Live
+        // numbers after the 2026-07 retighten: full 240, compact 167 tokens
+        // (~30% saved). The 80% ratio ceiling locks the win in while leaving
+        // headroom for small wording fixes.
         let compactLoop = SystemPromptTemplates.agentLoopGuidanceCompact
-        smaller(SystemPromptTemplates.agentLoopGuidance, compactLoop, label: "agent loop")
+        let fullLoopTokens = TokenEstimator.estimate(SystemPromptTemplates.agentLoopGuidance)
+        let compactLoopTokens = TokenEstimator.estimate(compactLoop)
+        #expect(
+            compactLoopTokens * 5 <= fullLoopTokens * 4,
+            "agent loop compact (\(compactLoopTokens)) is not ≤80% of full (\(fullLoopTokens)) — the compact variant has crept back toward full size"
+        )
         for tool in ["todo", "complete", "clarify", "share_artifact"] {
             #expect(compactLoop.contains(tool), "compact agent loop dropped \(tool)")
         }
+        // The anti-punt clarify discipline (W4 eval fix) must survive the
+        // retighten: the compact bootstrap skeleton truncates ClarifyTool's
+        // description to its first sentence, so this bullet is the only
+        // place a small model sees the "fully specified ≠ ambiguous" rule.
+        #expect(compactLoop.contains("last resort"))
+        #expect(compactLoop.contains("fully specified"))
 
         // Grounding (discovery-aware): compact keeps the capability-claim rule.
         smaller(

--- a/Packages/OsaurusCore/Tests/Chat/TranscriptPrefixMonotonicityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TranscriptPrefixMonotonicityTests.swift
@@ -1,0 +1,228 @@
+//
+//  TranscriptPrefixMonotonicityTests.swift
+//  osaurusTests
+//
+//  Cross-turn KV-prefix contract: the message array sent on turn N must be
+//  a strict prefix — role and content bytes — of the array sent on turn
+//  N+1. The static system+tools prefix is covered by PrefixHashTests /
+//  SessionPreflightCacheTests; this suite covers the CONVERSATION part,
+//  which regressed silently when per-turn memory / screen-context
+//  injection rewrote the previous user message between turns (turn N sent
+//  `u_N + [Memory]`, turn N+1 sent `u_N` clean), re-prefilling the whole
+//  last exchange every turn.
+//
+//  The simulation uses the exact primitives the chat surface now uses:
+//  a frozen `injectedContextPrefix` per user turn, rendered through
+//  `ChatSession.applyingFrozenInjectedPrefix`, plus the sticky
+//  `CompactionWatermark` that must NOT reset across append-only growth.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Transcript prefix monotonicity")
+struct TranscriptPrefixMonotonicityTests {
+
+    /// Byte-level equality of the shared prefix: every message of turn N's
+    /// outbound array must reappear at the same index in turn N+1's array
+    /// with identical role, content, and tool-call linkage.
+    private func expectStrictPrefix(_ earlier: [ChatMessage], of later: [ChatMessage]) {
+        #expect(earlier.count < later.count, "turn N+1 must extend turn N, not replace it")
+        for (idx, msg) in earlier.enumerated() {
+            #expect(later[idx].role == msg.role, "role diverged at index \(idx)")
+            #expect(later[idx].content == msg.content, "content bytes diverged at index \(idx)")
+            #expect(later[idx].tool_call_id == msg.tool_call_id, "tool linkage diverged at index \(idx)")
+        }
+    }
+
+    /// Render a simulated chat history the way `turnToMessage` now does:
+    /// system prompt first, user turns with their frozen prefix replayed,
+    /// assistant turns as-is.
+    @MainActor
+    private func render(
+        system: String,
+        turns: [(role: String, content: String, frozenPrefix: String?)]
+    ) -> [ChatMessage] {
+        var msgs: [ChatMessage] = [ChatMessage(role: "system", content: system)]
+        for turn in turns {
+            if turn.role == "user" {
+                let base = ChatMessage(role: "user", content: turn.content)
+                msgs.append(ChatSession.applyingFrozenInjectedPrefix(turn.frozenPrefix, to: base))
+            } else {
+                msgs.append(ChatMessage(role: turn.role, content: turn.content))
+            }
+        }
+        return msgs
+    }
+
+    /// Two consecutive turns with memory + screen context on: turn N's
+    /// outbound transcript must be a strict byte-prefix of turn N+1's.
+    /// This is the test that would have caught the injection divergence.
+    @Test @MainActor func turnN_isStrictBytePrefixOfTurnN1_withMemoryAndScreenContext() {
+        let system = "You are the local agent."
+        let screen = "[Screen Context]\nDoing: In Safari\n[/Screen Context]"
+
+        // Turn 1: the send path freezes memory+screen onto u1 at send time.
+        let prefix1 = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "fact for turn one",
+            screenContext: screen
+        )
+        let turn1 = render(
+            system: system,
+            turns: [("user", "first question", prefix1)]
+        )
+
+        // Turn 2: history is append-only; u1 keeps its frozen prefix, the
+        // new turn freezes its own (fresh memory recall, same frozen
+        // screen-context snapshot — it is per-session).
+        let prefix2 = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "different fact for turn two",
+            screenContext: screen
+        )
+        let turn2 = render(
+            system: system,
+            turns: [
+                ("user", "first question", prefix1),
+                ("assistant", "first answer", nil),
+                ("user", "second question", prefix2),
+            ]
+        )
+
+        expectStrictPrefix(turn1, of: turn2)
+
+        // And the divergence the fix removes: rendering u1 CLEAN on turn 2
+        // (the legacy behavior — injection rode only the latest message)
+        // breaks the byte prefix at u1.
+        let legacyTurn2 = render(
+            system: system,
+            turns: [
+                ("user", "first question", nil),
+                ("assistant", "first answer", nil),
+                ("user", "second question", prefix2),
+            ]
+        )
+        #expect(legacyTurn2[1].content != turn1[1].content)
+    }
+
+    /// Multi-turn: the property holds transitively across three turns with
+    /// changing memory, including a turn without any injected context
+    /// (memory recall can come back empty).
+    @Test @MainActor func monotonicityHoldsAcrossThreeTurns_withGapTurn() {
+        let system = "sys"
+        let p1 = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "m1",
+            screenContext: nil
+        )
+        let p3 = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "m3",
+            screenContext: nil
+        )
+
+        var history: [(role: String, content: String, frozenPrefix: String?)] = [
+            ("user", "q1", p1)
+        ]
+        let t1 = render(system: system, turns: history)
+
+        history += [("assistant", "a1", nil), ("user", "q2", nil)]  // no memory this turn
+        let t2 = render(system: system, turns: history)
+
+        history += [("assistant", "a2", nil), ("user", "q3", p3)]
+        let t3 = render(system: system, turns: history)
+
+        expectStrictPrefix(t1, of: t2)
+        expectStrictPrefix(t2, of: t3)
+        expectStrictPrefix(t1, of: t3)
+    }
+
+    /// The sticky compaction watermark must survive append-only growth of
+    /// the frozen-prefix transcript: identities recorded on turn N still
+    /// match on turn N+1, so verbatim/summarize/drop decisions replay
+    /// instead of resetting (a reset recomputes trims and can rewrite
+    /// mid-transcript bytes). Before the fix, the injected prefix vanished
+    /// from u_N between turns, changing its identity hash and resetting
+    /// the watermark every turn.
+    @Test @MainActor func watermark_decisionsSurviveAppendOnlyGrowth() {
+        let system = "sys"
+        let p1 = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "m1",
+            screenContext: nil
+        )
+        let p2 = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "m2",
+            screenContext: nil
+        )
+
+        let turn1 = render(system: system, turns: [("user", "q1", p1)])
+        let turn2 = render(
+            system: system,
+            turns: [
+                ("user", "q1", p1),
+                ("assistant", "a1", nil),
+                ("user", "q2", p2),
+            ]
+        )
+
+        // Big budget: nothing trims, every sent message is recorded verbatim.
+        let manager = ContextBudgetManager(contextLength: 128_000)
+        let watermark = CompactionWatermark()
+
+        let out1 = manager.trimMessagesReportingOverflow(turn1, watermark: watermark)
+        #expect(out1.messages.map(\.content) == turn1.map(\.content))
+
+        // Turn 2 validates identities against the grown history. If the
+        // frozen prefix had vanished (legacy divergence), index 1's identity
+        // would mismatch and reset every decision.
+        let out2 = manager.trimMessagesReportingOverflow(turn2, watermark: watermark)
+        #expect(out2.messages.map(\.content) == turn2.map(\.content))
+
+        // The turn-1 messages must still carry their verbatim markers —
+        // proof the watermark did NOT reset on turn 2.
+        for idx in turn1.indices {
+            switch watermark.decision(at: idx) {
+            case .verbatim: break
+            default: Issue.record("watermark reset: index \(idx) lost its verbatim marker")
+            }
+        }
+    }
+
+    /// Same property for the HTTP/plugin ledger path: two consecutive
+    /// requests through `applyFrozenMemoryPrefixes` produce monotonic
+    /// transcripts even though the client resends clean history.
+    @Test func ledgerPath_requestN_isStrictBytePrefixOfRequestN1() {
+        var ledger: [String: String] = [:]
+
+        var request1: [ChatMessage] = [
+            ChatMessage(role: "system", content: "sys"),
+            ChatMessage(role: "user", content: "q1"),
+        ]
+        if let rec = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "m1",
+            frozen: ledger,
+            into: &request1
+        ) {
+            ledger[rec.key] = rec.prefix
+        }
+
+        var request2: [ChatMessage] = [
+            ChatMessage(role: "system", content: "sys"),
+            ChatMessage(role: "user", content: "q1"),
+            ChatMessage(role: "assistant", content: "a1"),
+            ChatMessage(role: "user", content: "q2"),
+        ]
+        if let rec = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "m2",
+            frozen: ledger,
+            into: &request2
+        ) {
+            ledger[rec.key] = rec.prefix
+        }
+
+        #expect(request1.count < request2.count)
+        for (idx, msg) in request1.enumerated() {
+            #expect(request2[idx].role == msg.role, "role diverged at index \(idx)")
+            #expect(request2[idx].content == msg.content, "content bytes diverged at index \(idx)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/UserTurnInjectionFreezeTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/UserTurnInjectionFreezeTests.swift
@@ -1,0 +1,325 @@
+//
+//  UserTurnInjectionFreezeTests.swift
+//  osaurusTests
+//
+//  Coverage for the frozen user-turn context prefix (memory + screen
+//  context). The contract under test: once a user turn has been sent with
+//  an injected prefix, every later request must replay the exact same
+//  bytes for that turn —
+//    • `SystemPromptComposer.composeInjectedUserPrefix` renders the prefix
+//      byte-identically to the legacy per-iteration injectors,
+//    • `ChatSession.applyingFrozenInjectedPrefix` replays it onto a
+//      rendered user message (skipping multimodal parts messages),
+//    • `SystemPromptComposer.applyFrozenMemoryPrefixes` gives the
+//      HTTP/plugin paths (client-owned history) the same stability via a
+//      session ledger, and
+//    • the prefix survives ChatTurn / ChatTurnData persistence.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Frozen user-turn injection")
+struct UserTurnInjectionFreezeTests {
+
+    private let memory = "recent fact about the user"
+    private let screen = "[Screen Context]\nDoing: In Safari\n[/Screen Context]"
+
+    // MARK: - composeInjectedUserPrefix byte parity with the legacy injectors
+
+    /// `prefix + original` must reproduce what `injectMemoryPrefix` +
+    /// `injectScreenContextPrefix` used to produce, byte for byte — the KV
+    /// cache compares raw bytes, so "almost the same" is a full re-prefill.
+    @Test func composedPrefix_matchesLegacyInjectorBytes_bothBlocks() {
+        var msgs = [ChatMessage(role: "user", content: "hello world")]
+        SystemPromptComposer.injectMemoryPrefix(memory, into: &msgs)
+        SystemPromptComposer.injectScreenContextPrefix(screen, into: &msgs)
+        let legacy = msgs[0].content ?? ""
+
+        let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: memory,
+            screenContext: screen
+        )
+        #expect(prefix != nil)
+        #expect((prefix ?? "") + "hello world" == legacy)
+    }
+
+    @Test func composedPrefix_matchesLegacyInjectorBytes_memoryOnly() {
+        var msgs = [ChatMessage(role: "user", content: "question")]
+        SystemPromptComposer.injectMemoryPrefix(memory, into: &msgs)
+        let legacy = msgs[0].content ?? ""
+
+        let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: memory,
+            screenContext: nil
+        )
+        #expect((prefix ?? "") + "question" == legacy)
+    }
+
+    @Test func composedPrefix_matchesLegacyInjectorBytes_screenOnly() {
+        var msgs = [ChatMessage(role: "user", content: "question")]
+        SystemPromptComposer.injectScreenContextPrefix(screen, into: &msgs)
+        let legacy = msgs[0].content ?? ""
+
+        let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: nil,
+            screenContext: screen
+        )
+        #expect((prefix ?? "") + "question" == legacy)
+    }
+
+    /// Whitespace-only inputs collapse to nil exactly like the injectors
+    /// no-op, and surrounding whitespace is trimmed the same way.
+    @Test func composedPrefix_trimsAndCollapsesLikeInjectors() {
+        #expect(
+            SystemPromptComposer.composeInjectedUserPrefix(
+                memorySection: nil,
+                screenContext: nil
+            ) == nil
+        )
+        #expect(
+            SystemPromptComposer.composeInjectedUserPrefix(
+                memorySection: "   \n  ",
+                screenContext: "  \n "
+            ) == nil
+        )
+
+        var msgs = [ChatMessage(role: "user", content: "x")]
+        SystemPromptComposer.injectMemoryPrefix("  \(memory)\n", into: &msgs)
+        let legacy = msgs[0].content ?? ""
+        let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "  \(memory)\n",
+            screenContext: nil
+        )
+        #expect((prefix ?? "") + "x" == legacy)
+    }
+
+    // MARK: - applyingFrozenInjectedPrefix (chat render path)
+
+    @Test @MainActor func applyingPrefix_prependsToTextMessage() {
+        let base = ChatMessage(
+            role: "user",
+            content: "ask",
+            tool_calls: nil,
+            tool_call_id: "call_abc"
+        )
+        let out = ChatSession.applyingFrozenInjectedPrefix("[Memory]\nm\n[/Memory]\n\n", to: base)
+        #expect(out.content == "[Memory]\nm\n[/Memory]\n\nask")
+        #expect(out.role == "user")
+        #expect(out.tool_call_id == "call_abc")
+    }
+
+    @Test @MainActor func applyingPrefix_isNoopForNilOrEmptyPrefix() {
+        let base = ChatMessage(role: "user", content: "ask")
+        #expect(ChatSession.applyingFrozenInjectedPrefix(nil, to: base).content == "ask")
+        #expect(ChatSession.applyingFrozenInjectedPrefix("", to: base).content == "ask")
+    }
+
+    /// Multimodal parts messages are returned untouched — parity with the
+    /// injectors' `contentParts` guard, so a turn that renders as parts
+    /// (images/audio/video) never gains a text prefix.
+    @Test @MainActor func applyingPrefix_skipsMultimodalMessages() {
+        let base = ChatMessage(role: "user", content: "caption", contentParts: [.text("caption")])
+        let out = ChatSession.applyingFrozenInjectedPrefix("P\n\n", to: base)
+        #expect(out.contentParts != nil)
+        #expect(out.content == "caption")
+    }
+
+    // MARK: - applyFrozenMemoryPrefixes (HTTP / plugin session ledger)
+
+    @Test func ledger_injectsFreshMemoryIntoLatestAndReturnsRecord() {
+        var msgs: [ChatMessage] = [
+            ChatMessage(role: "system", content: "sys"),
+            ChatMessage(role: "user", content: "hello"),
+        ]
+        let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-1",
+            frozen: [:],
+            into: &msgs
+        )
+        #expect(recorded != nil)
+        #expect(msgs[1].content == "[Memory]\nfact-1\n[/Memory]\n\nhello")
+        #expect(recorded?.prefix == "[Memory]\nfact-1\n[/Memory]\n\n")
+        #expect(msgs[0].content == "sys")
+    }
+
+    /// The core divergence fix: request 2 resends CLEAN history, and the
+    /// ledger replays request 1's injected bytes onto the matching history
+    /// message while the fresh memory lands on the new latest message.
+    @Test func ledger_replaysRecordedPrefixOntoHistoryAcrossRequests() {
+        // Request 1.
+        var request1: [ChatMessage] = [ChatMessage(role: "user", content: "hello")]
+        var ledger: [String: String] = [:]
+        if let rec = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-1",
+            frozen: ledger,
+            into: &request1
+        ) {
+            ledger[rec.key] = rec.prefix
+        }
+        let request1LatestBytes = request1[0].content ?? ""
+
+        // Request 2: client-owned clean history + a new user message.
+        var request2: [ChatMessage] = [
+            ChatMessage(role: "user", content: "hello"),
+            ChatMessage(role: "assistant", content: "hi"),
+            ChatMessage(role: "user", content: "next question"),
+        ]
+        if let rec = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-2",
+            frozen: ledger,
+            into: &request2
+        ) {
+            ledger[rec.key] = rec.prefix
+        }
+
+        // History user message replays request 1's exact bytes.
+        #expect(request2[0].content == request1LatestBytes)
+        // Latest user message carries the fresh memory.
+        #expect(request2[2].content == "[Memory]\nfact-2\n[/Memory]\n\nnext question")
+        // Both entries recorded under distinct keys.
+        #expect(ledger.count == 2)
+    }
+
+    /// A retry that resends the identical latest message replays the
+    /// RECORDED prefix (byte stability) even when fresher memory exists,
+    /// and records nothing new.
+    @Test func ledger_identicalRetryReplaysRecordedPrefix() {
+        var request1: [ChatMessage] = [ChatMessage(role: "user", content: "hello")]
+        var ledger: [String: String] = [:]
+        if let rec = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-1",
+            frozen: ledger,
+            into: &request1
+        ) {
+            ledger[rec.key] = rec.prefix
+        }
+
+        var retry: [ChatMessage] = [ChatMessage(role: "user", content: "hello")]
+        let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-99",
+            frozen: ledger,
+            into: &retry
+        )
+        #expect(recorded == nil)
+        #expect(retry[0].content == request1[0].content)
+    }
+
+    /// Duplicate user texts ("yes", "continue") get distinct occurrence
+    /// ordinals, so the second occurrence gets its own fresh memory rather
+    /// than replaying the first occurrence's prefix.
+    @Test func ledger_duplicateUserTextsGetDistinctKeys() {
+        var request1: [ChatMessage] = [ChatMessage(role: "user", content: "yes")]
+        var ledger: [String: String] = [:]
+        if let rec = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-1",
+            frozen: ledger,
+            into: &request1
+        ) {
+            ledger[rec.key] = rec.prefix
+        }
+
+        var request2: [ChatMessage] = [
+            ChatMessage(role: "user", content: "yes"),
+            ChatMessage(role: "assistant", content: "ok"),
+            ChatMessage(role: "user", content: "yes"),
+        ]
+        let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact-2",
+            frozen: ledger,
+            into: &request2
+        )
+        // First "yes" replays fact-1; second "yes" gets fact-2 under a new key.
+        #expect(request2[0].content == "[Memory]\nfact-1\n[/Memory]\n\nyes")
+        #expect(request2[2].content == "[Memory]\nfact-2\n[/Memory]\n\nyes")
+        #expect(recorded != nil)
+        #expect(recorded.map { ledger[$0.key] == nil } == true)
+    }
+
+    @Test func ledger_skipsMultimodalLatestMessage() {
+        var msgs: [ChatMessage] = [
+            ChatMessage(role: "user", content: "caption", contentParts: [.text("caption")])
+        ]
+        let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: "fact",
+            frozen: [:],
+            into: &msgs
+        )
+        #expect(recorded == nil)
+        #expect(msgs[0].content == "caption")
+        #expect(msgs[0].contentParts != nil)
+    }
+
+    @Test func ledger_noMemoryAndNoLedgerIsNoop() {
+        var msgs: [ChatMessage] = [ChatMessage(role: "user", content: "hello")]
+        let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
+            memorySection: nil,
+            frozen: [:],
+            into: &msgs
+        )
+        #expect(recorded == nil)
+        #expect(msgs[0].content == "hello")
+    }
+
+    // MARK: - Session store ledger round trip
+
+    @Test func store_recordsAndReturnsPrefixes_andInvalidateClears() async {
+        let sid = "freeze-test-\(UUID().uuidString)"
+        let before = await SessionToolStateStore.shared.frozenUserPrefixes(sid)
+        #expect(before.isEmpty)
+
+        await SessionToolStateStore.shared.recordUserPrefix(sid, key: "abc#0", prefix: "P\n\n")
+        let after = await SessionToolStateStore.shared.frozenUserPrefixes(sid)
+        #expect(after["abc#0"] == "P\n\n")
+
+        await SessionToolStateStore.shared.invalidate(sid)
+        let cleared = await SessionToolStateStore.shared.frozenUserPrefixes(sid)
+        #expect(cleared.isEmpty)
+    }
+
+    // MARK: - Persistence round trip
+
+    @Test @MainActor func chatTurnData_roundTripsInjectedContextPrefix() throws {
+        let turn = ChatTurn(role: .user, content: "hello")
+        turn.injectedContextPrefix = "[Memory]\nfact\n[/Memory]\n\n"
+
+        let data = ChatTurnData(from: turn)
+        let encoded = try JSONEncoder().encode(data)
+        let decoded = try JSONDecoder().decode(ChatTurnData.self, from: encoded)
+        #expect(decoded.injectedContextPrefix == "[Memory]\nfact\n[/Memory]\n\n")
+
+        let restored = ChatTurn(from: decoded)
+        #expect(restored.injectedContextPrefix == "[Memory]\nfact\n[/Memory]\n\n")
+        #expect(restored.content == "hello")
+    }
+
+    /// Legacy sessions (no `injectedContextPrefix` key) must keep decoding.
+    @Test func chatTurnData_decodesLegacyJSONWithoutPrefixKey() throws {
+        let legacyJSON = """
+            {
+                "id": "\(UUID().uuidString)",
+                "role": "user",
+                "content": "old message",
+                "attachments": [],
+                "toolResults": {},
+                "thinking": ""
+            }
+            """
+        let decoded = try JSONDecoder().decode(ChatTurnData.self, from: Data(legacyJSON.utf8))
+        #expect(decoded.injectedContextPrefix == nil)
+        #expect(decoded.content == "old message")
+    }
+
+    @Test @MainActor func chatTurnPersisted_roundTripsInjectedContextPrefix() throws {
+        let turn = ChatTurn(role: .user, content: "hello")
+        turn.injectedContextPrefix = "P\n\n"
+
+        let persisted = turn.toPersisted()
+        let encoded = try JSONEncoder().encode(persisted)
+        let decoded = try JSONDecoder().decode(ChatTurn.Persisted.self, from: encoded)
+        let restored = ChatTurn.fromPersisted(decoded)
+        #expect(restored.injectedContextPrefix == "P\n\n")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/AnthropicAPITests.swift
+++ b/Packages/OsaurusCore/Tests/Model/AnthropicAPITests.swift
@@ -34,6 +34,77 @@ struct AnthropicAPITests {
         #expect(request.messages[0].content.plainText == "Hello, Claude!")
     }
 
+    // MARK: - Prompt caching (top-level cache_control)
+
+    @Test func outboundAnthropicRequestCarriesTopLevelCacheControl() throws {
+        let request = RemoteChatRequest(
+            model: "claude-opus-4-8",
+            messages: [ChatMessage(role: "user", content: "Hello")],
+            temperature: nil,
+            max_completion_tokens: 512,
+            stream: true,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            tools: nil,
+            tool_choice: nil,
+            reasoning_effort: nil,
+            reasoning: nil,
+            thinking: nil,
+            modelOptions: [:],
+            veniceParameters: nil
+        ).toAnthropicRequest()
+
+        #expect(request.cache_control?.type == "ephemeral")
+
+        // And it reaches the wire as a top-level key.
+        let encoded = try JSONEncoder.osaurusCanonical().encode(request)
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let cacheControl = json?["cache_control"] as? [String: Any]
+        #expect(cacheControl?["type"] as? String == "ephemeral")
+    }
+
+    @Test func inboundAnthropicRequestWithoutCacheControlStillDecodes() throws {
+        // Server-side compat path: SDK clients that don't send cache_control
+        // must keep decoding exactly as before.
+        let json = """
+            {
+                "model": "claude-3-5-sonnet-20241022",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "Hello"}
+                ]
+            }
+            """
+        let request = try JSONDecoder().decode(AnthropicMessagesRequest.self, from: Data(json.utf8))
+        #expect(request.cache_control == nil)
+    }
+
+    @Test func anthropicUsageDecodesCacheFields() throws {
+        let json = """
+            {
+                "input_tokens": 12,
+                "output_tokens": 34,
+                "cache_creation_input_tokens": 2048,
+                "cache_read_input_tokens": 4096
+            }
+            """
+        let usage = try JSONDecoder().decode(AnthropicUsage.self, from: Data(json.utf8))
+        #expect(usage.input_tokens == 12)
+        #expect(usage.output_tokens == 34)
+        #expect(usage.cache_creation_input_tokens == 2048)
+        #expect(usage.cache_read_input_tokens == 4096)
+
+        // Absent fields stay nil (server-side writer / non-caching providers).
+        let bare = try JSONDecoder().decode(
+            AnthropicUsage.self,
+            from: Data(#"{"input_tokens": 1, "output_tokens": 2}"#.utf8)
+        )
+        #expect(bare.cache_creation_input_tokens == nil)
+        #expect(bare.cache_read_input_tokens == nil)
+    }
+
     @Test func parseAnthropicRequestWithSystem() throws {
         let json = """
             {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -1578,6 +1578,112 @@ struct RemoteChatRequestEncodingTests {
         #expect(!openAICompatBody.contains("\"clamp_to_balance\""))
     }
 
+    // MARK: - prompt_cache_key (session-scoped OpenAI prompt-cache routing)
+
+    @Test func supportsPromptCacheKey_onlyForGenuineOpenAIHosts() throws {
+        #expect(
+            RemoteProviderService.supportsPromptCacheKey(
+                providerType: .openaiLegacy,
+                host: "api.openai.com"
+            )
+        )
+        #expect(
+            RemoteProviderService.supportsPromptCacheKey(
+                providerType: .openaiLegacy,
+                host: "eu.api.openai.com"
+            )
+        )
+        // Third-party OpenAI-compat schemas can be strict about unknown
+        // fields — same rationale as router-only `idempotency_key`.
+        #expect(
+            !RemoteProviderService.supportsPromptCacheKey(
+                providerType: .openaiLegacy,
+                host: "api.x.ai"
+            )
+        )
+        #expect(
+            !RemoteProviderService.supportsPromptCacheKey(
+                providerType: .osaurusRouter,
+                host: "router.osaurus.ai"
+            )
+        )
+        #expect(
+            !RemoteProviderService.supportsPromptCacheKey(
+                providerType: .anthropic,
+                host: "api.anthropic.com"
+            )
+        )
+    }
+
+    @Test func wireBody_carriesPromptCacheKeyOnlyWhenSet() throws {
+        var request = Self.makeRequest(model: "gpt-5.2", maxTokens: 128)
+        let bare = try JSONEncoder.osaurusCanonical().encode(request)
+        #expect(!String(decoding: bare, as: UTF8.self).contains("prompt_cache_key"))
+
+        request.promptCacheKey = "osaurus-session-ABC"
+        let payload = try Self.decodeAsDictionary(
+            try JSONEncoder.osaurusCanonical().encode(request)
+        )
+        #expect(payload["prompt_cache_key"] as? String == "osaurus-session-ABC")
+    }
+
+    @Test func buildChatRequest_setsSessionScopedPromptCacheKeyForOpenAIOnly() async throws {
+        func service(host: String, providerType: RemoteProviderType) -> RemoteProviderService {
+            RemoteProviderService(
+                provider: RemoteProvider(
+                    name: "p",
+                    host: host,
+                    providerProtocol: .https,
+                    port: nil,
+                    basePath: "/v1",
+                    authType: .none,
+                    providerType: providerType
+                ),
+                models: ["gpt-5.2"],
+                resolvedHeaders: [:]
+            )
+        }
+        let params = GenerationParameters(
+            temperature: 0.7,
+            maxTokens: 256,
+            sessionId: "SESSION-1"
+        )
+
+        let openAIReq = await service(host: "api.openai.com", providerType: .openaiLegacy)
+            .buildChatRequest(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                parameters: params,
+                model: "gpt-5.2",
+                stream: true,
+                tools: nil,
+                toolChoice: nil
+            )
+        #expect(openAIReq.promptCacheKey == "osaurus-session-SESSION-1")
+
+        let compatReq = await service(host: "api.x.ai", providerType: .openaiLegacy)
+            .buildChatRequest(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                parameters: params,
+                model: "grok-4",
+                stream: true,
+                tools: nil,
+                toolChoice: nil
+            )
+        #expect(compatReq.promptCacheKey == nil)
+
+        // No session id → no key, even on the genuine OpenAI host.
+        let noSessionReq = await service(host: "api.openai.com", providerType: .openaiLegacy)
+            .buildChatRequest(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                parameters: GenerationParameters(temperature: 0.7, maxTokens: 256),
+                model: "gpt-5.2",
+                stream: true,
+                tools: nil,
+                toolChoice: nil
+            )
+        #expect(noSessionReq.promptCacheKey == nil)
+    }
+
     @Test func wireBody_routerMatchesVeniceToolRequest_exceptRouterOnlyFields() throws {
         let priorCall = ToolCall(
             id: "call_write_1",

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -316,7 +316,14 @@ struct RuntimePolicySourceTests {
         #expect(source.contains("query: extractLatestUserQuery(from: messages)"))
         #expect(source.contains("messages: messages"))
         #expect(source.contains("memorySection: composed.memorySection"))
-        #expect(source.contains("SystemPromptComposer.injectMemoryPrefix(ctx.memorySection, into: &messages)"))
+        // Memory rides the latest user message via the session-stable frozen
+        // prefix path (KV-safe across requests), not a per-request injection
+        // that vanishes from the next request's history.
+        #expect(source.contains("SystemPromptComposer.applyFrozenMemoryPrefixes("))
+        #expect(source.contains("memorySection: ctx.memorySection"))
+        #expect(source.contains("frozen: frozenUserPrefixes"))
+        #expect(source.contains("recordUserPrefix("))
+        #expect(!source.contains("SystemPromptComposer.injectMemoryPrefix("))
     }
 
     @Test("plugin host inference defaults to a real tool loop")

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1166,6 +1166,25 @@ final class ChatSession: ObservableObject {
         return ChatMessage(role: "user", content: messageText)
     }
 
+    /// Prepend a user turn's frozen memory / screen-context prefix to its
+    /// rendered message. The prefix already carries its trailing separator
+    /// (`SystemPromptComposer.composeInjectedUserPrefix`), so this is a pure
+    /// byte concatenation — `prefix + content` reproduces exactly what the
+    /// legacy per-iteration injectors used to send. Multimodal messages are
+    /// returned unchanged, matching the injectors' `contentParts` guard.
+    static func applyingFrozenInjectedPrefix(
+        _ prefix: String?,
+        to message: ChatMessage
+    ) -> ChatMessage {
+        guard let prefix, !prefix.isEmpty, message.contentParts == nil else { return message }
+        return ChatMessage(
+            role: message.role,
+            content: prefix + (message.content ?? ""),
+            tool_calls: message.tool_calls,
+            tool_call_id: message.tool_call_id
+        )
+    }
+
     private static func audioPayload(from attachment: Attachment) -> (
         data: Data,
         format: String,
@@ -3191,6 +3210,46 @@ final class ChatSession: ObservableObject {
         isDirty = true
     }
 
+    /// Freeze this run's memory + screen-context blocks onto the latest user
+    /// turn, once, at send time. From then on `turnToMessage` replays the
+    /// prefix verbatim on every request, so the turn's wire bytes are
+    /// byte-identical across loop iterations AND across later turns — the
+    /// paged KV cache reuses the whole prior exchange instead of
+    /// re-prefilling it (the prefix used to vanish from history the moment
+    /// the next turn became "latest"). Mirrors how `frozenManifest` /
+    /// `frozenSoul` freeze the static prompt side.
+    private func freezeInjectedContextOntoLatestUserTurn(
+        memorySection: String?,
+        screenContext: String?
+    ) {
+        guard let turn = turns.last(where: { $0.role == .user }) else { return }
+        // Regeneration re-runs an already-sent turn: keep the original
+        // bytes. The KV prefix through this turn is still valid, and the
+        // model already read the original memory block — fresher recall is
+        // not worth rewriting sent history.
+        guard turn.injectedContextPrefix == nil else { return }
+        // Parity with the legacy injector guard: a turn that renders as a
+        // multimodal parts message never carries an injected prefix.
+        if !turn.attachments.isEmpty {
+            let rendered = Self.buildUserChatMessage(
+                content: turn.content,
+                attachments: turn.attachments,
+                supportsImages: selectedModelSupportsImages,
+                supportsAudio: selectedModelSupportsAudio,
+                supportsVideo: selectedModelSupportsVideo
+            )
+            if rendered.contentParts != nil { return }
+        }
+        guard
+            let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+                memorySection: memorySection,
+                screenContext: screenContext
+            )
+        else { return }
+        turn.injectedContextPrefix = prefix
+        isDirty = true
+    }
+
     func send(_ text: String, attachments: [Attachment] = []) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasContent = !trimmed.isEmpty || !attachments.isEmpty
@@ -3495,6 +3554,23 @@ final class ChatSession: ObservableObject {
                     budgetTracker.snapshot(context: context)
                     budgetTracker.updateScreenContext(tokens: cachedScreenContextTokens)
 
+                    // Freeze this turn's memory + screen-context prefix into
+                    // the turn history BEFORE any messages are rendered: the
+                    // injected bytes become part of the turn's permanent
+                    // rendering, so turn N+1 replays turn N byte-identically
+                    // and the paged KV cache reuses the whole previous
+                    // exchange. (Previously the prefix was re-injected onto
+                    // whichever user message was latest and vanished from
+                    // history on the next turn, re-prefilling the last
+                    // exchange every turn.) Skipped in Mode 2: requests stay
+                    // bare and the remote agent applies its own context.
+                    if !isRemoteAgentTarget {
+                        freezeInjectedContextOntoLatestUserTurn(
+                            memorySection: context.memorySection,
+                            screenContext: screenContextEnabled ? frozenScreenContext : nil
+                        )
+                    }
+
                     let effectiveMaxTokensForAgent = AgentManager.shared.effectiveMaxTokens(for: effectiveAgentId)
 
                     // KV-cache-aware history compaction: shared window
@@ -3553,12 +3629,23 @@ final class ChatSession: ObservableObject {
                                 tool_call_id: t.toolCallId
                             )
                         case .user:
-                            return Self.buildUserChatMessage(
+                            let base = Self.buildUserChatMessage(
                                 content: t.content,
                                 attachments: t.attachments,
                                 supportsImages: selectedModelSupportsImages,
                                 supportsAudio: selectedModelSupportsAudio,
                                 supportsVideo: selectedModelSupportsVideo
+                            )
+                            // Replay the frozen memory / screen-context block
+                            // this turn was originally sent with, so its wire
+                            // bytes never change once it has been part of a
+                            // token stream (paged-KV prefix reuse across
+                            // turns). Mode 2 requests stay bare — the local
+                            // agent's memory must not ride to a remote agent.
+                            if isRemoteAgentTarget { return base }
+                            return Self.applyingFrozenInjectedPrefix(
+                                t.injectedContextPrefix,
+                                to: base
                             )
                         default:
                             return ChatMessage(role: t.role.rawValue, content: t.content)
@@ -4130,44 +4217,30 @@ final class ChatSession: ObservableObject {
                                 )
                             }
 
-                            // Conversation tokens are measured BEFORE the memory
-                            // + screen-context prefixes are injected, so each is
-                            // attributed to its own budget row (Memory / Screen
-                            // Context) instead of being double-counted inside the
-                            // Conversation total.
+                            // Memory + screen context ride the latest user
+                            // message as a FROZEN turn prefix (see
+                            // `freezeInjectedContextOntoLatestUserTurn`), so
+                            // `buildMessages()` already rendered them and the
+                            // trimmer/watermark above saw the final bytes.
+                            // The current turn's injected block is attributed
+                            // to its own budget rows (Memory / Screen
+                            // Context), so subtract it from the Conversation
+                            // total; PAST turns' frozen prefixes are genuine
+                            // history bytes and stay counted here.
+                            let currentInjectedTokens =
+                                self.turns.last(where: { $0.role == .user })?
+                                .injectedContextPrefix
+                                .map { ContextBudgetManager.estimateTokens(for: $0) } ?? 0
                             let convTokens =
                                 msgs
                                 .filter { $0.role != "system" }
                                 .reduce(0) { $0 + ContextBudgetManager.estimateTokens(for: $1.content) }
+                                - currentInjectedTokens
                             self.budgetTracker.updateConversation(
-                                tokens: convTokens,
+                                tokens: max(0, convTokens),
                                 finishedOutputTurn: assistantTurn
                             )
 
-                            // Memory now lives on the latest user message instead of
-                            // the system prompt — keeps the system prefix byte-stable
-                            // across turns so the MLX paged KV cache can reuse the
-                            // entire conversation prefix. Skipped in Mode 2: this is
-                            // the *local* agent's memory and must not ride along to
-                            // the remote agent, which applies its own.
-                            if !self.isRemoteAgentTarget {
-                                SystemPromptComposer.injectMemoryPrefix(
-                                    context.memorySection,
-                                    into: &msgs
-                                )
-                            }
-
-                            // Opt-in: prepend the frozen screen-context snapshot
-                            // to the latest user message (same seam as memory).
-                            // Keeps the system prefix KV-stable and routes the
-                            // snapshot through the Privacy Filter on cloud sends.
-                            // Skipped in Mode 2 (no local context leaves the client).
-                            if !self.isRemoteAgentTarget, screenContextEnabled {
-                                SystemPromptComposer.injectScreenContextPrefix(
-                                    self.frozenScreenContext,
-                                    into: &msgs
-                                )
-                            }
                             // `overBudget` (protected first message + tail
                             // alone exceed the budget after every compaction
                             // lever) ends the run with a distinct exit
@@ -4272,12 +4345,17 @@ final class ChatSession: ObservableObject {
                             // matching TTFT fields per send so we can audit KV reuse
                             // without instrumenting MLX. Helper lives on the store
                             // so the turn counter + previous-hint comparison sit
-                            // next to the state they describe.
+                            // next to the state they describe. Passing the outbound
+                            // messages adds the conversation-level line — reused vs
+                            // re-prefilled history tokens per send — which is the
+                            // tripwire for cross-turn byte divergence (frozen turn
+                            // prefixes keep it near-total reuse).
                             if let sid = self.sessionId {
                                 await SessionToolStateStore.shared.recordSend(
                                     sessionId: self.sessionStateKey(sid),
                                     cacheHint: context.cacheHint,
-                                    trace: ttftTrace
+                                    trace: ttftTrace,
+                                    conversation: msgs
                                 )
                             }
                             do {


### PR DESCRIPTION
## Summary

System-prompt efficiency audit follow-up. Three cost leaks, all fixed, with before/after eval proof that quality holds.

### Remote: enable provider prompt caching (pay-per-token savings)

- **Anthropic**: outbound requests now carry top-level `cache_control: {"type": "ephemeral"}`, so multi-turn Claude sessions re-read the shared prefix at 0.1x input price instead of re-paying full rate every turn (the canonical JSON encoder already guarantees byte-stable prefixes). Cache usage (`cache_read_input_tokens` / `cache_creation_input_tokens`) is parsed from both the streaming `message_start` event and non-streaming responses, and logged as `[Cache][Anthropic]` so the win is observable. The server-side Anthropic-compat decode path is unaffected (field is optional).
- **OpenAI**: genuine `*.openai.com` hosts get a session-scoped `prompt_cache_key` (`osaurus-session-<id>`) to route one conversation's turns to the same upstream cache shard. Gated by `supportsPromptCacheKey` so strict third-party OpenAI-compat schemas never see an unknown field (same rationale as router-only `idempotency_key`).

### Local: fix cross-turn KV-cache busts (prefill time/energy on user hardware)

- **The injection divergence**: memory / screen-context blocks were injected into whichever user message was *latest*, so turn N sent `u_N + [Memory]` but turn N+1 resent `u_N` clean. The paged-KV byte prefix diverged at that message and **the whole last exchange re-prefilled every turn** whenever memory or screen context was on.
  - Chat surface: the injected block is now **frozen onto the user turn at send time** (`ChatTurn.injectedContextPrefix`, persisted with the session) and replayed verbatim by `turnToMessage` on every later request. Regeneration keeps the original bytes; multimodal turns are skipped (parity with the legacy injector guard); Mode 2 remote-agent requests stay bare.
  - HTTP `/agents/{id}/run` + plugin host: same guarantee via a per-session prefix ledger (`SessionToolState.frozenUserPrefixes`, keyed by content-hash + occurrence), since those clients resend clean history each request.
- **Reuse telemetry**: `recordSend` now diffs each outbound transcript against the previous send and logs reused vs re-prefilled conversation tokens per turn (`[Cache] conv turn=N reused≈…`), the regression tripwire for any future byte divergence.

### Text trims (helps small local models most; eval-proofed)

- Deduped the anti-invention tool-grounding rule: it now lives once in `groundingDirective` (which co-fires with every tool-carrying request) instead of being restated in nearly every model-family block — ~40 tokens back per prompt, and family blocks no longer name `capabilities_discover` in schemas that can't call it. LFM2 keeps its fetch-it-yourself action bullet (targets an observed refusal mode).
- Retightened `agentLoopGuidanceCompact`: 240 → 167 tokens (~30% smaller vs ~6% before), keeping all four loop tools and the anti-punt clarify discipline (the compact bootstrap skeleton truncates ClarifyTool's description, so the prompt bullet is the only place a small model sees it).

### Proof

- **Evals** (Qwen3.5-4B-OptiQ-4bit, clean-main baseline vs this branch, `osaurus-evals diff`): **PASS, no blocking regressions.** AgentLoop domain 24/29 → 25/29 (`search-then-multi-file-edit` flipped to passing, ctx tokens −49% on that case), CapabilityClaims 10/11 → 10/11, ToolResultGrounding 2/2 → 2/2. Persistent failures are byte-identical to the baseline failures on main.
- **Tests**: full `make test` — 4605 tests in 544 suites green (with keychain-disabled + isolated `OSU_MODELS_DIR`; the AGENTS.md tip documents why). New suites: `PromptTokenTableTests` (per-section cost baseline), `TranscriptPrefixMonotonicityTests` (turn N is a strict byte-prefix of turn N+1 — would have caught the divergence), `UserTurnInjectionFreezeTests`, `ConversationReuseTelemetryTests`. Budget/audit ceilings re-anchored with live numbers.

## Test plan

- [x] `make test` (4605 tests / 544 suites) green with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=… OSU_MODELS_DIR=…`
- [x] OsaurusEvals AgentLoop / CapabilityClaims / ToolResultGrounding / PromptInjection before/after on a local model; diff verdict PASS
- [x] SwiftLint / swift-format clean on new files; no new warnings in touched files
- [ ] Live Claude session: confirm `[Cache][Anthropic]` logs show non-zero `cacheRead` from turn 2
- [ ] Live local two-turn chat with memory + screen context on: confirm `[Cache] conv` line reports near-total reuse on turn 2