### PR TITLE
fixed Mistral reasoning format

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -987,6 +987,57 @@ struct DeltaContent: Codable, Sendable {
         self.tool_calls = tool_calls
         self.reasoning_content = reasoning_content
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, refusal, tool_calls, reasoning_content
+    }
+
+    /// One entry of Mistral's structured `content` array. Mistral streams
+    /// reasoning models as `content: [{type:"thinking", thinking:[{type:"text",
+    /// text:…}]}, {type:"text", text:…}]` rather than the OpenAI-standard plain
+    /// `content` string plus separate `reasoning_content`. Decoded here so
+    /// thinking chunks route to `reasoning_content` and text chunks to `content`,
+    /// letting the rest of the streaming pipeline handle Mistral like every other
+    /// separate-channel reasoning provider.
+    private struct MistralContentChunk: Decodable {
+        let type: String?
+        let text: String?
+        let thinking: [InnerText]?
+
+        struct InnerText: Decodable {
+            let type: String?
+            let text: String?
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.role = try? container.decode(String.self, forKey: .role)
+        self.refusal = try? container.decode(String.self, forKey: .refusal)
+        self.tool_calls = try? container.decode([DeltaToolCall].self, forKey: .tool_calls)
+        let explicitReasoning = try? container.decode(String.self, forKey: .reasoning_content)
+
+        if let stringContent = try? container.decode(String.self, forKey: .content) {
+            self.content = stringContent
+            self.reasoning_content = explicitReasoning
+        } else if let chunks = try? container.decode([MistralContentChunk].self, forKey: .content) {
+            var visible = ""
+            var thinking = ""
+            for chunk in chunks {
+                if chunk.type == "thinking" {
+                    for part in chunk.thinking ?? [] { thinking += part.text ?? "" }
+                } else {
+                    visible += chunk.text ?? ""
+                }
+            }
+            self.content = visible.isEmpty ? nil : visible
+            let mergedReasoning = (explicitReasoning ?? "") + thinking
+            self.reasoning_content = mergedReasoning.isEmpty ? nil : mergedReasoning
+        } else {
+            self.content = nil
+            self.reasoning_content = explicitReasoning
+        }
+    }
 }
 
 /// Streaming choice

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -1011,16 +1011,26 @@ struct DeltaContent: Codable, Sendable {
     }
 
     init(from decoder: Decoder) throws {
+        // Preserve the synthesized decoder's throwing `decodeIfPresent`
+        // semantics for every field: a present-but-malformed value must throw so
+        // the stream parser's split-JSON recovery path can retry, rather than
+        // being silently dropped. Only `content` adds a string-or-array fallback.
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.role = try? container.decode(String.self, forKey: .role)
-        self.refusal = try? container.decode(String.self, forKey: .refusal)
-        self.tool_calls = try? container.decode([DeltaToolCall].self, forKey: .tool_calls)
-        let explicitReasoning = try? container.decode(String.self, forKey: .reasoning_content)
+        self.role = try container.decodeIfPresent(String.self, forKey: .role)
+        self.refusal = try container.decodeIfPresent(String.self, forKey: .refusal)
+        self.tool_calls = try container.decodeIfPresent([DeltaToolCall].self, forKey: .tool_calls)
+        let explicitReasoning = try container.decodeIfPresent(String.self, forKey: .reasoning_content)
 
-        if let stringContent = try? container.decode(String.self, forKey: .content) {
-            self.content = stringContent
+        do {
+            // Standard OpenAI-compatible shape: `content` is a string (or absent).
+            self.content = try container.decodeIfPresent(String.self, forKey: .content)
             self.reasoning_content = explicitReasoning
-        } else if let chunks = try? container.decode([MistralContentChunk].self, forKey: .content) {
+        } catch DecodingError.typeMismatch(_, _) {
+            // Mistral reasoning models stream `content` as a structured array of
+            // thinking/text chunks. Route thinking to `reasoning_content` and
+            // text to `content`. A genuine structural error (not a type mismatch)
+            // propagates from here so recovery can retry.
+            let chunks = try container.decode([MistralContentChunk].self, forKey: .content)
             var visible = ""
             var thinking = ""
             for chunk in chunks {
@@ -1033,9 +1043,6 @@ struct DeltaContent: Codable, Sendable {
             self.content = visible.isEmpty ? nil : visible
             let mergedReasoning = (explicitReasoning ?? "") + thinking
             self.reasoning_content = mergedReasoning.isEmpty ? nil : mergedReasoning
-        } else {
-            self.content = nil
-            self.reasoning_content = explicitReasoning
         }
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -118,7 +118,21 @@ enum ModelProfileRegistry {
         guard let persisted else { return [:] }
 
         let allowedIds = Set(definitions.map(\.id))
-        return persisted.filter { allowedIds.contains($0.key) }
+        // Segment ids allowed per option. A persisted segment value that is no
+        // longer offered (e.g. an old Mistral `reasoningEffort: "medium"` after
+        // the option set was narrowed to none/high) must be dropped, not sent to
+        // the wire, where it would be rejected.
+        let allowedSegmentValues: [String: Set<String>] = definitions.reduce(into: [:]) { acc, def in
+            if case .segmented(let segments) = def.kind {
+                acc[def.id] = Set(segments.map(\.id))
+            }
+        }
+        return persisted.filter { key, value in
+            guard allowedIds.contains(key) else { return false }
+            guard let segments = allowedSegmentValues[key] else { return true }
+            guard let stringValue = value.stringValue else { return true }
+            return segments.contains(stringValue)
+        }
     }
 
     static func boolOptionValue(
@@ -237,6 +251,9 @@ struct MistralReasoningProfile: ModelProfile {
         return bare.hasPrefix("mistral-small") || bare.hasPrefix("mistral-medium")
     }
 
+    // Mistral's chat-completions `reasoning_effort` accepts only `none` and
+    // `high` on mistral-small-latest / mistral-medium-3.5; `low` and `medium`
+    // are rejected with HTTP 400 (`invalid_request_invalid_args`).
     static let options: [ModelOptionDefinition] = [
         ModelOptionDefinition(
             id: "reasoningEffort",
@@ -244,15 +261,13 @@ struct MistralReasoningProfile: ModelProfile {
             icon: "brain",
             kind: .segmented([
                 ModelOptionSegment(id: "none", label: L("None")),
-                ModelOptionSegment(id: "low", label: L("Low")),
-                ModelOptionSegment(id: "medium", label: L("Medium")),
                 ModelOptionSegment(id: "high", label: L("High")),
             ])
         )
     ]
 
     static let defaults: [String: ModelOptionValue] = [
-        "reasoningEffort": .string("medium")
+        "reasoningEffort": .string("high")
     ]
 }
 

--- a/Packages/OsaurusCore/Services/Provider/RemoteReasoningPolicy.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteReasoningPolicy.swift
@@ -158,7 +158,12 @@ struct RemoteReasoningPolicy {
     var allowsReasoningObject: Bool {
         switch providerType {
         case .openaiLegacy:
-            return !host.lowercased().contains("openai.com")
+            let lowered = host.lowercased()
+            // Mistral's chat-completions schema accepts only the root-level
+            // `reasoning_effort` string; a sibling `reasoning: { effort }`
+            // object is rejected with HTTP 422 (`extra_forbidden`). OpenAI
+            // proper likewise only reads `reasoning_effort` here.
+            return !lowered.contains("openai.com") && !lowered.contains("mistral")
         case .azureOpenAI, .anthropic, .openResponses, .openAICodex, .gemini, .osaurus, .osaurusRouter:
             return false
         }

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -393,6 +393,41 @@ struct ModelProfileRegistryTests {
         #expect(explicit["reasoningEffort"]?.stringValue == "high")
     }
 
+    @Test("Mistral models expose only none/high reasoning effort and drop stale values")
+    func mistral_matchesReasoningEffortProfile() {
+        for id in [
+            "mistral-medium-3.5",
+            "mistral-small-latest",
+            "mistralai/mistral-medium-3.5",
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            #expect(profile?.displayName == MistralReasoningProfile.displayName)
+
+            guard case .segmented(let segments)? = ModelProfileRegistry.options(for: id).first?.kind
+            else {
+                Issue.record("expected segmented reasoningEffort option for \(id)")
+                continue
+            }
+            #expect(segments.map(\.id) == ["none", "high"])
+
+            // Values narrowed out of the option set (low/medium) must not reach
+            // the wire — Mistral rejects them with HTTP 400.
+            for stale in ["low", "medium"] {
+                let normalized = ModelProfileRegistry.normalizedOptions(
+                    for: id,
+                    persisted: ["reasoningEffort": .string(stale)]
+                )
+                #expect(normalized["reasoningEffort"] == nil)
+            }
+
+            let explicit = ModelProfileRegistry.normalizedOptions(
+                for: id,
+                persisted: ["reasoningEffort": .string("high")]
+            )
+            #expect(explicit["reasoningEffort"]?.stringValue == "high")
+        }
+    }
+
     @Test("DSV4 bundles expose instruct, reasoning, and max modes")
     func dsv4_matchesReasoningModeProfile() {
         for id in [

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -282,6 +282,36 @@ struct OpenAICompatibleStreamParserTests {
         #expect(visible == ["Answer", " text"])
     }
 
+    @Test func parser_routesSeparateReasoningContentFieldToReasoning() throws {
+        // Regression guard for the flexible `DeltaContent` decoder: the
+        // DeepSeek/Qwen/vLLM separate `reasoning_content` string field must
+        // still route to the reasoning channel and plain `content` to visible.
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        var yielded: [String] = []
+
+        _ = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(
+                #"{"id":"x","created":0,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}"#
+                    .utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+        _ = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(
+                #"{"id":"x","created":0,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}]}"#
+                    .utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+
+        let reasoning = yielded.compactMap { StreamingReasoningHint.decode($0) }
+        let visible = yielded.filter { StreamingReasoningHint.decode($0) == nil }
+        #expect(reasoning == ["thinking"])
+        #expect(visible == ["answer"])
+    }
+
     private func dispatchEvents(
         from parser: inout OpenAICompatibleStreamFramer.SSELineParser,
         options: OpenAICompatibleStreamFramer.Options

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -240,6 +240,48 @@ struct OpenAICompatibleStreamParserTests {
         #expect(yielded == ["partial"])
     }
 
+    @Test func parser_routesMistralStructuredThinkingContentToReasoning() throws {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        var yielded: [String] = []
+
+        // Thinking phase: Mistral streams `content` as an array of chunks.
+        let thinking = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(
+                #"{"id":"x","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":"let me think"}]}]},"finish_reason":null}]}"#
+                    .utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+        guard case .continue = thinking else {
+            Issue.record("Expected thinking chunk to continue, got \(thinking)")
+            return
+        }
+
+        // Transition chunk: a closing think chunk plus the first text chunk.
+        _ = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(
+                #"{"id":"x","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":" done"}]},{"type":"text","text":"Answer"}]},"finish_reason":null}]}"#
+                    .utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+
+        // Answer phase: `content` becomes a plain string.
+        _ = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(#"{"id":"x","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":" text"},"finish_reason":null}]}"#.utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+
+        let reasoning = yielded.compactMap { StreamingReasoningHint.decode($0) }
+        let visible = yielded.filter { StreamingReasoningHint.decode($0) == nil }
+        #expect(reasoning == ["let me think", " done"])
+        #expect(visible == ["Answer", " text"])
+    }
+
     private func dispatchEvents(
         from parser: inout OpenAICompatibleStreamFramer.SSELineParser,
         options: OpenAICompatibleStreamFramer.Options

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -247,7 +247,7 @@ struct OpenAICompatibleStreamParserTests {
         // Thinking phase: Mistral streams `content` as an array of chunks.
         let thinking = try OpenAICompatibleStreamParser.handleEvent(
             jsonData: Data(
-                #"{"id":"x","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":"let me think"}]}]},"finish_reason":null}]}"#
+                #"{"id":"x","object":"chat.completion.chunk","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":"let me think"}]}]},"finish_reason":null}]}"#
                     .utf8),
             options: .strict,
             state: &state,
@@ -261,7 +261,7 @@ struct OpenAICompatibleStreamParserTests {
         // Transition chunk: a closing think chunk plus the first text chunk.
         _ = try OpenAICompatibleStreamParser.handleEvent(
             jsonData: Data(
-                #"{"id":"x","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":" done"}]},{"type":"text","text":"Answer"}]},"finish_reason":null}]}"#
+                #"{"id":"x","object":"chat.completion.chunk","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":" done"}]},{"type":"text","text":"Answer"}]},"finish_reason":null}]}"#
                     .utf8),
             options: .strict,
             state: &state,
@@ -270,7 +270,7 @@ struct OpenAICompatibleStreamParserTests {
 
         // Answer phase: `content` becomes a plain string.
         _ = try OpenAICompatibleStreamParser.handleEvent(
-            jsonData: Data(#"{"id":"x","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":" text"},"finish_reason":null}]}"#.utf8),
+            jsonData: Data(#"{"id":"x","object":"chat.completion.chunk","created":0,"model":"mistral-medium-3.5","choices":[{"index":0,"delta":{"content":" text"},"finish_reason":null}]}"#.utf8),
             options: .strict,
             state: &state,
             yield: { yielded.append($0) }
@@ -291,7 +291,7 @@ struct OpenAICompatibleStreamParserTests {
 
         _ = try OpenAICompatibleStreamParser.handleEvent(
             jsonData: Data(
-                #"{"id":"x","created":0,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}"#
+                #"{"id":"x","object":"chat.completion.chunk","created":0,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}"#
                     .utf8),
             options: .strict,
             state: &state,
@@ -299,7 +299,7 @@ struct OpenAICompatibleStreamParserTests {
         )
         _ = try OpenAICompatibleStreamParser.handleEvent(
             jsonData: Data(
-                #"{"id":"x","created":0,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}]}"#
+                #"{"id":"x","object":"chat.completion.chunk","created":0,"model":"deepseek-reasoner","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}]}"#
                     .utf8),
             options: .strict,
             state: &state,

--- a/Packages/OsaurusCore/Tests/Provider/RemoteReasoningPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteReasoningPolicyTests.swift
@@ -149,6 +149,10 @@ struct RemoteReasoningPolicyTests {
                 .allowsReasoningObject == false
         )
         #expect(
+            RemoteReasoningPolicy.resolve(providerType: .openaiLegacy, host: "api.mistral.ai", model: "mistral-medium-3.5")
+                .allowsReasoningObject == false
+        )
+        #expect(
             RemoteReasoningPolicy.resolve(providerType: .anthropic, host: "api.anthropic.com", model: "x")
                 .allowsReasoningObject == false
         )


### PR DESCRIPTION
## Summary

- Stopped attaching the unsupported reasoning object to Mistral requests, which was rejected with an HTTP 422 and failed every reasoning-capable call
- Limited the Mistral reasoning effort control to the only values the models accept, so previously rejected effort levels no longer return an HTTP 400
- Dropped stale effort selections saved before the option set was narrowed, so upgrading users are not left sending a value the model rejects
- Routed Mistral's structured thinking output to the reasoning channel so the thinking block now appears in the UI instead of being silently dropped
- Added tests covering the request shape, the accepted effort values, the stale-value cleanup, and the streaming thinking-to-reasoning routing
- Confirmed the changes leave other providers untouched, with regression guards for the shared request and streaming paths

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
