### PR TITLE
Model catalog IA cleanup: family-grouped cards, variant picker, chat-only org fetch

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -23,19 +23,15 @@ enum ModelListTab: String, CaseIterable, AnimatedTabItem {
     case downloaded = "On Device"
 
     /// Full catalog rendered as a Recommended carousel + a newest-first grid.
+    /// Image models live in the dedicated Images pane; the catalog links to
+    /// it inline instead of carrying a fake hand-off tab.
     case all = "Catalog"
-
-    /// Not a content tab — selecting it hands off to the dedicated Image
-    /// Generation pane's Models sub-tab and the picker snaps back to the
-    /// previous tab. Kept in the enum so it renders in the shared tab selector.
-    case imageGeneration = "Images"
 
     /// Display name for the tab (required by AnimatedTabItem)
     var title: String {
         switch self {
         case .downloaded: return L("On Device")
         case .all: return L("Catalog")
-        case .imageGeneration: return L("Images")
         }
     }
 }
@@ -1234,6 +1230,41 @@ extension ModelManager {
         "osaurusai/gemma-4-26b-a4b-it-mxfp4",
         "osaurusai/diffusiongemma-26b-a4b-it-mxfp8",
     ]
+
+    /// HF `pipeline_tag` values that mark a repo as chat-capable (text or
+    /// multimodal generation). The org auto-fetch only admits repos whose
+    /// pipeline tag is in this set — guards (`token-classification`),
+    /// embeddings (`feature-extraction`/`sentence-similarity`), image
+    /// pipelines, and speech repos all belong to other Settings panels and
+    /// must not surface as chat cards in the Models catalog.
+    nonisolated static let chatCapablePipelineTags: Set<String> = [
+        "text-generation",
+        "text2text-generation",
+        "image-text-to-text",
+        "audio-text-to-text",
+        "video-text-to-text",
+        "any-to-any",
+    ]
+
+    /// OsaurusAI org repos owned by other Settings panels (Privacy, Voice,
+    /// Memory, Images) that must never appear as chat cards, even when the
+    /// repo has no `pipeline_tag` on HF. Belt-and-braces alongside the
+    /// pipeline-tag gate; lowercased for matching.
+    nonisolated static var panelOwnedOrgIds: Set<String> {
+        [
+            RampartModelManager.repoId.lowercased()
+        ]
+    }
+
+    /// True when an OsaurusAI org repo may appear in the LLM catalog.
+    /// Untagged repos pass (MLX conversions frequently omit `pipeline_tag`,
+    /// so `nil` is not evidence of a non-chat repo) unless they are owned by
+    /// another Settings panel.
+    nonisolated static func isChatCatalogEligible(id: String, pipelineTag: String?) -> Bool {
+        if panelOwnedOrgIds.contains(id.lowercased()) { return false }
+        guard let tag = pipelineTag?.lowercased(), !tag.isEmpty else { return true }
+        return chatCapablePipelineTags.contains(tag)
+    }
 }
 
 // MARK: - Installed models helpers for services
@@ -1294,6 +1325,7 @@ extension ModelManager {
     fileprivate struct HFModel: Decodable {
         let id: String
         let tags: [String]?
+        let pipeline_tag: String?
         let lastModified: String?
         let downloads: Int?
     }
@@ -1458,15 +1490,23 @@ extension ModelManager {
     }
 
     /// Builds an `MLXModel` for an HF repo that isn't in the curated list.
+    /// The use-case pill is inferred where the HF metadata supports it
+    /// (multimodal tags → Vision) so auto-fetched cards aren't all blank
+    /// next to curated ones.
     fileprivate static func makeAutoFetchedModel(from hf: HFModel) -> MLXModel {
-        MLXModel(
+        let modelType = inferModelType(from: hf.tags)
+        let isMultimodal =
+            modelType.map { VLMDetection.isVLM(modelType: $0) } ?? false
+            || (hf.pipeline_tag?.lowercased() == "image-text-to-text")
+        return MLXModel(
             id: hf.id,
             name: ModelMetadataParser.friendlyName(from: hf.id),
             description: "From OsaurusAI on Hugging Face.",
             downloadURL: "https://huggingface.co/\(hf.id)",
-            modelType: inferModelType(from: hf.tags),
+            modelType: modelType,
             releasedAt: parseHFTimestamp(hf.lastModified),
-            downloads: hf.downloads
+            downloads: hf.downloads,
+            useCase: isMultimodal ? .vision : nil
         )
     }
 
@@ -1482,7 +1522,16 @@ extension ModelManager {
             )
         else { return }
 
-        let raw = (try? await Self.requestHFModels(at: url)) ?? []
+        let fetched = (try? await Self.requestHFModels(at: url)) ?? []
+        guard !fetched.isEmpty else { return }
+
+        // Drop repos that other Settings panels own (rampart PII guard,
+        // embeddings, image/speech pipelines) before they can become chat
+        // cards. Curated entries never pass through this gate — they merge
+        // from `curatedSuggestedModels` directly.
+        let raw = fetched.filter {
+            Self.isChatCatalogEligible(id: $0.id, pipelineTag: $0.pipeline_tag)
+        }
         guard !raw.isEmpty else { return }
 
         let curatedIds = Self.curatedSuggestedIds
@@ -1564,6 +1613,7 @@ extension ModelManager {
         let enrichedAutoFetched =
             autoFetched
             .filter { !Self.retiredOsaurusOrgIds.contains($0.id.lowercased()) }
+            .filter { !Self.panelOwnedOrgIds.contains($0.id.lowercased()) }
             .map(enrich)
 
         // Drop previous OsaurusAI auto-fetched entries, keeping curated and

--- a/Packages/OsaurusCore/Models/Configuration/ModelMetadataParser.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMetadataParser.swift
@@ -128,7 +128,7 @@ enum ModelMetadataParser {
             #"(?i)\bit\b"#,  // "it" = instruction tuned
             #"(?i)\binstruct\b"#,
             #"(?i)\bchat\b"#,
-            #"(?i)\bjangtq\d*\b"#,  // TurboQuant variants
+            #"(?i)\bjangtq[_0-9a-z]*\b"#,  // TurboQuant variants (JANGTQ4, JANGTQ_K)
             #"(?i)\ba\d+(\.\d+)?b\b"#,  // A3B / A2.5B active param count
         ]
         for pat in dropPatterns {
@@ -170,6 +170,82 @@ enum ModelMetadataParser {
             .replacingOccurrences(of: "phi", with: "Phi", options: .caseInsensitive)
     }
 
+    // MARK: - Family grouping
+
+    /// Hyphen-delimited repo-id segments that encode precision, quantization,
+    /// or delivery format rather than model identity. Stripping them from a
+    /// repo id yields the "family" the catalog groups by: precision variants
+    /// of the same model (MXFP4 vs MXFP8 vs QAT vs JANGTQ…) collapse into one
+    /// card, while genuinely different sizes (9B vs 35B, E2B vs E4B) keep
+    /// their size tokens and stay separate.
+    private static let variantSegmentRegexes: [NSRegularExpression] = {
+        let patterns = [
+            #"^mxfp\d+$"#,  // MXFP4 / MXFP8
+            #"^qat$"#,  // quantization-aware-training marker
+            #"^jangtq[_0-9a-z]*$"#,  // JANGTQ / JANGTQ4 / JANGTQ_K TurboQuant
+            #"^jang_?\d+[a-z]?$"#,  // JANG_4M / JANG_2S mixed precision
+            #"^\d+-?bit$"#,  // 4bit / 8bit / 4-bit
+            #"^(fp16|bf16|fp32)$"#,
+            #"^q\d+(_[a-z0-9]+)*$"#,  // GGUF-style q4_0 / q8_k_m
+            #"^mtp$"#,  // multi-token-prediction speculative decode build
+            #"^mlx$"#,
+        ]
+        return patterns.compactMap {
+            try? NSRegularExpression(pattern: $0, options: .caseInsensitive)
+        }
+    }()
+
+    private nonisolated(unsafe) static var familyKeyCache: [String: String] = [:]
+
+    /// Lowercased grouping key for collapsing precision/quant variants of the
+    /// same model into a single catalog card. Keeps the org prefix so families
+    /// never merge across publishers. Falls back to the full lowercased id
+    /// when stripping would leave nothing.
+    static func familyKey(from repoId: String) -> String {
+        cacheLock.lock()
+        if let cached = familyKeyCache[repoId] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let kept = familySegments(from: repoId)
+        let org = repoId.split(separator: "/").dropLast().joined(separator: "/")
+        let tail =
+            kept.isEmpty
+            ? (repoId.split(separator: "/").last.map(String.init) ?? repoId)
+            : kept.joined(separator: "-")
+        let result = (org.isEmpty ? tail : "\(org)/\(tail)").lowercased()
+
+        cacheLock.lock()
+        familyKeyCache[repoId] = result
+        cacheLock.unlock()
+        return result
+    }
+
+    /// Display title for a family card: the repo tail with variant segments
+    /// removed, run through the friendly-name capitalization and the
+    /// developer-token stripper (drops "it"/"instruct"/active-param notation).
+    static func familyDisplayName(from repoId: String) -> String {
+        let kept = familySegments(from: repoId)
+        guard !kept.isEmpty else { return simpleName(from: friendlyName(from: repoId)) }
+        let joined = kept.joined(separator: "-")
+        let name = simpleName(from: friendlyName(from: joined))
+        return name.isEmpty ? friendlyName(from: repoId) : name
+    }
+
+    /// Repo-tail segments with precision/quant/delivery tokens removed,
+    /// original casing preserved.
+    private static func familySegments(from repoId: String) -> [String] {
+        let tail = repoId.split(separator: "/").last.map(String.init) ?? repoId
+        return tail.split(separator: "-").map(String.init).filter { segment in
+            let range = NSRange(segment.startIndex..., in: segment)
+            return !variantSegmentRegexes.contains {
+                $0.firstMatch(in: segment, options: [], range: range) != nil
+            }
+        }
+    }
+
     // MARK: - Private
 
     private static func extractBitWidth(from repoId: String) -> String? {
@@ -192,10 +268,12 @@ enum ModelMetadataParser {
             return String(text[match]).uppercased()
         }
         if let match = text.range(
-            of: #"jangtq\d*"#,
+            of: #"jangtq[_0-9a-z]*"#,
             options: .regularExpression
         ) {
-            return String(text[match]).uppercased()
+            // Underscore suffixes (`JANGTQ_K`) read as "JANGTQ K" in the UI,
+            // matching the JANG mixed-precision label treatment below.
+            return String(text[match]).uppercased().replacingOccurrences(of: "_", with: " ")
         }
         // JANG mixed-precision labels (`JANG_4M`/`4K`/`2L`/`2S`): the leading
         // digit encodes the dominant bit-class (4 ≈ 4-bit, 2 ≈ 2-bit). Surface

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1,7 +1,7 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "": {
+    "" : {
       "shouldTranslate" : false
     },
     " — %@" : {
@@ -3905,12 +3905,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld навык доступен"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -3921,6 +3915,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld навыков доступны"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld навык доступен"
                 }
               },
               "other" : {
@@ -4155,12 +4155,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Отправлен %lld инструмент"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -4171,6 +4165,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Отправлено %lld инструментов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Отправлен %lld инструмент"
                 }
               },
               "other" : {
@@ -12340,31 +12340,30 @@
       }
     },
     "AppleScript" : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "AppleScript automation" : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматизация AppleScript"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript automation"
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript automation"
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматизация AppleScript"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript automation"
@@ -12375,25 +12374,25 @@
     "AppleScript model" : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Модель AppleScript"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript model"
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript model"
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Модель AppleScript"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript model"
@@ -12404,25 +12403,25 @@
     "AppleScript runs on this Mac. The first time the agent controls an app, macOS asks you to allow Automation for Osaurus. Download AppleScript models in Settings → Computer Use → Models." : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AppleScript выполняется на этом Mac. Когда агент впервые управляет приложением, macOS попросит разрешить автоматизацию для Osaurus. Модели AppleScript можно загрузить в «Настройки» → «Использование компьютера» → «Модели»."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript runs on this Mac. The first time the agent controls an app, macOS asks you to allow Automation for Osaurus. Download AppleScript models in Settings → Computer Use → Models."
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript runs on this Mac. The first time the agent controls an app, macOS asks you to allow Automation for Osaurus. Download AppleScript models in Settings → Computer Use → Models."
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AppleScript выполняется на этом Mac. Когда агент впервые управляет приложением, macOS попросит разрешить автоматизацию для Osaurus. Модели AppleScript можно загрузить в «Настройки» → «Использование компьютера» → «Модели»."
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "AppleScript runs on this Mac. The first time the agent controls an app, macOS asks you to allow Automation for Osaurus. Download AppleScript models in Settings → Computer Use → Models."
@@ -14296,25 +14295,25 @@
     "Auto-run with warning" : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автозапуск с предупреждением"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Auto-run with warning"
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Auto-run with warning"
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автозапуск с предупреждением"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Auto-run with warning"
@@ -14863,12 +14862,10 @@
       }
     },
     "Automation allowed" : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Automation permission" : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Autonomous" : {
       "localizations" : {
@@ -16385,6 +16382,35 @@
         }
       }
     },
+    "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перед запуском вспомогательной задачи с изображением или текстом проверяется, поместится ли модель помощника в память после выгрузки модели чата. Если памяти не хватает, задача отклоняется вместо выгрузки модели чата и последующей ошибки загрузки помощника."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper."
+          }
+        }
+      }
+    },
     "Behavior" : {
       "localizations" : {
         "de" : {
@@ -17440,6 +17466,93 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存在钥匙串中的机器人令牌"
+          }
+        }
+      }
+    },
+    "Bottom Center" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Center"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Center"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Снизу по центру"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Center"
+          }
+        }
+      }
+    },
+    "Bottom Left" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Left"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Left"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Снизу слева"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Left"
+          }
+        }
+      }
+    },
+    "Bottom Right" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Right"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Right"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Снизу справа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bottom Right"
           }
         }
       }
@@ -25447,25 +25560,25 @@
     "Confirm each script" : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подтверждать каждый сценарий"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Confirm each script"
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Confirm each script"
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтверждать каждый сценарий"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Confirm each script"
@@ -27759,6 +27872,10 @@
         }
       },
       "shouldTranslate" : false
+    },
+    "Copy Redacted Export" : {
+      "comment" : "A button label that copies a redacted export of the audit log.",
+      "isCommentAutoGenerated" : true
     },
     "Copy relay URL" : {
       "localizations" : {
@@ -34985,6 +35102,10 @@
         }
       }
     },
+    "dispatch" : {
+      "comment" : "A label indicating that a decision should be dispatched.",
+      "isCommentAutoGenerated" : true
+    },
     "Dispatch a work or chat task to an agent" : {
       "localizations" : {
         "de" : {
@@ -35587,8 +35708,7 @@
       }
     },
     "Download a model below to choose one." : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Download failed" : {
       "localizations" : {
@@ -35732,7 +35852,7 @@
       }
     },
     "Download or import the model before Osaurus can inspect or prove local tool use." : {
-      "localizations" : {}
+
     },
     "Download required" : {
       "localizations" : {
@@ -37166,25 +37286,25 @@
     "Each generated AppleScript is shown for your approval before it runs." : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Каждый сгенерированный AppleScript показывается вам на подтверждение перед запуском."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Each generated AppleScript is shown for your approval before it runs."
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Each generated AppleScript is shown for your approval before it runs."
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Каждый сгенерированный AppleScript показывается вам на подтверждение перед запуском."
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Each generated AppleScript is shown for your approval before it runs."
@@ -46708,8 +46828,7 @@
       "shouldTranslate" : false
     },
     "Give agents a dedicated on-device model that writes and runs AppleScript to automate this Mac — controlling apps like Finder, Safari, Mail, Notes, and System Events. Turn it on per agent in the Agents tab; download a model below to make it available." : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Give the agent a tool it can call to read a reply aloud when you ask. For always-speak, use Auto Speak Responses in the Voice section." : {
       "comment" : "A description of a feature toggle that lets an agent read its responses aloud.",
@@ -48819,6 +48938,10 @@
         }
       }
     },
+    "Highest precision" : {
+      "comment" : "Label for the \"Highest precision\" row in the model detail view's precision variants picker.",
+      "isCommentAutoGenerated" : true
+    },
     "History" : {
       "localizations" : {
         "de" : {
@@ -49310,8 +49433,7 @@
       }
     },
     "How each generated script is gated before it runs." : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "How image jobs ask for permission and manage GPU memory between runs." : {
       "comment" : "A description of how image jobs interact with the system's GPU resources.",
@@ -50400,6 +50522,10 @@
           }
         }
       }
+    },
+    "Image generation and editing models live in Images settings." : {
+      "comment" : "A description below the link to the Images tab, explaining that the models for image generation and editing are stored there.",
+      "isCommentAutoGenerated" : true
     },
     "Image generation cancelled." : {
       "localizations" : {
@@ -56061,25 +56187,25 @@
     "Let the agent automate this Mac by writing and running AppleScript with an on-device model. Each script is shown for your approval or auto-run with a warning, per the mode below." : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Позвольте агенту автоматизировать этот Mac: писать и запускать AppleScript с помощью локальной модели. Каждый сценарий показывается для подтверждения или запускается автоматически с предупреждением — в зависимости от режима ниже."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Let the agent automate this Mac by writing and running AppleScript with an on-device model. Each script is shown for your approval or auto-run with a warning, per the mode below."
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Let the agent automate this Mac by writing and running AppleScript with an on-device model. Each script is shown for your approval or auto-run with a warning, per the mode below."
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Позвольте агенту автоматизировать этот Mac: писать и запускать AppleScript с помощью локальной модели. Каждый сценарий показывается для подтверждения или запускается автоматически с предупреждением — в зависимости от режима ниже."
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Let the agent automate this Mac by writing and running AppleScript with an on-device model. Each script is shown for your approval or auto-run with a warning, per the mode below."
@@ -58455,6 +58581,35 @@
         }
       }
     },
+    "Local Handoff & RAM Safety" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Local Handoff & RAM Safety"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Local Handoff & RAM Safety"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальная передача и проверка памяти"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Local Handoff & RAM Safety"
+          }
+        }
+      }
+    },
     "Local handoff and RAM-safety for spawn jobs are system settings in Settings → Subagents." : {
       "comment" : "A footnote explaining the local handoff and RAM-safety for spawn jobs.",
       "isCommentAutoGenerated" : true,
@@ -58594,6 +58749,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本地 OpenAI 兼容的校验对于不支持的采样器字段（例如 n > 1 或 response_format=json_schema）会返回类型化的 400 错误。"
+          }
+        }
+      }
+    },
+    "Local Orchestrator Handoff" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Local Orchestrator Handoff"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Local Orchestrator Handoff"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальная передача выполнения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Local Orchestrator Handoff"
           }
         }
       }
@@ -58941,6 +59125,9 @@
           }
         }
       }
+    },
+    "Looking for image models?" : {
+
     },
     "Low" : {
       "localizations" : {
@@ -62554,64 +62741,6 @@
         }
       }
     },
-    "Mistral" : {
-      "comment" : "Name of the credential prompt preset for Mistral.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mistral"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mistral"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мистраль"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mistral"
-          }
-        }
-      }
-    },
-    "Mistral Small/Medium models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Mistral Small/Medium-Modelle"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mistral Small/Medium 모델"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Модели Mistral Малый/Средний"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mistral Small/Medium 模型"
-          }
-        }
-      }
-    },
     "Minimum top-up is $5.00" : {
       "comment" : "A tooltip explaining that the minimum amount to top up their credit is $5.00.",
       "isCommentAutoGenerated" : true,
@@ -62876,6 +63005,64 @@
         }
       }
     },
+    "Mistral" : {
+      "comment" : "Name of the credential prompt preset for Mistral.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mistral"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mistral"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мистраль"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mistral"
+          }
+        }
+      }
+    },
+    "Mistral Small/Medium models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mistral Small/Medium-Modelle"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mistral Small/Medium 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Модели Mistral Малый/Средний"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mistral Small/Medium 模型"
+          }
+        }
+      }
+    },
     "Mode" : {
       "localizations" : {
         "de" : {
@@ -63055,7 +63242,7 @@
       }
     },
     "Model capability detection reports local tool calling as unsupported for this bundle." : {
-      "localizations" : {}
+
     },
     "Model Card" : {
       "comment" : "The title of a section that displays detailed information about a machine learning model.",
@@ -64744,6 +64931,10 @@
         }
       }
     },
+    "needs %@" : {
+      "comment" : "A plain-language string that combines a",
+      "isCommentAutoGenerated" : true
+    },
     "Needs Accessibility permission" : {
       "comment" : "A description of the Accessibility permission needed to use Computer Use.",
       "isCommentAutoGenerated" : true,
@@ -66013,25 +66204,25 @@
     "No AppleScript models installed yet. Download one in Settings → Computer Use → Models." : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Модели AppleScript ещё не установлены. Загрузите одну в «Настройки» → «Использование компьютера» → «Модели»."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "No AppleScript models installed yet. Download one in Settings → Computer Use → Models."
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "No AppleScript models installed yet. Download one in Settings → Computer Use → Models."
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Модели AppleScript ещё не установлены. Загрузите одну в «Настройки» → «Использование компьютера» → «Модели»."
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "No AppleScript models installed yet. Download one in Settings → Computer Use → Models."
@@ -66701,6 +66892,9 @@
         }
       }
     },
+    "no dispatch" : {
+
+    },
     "No downloaded models" : {
       "localizations" : {
         "de" : {
@@ -66957,9 +67151,6 @@
           }
         }
       }
-    },
-    "No live tool-call proof is recorded for this exact bundle yet." : {
-      "localizations" : {}
     },
     "No folder selected" : {
       "localizations" : {
@@ -67358,6 +67549,9 @@
           }
         }
       }
+    },
+    "No live tool-call proof is recorded for this exact bundle yet." : {
+
     },
     "No local benchmark proof is recorded here yet. A passing row needs visible output, token/s, RAM status, cancellation, and cache evidence." : {
       "localizations" : {
@@ -68533,6 +68727,10 @@
         }
       }
     },
+    "No receive audit events have been recorded for this scope." : {
+      "comment" : "A message indicating that no receive audit events have been recorded for a specific scope.",
+      "isCommentAutoGenerated" : true
+    },
     "No Remote Providers" : {
       "localizations" : {
         "de" : {
@@ -69272,6 +69470,10 @@
           }
         }
       }
+    },
+    "No stored message snapshots have been recorded for this scope." : {
+      "comment" : "A message displayed when there are no stored message snapshots to display in the \"Recent Inbox\" section of the agent channel connection center view.",
+      "isCommentAutoGenerated" : true
     },
     "No system prompt" : {
       "localizations" : {
@@ -70750,8 +70952,7 @@
       }
     },
     "Not yet granted" : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Note" : {
       "shouldTranslate" : false
@@ -72683,6 +72884,10 @@
         }
       }
     },
+    "Open Images" : {
+      "comment" : "A button label that opens the Images settings.",
+      "isCommentAutoGenerated" : true
+    },
     "Open in Finder" : {
       "localizations" : {
         "de" : {
@@ -73207,6 +73412,7 @@
     },
     "Open the Images pane in Settings" : {
       "comment" : "Description text in the EmptyStateView for the \"Images\" tab.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -74080,6 +74286,10 @@
           }
         }
       }
+    },
+    "Original" : {
+      "comment" : "Label for the original (quantized) model.",
+      "isCommentAutoGenerated" : true
     },
     "Osaurus" : {
       "localizations" : {
@@ -82051,12 +82261,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld номер счёта"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82067,6 +82271,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld номеров счёта"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld номер счёта"
                 }
               },
               "other" : {
@@ -82134,12 +82344,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld адрес"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82150,6 +82354,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld адресов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld адрес"
                 }
               },
               "other" : {
@@ -82252,12 +82462,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld дата"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82268,6 +82472,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld дат"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld дата"
                 }
               },
               "other" : {
@@ -82335,12 +82545,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld email"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82348,6 +82552,12 @@
                 }
               },
               "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld email"
+                }
+              },
+              "one" : {
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld email"
@@ -82418,12 +82628,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld имя"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82434,6 +82638,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld имён"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld имя"
                 }
               },
               "other" : {
@@ -82501,12 +82711,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld номер телефона"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82517,6 +82721,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld номеров телефона"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld номер телефона"
                 }
               },
               "other" : {
@@ -82619,12 +82829,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секрет"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82635,6 +82839,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld секретов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld секрет"
                 }
               },
               "other" : {
@@ -82737,12 +82947,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld URL"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -82750,6 +82954,12 @@
                 }
               },
               "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld URL"
+                }
+              },
+              "one" : {
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld URL"
@@ -85994,6 +86204,35 @@
         }
       }
     },
+    "RAM-Safety Preflight" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "RAM-Safety Preflight"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "RAM-Safety Preflight"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предварительная проверка памяти"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "RAM-Safety Preflight"
+          }
+        }
+      }
+    },
     "Ran a command" : {
       "localizations" : {
         "de" : {
@@ -87634,6 +87873,14 @@
         }
       }
     },
+    "Recent Decisions" : {
+      "comment" : "A label describing the section that lists recent decisions made by the agent.",
+      "isCommentAutoGenerated" : true
+    },
+    "Recent Inbox" : {
+      "comment" : "A label displayed above a section of a view that lists recent messages in an agent communication channel.",
+      "isCommentAutoGenerated" : true
+    },
     "RECENT PROCESSING LOG" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -88353,6 +88600,10 @@
           }
         }
       }
+    },
+    "Refresh Audit" : {
+      "comment" : "A button label that refreshes the audit workbench.",
+      "isCommentAutoGenerated" : true
     },
     "Refresh available devices" : {
       "localizations" : {
@@ -94721,25 +94972,25 @@
     },
     "Run AppleScript" : {
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запустить AppleScript"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Run AppleScript"
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Run AppleScript"
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запустить AppleScript"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Run AppleScript"
@@ -95544,25 +95795,25 @@
     "Running AppleScript that controls another app needs macOS Automation permission. The first time an agent controls an app, macOS asks you to allow it for Osaurus. You can prime the System Events grant now." : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для AppleScript, который управляет другим приложением, требуется разрешение macOS «Автоматизация». Когда агент впервые управляет приложением, macOS попросит разрешить это для Osaurus. Сейчас можно заранее выдать доступ к System Events."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Running AppleScript that controls another app needs macOS Automation permission. The first time an agent controls an app, macOS asks you to allow it for Osaurus. You can prime the System Events grant now."
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Running AppleScript that controls another app needs macOS Automation permission. The first time an agent controls an app, macOS asks you to allow it for Osaurus. You can prime the System Events grant now."
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для AppleScript, который управляет другим приложением, требуется разрешение macOS «Автоматизация». Когда агент впервые управляет приложением, macOS попросит разрешить это для Osaurus. Сейчас можно заранее выдать доступ к System Events."
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Running AppleScript that controls another app needs macOS Automation permission. The first time an agent controls an app, macOS asks you to allow it for Osaurus. You can prime the System Events grant now."
@@ -95974,11 +96225,9 @@
         }
       }
     },
-    "Runtime support is incomplete; a live tool-call proof is not meaningful until the runtime blocker is resolved." : {
-      "localizations" : {}
-    },
-    "Runtime preflight blocks this bundle, so Osaurus cannot run a tool-call proof." : {
-      "localizations" : {}
+    "Runs Well · needs %@" : {
+      "comment" : "Text that describes how well a model variant fits on a device based on its memory requirements. The argument is a string describing the memory requirement, or nil if the requirement is unknown.",
+      "isCommentAutoGenerated" : true
     },
     "Runtime" : {
       "localizations" : {
@@ -96008,6 +96257,9 @@
         }
       }
     },
+    "Runtime preflight blocks this bundle, so Osaurus cannot run a tool-call proof." : {
+
+    },
     "Runtime socket path exists." : {
       "localizations" : {
         "de" : {
@@ -96035,6 +96287,9 @@
           }
         }
       }
+    },
+    "Runtime support is incomplete; a live tool-call proof is not meaningful until the runtime blocker is resolved." : {
+
     },
     "Runtime Tools" : {
       "extractionState" : "manual",
@@ -98563,24 +98818,12 @@
       }
     },
     "Script" : {
-      "localizations" : {}
+
     },
     "Script execution" : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запуск сценариев"
-          }
-        },
         "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Script execution"
-          }
-        },
-        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Script execution"
@@ -98591,12 +98834,23 @@
             "state" : "needs_review",
             "value" : "Script execution"
           }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запуск сценариев"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Script execution"
+          }
         }
       }
     },
     "Scripts run automatically. A warning showing the script appears in the chat each time." : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Scroll" : {
       "shouldTranslate" : false
@@ -105327,6 +105581,10 @@
         }
       }
     },
+    "Smallest download" : {
+      "comment" : "Plain-language description of a model variant's position in a family: the smallest download.",
+      "isCommentAutoGenerated" : true
+    },
     "SMELT Mode" : {
       "localizations" : {
         "de" : {
@@ -110622,8 +110880,7 @@
       }
     },
     "Test automation" : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "Test buffer" : {
       "localizations" : {
@@ -110677,6 +110934,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "测试连接"
+          }
+        }
+      }
+    },
+    "Test Notification" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Test Notification"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Test Notification"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тестовое уведомление"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Test Notification"
           }
         }
       }
@@ -111449,7 +111735,7 @@
       }
     },
     "The bundle declares a tool-call parser (%@), but Osaurus still needs a live tool-call proof before marking it proven." : {
-      "localizations" : {}
+
     },
     "The bundle has the required local files. Runtime quality still depends on model-family support and live generation proof." : {
       "localizations" : {
@@ -111480,10 +111766,10 @@
       }
     },
     "The bundle is incomplete, so Osaurus cannot run a tool-call proof." : {
-      "localizations" : {}
+
     },
     "The bundle still needs a live tool-call proof before Osaurus should call it tool-use capable." : {
-      "localizations" : {}
+
     },
     "The config file is invalid JSON or has an incompatible shape." : {
       "localizations" : {
@@ -113288,8 +113574,7 @@
       }
     },
     "These apply to the main chat and any agent set to choose automatically. Each agent can override them in its own Subagents settings." : {
-      "extractionState" : "manual",
-      "localizations" : {}
+      "extractionState" : "manual"
     },
     "These artifacts couldn't be installed:" : {
       "localizations" : {
@@ -115170,6 +115455,10 @@
         }
       }
     },
+    "Tight Fit · needs %@" : {
+      "comment" : "A description of a model's compatibility with the user's device, including the amount of memory it requires. The argument is the formatted memory requirement.",
+      "isCommentAutoGenerated" : true
+    },
     "Tighter cap for the unauthenticated /pair endpoint. Should stay small." : {
       "localizations" : {
         "de" : {
@@ -115511,6 +115800,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "发送"
+          }
+        }
+      }
+    },
+    "Toast notifications are working!" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toast notifications are working!"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toast notifications are working!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всплывающие уведомления работают!"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toast notifications are working!"
           }
         }
       }
@@ -115985,6 +116303,10 @@
         }
       }
     },
+    "Too Large · needs %@" : {
+      "comment" : "A description of a model variant that is too large to run on the device. The argument is the formatted estimated memory of the variant.",
+      "isCommentAutoGenerated" : true
+    },
     "Too large for this Mac" : {
       "localizations" : {
         "de" : {
@@ -116279,21 +116601,6 @@
         }
       }
     },
-    "Tool use" : {
-      "localizations" : {}
-    },
-    "Tool use blocked" : {
-      "localizations" : {}
-    },
-    "Tool use proof required" : {
-      "localizations" : {}
-    },
-    "Tool use unproven" : {
-      "localizations" : {}
-    },
-    "Tool use unsupported" : {
-      "localizations" : {}
-    },
     "Tool Permissions" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -116322,6 +116629,21 @@
           }
         }
       }
+    },
+    "Tool use" : {
+
+    },
+    "Tool use blocked" : {
+
+    },
+    "Tool use proof required" : {
+
+    },
+    "Tool use unproven" : {
+
+    },
+    "Tool use unsupported" : {
+
     },
     "Tools" : {
       "localizations" : {
@@ -116494,6 +116816,64 @@
         }
       }
     },
+    "Top Center" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Center"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Center"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сверху по центру"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Center"
+          }
+        }
+      }
+    },
+    "Top Left" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Left"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Left"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сверху слева"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Left"
+          }
+        }
+      }
+    },
     "Top P Override" : {
       "localizations" : {
         "de" : {
@@ -116574,6 +116954,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首选推荐"
+          }
+        }
+      }
+    },
+    "Top Right" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Right"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Right"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сверху справа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top Right"
           }
         }
       }
@@ -121530,6 +121939,10 @@
         }
       }
     },
+    "Versions" : {
+      "comment" : "A label for the section that lists different versions of a model.",
+      "isCommentAutoGenerated" : true
+    },
     "Video file too large" : {
       "localizations" : {
         "de" : {
@@ -124097,6 +124510,35 @@
         }
       }
     },
+    "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если основная модель чата локальная, Osaurus выгружает её, запускает вспомогательную задачу, затем загружает обратно. Включено по умолчанию, чтобы локальный агент мог запускать локального помощника; отключите, чтобы запретить локальную передачу и избежать одновременной загрузки двух моделей. Облачным оркестраторам это не требуется."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)"
+          }
+        }
+      }
+    },
     "When to evict a loaded model from RAM, and how long to keep it warm after the last request." : {
       "localizations" : {
         "de" : {
@@ -124302,6 +124744,35 @@
       "comment" : "Subtitle for the Storage settings view.",
       "isCommentAutoGenerated" : true
     },
+    "Where toast notifications appear on screen" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Where toast notifications appear on screen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Where toast notifications appear on screen"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Где на экране появляются всплывающие уведомления"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Where toast notifications appear on screen"
+          }
+        }
+      }
+    },
     "Where toasts appear on screen" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -124363,25 +124834,25 @@
     "Which AppleScript model the agent uses." : {
       "extractionState" : "manual",
       "localizations" : {
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Какую модель AppleScript использует агент."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Which AppleScript model the agent uses."
           }
         },
-        "zh-Hans" : {
+        "ko" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Which AppleScript model the agent uses."
           }
         },
-        "ko" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Какую модель AppleScript использует агент."
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Which AppleScript model the agent uses."
@@ -126701,412 +127172,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zip 捆绑包"
-          }
-        }
-      }
-    },
-    "Local Handoff & RAM Safety" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Local Handoff & RAM Safety"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Local Handoff & RAM Safety"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Local Handoff & RAM Safety"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Локальная передача и проверка памяти"
-          }
-        }
-      }
-    },
-    "Local Orchestrator Handoff" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Local Orchestrator Handoff"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Local Orchestrator Handoff"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Local Orchestrator Handoff"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Локальная передача выполнения"
-          }
-        }
-      }
-    },
-    "RAM-Safety Preflight" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "RAM-Safety Preflight"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "RAM-Safety Preflight"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "RAM-Safety Preflight"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предварительная проверка памяти"
-          }
-        }
-      }
-    },
-    "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "When the main chat model is itself local, unload it to run the helper, then reload it afterward. On by default so a local agent can run a local helper; turn off to keep local-to-local handoff disabled and avoid double residency. (Cloud orchestrators never need this.)"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Если основная модель чата локальная, Osaurus выгружает её, запускает вспомогательную задачу, затем загружает обратно. Включено по умолчанию, чтобы локальный агент мог запускать локального помощника; отключите, чтобы запретить локальную передачу и избежать одновременной загрузки двух моделей. Облачным оркестраторам это не требуется."
-          }
-        }
-      }
-    },
-    "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Before a spawned image or text job, verify the helper model fits in memory once the chat model is freed. If it won't fit, refuse the job instead of unloading the chat model and failing to load the helper."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перед запуском вспомогательной задачи с изображением или текстом проверяется, поместится ли модель помощника в память после выгрузки модели чата. Если памяти не хватает, задача отклоняется вместо выгрузки модели чата и последующей ошибки загрузки помощника."
-          }
-        }
-      }
-    },
-    "Top Right" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Right"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Right"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Right"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сверху справа"
-          }
-        }
-      }
-    },
-    "Top Left" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Left"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Left"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Left"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сверху слева"
-          }
-        }
-      }
-    },
-    "Top Center" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Center"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Center"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Top Center"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сверху по центру"
-          }
-        }
-      }
-    },
-    "Bottom Right" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Right"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Right"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Right"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Снизу справа"
-          }
-        }
-      }
-    },
-    "Bottom Left" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Left"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Left"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Left"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Снизу слева"
-          }
-        }
-      }
-    },
-    "Bottom Center" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Center"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Center"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bottom Center"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Снизу по центру"
-          }
-        }
-      }
-    },
-    "Test Notification" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Test Notification"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Test Notification"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Test Notification"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тестовое уведомление"
-          }
-        }
-      }
-    },
-    "Toast notifications are working!" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Toast notifications are working!"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Toast notifications are working!"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Toast notifications are working!"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всплывающие уведомления работают!"
-          }
-        }
-      }
-    },
-    "Where toast notifications appear on screen" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Where toast notifications appear on screen"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Where toast notifications appear on screen"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Where toast notifications appear on screen"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Где на экране появляются всплывающие уведомления"
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Model/ModelDownloadViewFamilyGroupingTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelDownloadViewFamilyGroupingTests.swift
@@ -1,0 +1,149 @@
+//
+//  ModelDownloadViewFamilyGroupingTests.swift
+//  osaurusTests
+//
+//  Covers the catalog's family grouping: precision/quant variants collapse
+//  into one card whose representative ("default variant") is the build that
+//  suits the current Mac best.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ModelDownloadViewFamilyGroupingTests {
+
+    private static let gb: Int64 = 1024 * 1024 * 1024
+
+    private func model(
+        id: String,
+        sizeGB: Int64? = nil,
+        isTopSuggestion: Bool = false,
+        releasedAt: Date? = nil
+    ) -> MLXModel {
+        MLXModel(
+            id: id,
+            name: ModelMetadataParser.friendlyName(from: id),
+            description: "test",
+            downloadURL: "https://huggingface.co/\(id)",
+            isTopSuggestion: isTopSuggestion,
+            downloadSizeBytes: sizeGB.map { $0 * Self.gb },
+            releasedAt: releasedAt,
+            // Pin to a directory that never exists so `isDownloaded` is
+            // deterministically false — otherwise a dev machine that
+            // actually has one of these repos on disk skews the ranking.
+            rootDirectory: URL(fileURLWithPath: "/nonexistent/osaurus-grouping-tests")
+        )
+    }
+
+    @Test func precisionVariantsCollapseToOneCard() {
+        let variants = [
+            model(id: "OsaurusAI/gemma-4-12B-it-MXFP8", sizeGB: 13),
+            model(id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4", sizeGB: 8),
+            model(id: "OsaurusAI/gemma-4-31B-it-qat-MXFP4", sizeGB: 18),
+        ]
+        let cards = ModelDownloadView.groupIntoFamilyCards(
+            variants,
+            totalMemoryGB: 48,
+            downloadStates: [:]
+        )
+        // 12B family collapses; 31B is its own card.
+        #expect(cards.count == 2)
+        #expect(
+            cards.contains { ModelMetadataParser.familyKey(from: $0.id) == "osaurusai/gemma-4-12b-it" }
+        )
+    }
+
+    @Test func groupingPreservesFirstSeenOrder() {
+        let variants = [
+            model(id: "OsaurusAI/Qwen3.6-27B-MXFP4", sizeGB: 15),
+            model(id: "OsaurusAI/gemma-4-12B-it-MXFP8", sizeGB: 13),
+            model(id: "OsaurusAI/Qwen3.6-27B-MXFP8-MTP", sizeGB: 28),
+        ]
+        let cards = ModelDownloadView.groupIntoFamilyCards(
+            variants,
+            totalMemoryGB: 128,
+            downloadStates: [:]
+        )
+        #expect(cards.count == 2)
+        // Qwen family card keeps position 0 (its first-listed variant's slot).
+        #expect(ModelMetadataParser.familyKey(from: cards[0].id) == "osaurusai/qwen3.6-27b")
+    }
+
+    @Test func defaultVariant_prefersHighestPrecisionThatFits() {
+        // On a 48 GB Mac both fit → prefer the larger (higher precision) build.
+        let small = model(id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4", sizeGB: 8)
+        let large = model(id: "OsaurusAI/gemma-4-12B-it-MXFP8", sizeGB: 13)
+        let pick = ModelDownloadView.defaultFamilyVariant(
+            among: [small, large],
+            totalMemoryGB: 48,
+            downloadStates: [:]
+        )
+        #expect(pick.id == large.id)
+    }
+
+    @Test func defaultVariant_fallsBackToBuildThatFitsOnSmallMacs() {
+        // On a 16 GB Mac the 20 GB build is too large → the 8 GB build wins
+        // despite lower precision.
+        let small = model(id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4", sizeGB: 8)
+        let large = model(id: "OsaurusAI/gemma-4-12B-it-MXFP8", sizeGB: 20)
+        let pick = ModelDownloadView.defaultFamilyVariant(
+            among: [small, large],
+            totalMemoryGB: 16,
+            downloadStates: [:]
+        )
+        #expect(pick.id == small.id)
+    }
+
+    @Test func defaultVariant_prefersActiveDownload() {
+        let idle = model(id: "OsaurusAI/gemma-4-12B-it-MXFP8", sizeGB: 13)
+        let downloading = model(id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4", sizeGB: 8)
+        let pick = ModelDownloadView.defaultFamilyVariant(
+            among: [idle, downloading],
+            totalMemoryGB: 48,
+            downloadStates: [downloading.id: .downloading(progress: 0.4)]
+        )
+        #expect(pick.id == downloading.id)
+    }
+
+    @Test func makeGridLists_collapsesCatalogFamiliesAndExposesVariantMap() {
+        let mxfp8 = model(id: "OsaurusAI/gemma-4-12B-it-MXFP8", sizeGB: 13)
+        let qat = model(id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4", sizeGB: 8)
+        let big = model(id: "OsaurusAI/gemma-4-31B-it-qat-MXFP4", sizeGB: 18)
+
+        let input = ModelDownloadView.GridListInput(
+            availableModels: [],
+            suggestedModels: [mxfp8, qat, big],
+            deduplicatedModels: [],
+            downloadStates: [:],
+            searchText: "",
+            filterState: ModelManager.ModelFilterState(),
+            selectedTab: .all,
+            sortOption: .recommended,
+            totalMemoryGB: 48
+        )
+        let lists = ModelDownloadView.makeGridLists(input)
+
+        // Two family cards: the 12B precision pair collapses, 31B stands alone.
+        #expect(lists.displayed.count == 2)
+        // On a 48 GB Mac the 12B card fronts the higher-precision MXFP8 build.
+        #expect(lists.displayed.contains { $0.id == mxfp8.id })
+        #expect(!lists.displayed.contains { $0.id == qat.id })
+        // The variant map still carries both builds for the detail sheet.
+        #expect(lists.variantsByFamily["osaurusai/gemma-4-12b-it"]?.count == 2)
+    }
+
+    @Test func defaultVariant_prefersCuratedOverAutoFetched() {
+        // Same fit and size class: the curated build beats the auto-fetched
+        // one so editorial descriptions/Top Pick flags surface on the card.
+        let curated = model(id: "OsaurusAI/Qwen3.6-27B-MXFP4", sizeGB: 15)
+        let autoFetched = model(id: "OsaurusAI/Qwen3.6-27B-JANG_4M", sizeGB: 15)
+        let pick = ModelDownloadView.defaultFamilyVariant(
+            among: [autoFetched, curated],
+            totalMemoryGB: 64,
+            downloadStates: [:]
+        )
+        #expect(pick.id == curated.id)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -312,6 +312,51 @@ struct ModelManagerSuggestedTests {
         }
     }
 
+    // MARK: - Non-chat repo gate (rampart, embeddings, image/speech pipelines)
+
+    @Test func chatCatalogEligibility_rejectsNonChatPipelinesAndPanelOwnedRepos() {
+        // Rampart is owned by Settings → Privacy; excluded even without a tag.
+        #expect(
+            !ModelManager.isChatCatalogEligible(id: "OsaurusAI/rampart-mlx", pipelineTag: nil)
+        )
+        // Non-chat pipeline tags never surface as chat cards.
+        for tag in [
+            "token-classification", "feature-extraction", "sentence-similarity",
+            "text-to-image", "image-to-image", "automatic-speech-recognition",
+            "text-to-speech",
+        ] {
+            #expect(
+                !ModelManager.isChatCatalogEligible(id: "OsaurusAI/some-utility", pipelineTag: tag),
+                "expected pipeline tag \(tag) to be rejected"
+            )
+        }
+        // Chat-capable pipelines pass.
+        for tag in ["text-generation", "image-text-to-text", "any-to-any"] {
+            #expect(
+                ModelManager.isChatCatalogEligible(id: "OsaurusAI/some-chat-model", pipelineTag: tag),
+                "expected pipeline tag \(tag) to be accepted"
+            )
+        }
+        // Untagged MLX conversions stay eligible (nil is not evidence of non-chat).
+        #expect(
+            ModelManager.isChatCatalogEligible(id: "OsaurusAI/Untagged-Chat-Model", pipelineTag: nil)
+        )
+    }
+
+    @Test @MainActor func panelOwnedRepos_droppedFromAutoFetchMerge() async {
+        await withIsolatedModelSizeCache {
+            let manager = ModelManager()
+            let rampart = MLXModel(
+                id: "OsaurusAI/rampart-mlx",
+                name: "rampart mlx",
+                description: "From OsaurusAI on Hugging Face.",
+                downloadURL: "https://huggingface.co/OsaurusAI/rampart-mlx"
+            )
+            manager.applyOsaurusOrgFetch(autoFetched: [rampart])
+            #expect(!manager.suggestedModels.contains { $0.id == rampart.id })
+        }
+    }
+
     // MARK: - Onboarding default scenario matrix (Phase 4c)
 
     @Test @MainActor func onboardingDefault_landsOnGemmaQATSpinePerRAMTier() async {

--- a/Packages/OsaurusCore/Tests/Model/ModelMetadataParserFamilyKeyTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMetadataParserFamilyKeyTests.swift
@@ -1,0 +1,99 @@
+//
+//  ModelMetadataParserFamilyKeyTests.swift
+//  osaurusTests
+//
+//  Covers the family-key derivation that collapses precision/quant variants
+//  of the same model (MXFP4/MXFP8/QAT/JANGTQ/…) into one catalog card while
+//  keeping genuinely different sizes (9B vs 35B, E2B vs E4B) separate.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ModelMetadataParserFamilyKeyTests {
+
+    @Test func precisionVariantsShareOneFamily() {
+        let gemma12B = [
+            "OsaurusAI/gemma-4-12B-it-MXFP8",
+            "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
+        ]
+        let keys = Set(gemma12B.map(ModelMetadataParser.familyKey(from:)))
+        #expect(keys.count == 1)
+        #expect(keys.first == "osaurusai/gemma-4-12b-it")
+    }
+
+    @Test func mtpAndCaseVariantsShareOneFamily() {
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP")
+                == ModelMetadataParser.familyKey(from: "OsaurusAI/Qwen3.6-35B-A3B-mxfp4")
+        )
+    }
+
+    @Test func turboQuantVariantsShareOneFamily() {
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/MiniMax-M2.7-JANGTQ4")
+                == ModelMetadataParser.familyKey(from: "OsaurusAI/MiniMax-M2.7-JANGTQ")
+        )
+        // Lettered TurboQuant flavors (JANGTQ_K, live on the org) collapse too.
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/MiniMax-M2.7-JANGTQ_K")
+                == ModelMetadataParser.familyKey(from: "OsaurusAI/MiniMax-M2.7-JANGTQ")
+        )
+    }
+
+    @Test func differentSizesStaySeparate() {
+        // 27B vs 35B MoE are different models, not precision variants.
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/Qwen3.6-27B-MXFP4")
+                != ModelMetadataParser.familyKey(from: "OsaurusAI/Qwen3.6-35B-A3B-mxfp4")
+        )
+        // E2B vs E4B edge sizes stay separate.
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/gemma-4-E2B-it-qat-MXFP4")
+                != ModelMetadataParser.familyKey(from: "OsaurusAI/gemma-4-E4B-it-qat-MXFP4")
+        )
+        // "Small" is a size tier, not a quant token.
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/MiniMax-M2.7-Small-JANGTQ")
+                != ModelMetadataParser.familyKey(from: "OsaurusAI/MiniMax-M2.7-JANGTQ")
+        )
+    }
+
+    @Test func familiesNeverMergeAcrossOrgs() {
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/gpt-oss-20b-MXFP4")
+                != ModelMetadataParser.familyKey(from: "lmstudio-community/gpt-oss-20b-MXFP4")
+        )
+    }
+
+    @Test func jangMixedPrecisionCollapses() {
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/Ornith-1.0-35B-JANG_4M")
+                == ModelMetadataParser.familyKey(from: "OsaurusAI/Ornith-1.0-35B-MXFP4")
+        )
+    }
+
+    @Test func idWithoutVariantTokensIsItsOwnFamily() {
+        #expect(
+            ModelMetadataParser.familyKey(from: "OsaurusAI/rampart-mlx")
+                == "osaurusai/rampart"
+        )
+        #expect(
+            ModelMetadataParser.familyKey(from: "some-org/plain-model")
+                == "some-org/plain-model"
+        )
+    }
+
+    @Test func familyDisplayNameDropsQuantAndTuningTokens() {
+        #expect(
+            ModelMetadataParser.familyDisplayName(from: "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
+                == "Gemma 4 12B"
+        )
+        #expect(
+            ModelMetadataParser.familyDisplayName(from: "OsaurusAI/MiniMax-M2.7-JANGTQ4")
+                == "MiniMax M2.7"
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Common/EmptyStateView.swift
+++ b/Packages/OsaurusCore/Views/Common/EmptyStateView.swift
@@ -73,8 +73,6 @@ struct EmptyStateView: View {
             return L("No models available")
         case .downloaded:
             return L("No downloaded models")
-        case .imageGeneration:
-            return L("Images")
         }
     }
 
@@ -89,8 +87,6 @@ struct EmptyStateView: View {
             return L("Language models will appear here")
         case .downloaded:
             return L("Downloaded models will appear here")
-        case .imageGeneration:
-            return L("Open the Images pane in Settings")
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -31,8 +31,18 @@ struct ModelDetailView: View, Identifiable {
     /// Unique identifier for Identifiable conformance (used for sheet presentation)
     let id = UUID()
 
-    /// The model to display details for
-    let model: MLXModel
+    /// The build currently displayed. Starts as the model the sheet was
+    /// opened with; the Versions picker swaps it in place (see
+    /// `selectVariant`) so the sheet doesn't tear down and re-animate.
+    @State private var selectedModel: MLXModel
+
+    /// Alias so the body reads naturally and existing call sites compile
+    /// unchanged.
+    private var model: MLXModel { selectedModel }
+
+    /// Every precision/quant build of this model's family (including
+    /// `model` itself). More than one entry surfaces the Versions picker.
+    var variants: [MLXModel] = []
 
     // MARK: - State
 
@@ -90,8 +100,9 @@ struct ModelDetailView: View, Identifiable {
     /// shared cache in `init` so a warm cache shows the checkmark immediately.
     @State private var resolvedIsDownloaded: Bool
 
-    init(model: MLXModel) {
-        self.model = model
+    init(model: MLXModel, variants: [MLXModel] = []) {
+        self._selectedModel = State(initialValue: model)
+        self.variants = variants
         self._resolvedIsDownloaded = State(
             initialValue: MLXModelDownloadCache.value(for: model.id) ?? false
         )
@@ -118,6 +129,8 @@ struct ModelDetailView: View, Identifiable {
             ScrollView {
                 VStack(spacing: 14) {
                     compatibilityLine
+
+                    variantPickerSection
 
                     runtimeDiagnosticsCard
 
@@ -167,12 +180,58 @@ struct ModelDetailView: View, Identifiable {
         }
     }
 
+    /// Swap the displayed build in place: clear everything keyed to the old
+    /// repo and reload for the new one. The view (and its sheet) stay alive,
+    /// so there's no teardown/entrance animation — sections just show their
+    /// loading placeholders until the new repo's data lands.
+    private func selectVariant(_ variant: MLXModel) {
+        guard variant.id != selectedModel.id else { return }
+        selectedModel = variant
+
+        estimatedSize = nil
+        isEstimating = false
+        estimateError = nil
+        hfDetails = nil
+        isLoadingHFDetails = false
+        readme = nil
+        isLoadingReadme = false
+        allFiles = nil
+        isLoadingFiles = false
+        isRepairing = false
+        repairResult = nil
+        didCopyPath = false
+        diagnostics = nil
+        resolvedIsDownloaded = MLXModelDownloadCache.value(for: variant.id) ?? false
+
+        Task { await loadDiagnostics() }
+        Task { await loadDownloadState() }
+        Task {
+            await estimateIfNeeded()
+            await loadHFDetails()
+            await loadReadmeIfNeeded()
+        }
+        // The file listing normally loads when the section is expanded; if
+        // it's already open, refetch for the new repo right away.
+        if isFilesExpanded {
+            Task { await loadAllFiles() }
+        }
+    }
+
+    /// True while a loader's result still belongs to the displayed repo.
+    /// In-flight loads for a previous variant bail instead of clobbering
+    /// the freshly reset state.
+    private func isCurrent(_ repoId: String) -> Bool {
+        selectedModel.id == repoId
+    }
+
     /// Resolve `model.isDownloaded` off the main thread and publish it. Reading
     /// it goes through the shared cache and, on a miss, enumerates the bundle
     /// directory — too slow to run inside the view body on a cold or slow disk.
     private func loadDownloadState() async {
-        let value = await Self.computeDownloadState(for: model)
+        let target = model
+        let value = await Self.computeDownloadState(for: target)
         await MainActor.run {
+            guard isCurrent(target.id) else { return }
             self.resolvedIsDownloaded = value
         }
     }
@@ -187,8 +246,10 @@ struct ModelDetailView: View, Identifiable {
     /// thread on a cold or slow disk.
     private func loadDiagnostics() async {
         guard diagnostics == nil else { return }
-        let report = await Self.computeDiagnostics(for: model)
+        let target = model
+        let report = await Self.computeDiagnostics(for: target)
         await MainActor.run {
+            guard isCurrent(target.id) else { return }
             self.diagnostics = report
         }
     }
@@ -204,8 +265,10 @@ struct ModelDetailView: View, Identifiable {
     private func loadReadmeIfNeeded() async {
         guard readme == nil, !isLoadingReadme else { return }
         isLoadingReadme = true
-        let text = await HuggingFaceService.shared.fetchReadme(repoId: model.id)
+        let repoId = model.id
+        let text = await HuggingFaceService.shared.fetchReadme(repoId: repoId)
         await MainActor.run {
+            guard isCurrent(repoId) else { return }
             self.readme = text
             self.isLoadingReadme = false
         }
@@ -215,12 +278,14 @@ struct ModelDetailView: View, Identifiable {
     private func loadAllFiles() async {
         guard allFiles == nil, !isLoadingFiles else { return }
         isLoadingFiles = true
+        let repoId = model.id
         let files = await HuggingFaceService.shared.fetchAllFiles(
-            repoId: model.id,
+            repoId: repoId,
             downloadPatterns: ModelDownloadService.downloadFilePatterns,
             excludedFiles: ModelDownloadService.downloadExcludedFiles
         )
         await MainActor.run {
+            guard isCurrent(repoId) else { return }
             self.allFiles = files
             self.isLoadingFiles = false
         }
@@ -230,8 +295,10 @@ struct ModelDetailView: View, Identifiable {
     private func loadHFDetails() async {
         guard !isLoadingHFDetails else { return }
         isLoadingHFDetails = true
-        let details = await HuggingFaceService.shared.fetchModelDetails(repoId: model.id)
+        let repoId = model.id
+        let details = await HuggingFaceService.shared.fetchModelDetails(repoId: repoId)
         await MainActor.run {
+            guard isCurrent(repoId) else { return }
             self.hfDetails = details
             self.isLoadingHFDetails = false
         }
@@ -691,6 +758,181 @@ struct ModelDetailView: View, Identifiable {
         )
     }
 
+    // MARK: - Versions (precision variants)
+
+    /// Picker over every precision/quant build of this model family, shown
+    /// only when there is more than one. Rows lead with plain language
+    /// ("Highest precision" / "Smallest download") plus size and RAM fit;
+    /// selecting a row swaps the whole sheet to that build so the footer's
+    /// Download/Delete act on it. The build the catalog card represents is
+    /// marked Recommended.
+    @ViewBuilder
+    private var variantPickerSection: some View {
+        if variants.count > 1 {
+            let totalMem = systemMonitor.totalMemoryGB
+            let recommendedId = ModelDownloadView.defaultFamilyVariant(
+                among: variants,
+                totalMemoryGB: totalMem,
+                downloadStates: modelManager.downloadStates
+            ).id
+            let ordered = variants.sorted { lhs, rhs in
+                let l = lhs.totalSizeEstimateBytes ?? 0
+                let r = rhs.totalSizeEstimateBytes ?? 0
+                if l != r { return l > r }
+                return lhs.id.localizedCaseInsensitiveCompare(rhs.id) == .orderedAscending
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    Text("Versions", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text("\(variants.count)")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.tertiaryText)
+                    Spacer(minLength: 0)
+                }
+
+                VStack(spacing: 6) {
+                    ForEach(ordered, id: \.id) { variant in
+                        variantRow(
+                            variant,
+                            isRecommended: variant.id == recommendedId,
+                            framing: variantFraming(variant, in: ordered),
+                            totalMemoryGB: totalMem
+                        )
+                    }
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .detailCardSurface()
+        }
+    }
+
+    /// Plain-language one-liner for a variant's position in the family:
+    /// the largest build is the quality pick, the smallest the download
+    /// pick. `ordered` is size-descending.
+    private func variantFraming(_ variant: MLXModel, in ordered: [MLXModel]) -> String? {
+        guard ordered.count > 1 else { return nil }
+        if variant.id == ordered.first?.id { return L("Highest precision") }
+        if variant.id == ordered.last?.id { return L("Smallest download") }
+        return nil
+    }
+
+    private func variantRow(
+        _ variant: MLXModel,
+        isRecommended: Bool,
+        framing: String?,
+        totalMemoryGB: Double
+    ) -> some View {
+        let isSelected = variant.id == model.id
+        let isOnDisk = MLXModelDownloadCache.value(for: variant.id) ?? false
+        let quantLabel =
+            ModelMetadataParser.quantization(from: variant.id) ?? L("Original")
+        let repoTail = variant.id.split(separator: "/").last.map(String.init) ?? variant.id
+
+        let (fitText, fitTint): (String?, Color) = {
+            let memory = variant.formattedEstimatedMemory
+            switch variant.compatibility(totalMemoryGB: totalMemoryGB) {
+            case .compatible:
+                return (memory.map { L("Runs Well · needs \($0)") } ?? L("Runs Well"), theme.successColor)
+            case .tight:
+                return (memory.map { L("Tight Fit · needs \($0)") } ?? L("Tight Fit"), theme.warningColor)
+            case .tooLarge:
+                return (memory.map { L("Too Large · needs \($0)") } ?? L("Too Large"), theme.errorColor)
+            case .unknown:
+                return (nil, theme.tertiaryText)
+            }
+        }()
+
+        return Button {
+            guard !isSelected else { return }
+            selectVariant(variant)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(isSelected ? theme.accentColor : theme.tertiaryText)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(quantLabel)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+
+                        if let framing {
+                            Text(framing)
+                                .font(.system(size: 11))
+                                .foregroundColor(theme.secondaryText)
+                        }
+
+                        if isRecommended {
+                            Text("Recommended", bundle: .module)
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundColor(theme.accentColor)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(theme.accentColor.opacity(0.12)))
+                        }
+
+                        if isOnDisk {
+                            HStack(spacing: 3) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .font(.system(size: 9, weight: .bold))
+                                Text("Downloaded", bundle: .module)
+                                    .font(.system(size: 9, weight: .bold))
+                            }
+                            .foregroundColor(theme.successColor)
+                        }
+                    }
+
+                    Text(repoTail)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer(minLength: 8)
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    if let size = variant.formattedDownloadSize {
+                        Text(size)
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundColor(theme.secondaryText)
+                    }
+                    if let fitText {
+                        Text(fitText)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(fitTint)
+                    }
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(
+                        isSelected
+                            ? theme.accentColor.opacity(0.08)
+                            : theme.tertiaryBackground.opacity(0.4)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(
+                                isSelected
+                                    ? theme.accentColor.opacity(0.35)
+                                    : theme.cardBorder.opacity(0.5),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
     // MARK: - Model Card (README)
 
     /// The model's README, rendered with the full-fidelity chat markdown
@@ -1142,8 +1384,10 @@ struct ModelDetailView: View, Identifiable {
         if !force, let est = estimatedSize, est > 0 { return }
         isEstimating = true
         estimateError = nil
-        let size = await modelManager.estimateDownloadSize(for: model)
+        let target = model
+        let size = await modelManager.estimateDownloadSize(for: target)
         await MainActor.run {
+            guard isCurrent(target.id) else { return }
             self.estimatedSize = size
             if size == nil { self.estimateError = "Could not estimate size right now." }
             self.isEstimating = false

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -200,17 +200,7 @@ struct ModelDownloadView: View {
             gridListsRefreshTask?.cancel()
             gridListsRefreshTask = nil
         }
-        .onChange(of: selectedTab) { oldTab, newTab in
-            // The Images tab is a shortcut, not real content: hand off to the
-            // dedicated Image Generation pane's Models sub-tab and snap the
-            // picker back to the tab the user was actually viewing.
-            if newTab == .imageGeneration {
-                ManagementStateManager.shared.selectedTab = .imageGeneration
-                ManagementStateManager.shared.imageGenerationSubTabRequest =
-                    ImageGenerationTab.models.rawValue
-                selectedTab = oldTab == .imageGeneration ? .all : oldTab
-                return
-            }
+        .onChange(of: selectedTab) { _, _ in
             refreshGridLists()
         }
         .onChange(of: sortOption) { _, _ in refreshGridLists() }
@@ -246,8 +236,16 @@ struct ModelDownloadView: View {
             }
         }
         .sheet(item: $modelToShowDetails) { model in
-            ModelDetailView(model: model)
-                .environment(\.theme, themeManager.currentTheme)
+            // Family cards open with their full variant list so the sheet
+            // can offer the Versions picker; single-build models get an
+            // empty/1-element list, which hides it.
+            ModelDetailView(
+                model: model,
+                variants: gridListsSnapshot.variantsByFamily[
+                    ModelMetadataParser.familyKey(from: model.id)
+                ] ?? []
+            )
+            .environment(\.theme, themeManager.currentTheme)
         }
         .sheet(isPresented: $showImportSheet) {
             HuggingFaceImportSheet(
@@ -684,10 +682,22 @@ struct ModelDownloadView: View {
 
     /// A single model card wired to the manager's download actions. Shared
     /// by the catalog grid and the Recommended carousel so their behavior
-    /// stays identical.
+    /// stays identical. Catalog cards are family cards (one per model, all
+    /// precision builds behind it); On Device stays one card per bundle, so
+    /// the version indicator only applies on the Catalog tab.
     private func modelCard(for model: MLXModel) -> some View {
-        ModelRowView(
-            content: ModelCardContent(model: model, totalMemoryGB: systemMonitor.totalMemoryGB),
+        let variantCount =
+            selectedTab == .all
+            ? (gridListsSnapshot.variantsByFamily[
+                ModelMetadataParser.familyKey(from: model.id)
+            ]?.count ?? 1)
+            : 1
+        return ModelRowView(
+            content: ModelCardContent(
+                model: model,
+                totalMemoryGB: systemMonitor.totalMemoryGB,
+                variantCount: variantCount
+            ),
             downloadState: modelManager.effectiveDownloadState(for: model),
             metrics: modelManager.downloadMetrics[model.id],
             onViewDetails: { modelToShowDetails = model },
@@ -836,10 +846,63 @@ struct ModelDownloadView: View {
                         isFirst: true
                     )
                 }
+                imageModelsLinkRow
             }
         } else {
             modelGrid(models: lists.displayed)
         }
+    }
+
+    /// Inline pointer to the dedicated Images pane. Replaces the old fake
+    /// "Images" tab (which navigated away and snapped the selector back) with
+    /// an honest link at the end of the catalog.
+    private var imageModelsLinkRow: some View {
+        Button {
+            ManagementStateManager.shared.selectedTab = .imageGeneration
+            ManagementStateManager.shared.imageGenerationSubTabRequest =
+                ImageGenerationTab.models.rawValue
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "photo.on.rectangle.angled")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Looking for image models?", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(
+                        "Image generation and editing models live in Images settings.",
+                        bundle: .module
+                    )
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+                }
+
+                Spacer(minLength: 8)
+
+                HStack(spacing: 4) {
+                    Text("Open Images", bundle: .module)
+                        .font(.system(size: 12, weight: .medium))
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                .foregroundColor(theme.accentColor)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(theme.tertiaryBackground.opacity(0.4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(theme.cardBorder.opacity(0.6), lineWidth: 1)
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(PlainButtonStyle())
+        .padding(.top, 4)
     }
 
     /// Main content area with scrollable model list
@@ -868,10 +931,6 @@ struct ModelDownloadView: View {
                                     catalogContent(lists: lists)
                                 case .downloaded:
                                     modelGrid(models: lists.downloaded)
-                                case .imageGeneration:
-                                    // Transient — the picker snaps back off this
-                                    // tab as soon as it hands off to Settings.
-                                    EmptyView()
                                 }
                             }
                         }
@@ -1222,8 +1281,6 @@ struct ModelDownloadView: View {
             return "cube.box"
         case .downloaded:
             return "internaldrive"
-        case .imageGeneration:
-            return "photo.on.rectangle.angled"
         }
     }
 
@@ -1236,8 +1293,6 @@ struct ModelDownloadView: View {
             return L("No models available")
         case .downloaded:
             return L("No models on device yet")
-        case .imageGeneration:
-            return L("Images")
         }
     }
 
@@ -1251,6 +1306,11 @@ struct ModelDownloadView: View {
         let others: [MLXModel]
         let downloaded: [MLXModel]
         let displayed: [MLXModel]
+        /// Every catalog build keyed by `ModelMetadataParser.familyKey`,
+        /// built from the unfiltered merged catalog so the detail sheet's
+        /// variant picker always shows the full family even while the grid
+        /// is searched or filtered.
+        var variantsByFamily: [String: [MLXModel]] = [:]
     }
 
     /// Single token for the implicit grid animation. Driving the implicit
@@ -1321,6 +1381,86 @@ struct ModelDownloadView: View {
             sortOption: sortOption,
             totalMemoryGB: systemMonitor.totalMemoryGB
         )
+    }
+
+    // MARK: - Family grouping
+
+    /// One card per model family: precision/quant variants of the same model
+    /// (MXFP4 vs MXFP8 vs QAT vs JANGTQ…) collapse into a single
+    /// representative card. `models` must already be searched/filtered/sorted;
+    /// each family keeps the position of its first-listed variant so the
+    /// active sort still drives card order.
+    nonisolated static func groupIntoFamilyCards(
+        _ models: [MLXModel],
+        totalMemoryGB: Double,
+        downloadStates: [String: DownloadState]
+    ) -> [MLXModel] {
+        var order: [String] = []
+        var buckets: [String: [MLXModel]] = [:]
+        for model in models {
+            let key = ModelMetadataParser.familyKey(from: model.id)
+            if buckets[key] == nil { order.append(key) }
+            buckets[key, default: []].append(model)
+        }
+        return order.compactMap { key in
+            buckets[key].map {
+                defaultFamilyVariant(
+                    among: $0,
+                    totalMemoryGB: totalMemoryGB,
+                    downloadStates: downloadStates
+                )
+            }
+        }
+    }
+
+    /// The build a family card represents (and the one its Download button
+    /// installs by default). Anything the user already owns or is actively
+    /// downloading wins; otherwise the best build for this Mac: better RAM
+    /// fit first, then curated over auto-fetched, Top Pick over plain, then
+    /// highest precision (largest download) among equals, newest as the
+    /// final tiebreak.
+    nonisolated static func defaultFamilyVariant(
+        among variants: [MLXModel],
+        totalMemoryGB: Double,
+        downloadStates: [String: DownloadState]
+    ) -> MLXModel {
+        func isActive(_ m: MLXModel) -> Bool {
+            switch downloadStates[m.id] ?? .notStarted {
+            case .downloading, .paused: return true
+            default: return false
+            }
+        }
+        func compatRank(_ m: MLXModel) -> Int {
+            switch m.compatibility(totalMemoryGB: totalMemoryGB) {
+            case .compatible: return 0
+            case .tight: return 1
+            case .tooLarge: return 2
+            case .unknown: return 3
+            }
+        }
+        let curatedIds = ModelManager.curatedSuggestedIds
+        let best = variants.min { lhs, rhs in
+            if isActive(lhs) != isActive(rhs) { return isActive(lhs) }
+            if lhs.isDownloaded != rhs.isDownloaded { return lhs.isDownloaded }
+            let lc = compatRank(lhs)
+            let rc = compatRank(rhs)
+            if lc != rc { return lc < rc }
+            let lCurated = curatedIds.contains(lhs.id.lowercased())
+            let rCurated = curatedIds.contains(rhs.id.lowercased())
+            if lCurated != rCurated { return lCurated }
+            if lhs.isTopSuggestion != rhs.isTopSuggestion { return lhs.isTopSuggestion }
+            let ls = lhs.totalSizeEstimateBytes ?? 0
+            let rs = rhs.totalSizeEstimateBytes ?? 0
+            if ls != rs { return ls > rs }
+            switch (lhs.releasedAt, rhs.releasedAt) {
+            case let (l?, r?) where l != r: return l > r
+            case (_?, nil): return true
+            case (nil, _?): return false
+            default: break
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        return best ?? variants[0]
     }
 
     /// Consolidates all list computations. Pure over `GridListInput` so it can
@@ -1474,35 +1614,55 @@ struct ModelDownloadView: View {
 
         // The Top Picks carousel only exists under the default Recommended
         // sort. Any explicit sort merges the picks back into the grid so they
-        // sort alongside everything else. The carousel itself is newest-first.
+        // sort alongside everything else. The carousel itself is newest-first,
+        // one card per family — precision siblings collapse into the variant
+        // that suits this Mac best.
         let topPicks =
             sortOption == .recommended
-            ? sortedCatalog(recommended.filter { $0.isTopSuggestion })
+            ? groupIntoFamilyCards(
+                sortedCatalog(recommended.filter { $0.isTopSuggestion }),
+                totalMemoryGB: mem,
+                downloadStates: downloadStates
+            )
             : []
-        let topPickIds = Set(topPicks.map { $0.id.lowercased() })
+        // Exclude by family, not id, so demoted precision siblings of a Top
+        // Pick don't reappear as separate grid cards below the carousel.
+        let topPickFamilies = Set(topPicks.map { ModelMetadataParser.familyKey(from: $0.id) })
 
         // The grid is the rest of the catalog — recommended non-top picks plus
         // everything else — deduped and ordered newest-first (or by the
-        // explicit sort choice). This keeps the grid "how it was" minus the
-        // models promoted into the carousel.
+        // explicit sort choice), then collapsed to one card per family.
         var seenCatalog: Set<String> = []
         var catalogRest: [MLXModel] = []
         for model in recommended + allFiltered {
             let key = model.id.lowercased()
-            if topPickIds.contains(key) { continue }
+            if topPickFamilies.contains(ModelMetadataParser.familyKey(from: model.id)) { continue }
             if seenCatalog.insert(key).inserted {
                 catalogRest.append(model)
             }
         }
-        let others = sortedCatalog(catalogRest)
+        let others = groupIntoFamilyCards(
+            sortedCatalog(catalogRest),
+            totalMemoryGB: mem,
+            downloadStates: downloadStates
+        )
 
         let downloaded = computeDownloadedList()
+
+        // Full variant lists per family from the unfiltered merged catalog,
+        // for the detail sheet's variant picker and the cards' "N versions"
+        // indicator.
+        var variantsByFamily: [String: [MLXModel]] = [:]
+        var seenVariantIds: Set<String> = []
+        for model in input.suggestedModels + input.availableModels {
+            guard seenVariantIds.insert(model.id.lowercased()).inserted else { continue }
+            variantsByFamily[ModelMetadataParser.familyKey(from: model.id), default: []].append(model)
+        }
 
         let displayed: [MLXModel]
         switch input.selectedTab {
         case .all: displayed = topPicks + others
         case .downloaded: displayed = downloaded
-        case .imageGeneration: displayed = []
         }
 
         // Warm disk-backed verdicts while still off the main actor. The catalog
@@ -1516,7 +1676,13 @@ struct ModelDownloadView: View {
             _ = model.isMLXFormat
         }
 
-        return GridLists(suggested: topPicks, others: others, downloaded: downloaded, displayed: displayed)
+        return GridLists(
+            suggested: topPicks,
+            others: others,
+            downloaded: downloaded,
+            displayed: displayed,
+            variantsByFamily: variantsByFamily
+        )
     }
 
     /// Eager refresh of the cached snapshot. Called from `.onAppear` and

--- a/Packages/OsaurusCore/Views/Model/ModelRowView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelRowView.swift
@@ -359,14 +359,21 @@ struct ModelRowView: View {
 
     /// Fixed three-column spec strip. Columns stay in the same order with
     /// a "—" placeholder for missing values so cards line up for
-    /// side-by-side comparison.
+    /// side-by-side comparison. Family cards replace the quant column (the
+    /// representative build's quant would be misleading for a multi-build
+    /// card) with the number of available versions; single-build cards keep
+    /// the quant label since it's what distinguishes them.
     private var statStrip: some View {
         HStack(spacing: 0) {
             StatSegment(label: L("Size"), value: content.size)
             statDivider
             StatSegment(label: L("Params"), value: content.params)
             statDivider
-            StatSegment(label: L("Quant"), value: content.quant)
+            if content.variantCount > 1 {
+                StatSegment(label: L("Versions"), value: "\(content.variantCount)")
+            } else {
+                StatSegment(label: L("Quant"), value: content.quant)
+            }
         }
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity)
@@ -418,18 +425,38 @@ struct ModelRowView: View {
         }
     }
 
+    /// Plain-language fit verdict. When the RAM estimate is known it reads
+    /// as "Runs Well · needs ~10 GB" so new users get the "will this work on
+    /// my Mac" answer without decoding quant/param jargon.
     @ViewBuilder
     private var compatibilityBadge: some View {
         switch content.compatibility {
         case .compatible:
-            TintedPill(icon: "checkmark.shield", label: Text(L("Runs Well")), color: theme.successColor)
+            TintedPill(
+                icon: "checkmark.shield",
+                label: Text(fitText(verdict: L("Runs Well"))),
+                color: theme.successColor
+            )
         case .tight:
-            TintedPill(icon: "exclamationmark.triangle", label: Text(L("Tight Fit")), color: theme.warningColor)
+            TintedPill(
+                icon: "exclamationmark.triangle",
+                label: Text(fitText(verdict: L("Tight Fit"))),
+                color: theme.warningColor
+            )
         case .tooLarge:
-            TintedPill(icon: "xmark.circle", label: Text(L("Too Large")), color: theme.errorColor)
+            TintedPill(
+                icon: "xmark.circle",
+                label: Text(fitText(verdict: L("Too Large"))),
+                color: theme.errorColor
+            )
         case .unknown:
             EmptyView()
         }
+    }
+
+    private func fitText(verdict: String) -> String {
+        guard let memory = content.memoryNeeded else { return verdict }
+        return "\(verdict) · \(L("needs \(memory)"))"
     }
 
     /// Badge showing whether the model is an LLM, VLM, or image generator.
@@ -464,11 +491,19 @@ struct ModelCardContent {
     var isUnsupportedFormat: Bool = false
     let useCase: ModelUseCase?
     let compatibility: ModelCompatibility
+    /// Formatted RAM the model needs at runtime (e.g. "~10.2 GB"), rendered
+    /// inside the compatibility pill so the fit verdict reads in plain
+    /// language instead of leaning on quant jargon.
+    var memoryNeeded: String? = nil
     /// LLM / VLM / Image pill; `nil` to omit.
     let type: ModelCardType?
     let size: String?
     let params: String?
     let quant: String?
+    /// Number of precision/quant builds this card represents. Catalog cards
+    /// grouped by family carry the family's build count; ungrouped contexts
+    /// (On Device, image models) leave it at 1, which hides the indicator.
+    var variantCount: Int = 1
     /// Raw popularity / release strings; the footer applies its own wording.
     let downloadsText: String?
     let releaseText: String?
@@ -481,11 +516,15 @@ enum ModelCardType {
 }
 
 extension ModelCardContent {
-    /// LLM/VLM card content, preserving the exact values the catalog cards
-    /// rendered before the presentation-model refactor.
-    init(model: MLXModel, totalMemoryGB: Double) {
+    /// LLM/VLM card content. `variantCount > 1` marks a family card (one
+    /// card representing several precision/quant builds): the title becomes
+    /// the family name so a build suffix like "qat MXFP4" never leads, and
+    /// the quant column gives way to the version count.
+    init(model: MLXModel, totalMemoryGB: Double, variantCount: Int = 1) {
         self.init(
-            name: model.name,
+            name: variantCount > 1
+                ? ModelMetadataParser.familyDisplayName(from: model.id)
+                : model.name,
             description: model.description,
             gradientColors: ModelCardGradient.colors(for: model),
             isTopSuggestion: model.isTopSuggestion,
@@ -493,10 +532,12 @@ extension ModelCardContent {
             isUnsupportedFormat: model.isDownloaded && !model.isMLXFormat,
             useCase: model.useCase,
             compatibility: model.compatibility(totalMemoryGB: totalMemoryGB),
+            memoryNeeded: model.formattedEstimatedMemory,
             type: model.useCase == .vision ? nil : (model.isVLM ? .vlm : .llm),
             size: model.formattedDownloadSize,
             params: model.parameterCount,
             quant: model.quantization,
+            variantCount: variantCount,
             downloadsText: model.formattedDownloads,
             releaseText: model.formattedReleaseMonth
         )


### PR DESCRIPTION
## Summary
- **Catalog hygiene:** the OsaurusAI org auto-fetch now admits only chat-capable repos (`pipeline_tag` gate: `text-generation`, `image-text-to-text`, etc.) and hard-excludes panel-owned repos like the Rampart PII guard, so embeddings/guard/image/speech repos no longer surface as chat cards. Untagged repos still pass since MLX conversions frequently omit the tag.
- **Family grouping:** precision/quant builds of the same model (MXFP4 / MXFP8 / QAT / JANGTQ…) collapse into a single catalog card via a new `ModelMetadataParser.familyKey`. Each card represents the best build for this Mac (downloaded/active builds win, then RAM fit, curation, precision, recency) and shows a "Versions" count in place of the quant column.
- **Variant picker:** the detail sheet lists every build in the family with plain-language framing ("Highest precision" / "Smallest download"), size, RAM fit, Recommended and Downloaded badges. Picking a build swaps the sheet's content in place — per-repo state resets and reloads without tearing the view down, and stale in-flight loads for the previous build are discarded.
- **Plain-language cards:** compatibility pills now read "Runs Well · needs ~10 GB"; auto-fetched multimodal repos get the Vision use-case pill.
- **Images tab removed:** the fake "Images" tab (which navigated away and snapped the selector back) is replaced by an inline link row at the end of the catalog pointing to the Images settings pane.

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` passes
- [x] New unit suites pass: `ModelMetadataParserFamilyKeyTests` (family key/display-name parsing incl. JANGTQ_K), `ModelDownloadViewFamilyGroupingTests` (grouping, default-variant selection, end-to-end `makeGridLists`), plus extended `ModelManagerSuggestedTests` (pipeline-tag and panel-owned filtering) — 35 tests, 3 suites
- [x] Live spot-check: rampart absent from the catalog, families collapse to one card with correct version counts, variant switching updates the sheet in place without a reload animation
- [ ] Reviewer: sanity-check the catalog grid and Versions picker on a low-RAM Mac (recommended default should prefer the build that fits)