### PR TITLE
gated Rampart PII scan and media prep as exclusive GPU producers

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
@@ -11,6 +11,12 @@
 //  An `actor` so model load and every forward pass run off the main
 //  thread (MLX inference must not block the UI — see app-hang guidance).
 //
+//  Both the load (`RampartPII(directory:)` evals the weights) and every
+//  `detect` forward pass are MLX *GPU producers* on the shared Metal
+//  device, so they must hold `MetalGate` — unserialized they race a
+//  concurrent generation's decode on the Metal command queue and abort
+//  in the driver.
+//
 
 import Foundation
 import RampartPII
@@ -22,9 +28,16 @@ actor RampartPrivacyDetector {
     /// Load the model from a bundle directory containing
     /// `model.safetensors`, `config.json`, and `vocab.txt`. No-op when
     /// already loaded from the same directory.
-    func loadIfNeeded(bundle directory: URL) throws {
+    func loadIfNeeded(bundle directory: URL) async throws {
         if let loadedDirectory, loadedDirectory == directory, model != nil { return }
-        model = try RampartPII(directory: directory)
+        await MetalGate.shared.enterPIIDetection()
+        do {
+            model = try RampartPII(directory: directory)
+            await MetalGate.shared.exitPIIDetection()
+        } catch {
+            await MetalGate.shared.exitPIIDetection()
+            throw error
+        }
         loadedDirectory = directory
     }
 
@@ -34,10 +47,15 @@ actor RampartPrivacyDetector {
     /// Returns `[]` when the model isn't loaded. Rampart character offsets
     /// are converted to `String.Index` ranges (Rampart indexes by
     /// `Character`, matching `String.index(_:offsetBy:)`).
-    func modelSpans(in text: String) -> [(category: EntityCategory, range: Range<String.Index>)] {
+    func modelSpans(in text: String) async -> [(category: EntityCategory, range: Range<String.Index>)] {
         guard !text.isEmpty, let model else { return [] }
+        // Hold the gate only across the forward pass; the span/index mapping
+        // below is CPU-only string work.
+        await MetalGate.shared.enterPIIDetection()
+        let detected = model.detect(text)
+        await MetalGate.shared.exitPIIDetection()
         var raw: [(category: EntityCategory, range: Range<String.Index>)] = []
-        for span in model.detect(text) {
+        for span in detected {
             guard let category = Self.category(for: span.type) else { continue }
             guard
                 let lo = text.index(

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -952,6 +952,24 @@ struct MLXBatchAdapter {
 
     // MARK: - Submission
 
+    /// Sendable box for a chat snapshot built once before the prep gate.
+    ///
+    /// `MLXLMCommon.Chat.Message` is not `Sendable`, but the snapshot is
+    /// immutable and only read from the downstream `buildChat` closure —
+    /// same rationale as `ModelRuntime.ChatMessageBox`.
+    private final class PrepChatBox: @unchecked Sendable {
+        let messages: [MLXLMCommon.Chat.Message]
+        init(_ messages: [MLXLMCommon.Chat.Message]) { self.messages = messages }
+
+        /// Media attachments mean `prepareInput` will run GPU evals (audio
+        /// pre-encode, VLM media encode) on the submitting thread.
+        var hasMedia: Bool {
+            messages.contains {
+                !($0.images.isEmpty && $0.videos.isEmpty && $0.audios.isEmpty)
+            }
+        }
+    }
+
     /// Tokenize the chat + tools, fetch (or create) the per-model
     /// `BatchEngine`, and submit one request via `engine.generate`. Returns
     /// the resulting `Generation` stream wrapped with cancellation plumbing.
@@ -996,28 +1014,51 @@ struct MLXBatchAdapter {
         // `prepareInput` can run a GPU eval on THIS submit thread before the
         // generation gate is taken below — notably the Nemotron-Omni audio
         // pre-encode (`MLX.eval` in `preencodedAudio`) and any media encoder
-        // that materializes during `UserInputProcessor.prepare`. Hold the Metal
-        // gate's shared lock across `prepareInput` too, so that eval can't race
-        // a concurrent Model2Vec embedder on the Metal command buffer (the same
-        // `addCompletedHandler:` crash class the gate exists to prevent). This
-        // is a separate, fully-balanced acquire/release from the generation
-        // gate below; the brief window between them is eval-free.
+        // that materializes during `UserInputProcessor.prepare`. Those evals
+        // happen OUTSIDE the `BatchEngine` actor loop, so under the shared
+        // `gen:` owner they could encode concurrently with an in-flight
+        // decode or another request's prep on the shared Metal command queue
+        // (the driver-assert crash class the gate exists to prevent). So:
+        // media-bearing prep takes the gate EXCLUSIVELY; text-only prep does
+        // no GPU encode (CPU tokenization + data-backed arrays) and keeps the
+        // shared generation owner, preserving same-model batching. Either
+        // acquire is fully balanced before the generation gate below; the
+        // brief window between them is eval-free.
+        let prepChat: PrepChatBox? = buildRawPrompt == nil ? PrepChatBox(buildChat()) : nil
+        let prepBuildChat: @Sendable () -> [MLXLMCommon.Chat.Message]
+        if let prepChat {
+            prepBuildChat = { prepChat.messages }
+        } else {
+            prepBuildChat = buildChat
+        }
+        let prepIsExclusive = prepChat?.hasMedia ?? false
         let prepared: PreparedInput
-        await MetalGate.shared.enterGeneration(model: modelName)
+        if prepIsExclusive {
+            await MetalGate.shared.enterMediaPrep(model: modelName)
+        } else {
+            await MetalGate.shared.enterGeneration(model: modelName)
+        }
+        func exitPrepGate() async {
+            if prepIsExclusive {
+                await MetalGate.shared.exitMediaPrep(model: modelName)
+            } else {
+                await MetalGate.shared.exitGeneration(model: modelName)
+            }
+        }
         do {
             prepared = try await prepareInput(
                 modelName: modelName,
                 container: container,
-                buildChat: buildChat,
+                buildChat: prepBuildChat,
                 buildToolsSpec: buildToolsSpec,
                 buildRawPrompt: buildRawPrompt,
                 generation: generation,
                 toolChoice: toolChoice,
                 trace: trace
             )
-            await MetalGate.shared.exitGeneration(model: modelName)
+            await exitPrepGate()
         } catch {
-            await MetalGate.shared.exitGeneration(model: modelName)
+            await exitPrepGate()
             if let soloLease { await soloLease.release() }
             throw error
         }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1024,14 +1024,14 @@ struct MLXBatchAdapter {
         // shared generation owner, preserving same-model batching. Either
         // acquire is fully balanced before the generation gate below; the
         // brief window between them is eval-free.
-        let prepChat: PrepChatBox? = buildRawPrompt == nil ? PrepChatBox(buildChat()) : nil
-        let prepBuildChat: @Sendable () -> [MLXLMCommon.Chat.Message]
-        if let prepChat {
-            prepBuildChat = { prepChat.messages }
-        } else {
-            prepBuildChat = buildChat
-        }
-        let prepIsExclusive = prepChat?.hasMedia ?? false
+        // Snapshot the chat once up front (empty on the raw-prompt path,
+        // where `prepareInput` never invokes its chat builder). The box keeps
+        // the snapshot Sendable, and passing a box-backed closure below —
+        // rather than rebinding the non-escaping `buildChat` parameter —
+        // avoids both a second `buildChat()` call and an escaping-parameter
+        // diagnostic.
+        let prepChat = PrepChatBox(buildRawPrompt == nil ? buildChat() : [])
+        let prepIsExclusive = prepChat.hasMedia
         let prepared: PreparedInput
         if prepIsExclusive {
             await MetalGate.shared.enterMediaPrep(model: modelName)
@@ -1049,7 +1049,7 @@ struct MLXBatchAdapter {
             prepared = try await prepareInput(
                 modelName: modelName,
                 container: container,
-                buildChat: prepBuildChat,
+                buildChat: { prepChat.messages },
                 buildToolsSpec: buildToolsSpec,
                 buildRawPrompt: buildRawPrompt,
                 generation: generation,

--- a/Packages/OsaurusCore/Services/ModelRuntime/MetalGate.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MetalGate.swift
@@ -131,6 +131,25 @@ public actor MetalGate {
         release("embedding")
     }
 
+    // MARK: - Media prep (audio/image/video encode before generation) — exclusive
+
+    /// Preparing a media-bearing request runs GPU evals on the SUBMITTING
+    /// task's thread — the Nemotron-Omni audio pre-encode and any VLM media
+    /// encoder that materializes during `UserInputProcessor.prepare` — i.e.
+    /// outside the `BatchEngine` actor loop that makes same-model generation
+    /// overlap safe. Under the shared `gen:` owner those prep evals could
+    /// encode concurrently with an in-flight decode (or another request's
+    /// prep) on the shared Metal command queue. Media prep therefore takes
+    /// its own exclusive owner; text-only prep does no GPU encode and keeps
+    /// the shared generation owner so batching is preserved.
+    public func enterMediaPrep(model: String) async {
+        await acquire("prep:\(model)", shared: false)
+    }
+
+    public func exitMediaPrep(model: String) {
+        release("prep:\(model)")
+    }
+
     // MARK: - PII detection (Rampart NER behind the privacy filter) — exclusive
 
     /// The Rampart PII model (an MLX BERT token classifier) is another MLX

--- a/Packages/OsaurusCore/Services/ModelRuntime/MetalGate.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MetalGate.swift
@@ -4,7 +4,8 @@
 //
 //  Process-wide mutual-exclusion gate across every MLX/Metal *GPU producer*
 //  in the app — LLM generation (vmlx-swift's `BatchEngine`), the Model2Vec
-//  embedder behind capability/memory search, and model loading (weight
+//  embedder behind capability/memory search, the Rampart PII detector behind
+//  the privacy filter, and model loading (weight
 //  dequantization + kernel compilation). All submit work to the same Metal
 //  device on different threads, and two distinct producers driving the Metal
 //  command queue at once race on the command buffer and abort with crashes
@@ -128,6 +129,24 @@ public actor MetalGate {
 
     public func exitEmbedding() {
         release("embedding")
+    }
+
+    // MARK: - PII detection (Rampart NER behind the privacy filter) — exclusive
+
+    /// The Rampart PII model (an MLX BERT token classifier) is another MLX
+    /// graph on the shared Metal device: its load materializes the weights
+    /// with an `eval`, and every `detect` runs a forward pass (including a
+    /// cold-start kernel JIT compile). Observed live as the outbound privacy
+    /// scan of a remote-provider request racing an in-flight local
+    /// generation's decode on the shared command queue
+    /// (`tryCoalescingPreviousComputeCommandEncoder` abort). Exclusive, like
+    /// the embedder.
+    public func enterPIIDetection() async {
+        await acquire("pii", shared: false)
+    }
+
+    public func exitPIIDetection() {
+        release("pii")
     }
 
     // MARK: - Model load (weight dequant + kernel compile) — exclusive

--- a/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
@@ -280,6 +280,45 @@ struct MetalGateTests {
         )
     }
 
+    // MARK: - Source contract: gate-holding code never awaits the PII owner
+
+    @Test func gateHoldersDoNotInvokePrivacyFilter() throws {
+        // Deadlock invariant: `enterPIIDetection()` waits for every other
+        // owner, so code that HOLDS a MetalGate owner (the ModelRuntime
+        // generation/load/teardown paths) must never call into the privacy
+        // filter — a generation awaiting its own PII scan would wait on
+        // itself forever. Today the pipeline's only Services caller is
+        // `RemoteProviderService`, which holds no gate owner; pin that so a
+        // future "filter local output too" refactor trips this test instead
+        // of shipping a deadlock.
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Service/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+
+        let runtimeDir = coreRoot.appendingPathComponent("Services/ModelRuntime")
+        let files = try FileManager.default.contentsOfDirectory(
+            at: runtimeDir,
+            includingPropertiesForKeys: nil
+        )
+        .filter { $0.pathExtension == "swift" }
+        + [coreRoot.appendingPathComponent("Services/ModelRuntime.swift")]
+
+        #expect(!files.isEmpty)
+        for file in files {
+            let source = try String(contentsOf: file, encoding: .utf8)
+            let name = file.lastPathComponent
+            #expect(
+                !source.contains("PrivacyFilterPipeline"),
+                "\(name) references PrivacyFilterPipeline from gate-holding code"
+            )
+            #expect(
+                !source.contains("RampartModelManager"),
+                "\(name) references RampartModelManager from gate-holding code"
+            )
+        }
+    }
+
     // MARK: - Source contract: the unload teardown is actually gate-bracketed
 
     @Test func unloadTeardownIsGateBracketedInSource() throws {

--- a/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
@@ -195,7 +195,7 @@ struct MetalGateTests {
         // The adapter branches on media and brackets prep with the right owner.
         #expect(adapter.contains("await MetalGate.shared.enterMediaPrep(model: modelName)"))
         #expect(adapter.contains("await MetalGate.shared.exitMediaPrep(model: modelName)"))
-        #expect(adapter.contains("let prepIsExclusive = prepChat?.hasMedia ?? false"))
+        #expect(adapter.contains("let prepIsExclusive = prepChat.hasMedia"))
     }
 
     // MARK: - PII detection (Rampart) owner — exclusive against every producer

--- a/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
@@ -120,6 +120,84 @@ struct MetalGateTests {
         #expect(events == ["teardown-released", "gen-acquired"])
     }
 
+    // MARK: - Media prep owner — exclusive against every producer
+
+    @Test func mediaPrepProceedsWhenIdle() async {
+        await MetalGate.shared.enterMediaPrep(model: "omni-model")
+        await MetalGate.shared.exitMediaPrep(model: "omni-model")
+    }
+
+    @Test func mediaPrepWaitsForSameModelGenerationToRelease() async {
+        // The prepareInput hole: a media request's submit-thread encode evals
+        // must not overlap an in-flight decode even for the SAME model — the
+        // shared gen owner would have admitted it. Prove the exclusive prep
+        // owner waits for the generation to release.
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterGeneration(model: "omni-model")
+        let waiter = Task {
+            await MetalGate.shared.enterMediaPrep(model: "omni-model")
+            await rec.record("prep-acquired")
+            await MetalGate.shared.exitMediaPrep(model: "omni-model")
+        }
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("gen-released")
+        await MetalGate.shared.exitGeneration(model: "omni-model")
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["gen-released", "prep-acquired"])
+    }
+
+    @Test func mediaPrepsAreMutuallyExclusive() async {
+        // Two media requests' prep evals must not encode concurrently either
+        // (prep-vs-prep on two submit threads).
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterMediaPrep(model: "omni-model")
+        let waiter = Task {
+            await MetalGate.shared.enterMediaPrep(model: "omni-model")
+            await rec.record("second-prep-acquired")
+            await MetalGate.shared.exitMediaPrep(model: "omni-model")
+        }
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("first-prep-released")
+        await MetalGate.shared.exitMediaPrep(model: "omni-model")
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["first-prep-released", "second-prep-acquired"])
+    }
+
+    // MARK: - Source contract: media prep is actually gate-bracketed
+
+    @Test func mediaPrepIsGateBracketedInSource() throws {
+        // Pin the adapter wiring textually (no Metal in CI): the exclusive
+        // prep owner exists, and the adapter routes media-bearing prep
+        // through it while text-only prep keeps the shared generation owner.
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Service/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+
+        let gate = try String(
+            contentsOf: coreRoot.appendingPathComponent("Services/ModelRuntime/MetalGate.swift"),
+            encoding: .utf8
+        )
+        let adapter = try String(
+            contentsOf: coreRoot.appendingPathComponent(
+                "Services/ModelRuntime/MLXBatchAdapter.swift"
+            ),
+            encoding: .utf8
+        )
+
+        // Exclusive media-prep owner.
+        #expect(gate.contains("public func enterMediaPrep(model: String) async"))
+        #expect(gate.contains("public func exitMediaPrep(model: String)"))
+        #expect(gate.contains(#"acquire("prep:\(model)", shared: false)"#))
+
+        // The adapter branches on media and brackets prep with the right owner.
+        #expect(adapter.contains("await MetalGate.shared.enterMediaPrep(model: modelName)"))
+        #expect(adapter.contains("await MetalGate.shared.exitMediaPrep(model: modelName)"))
+        #expect(adapter.contains("let prepIsExclusive = prepChat?.hasMedia ?? false"))
+    }
+
     // MARK: - PII detection (Rampart) owner — exclusive against every producer
 
     @Test func piiDetectionProceedsWhenIdle() async {

--- a/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
@@ -120,6 +120,88 @@ struct MetalGateTests {
         #expect(events == ["teardown-released", "gen-acquired"])
     }
 
+    // MARK: - PII detection (Rampart) owner — exclusive against every producer
+
+    @Test func piiDetectionProceedsWhenIdle() async {
+        await MetalGate.shared.enterPIIDetection()
+        await MetalGate.shared.exitPIIDetection()
+    }
+
+    @Test func piiDetectionWaitsForGenerationToRelease() async {
+        // The 0.21.3 crash shape: an outbound privacy scan's Rampart forward
+        // pass must not encode while a local generation holds the device.
+        // Prove the PII owner cannot acquire until the generation releases.
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterGeneration(model: "chat-model")
+        let waiter = Task {
+            await MetalGate.shared.enterPIIDetection()
+            await rec.record("pii-acquired")
+            await MetalGate.shared.exitPIIDetection()
+        }
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("gen-released")
+        await MetalGate.shared.exitGeneration(model: "chat-model")
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["gen-released", "pii-acquired"])
+    }
+
+    @Test func generationWaitsForPIIDetectionToRelease() async {
+        // And the reverse: a generation admitted mid-scan would race the
+        // Rampart eval the same way.
+        let rec = GateOrderRecorder()
+        await MetalGate.shared.enterPIIDetection()
+        let waiter = Task {
+            await MetalGate.shared.enterGeneration(model: "chat-model")
+            await rec.record("gen-acquired")
+            await MetalGate.shared.exitGeneration(model: "chat-model")
+        }
+        try? await Task.sleep(for: .milliseconds(80))
+        await rec.record("pii-released")
+        await MetalGate.shared.exitPIIDetection()
+        _ = await waiter.value
+        let events = await rec.events
+        #expect(events == ["pii-released", "gen-acquired"])
+    }
+
+    // MARK: - Source contract: the Rampart detector is actually gate-bracketed
+
+    @Test func rampartDetectorIsGateBracketedInSource() throws {
+        // The Rampart forward pass itself can't be unit-run (no Metal in CI),
+        // so pin the wiring textually: the PII owner exists and is exclusive,
+        // and the detector brackets both its model load and its detect eval
+        // with it. Mirrors `unloadTeardownIsGateBracketedInSource`.
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Service/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+
+        let gate = try String(
+            contentsOf: coreRoot.appendingPathComponent("Services/ModelRuntime/MetalGate.swift"),
+            encoding: .utf8
+        )
+        let detector = try String(
+            contentsOf: coreRoot.appendingPathComponent(
+                "PrivacyFilter/Rampart/RampartPrivacyDetector.swift"
+            ),
+            encoding: .utf8
+        )
+
+        // Exclusive PII owner.
+        #expect(gate.contains("public func enterPIIDetection() async"))
+        #expect(gate.contains("public func exitPIIDetection()"))
+        #expect(gate.contains(#"acquire("pii", shared: false)"#))
+
+        // The detector holds the gate across the load eval and the forward pass.
+        #expect(detector.contains("await MetalGate.shared.enterPIIDetection()"))
+        #expect(detector.contains("await MetalGate.shared.exitPIIDetection()"))
+        #expect(
+            detector.contains(
+                "await MetalGate.shared.enterPIIDetection()\n        let detected = model.detect(text)"
+            )
+        )
+    }
+
     // MARK: - Source contract: the unload teardown is actually gate-bracketed
 
     @Test func unloadTeardownIsGateBracketedInSource() throws {


### PR DESCRIPTION
## Summary

- Fixed a crash reported on 0.21.3 where the app aborted in the Metal driver about 10 seconds after launch. A symbolicated user crash report showed the outbound privacy scan of a remote provider request running its PII model on the GPU while a local generation was streaming, with nothing serializing the two on the shared Metal command queue.
- Registered the PII detector as an exclusive GPU producer so its model load and every detection pass now wait for any in-flight producer to drain, matching the existing embedder pattern. The scan still always runs before anything is sent to a remote provider.
- Closed a second window of the same crash class: preparing a media-bearing request runs GPU work on the submitting thread outside the engine loop, which the shared per-model admission would have allowed to overlap an in-flight decode. Media prep now takes its own exclusive owner, while text-only prep keeps the shared owner so same-model batching is unchanged.
- Added ordering and exclusion tests for both new owners, source contract tests pinning the wiring, and a guard test for the deadlock invariant that gate-holding code never invokes the privacy filter.
- Known trade-off: a remote request submitted during a long local generation now waits for the stream to finish before its privacy scan runs, and media requests queue behind in-flight streams. Waiting replaces crashing.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
