### PR TITLE
Register Agent Channel tools for app testing

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9279,8 +9279,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logUserAgent = userAgent
         let logSelf = self
         runRequestTask(priority: .userInitiated) {
-            // External callers never see the externally-denied tool classes
-            // (folder write/shell) — `/mcp/call` refuses them too.
+            // External callers never see app-only tool classes; `/mcp/call`
+            // refuses the same deny list too.
             let entries = await MainActor.run {
                 ToolRegistry.shared.listTools().filter {
                     $0.enabled && !ToolRegistry.externallyDeniedToolNames.contains($0.name)
@@ -9460,12 +9460,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return "{}"
         }()
 
-        // External deny list: folder write/shell tool classes are never
-        // invocable through the MCP bridge (they're also hidden from
-        // `/mcp/tools`). Refuse before any schema validation or gating.
+        // External deny list: app-only tool classes are never invocable
+        // through the MCP bridge (they're also hidden from `/mcp/tools`).
+        // Refuse before any schema validation or gating.
         if ToolRegistry.externallyDeniedToolNames.contains(req.name) {
             let message =
-                "'\(req.name)' is not available to external callers. Folder write and shell tools can only run from the Osaurus app."
+                "'\(req.name)' is not available to external callers. App-only tools can only run from the Osaurus app."
             let bodyJSON = #"{"error":"tool_not_exposable","message":"\#(message)"}"#
             sendResponse(
                 context: context,

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5495,6 +5495,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     // MARK: - Dispatch & Task Endpoints
 
+    nonisolated static func shouldBindExternalSurfaceForDispatch(isLoopback: Bool) -> Bool {
+        !isLoopback
+    }
+
     /// POST /agents/{identifier}/dispatch — dispatch work/chat task
     /// The identifier can be an agent UUID or a crypto address (0x...).
     private func handleDispatchEndpoint(
@@ -5694,7 +5698,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 externalSessionKey: externalSessionKey
             )
 
-            let handle = await TaskDispatcher.shared.dispatch(request)
+            let handle: DispatchHandle?
+            if Self.shouldBindExternalSurfaceForDispatch(isLoopback: isLoopback) {
+                handle = await ChatExecutionContext.$isExternalSurface.withValue(true) {
+                    await TaskDispatcher.shared.dispatch(request)
+                }
+            } else {
+                handle = await TaskDispatcher.shared.dispatch(request)
+            }
             let responseBody: String
             let status: HTTPResponseStatus
 

--- a/Packages/OsaurusCore/Services/MCP/MCPServerManager.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerManager.swift
@@ -68,9 +68,11 @@ final class MCPServerManager {
 
     // MARK: - Internal
     private func registerHandlers(on server: MCP.Server) async {
-        // ListTools returns only enabled tools from ToolRegistry
+        // ListTools returns only enabled, externally exposable tools from ToolRegistry.
         await server.withMethodHandler(MCP.ListTools.self) { _ in
-            let entries = await ToolRegistry.shared.listTools().filter { $0.enabled }
+            let entries = await ToolRegistry.shared.listTools().filter {
+                Self.isToolVisibleToExternalMCP(name: $0.name, enabled: $0.enabled)
+            }
             let tools: [MCP.Tool] = entries.map { entry in
                 let schema: MCP.Value = entry.parameters.map { Self.toMCPValue($0) } ?? .null
                 return MCP.Tool(name: entry.name, description: entry.description, inputSchema: schema)
@@ -107,12 +109,25 @@ final class MCPServerManager {
             }()
             let argsJSON: String = {
                 if let d = argsData {
-                    return String(decoding: d, as: UTF8.self)
+                    return String(data: d, encoding: .utf8) ?? "{}"
                 }
                 return "{}"
             }()
 
             do {
+                if let denial = Self.externalMCPDenialMessage(for: params.name) {
+                    return .init(
+                        content: [
+                            .text(
+                                text: denial,
+                                annotations: nil,
+                                _meta: nil
+                            )
+                        ],
+                        isError: true
+                    )
+                }
+
                 // Validate against tool schema when available
                 if let schema = await ToolRegistry.shared.parametersForTool(name: params.name) {
                     let result = SchemaValidator.validate(arguments: argumentsAny, against: schema)
@@ -122,7 +137,10 @@ final class MCPServerManager {
                     }
                 }
 
-                let result = try await ToolRegistry.shared.execute(name: params.name, argumentsJSON: argsJSON)
+                let result = try await Self.executeToolAsExternalMCP(
+                    name: params.name,
+                    argumentsJSON: argsJSON
+                )
                 return .init(content: [.text(text: result, annotations: nil, _meta: nil)], isError: false)
             } catch {
                 return .init(
@@ -130,6 +148,22 @@ final class MCPServerManager {
                     isError: true
                 )
             }
+        }
+    }
+
+    nonisolated static func isToolVisibleToExternalMCP(name: String, enabled: Bool) -> Bool {
+        enabled && !ToolRegistry.externallyDeniedToolNames.contains(name)
+    }
+
+    nonisolated static func externalMCPDenialMessage(for name: String) -> String? {
+        guard ToolRegistry.externallyDeniedToolNames.contains(name) else { return nil }
+        return "'\(name)' is not available to external callers. "
+            + "App-only tools can only run from the Osaurus app."
+    }
+
+    static func executeToolAsExternalMCP(name: String, argumentsJSON: String) async throws -> String {
+        try await ChatExecutionContext.$isExternalSurface.withValue(true) {
+            try await ToolRegistry.shared.execute(name: name, argumentsJSON: argumentsJSON)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
@@ -1842,25 +1842,28 @@ struct DiscordConnectionTests {
             "discord_send_message",
             "discord_reply_to_thread",
         ]
-        let (registeredNames, builtInNames, runtimeNames, pluginNames, alwaysLoadedNames, phantomNames) = await MainActor.run {
-            (
-                Set(ToolRegistry.shared.listTools().map(\.name)),
-                ToolRegistry.shared.builtInToolNames,
-                ToolRegistry.shared.runtimeManagedToolNames,
-                names.filter { ToolRegistry.shared.isPluginTool($0) },
-                Set(ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)),
-                phantomDiscordNames.filter { ToolRegistry.shared.entry(named: $0) != nil }
+        let snapshot = await MainActor.run {
+            let registered = Set(ToolRegistry.shared.listTools().map(\.name))
+            return AgentChannelRegistrySnapshot(
+                registeredNames: registered,
+                registeredChannelNames: Set(registered.filter { $0.hasPrefix("agent_channel_") }),
+                builtInNames: ToolRegistry.shared.builtInToolNames,
+                runtimeNames: ToolRegistry.shared.runtimeManagedToolNames,
+                pluginNames: Set(names.filter { ToolRegistry.shared.isPluginTool($0) }),
+                alwaysLoadedNames: Set(ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)),
+                phantomNames: Set(phantomDiscordNames.filter { ToolRegistry.shared.entry(named: $0) != nil })
             )
         }
         // Agent Channel actions are provider-neutral native dynamic tools:
         // callable by the app runtime, but not injected into the always-loaded
         // prompt baseline.
-        #expect(Set(names).isSubset(of: registeredNames))
-        #expect(pluginNames.isEmpty)
-        #expect(Set(names).isDisjoint(with: builtInNames))
-        #expect(Set(names).isDisjoint(with: runtimeNames))
-        #expect(Set(names).isDisjoint(with: alwaysLoadedNames))
-        #expect(phantomNames.isEmpty)
+        #expect(Set(names).isSubset(of: snapshot.registeredNames))
+        #expect(snapshot.registeredChannelNames == Set(names))
+        #expect(snapshot.pluginNames.isEmpty)
+        #expect(Set(names).isDisjoint(with: snapshot.builtInNames))
+        #expect(Set(names).isDisjoint(with: snapshot.runtimeNames))
+        #expect(Set(names).isDisjoint(with: snapshot.alwaysLoadedNames))
+        #expect(snapshot.phantomNames.isEmpty)
 
         // The native action vocabulary stays restricted to the app surface.
         // External HTTP/MCP callers must not be able to send channel messages
@@ -2133,6 +2136,16 @@ private final class DiscordHTTPStubProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+}
+
+private struct AgentChannelRegistrySnapshot {
+    let registeredNames: Set<String>
+    let registeredChannelNames: Set<String>
+    let builtInNames: Set<String>
+    let runtimeNames: Set<String>
+    let pluginNames: Set<String>
+    let alwaysLoadedNames: Set<String>
+    let phantomNames: Set<String>
 }
 
 private extension DiscordMessage {

--- a/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
@@ -1829,7 +1829,7 @@ struct DiscordConnectionTests {
         }
     }
 
-    @Test func nativeAgentChannelToolsAreDisabledButRemainExternallyDenied() async throws {
+    @Test func nativeAgentChannelToolsAreRegisteredAsDynamicNativeToolsAndRemainExternallyDenied() async throws {
         let names = ToolRegistry.agentChannelToolNames.sorted()
         let phantomDiscordNames: Set<String> = [
             "discord_diagnostics",
@@ -1842,28 +1842,31 @@ struct DiscordConnectionTests {
             "discord_send_message",
             "discord_reply_to_thread",
         ]
-        let (registeredNames, builtInNames, pluginNames, phantomNames) = await MainActor.run {
+        let (registeredNames, builtInNames, runtimeNames, pluginNames, alwaysLoadedNames, phantomNames) = await MainActor.run {
             (
                 Set(ToolRegistry.shared.listTools().map(\.name)),
                 ToolRegistry.shared.builtInToolNames,
+                ToolRegistry.shared.runtimeManagedToolNames,
                 names.filter { ToolRegistry.shared.isPluginTool($0) },
+                Set(ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)),
                 phantomDiscordNames.filter { ToolRegistry.shared.entry(named: $0) != nil }
             )
         }
-        // Agent Channel tool registration is intentionally disabled in
-        // `ToolRegistry.registerBuiltInTools`, so none of the native action
-        // tools are live in the registry. They must also never leak in as
-        // plugin-owned tools or collide with the phantom Discord vocabulary.
-        #expect(Set(names).isDisjoint(with: registeredNames))
+        // Agent Channel actions are provider-neutral native dynamic tools:
+        // callable by the app runtime, but not injected into the always-loaded
+        // prompt baseline.
+        #expect(Set(names).isSubset(of: registeredNames))
         #expect(pluginNames.isEmpty)
+        #expect(Set(names).isDisjoint(with: builtInNames))
+        #expect(Set(names).isDisjoint(with: runtimeNames))
+        #expect(Set(names).isDisjoint(with: alwaysLoadedNames))
         #expect(phantomNames.isEmpty)
 
-        // Even while the tools are disabled, their names stay on the
-        // external-surface deny list (defense in depth) and must never be
-        // promoted to built-ins.
+        // The native action vocabulary stays restricted to the app surface.
+        // External HTTP/MCP callers must not be able to send channel messages
+        // through these tools.
         for name in names {
             #expect(ToolRegistry.externallyDeniedToolNames.contains(name))
-            #expect(!builtInNames.contains(name))
             #expect(!ToolRegistry.isDeniedForCurrentSurface(name))
             let denied = ChatExecutionContext.$isExternalSurface.withValue(true) {
                 ToolRegistry.isDeniedForCurrentSurface(name)

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -206,6 +206,44 @@ struct MCPHTTPHandlerTests {
         }
     }
 
+    @Test func stdio_mcp_policy_hides_externally_denied_tools() {
+        #expect(MCPServerManager.isToolVisibleToExternalMCP(name: EchoTool.nameStatic, enabled: true))
+        #expect(!MCPServerManager.isToolVisibleToExternalMCP(name: EchoTool.nameStatic, enabled: false))
+
+        for name in ["file_write", "shell_run", "agent_channel_send_message"] {
+            #expect(!MCPServerManager.isToolVisibleToExternalMCP(name: name, enabled: true))
+            let denial = MCPServerManager.externalMCPDenialMessage(for: name)
+            #expect(denial?.contains("App-only tools") == true)
+        }
+    }
+
+    @Test func stdio_mcp_execution_binds_external_surface() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            ToolRegistry.shared.register(ExternalSurfaceProbeTool())
+            ToolRegistry.shared.setEnabled(true, for: ExternalSurfaceProbeTool.nameStatic)
+            defer { ToolRegistry.shared.unregister(names: [ExternalSurfaceProbeTool.nameStatic]) }
+
+            let text = try await MCPServerManager.executeToolAsExternalMCP(
+                name: ExternalSurfaceProbeTool.nameStatic,
+                argumentsJSON: "{}"
+            )
+            let envelope =
+                try JSONSerialization.jsonObject(
+                    with: Data(text.utf8)
+                ) as? [String: Any]
+            #expect(envelope?["ok"] as? Bool == true)
+            let result = envelope?["result"] as? [String: Any]
+            #expect(result?["text"] as? String == "external")
+        }
+    }
+
     @Test func mcp_call_with_missing_required_arg_returns_error() async throws {
         try await DynamicCatalogTestLock.shared.run {
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -265,6 +303,17 @@ private struct NamedEchoTool: OsaurusTool {
     let parameters: JSONValue? = nil
     func execute(argumentsJSON: String) async throws -> String {
         return argumentsJSON
+    }
+}
+
+private struct ExternalSurfaceProbeTool: OsaurusTool {
+    static let nameStatic: String = "external_surface_probe"
+    let name: String = ExternalSurfaceProbeTool.nameStatic
+    let description: String = "Reports whether the current execution surface is external"
+    let parameters: JSONValue? = nil
+
+    func execute(argumentsJSON: String) async throws -> String {
+        ChatExecutionContext.isExternalSurface ? "external" : "internal"
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -141,7 +141,7 @@ struct MCPHTTPHandlerTests {
         let server = try await startTestServer()
         defer { Task { await server.shutdown() } }
 
-        for tool in ["file_write", "file_edit", "shell_run", "git_commit"] {
+        for tool in ["file_write", "file_edit", "shell_run", "git_commit", "agent_channel_send_message"] {
             var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)/mcp/call")!)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -155,6 +155,43 @@ struct MCPHTTPHandlerTests {
             #expect(status == 403, "expected 403 for \(tool), got \(status)")
             #expect(body.contains("tool_not_exposable"))
         }
+    }
+
+    @Test func remote_dispatch_surface_binding_denies_agent_channel_tools() {
+        #expect(!HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: true))
+        #expect(HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false))
+
+        let local = ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: true)
+        ) {
+            ToolRegistry.isDeniedForCurrentSurface("agent_channel_send_message")
+        }
+        #expect(!local)
+
+        let remote = ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false)
+        ) {
+            ToolRegistry.isDeniedForCurrentSurface("agent_channel_send_message")
+        }
+        #expect(remote)
+
+        let remoteHostWrite = ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false)
+        ) {
+            ToolRegistry.isDeniedForCurrentSurface("file_write")
+        }
+        #expect(remoteHostWrite)
+    }
+
+    @Test func remote_dispatch_surface_binding_propagates_to_unstructured_tasks() async {
+        let inherited = await ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false)
+        ) {
+            await Task {
+                ToolRegistry.isDeniedForCurrentSurface("agent_channel_send_message")
+            }.value
+        }
+        #expect(inherited)
     }
 
     @Test func mcp_call_rejects_malformed_agent_header() async throws {

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -284,9 +284,9 @@ public final class ToolRegistry: ObservableObject {
             ToolConfigurationStore.save(configuration)
         }
 
-        // for tool in Self.agentChannelTools {
-        //     registerNativeDynamicTool(tool)
-        // }
+        for tool in Self.agentChannelTools {
+            registerNativeDynamicTool(tool)
+        }
     }
 
     private static let agentChannelTools: [OsaurusTool] = [

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -19,6 +19,12 @@ The model-facing tools use these standard verbs through `agent_channel_*`
 tools. Provider-specific adapters translate the standard action into the
 provider API. Discord is the first executable adapter.
 
+The `agent_channel_*` tools are native dynamic tools. They are available to the
+app runtime and can be loaded through the capability flow, but they are not part
+of the always-loaded prompt baseline. They are also denied to external HTTP/MCP
+surfaces; channel reads and writes must originate from the Osaurus app surface
+where connection policy, confirmations, and local credentials are available.
+
 Each connection also reports provider-neutral action policy metadata in
 `agent_channel_list_connections` and `agent_channel_diagnostics`:
 
@@ -54,6 +60,31 @@ but no space allowlist is configured, unless the connection explicitly opts into
 `allowUnscopedSpaces`. Each decision carries an `audit_decision_reason` so
 denied relays can be logged without exposing secrets or external message
 content.
+
+## Service-Level Smoke Boundary
+
+Agent Channels are ready for provider smoke testing when a disposable connection
+can exercise the standard app-surface tools without exposing unfinished settings
+UI or external caller access. A smoke pass should use a disposable workspace,
+server, bot, or chat and prove:
+
+1. `agent_channel_list_connections` reports the connection with readable action
+   policy, write confirmation requirements, and no raw secrets.
+2. `agent_channel_diagnostics` reports missing credentials, disabled writes,
+   denied rooms/chats, and provider auth failures as explicit failure states.
+3. `agent_channel_read_messages` or `agent_channel_search_messages` returns
+   only allowlisted rooms/chats and treats provider message content as external
+   data.
+4. `agent_channel_draft_message` returns a redacted local preview and never
+   dispatches to the provider.
+5. `agent_channel_send_message` or `agent_channel_reply_thread` succeeds only
+   with `confirm_send: true`, a write-allowlisted destination, and a provider
+   response that can be mapped to a confirmed delivery.
+6. External HTTP/MCP surfaces reject the same `agent_channel_*` tool names.
+
+The smoke boundary does not require final visible settings placement,
+production webhook hosting, or background polling. Those remain integration
+work layered on top of the shared action vocabulary and policy gates.
 
 ## Configuration
 

--- a/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
+++ b/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
@@ -1,5 +1,68 @@
 # Open PR and Bug Development Plan
 
+Snapshot update: 2026-07-02 13:30 UTC, repo `osaurus-ai/osaurus`.
+
+This snapshot supersedes the older channel sections below for the Agent Channel
+testing question.
+
+## Agent Channel Readiness - 2026-07-02
+
+Maintainer question: "how are you doing with the agent channels? is it ready for
+testing?"
+
+Current answer:
+
+- Slack Agent Channel (#1707) is draft, merge-clean, and green on required CI.
+  It provides the Slack adapter, credential storage, allowlists, read/search/send
+  routing, inbound normalization, and service/security tests.
+- Telegram Agent Channel (#1709) is draft, merge-clean, and green on required
+  CI. It provides the Telegram adapter, token storage, chat/topic allowlists,
+  read/search/send routing, update dedupe, message storage, and service/security
+  tests.
+- The shared `agent_channel_*` action vocabulary existed on `main`, but the
+  native tools were not registered in `ToolRegistry`. That made the adapters
+  service-testable but not end-to-end testable from the agent tool path.
+
+Goal:
+
+- Make Agent Channels ready for maintainer service-level testing through the
+  provider-neutral `agent_channel_*` tools, while keeping WIP settings UI hidden
+  and preventing external API/MCP callers from sending channel messages.
+
+Execution plan:
+
+1. Shared readiness PR:
+   - Register the provider-neutral Agent Channel tools as native dynamic tools.
+   - Keep them out of the always-loaded prompt baseline.
+   - Keep them off external surfaces through `externallyDeniedToolNames`.
+   - Prove no Discord-specific phantom tools are introduced.
+   - Run focused channel, registry, and external-denial tests.
+2. Adapter PR refresh, parallel after the shared readiness PR is available:
+   - Keep #1707 and #1709 draft until the shared tool registration branch is
+     merged or explicitly used as their base.
+   - Rebase Slack and Telegram independently after the shared registration path
+     lands.
+   - Re-run the adapter tests plus one shared Agent Channel tool-path smoke for
+     each adapter.
+3. Testing boundary:
+   - Ready for maintainer testing means app-surface `agent_channel_*` calls can
+     list connections, inspect diagnostics, read/search permitted messages,
+     draft outbound messages, and send/reply only when the connection policy
+     allows it.
+   - Live Slack/Telegram tests still require real bot credentials and
+     workspace/chat allowlists.
+   - Production webhook receiver, background poller, and final visible settings
+     placement remain follow-up integration work.
+
+Parallelization notes:
+
+- The shared readiness PR owns only `ToolRegistry`, focused registry/security
+  tests, and this plan update.
+- Slack and Telegram adapter branches stay independent once they consume the
+  shared registration behavior.
+- Inbox/audit UI and remote Computer Use-over-channel work should remain
+  separate until at least one native adapter completes service-level testing.
+
 Snapshot update: 2026-06-16 23:11 UTC, repo `osaurus-ai/osaurus`.
 
 This section is the current actionable plan. Older dated sections remain below


### PR DESCRIPTION
## Summary

- Registers the provider-neutral `agent_channel_*` actions as native dynamic app-surface tools so Agent Channel adapters can be exercised through the shared tool path.
- Keeps those actions out of the always-loaded prompt baseline and blocks them from external HTTP/MCP surfaces, including stdio MCP and non-loopback `/agents/{id}/dispatch`.
- Documents the service-level smoke boundary for Slack/Telegram testing and updates the active development plan.

## Validation

- `git diff --check`
- `swiftlint lint Packages/OsaurusCore/Networking/HTTPHandler.swift Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift Packages/OsaurusCore/Tools/ToolRegistry.swift Packages/OsaurusCore/Services/MCP/MCPServerManager.swift` (0 serious findings; existing warnings in large legacy files)
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-mcp-dispatch-fix-4 swift test --package-path Packages/OsaurusCore --filter 'remote_dispatch_surface_binding_denies_agent_channel_tools|remote_dispatch_surface_binding_propagates_to_unstructured_tasks|stdio_mcp_policy_hides_externally_denied_tools|stdio_mcp_execution_binds_external_surface|mcp_call_refuses_externally_denied_tools|mcp_tools_hides_externally_denied_tools'`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-channel-final-4 swift test --package-path Packages/OsaurusCore --filter 'DiscordConnectionTests|CapabilityToolsTests|AgentChannelAsyncSubstrateTests'`

## Testing boundary

- Ready for service-level app-surface smoke once GitHub CI is green and merge state is clean.
- Live Slack/Telegram smoke still requires disposable credentials and allowlists.
- Final visible settings placement, webhook receiver, and background poller remain follow-up integration work.
