### PR TITLE
Polish Slack and Telegram Agent Channels

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -473,6 +473,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // Initialize WatcherManager to start file system watchers
         _ = WatcherManager.shared
 
+        if !keychainDisabledTestMode {
+            Task.detached(priority: .utility) {
+                await AgentChannelTransportSupervisor.shared.startFromLaunch()
+            }
+        }
+
         // Start the self-scheduling loop once storage is ready. In plaintext
         // mode (the default) that's immediate; in opt-in encrypted mode it
         // waits until the key is resident so startup never triggers a
@@ -645,8 +651,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             // last-resort fallback if no app window is up.
             let scope: ThemedAlertScope
             if let chatId = ChatWindowManager.shared.lastFocusedWindowId,
-                ChatWindowManager.shared.windowExists(id: chatId)
-            {
+                ChatWindowManager.shared.windowExists(id: chatId) {
                 scope = .chat(chatId)
             } else if WindowManager.shared.isVisible(.management) {
                 scope = .management
@@ -1086,6 +1091,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             SystemMonitorService.shared.stopMonitoring()
             ScheduleManager.shared.stop()
             WatcherManager.shared.stop()
+            await runWithDeadline(seconds: 2) {
+                await AgentChannelTransportSupervisor.shared.stop()
+            }
             // MemoryConsolidator / StorageMaintenance are actors; their stop()
             // just cancels timers, so the actor hop is quick — bound it anyway
             // so a busy actor can't stall phase 0.

--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
@@ -570,6 +570,7 @@ struct AgentChannelCustomHTTPConfiguration: Codable, Equatable, Sendable {
 
 struct AgentChannelConnection: Codable, Equatable, Identifiable, Sendable {
     static let nativeDiscordConnectionId = "discord"
+    static let nativeSlackConnectionId = "slack"
 
     var id: String
     var name: String

--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
@@ -570,6 +570,7 @@ struct AgentChannelCustomHTTPConfiguration: Codable, Equatable, Sendable {
 
 struct AgentChannelConnection: Codable, Equatable, Identifiable, Sendable {
     static let nativeDiscordConnectionId = "discord"
+    static let nativeTelegramConnectionId = "telegram"
 
     var id: String
     var name: String

--- a/Packages/OsaurusCore/Models/Configuration/ManagementTab.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ManagementTab.swift
@@ -102,8 +102,8 @@ public enum ManagementTab: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    /// Resolves a sidebar tab id, including legacy raw values that no longer
-    /// exist as cases (`"dashboard"` → Credits, `"channels"` → Agents).
+    /// Resolves a sidebar tab id, including legacy raw values whose destination
+    /// has moved (`"dashboard"` → Credits, `"channels"` → Agent Channels).
     public static func resolved(from rawValue: String) -> ManagementTab? {
         switch rawValue {
         case "dashboard": .credits

--- a/Packages/OsaurusCore/Models/Configuration/ManagementTab.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ManagementTab.swift
@@ -41,7 +41,7 @@ public enum ManagementSection: String, CaseIterable, Identifiable, Sendable {
         case .models: [.models, .providers, .imageGeneration]
         case .agentsAutomation:
             [
-                .agents, .memory, .tools, .skills, .commands, .plugins,
+                .agents, .agentChannels, .memory, .tools, .skills, .commands, .plugins,
                 .schedules, .watchers, .sandbox, .computerUse,
             ]
         case .server: [.server]
@@ -63,6 +63,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable, Sendable {
     case providers
     case imageGeneration
     case agents
+    case agentChannels
     case memory
     case tools
     case skills
@@ -92,7 +93,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable, Sendable {
         switch self {
         case .settings, .chat, .voice, .themes: .general
         case .models, .providers, .imageGeneration: .models
-        case .agents, .memory, .tools, .skills, .commands, .plugins,
+        case .agents, .agentChannels, .memory, .tools, .skills, .commands, .plugins,
             .schedules, .watchers, .sandbox, .computerUse:
             .agentsAutomation
         case .server: .server
@@ -106,7 +107,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable, Sendable {
     public static func resolved(from rawValue: String) -> ManagementTab? {
         switch rawValue {
         case "dashboard": .credits
-        case "channels": .agents
+        case "channels", "integrations", "agent-channels": .agentChannels
         default: ManagementTab(rawValue: rawValue)
         }
     }
@@ -117,6 +118,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable, Sendable {
         case .models: "cube.box.fill"
         case .providers: "cloud.fill"
         case .agents: "person.2.fill"
+        case .agentChannels: "bubble.left.and.bubble.right.fill"
         case .plugins: "puzzlepiece.extension.fill"
         case .sandbox: "shippingbox.fill"
         case .tools: "wrench.and.screwdriver.fill"
@@ -146,6 +148,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable, Sendable {
         case .models: L("Models")
         case .providers: L("Providers")
         case .agents: L("Agents")
+        case .agentChannels: L("Agent Channels")
         case .plugins: L("Plugins")
         case .sandbox: L("Sandbox")
         case .tools: L("Tools")

--- a/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
+++ b/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
@@ -451,6 +451,59 @@ public enum SettingsSearchIndex {
             keywords: ["screen control", "cursor", "automation", "accessibility", "per-app"]
         ),
 
+        // MARK: Agent Channels / Integrations
+        .init(
+            id: "agentChannels.overview",
+            tab: .agentChannels,
+            title: "Agent Channels",
+            keywords: [
+                "integrations", "channels", "discord", "slack", "telegram",
+                "custom json", "custom http", "remote channel",
+            ]
+        ),
+        .init(
+            id: "agentChannels.globalWrites",
+            tab: .agentChannels,
+            section: "Global Channel Safety",
+            title: "Global Channel Writes",
+            keywords: ["kill switch", "disable writes", "remote writes", "channel writes"]
+        ),
+        .init(
+            id: "agentChannels.discord",
+            tab: .agentChannels,
+            section: "Native Integrations",
+            title: "Discord",
+            keywords: ["discord bot token", "discord server ids", "discord channel allowlist"]
+        ),
+        .init(
+            id: "agentChannels.slack",
+            tab: .agentChannels,
+            section: "Native Integrations",
+            title: "Slack",
+            keywords: [
+                "slack bot token", "slack signing secret", "socket mode",
+                "slack workspace ids", "slack channel allowlist",
+            ]
+        ),
+        .init(
+            id: "agentChannels.telegram",
+            tab: .agentChannels,
+            section: "Native Integrations",
+            title: "Telegram",
+            keywords: [
+                "telegram bot token", "telegram chat ids", "sender allowlist",
+                "telegram channel allowlist", "telegram long polling",
+                "telegram getupdates", "store incoming messages",
+            ]
+        ),
+        .init(
+            id: "agentChannels.customJSON",
+            tab: .agentChannels,
+            section: "Custom JSON Connections",
+            title: "Custom HTTP Connections",
+            keywords: ["custom json channels", "webhook", "agent-channels.json", "secret references"]
+        ),
+
         // MARK: Image Generation tab (subTab values are ImageGenerationTab raw values)
         .init(
             id: "imageGeneration.tab",

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CryptoKit
 
 struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
     var configuredTeamIds: [String]
@@ -14,6 +15,9 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
     var writeEnabled: Bool
     var defaultReadLimit: Int
     var allowBroadcastMentions: Bool
+    var botUserId: String?
+    var botId: String?
+    var apiAppId: String?
 
     init(
         configuredTeamIds: [String] = [],
@@ -21,7 +25,10 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
         writableChannelIds: [String] = [],
         writeEnabled: Bool = false,
         defaultReadLimit: Int = 50,
-        allowBroadcastMentions: Bool = false
+        allowBroadcastMentions: Bool = false,
+        botUserId: String? = nil,
+        botId: String? = nil,
+        apiAppId: String? = nil
     ) {
         self.configuredTeamIds = Self.normalizedIds(configuredTeamIds)
         self.readableChannelIds = Self.normalizedIds(readableChannelIds)
@@ -29,6 +36,9 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
         self.writeEnabled = writeEnabled
         self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
         self.allowBroadcastMentions = allowBroadcastMentions
+        self.botUserId = Self.normalizedOptionalId(botUserId)
+        self.botId = Self.normalizedOptionalId(botId)
+        self.apiAppId = Self.normalizedOptionalId(apiAppId)
     }
 
     var normalized: SlackConnectionConfiguration {
@@ -38,7 +48,10 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
             writableChannelIds: writableChannelIds,
             writeEnabled: writeEnabled,
             defaultReadLimit: defaultReadLimit,
-            allowBroadcastMentions: allowBroadcastMentions
+            allowBroadcastMentions: allowBroadcastMentions,
+            botUserId: botUserId,
+            botId: botId,
+            apiAppId: apiAppId
         )
     }
 
@@ -64,6 +77,11 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
 
     static func normalizedId(_ id: String) -> String {
         id.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func normalizedOptionalId(_ id: String?) -> String? {
+        let normalized = normalizedId(id ?? "")
+        return normalized.isEmpty ? nil : normalized
     }
 
     static func isValidSlackId(_ id: String) -> Bool {
@@ -252,5 +270,45 @@ enum SlackSecurity {
             return text
         }
         return text.replacingOccurrences(of: value, with: replacement)
+    }
+}
+
+enum SlackSignatureVerifier {
+    static func isAuthorized(
+        signingSecret: String,
+        timestamp: String,
+        body: Data,
+        signature: String,
+        now: Date = Date(),
+        tolerance: TimeInterval = 300
+    ) -> Bool {
+        let trimmedSecret = signingSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTimestamp = timestamp.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSignature = signature.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmedSecret.isEmpty,
+              let timestampSeconds = TimeInterval(trimmedTimestamp),
+              abs(now.timeIntervalSince1970 - timestampSeconds) <= tolerance,
+              trimmedSignature.hasPrefix("v0=")
+        else {
+            return false
+        }
+
+        var base = Data("v0:\(trimmedTimestamp):".utf8)
+        base.append(body)
+        let key = SymmetricKey(data: Data(trimmedSecret.utf8))
+        let digest = HMAC<SHA256>.authenticationCode(for: base, using: key)
+        let expected = "v0=" + digest.map { String(format: "%02x", $0) }.joined()
+        return constantTimeEquals(trimmedSignature, expected)
+    }
+
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        guard lhsBytes.count == rhsBytes.count else { return false }
+        var difference: UInt8 = 0
+        for index in lhsBytes.indices {
+            difference |= lhsBytes[index] ^ rhsBytes[index]
+        }
+        return difference == 0
     }
 }

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -1,0 +1,256 @@
+//
+//  SlackConnectionConfiguration.swift
+//  osaurus
+//
+//  Non-secret configuration for the native Slack connection.
+//
+
+import Foundation
+
+struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
+    var configuredTeamIds: [String]
+    var readableChannelIds: [String]
+    var writableChannelIds: [String]
+    var writeEnabled: Bool
+    var defaultReadLimit: Int
+    var allowBroadcastMentions: Bool
+
+    init(
+        configuredTeamIds: [String] = [],
+        readableChannelIds: [String] = [],
+        writableChannelIds: [String] = [],
+        writeEnabled: Bool = false,
+        defaultReadLimit: Int = 50,
+        allowBroadcastMentions: Bool = false
+    ) {
+        self.configuredTeamIds = Self.normalizedIds(configuredTeamIds)
+        self.readableChannelIds = Self.normalizedIds(readableChannelIds)
+        self.writableChannelIds = Self.normalizedIds(writableChannelIds)
+        self.writeEnabled = writeEnabled
+        self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
+        self.allowBroadcastMentions = allowBroadcastMentions
+    }
+
+    var normalized: SlackConnectionConfiguration {
+        SlackConnectionConfiguration(
+            configuredTeamIds: configuredTeamIds,
+            readableChannelIds: readableChannelIds,
+            writableChannelIds: writableChannelIds,
+            writeEnabled: writeEnabled,
+            defaultReadLimit: defaultReadLimit,
+            allowBroadcastMentions: allowBroadcastMentions
+        )
+    }
+
+    func canRead(channelId: String) -> Bool {
+        readableChannelIds.contains(Self.normalizedId(channelId))
+    }
+
+    func canWrite(channelId: String) -> Bool {
+        writeEnabled && writableChannelIds.contains(Self.normalizedId(channelId))
+    }
+
+    func canUseTeam(teamId: String) -> Bool {
+        let normalized = Self.normalizedId(teamId)
+        return configuredTeamIds.isEmpty || configuredTeamIds.contains(normalized)
+    }
+
+    static func normalizedIds(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return ids
+            .map(normalizedId)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    static func normalizedId(_ id: String) -> String {
+        id.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func isValidSlackId(_ id: String) -> Bool {
+        let trimmed = normalizedId(id)
+        guard (2 ... 64).contains(trimmed.count) else { return false }
+        return trimmed.allSatisfy { character in
+            character.isASCII && (character.isLetter || character.isNumber || character == "." || character == "-")
+        }
+    }
+
+    static func clampReadLimit(_ value: Int) -> Int {
+        min(max(value, 1), 100)
+    }
+}
+
+enum SlackConnectionConfigurationStore {
+    nonisolated(unsafe) static var overrideDirectory: URL?
+
+    private static let fileName = "slack.json"
+
+    static func load() -> SlackConnectionConfiguration {
+        let url = configurationFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return SlackConnectionConfiguration()
+        }
+        do {
+            return try JSONDecoder()
+                .decode(SlackConnectionConfiguration.self, from: Data(contentsOf: url))
+                .normalized
+        } catch {
+            NSLog("[Slack] Failed to load Slack configuration: \(error.localizedDescription)")
+            return SlackConnectionConfiguration()
+        }
+    }
+
+    static func save(_ configuration: SlackConnectionConfiguration) throws {
+        let url = configurationFileURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(configuration.normalized).write(to: url, options: [.atomic])
+    }
+
+    static func configurationFileURL() -> URL {
+        if let overrideDirectory {
+            return overrideDirectory.appendingPathComponent(fileName)
+        }
+        return OsaurusPaths.config().appendingPathComponent(fileName)
+    }
+}
+
+enum SlackCredentialStore {
+    static let pluginId = "osaurus.slack"
+    static let botTokenKey = "bot_token"
+    static let signingSecretKey = "signing_secret"
+
+    @discardableResult
+    static func saveBotToken(_ token: String) -> Bool {
+        saveSecret(token, id: botTokenKey)
+    }
+
+    static func botToken() -> String? {
+        secret(id: botTokenKey)
+    }
+
+    static func hasBotToken() -> Bool {
+        hasSecret(id: botTokenKey)
+    }
+
+    @discardableResult
+    static func deleteBotToken() -> Bool {
+        deleteSecret(id: botTokenKey)
+    }
+
+    @discardableResult
+    static func saveSigningSecret(_ secret: String) -> Bool {
+        saveSecret(secret, id: signingSecretKey)
+    }
+
+    static func signingSecret() -> String? {
+        secret(id: signingSecretKey)
+    }
+
+    static func hasSigningSecret() -> Bool {
+        hasSecret(id: signingSecretKey)
+    }
+
+    @discardableResult
+    static func deleteSigningSecret() -> Bool {
+        deleteSecret(id: signingSecretKey)
+    }
+
+    private static func saveSecret(_ value: String, id: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return ToolSecretsKeychain.saveSecret(
+            trimmed,
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    private static func secret(id: String) -> String? {
+        ToolSecretsKeychain.getSecret(
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    private static func hasSecret(id: String) -> Bool {
+        ToolSecretsKeychain.hasSecret(
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    @discardableResult
+    private static func deleteSecret(id: String) -> Bool {
+        ToolSecretsKeychain.deleteSecret(
+            id: id,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+}
+
+protocol SlackCredentialStorage: Sendable {
+    func saveBotToken(_ token: String) -> Bool
+    func botToken() -> String?
+    func hasBotToken() -> Bool
+    func deleteBotToken() -> Bool
+    func saveSigningSecret(_ secret: String) -> Bool
+    func signingSecret() -> String?
+    func hasSigningSecret() -> Bool
+    func deleteSigningSecret() -> Bool
+}
+
+struct KeychainSlackCredentialStorage: SlackCredentialStorage {
+    func saveBotToken(_ token: String) -> Bool {
+        SlackCredentialStore.saveBotToken(token)
+    }
+
+    func botToken() -> String? {
+        SlackCredentialStore.botToken()
+    }
+
+    func hasBotToken() -> Bool {
+        SlackCredentialStore.hasBotToken()
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        SlackCredentialStore.deleteBotToken()
+    }
+
+    func saveSigningSecret(_ secret: String) -> Bool {
+        SlackCredentialStore.saveSigningSecret(secret)
+    }
+
+    func signingSecret() -> String? {
+        SlackCredentialStore.signingSecret()
+    }
+
+    func hasSigningSecret() -> Bool {
+        SlackCredentialStore.hasSigningSecret()
+    }
+
+    @discardableResult
+    func deleteSigningSecret() -> Bool {
+        SlackCredentialStore.deleteSigningSecret()
+    }
+}
+
+enum SlackSecurity {
+    static func redact(_ text: String, token: String?, signingSecret: String? = nil) -> String {
+        var redacted = redactValue(text, value: token, replacement: "[REDACTED:SLACK_BOT_TOKEN]")
+        redacted = redactValue(redacted, value: signingSecret, replacement: "[REDACTED:SLACK_SIGNING_SECRET]")
+        return redacted
+    }
+
+    private static func redactValue(_ text: String, value: String?, replacement: String) -> String {
+        guard let value, value.count >= SecretScrubber.minimumValueLength else {
+            return text
+        }
+        return text.replacingOccurrences(of: value, with: replacement)
+    }
+}

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -137,6 +137,7 @@ enum SlackCredentialStore {
     static let pluginId = "osaurus.slack"
     static let botTokenKey = "bot_token"
     static let signingSecretKey = "signing_secret"
+    static let appTokenKey = "app_token"
 
     @discardableResult
     static func saveBotToken(_ token: String) -> Bool {
@@ -172,6 +173,24 @@ enum SlackCredentialStore {
     @discardableResult
     static func deleteSigningSecret() -> Bool {
         deleteSecret(id: signingSecretKey)
+    }
+
+    @discardableResult
+    static func saveAppToken(_ token: String) -> Bool {
+        saveSecret(token, id: appTokenKey)
+    }
+
+    static func appToken() -> String? {
+        secret(id: appTokenKey)
+    }
+
+    static func hasAppToken() -> Bool {
+        hasSecret(id: appTokenKey)
+    }
+
+    @discardableResult
+    static func deleteAppToken() -> Bool {
+        deleteSecret(id: appTokenKey)
     }
 
     private static func saveSecret(_ value: String, id: String) -> Bool {
@@ -220,6 +239,10 @@ protocol SlackCredentialStorage: Sendable {
     func signingSecret() -> String?
     func hasSigningSecret() -> Bool
     func deleteSigningSecret() -> Bool
+    func saveAppToken(_ token: String) -> Bool
+    func appToken() -> String?
+    func hasAppToken() -> Bool
+    func deleteAppToken() -> Bool
 }
 
 struct KeychainSlackCredentialStorage: SlackCredentialStorage {
@@ -256,12 +279,35 @@ struct KeychainSlackCredentialStorage: SlackCredentialStorage {
     func deleteSigningSecret() -> Bool {
         SlackCredentialStore.deleteSigningSecret()
     }
+
+    func saveAppToken(_ token: String) -> Bool {
+        SlackCredentialStore.saveAppToken(token)
+    }
+
+    func appToken() -> String? {
+        SlackCredentialStore.appToken()
+    }
+
+    func hasAppToken() -> Bool {
+        SlackCredentialStore.hasAppToken()
+    }
+
+    @discardableResult
+    func deleteAppToken() -> Bool {
+        SlackCredentialStore.deleteAppToken()
+    }
 }
 
 enum SlackSecurity {
-    static func redact(_ text: String, token: String?, signingSecret: String? = nil) -> String {
+    static func redact(
+        _ text: String,
+        token: String?,
+        signingSecret: String? = nil,
+        appToken: String? = nil
+    ) -> String {
         var redacted = redactValue(text, value: token, replacement: "[REDACTED:SLACK_BOT_TOKEN]")
         redacted = redactValue(redacted, value: signingSecret, replacement: "[REDACTED:SLACK_SIGNING_SECRET]")
+        redacted = redactValue(redacted, value: appToken, replacement: "[REDACTED:SLACK_APP_TOKEN]")
         return redacted
     }
 

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -12,6 +12,7 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
     var configuredTeamIds: [String]
     var readableChannelIds: [String]
     var writableChannelIds: [String]
+    var senderAllowlist: [String]
     var writeEnabled: Bool
     var defaultReadLimit: Int
     var allowBroadcastMentions: Bool
@@ -23,6 +24,7 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
         configuredTeamIds: [String] = [],
         readableChannelIds: [String] = [],
         writableChannelIds: [String] = [],
+        senderAllowlist: [String] = [],
         writeEnabled: Bool = false,
         defaultReadLimit: Int = 50,
         allowBroadcastMentions: Bool = false,
@@ -33,6 +35,7 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
         self.configuredTeamIds = Self.normalizedIds(configuredTeamIds)
         self.readableChannelIds = Self.normalizedIds(readableChannelIds)
         self.writableChannelIds = Self.normalizedIds(writableChannelIds)
+        self.senderAllowlist = Self.normalizedIds(senderAllowlist)
         self.writeEnabled = writeEnabled
         self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
         self.allowBroadcastMentions = allowBroadcastMentions
@@ -46,6 +49,7 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
             configuredTeamIds: configuredTeamIds,
             readableChannelIds: readableChannelIds,
             writableChannelIds: writableChannelIds,
+            senderAllowlist: senderAllowlist,
             writeEnabled: writeEnabled,
             defaultReadLimit: defaultReadLimit,
             allowBroadcastMentions: allowBroadcastMentions,
@@ -66,6 +70,45 @@ struct SlackConnectionConfiguration: Codable, Equatable, Sendable {
     func canUseTeam(teamId: String) -> Bool {
         let normalized = Self.normalizedId(teamId)
         return configuredTeamIds.isEmpty || configuredTeamIds.contains(normalized)
+    }
+
+    func canUseSender(senderId: String?) -> Bool {
+        guard let normalized = Self.normalizedOptionalId(senderId) else {
+            return false
+        }
+        return !senderAllowlist.isEmpty && senderAllowlist.contains(normalized)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case configuredTeamIds
+        case readableChannelIds
+        case writableChannelIds
+        case senderAllowlist
+        case writeEnabled
+        case defaultReadLimit
+        case allowBroadcastMentions
+        case botUserId
+        case botId
+        case apiAppId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            configuredTeamIds: try container.decodeIfPresent([String].self, forKey: .configuredTeamIds) ?? [],
+            readableChannelIds: try container.decodeIfPresent([String].self, forKey: .readableChannelIds) ?? [],
+            writableChannelIds: try container.decodeIfPresent([String].self, forKey: .writableChannelIds) ?? [],
+            senderAllowlist: try container.decodeIfPresent([String].self, forKey: .senderAllowlist) ?? [],
+            writeEnabled: try container.decodeIfPresent(Bool.self, forKey: .writeEnabled) ?? false,
+            defaultReadLimit: try container.decodeIfPresent(Int.self, forKey: .defaultReadLimit) ?? 50,
+            allowBroadcastMentions: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .allowBroadcastMentions
+            ) ?? false,
+            botUserId: try container.decodeIfPresent(String.self, forKey: .botUserId),
+            botId: try container.decodeIfPresent(String.self, forKey: .botId),
+            apiAppId: try container.decodeIfPresent(String.self, forKey: .apiAppId)
+        )
     }
 
     static func normalizedIds(_ ids: [String]) -> [String] {

--- a/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
@@ -15,6 +15,10 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
     var defaultReadLimit: Int
     var ignoreSelfMessages: Bool
     var ignoreBotMessages: Bool
+    var receiveStorageEnabled: Bool
+    var longPollingEnabled: Bool
+    var longPollingLimit: Int
+    var longPollingTimeoutSeconds: Int
 
     enum CodingKeys: String, CodingKey {
         case readableChatIds
@@ -24,6 +28,10 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
         case defaultReadLimit
         case ignoreSelfMessages
         case ignoreBotMessages
+        case receiveStorageEnabled
+        case longPollingEnabled
+        case longPollingLimit
+        case longPollingTimeoutSeconds
     }
 
     init(
@@ -33,7 +41,11 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
         writeEnabled: Bool = false,
         defaultReadLimit: Int = 50,
         ignoreSelfMessages: Bool = true,
-        ignoreBotMessages: Bool = true
+        ignoreBotMessages: Bool = true,
+        receiveStorageEnabled: Bool = true,
+        longPollingEnabled: Bool = false,
+        longPollingLimit: Int = 100,
+        longPollingTimeoutSeconds: Int = 20
     ) {
         self.readableChatIds = Self.normalizedIds(readableChatIds)
         self.writableChatIds = Self.normalizedIds(writableChatIds)
@@ -42,6 +54,10 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
         self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
         self.ignoreSelfMessages = ignoreSelfMessages
         self.ignoreBotMessages = ignoreBotMessages
+        self.receiveStorageEnabled = receiveStorageEnabled
+        self.longPollingEnabled = longPollingEnabled
+        self.longPollingLimit = Self.clampLongPollingLimit(longPollingLimit)
+        self.longPollingTimeoutSeconds = Self.clampLongPollingTimeoutSeconds(longPollingTimeoutSeconds)
     }
 
     init(from decoder: Decoder) throws {
@@ -53,7 +69,17 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
             writeEnabled: try container.decodeIfPresent(Bool.self, forKey: .writeEnabled) ?? false,
             defaultReadLimit: try container.decodeIfPresent(Int.self, forKey: .defaultReadLimit) ?? 50,
             ignoreSelfMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreSelfMessages) ?? true,
-            ignoreBotMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreBotMessages) ?? true
+            ignoreBotMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreBotMessages) ?? true,
+            receiveStorageEnabled: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .receiveStorageEnabled
+            ) ?? true,
+            longPollingEnabled: try container.decodeIfPresent(Bool.self, forKey: .longPollingEnabled) ?? false,
+            longPollingLimit: try container.decodeIfPresent(Int.self, forKey: .longPollingLimit) ?? 100,
+            longPollingTimeoutSeconds: try container.decodeIfPresent(
+                Int.self,
+                forKey: .longPollingTimeoutSeconds
+            ) ?? 20
         )
     }
 
@@ -65,7 +91,11 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
             writeEnabled: writeEnabled,
             defaultReadLimit: defaultReadLimit,
             ignoreSelfMessages: ignoreSelfMessages,
-            ignoreBotMessages: ignoreBotMessages
+            ignoreBotMessages: ignoreBotMessages,
+            receiveStorageEnabled: receiveStorageEnabled,
+            longPollingEnabled: longPollingEnabled,
+            longPollingLimit: longPollingLimit,
+            longPollingTimeoutSeconds: longPollingTimeoutSeconds
         )
     }
 
@@ -127,6 +157,14 @@ struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
 
     static func clampReadLimit(_ value: Int) -> Int {
         min(max(value, 1), 100)
+    }
+
+    static func clampLongPollingLimit(_ value: Int) -> Int {
+        min(max(value, 1), 100)
+    }
+
+    static func clampLongPollingTimeoutSeconds(_ value: Int) -> Int {
+        min(max(value, 1), 50)
     }
 }
 

--- a/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
@@ -1,0 +1,244 @@
+//
+//  TelegramConnectionConfiguration.swift
+//  osaurus
+//
+//  Non-secret configuration for the native Telegram connection.
+//
+
+import Foundation
+
+struct TelegramConnectionConfiguration: Codable, Equatable, Sendable {
+    var readableChatIds: [String]
+    var writableChatIds: [String]
+    var senderAllowlist: [String]
+    var writeEnabled: Bool
+    var defaultReadLimit: Int
+    var ignoreSelfMessages: Bool
+    var ignoreBotMessages: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case readableChatIds
+        case writableChatIds
+        case senderAllowlist
+        case writeEnabled
+        case defaultReadLimit
+        case ignoreSelfMessages
+        case ignoreBotMessages
+    }
+
+    init(
+        readableChatIds: [String] = [],
+        writableChatIds: [String] = [],
+        senderAllowlist: [String] = [],
+        writeEnabled: Bool = false,
+        defaultReadLimit: Int = 50,
+        ignoreSelfMessages: Bool = true,
+        ignoreBotMessages: Bool = true
+    ) {
+        self.readableChatIds = Self.normalizedIds(readableChatIds)
+        self.writableChatIds = Self.normalizedIds(writableChatIds)
+        self.senderAllowlist = Self.normalizedIds(senderAllowlist)
+        self.writeEnabled = writeEnabled
+        self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
+        self.ignoreSelfMessages = ignoreSelfMessages
+        self.ignoreBotMessages = ignoreBotMessages
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            readableChatIds: try container.decodeIfPresent([String].self, forKey: .readableChatIds) ?? [],
+            writableChatIds: try container.decodeIfPresent([String].self, forKey: .writableChatIds) ?? [],
+            senderAllowlist: try container.decodeIfPresent([String].self, forKey: .senderAllowlist) ?? [],
+            writeEnabled: try container.decodeIfPresent(Bool.self, forKey: .writeEnabled) ?? false,
+            defaultReadLimit: try container.decodeIfPresent(Int.self, forKey: .defaultReadLimit) ?? 50,
+            ignoreSelfMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreSelfMessages) ?? true,
+            ignoreBotMessages: try container.decodeIfPresent(Bool.self, forKey: .ignoreBotMessages) ?? true
+        )
+    }
+
+    var normalized: TelegramConnectionConfiguration {
+        TelegramConnectionConfiguration(
+            readableChatIds: readableChatIds,
+            writableChatIds: writableChatIds,
+            senderAllowlist: senderAllowlist,
+            writeEnabled: writeEnabled,
+            defaultReadLimit: defaultReadLimit,
+            ignoreSelfMessages: ignoreSelfMessages,
+            ignoreBotMessages: ignoreBotMessages
+        )
+    }
+
+    func canRead(chatId: String) -> Bool {
+        readableChatIds.contains(Self.normalizedChatId(chatId))
+    }
+
+    func readableRoomId(for chat: TelegramChat) -> String? {
+        let stableId = chat.stableId
+        if canRead(chatId: stableId) {
+            return stableId
+        }
+        if let username = chat.username?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !username.isEmpty {
+            let handle = Self.normalizedChatId("@\(username)")
+            if canRead(chatId: handle) {
+                return handle
+            }
+        }
+        return nil
+    }
+
+    func canWrite(chatId: String) -> Bool {
+        writeEnabled && writableChatIds.contains(Self.normalizedChatId(chatId))
+    }
+
+    var configuredChatIds: [String] {
+        Self.normalizedIds(readableChatIds + writableChatIds)
+    }
+
+    static func normalizedIds(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        return
+            ids
+            .map(normalizedChatId)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    static func normalizedChatId(_ id: String) -> String {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("@") {
+            return trimmed.lowercased()
+        }
+        return trimmed
+    }
+
+    static func isValidChatId(_ id: String) -> Bool {
+        let trimmed = normalizedChatId(id)
+        guard !trimmed.isEmpty else { return false }
+        if trimmed.hasPrefix("@") {
+            let username = String(trimmed.dropFirst())
+            guard (5 ... 32).contains(username.count) else { return false }
+            return username.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "_") }
+        }
+        let digits = trimmed.hasPrefix("-") ? String(trimmed.dropFirst()) : trimmed
+        guard (1 ... 32).contains(digits.count) else { return false }
+        return digits.allSatisfy { $0.isASCII && $0.isNumber }
+    }
+
+    static func clampReadLimit(_ value: Int) -> Int {
+        min(max(value, 1), 100)
+    }
+}
+
+enum TelegramConnectionConfigurationStore {
+    nonisolated(unsafe) static var overrideDirectory: URL?
+
+    private static let fileName = "telegram.json"
+
+    static func load() -> TelegramConnectionConfiguration {
+        let url = configurationFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return TelegramConnectionConfiguration()
+        }
+        do {
+            return try JSONDecoder()
+                .decode(TelegramConnectionConfiguration.self, from: Data(contentsOf: url))
+                .normalized
+        } catch {
+            NSLog("[Telegram] Failed to load Telegram configuration: \(error.localizedDescription)")
+            return TelegramConnectionConfiguration()
+        }
+    }
+
+    static func save(_ configuration: TelegramConnectionConfiguration) throws {
+        let url = configurationFileURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(configuration.normalized).write(to: url, options: [.atomic])
+    }
+
+    static func configurationFileURL() -> URL {
+        if let overrideDirectory {
+            return overrideDirectory.appendingPathComponent(fileName)
+        }
+        return OsaurusPaths.config().appendingPathComponent(fileName)
+    }
+}
+
+enum TelegramCredentialStore {
+    static let pluginId = "osaurus.telegram"
+    static let botTokenKey = "bot_token"
+
+    @discardableResult
+    static func saveBotToken(_ token: String) -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return ToolSecretsKeychain.saveSecret(
+            trimmed,
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    static func botToken() -> String? {
+        ToolSecretsKeychain.getSecret(
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    static func hasBotToken() -> Bool {
+        ToolSecretsKeychain.hasSecret(
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+
+    @discardableResult
+    static func deleteBotToken() -> Bool {
+        ToolSecretsKeychain.deleteSecret(
+            id: botTokenKey,
+            for: pluginId,
+            agentId: Agent.defaultId
+        )
+    }
+}
+
+protocol TelegramCredentialStorage: Sendable {
+    func saveBotToken(_ token: String) -> Bool
+    func botToken() -> String?
+    func hasBotToken() -> Bool
+    func deleteBotToken() -> Bool
+}
+
+struct KeychainTelegramCredentialStorage: TelegramCredentialStorage {
+    func saveBotToken(_ token: String) -> Bool {
+        TelegramCredentialStore.saveBotToken(token)
+    }
+
+    func botToken() -> String? {
+        TelegramCredentialStore.botToken()
+    }
+
+    func hasBotToken() -> Bool {
+        TelegramCredentialStore.hasBotToken()
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        TelegramCredentialStore.deleteBotToken()
+    }
+}
+
+enum TelegramSecurity {
+    static func redact(_ text: String, token: String?) -> String {
+        guard let token, token.count >= SecretScrubber.minimumValueLength else {
+            return text
+        }
+        return text.replacingOccurrences(of: token, with: "[REDACTED:TELEGRAM_BOT_TOKEN]")
+    }
+}

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9279,8 +9279,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logUserAgent = userAgent
         let logSelf = self
         runRequestTask(priority: .userInitiated) {
-            // External callers never see the externally-denied tool classes
-            // (folder write/shell) — `/mcp/call` refuses them too.
+            // External callers never see app-only tool classes; `/mcp/call`
+            // refuses the same deny list too.
             let entries = await MainActor.run {
                 ToolRegistry.shared.listTools().filter {
                     $0.enabled && !ToolRegistry.externallyDeniedToolNames.contains($0.name)
@@ -9460,12 +9460,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return "{}"
         }()
 
-        // External deny list: folder write/shell tool classes are never
-        // invocable through the MCP bridge (they're also hidden from
-        // `/mcp/tools`). Refuse before any schema validation or gating.
+        // External deny list: app-only tool classes are never invocable
+        // through the MCP bridge (they're also hidden from `/mcp/tools`).
+        // Refuse before any schema validation or gating.
         if ToolRegistry.externallyDeniedToolNames.contains(req.name) {
             let message =
-                "'\(req.name)' is not available to external callers. Folder write and shell tools can only run from the Osaurus app."
+                "'\(req.name)' is not available to external callers. App-only tools can only run from the Osaurus app."
             let bodyJSON = #"{"error":"tool_not_exposable","message":"\#(message)"}"#
             sendResponse(
                 context: context,

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5495,6 +5495,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     // MARK: - Dispatch & Task Endpoints
 
+    nonisolated static func shouldBindExternalSurfaceForDispatch(isLoopback: Bool) -> Bool {
+        !isLoopback
+    }
+
     /// POST /agents/{identifier}/dispatch — dispatch work/chat task
     /// The identifier can be an agent UUID or a crypto address (0x...).
     private func handleDispatchEndpoint(
@@ -5694,7 +5698,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 externalSessionKey: externalSessionKey
             )
 
-            let handle = await TaskDispatcher.shared.dispatch(request)
+            let handle: DispatchHandle?
+            if Self.shouldBindExternalSurfaceForDispatch(isLoopback: isLoopback) {
+                handle = await ChatExecutionContext.$isExternalSurface.withValue(true) {
+                    await TaskDispatcher.shared.dispatch(request)
+                }
+            } else {
+                handle = await TaskDispatcher.shared.dispatch(request)
+            }
             let responseBody: String
             let status: HTTPResponseStatus
 

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
@@ -28,7 +28,7 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
         case .emptyConnectionId:
             return "Agent channel connection id is required."
         case .reservedConnectionId(let id):
-            return "`\(id)` is reserved for the native Discord connection."
+            return "`\(id)` is reserved for a native Agent Channel connection."
         case .emptyName:
             return "Agent channel connection name is required."
         case .missingSupportedActions(let id):
@@ -60,7 +60,10 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
 final class AgentChannelConnectionManager: @unchecked Sendable {
     static let shared = AgentChannelConnectionManager()
 
-    private static let reservedConnectionIds = Set([AgentChannelConnection.nativeDiscordConnectionId])
+    private static let reservedConnectionIds = Set([
+        AgentChannelConnection.nativeDiscordConnectionId,
+        AgentChannelConnection.nativeSlackConnectionId,
+    ])
     private static let supportedHTTPMethods = Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
 
     func configurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
@@ -28,7 +28,7 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
         case .emptyConnectionId:
             return "Agent channel connection id is required."
         case .reservedConnectionId(let id):
-            return "`\(id)` is reserved for the native Discord connection."
+            return "`\(id)` is reserved for a native Agent Channel connection."
         case .emptyName:
             return "Agent channel connection name is required."
         case .missingSupportedActions(let id):
@@ -60,7 +60,10 @@ enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
 final class AgentChannelConnectionManager: @unchecked Sendable {
     static let shared = AgentChannelConnectionManager()
 
-    private static let reservedConnectionIds = Set([AgentChannelConnection.nativeDiscordConnectionId])
+    private static let reservedConnectionIds = Set([
+        AgentChannelConnection.nativeDiscordConnectionId,
+        AgentChannelConnection.nativeTelegramConnectionId,
+    ])
     private static let supportedHTTPMethods = Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
 
     func configurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -31,24 +31,31 @@ enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
 }
 
 final class AgentChannelConnectionService: @unchecked Sendable {
-    static let shared = AgentChannelConnectionService(discordService: .shared)
+    static let shared = AgentChannelConnectionService(discordService: .shared, telegramService: .shared)
 
     private static let discordConnectionId = AgentChannelConnection.nativeDiscordConnectionId
+    private static let telegramConnectionId = AgentChannelConnection.nativeTelegramConnectionId
     private let discordService: DiscordConnectionService
+    private let telegramService: TelegramConnectionService
     private let customJSONRunner: any AgentChannelCustomJSONRunning
 
     init(
         discordService: DiscordConnectionService,
+        telegramService: TelegramConnectionService = .shared,
         customJSONRunner: any AgentChannelCustomJSONRunning = AgentChannelCustomJSONRunner()
     ) {
         self.discordService = discordService
+        self.telegramService = telegramService
         self.customJSONRunner = customJSONRunner
     }
 
     func listConnections() -> [[String: Any]] {
-        var rows = [discordConnectionDictionary()]
+        var rows = [discordConnectionDictionary(), telegramConnectionDictionary()]
         let customRows = AgentChannelConfigurationStore.load().connections
-            .filter { $0.id.lowercased() != Self.discordConnectionId }
+            .filter {
+                let id = $0.id.lowercased()
+                return id != Self.discordConnectionId && id != Self.telegramConnectionId
+            }
             .map(connectionDictionary)
         rows.append(contentsOf: customRows)
         return rows
@@ -67,6 +74,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 payload["message_store"] = discordService.messageStoreDiagnostics()
                 return payload
+            case .telegram:
+                var payload = await telegramService.diagnostics().dictionary
+                payload["connection_id"] = connection.id
+                payload["kind"] = connection.kind.rawValue
+                payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
+                payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
+                payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
+                payload["message_store"] = telegramService.messageStoreDiagnostics()
+                return payload
             case .customHTTP:
                 var payload = await customJSONRunner.diagnostics(connection: connection)
                 payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
@@ -74,7 +90,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 return payload
-            case .slack, .telegram:
+            case .slack:
                 return [
                     "connection_id": connection.id,
                     "kind": connection.kind.rawValue,
@@ -106,9 +122,19 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .telegram:
+            return telegramService.listSpaces().map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": row["kind"] ?? "messaging_network",
+                    "connection_id": connection.id,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listSpaces(connection: connection)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -129,9 +155,22 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .telegram:
+            return try await telegramService.listChats().map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": row["kind"] ?? "chat",
+                    "space_id": spaceId,
+                    "connection_id": connection.id,
+                    "read_allowed": row["read_allowed"] ?? false,
+                    "write_allowed": row["write_allowed"] ?? false,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listRooms(connection: connection, spaceId: spaceId)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -145,9 +184,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "channel_messages"
             return payload
+        case .telegram:
+            var payload = try telegramService.readChat(TelegramReadRequest(chatId: roomId, limit: limit))
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "chat_messages"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.readMessages(connection: connection, roomId: roomId, limit: limit)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -188,6 +233,17 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_ids"] = roomIds ?? []
             payload["standard_kind"] = "message_search"
             return payload
+        case .telegram:
+            var payload = try telegramService.searchMessages(
+                query: query,
+                chatIds: roomIds,
+                limitPerChat: limitPerRoom,
+                maxMatches: maxMatches
+            )
+            payload["connection_id"] = connection.id
+            payload["room_ids"] = roomIds ?? []
+            payload["standard_kind"] = "message_search"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.searchMessages(
                 connection: connection,
@@ -196,7 +252,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 limitPerRoom: limitPerRoom,
                 maxMatches: maxMatches
             )
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -210,9 +266,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_draft"
             return payload
+        case .telegram:
+            var payload = try telegramService.draftMessage(chatId: roomId, content: content)
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_draft"
+            return payload
         case .customHTTP:
             return try customJSONRunner.draftMessage(connection: connection, roomId: roomId, content: content)
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -235,6 +297,19 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_sent"
             return payload
+        case .telegram:
+            var payload = try await telegramService.sendMessage(
+                TelegramWriteRequest(
+                    chatId: roomId,
+                    text: content,
+                    replyToMessageId: nil,
+                    confirmSend: confirmSend
+                )
+            )
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_sent"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.sendMessage(
                 connection: connection,
@@ -242,7 +317,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 content: content,
                 confirmSend: confirmSend
             )
-        case .slack, .telegram:
+        case .slack:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -420,6 +495,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         if resolvedId.lowercased() == Self.discordConnectionId {
             return discordConnection()
         }
+        if resolvedId.lowercased() == Self.telegramConnectionId {
+            return telegramConnection()
+        }
         guard let connection = AgentChannelConfigurationStore.load().connection(id: resolvedId) else {
             throw AgentChannelConnectionServiceError.connectionNotFound(resolvedId)
         }
@@ -464,6 +542,56 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         let writeRooms = row["write_room_allowlist"] as? [String] ?? []
         row["configured"] =
             discordService.hasBotToken()
+            && (!readRooms.isEmpty || !writeRooms.isEmpty)
+        return row
+    }
+
+    private func telegramConnection() -> AgentChannelConnection {
+        let config = telegramService.configuration()
+        return AgentChannelConnection(
+            id: Self.telegramConnectionId,
+            name: "Telegram",
+            kind: .telegram,
+            enabled: true,
+            supportedActions: [
+                .diagnostics,
+                .listSpaces,
+                .listRooms,
+                .readMessages,
+                .searchMessages,
+                .draftMessage,
+                .sendMessage,
+            ],
+            spaceAllowlist: ["telegram"],
+            readRoomAllowlist: config.readableChatIds,
+            writeRoomAllowlist: config.writableChatIds,
+            writeEnabled: config.writeEnabled,
+            defaultReadLimit: config.defaultReadLimit,
+            secrets: [
+                AgentChannelSecretReference(
+                    name: "bot_token",
+                    keychainId: TelegramCredentialStore.botTokenKey
+                )
+            ],
+            inboundAuthorization: AgentChannelInboundAuthorizationPolicy(
+                senderAllowlist: config.senderAllowlist,
+                roomAllowlist: config.readableChatIds,
+                allowUnscopedSpaces: false,
+                allowBotMessages: !config.ignoreBotMessages,
+                allowSelfMessages: !config.ignoreSelfMessages,
+                requireProviderEventId: true,
+                auditDecisionReason: "telegram_receive_authorization"
+            )
+        )
+    }
+
+    private func telegramConnectionDictionary() -> [String: Any] {
+        var row = connectionDictionary(telegramConnection())
+        row["credential_saved"] = telegramService.hasBotToken()
+        let readRooms = row["read_room_allowlist"] as? [String] ?? []
+        let writeRooms = row["write_room_allowlist"] as? [String] ?? []
+        row["configured"] =
+            telegramService.hasBotToken()
             && (!readRooms.isEmpty || !writeRooms.isEmpty)
         return row
     }
@@ -554,9 +682,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 }
                 return (.available, nil)
             }
-        case .slack, .telegram:
+        case .slack:
             return (.configuredOnly, "Provider adapter is configured, but execution is not implemented yet.")
-        case .discord:
+        case .discord, .telegram:
             switch action {
             case .diagnostics, .listSpaces:
                 return (.available, nil)

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -640,6 +640,10 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     name: "signing_secret",
                     keychainId: SlackCredentialStore.signingSecretKey
                 ),
+                AgentChannelSecretReference(
+                    name: "app_token",
+                    keychainId: SlackCredentialStore.appTokenKey
+                ),
             ]
         )
     }
@@ -660,6 +664,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         row["credential_saved"] = slackService.hasBotToken()
         row["bot_token_saved"] = slackService.hasBotToken()
         row["signing_secret_saved"] = slackService.hasSigningSecret()
+        row["app_token_saved"] = slackService.hasAppToken()
         let readRooms = row["read_room_allowlist"] as? [String] ?? []
         let writeRooms = row["write_room_allowlist"] as? [String] ?? []
         row["configured"] = slackService.hasBotToken()

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -10,6 +10,7 @@ import Foundation
 enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
     case connectionNotFound(String)
     case connectionDisabled(String)
+    case globalWritesDisabled(generation: Int)
     case unsupportedKind(AgentChannelKind)
     case unsupportedAction(action: AgentChannelAction, connectionId: String)
     case customExecutionNotImplemented(String)
@@ -20,6 +21,8 @@ enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
             return "Agent channel connection `\(connectionId)` is not configured."
         case .connectionDisabled(let connectionId):
             return "Agent channel connection `\(connectionId)` is disabled."
+        case .globalWritesDisabled(let generation):
+            return "Global Agent Channel writes are disabled by the write kill switch (generation \(generation))."
         case .unsupportedKind(let kind):
             return "Agent channel kind `\(kind.rawValue)` is not executable yet."
         case .unsupportedAction(let action, let connectionId):
@@ -44,17 +47,20 @@ final class AgentChannelConnectionService: @unchecked Sendable {
     private let slackService: SlackConnectionService
     private let telegramService: TelegramConnectionService
     private let customJSONRunner: any AgentChannelCustomJSONRunning
+    private let writeKillSwitch: ChannelWriteKillSwitch
 
     init(
         discordService: DiscordConnectionService,
         slackService: SlackConnectionService = .shared,
         telegramService: TelegramConnectionService = .shared,
-        customJSONRunner: any AgentChannelCustomJSONRunning = AgentChannelCustomJSONRunner()
+        customJSONRunner: any AgentChannelCustomJSONRunning = AgentChannelCustomJSONRunner(),
+        writeKillSwitch: ChannelWriteKillSwitch = .shared
     ) {
         self.discordService = discordService
         self.slackService = slackService
         self.telegramService = telegramService
         self.customJSONRunner = customJSONRunner
+        self.writeKillSwitch = writeKillSwitch
     }
 
     func listConnections() -> [[String: Any]] {
@@ -96,6 +102,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 payload["message_store"] = slackService.messageStoreDiagnostics()
+                payload["transport_health"] = await AgentChannelTransportHealthCenter.shared
+                    .allStates(connectionId: connection.id)
+                    .map(\.dictionary)
+                payload["receive_transport"] = [
+                    "status": slackService.hasAppToken() ? "configured" : "not_configured",
+                    "transport_id": SlackSocketModeTransportRuntime.transportId,
+                    "summary": "Slack Socket Mode receive starts when an app token, readable channels, and authorized sender IDs are configured.",
+                    "app_token_saved": slackService.hasAppToken(),
+                ]
                 return payload
             case .telegram:
                 var payload = await telegramService.diagnostics().dictionary
@@ -105,6 +120,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 payload["message_store"] = telegramService.messageStoreDiagnostics()
+                payload["transport_health"] = await AgentChannelTransportHealthCenter.shared
+                    .allStates(connectionId: connection.id)
+                    .map(\.dictionary)
                 return payload
             case .customHTTP:
                 var payload = await customJSONRunner.diagnostics(connection: connection)
@@ -340,6 +358,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         confirmSend: Bool
     ) async throws -> [String: Any] {
         let connection = try requireAction(.sendMessage, connectionId: connectionId)
+        try requireGlobalWritesEnabled()
         switch connection.kind {
         case .discord:
             var payload = try await discordService.sendMessage(
@@ -391,6 +410,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         confirmSend: Bool
     ) async throws -> [String: Any] {
         let connection = try requireAction(.replyThread, connectionId: connectionId)
+        try requireGlobalWritesEnabled()
         switch connection.kind {
         case .discord:
             var payload = try await discordService.replyToThread(
@@ -560,6 +580,13 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         return connection
     }
 
+    private func requireGlobalWritesEnabled() throws {
+        let snapshot = writeKillSwitch.snapshot()
+        guard snapshot.writeEnabled else {
+            throw AgentChannelConnectionServiceError.globalWritesDisabled(generation: snapshot.generation)
+        }
+    }
+
     private func resolveConnection(_ connectionId: String?) throws -> AgentChannelConnection {
         let id = AgentChannelConnection.normalizedId(connectionId ?? "")
         let resolvedId = id.isEmpty ? Self.discordConnectionId : id
@@ -644,7 +671,16 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     name: "app_token",
                     keychainId: SlackCredentialStore.appTokenKey
                 ),
-            ]
+            ],
+            inboundAuthorization: AgentChannelInboundAuthorizationPolicy(
+                senderAllowlist: config.senderAllowlist,
+                roomAllowlist: config.readableChannelIds,
+                allowUnscopedSpaces: config.configuredTeamIds.isEmpty,
+                allowBotMessages: false,
+                allowSelfMessages: false,
+                requireProviderEventId: true,
+                auditDecisionReason: "slack_receive_authorization"
+            )
         )
     }
 
@@ -665,6 +701,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         row["bot_token_saved"] = slackService.hasBotToken()
         row["signing_secret_saved"] = slackService.hasSigningSecret()
         row["app_token_saved"] = slackService.hasAppToken()
+        row["sender_allowlist"] = slackService.configuration().senderAllowlist
         let readRooms = row["read_room_allowlist"] as? [String] ?? []
         let writeRooms = row["write_room_allowlist"] as? [String] ?? []
         row["configured"] = slackService.hasBotToken()
@@ -806,6 +843,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 guard !connection.writeRoomAllowlist.isEmpty else {
                     return (.unavailable, "No rooms are allowlisted for write access.")
                 }
+                guard action == .draftMessage || writeKillSwitch.snapshot().writeEnabled else {
+                    return (.unavailable, "Global Agent Channel writes are disabled.")
+                }
                 return (.available, nil)
             }
         case .discord, .slack, .telegram:
@@ -828,6 +868,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 }
                 guard !connection.writeRoomAllowlist.isEmpty else {
                     return (.unavailable, "No rooms are allowlisted for write access.")
+                }
+                guard action == .draftMessage || writeKillSwitch.snapshot().writeEnabled else {
+                    return (.unavailable, "Global Agent Channel writes are disabled.")
                 }
                 return (.available, nil)
             }

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -31,24 +31,31 @@ enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
 }
 
 final class AgentChannelConnectionService: @unchecked Sendable {
-    static let shared = AgentChannelConnectionService(discordService: .shared)
+    static let shared = AgentChannelConnectionService(discordService: .shared, slackService: .shared)
 
     private static let discordConnectionId = AgentChannelConnection.nativeDiscordConnectionId
+    private static let slackConnectionId = AgentChannelConnection.nativeSlackConnectionId
     private let discordService: DiscordConnectionService
+    private let slackService: SlackConnectionService
     private let customJSONRunner: any AgentChannelCustomJSONRunning
 
     init(
         discordService: DiscordConnectionService,
+        slackService: SlackConnectionService = .shared,
         customJSONRunner: any AgentChannelCustomJSONRunning = AgentChannelCustomJSONRunner()
     ) {
         self.discordService = discordService
+        self.slackService = slackService
         self.customJSONRunner = customJSONRunner
     }
 
     func listConnections() -> [[String: Any]] {
-        var rows = [discordConnectionDictionary()]
+        var rows = [discordConnectionDictionary(), slackConnectionDictionary()]
         let customRows = AgentChannelConfigurationStore.load().connections
-            .filter { $0.id.lowercased() != Self.discordConnectionId }
+            .filter { connection in
+                let id = connection.id.lowercased()
+                return id != Self.discordConnectionId && id != Self.slackConnectionId
+            }
             .map(connectionDictionary)
         rows.append(contentsOf: customRows)
         return rows
@@ -67,6 +74,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 payload["message_store"] = discordService.messageStoreDiagnostics()
                 return payload
+            case .slack:
+                var payload = await slackService.diagnostics().dictionary
+                payload["connection_id"] = connection.id
+                payload["kind"] = connection.kind.rawValue
+                payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
+                payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
+                payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
+                payload["message_store"] = slackService.messageStoreDiagnostics()
+                return payload
             case .customHTTP:
                 var payload = await customJSONRunner.diagnostics(connection: connection)
                 payload["standard_actions"] = connection.supportedActions.map(\.rawValue)
@@ -74,7 +90,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 payload["action_policies"] = actionPolicies(for: connection).map(\.dictionary)
                 payload["relay_receive_policy"] = relayReceivePolicy(for: connection).dictionary
                 return payload
-            case .slack, .telegram:
+            case .telegram:
                 return [
                     "connection_id": connection.id,
                     "kind": connection.kind.rawValue,
@@ -106,9 +122,19 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .slack:
+            return try await slackService.listWorkspaces().map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": "workspace",
+                    "connection_id": connection.id,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listSpaces(connection: connection)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -129,9 +155,22 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                     "raw": row,
                 ]
             }
+        case .slack:
+            return try await slackService.listChannels(teamId: spaceId).map { row in
+                [
+                    "id": row["id"] ?? "",
+                    "name": row["name"] ?? "",
+                    "kind": "room",
+                    "space_id": spaceId,
+                    "connection_id": connection.id,
+                    "read_allowed": row["read_allowed"] ?? false,
+                    "write_allowed": row["write_allowed"] ?? false,
+                    "raw": row,
+                ]
+            }
         case .customHTTP:
             return try await customJSONRunner.listRooms(connection: connection, spaceId: spaceId)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -145,9 +184,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "channel_messages"
             return payload
+        case .slack:
+            var payload = try await slackService.readChannel(channelId: roomId, limit: limit)
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "channel_messages"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.readMessages(connection: connection, roomId: roomId, limit: limit)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -161,9 +206,14 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["thread_id"] = threadId
             payload["standard_kind"] = "thread_messages"
             return payload
+        case .slack:
+            var payload = try await slackService.readThread(threadId: threadId, limit: limit)
+            payload["connection_id"] = connection.id
+            payload["standard_kind"] = "thread_messages"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.readThread(connection: connection, threadId: threadId, limit: limit)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -188,6 +238,17 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_ids"] = roomIds ?? []
             payload["standard_kind"] = "message_search"
             return payload
+        case .slack:
+            var payload = try await slackService.findRecentMessages(
+                query: query,
+                channelIds: roomIds,
+                limitPerChannel: limitPerRoom,
+                maxMatches: maxMatches
+            )
+            payload["connection_id"] = connection.id
+            payload["room_ids"] = roomIds ?? []
+            payload["standard_kind"] = "message_search"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.searchMessages(
                 connection: connection,
@@ -196,7 +257,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 limitPerRoom: limitPerRoom,
                 maxMatches: maxMatches
             )
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -210,9 +271,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_draft"
             return payload
+        case .slack:
+            var payload = try slackService.draftMessage(channelId: roomId, content: content)
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_draft"
+            return payload
         case .customHTTP:
             return try customJSONRunner.draftMessage(connection: connection, roomId: roomId, content: content)
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -235,6 +302,16 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["room_id"] = roomId
             payload["standard_kind"] = "message_sent"
             return payload
+        case .slack:
+            var payload = try await slackService.sendMessage(
+                channelId: roomId,
+                content: content,
+                confirmSend: confirmSend
+            )
+            payload["connection_id"] = connection.id
+            payload["room_id"] = roomId
+            payload["standard_kind"] = "message_sent"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.sendMessage(
                 connection: connection,
@@ -242,7 +319,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 content: content,
                 confirmSend: confirmSend
             )
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -264,6 +341,15 @@ final class AgentChannelConnectionService: @unchecked Sendable {
             payload["connection_id"] = connection.id
             payload["standard_kind"] = "thread_reply_sent"
             return payload
+        case .slack:
+            var payload = try await slackService.replyToThread(
+                threadId: threadId,
+                content: content,
+                confirmSend: confirmSend
+            )
+            payload["connection_id"] = connection.id
+            payload["standard_kind"] = "thread_reply_sent"
+            return payload
         case .customHTTP:
             return try await customJSONRunner.replyThread(
                 connection: connection,
@@ -271,7 +357,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 content: content,
                 confirmSend: confirmSend
             )
-        case .slack, .telegram:
+        case .telegram:
             throw AgentChannelConnectionServiceError.unsupportedKind(connection.kind)
         }
     }
@@ -420,6 +506,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         if resolvedId.lowercased() == Self.discordConnectionId {
             return discordConnection()
         }
+        if resolvedId.lowercased() == Self.slackConnectionId {
+            return slackConnection()
+        }
         guard let connection = AgentChannelConfigurationStore.load().connection(id: resolvedId) else {
             throw AgentChannelConnectionServiceError.connectionNotFound(resolvedId)
         }
@@ -457,6 +546,41 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         )
     }
 
+    private func slackConnection() -> AgentChannelConnection {
+        let config = slackService.configuration()
+        return AgentChannelConnection(
+            id: Self.slackConnectionId,
+            name: "Slack",
+            kind: .slack,
+            enabled: true,
+            supportedActions: [
+                .diagnostics,
+                .listSpaces,
+                .listRooms,
+                .readMessages,
+                .searchMessages,
+                .draftMessage,
+                .sendMessage,
+                .replyThread,
+            ],
+            spaceAllowlist: config.configuredTeamIds,
+            readRoomAllowlist: config.readableChannelIds,
+            writeRoomAllowlist: config.writableChannelIds,
+            writeEnabled: config.writeEnabled,
+            defaultReadLimit: config.defaultReadLimit,
+            secrets: [
+                AgentChannelSecretReference(
+                    name: "bot_token",
+                    keychainId: SlackCredentialStore.botTokenKey
+                ),
+                AgentChannelSecretReference(
+                    name: "signing_secret",
+                    keychainId: SlackCredentialStore.signingSecretKey
+                ),
+            ]
+        )
+    }
+
     private func discordConnectionDictionary() -> [String: Any] {
         var row = connectionDictionary(discordConnection())
         row["credential_saved"] = discordService.hasBotToken()
@@ -464,6 +588,18 @@ final class AgentChannelConnectionService: @unchecked Sendable {
         let writeRooms = row["write_room_allowlist"] as? [String] ?? []
         row["configured"] =
             discordService.hasBotToken()
+            && (!readRooms.isEmpty || !writeRooms.isEmpty)
+        return row
+    }
+
+    private func slackConnectionDictionary() -> [String: Any] {
+        var row = connectionDictionary(slackConnection())
+        row["credential_saved"] = slackService.hasBotToken()
+        row["bot_token_saved"] = slackService.hasBotToken()
+        row["signing_secret_saved"] = slackService.hasSigningSecret()
+        let readRooms = row["read_room_allowlist"] as? [String] ?? []
+        let writeRooms = row["write_room_allowlist"] as? [String] ?? []
+        row["configured"] = slackService.hasBotToken()
             && (!readRooms.isEmpty || !writeRooms.isEmpty)
         return row
     }
@@ -554,9 +690,9 @@ final class AgentChannelConnectionService: @unchecked Sendable {
                 }
                 return (.available, nil)
             }
-        case .slack, .telegram:
+        case .telegram:
             return (.configuredOnly, "Provider adapter is configured, but execution is not implemented yet.")
-        case .discord:
+        case .discord, .slack:
             switch action {
             case .diagnostics, .listSpaces:
                 return (.available, nil)

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelTransportHealth.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelTransportHealth.swift
@@ -1,0 +1,185 @@
+//
+//  AgentChannelTransportHealth.swift
+//  osaurus
+//
+//  Shared health state for Agent Channel receive transports.
+//
+
+import Foundation
+
+enum AgentChannelTransportHealthSeverity: String, Codable, CaseIterable, Sendable {
+    case info
+    case warning
+    case error
+}
+
+enum AgentChannelTransportHealthStatus: String, Codable, CaseIterable, Sendable {
+    case disabled
+    case idle
+    case healthy
+    case degraded
+    case conflict
+    case failed
+}
+
+struct AgentChannelTransportHealthState: Codable, Equatable, Sendable {
+    var connectionId: String
+    var transportId: String
+    var provider: AgentChannelKind
+    var status: AgentChannelTransportHealthStatus
+    var severity: AgentChannelTransportHealthSeverity
+    var summary: String
+    var detail: String?
+    var isRunning: Bool
+    var receiveEnabled: Bool
+    var lastSuccessAt: Date?
+    var lastFailureAt: Date?
+    var nextRetryAt: Date?
+    var consecutiveFailures: Int
+    var lastReceivedCount: Int
+    var lastStoredCount: Int
+    var dispatchSuppressedCount: Int
+    var updatedAt: Date
+
+    init(
+        connectionId: String,
+        transportId: String,
+        provider: AgentChannelKind,
+        status: AgentChannelTransportHealthStatus,
+        severity: AgentChannelTransportHealthSeverity,
+        summary: String,
+        detail: String? = nil,
+        isRunning: Bool,
+        receiveEnabled: Bool,
+        lastSuccessAt: Date? = nil,
+        lastFailureAt: Date? = nil,
+        nextRetryAt: Date? = nil,
+        consecutiveFailures: Int = 0,
+        lastReceivedCount: Int = 0,
+        lastStoredCount: Int = 0,
+        dispatchSuppressedCount: Int = 0,
+        updatedAt: Date = Date()
+    ) {
+        self.connectionId = AgentChannelConnection.normalizedId(connectionId)
+        self.transportId = AgentChannelConnection.normalizedId(transportId)
+        self.provider = provider
+        self.status = status
+        self.severity = severity
+        self.summary = summary
+        self.detail = detail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.isRunning = isRunning
+        self.receiveEnabled = receiveEnabled
+        self.lastSuccessAt = lastSuccessAt
+        self.lastFailureAt = lastFailureAt
+        self.nextRetryAt = nextRetryAt
+        self.consecutiveFailures = max(0, consecutiveFailures)
+        self.lastReceivedCount = max(0, lastReceivedCount)
+        self.lastStoredCount = max(0, lastStoredCount)
+        self.dispatchSuppressedCount = max(0, dispatchSuppressedCount)
+        self.updatedAt = updatedAt
+    }
+
+    var notificationIdentifier: String {
+        "\(connectionId).\(transportId).\(status.rawValue)"
+    }
+
+    var shouldNotify: Bool {
+        switch severity {
+        case .info:
+            return false
+        case .warning, .error:
+            return status != .disabled
+        }
+    }
+
+    var dictionary: [String: Any] {
+        var row: [String: Any] = [
+            "connection_id": connectionId,
+            "transport_id": transportId,
+            "provider": provider.rawValue,
+            "status": status.rawValue,
+            "severity": severity.rawValue,
+            "summary": summary,
+            "is_running": isRunning,
+            "receive_enabled": receiveEnabled,
+            "consecutive_failures": consecutiveFailures,
+            "last_received_count": lastReceivedCount,
+            "last_stored_count": lastStoredCount,
+            "dispatch_suppressed_count": dispatchSuppressedCount,
+            "notification_identifier": notificationIdentifier,
+            "should_notify": shouldNotify,
+            "updated_at": Self.iso8601(updatedAt),
+        ]
+        if let detail, !detail.isEmpty {
+            row["detail"] = detail
+        }
+        if let lastSuccessAt {
+            row["last_success_at"] = Self.iso8601(lastSuccessAt)
+        }
+        if let lastFailureAt {
+            row["last_failure_at"] = Self.iso8601(lastFailureAt)
+        }
+        if let nextRetryAt {
+            row["next_retry_at"] = Self.iso8601(nextRetryAt)
+        }
+        return row
+    }
+
+    private static func iso8601(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+}
+
+actor AgentChannelTransportHealthCenter {
+    static let shared = AgentChannelTransportHealthCenter()
+
+    private var states: [String: AgentChannelTransportHealthState] = [:]
+
+    @discardableResult
+    func update(_ state: AgentChannelTransportHealthState) -> AgentChannelTransportHealthState {
+        states[Self.key(connectionId: state.connectionId, transportId: state.transportId)] = state
+        return state
+    }
+
+    func state(connectionId: String, transportId: String) -> AgentChannelTransportHealthState? {
+        states[
+            Self.key(
+                connectionId: AgentChannelConnection.normalizedId(connectionId),
+                transportId: AgentChannelConnection.normalizedId(transportId)
+            )
+        ]
+    }
+
+    func allStates(connectionId: String? = nil) -> [AgentChannelTransportHealthState] {
+        let normalizedConnectionId = connectionId.map(AgentChannelConnection.normalizedId)
+        return states.values
+            .filter { state in
+                guard let normalizedConnectionId else { return true }
+                return state.connectionId == normalizedConnectionId
+            }
+            .sorted {
+                if $0.connectionId == $1.connectionId {
+                    return $0.transportId < $1.transportId
+                }
+                return $0.connectionId < $1.connectionId
+            }
+    }
+
+    func clear(connectionId: String, transportId: String? = nil) {
+        let normalizedConnectionId = AgentChannelConnection.normalizedId(connectionId)
+        if let transportId {
+            states.removeValue(
+                forKey: Self.key(
+                    connectionId: normalizedConnectionId,
+                    transportId: AgentChannelConnection.normalizedId(transportId)
+                )
+            )
+            return
+        }
+        states = states.filter { _, state in state.connectionId != normalizedConnectionId }
+    }
+
+    private static func key(connectionId: String, transportId: String) -> String {
+        "\(connectionId)\u{1F}\(transportId)"
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelTransportRuntime.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelTransportRuntime.swift
@@ -1,0 +1,183 @@
+//
+//  AgentChannelTransportRuntime.swift
+//  osaurus
+//
+//  Provider-neutral receive transport runtime primitives.
+//
+
+import Foundation
+
+enum AgentChannelTransportStepDisposition: String, Codable, Sendable {
+    case skipped
+    case succeeded
+    case failed
+    case conflict
+}
+
+struct AgentChannelTransportStepResult: Equatable, Sendable {
+    var disposition: AgentChannelTransportStepDisposition
+    var health: AgentChannelTransportHealthState
+    var received: Int
+    var stored: Int
+    var dispatchAttempted: Int
+    var dispatchSuppressed: Int
+    var retryDelay: TimeInterval?
+
+    init(
+        disposition: AgentChannelTransportStepDisposition,
+        health: AgentChannelTransportHealthState,
+        received: Int = 0,
+        stored: Int = 0,
+        dispatchAttempted: Int = 0,
+        dispatchSuppressed: Int = 0,
+        retryDelay: TimeInterval? = nil
+    ) {
+        self.disposition = disposition
+        self.health = health
+        self.received = max(0, received)
+        self.stored = max(0, stored)
+        self.dispatchAttempted = max(0, dispatchAttempted)
+        self.dispatchSuppressed = max(0, dispatchSuppressed)
+        self.retryDelay = retryDelay.map { max(0, $0) }
+    }
+}
+
+struct AgentChannelTransportBackoffPolicy: Codable, Equatable, Sendable {
+    var initialDelay: TimeInterval
+    var multiplier: Double
+    var maxDelay: TimeInterval
+    var jitterFraction: Double
+
+    init(
+        initialDelay: TimeInterval = 1,
+        multiplier: Double = 2,
+        maxDelay: TimeInterval = 60,
+        jitterFraction: Double = 0.2
+    ) {
+        self.initialDelay = max(0, initialDelay)
+        self.multiplier = max(1, multiplier)
+        self.maxDelay = max(0, maxDelay)
+        self.jitterFraction = min(max(jitterFraction, 0), 1)
+    }
+
+    func delay(consecutiveFailures: Int, jitter: Double) -> TimeInterval {
+        guard maxDelay > 0 else { return 0 }
+        let failures = max(1, consecutiveFailures)
+        let exponent = min(max(0, failures - 1), 30)
+        let exponential = initialDelay * pow(multiplier, Double(exponent))
+        let capped = min(maxDelay, max(0, exponential))
+        let normalizedJitter = min(max(jitter, 0), 1)
+        let jitterScale = 1 + ((normalizedJitter * 2) - 1) * jitterFraction
+        return min(maxDelay, max(0, capped * jitterScale))
+    }
+}
+
+protocol AgentChannelTransportSleeping: Sendable {
+    func sleep(for duration: TimeInterval) async throws
+}
+
+struct AgentChannelTransportTaskSleeper: AgentChannelTransportSleeping {
+    func sleep(for duration: TimeInterval) async throws {
+        let clamped = min(max(duration, 0), 3_600)
+        guard clamped > 0 else { return }
+        try await Task.sleep(nanoseconds: UInt64((clamped * 1_000_000_000).rounded()))
+    }
+}
+
+protocol AgentChannelReceiveTransportRuntime: Sendable {
+    func start(pollInterval: TimeInterval) async
+    func stop(now: Date) async
+}
+
+actor AgentChannelTransportSupervisor {
+    static let shared = AgentChannelTransportSupervisor()
+
+    private let slackConfiguration: @Sendable () -> SlackConnectionConfiguration
+    private let slackHasBotToken: @Sendable () -> Bool
+    private let slackHasAppToken: @Sendable () -> Bool
+    private let slackRuntime: any AgentChannelReceiveTransportRuntime
+    private let telegramConfiguration: @Sendable () -> TelegramConnectionConfiguration
+    private let telegramHasBotToken: @Sendable () -> Bool
+    private let telegramRuntime: any AgentChannelReceiveTransportRuntime
+    private var slackStarted = false
+    private var telegramStarted = false
+
+    init(
+        slackConfiguration: @escaping @Sendable () -> SlackConnectionConfiguration = {
+            SlackConnectionService.shared.configuration()
+        },
+        slackHasBotToken: @escaping @Sendable () -> Bool = {
+            SlackConnectionService.shared.hasBotToken()
+        },
+        slackHasAppToken: @escaping @Sendable () -> Bool = {
+            SlackConnectionService.shared.hasAppToken()
+        },
+        slackRuntime: any AgentChannelReceiveTransportRuntime = SlackSocketModeTransportRuntime(),
+        telegramConfiguration: @escaping @Sendable () -> TelegramConnectionConfiguration = {
+            TelegramConnectionService.shared.configuration()
+        },
+        telegramHasBotToken: @escaping @Sendable () -> Bool = {
+            TelegramConnectionService.shared.hasBotToken()
+        },
+        telegramRuntime: any AgentChannelReceiveTransportRuntime = TelegramLongPollTransportRuntime()
+    ) {
+        self.slackConfiguration = slackConfiguration
+        self.slackHasBotToken = slackHasBotToken
+        self.slackHasAppToken = slackHasAppToken
+        self.slackRuntime = slackRuntime
+        self.telegramConfiguration = telegramConfiguration
+        self.telegramHasBotToken = telegramHasBotToken
+        self.telegramRuntime = telegramRuntime
+    }
+
+    func startFromLaunch() async {
+        await refreshSlackRuntime()
+        await refreshTelegramRuntime()
+    }
+
+    func refreshSlackRuntime(now: Date = Date()) async {
+        let configuration = slackConfiguration()
+        if slackHasBotToken()
+            && slackHasAppToken()
+            && !configuration.readableChannelIds.isEmpty
+            && !configuration.senderAllowlist.isEmpty {
+            guard !slackStarted else { return }
+            slackStarted = true
+            await slackRuntime.start(pollInterval: 1)
+            return
+        }
+
+        guard slackStarted else { return }
+        slackStarted = false
+        await slackRuntime.stop(now: now)
+    }
+
+    func refreshTelegramRuntime(now: Date = Date()) async {
+        let configuration = telegramConfiguration()
+        if configuration.receiveStorageEnabled
+            && configuration.longPollingEnabled
+            && telegramHasBotToken()
+            && !configuration.readableChatIds.isEmpty
+            && !configuration.senderAllowlist.isEmpty {
+            guard !telegramStarted else { return }
+            telegramStarted = true
+            await telegramRuntime.start(pollInterval: 0)
+            return
+        }
+
+        guard telegramStarted else { return }
+        telegramStarted = false
+        await telegramRuntime.stop(now: now)
+    }
+
+    func stop(now: Date = Date()) async {
+        if slackStarted {
+            slackStarted = false
+            await slackRuntime.stop(now: now)
+        }
+        if telegramStarted {
+            telegramStarted = false
+            await telegramRuntime.stop(now: now)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPServerManager.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerManager.swift
@@ -68,9 +68,11 @@ final class MCPServerManager {
 
     // MARK: - Internal
     private func registerHandlers(on server: MCP.Server) async {
-        // ListTools returns only enabled tools from ToolRegistry
+        // ListTools returns only enabled, externally exposable tools from ToolRegistry.
         await server.withMethodHandler(MCP.ListTools.self) { _ in
-            let entries = await ToolRegistry.shared.listTools().filter { $0.enabled }
+            let entries = await ToolRegistry.shared.listTools().filter {
+                Self.isToolVisibleToExternalMCP(name: $0.name, enabled: $0.enabled)
+            }
             let tools: [MCP.Tool] = entries.map { entry in
                 let schema: MCP.Value = entry.parameters.map { Self.toMCPValue($0) } ?? .null
                 return MCP.Tool(name: entry.name, description: entry.description, inputSchema: schema)
@@ -107,12 +109,25 @@ final class MCPServerManager {
             }()
             let argsJSON: String = {
                 if let d = argsData {
-                    return String(decoding: d, as: UTF8.self)
+                    return String(data: d, encoding: .utf8) ?? "{}"
                 }
                 return "{}"
             }()
 
             do {
+                if let denial = Self.externalMCPDenialMessage(for: params.name) {
+                    return .init(
+                        content: [
+                            .text(
+                                text: denial,
+                                annotations: nil,
+                                _meta: nil
+                            )
+                        ],
+                        isError: true
+                    )
+                }
+
                 // Validate against tool schema when available
                 if let schema = await ToolRegistry.shared.parametersForTool(name: params.name) {
                     let result = SchemaValidator.validate(arguments: argumentsAny, against: schema)
@@ -122,7 +137,10 @@ final class MCPServerManager {
                     }
                 }
 
-                let result = try await ToolRegistry.shared.execute(name: params.name, argumentsJSON: argsJSON)
+                let result = try await Self.executeToolAsExternalMCP(
+                    name: params.name,
+                    argumentsJSON: argsJSON
+                )
                 return .init(content: [.text(text: result, annotations: nil, _meta: nil)], isError: false)
             } catch {
                 return .init(
@@ -130,6 +148,22 @@ final class MCPServerManager {
                     isError: true
                 )
             }
+        }
+    }
+
+    nonisolated static func isToolVisibleToExternalMCP(name: String, enabled: Bool) -> Bool {
+        enabled && !ToolRegistry.externallyDeniedToolNames.contains(name)
+    }
+
+    nonisolated static func externalMCPDenialMessage(for name: String) -> String? {
+        guard ToolRegistry.externallyDeniedToolNames.contains(name) else { return nil }
+        return "'\(name)' is not available to external callers. "
+            + "App-only tools can only run from the Osaurus app."
+    }
+
+    static func executeToolAsExternalMCP(name: String, argumentsJSON: String) async throws -> String {
+        try await ChatExecutionContext.$isExternalSurface.withValue(true) {
+            try await ToolRegistry.shared.execute(name: name, argumentsJSON: argumentsJSON)
         }
     }
 

--- a/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
@@ -1,0 +1,354 @@
+//
+//  SlackAPIClient.swift
+//  osaurus
+//
+//  Minimal Slack Web API client for the native Agent Channel adapter.
+//
+
+import Foundation
+
+struct SlackAuthIdentity: Codable, Equatable, Sendable {
+    let url: String?
+    let team: String?
+    let user: String?
+    let teamId: String
+    let userId: String?
+    let botId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case url
+        case team
+        case user
+        case teamId = "team_id"
+        case userId = "user_id"
+        case botId = "bot_id"
+    }
+}
+
+struct SlackConversation: Codable, Equatable, Sendable {
+    let id: String
+    let name: String?
+    let isChannel: Bool?
+    let isGroup: Bool?
+    let isIM: Bool?
+    let isMPIM: Bool?
+    let isPrivate: Bool?
+    let isArchived: Bool?
+    let isMember: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case isChannel = "is_channel"
+        case isGroup = "is_group"
+        case isIM = "is_im"
+        case isMPIM = "is_mpim"
+        case isPrivate = "is_private"
+        case isArchived = "is_archived"
+        case isMember = "is_member"
+    }
+
+    var displayName: String {
+        guard let name, !name.isEmpty else { return id }
+        return name
+    }
+
+    var kind: String {
+        if isIM == true { return "im" }
+        if isMPIM == true { return "mpim" }
+        if isGroup == true { return "private_channel" }
+        return "channel"
+    }
+}
+
+struct SlackMessage: Codable, Equatable, Sendable {
+    let type: String?
+    let user: String?
+    let username: String?
+    let botId: String?
+    let text: String?
+    let ts: String
+    let threadTs: String?
+    let replyCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case user
+        case username
+        case botId = "bot_id"
+        case text
+        case ts
+        case threadTs = "thread_ts"
+        case replyCount = "reply_count"
+    }
+}
+
+enum SlackAPIError: LocalizedError, Equatable, Sendable {
+    case invalidToken
+    case missingPermissions(String)
+    case notFound(String)
+    case rateLimited(String)
+    case invalidResponse(String)
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidToken:
+            return "Slack rejected the bot token."
+        case .missingPermissions(let message):
+            return message
+        case .notFound(let message):
+            return message
+        case .rateLimited(let message):
+            return message
+        case .invalidResponse(let message):
+            return message
+        case .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+protocol SlackAPIClientProtocol: Sendable {
+    func authTest(token: String) async throws -> SlackAuthIdentity
+    func conversations(token: String, limit: Int) async throws -> [SlackConversation]
+    func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage]
+    func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage]
+    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage
+}
+
+final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
+    private struct ConversationListPayload: Decodable {
+        let channels: [SlackConversation]
+    }
+
+    private struct MessageListPayload: Decodable {
+        let messages: [SlackMessage]
+    }
+
+    private struct PostMessagePayload: Decodable {
+        let message: SlackMessage?
+        let ts: String?
+        let channel: String?
+    }
+
+    private let baseURL: URL
+    private let sessionProvider: @Sendable () -> URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://slack.com/api")!,
+        sessionProvider: @escaping @Sendable () -> URLSession = { GlobalProxySettings.sharedSession() }
+    ) {
+        self.baseURL = baseURL
+        self.sessionProvider = sessionProvider
+    }
+
+    func authTest(token: String) async throws -> SlackAuthIdentity {
+        try await postForm(method: "auth.test", token: token, form: [:])
+    }
+
+    func conversations(token: String, limit: Int) async throws -> [SlackConversation] {
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit)
+        let payload: ConversationListPayload = try await postForm(
+            method: "conversations.list",
+            token: token,
+            form: [
+                "exclude_archived": "true",
+                "limit": "\(safeLimit)",
+                "types": "public_channel,private_channel,mpim,im",
+            ]
+        )
+        return payload.channels
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        try validateSlackId(channelId, label: "channel_id")
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit)
+        let payload: MessageListPayload = try await postForm(
+            method: "conversations.history",
+            token: token,
+            form: [
+                "channel": channelId,
+                "inclusive": "true",
+                "limit": "\(safeLimit)",
+            ]
+        )
+        return payload.messages
+    }
+
+    func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        try validateSlackId(channelId, label: "channel_id")
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit)
+        let payload: MessageListPayload = try await postForm(
+            method: "conversations.replies",
+            token: token,
+            form: [
+                "channel": channelId,
+                "inclusive": "true",
+                "limit": "\(safeLimit)",
+                "ts": threadTs,
+            ]
+        )
+        return payload.messages
+    }
+
+    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
+        try validateSlackId(channelId, label: "channel_id")
+        var body: [String: Any] = [
+            "channel": channelId,
+            "text": content,
+            "parse": "none",
+            "link_names": false,
+            "unfurl_links": false,
+            "unfurl_media": false,
+            "reply_broadcast": false,
+        ]
+        if let threadTs, !threadTs.isEmpty {
+            body["thread_ts"] = threadTs
+        }
+        let payload: PostMessagePayload = try await postJSON(method: "chat.postMessage", token: token, body: body)
+        if let message = payload.message {
+            return message
+        }
+        if let ts = payload.ts {
+            return SlackMessage(
+                type: "message",
+                user: nil,
+                username: nil,
+                botId: nil,
+                text: content,
+                ts: ts,
+                threadTs: threadTs,
+                replyCount: nil
+            )
+        }
+        throw SlackAPIError.invalidResponse("Slack postMessage response did not include a message timestamp.")
+    }
+
+    private func postForm<Payload: Decodable>(
+        method: String,
+        token: String,
+        form: [String: String]
+    ) async throws -> Payload {
+        var request = makeRequest(method: method, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = form
+            .map { key, value in
+                "\(Self.urlEncode(key))=\(Self.urlEncode(value))"
+            }
+            .joined(separator: "&")
+            .data(using: .utf8)
+        return try await perform(request, token: token)
+    }
+
+    private func postJSON<Payload: Decodable>(
+        method: String,
+        token: String,
+        body: [String: Any]
+    ) async throws -> Payload {
+        var request = makeRequest(method: method, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .osaurusCanonical)
+        return try await perform(request, token: token)
+    }
+
+    private func makeRequest(method: String, token: String) -> URLRequest {
+        let url = baseURL.appendingPathComponent(method)
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Osaurus Slack Native Agent Channel", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 30
+        return request
+    }
+
+    private func perform<Payload: Decodable>(_ request: URLRequest, token: String) async throws -> Payload {
+        do {
+            let (data, response) = try await sessionProvider().data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw SlackAPIError.invalidResponse("Slack returned a non-HTTP response.")
+            }
+            guard http.statusCode != 429 else {
+                throw SlackAPIError.rateLimited("Slack rate limited this request.")
+            }
+            guard (200 ..< 300).contains(http.statusCode) else {
+                throw mapHTTPError(status: http.statusCode, data: data, token: token)
+            }
+            do {
+                let status = try JSONDecoder().decode(SlackStatusEnvelope.self, from: data)
+                guard status.ok else {
+                    throw mapSlackError(status.error, token: token)
+                }
+                return try JSONDecoder().decode(Payload.self, from: data)
+            } catch let error as SlackAPIError {
+                throw error
+            } catch {
+                throw SlackAPIError.invalidResponse("Slack response could not be decoded.")
+            }
+        } catch let error as SlackAPIError {
+            throw error
+        } catch {
+            throw SlackAPIError.requestFailed(
+                SlackSecurity.redact(error.localizedDescription, token: token)
+            )
+        }
+    }
+
+    private func mapHTTPError(status: Int, data: Data, token: String) -> SlackAPIError {
+        let message = slackErrorMessage(from: data)
+            .map { SlackSecurity.redact($0, token: token) }
+        switch status {
+        case 401:
+            return .invalidToken
+        case 403:
+            return .missingPermissions(message ?? "Slack denied access for this bot or channel.")
+        case 404:
+            return .notFound(message ?? "Slack resource was not found.")
+        default:
+            return .requestFailed(message ?? "Slack request failed with HTTP \(status).")
+        }
+    }
+
+    private func mapSlackError(_ error: String?, token: String) -> SlackAPIError {
+        let code = error ?? "unknown_error"
+        let message = SlackSecurity.redact("Slack API returned `\(code)`.", token: token)
+        switch code {
+        case "invalid_auth", "not_authed", "account_inactive", "token_revoked":
+            return .invalidToken
+        case "missing_scope", "no_permission", "not_in_channel", "is_archived", "restricted_action":
+            return .missingPermissions(message)
+        case "channel_not_found", "user_not_found", "team_not_found", "thread_not_found":
+            return .notFound(message)
+        case "ratelimited":
+            return .rateLimited(message)
+        default:
+            return .requestFailed(message)
+        }
+    }
+
+    private func slackErrorMessage(from data: Data) -> String? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = object["error"] as? String,
+            !error.isEmpty
+        else { return nil }
+        return "Slack API returned `\(error)`."
+    }
+
+    private func validateSlackId(_ id: String, label: String) throws {
+        guard SlackConnectionConfiguration.isValidSlackId(id) else {
+            throw SlackAPIError.invalidResponse("Invalid Slack \(label).")
+        }
+    }
+
+    private static func urlEncode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+    }
+}
+
+private struct SlackStatusEnvelope: Decodable {
+    let ok: Bool
+    let error: String?
+}

--- a/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
@@ -195,6 +195,7 @@ enum SlackAPIError: LocalizedError, Equatable, Sendable {
 
 protocol SlackAPIClientProtocol: Sendable {
     func authTest(token: String) async throws -> SlackAuthIdentity
+    func openSocketModeConnection(appToken: String) async throws -> URL
     func conversations(token: String, limit: Int) async throws -> [SlackConversation]
     func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage]
     func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage]
@@ -202,6 +203,10 @@ protocol SlackAPIClientProtocol: Sendable {
 }
 
 final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
+    private struct SocketModeConnectionPayload: Decodable {
+        let url: String
+    }
+
     private struct ConversationListPayload: Decodable {
         let channels: [SlackConversation]
     }
@@ -229,6 +234,20 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
 
     func authTest(token: String) async throws -> SlackAuthIdentity {
         try await postForm(method: "auth.test", token: token, form: [:])
+    }
+
+    func openSocketModeConnection(appToken: String) async throws -> URL {
+        let payload: SocketModeConnectionPayload = try await postForm(
+            method: "apps.connections.open",
+            token: appToken,
+            form: [:]
+        )
+        guard let url = URL(string: payload.url),
+              ["wss", "ws"].contains(url.scheme?.lowercased() ?? "")
+        else {
+            throw SlackAPIError.invalidResponse("Slack Socket Mode response did not include a WebSocket URL.")
+        }
+        return url
     }
 
     func conversations(token: String, limit: Int) async throws -> [SlackConversation] {

--- a/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackAPIClient.swift
@@ -28,13 +28,13 @@ struct SlackAuthIdentity: Codable, Equatable, Sendable {
 struct SlackConversation: Codable, Equatable, Sendable {
     let id: String
     let name: String?
-    let isChannel: Bool?
-    let isGroup: Bool?
-    let isIM: Bool?
-    let isMPIM: Bool?
-    let isPrivate: Bool?
-    let isArchived: Bool?
-    let isMember: Bool?
+    let isChannel: Bool
+    let isGroup: Bool
+    let isIM: Bool
+    let isMPIM: Bool
+    let isPrivate: Bool
+    let isArchived: Bool
+    let isMember: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -48,15 +48,52 @@ struct SlackConversation: Codable, Equatable, Sendable {
         case isMember = "is_member"
     }
 
+    init(
+        id: String,
+        name: String? = nil,
+        isChannel: Bool = false,
+        isGroup: Bool = false,
+        isIM: Bool = false,
+        isMPIM: Bool = false,
+        isPrivate: Bool = false,
+        isArchived: Bool = false,
+        isMember: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.isChannel = isChannel
+        self.isGroup = isGroup
+        self.isIM = isIM
+        self.isMPIM = isMPIM
+        self.isPrivate = isPrivate
+        self.isArchived = isArchived
+        self.isMember = isMember
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decode(String.self, forKey: .id),
+            name: try container.decodeIfPresent(String.self, forKey: .name),
+            isChannel: try container.decodeIfPresent(Bool.self, forKey: .isChannel) ?? false,
+            isGroup: try container.decodeIfPresent(Bool.self, forKey: .isGroup) ?? false,
+            isIM: try container.decodeIfPresent(Bool.self, forKey: .isIM) ?? false,
+            isMPIM: try container.decodeIfPresent(Bool.self, forKey: .isMPIM) ?? false,
+            isPrivate: try container.decodeIfPresent(Bool.self, forKey: .isPrivate) ?? false,
+            isArchived: try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false,
+            isMember: try container.decodeIfPresent(Bool.self, forKey: .isMember) ?? false
+        )
+    }
+
     var displayName: String {
         guard let name, !name.isEmpty else { return id }
         return name
     }
 
     var kind: String {
-        if isIM == true { return "im" }
-        if isMPIM == true { return "mpim" }
-        if isGroup == true { return "private_channel" }
+        if isIM { return "im" }
+        if isMPIM { return "mpim" }
+        if isGroup { return "private_channel" }
         return "channel"
     }
 }
@@ -80,6 +117,53 @@ struct SlackMessage: Codable, Equatable, Sendable {
         case ts
         case threadTs = "thread_ts"
         case replyCount = "reply_count"
+    }
+}
+
+struct SlackOutboundMessageRequest: Equatable, Sendable {
+    let channelId: String
+    let content: String
+    let threadTs: String?
+    let parse: String
+    let linkNames: Bool
+    let unfurlLinks: Bool
+    let unfurlMedia: Bool
+    let replyBroadcast: Bool
+
+    init(
+        channelId: String,
+        content: String,
+        threadTs: String? = nil,
+        parse: String = "none",
+        linkNames: Bool = false,
+        unfurlLinks: Bool = false,
+        unfurlMedia: Bool = false,
+        replyBroadcast: Bool = false
+    ) {
+        self.channelId = channelId
+        self.content = content
+        self.threadTs = threadTs
+        self.parse = parse
+        self.linkNames = linkNames
+        self.unfurlLinks = unfurlLinks
+        self.unfurlMedia = unfurlMedia
+        self.replyBroadcast = replyBroadcast
+    }
+
+    var jsonBody: [String: Any] {
+        var body: [String: Any] = [
+            "channel": channelId,
+            "text": content,
+            "parse": parse,
+            "link_names": linkNames,
+            "unfurl_links": unfurlLinks,
+            "unfurl_media": unfurlMedia,
+            "reply_broadcast": replyBroadcast,
+        ]
+        if let threadTs, !threadTs.isEmpty {
+            body["thread_ts"] = threadTs
+        }
+        return body
     }
 }
 
@@ -114,7 +198,7 @@ protocol SlackAPIClientProtocol: Sendable {
     func conversations(token: String, limit: Int) async throws -> [SlackConversation]
     func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage]
     func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage]
-    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage
+    func sendMessage(_ request: SlackOutboundMessageRequest, token: String) async throws -> SlackMessage
 }
 
 final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
@@ -192,21 +276,13 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
         return payload.messages
     }
 
-    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
-        try validateSlackId(channelId, label: "channel_id")
-        var body: [String: Any] = [
-            "channel": channelId,
-            "text": content,
-            "parse": "none",
-            "link_names": false,
-            "unfurl_links": false,
-            "unfurl_media": false,
-            "reply_broadcast": false,
-        ]
-        if let threadTs, !threadTs.isEmpty {
-            body["thread_ts"] = threadTs
-        }
-        let payload: PostMessagePayload = try await postJSON(method: "chat.postMessage", token: token, body: body)
+    func sendMessage(_ request: SlackOutboundMessageRequest, token: String) async throws -> SlackMessage {
+        try validateSlackId(request.channelId, label: "channel_id")
+        let payload: PostMessagePayload = try await postJSON(
+            method: "chat.postMessage",
+            token: token,
+            body: request.jsonBody
+        )
         if let message = payload.message {
             return message
         }
@@ -216,9 +292,9 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
                 user: nil,
                 username: nil,
                 botId: nil,
-                text: content,
+                text: request.content,
                 ts: ts,
-                threadTs: threadTs,
+                threadTs: request.threadTs,
                 replyCount: nil
             )
         }
@@ -271,7 +347,9 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
                 throw SlackAPIError.invalidResponse("Slack returned a non-HTTP response.")
             }
             guard http.statusCode != 429 else {
-                throw SlackAPIError.rateLimited("Slack rate limited this request.")
+                let retryAfter = http.value(forHTTPHeaderField: "Retry-After")
+                let suffix = retryAfter.map { " Retry after \($0) seconds." } ?? ""
+                throw SlackAPIError.rateLimited("Slack rate limited this request.\(suffix)")
             }
             guard (200 ..< 300).contains(http.statusCode) else {
                 throw mapHTTPError(status: http.statusCode, data: data, token: token)
@@ -344,7 +422,9 @@ final class SlackAPIClient: SlackAPIClientProtocol, @unchecked Sendable {
     }
 
     private static func urlEncode(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 }
 

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -1,0 +1,574 @@
+//
+//  SlackConnectionService.swift
+//  osaurus
+//
+//  Policy and diagnostics layer for the native Slack Agent Channel adapter.
+//
+
+import Foundation
+
+struct SlackConfiguredTeamDiagnostic: Equatable, Sendable {
+    let id: String
+    let name: String
+    let status: String
+    let reason: String?
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "id": id,
+            "name": name,
+            "status": status,
+        ]
+        if let reason {
+            result["reason"] = reason
+        }
+        return result
+    }
+}
+
+struct SlackConnectionDiagnostics: Equatable, Sendable {
+    let botTokenSaved: Bool
+    let signingSecretSaved: Bool
+    let identity: SlackAuthIdentity?
+    let configuredTeams: [SlackConfiguredTeamDiagnostic]
+    let readableChannelIds: [String]
+    let writableChannelIds: [String]
+    let writeEnabled: Bool
+    let allowBroadcastMentions: Bool
+    let status: String
+    let failures: [String]
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "bot_token_saved": botTokenSaved,
+            "signing_secret_saved": signingSecretSaved,
+            "configured_teams": configuredTeams.map(\.dictionary),
+            "readable_channel_ids": readableChannelIds,
+            "writable_channel_ids": writableChannelIds,
+            "write_enabled": writeEnabled,
+            "allow_broadcast_mentions": allowBroadcastMentions,
+            "status": status,
+            "failures": failures,
+        ]
+        if let identity {
+            result["bot"] = [
+                "bot_id": identity.botId ?? "",
+                "team": identity.team ?? "",
+                "team_id": identity.teamId,
+                "user": identity.user ?? "",
+                "user_id": identity.userId ?? "",
+            ]
+        }
+        return result
+    }
+}
+
+enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
+    case notConfigured
+    case invalidId(field: String)
+    case teamNotConfigured(String)
+    case channelNotReadable(String)
+    case channelNotWritable(String)
+    case writeDisabled
+    case sendConfirmationRequired
+    case messageTooLong
+    case emptyMessage
+    case broadcastMentionDenied
+    case invalidThreadId(String)
+    case configurationSaveFailed(String)
+    case api(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Slack is not configured. Add a bot token and allowlist at least one channel."
+        case .invalidId(let field):
+            return "`\(field)` must be a Slack ID."
+        case .teamNotConfigured(let teamId):
+            return "Slack workspace `\(teamId)` is not allowlisted in settings."
+        case .channelNotReadable(let channelId):
+            return "Slack channel `\(channelId)` is not allowlisted for read access."
+        case .channelNotWritable(let channelId):
+            return "Slack channel `\(channelId)` is not allowlisted for write access."
+        case .writeDisabled:
+            return "Slack write access is disabled in settings."
+        case .sendConfirmationRequired:
+            return "`confirm_send` must be true before Osaurus posts to Slack."
+        case .messageTooLong:
+            return "Slack messages must be 40000 characters or fewer."
+        case .emptyMessage:
+            return "Slack message content must not be empty."
+        case .broadcastMentionDenied:
+            return "Slack broadcast mentions are disabled for this connection."
+        case .invalidThreadId(let threadId):
+            return "Slack thread id `\(threadId)` must use `channel_id:thread_ts`."
+        case .configurationSaveFailed(let message):
+            return "Slack configuration could not be saved: \(message)"
+        case .api(let message):
+            return message
+        }
+    }
+}
+
+final class SlackConnectionService: @unchecked Sendable {
+    static let shared = SlackConnectionService(
+        client: SlackAPIClient(),
+        credentialStore: KeychainSlackCredentialStorage()
+    )
+
+    private let client: SlackAPIClientProtocol
+    private let credentialStore: any SlackCredentialStorage
+
+    init(
+        client: SlackAPIClientProtocol,
+        credentialStore: any SlackCredentialStorage = KeychainSlackCredentialStorage()
+    ) {
+        self.client = client
+        self.credentialStore = credentialStore
+    }
+
+    func configuration() -> SlackConnectionConfiguration {
+        SlackConnectionConfigurationStore.load()
+    }
+
+    func saveConfiguration(_ configuration: SlackConnectionConfiguration) throws {
+        do {
+            try SlackConnectionConfigurationStore.save(configuration)
+        } catch {
+            throw SlackConnectionServiceError.configurationSaveFailed(error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    func saveBotToken(_ token: String) throws -> Bool {
+        let saved = credentialStore.saveBotToken(token)
+        if !saved {
+            throw SlackConnectionServiceError.configurationSaveFailed(
+                "The bot token was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        credentialStore.deleteBotToken()
+    }
+
+    func hasBotToken() -> Bool {
+        credentialStore.hasBotToken()
+    }
+
+    @discardableResult
+    func saveSigningSecret(_ secret: String) throws -> Bool {
+        let saved = credentialStore.saveSigningSecret(secret)
+        if !saved {
+            throw SlackConnectionServiceError.configurationSaveFailed(
+                "The signing secret was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteSigningSecret() -> Bool {
+        credentialStore.deleteSigningSecret()
+    }
+
+    func hasSigningSecret() -> Bool {
+        credentialStore.hasSigningSecret()
+    }
+
+    func diagnostics() async -> SlackConnectionDiagnostics {
+        let config = configuration()
+        guard let token = credentialStore.botToken() else {
+            return SlackConnectionDiagnostics(
+                botTokenSaved: false,
+                signingSecretSaved: credentialStore.hasSigningSecret(),
+                identity: nil,
+                configuredTeams: [],
+                readableChannelIds: config.readableChannelIds,
+                writableChannelIds: config.writableChannelIds,
+                writeEnabled: config.writeEnabled,
+                allowBroadcastMentions: config.allowBroadcastMentions,
+                status: "not_configured",
+                failures: ["No Slack bot token is saved."]
+            )
+        }
+        let signingSecret = credentialStore.signingSecret()
+
+        let identity: SlackAuthIdentity?
+        var failures: [String] = []
+        do {
+            identity = try await client.authTest(token: token)
+        } catch {
+            identity = nil
+            failures.append(redacted(error, token: token, signingSecret: signingSecret))
+        }
+
+        var teamRows: [SlackConfiguredTeamDiagnostic] = []
+        if let identity {
+            let allowed = config.canUseTeam(teamId: identity.teamId)
+            teamRows.append(SlackConfiguredTeamDiagnostic(
+                id: identity.teamId,
+                name: identity.team ?? "",
+                status: allowed ? "accessible" : "not_allowlisted",
+                reason: allowed ? nil : "Workspace is not in configuredTeamIds."
+            ))
+        }
+        for teamId in config.configuredTeamIds where teamRows.allSatisfy({ $0.id != teamId }) {
+            teamRows.append(SlackConfiguredTeamDiagnostic(
+                id: teamId,
+                name: "",
+                status: "configured_not_current_token_team",
+                reason: "The saved bot token did not authenticate as this workspace."
+            ))
+        }
+
+        let status: String
+        if identity == nil {
+            status = "token_invalid_or_unavailable"
+        } else if let identity, !config.canUseTeam(teamId: identity.teamId) {
+            status = "connected_team_not_allowlisted"
+        } else if config.readableChannelIds.isEmpty && config.writableChannelIds.isEmpty {
+            status = "connected_needs_allowlist"
+        } else if config.writeEnabled && config.writableChannelIds.isEmpty {
+            status = "connected_read_only_write_needs_channels"
+        } else if config.writeEnabled {
+            status = "connected_read_write"
+        } else {
+            status = "connected_read_only"
+        }
+
+        return SlackConnectionDiagnostics(
+            botTokenSaved: true,
+            signingSecretSaved: signingSecret != nil,
+            identity: identity,
+            configuredTeams: teamRows,
+            readableChannelIds: config.readableChannelIds,
+            writableChannelIds: config.writableChannelIds,
+            writeEnabled: config.writeEnabled,
+            allowBroadcastMentions: config.allowBroadcastMentions,
+            status: status,
+            failures: failures
+        )
+    }
+
+    func listWorkspaces() async throws -> [[String: Any]] {
+        let token = try requireToken()
+        let config = configuration()
+        let identity = try await client.authTest(token: token)
+        guard config.canUseTeam(teamId: identity.teamId) else {
+            throw SlackConnectionServiceError.teamNotConfigured(identity.teamId)
+        }
+        return [[
+            "id": identity.teamId,
+            "name": identity.team ?? identity.teamId,
+            "configured": config.configuredTeamIds.isEmpty || config.configuredTeamIds.contains(identity.teamId),
+        ]]
+    }
+
+    func listChannels(teamId: String) async throws -> [[String: Any]] {
+        let token = try requireToken()
+        let config = configuration()
+        let normalizedTeamId = try requireSlackId(teamId, field: "team_id")
+        guard config.canUseTeam(teamId: normalizedTeamId) else {
+            throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
+        }
+        let identity = try await client.authTest(token: token)
+        guard identity.teamId == normalizedTeamId else {
+            throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
+        }
+
+        let channels = try await client.conversations(token: token, limit: 100)
+        return channels.map { channel in
+            [
+                "id": channel.id,
+                "name": channel.displayName,
+                "type": channel.kind,
+                "team_id": normalizedTeamId,
+                "is_private": channel.isPrivate ?? false,
+                "is_member": channel.isMember ?? false,
+                "read_allowed": config.canRead(channelId: channel.id),
+                "write_allowed": config.canWrite(channelId: channel.id),
+            ]
+        }
+    }
+
+    func readChannel(channelId: String, limit: Int?) async throws -> [String: Any] {
+        let token = try requireToken()
+        let config = configuration()
+        let normalizedChannelId = try requireReadableChannel(channelId, config: config)
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit ?? config.defaultReadLimit)
+        let messages = try await client.messages(
+            channelId: normalizedChannelId,
+            token: token,
+            limit: safeLimit
+        )
+        return [
+            "kind": "slack_recent_messages",
+            "channel_id": normalizedChannelId,
+            "limit": safeLimit,
+            "partial": true,
+            "messages": messages.map { Self.messageDictionary($0, channelId: normalizedChannelId) },
+        ]
+    }
+
+    func readThread(threadId: String, limit: Int?) async throws -> [String: Any] {
+        let token = try requireToken()
+        let config = configuration()
+        let parsed = try parseThreadId(threadId)
+        let normalizedChannelId = try requireReadableChannel(parsed.channelId, config: config)
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limit ?? config.defaultReadLimit)
+        let messages = try await client.threadMessages(
+            channelId: normalizedChannelId,
+            threadTs: parsed.threadTs,
+            token: token,
+            limit: safeLimit
+        )
+        return [
+            "kind": "slack_thread_messages",
+            "channel_id": normalizedChannelId,
+            "thread_id": "\(normalizedChannelId):\(parsed.threadTs)",
+            "thread_ts": parsed.threadTs,
+            "limit": safeLimit,
+            "partial": true,
+            "messages": messages.map { Self.messageDictionary($0, channelId: normalizedChannelId) },
+        ]
+    }
+
+    func findRecentMessages(
+        query: String,
+        channelIds: [String]?,
+        limitPerChannel: Int?,
+        maxMatches: Int?
+    ) async throws -> [String: Any] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else {
+            throw SlackConnectionServiceError.emptyMessage
+        }
+
+        let config = configuration()
+        let candidateChannels = SlackConnectionConfiguration.normalizedIds(
+            channelIds ?? config.readableChannelIds
+        )
+        let allowedChannels = candidateChannels.filter { config.canRead(channelId: $0) }
+        guard !allowedChannels.isEmpty else {
+            throw SlackConnectionServiceError.channelNotReadable(candidateChannels.first ?? "")
+        }
+
+        let token = try requireToken()
+        let safeLimit = SlackConnectionConfiguration.clampReadLimit(limitPerChannel ?? config.defaultReadLimit)
+        let safeMaxMatches = min(max(maxMatches ?? 25, 1), 50)
+        let needle = trimmedQuery.lowercased()
+        var matches: [[String: Any]] = []
+
+        for channelId in allowedChannels {
+            let messages = try await client.messages(channelId: channelId, token: token, limit: safeLimit)
+            for message in messages {
+                let haystack = "\(message.text ?? "") \(message.user ?? "") \(message.username ?? "")"
+                    .lowercased()
+                guard haystack.contains(needle) else { continue }
+                matches.append(Self.messageDictionary(message, channelId: channelId))
+                if matches.count >= safeMaxMatches { break }
+            }
+            if matches.count >= safeMaxMatches { break }
+        }
+
+        return [
+            "kind": "slack_recent_message_search",
+            "query": trimmedQuery,
+            "searched_channel_ids": allowedChannels,
+            "limit_per_channel": safeLimit,
+            "max_matches": safeMaxMatches,
+            "match_count": matches.count,
+            "partial": true,
+            "messages": matches,
+        ]
+    }
+
+    func draftMessage(channelId: String, content: String) throws -> [String: Any] {
+        let config = configuration()
+        let normalizedChannelId = try requireWritableChannel(channelId, config: config)
+        let trimmedContent = try validateMessageContent(content, config: config)
+        return [
+            "kind": "slack_message_draft",
+            "channel_id": normalizedChannelId,
+            "content": trimmedContent,
+            "requires_send_confirmation": true,
+            "mention_policy": mentionPolicyDictionary(config: config),
+        ]
+    }
+
+    func sendMessage(
+        channelId: String,
+        content: String,
+        confirmSend: Bool
+    ) async throws -> [String: Any] {
+        guard confirmSend else {
+            throw SlackConnectionServiceError.sendConfirmationRequired
+        }
+        let token = try requireToken()
+        let config = configuration()
+        let normalizedChannelId = try requireWritableChannel(channelId, config: config)
+        let trimmedContent = try validateMessageContent(content, config: config)
+        let message = try await client.sendMessage(
+            channelId: normalizedChannelId,
+            content: trimmedContent,
+            threadTs: nil,
+            token: token
+        )
+        return [
+            "kind": "slack_message_sent",
+            "channel_id": normalizedChannelId,
+            "message": Self.messageDictionary(message, channelId: normalizedChannelId),
+            "mention_policy": mentionPolicyDictionary(config: config),
+        ]
+    }
+
+    func replyToThread(
+        threadId: String,
+        content: String,
+        confirmSend: Bool
+    ) async throws -> [String: Any] {
+        guard confirmSend else {
+            throw SlackConnectionServiceError.sendConfirmationRequired
+        }
+        let token = try requireToken()
+        let config = configuration()
+        let parsed = try parseThreadId(threadId)
+        let normalizedChannelId = try requireWritableChannel(parsed.channelId, config: config)
+        let trimmedContent = try validateMessageContent(content, config: config)
+        let message = try await client.sendMessage(
+            channelId: normalizedChannelId,
+            content: trimmedContent,
+            threadTs: parsed.threadTs,
+            token: token
+        )
+        return [
+            "kind": "slack_thread_reply_sent",
+            "channel_id": normalizedChannelId,
+            "thread_id": "\(normalizedChannelId):\(parsed.threadTs)",
+            "thread_ts": parsed.threadTs,
+            "message": Self.messageDictionary(message, channelId: normalizedChannelId),
+            "mention_policy": mentionPolicyDictionary(config: config),
+        ]
+    }
+
+    private func requireToken() throws -> String {
+        guard let token = credentialStore.botToken() else {
+            throw SlackConnectionServiceError.notConfigured
+        }
+        return token
+    }
+
+    private func requireSlackId(_ id: String, field: String) throws -> String {
+        let normalized = SlackConnectionConfiguration.normalizedId(id)
+        guard SlackConnectionConfiguration.isValidSlackId(normalized) else {
+            throw SlackConnectionServiceError.invalidId(field: field)
+        }
+        return normalized
+    }
+
+    private func requireReadableChannel(
+        _ channelId: String,
+        config: SlackConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireSlackId(channelId, field: "channel_id")
+        guard config.canRead(channelId: normalized) else {
+            throw SlackConnectionServiceError.channelNotReadable(normalized)
+        }
+        return normalized
+    }
+
+    private func requireWritableChannel(
+        _ channelId: String,
+        config: SlackConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireSlackId(channelId, field: "channel_id")
+        guard config.writeEnabled else {
+            throw SlackConnectionServiceError.writeDisabled
+        }
+        guard config.canWrite(channelId: normalized) else {
+            throw SlackConnectionServiceError.channelNotWritable(normalized)
+        }
+        return normalized
+    }
+
+    private func validateMessageContent(
+        _ content: String,
+        config: SlackConnectionConfiguration
+    ) throws -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw SlackConnectionServiceError.emptyMessage
+        }
+        guard trimmed.count <= 40_000 else {
+            throw SlackConnectionServiceError.messageTooLong
+        }
+        if !config.allowBroadcastMentions && Self.containsBroadcastMention(trimmed) {
+            throw SlackConnectionServiceError.broadcastMentionDenied
+        }
+        return trimmed
+    }
+
+    private func parseThreadId(_ threadId: String) throws -> (channelId: String, threadTs: String) {
+        let normalized = SlackConnectionConfiguration.normalizedId(threadId)
+        let parts = normalized.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2,
+              SlackConnectionConfiguration.isValidSlackId(String(parts[0])),
+              Self.isValidThreadTimestamp(String(parts[1]))
+        else {
+            throw SlackConnectionServiceError.invalidThreadId(normalized)
+        }
+        return (String(parts[0]), String(parts[1]))
+    }
+
+    private func redacted(_ error: Error, token: String, signingSecret: String?) -> String {
+        SlackSecurity.redact(error.localizedDescription, token: token, signingSecret: signingSecret)
+    }
+
+    private func mentionPolicyDictionary(config: SlackConnectionConfiguration) -> [String: Any] {
+        [
+            "parse": "none",
+            "link_names": false,
+            "reply_broadcast": false,
+            "allow_broadcast_mentions": config.allowBroadcastMentions,
+        ]
+    }
+
+    private static func containsBroadcastMention(_ content: String) -> Bool {
+        let lowered = content.lowercased()
+        return lowered.contains("<!channel")
+            || lowered.contains("<!here")
+            || lowered.contains("<!everyone")
+    }
+
+    private static func isValidThreadTimestamp(_ value: String) -> Bool {
+        let parts = value.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2 else { return false }
+        return parts.allSatisfy { part in
+            !part.isEmpty && part.allSatisfy { $0.isASCII && $0.isNumber }
+        }
+    }
+
+    private static func messageDictionary(_ message: SlackMessage, channelId: String) -> [String: Any] {
+        let threadTs = message.threadTs ?? message.ts
+        return [
+            "id": message.ts,
+            "channel_id": channelId,
+            "content": message.text ?? "",
+            "timestamp": message.ts,
+            "thread_id": "\(channelId):\(threadTs)",
+            "thread_ts": threadTs,
+            "author": [
+                "id": message.user ?? message.botId ?? "",
+                "username": message.username ?? "",
+                "display_name": message.username ?? message.user ?? message.botId ?? "",
+                "is_bot": message.botId != nil,
+            ],
+            "reply_count": message.replyCount ?? 0,
+            "attachments": [] as [[String: Any]],
+        ]
+    }
+}

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -29,6 +29,7 @@ struct SlackConfiguredTeamDiagnostic: Equatable, Sendable {
 struct SlackConnectionDiagnostics: Equatable, Sendable {
     let botTokenSaved: Bool
     let signingSecretSaved: Bool
+    let appTokenSaved: Bool
     let identity: SlackAuthIdentity?
     let configuredTeams: [SlackConfiguredTeamDiagnostic]
     let readableChannelIds: [String]
@@ -42,6 +43,7 @@ struct SlackConnectionDiagnostics: Equatable, Sendable {
         var result: [String: Any] = [
             "bot_token_saved": botTokenSaved,
             "signing_secret_saved": signingSecretSaved,
+            "app_token_saved": appTokenSaved,
             "configured_teams": configuredTeams.map(\.dictionary),
             "readable_channel_ids": readableChannelIds,
             "writable_channel_ids": writableChannelIds,
@@ -284,6 +286,26 @@ final class SlackConnectionService: @unchecked Sendable {
         credentialStore.hasSigningSecret()
     }
 
+    @discardableResult
+    func saveAppToken(_ token: String) throws -> Bool {
+        let saved = credentialStore.saveAppToken(token)
+        if !saved {
+            throw SlackConnectionServiceError.configurationSaveFailed(
+                "The app-level token was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteAppToken() -> Bool {
+        credentialStore.deleteAppToken()
+    }
+
+    func hasAppToken() -> Bool {
+        credentialStore.hasAppToken()
+    }
+
     func messageStoreDiagnostics() -> [String: Any] {
         [
             "enabled": messageStore != nil,
@@ -300,6 +322,7 @@ final class SlackConnectionService: @unchecked Sendable {
             return SlackConnectionDiagnostics(
                 botTokenSaved: false,
                 signingSecretSaved: credentialStore.hasSigningSecret(),
+                appTokenSaved: credentialStore.hasAppToken(),
                 identity: nil,
                 configuredTeams: [],
                 readableChannelIds: config.readableChannelIds,
@@ -311,6 +334,7 @@ final class SlackConnectionService: @unchecked Sendable {
             )
         }
         let signingSecret = credentialStore.signingSecret()
+        let appToken = credentialStore.appToken()
 
         let identity: SlackAuthIdentity?
         var failures: [String] = []
@@ -321,7 +345,7 @@ final class SlackConnectionService: @unchecked Sendable {
             }
         } catch {
             identity = nil
-            failures.append(redacted(error, token: token, signingSecret: signingSecret))
+            failures.append(redacted(error, token: token, signingSecret: signingSecret, appToken: appToken))
         }
 
         var teamRows: [SlackConfiguredTeamDiagnostic] = []
@@ -361,6 +385,7 @@ final class SlackConnectionService: @unchecked Sendable {
         return SlackConnectionDiagnostics(
             botTokenSaved: true,
             signingSecretSaved: signingSecret != nil,
+            appTokenSaved: appToken != nil,
             identity: identity,
             configuredTeams: teamRows,
             readableChannelIds: config.readableChannelIds,
@@ -649,8 +674,18 @@ final class SlackConnectionService: @unchecked Sendable {
         return (String(parts[0]), String(parts[1]))
     }
 
-    private func redacted(_ error: Error, token: String, signingSecret: String?) -> String {
-        SlackSecurity.redact(error.localizedDescription, token: token, signingSecret: signingSecret)
+    private func redacted(
+        _ error: Error,
+        token: String,
+        signingSecret: String?,
+        appToken: String?
+    ) -> String {
+        SlackSecurity.redact(
+            error.localizedDescription,
+            token: token,
+            signingSecret: signingSecret,
+            appToken: appToken
+        )
     }
 
     func normalizeInboundEvent(_ envelope: SlackEventEnvelope) -> SlackNormalizedInboundMessage? {

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -34,6 +34,7 @@ struct SlackConnectionDiagnostics: Equatable, Sendable {
     let configuredTeams: [SlackConfiguredTeamDiagnostic]
     let readableChannelIds: [String]
     let writableChannelIds: [String]
+    let senderAllowlist: [String]
     let writeEnabled: Bool
     let allowBroadcastMentions: Bool
     let status: String
@@ -47,6 +48,7 @@ struct SlackConnectionDiagnostics: Equatable, Sendable {
             "configured_teams": configuredTeams.map(\.dictionary),
             "readable_channel_ids": readableChannelIds,
             "writable_channel_ids": writableChannelIds,
+            "sender_allowlist": senderAllowlist,
             "write_enabled": writeEnabled,
             "allow_broadcast_mentions": allowBroadcastMentions,
             "status": status,
@@ -226,7 +228,18 @@ final class SlackConnectionService: @unchecked Sendable {
 
     func saveConfiguration(_ configuration: SlackConnectionConfiguration) throws {
         do {
-            try SlackConnectionConfigurationStore.save(configuration)
+            var merged = configuration.normalized
+            let current = SlackConnectionConfigurationStore.load()
+            if merged.botUserId == nil {
+                merged.botUserId = current.botUserId
+            }
+            if merged.botId == nil {
+                merged.botId = current.botId
+            }
+            if merged.apiAppId == nil {
+                merged.apiAppId = current.apiAppId
+            }
+            try SlackConnectionConfigurationStore.save(merged)
         } catch {
             throw SlackConnectionServiceError.configurationSaveFailed(error.localizedDescription)
         }
@@ -306,6 +319,29 @@ final class SlackConnectionService: @unchecked Sendable {
         credentialStore.hasAppToken()
     }
 
+    func socketModeAppToken() -> String? {
+        credentialStore.appToken()
+    }
+
+    @discardableResult
+    func ensureBotIdentity() async throws -> SlackAuthIdentity? {
+        let config = configuration()
+        guard config.botUserId == nil && config.botId == nil else { return nil }
+        let token = try requireToken()
+        do {
+            let identity = try await client.authTest(token: token)
+            persistIdentity(identity)
+            return identity
+        } catch {
+            throw SlackConnectionServiceError.api(redacted(
+                error,
+                token: token,
+                signingSecret: credentialStore.signingSecret(),
+                appToken: credentialStore.appToken()
+            ))
+        }
+    }
+
     func messageStoreDiagnostics() -> [String: Any] {
         [
             "enabled": messageStore != nil,
@@ -327,6 +363,7 @@ final class SlackConnectionService: @unchecked Sendable {
                 configuredTeams: [],
                 readableChannelIds: config.readableChannelIds,
                 writableChannelIds: config.writableChannelIds,
+                senderAllowlist: config.senderAllowlist,
                 writeEnabled: config.writeEnabled,
                 allowBroadcastMentions: config.allowBroadcastMentions,
                 status: "not_configured",
@@ -367,6 +404,11 @@ final class SlackConnectionService: @unchecked Sendable {
             ))
         }
 
+        let receiveCredentialSaved = signingSecret != nil || appToken != nil
+        let receiveNeedsSenderAllowlist = receiveCredentialSaved
+            && !config.readableChannelIds.isEmpty
+            && config.senderAllowlist.isEmpty
+
         let status: String
         if identity == nil {
             status = "token_invalid_or_unavailable"
@@ -374,12 +416,20 @@ final class SlackConnectionService: @unchecked Sendable {
             status = "connected_team_not_allowlisted"
         } else if config.readableChannelIds.isEmpty && config.writableChannelIds.isEmpty {
             status = "connected_needs_allowlist"
+        } else if receiveNeedsSenderAllowlist {
+            status = "connected_receive_needs_sender_allowlist"
         } else if config.writeEnabled && config.writableChannelIds.isEmpty {
             status = "connected_read_only_write_needs_channels"
         } else if config.writeEnabled {
             status = "connected_read_write"
         } else {
             status = "connected_read_only"
+        }
+
+        if receiveNeedsSenderAllowlist {
+            failures.append(
+                "Slack receive is configured with readable channels but no authorized sender IDs; inbound events will be denied before storage or dispatch."
+            )
         }
 
         return SlackConnectionDiagnostics(
@@ -390,6 +440,7 @@ final class SlackConnectionService: @unchecked Sendable {
             configuredTeams: teamRows,
             readableChannelIds: config.readableChannelIds,
             writableChannelIds: config.writableChannelIds,
+            senderAllowlist: config.senderAllowlist,
             writeEnabled: config.writeEnabled,
             allowBroadcastMentions: config.allowBroadcastMentions,
             status: status,
@@ -696,6 +747,14 @@ final class SlackConnectionService: @unchecked Sendable {
         _ envelope: SlackEventEnvelope,
         config: SlackConnectionConfiguration
     ) -> SlackNormalizedInboundMessage? {
+        normalizeInboundEvent(envelope, config: config, enforceSenderAllowlist: true)
+    }
+
+    private func normalizeInboundEvent(
+        _ envelope: SlackEventEnvelope,
+        config: SlackConnectionConfiguration,
+        enforceSenderAllowlist: Bool
+    ) -> SlackNormalizedInboundMessage? {
         guard let providerEventId = envelope.eventId?.trimmingCharacters(in: .whitespacesAndNewlines),
               !providerEventId.isEmpty,
               let event = envelope.event,
@@ -721,6 +780,11 @@ final class SlackConnectionService: @unchecked Sendable {
             return nil
         }
 
+        let authorId = event.user ?? event.botId
+        if enforceSenderAllowlist && !config.canUseSender(senderId: authorId) {
+            return nil
+        }
+
         let content = event.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let threadTs = event.threadTs.flatMap { candidate -> String? in
             let normalized = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -736,7 +800,7 @@ final class SlackConnectionService: @unchecked Sendable {
             providerMessageId: messageTs,
             threadId: "\(channelId):\(threadTs)",
             threadTs: threadTs,
-            authorId: event.user ?? event.botId,
+            authorId: authorId,
             content: content,
             isThreadReply: threadTs != messageTs,
             isMention: event.type == "app_mention" || mentionsBot,
@@ -770,22 +834,48 @@ final class SlackConnectionService: @unchecked Sendable {
     }
 
     func recordInboundEvent(_ envelope: SlackEventEnvelope) throws -> SlackNormalizedInboundMessage? {
-        guard let normalized = normalizeInboundEvent(envelope) else { return nil }
-        guard let messageStore else { return normalized }
+        let config = configuration()
+        guard let normalized = normalizeInboundEvent(
+            envelope,
+            config: config,
+            enforceSenderAllowlist: messageStore == nil
+        ) else { return nil }
+        guard let messageStore else {
+            return normalized
+        }
         try messageStore.openIfNeeded()
-        guard try messageStore.markEventSeen(
+        let authorizationService = AgentChannelConnectionService(
+            discordService: .shared,
+            slackService: self,
+            telegramService: .shared
+        )
+        let authorization = try authorizationService.authorizeInboundMessage(
+            AgentChannelInboundMessageAuthorizationRequest(
+                connectionId: normalized.connectionId,
+                providerEventId: normalized.providerEventId,
+                providerMessageId: normalized.providerMessageId,
+                spaceId: normalized.teamId,
+                roomId: normalized.roomId,
+                senderId: normalized.authorId,
+                isBotMessage: envelope.event?.botId != nil,
+                isSelfMessage: false
+            ),
+            messageStore: messageStore
+        )
+        _ = try messageStore.recordReceiveEvent(
             connectionId: normalized.connectionId,
-            providerEventId: normalized.providerEventId
-        ) else {
+            providerEventId: normalized.providerEventId,
+            authorization: authorization,
+            message: normalized.storedMessage
+        )
+        guard authorization.decision == .allow,
+              try messageStore.markEventSeen(
+                  connectionId: normalized.connectionId,
+                  providerEventId: Self.inboundDispatchEventId(normalized)
+              )
+        else {
             return nil
         }
-        guard try messageStore.markEventSeen(
-            connectionId: normalized.connectionId,
-            providerEventId: Self.inboundDispatchEventId(normalized)
-        ) else {
-            return nil
-        }
-        _ = try messageStore.recordMessages([normalized.storedMessage])
         return normalized
     }
 

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -63,6 +63,81 @@ struct SlackConnectionDiagnostics: Equatable, Sendable {
     }
 }
 
+struct SlackEventEnvelope: Codable, Equatable, Sendable {
+    let token: String?
+    let teamId: String?
+    let apiAppId: String?
+    let event: SlackEventMessage?
+    let type: String?
+    let eventId: String?
+    let eventTime: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case teamId = "team_id"
+        case apiAppId = "api_app_id"
+        case event
+        case type
+        case eventId = "event_id"
+        case eventTime = "event_time"
+    }
+}
+
+struct SlackEventMessage: Codable, Equatable, Sendable {
+    let type: String?
+    let subtype: String?
+    let channel: String?
+    let user: String?
+    let botId: String?
+    let text: String?
+    let ts: String?
+    let threadTs: String?
+    let channelType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case subtype
+        case channel
+        case user
+        case botId = "bot_id"
+        case text
+        case ts
+        case threadTs = "thread_ts"
+        case channelType = "channel_type"
+    }
+}
+
+struct SlackNormalizedInboundMessage: Equatable, Sendable {
+    let connectionId: String
+    let providerEventId: String
+    let teamId: String?
+    let roomId: String
+    let providerMessageId: String
+    let threadId: String
+    let threadTs: String
+    let authorId: String?
+    let content: String
+    let isThreadReply: Bool
+    let isMention: Bool
+    let mentionedUserIds: [String]
+    let payloadJSON: String
+
+    var storedMessage: AgentChannelStoredMessage {
+        AgentChannelStoredMessage(
+            connectionId: connectionId,
+            roomId: roomId,
+            providerMessageId: providerMessageId,
+            direction: .inbound,
+            threadId: threadId,
+            authorId: authorId,
+            authorName: nil,
+            content: content,
+            payloadJSON: payloadJSON,
+            providerTimestamp: providerMessageId
+        )
+    }
+}
+
 enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
     case notConfigured
     case invalidId(field: String)
@@ -76,6 +151,9 @@ enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
     case broadcastMentionDenied
     case invalidThreadId(String)
     case configurationSaveFailed(String)
+    case signingSecretNotConfigured
+    case signatureVerificationFailed
+    case invalidInboundPayload
     case api(String)
 
     var errorDescription: String? {
@@ -104,6 +182,12 @@ enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
             return "Slack thread id `\(threadId)` must use `channel_id:thread_ts`."
         case .configurationSaveFailed(let message):
             return "Slack configuration could not be saved: \(message)"
+        case .signingSecretNotConfigured:
+            return "Slack signing secret is not configured."
+        case .signatureVerificationFailed:
+            return "Slack request signature could not be verified."
+        case .invalidInboundPayload:
+            return "Slack inbound event payload could not be decoded."
         case .api(let message):
             return message
         }
@@ -113,18 +197,25 @@ enum SlackConnectionServiceError: LocalizedError, Equatable, Sendable {
 final class SlackConnectionService: @unchecked Sendable {
     static let shared = SlackConnectionService(
         client: SlackAPIClient(),
-        credentialStore: KeychainSlackCredentialStorage()
+        credentialStore: KeychainSlackCredentialStorage(),
+        messageStore: AgentChannelMessageStore.shared
     )
 
     private let client: SlackAPIClientProtocol
     private let credentialStore: any SlackCredentialStorage
+    private let messageStore: AgentChannelMessageStore?
+    private let recordMessageSnapshotsInline: Bool
 
     init(
         client: SlackAPIClientProtocol,
-        credentialStore: any SlackCredentialStorage = KeychainSlackCredentialStorage()
+        credentialStore: any SlackCredentialStorage = KeychainSlackCredentialStorage(),
+        messageStore: AgentChannelMessageStore? = nil,
+        recordMessageSnapshotsInline: Bool = false
     ) {
         self.client = client
         self.credentialStore = credentialStore
+        self.messageStore = messageStore
+        self.recordMessageSnapshotsInline = recordMessageSnapshotsInline
     }
 
     func configuration() -> SlackConnectionConfiguration {
@@ -136,6 +227,20 @@ final class SlackConnectionService: @unchecked Sendable {
             try SlackConnectionConfigurationStore.save(configuration)
         } catch {
             throw SlackConnectionServiceError.configurationSaveFailed(error.localizedDescription)
+        }
+    }
+
+    private func persistIdentity(_ identity: SlackAuthIdentity) {
+        var config = configuration()
+        guard config.botUserId != identity.userId || config.botId != identity.botId else {
+            return
+        }
+        config.botUserId = identity.userId
+        config.botId = identity.botId
+        do {
+            try SlackConnectionConfigurationStore.save(config)
+        } catch {
+            NSLog("[Slack] Failed to persist bot identity: \(error.localizedDescription)")
         }
     }
 
@@ -179,6 +284,16 @@ final class SlackConnectionService: @unchecked Sendable {
         credentialStore.hasSigningSecret()
     }
 
+    func messageStoreDiagnostics() -> [String: Any] {
+        [
+            "enabled": messageStore != nil,
+            "open": messageStore?.isOpen ?? false,
+            "database_path": OsaurusPaths.agentChannelMessagesDatabaseFile().path,
+            "message_dedupe": "connection_id + room_id + provider_message_id",
+            "event_dedupe": "connection_id + provider_event_id",
+        ]
+    }
+
     func diagnostics() async -> SlackConnectionDiagnostics {
         let config = configuration()
         guard let token = credentialStore.botToken() else {
@@ -201,6 +316,9 @@ final class SlackConnectionService: @unchecked Sendable {
         var failures: [String] = []
         do {
             identity = try await client.authTest(token: token)
+            if let identity {
+                persistIdentity(identity)
+            }
         } catch {
             identity = nil
             failures.append(redacted(error, token: token, signingSecret: signingSecret))
@@ -258,6 +376,7 @@ final class SlackConnectionService: @unchecked Sendable {
         let token = try requireToken()
         let config = configuration()
         let identity = try await client.authTest(token: token)
+        persistIdentity(identity)
         guard config.canUseTeam(teamId: identity.teamId) else {
             throw SlackConnectionServiceError.teamNotConfigured(identity.teamId)
         }
@@ -276,6 +395,7 @@ final class SlackConnectionService: @unchecked Sendable {
             throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
         }
         let identity = try await client.authTest(token: token)
+        persistIdentity(identity)
         guard identity.teamId == normalizedTeamId else {
             throw SlackConnectionServiceError.teamNotConfigured(normalizedTeamId)
         }
@@ -287,8 +407,8 @@ final class SlackConnectionService: @unchecked Sendable {
                 "name": channel.displayName,
                 "type": channel.kind,
                 "team_id": normalizedTeamId,
-                "is_private": channel.isPrivate ?? false,
-                "is_member": channel.isMember ?? false,
+                "is_private": channel.isPrivate,
+                "is_member": channel.isMember,
                 "read_allowed": config.canRead(channelId: channel.id),
                 "write_allowed": config.canWrite(channelId: channel.id),
             ]
@@ -305,6 +425,7 @@ final class SlackConnectionService: @unchecked Sendable {
             token: token,
             limit: safeLimit
         )
+        recordMessages(messages, channelId: normalizedChannelId, direction: .inbound)
         return [
             "kind": "slack_recent_messages",
             "channel_id": normalizedChannelId,
@@ -326,6 +447,7 @@ final class SlackConnectionService: @unchecked Sendable {
             token: token,
             limit: safeLimit
         )
+        recordMessages(messages, channelId: normalizedChannelId, direction: .inbound)
         return [
             "kind": "slack_thread_messages",
             "channel_id": normalizedChannelId,
@@ -365,6 +487,7 @@ final class SlackConnectionService: @unchecked Sendable {
 
         for channelId in allowedChannels {
             let messages = try await client.messages(channelId: channelId, token: token, limit: safeLimit)
+            recordMessages(messages, channelId: channelId, direction: .inbound)
             for message in messages {
                 let haystack = "\(message.text ?? "") \(message.user ?? "") \(message.username ?? "")"
                     .lowercased()
@@ -412,12 +535,13 @@ final class SlackConnectionService: @unchecked Sendable {
         let config = configuration()
         let normalizedChannelId = try requireWritableChannel(channelId, config: config)
         let trimmedContent = try validateMessageContent(content, config: config)
-        let message = try await client.sendMessage(
+        let request = SlackOutboundMessageRequest(
             channelId: normalizedChannelId,
             content: trimmedContent,
-            threadTs: nil,
-            token: token
+            threadTs: nil
         )
+        let message = try await client.sendMessage(request, token: token)
+        recordMessages([message], channelId: normalizedChannelId, direction: .outbound)
         return [
             "kind": "slack_message_sent",
             "channel_id": normalizedChannelId,
@@ -439,12 +563,13 @@ final class SlackConnectionService: @unchecked Sendable {
         let parsed = try parseThreadId(threadId)
         let normalizedChannelId = try requireWritableChannel(parsed.channelId, config: config)
         let trimmedContent = try validateMessageContent(content, config: config)
-        let message = try await client.sendMessage(
+        let request = SlackOutboundMessageRequest(
             channelId: normalizedChannelId,
             content: trimmedContent,
-            threadTs: parsed.threadTs,
-            token: token
+            threadTs: parsed.threadTs
         )
+        let message = try await client.sendMessage(request, token: token)
+        recordMessages([message], channelId: normalizedChannelId, direction: .outbound)
         return [
             "kind": "slack_thread_reply_sent",
             "channel_id": normalizedChannelId,
@@ -528,6 +653,188 @@ final class SlackConnectionService: @unchecked Sendable {
         SlackSecurity.redact(error.localizedDescription, token: token, signingSecret: signingSecret)
     }
 
+    func normalizeInboundEvent(_ envelope: SlackEventEnvelope) -> SlackNormalizedInboundMessage? {
+        normalizeInboundEvent(envelope, config: configuration())
+    }
+
+    func normalizeInboundEvent(
+        _ envelope: SlackEventEnvelope,
+        config: SlackConnectionConfiguration
+    ) -> SlackNormalizedInboundMessage? {
+        guard let providerEventId = envelope.eventId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !providerEventId.isEmpty,
+              let event = envelope.event,
+              ["message", "app_mention"].contains(event.type ?? ""),
+              event.subtype == nil,
+              let teamId = envelope.teamId.map(SlackConnectionConfiguration.normalizedId),
+              SlackConnectionConfiguration.isValidSlackId(teamId),
+              let channelId = event.channel.map(SlackConnectionConfiguration.normalizedId),
+              SlackConnectionConfiguration.isValidSlackId(channelId),
+              let messageTs = event.ts?.trimmingCharacters(in: .whitespacesAndNewlines),
+              Self.isValidThreadTimestamp(messageTs)
+        else {
+            return nil
+        }
+        guard config.canUseTeam(teamId: teamId),
+              config.canRead(channelId: channelId),
+              config.botUserId != nil || config.botId != nil
+        else {
+            return nil
+        }
+
+        guard !Self.isOwnMessage(event: event, config: config) else {
+            return nil
+        }
+
+        let content = event.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let threadTs = event.threadTs.flatMap { candidate -> String? in
+            let normalized = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            return Self.isValidThreadTimestamp(normalized) ? normalized : nil
+        } ?? messageTs
+        let mentionedUserIds = Self.mentionedUserIds(in: content)
+        let mentionsBot = config.botUserId.map(mentionedUserIds.contains) ?? false
+        return SlackNormalizedInboundMessage(
+            connectionId: AgentChannelConnection.nativeSlackConnectionId,
+            providerEventId: providerEventId,
+            teamId: teamId,
+            roomId: channelId,
+            providerMessageId: messageTs,
+            threadId: "\(channelId):\(threadTs)",
+            threadTs: threadTs,
+            authorId: event.user ?? event.botId,
+            content: content,
+            isThreadReply: threadTs != messageTs,
+            isMention: event.type == "app_mention" || mentionsBot,
+            mentionedUserIds: mentionedUserIds,
+            payloadJSON: Self.encodedInboundPayload(envelope)
+        )
+    }
+
+    func recordVerifiedInboundEvent(
+        body: Data,
+        timestamp: String,
+        signature: String,
+        now: Date = Date()
+    ) throws -> SlackNormalizedInboundMessage? {
+        guard let signingSecret = credentialStore.signingSecret() else {
+            throw SlackConnectionServiceError.signingSecretNotConfigured
+        }
+        guard SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: body,
+            signature: signature,
+            now: now
+        ) else {
+            throw SlackConnectionServiceError.signatureVerificationFailed
+        }
+        guard let envelope = try? JSONDecoder().decode(SlackEventEnvelope.self, from: body) else {
+            throw SlackConnectionServiceError.invalidInboundPayload
+        }
+        return try recordInboundEvent(envelope)
+    }
+
+    func recordInboundEvent(_ envelope: SlackEventEnvelope) throws -> SlackNormalizedInboundMessage? {
+        guard let normalized = normalizeInboundEvent(envelope) else { return nil }
+        guard let messageStore else { return normalized }
+        try messageStore.openIfNeeded()
+        guard try messageStore.markEventSeen(
+            connectionId: normalized.connectionId,
+            providerEventId: normalized.providerEventId
+        ) else {
+            return nil
+        }
+        guard try messageStore.markEventSeen(
+            connectionId: normalized.connectionId,
+            providerEventId: Self.inboundDispatchEventId(normalized)
+        ) else {
+            return nil
+        }
+        _ = try messageStore.recordMessages([normalized.storedMessage])
+        return normalized
+    }
+
+    private static func inboundDispatchEventId(_ message: SlackNormalizedInboundMessage) -> String {
+        "slack-dispatch:\(message.roomId):\(message.providerMessageId)"
+    }
+
+    private func recordMessages(
+        _ messages: [SlackMessage],
+        channelId: String,
+        direction: AgentChannelStoredMessageDirection
+    ) {
+        guard let messageStore, !messages.isEmpty else { return }
+        let rows = messages.map { message in
+            Self.storedMessage(
+                message,
+                channelId: channelId,
+                direction: direction
+            )
+        }
+        if recordMessageSnapshotsInline {
+            Self.persistMessages(rows, messageStore: messageStore)
+        } else {
+            Task.detached(priority: .utility) {
+                Self.persistMessages(rows, messageStore: messageStore)
+            }
+        }
+    }
+
+    private static func persistMessages(
+        _ rows: [AgentChannelStoredMessage],
+        messageStore: AgentChannelMessageStore
+    ) {
+        do {
+            try messageStore.openIfNeeded()
+            _ = try messageStore.recordMessages(rows)
+        } catch {
+            NSLog("[Slack] Failed to record Agent Channel messages: \(error.localizedDescription)")
+        }
+    }
+
+    private static func storedMessage(
+        _ message: SlackMessage,
+        channelId: String,
+        direction: AgentChannelStoredMessageDirection
+    ) -> AgentChannelStoredMessage {
+        let threadTs = message.threadTs ?? message.ts
+        return AgentChannelStoredMessage(
+            connectionId: AgentChannelConnection.nativeSlackConnectionId,
+            roomId: channelId,
+            providerMessageId: message.ts,
+            direction: direction,
+            threadId: "\(channelId):\(threadTs)",
+            authorId: message.user ?? message.botId,
+            authorName: message.username,
+            content: message.text ?? "",
+            payloadJSON: encodedPayload(message),
+            providerTimestamp: message.ts
+        )
+    }
+
+    private static func encodedPayload<Payload: Encodable>(_ payload: Payload) -> String {
+        guard let data = try? JSONEncoder().encode(payload),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func encodedInboundPayload(_ envelope: SlackEventEnvelope) -> String {
+        encodedPayload(
+            SlackEventEnvelope(
+                token: nil,
+                teamId: envelope.teamId,
+                apiAppId: envelope.apiAppId,
+                event: envelope.event,
+                type: envelope.type,
+                eventId: envelope.eventId,
+                eventTime: envelope.eventTime
+            )
+        )
+    }
+
     private func mentionPolicyDictionary(config: SlackConnectionConfiguration) -> [String: Any] {
         [
             "parse": "none",
@@ -542,6 +849,33 @@ final class SlackConnectionService: @unchecked Sendable {
         return lowered.contains("<!channel")
             || lowered.contains("<!here")
             || lowered.contains("<!everyone")
+            || lowered.contains("<!subteam^")
+    }
+
+    private static func mentionedUserIds(in content: String) -> [String] {
+        let pattern = #"<@([A-Z0-9][A-Z0-9.-]{1,63})(?:\|[^>]+)?>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(content.startIndex ..< content.endIndex, in: content)
+        var seen = Set<String>()
+        return regex.matches(in: content, range: range).compactMap { match in
+            guard match.numberOfRanges == 2,
+                  let idRange = Range(match.range(at: 1), in: content)
+            else {
+                return nil
+            }
+            let id = String(content[idRange])
+            return seen.insert(id).inserted ? id : nil
+        }
+    }
+
+    private static func isOwnMessage(
+        event: SlackEventMessage,
+        config: SlackConnectionConfiguration
+    ) -> Bool {
+        let userId = SlackConnectionConfiguration.normalizedOptionalId(event.user)
+        let botId = SlackConnectionConfiguration.normalizedOptionalId(event.botId)
+        return userId.map { $0 == config.botUserId } == true
+            || botId.map { $0 == config.botId } == true
     }
 
     private static func isValidThreadTimestamp(_ value: String) -> Bool {

--- a/Packages/OsaurusCore/Services/Slack/SlackSocketModeTransportRuntime.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackSocketModeTransportRuntime.swift
@@ -1,0 +1,386 @@
+//
+//  SlackSocketModeTransportRuntime.swift
+//  osaurus
+//
+//  Desktop Slack Socket Mode receive runtime for native Agent Channels.
+//
+
+import Foundation
+
+protocol SlackSocketModeWebSocket: Sendable {
+    func receiveText() async throws -> String
+    func sendText(_ text: String) async throws
+    func cancel()
+}
+
+protocol SlackSocketModeWebSocketFactory: Sendable {
+    func connect(to url: URL) -> any SlackSocketModeWebSocket
+}
+
+struct URLSessionSlackSocketModeWebSocketFactory: SlackSocketModeWebSocketFactory {
+    private let sessionProvider: @Sendable () -> URLSession
+
+    init(sessionProvider: @escaping @Sendable () -> URLSession = { GlobalProxySettings.sharedSession() }) {
+        self.sessionProvider = sessionProvider
+    }
+
+    func connect(to url: URL) -> any SlackSocketModeWebSocket {
+        URLSessionSlackSocketModeWebSocket(url: url, session: sessionProvider())
+    }
+}
+
+final class URLSessionSlackSocketModeWebSocket: SlackSocketModeWebSocket, @unchecked Sendable {
+    private let task: URLSessionWebSocketTask
+
+    init(url: URL, session: URLSession) {
+        self.task = session.webSocketTask(with: url)
+        self.task.resume()
+    }
+
+    func receiveText() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            task.receive { result in
+                switch result {
+                case .success(.string(let text)):
+                    continuation.resume(returning: text)
+                case .success(.data(let data)):
+                    if let text = String(data: data, encoding: .utf8) {
+                        continuation.resume(returning: text)
+                    } else {
+                        continuation.resume(throwing: SlackSocketModeTransportError.invalidEnvelope)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                @unknown default:
+                    continuation.resume(throwing: SlackSocketModeTransportError.invalidEnvelope)
+                }
+            }
+        }
+    }
+
+    func sendText(_ text: String) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            task.send(.string(text)) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        task.cancel(with: .goingAway, reason: nil)
+    }
+}
+
+enum SlackSocketModeTransportError: LocalizedError, Equatable, Sendable {
+    case missingAppToken
+    case receiveNotConfigured
+    case invalidEnvelope
+    case disconnected(String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAppToken:
+            return "Slack Socket Mode app token is not configured."
+        case .receiveNotConfigured:
+            return "Slack Socket Mode receive requires readable channels and authorized sender IDs."
+        case .invalidEnvelope:
+            return "Slack Socket Mode envelope could not be decoded."
+        case .disconnected(let reason):
+            return reason.map { "Slack Socket Mode disconnected: \($0)" }
+                ?? "Slack Socket Mode disconnected."
+        }
+    }
+}
+
+struct SlackSocketModeProcessResult: Equatable, Sendable {
+    var received: Int
+    var stored: Int
+    var dispatchSuppressed: Int
+}
+
+actor SlackSocketModeTransportRuntime {
+    static let transportId = "slack_socket_mode"
+
+    private let service: SlackConnectionService
+    private let client: SlackAPIClientProtocol
+    private let webSocketFactory: any SlackSocketModeWebSocketFactory
+    private let healthCenter: AgentChannelTransportHealthCenter
+    private let backoffPolicy: AgentChannelTransportBackoffPolicy
+    private let sleeper: any AgentChannelTransportSleeping
+    private var worker: Task<Void, Never>?
+    private var currentSocket: (any SlackSocketModeWebSocket)?
+    private var consecutiveFailures = 0
+    private var lastHealth: AgentChannelTransportHealthState
+
+    init(
+        service: SlackConnectionService = .shared,
+        client: SlackAPIClientProtocol = SlackAPIClient(),
+        webSocketFactory: any SlackSocketModeWebSocketFactory = URLSessionSlackSocketModeWebSocketFactory(),
+        healthCenter: AgentChannelTransportHealthCenter = .shared,
+        backoffPolicy: AgentChannelTransportBackoffPolicy = AgentChannelTransportBackoffPolicy(),
+        sleeper: any AgentChannelTransportSleeping = AgentChannelTransportTaskSleeper()
+    ) {
+        self.service = service
+        self.client = client
+        self.webSocketFactory = webSocketFactory
+        self.healthCenter = healthCenter
+        self.backoffPolicy = backoffPolicy
+        self.sleeper = sleeper
+        self.lastHealth = AgentChannelTransportHealthState(
+            connectionId: AgentChannelConnection.nativeSlackConnectionId,
+            transportId: Self.transportId,
+            provider: .slack,
+            status: .idle,
+            severity: .info,
+            summary: "Slack Socket Mode is idle.",
+            isRunning: false,
+            receiveEnabled: false
+        )
+    }
+
+    func health() -> AgentChannelTransportHealthState {
+        lastHealth
+    }
+
+    func start(pollInterval: TimeInterval = 1) {
+        guard worker == nil else { return }
+        worker = Task { [weak self] in
+            await self?.runLoop(pollInterval: pollInterval)
+        }
+    }
+
+    func stop(now: Date = Date()) async {
+        let oldWorker = worker
+        worker = nil
+        currentSocket?.cancel()
+        currentSocket = nil
+        oldWorker?.cancel()
+        await oldWorker?.value
+        consecutiveFailures = 0
+        await publish(
+            AgentChannelTransportHealthState(
+                connectionId: AgentChannelConnection.nativeSlackConnectionId,
+                transportId: Self.transportId,
+                provider: .slack,
+                status: .idle,
+                severity: .info,
+                summary: "Slack Socket Mode is idle.",
+                isRunning: false,
+                receiveEnabled: service.hasAppToken(),
+                updatedAt: now
+            )
+        )
+    }
+
+    func runStep(
+        maxMessages: Int? = nil,
+        now: Date = Date(),
+        jitter: Double = Double.random(in: 0 ... 1)
+    ) async -> AgentChannelTransportStepResult {
+        let configuration = service.configuration()
+        guard let appToken = service.socketModeAppToken() else {
+            consecutiveFailures = 0
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: AgentChannelConnection.nativeSlackConnectionId,
+                    transportId: Self.transportId,
+                    provider: .slack,
+                    status: .disabled,
+                    severity: .info,
+                    summary: "Slack Socket Mode app token is not configured.",
+                    isRunning: false,
+                    receiveEnabled: false,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(disposition: .skipped, health: health)
+        }
+        guard !configuration.readableChannelIds.isEmpty,
+              !configuration.senderAllowlist.isEmpty
+        else {
+            consecutiveFailures = 0
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: AgentChannelConnection.nativeSlackConnectionId,
+                    transportId: Self.transportId,
+                    provider: .slack,
+                    status: .disabled,
+                    severity: .warning,
+                    summary: "Slack Socket Mode receive requires readable channels and authorized sender IDs.",
+                    isRunning: false,
+                    receiveEnabled: true,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(disposition: .skipped, health: health)
+        }
+
+        do {
+            try await service.ensureBotIdentity()
+            let url = try await client.openSocketModeConnection(appToken: appToken)
+            let socket = webSocketFactory.connect(to: url)
+            currentSocket = socket
+            consecutiveFailures = 0
+            _ = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: AgentChannelConnection.nativeSlackConnectionId,
+                    transportId: Self.transportId,
+                    provider: .slack,
+                    status: .healthy,
+                    severity: .info,
+                    summary: "Slack Socket Mode is connected.",
+                    isRunning: worker != nil,
+                    receiveEnabled: true,
+                    lastSuccessAt: now,
+                    updatedAt: now
+                )
+            )
+
+            var received = 0
+            var stored = 0
+            var suppressed = 0
+            while !Task.isCancelled {
+                if let maxMessages, received >= maxMessages {
+                    break
+                }
+                let text = try await socket.receiveText()
+                let result = try await processEnvelope(text, socket: socket)
+                received += result.received
+                stored += result.stored
+                suppressed += result.dispatchSuppressed
+            }
+            currentSocket = nil
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: AgentChannelConnection.nativeSlackConnectionId,
+                    transportId: Self.transportId,
+                    provider: .slack,
+                    status: .healthy,
+                    severity: .info,
+                    summary: "Slack Socket Mode processed inbound events.",
+                    isRunning: worker != nil,
+                    receiveEnabled: true,
+                    lastSuccessAt: now,
+                    lastReceivedCount: received,
+                    lastStoredCount: stored,
+                    dispatchSuppressedCount: suppressed,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(
+                disposition: .succeeded,
+                health: health,
+                received: received,
+                stored: stored,
+                dispatchAttempted: 0,
+                dispatchSuppressed: suppressed
+            )
+        } catch is CancellationError {
+            currentSocket?.cancel()
+            currentSocket = nil
+            let health = await publish(lastHealth)
+            return AgentChannelTransportStepResult(disposition: .skipped, health: health)
+        } catch {
+            currentSocket?.cancel()
+            currentSocket = nil
+            consecutiveFailures += 1
+            let delay = backoffPolicy.delay(consecutiveFailures: consecutiveFailures, jitter: jitter)
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: AgentChannelConnection.nativeSlackConnectionId,
+                    transportId: Self.transportId,
+                    provider: .slack,
+                    status: .failed,
+                    severity: .warning,
+                    summary: "Slack Socket Mode receive failed.",
+                    detail: error.localizedDescription,
+                    isRunning: worker != nil,
+                    receiveEnabled: true,
+                    lastFailureAt: now,
+                    nextRetryAt: now.addingTimeInterval(delay),
+                    consecutiveFailures: consecutiveFailures,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(
+                disposition: .failed,
+                health: health,
+                retryDelay: delay
+            )
+        }
+    }
+
+    func processEnvelope(
+        _ text: String,
+        socket: any SlackSocketModeWebSocket
+    ) async throws -> SlackSocketModeProcessResult {
+        guard let data = text.data(using: .utf8),
+              let envelope = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw SlackSocketModeTransportError.invalidEnvelope
+        }
+
+        if let envelopeId = envelope["envelope_id"] as? String,
+           !envelopeId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try await socket.sendText(Self.ackPayload(envelopeId: envelopeId))
+        }
+
+        if envelope["type"] as? String == "disconnect" {
+            throw SlackSocketModeTransportError.disconnected(envelope["reason"] as? String)
+        }
+
+        guard let payloadObject = envelope["payload"],
+              JSONSerialization.isValidJSONObject(payloadObject),
+              let payloadData = try? JSONSerialization.data(withJSONObject: payloadObject)
+        else {
+            return SlackSocketModeProcessResult(received: 0, stored: 0, dispatchSuppressed: 0)
+        }
+
+        guard let slackEnvelope = try? JSONDecoder().decode(SlackEventEnvelope.self, from: payloadData) else {
+            return SlackSocketModeProcessResult(received: 1, stored: 0, dispatchSuppressed: 0)
+        }
+
+        let stored = try service.recordInboundEvent(slackEnvelope) != nil ? 1 : 0
+        return SlackSocketModeProcessResult(
+            received: 1,
+            stored: stored,
+            dispatchSuppressed: stored
+        )
+    }
+
+    private func runLoop(pollInterval: TimeInterval) async {
+        while !Task.isCancelled {
+            let result = await runStep()
+            let delay = max(result.retryDelay ?? pollInterval, 1)
+            do {
+                try await sleeper.sleep(for: delay)
+            } catch {
+                break
+            }
+        }
+    }
+
+    @discardableResult
+    private func publish(_ health: AgentChannelTransportHealthState) async -> AgentChannelTransportHealthState {
+        lastHealth = health
+        await healthCenter.update(health)
+        return health
+    }
+
+    private static func ackPayload(envelopeId: String) throws -> String {
+        let data = try JSONSerialization.data(
+            withJSONObject: ["envelope_id": envelopeId],
+            options: .sortedKeys
+        )
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw SlackSocketModeTransportError.invalidEnvelope
+        }
+        return text
+    }
+}
+
+extension SlackSocketModeTransportRuntime: AgentChannelReceiveTransportRuntime {}

--- a/Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift
@@ -1,0 +1,338 @@
+//
+//  TelegramAPIClient.swift
+//  osaurus
+//
+//  Minimal Telegram Bot API client for the native agent channel.
+//
+
+import Foundation
+
+struct TelegramUser: Codable, Equatable, Sendable {
+    let id: Int64
+    let isBot: Bool
+    let firstName: String
+    let lastName: String?
+    let username: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case isBot = "is_bot"
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case username
+    }
+
+    var displayName: String {
+        if let username, !username.isEmpty { return "@\(username)" }
+        if let lastName, !lastName.isEmpty { return "\(firstName) \(lastName)" }
+        return firstName
+    }
+}
+
+struct TelegramChat: Codable, Equatable, Sendable {
+    let id: Int64
+    let type: String
+    let title: String?
+    let username: String?
+    let firstName: String?
+    let lastName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case title
+        case username
+        case firstName = "first_name"
+        case lastName = "last_name"
+    }
+
+    var stableId: String { "\(id)" }
+
+    var displayName: String {
+        if let title, !title.isEmpty { return title }
+        if let username, !username.isEmpty { return "@\(username)" }
+        if let firstName, let lastName, !lastName.isEmpty { return "\(firstName) \(lastName)" }
+        if let firstName, !firstName.isEmpty { return firstName }
+        return stableId
+    }
+}
+
+struct TelegramMessageReference: Codable, Equatable, Sendable {
+    let messageId: Int
+
+    enum CodingKeys: String, CodingKey {
+        case messageId = "message_id"
+    }
+}
+
+struct TelegramMessage: Codable, Equatable, Sendable {
+    let messageId: Int
+    let date: Int
+    let chat: TelegramChat
+    let from: TelegramUser?
+    let senderChat: TelegramChat?
+    let text: String?
+    let caption: String?
+    let replyToMessage: TelegramMessageReference?
+
+    enum CodingKeys: String, CodingKey {
+        case messageId = "message_id"
+        case date
+        case chat
+        case from
+        case senderChat = "sender_chat"
+        case text
+        case caption
+        case replyToMessage = "reply_to_message"
+    }
+
+    var contentText: String {
+        text ?? caption ?? ""
+    }
+}
+
+struct TelegramUpdate: Codable, Equatable, Sendable {
+    let updateId: Int64
+    let message: TelegramMessage?
+    let editedMessage: TelegramMessage?
+    let channelPost: TelegramMessage?
+    let editedChannelPost: TelegramMessage?
+
+    enum CodingKeys: String, CodingKey {
+        case updateId = "update_id"
+        case message
+        case editedMessage = "edited_message"
+        case channelPost = "channel_post"
+        case editedChannelPost = "edited_channel_post"
+    }
+
+    var primaryMessage: TelegramMessage? {
+        message ?? editedMessage ?? channelPost ?? editedChannelPost
+    }
+}
+
+enum TelegramDeliveryStatus: String, Codable, Equatable, Sendable {
+    case accepted
+    case sent
+    case duplicate
+    case ignored
+    case unauthorized
+    case failed
+}
+
+struct TelegramReadRequest: Equatable, Sendable {
+    let chatId: String
+    let limit: Int?
+}
+
+struct TelegramWriteRequest: Equatable, Sendable {
+    let chatId: String
+    let text: String
+    let replyToMessageId: Int?
+    let confirmSend: Bool
+}
+
+struct TelegramNormalizedInboundEvent: Equatable, Sendable {
+    let providerEventId: String
+    let roomId: String
+    let providerMessageId: String
+    let content: String
+    let senderId: String?
+    let authorName: String?
+    let isBotMessage: Bool
+    let isSelfMessage: Bool
+    let providerTimestamp: String
+    let payloadJSON: String
+}
+
+struct TelegramReceiveResult: Equatable, Sendable {
+    let providerEventId: String
+    let roomId: String?
+    let providerMessageId: String?
+    let status: TelegramDeliveryStatus
+    let reason: String?
+}
+
+struct TelegramReceiveBatchResult: Equatable, Sendable {
+    let source: String
+    let received: Int
+    let stored: Int
+    let results: [TelegramReceiveResult]
+}
+
+enum TelegramAPIError: LocalizedError, Equatable, Sendable {
+    case invalidToken
+    case forbidden(String)
+    case notFound(String)
+    case rateLimited(String)
+    case invalidResponse(String)
+    case requestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidToken:
+            return "Telegram rejected the bot token."
+        case .forbidden(let message),
+            .notFound(let message),
+            .rateLimited(let message),
+            .invalidResponse(let message),
+            .requestFailed(let message):
+            return message
+        }
+    }
+}
+
+protocol TelegramAPIClientProtocol: Sendable {
+    func getMe(token: String) async throws -> TelegramUser
+    func getChat(chatId: String, token: String) async throws -> TelegramChat
+    func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate]
+    func sendMessage(
+        chatId: String,
+        text: String,
+        replyToMessageId: Int?,
+        token: String
+    ) async throws -> TelegramMessage
+}
+
+final class TelegramAPIClient: TelegramAPIClientProtocol, @unchecked Sendable {
+    private let baseURL: URL
+    private let sessionProvider: @Sendable () -> URLSession
+
+    init(
+        baseURL: URL = URL(string: "https://api.telegram.org")!,
+        sessionProvider: @escaping @Sendable () -> URLSession = { GlobalProxySettings.sharedSession() }
+    ) {
+        self.baseURL = baseURL
+        self.sessionProvider = sessionProvider
+    }
+
+    func getMe(token: String) async throws -> TelegramUser {
+        try await post(method: "getMe", token: token, body: [:])
+    }
+
+    func getChat(chatId: String, token: String) async throws -> TelegramChat {
+        try await post(method: "getChat", token: token, body: ["chat_id": chatId])
+    }
+
+    func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate] {
+        var body: [String: Any] = [
+            "limit": min(max(limit, 1), 100),
+            "timeout": min(max(timeout, 0), 50),
+            "allowed_updates": ["message", "edited_message", "channel_post", "edited_channel_post"],
+        ]
+        if let offset {
+            body["offset"] = offset
+        }
+        return try await post(method: "getUpdates", token: token, body: body)
+    }
+
+    func sendMessage(
+        chatId: String,
+        text: String,
+        replyToMessageId: Int?,
+        token: String
+    ) async throws -> TelegramMessage {
+        var body: [String: Any] = [
+            "chat_id": chatId,
+            "text": text,
+            "disable_web_page_preview": true,
+        ]
+        if let replyToMessageId {
+            body["reply_to_message_id"] = replyToMessageId
+        }
+        return try await post(method: "sendMessage", token: token, body: body)
+    }
+
+    private func post<T: Decodable>(method: String, token: String, body: [String: Any]) async throws -> T {
+        var request = try makeRequest(method: method, token: token)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .osaurusCanonical)
+        return try await perform(request, token: token)
+    }
+
+    private func makeRequest(method: String, token: String) throws -> URLRequest {
+        guard !method.contains("/") else {
+            throw TelegramAPIError.invalidResponse("Telegram method name is invalid.")
+        }
+        let url = baseURL
+            .appendingPathComponent("bot\(token)")
+            .appendingPathComponent(method)
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Osaurus Telegram Native Agent Channel", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 30
+        return request
+    }
+
+    private func perform<T: Decodable>(_ request: URLRequest, token: String) async throws -> T {
+        do {
+            let (data, response) = try await sessionProvider().data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw TelegramAPIError.invalidResponse("Telegram returned a non-HTTP response.")
+            }
+            let envelope = try decodeEnvelope(T.self, from: data, token: token)
+            guard (200 ..< 300).contains(http.statusCode), envelope.ok, let result = envelope.result else {
+                throw mapHTTPError(status: http.statusCode, envelope: envelope, token: token)
+            }
+            return result
+        } catch let error as TelegramAPIError {
+            throw error
+        } catch {
+            throw TelegramAPIError.requestFailed(
+                TelegramSecurity.redact(error.localizedDescription, token: token)
+            )
+        }
+    }
+
+    private func decodeEnvelope<T: Decodable>(
+        _ type: T.Type,
+        from data: Data,
+        token: String
+    ) throws -> TelegramAPIEnvelope<T> {
+        do {
+            return try JSONDecoder().decode(TelegramAPIEnvelope<T>.self, from: data)
+        } catch {
+            throw TelegramAPIError.invalidResponse(
+                TelegramSecurity.redact("Telegram response could not be decoded.", token: token)
+            )
+        }
+    }
+
+    private func mapHTTPError<T>(
+        status: Int,
+        envelope: TelegramAPIEnvelope<T>,
+        token: String
+    ) -> TelegramAPIError {
+        let message = TelegramSecurity.redact(
+            envelope.description ?? "Telegram request failed with HTTP \(status).",
+            token: token
+        )
+        switch status {
+        case 401:
+            return .invalidToken
+        case 403:
+            return .forbidden(message)
+        case 404:
+            return .notFound(message)
+        case 429:
+            return .rateLimited(message)
+        default:
+            return .requestFailed(message)
+        }
+    }
+}
+
+private struct TelegramAPIEnvelope<Result: Decodable>: Decodable {
+    let ok: Bool
+    let result: Result?
+    let description: String?
+    let errorCode: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case result
+        case description
+        case errorCode = "error_code"
+    }
+}

--- a/Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramAPIClient.swift
@@ -163,6 +163,7 @@ struct TelegramReceiveBatchResult: Equatable, Sendable {
 enum TelegramAPIError: LocalizedError, Equatable, Sendable {
     case invalidToken
     case forbidden(String)
+    case conflict(String)
     case notFound(String)
     case rateLimited(String)
     case invalidResponse(String)
@@ -173,6 +174,7 @@ enum TelegramAPIError: LocalizedError, Equatable, Sendable {
         case .invalidToken:
             return "Telegram rejected the bot token."
         case .forbidden(let message),
+            .conflict(let message),
             .notFound(let message),
             .rateLimited(let message),
             .invalidResponse(let message),
@@ -215,15 +217,21 @@ final class TelegramAPIClient: TelegramAPIClientProtocol, @unchecked Sendable {
     }
 
     func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate] {
+        let boundedTimeout = TelegramConnectionConfiguration.clampLongPollingTimeoutSeconds(timeout)
         var body: [String: Any] = [
-            "limit": min(max(limit, 1), 100),
-            "timeout": min(max(timeout, 0), 50),
+            "limit": TelegramConnectionConfiguration.clampLongPollingLimit(limit),
+            "timeout": boundedTimeout,
             "allowed_updates": ["message", "edited_message", "channel_post", "edited_channel_post"],
         ]
         if let offset {
             body["offset"] = offset
         }
-        return try await post(method: "getUpdates", token: token, body: body)
+        return try await post(
+            method: "getUpdates",
+            token: token,
+            body: body,
+            timeoutInterval: TimeInterval(boundedTimeout + 10)
+        )
     }
 
     func sendMessage(
@@ -243,10 +251,18 @@ final class TelegramAPIClient: TelegramAPIClientProtocol, @unchecked Sendable {
         return try await post(method: "sendMessage", token: token, body: body)
     }
 
-    private func post<T: Decodable>(method: String, token: String, body: [String: Any]) async throws -> T {
+    private func post<T: Decodable>(
+        method: String,
+        token: String,
+        body: [String: Any],
+        timeoutInterval: TimeInterval? = nil
+    ) async throws -> T {
         var request = try makeRequest(method: method, token: token)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let timeoutInterval {
+            request.timeoutInterval = timeoutInterval
+        }
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .osaurusCanonical)
         return try await perform(request, token: token)
     }
@@ -313,6 +329,8 @@ final class TelegramAPIClient: TelegramAPIClientProtocol, @unchecked Sendable {
             return .invalidToken
         case 403:
             return .forbidden(message)
+        case 409:
+            return .conflict(message)
         case 404:
             return .notFound(message)
         case 429:

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -188,14 +188,16 @@ private enum TelegramReceivePendingResult {
 }
 
 final class TelegramConnectionService: @unchecked Sendable {
+    static let nativeConnectionId = TelegramUpdateNormalizer.connectionId
+    static let updatesCursorRoomId = "__telegram_updates__"
+
     static let shared = TelegramConnectionService(
         client: TelegramAPIClient(),
         credentialStore: KeychainTelegramCredentialStorage(),
         messageStore: AgentChannelMessageStore.shared
     )
 
-    private static let connectionId = TelegramUpdateNormalizer.connectionId
-    private static let updatesCursorRoomId = "__telegram_updates__"
+    private static let connectionId = nativeConnectionId
 
     private let client: TelegramAPIClientProtocol
     private let credentialStore: any TelegramCredentialStorage
@@ -274,17 +276,30 @@ final class TelegramConnectionService: @unchecked Sendable {
             failures.append(redacted(error, token: token))
         }
 
+        let receiveNeedsSenderAllowlist = config.receiveStorageEnabled
+            && config.longPollingEnabled
+            && !config.readableChatIds.isEmpty
+            && config.senderAllowlist.isEmpty
+
         let status: String
         if bot == nil {
             status = "token_invalid_or_unavailable"
         } else if config.readableChatIds.isEmpty {
             status = "connected_needs_allowlist"
+        } else if receiveNeedsSenderAllowlist {
+            status = "connected_receive_needs_sender_allowlist"
         } else if config.writeEnabled && config.writableChatIds.isEmpty {
             status = "connected_read_only_write_needs_chats"
         } else if config.writeEnabled {
             status = "connected_read_write"
         } else {
             status = "connected_read_only"
+        }
+
+        if receiveNeedsSenderAllowlist {
+            failures.append(
+                "Telegram long polling is enabled with readable chats but no authorized sender IDs; inbound updates will be denied before storage or dispatch."
+            )
         }
 
         return TelegramConnectionDiagnostics(
@@ -307,6 +322,7 @@ final class TelegramConnectionService: @unchecked Sendable {
             "message_dedupe": "connection_id + room_id + provider_message_id",
             "event_dedupe": "connection_id + provider_event_id",
             "cursor": "telegram getUpdates offset stored in channel_receive_cursors",
+            "transport_runtime": "telegram_long_poll",
         ]
     }
 
@@ -463,7 +479,8 @@ final class TelegramConnectionService: @unchecked Sendable {
         secretTokenHeader: String? = nil,
         expectedSecretToken: String? = nil
     ) async throws -> TelegramReceiveBatchResult {
-        if let expectedSecretToken, secretTokenHeader != expectedSecretToken {
+        if let expectedSecretToken,
+           !Self.constantTimeEquals(secretTokenHeader ?? "", expectedSecretToken) {
             throw TelegramConnectionServiceError.invalidWebhookSecret
         }
         let update = try JSONDecoder().decode(TelegramUpdate.self, from: data)
@@ -483,8 +500,8 @@ final class TelegramConnectionService: @unchecked Sendable {
         let offset = cursor.flatMap(Int64.init)
         let updates = try await client.getUpdates(
             offset: offset,
-            limit: min(max(limit, 1), 100),
-            timeout: min(max(timeout, 0), 50),
+            limit: TelegramConnectionConfiguration.clampLongPollingLimit(limit),
+            timeout: TelegramConnectionConfiguration.clampLongPollingTimeoutSeconds(timeout),
             token: token
         )
         return try await processUpdates(updates, source: "long_poll")
@@ -737,6 +754,19 @@ final class TelegramConnectionService: @unchecked Sendable {
             ],
         ]
     }
+
+    private static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+        let left = Array(lhs.utf8)
+        let right = Array(rhs.utf8)
+        let count = max(left.count, right.count)
+        var difference = left.count ^ right.count
+        for index in 0 ..< count {
+            let leftByte = index < left.count ? left[index] : 0
+            let rightByte = index < right.count ? right[index] : 0
+            difference |= Int(leftByte ^ rightByte)
+        }
+        return difference == 0
+    }
 }
 
 private extension TelegramUpdateNormalizer {
@@ -744,3 +774,215 @@ private extension TelegramUpdateNormalizer {
         ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(date)))
     }
 }
+
+actor TelegramLongPollTransportRuntime {
+    static let transportId = "telegram_long_poll"
+
+    private let service: TelegramConnectionService
+    private let healthCenter: AgentChannelTransportHealthCenter
+    private let backoffPolicy: AgentChannelTransportBackoffPolicy
+    private let sleeper: any AgentChannelTransportSleeping
+    private var worker: Task<Void, Never>?
+    private var consecutiveFailures = 0
+    private var lastHealth: AgentChannelTransportHealthState
+
+    init(
+        service: TelegramConnectionService = .shared,
+        healthCenter: AgentChannelTransportHealthCenter = .shared,
+        backoffPolicy: AgentChannelTransportBackoffPolicy = AgentChannelTransportBackoffPolicy(),
+        sleeper: any AgentChannelTransportSleeping = AgentChannelTransportTaskSleeper()
+    ) {
+        self.service = service
+        self.healthCenter = healthCenter
+        self.backoffPolicy = backoffPolicy
+        self.sleeper = sleeper
+        self.lastHealth = AgentChannelTransportHealthState(
+            connectionId: TelegramConnectionService.nativeConnectionId,
+            transportId: Self.transportId,
+            provider: .telegram,
+            status: .idle,
+            severity: .info,
+            summary: "Telegram long polling is idle.",
+            isRunning: false,
+            receiveEnabled: false
+        )
+    }
+
+    func health() -> AgentChannelTransportHealthState {
+        lastHealth
+    }
+
+    func start(pollInterval: TimeInterval = 0) {
+        guard worker == nil else { return }
+        worker = Task { [weak self] in
+            await self?.runLoop(pollInterval: pollInterval)
+        }
+    }
+
+    func stop(now: Date = Date()) async {
+        let oldWorker = worker
+        worker = nil
+        oldWorker?.cancel()
+        await oldWorker?.value
+        consecutiveFailures = 0
+        await publish(
+            AgentChannelTransportHealthState(
+                connectionId: TelegramConnectionService.nativeConnectionId,
+                transportId: Self.transportId,
+                provider: .telegram,
+                status: .idle,
+                severity: .info,
+                summary: "Telegram long polling is idle.",
+                isRunning: false,
+                receiveEnabled: service.configuration().longPollingEnabled,
+                updatedAt: now
+            )
+        )
+    }
+
+    func runStep(
+        now: Date = Date(),
+        jitter: Double = Double.random(in: 0 ... 1)
+    ) async -> AgentChannelTransportStepResult {
+        let configuration = service.configuration()
+        guard configuration.receiveStorageEnabled else {
+            consecutiveFailures = 0
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: TelegramConnectionService.nativeConnectionId,
+                    transportId: Self.transportId,
+                    provider: .telegram,
+                    status: .disabled,
+                    severity: .info,
+                    summary: "Telegram receive storage is disabled.",
+                    isRunning: false,
+                    receiveEnabled: false,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(disposition: .skipped, health: health)
+        }
+        guard configuration.longPollingEnabled else {
+            consecutiveFailures = 0
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: TelegramConnectionService.nativeConnectionId,
+                    transportId: Self.transportId,
+                    provider: .telegram,
+                    status: .disabled,
+                    severity: .info,
+                    summary: "Telegram long polling is disabled.",
+                    isRunning: false,
+                    receiveEnabled: true,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(disposition: .skipped, health: health)
+        }
+
+        do {
+            let batch = try await service.pollUpdates(
+                limit: configuration.longPollingLimit,
+                timeout: configuration.longPollingTimeoutSeconds
+            )
+            consecutiveFailures = 0
+            let dispatchSuppressed = batch.results.filter { $0.status == .accepted }.count
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: TelegramConnectionService.nativeConnectionId,
+                    transportId: Self.transportId,
+                    provider: .telegram,
+                    status: .healthy,
+                    severity: .info,
+                    summary: "Telegram long polling is healthy.",
+                    isRunning: worker != nil,
+                    receiveEnabled: true,
+                    lastSuccessAt: now,
+                    lastReceivedCount: batch.received,
+                    lastStoredCount: batch.stored,
+                    dispatchSuppressedCount: dispatchSuppressed,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(
+                disposition: .succeeded,
+                health: health,
+                received: batch.received,
+                stored: batch.stored,
+                dispatchAttempted: 0,
+                dispatchSuppressed: dispatchSuppressed
+            )
+        } catch TelegramAPIError.conflict(let message) {
+            consecutiveFailures += 1
+            let delay = backoffPolicy.delay(consecutiveFailures: consecutiveFailures, jitter: jitter)
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: TelegramConnectionService.nativeConnectionId,
+                    transportId: Self.transportId,
+                    provider: .telegram,
+                    status: .conflict,
+                    severity: .error,
+                    summary: "Telegram long polling has a competing consumer.",
+                    detail: message,
+                    isRunning: worker != nil,
+                    receiveEnabled: true,
+                    lastFailureAt: now,
+                    nextRetryAt: now.addingTimeInterval(delay),
+                    consecutiveFailures: consecutiveFailures,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(
+                disposition: .conflict,
+                health: health,
+                retryDelay: delay
+            )
+        } catch {
+            consecutiveFailures += 1
+            let delay = backoffPolicy.delay(consecutiveFailures: consecutiveFailures, jitter: jitter)
+            let health = await publish(
+                AgentChannelTransportHealthState(
+                    connectionId: TelegramConnectionService.nativeConnectionId,
+                    transportId: Self.transportId,
+                    provider: .telegram,
+                    status: .failed,
+                    severity: .warning,
+                    summary: "Telegram long polling failed.",
+                    detail: error.localizedDescription,
+                    isRunning: worker != nil,
+                    receiveEnabled: true,
+                    lastFailureAt: now,
+                    nextRetryAt: now.addingTimeInterval(delay),
+                    consecutiveFailures: consecutiveFailures,
+                    updatedAt: now
+                )
+            )
+            return AgentChannelTransportStepResult(
+                disposition: .failed,
+                health: health,
+                retryDelay: delay
+            )
+        }
+    }
+
+    private func runLoop(pollInterval: TimeInterval) async {
+        while !Task.isCancelled {
+            let result = await runStep()
+            let delay = max(result.retryDelay ?? pollInterval, 1)
+            do {
+                try await sleeper.sleep(for: delay)
+            } catch {
+                break
+            }
+        }
+    }
+
+    @discardableResult
+    private func publish(_ health: AgentChannelTransportHealthState) async -> AgentChannelTransportHealthState {
+        lastHealth = health
+        await healthCenter.update(health)
+        return health
+    }
+}
+
+extension TelegramLongPollTransportRuntime: AgentChannelReceiveTransportRuntime {}

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -1,0 +1,746 @@
+//
+//  TelegramConnectionService.swift
+//  osaurus
+//
+//  Policy, normalization, and diagnostics layer for the native Telegram channel.
+//
+
+import Foundation
+
+struct TelegramConnectionDiagnostics: Equatable, Sendable {
+    let tokenSaved: Bool
+    let bot: TelegramUser?
+    let readableChatIds: [String]
+    let writableChatIds: [String]
+    let senderAllowlist: [String]
+    let writeEnabled: Bool
+    let status: String
+    let failures: [String]
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "token_saved": tokenSaved,
+            "readable_chat_ids": readableChatIds,
+            "writable_chat_ids": writableChatIds,
+            "sender_allowlist": senderAllowlist,
+            "write_enabled": writeEnabled,
+            "status": status,
+            "failures": failures,
+        ]
+        if let bot {
+            result["bot"] = [
+                "id": "\(bot.id)",
+                "username": bot.username ?? "",
+                "display_name": bot.displayName,
+                "is_bot": bot.isBot,
+            ]
+        }
+        return result
+    }
+}
+
+enum TelegramConnectionServiceError: LocalizedError, Equatable, Sendable {
+    case notConfigured
+    case invalidChatId(String)
+    case chatNotReadable(String)
+    case chatNotWritable(String)
+    case writeDisabled
+    case sendConfirmationRequired
+    case messageTooLong
+    case emptyMessage
+    case configurationSaveFailed(String)
+    case messageStoreUnavailable
+    case invalidWebhookSecret
+    case api(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Telegram is not configured. Add a bot token in Settings and allowlist at least one chat."
+        case .invalidChatId(let chatId):
+            return "`\(chatId)` is not a valid Telegram chat id or @channel username."
+        case .chatNotReadable(let chatId):
+            return "Telegram chat `\(chatId)` is not allowlisted for read access."
+        case .chatNotWritable(let chatId):
+            return "Telegram chat `\(chatId)` is not allowlisted for write access."
+        case .writeDisabled:
+            return "Telegram write access is disabled in settings."
+        case .sendConfirmationRequired:
+            return "`confirm_send` must be true before Osaurus posts to Telegram."
+        case .messageTooLong:
+            return "Telegram messages must fit Telegram's 4096-character limit."
+        case .emptyMessage:
+            return "Telegram message content must not be empty."
+        case .configurationSaveFailed(let message):
+            return "Telegram configuration could not be saved: \(message)"
+        case .messageStoreUnavailable:
+            return "Telegram message store is unavailable."
+        case .invalidWebhookSecret:
+            return "Telegram webhook secret token did not match the configured value."
+        case .api(let message):
+            return message
+        }
+    }
+}
+
+enum TelegramUpdateNormalizer {
+    static let connectionId = "telegram"
+    static let maxInboundContentLength = 4096
+
+    static func normalize(
+        update: TelegramUpdate,
+        botId: Int64?,
+        configuration: TelegramConnectionConfiguration
+    ) -> TelegramReceiveResultOrEvent {
+        let providerEventId = "\(update.updateId)"
+        guard let message = update.primaryMessage else {
+            return .result(
+                TelegramReceiveResult(
+                    providerEventId: providerEventId,
+                    roomId: nil,
+                    providerMessageId: nil,
+                    status: .ignored,
+                    reason: "update_has_no_message"
+                )
+            )
+        }
+
+        let stableRoomId = message.chat.stableId
+        let providerMessageId = "\(message.messageId)"
+        let roomId = configuration.readableRoomId(for: message.chat) ?? stableRoomId
+        let senderId = message.from.map { "\($0.id)" } ?? message.senderChat.map { "\($0.id)" }
+        let content = message.contentText
+        guard !content.isEmpty else {
+            return .result(
+                TelegramReceiveResult(
+                    providerEventId: providerEventId,
+                    roomId: stableRoomId,
+                    providerMessageId: providerMessageId,
+                    status: .ignored,
+                    reason: "empty_message_content"
+                )
+            )
+        }
+        guard content.utf16.count <= Self.maxInboundContentLength else {
+            return .result(
+                TelegramReceiveResult(
+                    providerEventId: providerEventId,
+                    roomId: roomId,
+                    providerMessageId: providerMessageId,
+                    status: .ignored,
+                    reason: "message_too_long"
+                )
+            )
+        }
+
+        return .event(
+            TelegramNormalizedInboundEvent(
+                providerEventId: providerEventId,
+                roomId: roomId,
+                providerMessageId: providerMessageId,
+                content: content,
+                senderId: senderId,
+                authorName: message.from?.displayName ?? message.senderChat?.displayName,
+                isBotMessage: message.from?.isBot == true,
+                isSelfMessage: botId != nil && message.from?.id == botId,
+                providerTimestamp: Self.iso8601Timestamp(fromTelegramDate: message.date),
+                payloadJSON: encodedPayload(update)
+            )
+        )
+    }
+
+    static func storedMessage(_ event: TelegramNormalizedInboundEvent) -> AgentChannelStoredMessage {
+        AgentChannelStoredMessage(
+            connectionId: connectionId,
+            roomId: event.roomId,
+            providerMessageId: event.providerMessageId,
+            direction: .inbound,
+            authorId: event.senderId,
+            authorName: event.authorName,
+            content: event.content,
+            payloadJSON: event.payloadJSON,
+            providerTimestamp: event.providerTimestamp
+        )
+    }
+
+    private static func encodedPayload(_ update: TelegramUpdate) -> String {
+        guard let data = try? JSONEncoder().encode(update),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func iso8601Timestamp(fromTelegramDate date: Int) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(date)))
+    }
+}
+
+enum TelegramReceiveResultOrEvent: Equatable, Sendable {
+    case result(TelegramReceiveResult)
+    case event(TelegramNormalizedInboundEvent)
+}
+
+private enum TelegramReceivePendingResult {
+    case result(TelegramReceiveResult)
+    case event(TelegramNormalizedInboundEvent)
+}
+
+final class TelegramConnectionService: @unchecked Sendable {
+    static let shared = TelegramConnectionService(
+        client: TelegramAPIClient(),
+        credentialStore: KeychainTelegramCredentialStorage(),
+        messageStore: AgentChannelMessageStore.shared
+    )
+
+    private static let connectionId = TelegramUpdateNormalizer.connectionId
+    private static let updatesCursorRoomId = "__telegram_updates__"
+
+    private let client: TelegramAPIClientProtocol
+    private let credentialStore: any TelegramCredentialStorage
+    private let messageStore: AgentChannelMessageStore?
+    private let recordMessageSnapshotsInline: Bool
+    private let botIdentityLock = NSLock()
+    private var cachedBotId: Int64?
+
+    init(
+        client: TelegramAPIClientProtocol,
+        credentialStore: any TelegramCredentialStorage = KeychainTelegramCredentialStorage(),
+        messageStore: AgentChannelMessageStore? = nil,
+        recordMessageSnapshotsInline: Bool = false
+    ) {
+        self.client = client
+        self.credentialStore = credentialStore
+        self.messageStore = messageStore
+        self.recordMessageSnapshotsInline = recordMessageSnapshotsInline
+    }
+
+    func configuration() -> TelegramConnectionConfiguration {
+        TelegramConnectionConfigurationStore.load()
+    }
+
+    func saveConfiguration(_ configuration: TelegramConnectionConfiguration) throws {
+        do {
+            try TelegramConnectionConfigurationStore.save(configuration)
+        } catch {
+            throw TelegramConnectionServiceError.configurationSaveFailed(error.localizedDescription)
+        }
+    }
+
+    @discardableResult
+    func saveBotToken(_ token: String) throws -> Bool {
+        clearCachedBotIdentity()
+        let saved = credentialStore.saveBotToken(token)
+        if !saved {
+            throw TelegramConnectionServiceError.configurationSaveFailed(
+                "The token was empty or Keychain storage was unavailable."
+            )
+        }
+        return saved
+    }
+
+    @discardableResult
+    func deleteBotToken() -> Bool {
+        clearCachedBotIdentity()
+        return credentialStore.deleteBotToken()
+    }
+
+    func hasBotToken() -> Bool {
+        credentialStore.hasBotToken()
+    }
+
+    func diagnostics() async -> TelegramConnectionDiagnostics {
+        let config = configuration()
+        guard let token = credentialStore.botToken() else {
+            return TelegramConnectionDiagnostics(
+                tokenSaved: false,
+                bot: nil,
+                readableChatIds: config.readableChatIds,
+                writableChatIds: config.writableChatIds,
+                senderAllowlist: config.senderAllowlist,
+                writeEnabled: config.writeEnabled,
+                status: "not_configured",
+                failures: ["No Telegram bot token is saved."]
+            )
+        }
+
+        var failures: [String] = []
+        let bot: TelegramUser?
+        do {
+            bot = try await client.getMe(token: token)
+        } catch {
+            bot = nil
+            failures.append(redacted(error, token: token))
+        }
+
+        let status: String
+        if bot == nil {
+            status = "token_invalid_or_unavailable"
+        } else if config.readableChatIds.isEmpty {
+            status = "connected_needs_allowlist"
+        } else if config.writeEnabled && config.writableChatIds.isEmpty {
+            status = "connected_read_only_write_needs_chats"
+        } else if config.writeEnabled {
+            status = "connected_read_write"
+        } else {
+            status = "connected_read_only"
+        }
+
+        return TelegramConnectionDiagnostics(
+            tokenSaved: true,
+            bot: bot,
+            readableChatIds: config.readableChatIds,
+            writableChatIds: config.writableChatIds,
+            senderAllowlist: config.senderAllowlist,
+            writeEnabled: config.writeEnabled,
+            status: status,
+            failures: failures
+        )
+    }
+
+    func messageStoreDiagnostics() -> [String: Any] {
+        [
+            "enabled": messageStore != nil,
+            "open": messageStore?.isOpen ?? false,
+            "database_path": OsaurusPaths.agentChannelMessagesDatabaseFile().path,
+            "message_dedupe": "connection_id + room_id + provider_message_id",
+            "event_dedupe": "connection_id + provider_event_id",
+            "cursor": "telegram getUpdates offset stored in channel_receive_cursors",
+        ]
+    }
+
+    func listSpaces() -> [[String: Any]] {
+        [
+            [
+                "id": "telegram",
+                "name": "Telegram",
+                "kind": "messaging_network",
+            ]
+        ]
+    }
+
+    func listChats() async throws -> [[String: Any]] {
+        let config = configuration()
+        let token = credentialStore.botToken()
+        var rows: [[String: Any]] = []
+        for chatId in config.configuredChatIds {
+            var row: [String: Any] = [
+                "id": chatId,
+                "name": chatId,
+                "kind": "chat",
+                "read_allowed": config.canRead(chatId: chatId),
+                "write_allowed": config.canWrite(chatId: chatId),
+            ]
+            if let token {
+                do {
+                    let chat = try await client.getChat(chatId: chatId, token: token)
+                    row["provider_chat_id"] = chat.stableId
+                    row["name"] = chat.displayName
+                    row["type"] = chat.type
+                    row["username"] = chat.username ?? ""
+                } catch {
+                    row["error"] = redacted(error, token: token)
+                }
+            }
+            rows.append(row)
+        }
+        return rows
+    }
+
+    func readChat(_ request: TelegramReadRequest) throws -> [String: Any] {
+        let config = configuration()
+        let chatId = try requireReadableChat(request.chatId, config: config)
+        let safeLimit = TelegramConnectionConfiguration.clampReadLimit(request.limit ?? config.defaultReadLimit)
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+        let rows = try messageStore.recentMessages(
+            connectionId: Self.connectionId,
+            roomId: chatId,
+            limit: safeLimit
+        )
+        return [
+            "kind": "telegram_stored_messages",
+            "chat_id": chatId,
+            "limit": safeLimit,
+            "partial": true,
+            "messages": rows.map(Self.storedMessageDictionary),
+        ]
+    }
+
+    func searchMessages(
+        query: String,
+        chatIds: [String]?,
+        limitPerChat: Int?,
+        maxMatches: Int?
+    ) throws -> [String: Any] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else {
+            throw TelegramConnectionServiceError.emptyMessage
+        }
+        let config = configuration()
+        let candidateChats = TelegramConnectionConfiguration.normalizedIds(chatIds ?? config.readableChatIds)
+        let allowedChats = candidateChats.filter { config.canRead(chatId: $0) }
+        guard !allowedChats.isEmpty else {
+            throw TelegramConnectionServiceError.chatNotReadable(candidateChats.first ?? "")
+        }
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+
+        let safeLimit = TelegramConnectionConfiguration.clampReadLimit(limitPerChat ?? config.defaultReadLimit)
+        let safeMaxMatches = min(max(maxMatches ?? 25, 1), 50)
+        let needle = trimmedQuery.lowercased()
+        var matches: [[String: Any]] = []
+
+        for chatId in allowedChats {
+            let rows = try messageStore.recentMessages(
+                connectionId: Self.connectionId,
+                roomId: chatId,
+                limit: safeLimit
+            )
+            for row in rows {
+                let haystack = "\(row.content) \(row.authorName ?? "") \(row.authorId ?? "")".lowercased()
+                guard haystack.contains(needle) else { continue }
+                matches.append(Self.storedMessageDictionary(row))
+                if matches.count >= safeMaxMatches { break }
+            }
+            if matches.count >= safeMaxMatches { break }
+        }
+
+        return [
+            "kind": "telegram_stored_message_search",
+            "query": trimmedQuery,
+            "searched_chat_ids": allowedChats,
+            "limit_per_chat": safeLimit,
+            "max_matches": safeMaxMatches,
+            "match_count": matches.count,
+            "partial": true,
+            "messages": matches,
+        ]
+    }
+
+    func draftMessage(chatId: String, content: String) throws -> [String: Any] {
+        let config = configuration()
+        let normalizedChatId = try requireWritableChat(chatId, config: config)
+        let trimmedContent = try validateMessageContent(content)
+        return [
+            "kind": "telegram_message_draft",
+            "chat_id": normalizedChatId,
+            "content": trimmedContent,
+            "requires_send_confirmation": true,
+        ]
+    }
+
+    func sendMessage(_ request: TelegramWriteRequest) async throws -> [String: Any] {
+        guard request.confirmSend else {
+            throw TelegramConnectionServiceError.sendConfirmationRequired
+        }
+        let token = try requireToken()
+        let config = configuration()
+        let chatId = try requireWritableChat(request.chatId, config: config)
+        let text = try validateMessageContent(request.text)
+        let message = try await client.sendMessage(
+            chatId: chatId,
+            text: text,
+            replyToMessageId: request.replyToMessageId,
+            token: token
+        )
+        recordMessages([Self.storedMessage(message, roomId: chatId, direction: .outbound)])
+        return [
+            "kind": "telegram_message_sent",
+            "chat_id": chatId,
+            "delivery_status": TelegramDeliveryStatus.sent.rawValue,
+            "message": Self.messageDictionary(message),
+        ]
+    }
+
+    func processWebhookPayload(
+        _ data: Data,
+        secretTokenHeader: String? = nil,
+        expectedSecretToken: String? = nil
+    ) async throws -> TelegramReceiveBatchResult {
+        if let expectedSecretToken, secretTokenHeader != expectedSecretToken {
+            throw TelegramConnectionServiceError.invalidWebhookSecret
+        }
+        let update = try JSONDecoder().decode(TelegramUpdate.self, from: data)
+        return try await processUpdates([update], source: "webhook")
+    }
+
+    func pollUpdates(limit: Int = 100, timeout: Int = 0) async throws -> TelegramReceiveBatchResult {
+        let token = try requireToken()
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+        let cursor = try messageStore.cursor(
+            connectionId: Self.connectionId,
+            roomId: Self.updatesCursorRoomId
+        )
+        let offset = cursor.flatMap(Int64.init)
+        let updates = try await client.getUpdates(
+            offset: offset,
+            limit: min(max(limit, 1), 100),
+            timeout: min(max(timeout, 0), 50),
+            token: token
+        )
+        return try await processUpdates(updates, source: "long_poll")
+    }
+
+    func processUpdates(_ updates: [TelegramUpdate], source: String) async throws -> TelegramReceiveBatchResult {
+        guard let messageStore else {
+            throw TelegramConnectionServiceError.messageStoreUnavailable
+        }
+        try messageStore.openIfNeeded()
+
+        let config = configuration()
+        let botId = await currentBotIdForNormalization()
+        var pending: [TelegramReceivePendingResult] = []
+        var maxUpdateId: Int64?
+
+        for update in updates {
+            maxUpdateId = max(maxUpdateId ?? update.updateId, update.updateId)
+            switch TelegramUpdateNormalizer.normalize(update: update, botId: botId, configuration: config) {
+            case .result(let result):
+                pending.append(.result(result))
+            case .event(let event):
+                pending.append(.event(event))
+            }
+        }
+
+        var inserted = 0
+        var results: [TelegramReceiveResult] = []
+        let authorizationService = AgentChannelConnectionService(
+            discordService: .shared,
+            telegramService: self
+        )
+        for item in pending {
+            switch item {
+            case .result(let result):
+                results.append(result)
+            case .event(let event):
+                let authorization = try authorizationService.authorizeInboundMessage(
+                    AgentChannelInboundMessageAuthorizationRequest(
+                        connectionId: Self.connectionId,
+                        providerEventId: event.providerEventId,
+                        providerMessageId: event.providerMessageId,
+                        spaceId: "telegram",
+                        roomId: event.roomId,
+                        senderId: event.senderId,
+                        isBotMessage: event.isBotMessage,
+                        isSelfMessage: event.isSelfMessage
+                    ),
+                    messageStore: messageStore
+                )
+                let receive = try messageStore.recordReceiveEvent(
+                    connectionId: Self.connectionId,
+                    providerEventId: event.providerEventId,
+                    authorization: authorization,
+                    message: TelegramUpdateNormalizer.storedMessage(event)
+                )
+                if receive.messageInserted { inserted += 1 }
+                results.append(
+                    TelegramReceiveResult(
+                        providerEventId: event.providerEventId,
+                        roomId: event.roomId,
+                        providerMessageId: event.providerMessageId,
+                        status: Self.deliveryStatus(for: receive),
+                        reason: receive.disposition == .accepted ? nil : receive.authorizationReason
+                    )
+                )
+            }
+        }
+        if source == "long_poll", let maxUpdateId {
+            try messageStore.upsertCursor(
+                connectionId: Self.connectionId,
+                roomId: Self.updatesCursorRoomId,
+                cursor: "\(maxUpdateId + 1)"
+            )
+        }
+
+        return TelegramReceiveBatchResult(
+            source: source,
+            received: updates.count,
+            stored: inserted,
+            results: results
+        )
+    }
+
+    private func currentBotIdForNormalization() async -> Int64? {
+        if let cached = botIdentityLock.withLock({ cachedBotId }) {
+            return cached
+        }
+        guard let token = credentialStore.botToken() else { return nil }
+        do {
+            let botId = try await client.getMe(token: token).id
+            botIdentityLock.withLock { cachedBotId = botId }
+            return botId
+        } catch {
+            return botIdentityLock.withLock { cachedBotId }
+        }
+    }
+
+    private func clearCachedBotIdentity() {
+        botIdentityLock.withLock { cachedBotId = nil }
+    }
+
+    private func requireToken() throws -> String {
+        guard let token = credentialStore.botToken() else {
+            throw TelegramConnectionServiceError.notConfigured
+        }
+        return token
+    }
+
+    private func requireChatId(_ chatId: String) throws -> String {
+        let normalized = TelegramConnectionConfiguration.normalizedChatId(chatId)
+        guard TelegramConnectionConfiguration.isValidChatId(normalized) else {
+            throw TelegramConnectionServiceError.invalidChatId(chatId)
+        }
+        return normalized
+    }
+
+    private func requireReadableChat(
+        _ chatId: String,
+        config: TelegramConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireChatId(chatId)
+        guard config.canRead(chatId: normalized) else {
+            throw TelegramConnectionServiceError.chatNotReadable(normalized)
+        }
+        return normalized
+    }
+
+    private func requireWritableChat(
+        _ chatId: String,
+        config: TelegramConnectionConfiguration
+    ) throws -> String {
+        let normalized = try requireChatId(chatId)
+        guard config.writeEnabled else {
+            throw TelegramConnectionServiceError.writeDisabled
+        }
+        guard config.canWrite(chatId: normalized) else {
+            throw TelegramConnectionServiceError.chatNotWritable(normalized)
+        }
+        return normalized
+    }
+
+    private func validateMessageContent(_ content: String) throws -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw TelegramConnectionServiceError.emptyMessage
+        }
+        guard trimmed.utf16.count <= TelegramUpdateNormalizer.maxInboundContentLength else {
+            throw TelegramConnectionServiceError.messageTooLong
+        }
+        return trimmed
+    }
+
+    private static func deliveryStatus(for receive: AgentChannelReceiveResult) -> TelegramDeliveryStatus {
+        switch receive.disposition {
+        case .accepted:
+            return .accepted
+        case .duplicate:
+            return .duplicate
+        case .denied:
+            switch receive.authorizationReason {
+            case "self_message_denied", "bot_message_denied":
+                return .ignored
+            default:
+                return .unauthorized
+            }
+        }
+    }
+
+    private func redacted(_ error: Error, token: String) -> String {
+        TelegramSecurity.redact(error.localizedDescription, token: token)
+    }
+
+    private func recordMessages(_ messages: [AgentChannelStoredMessage]) {
+        guard let messageStore, !messages.isEmpty else { return }
+        if recordMessageSnapshotsInline {
+            Self.persistMessages(messages, messageStore: messageStore)
+        } else {
+            Task.detached(priority: .utility) {
+                Self.persistMessages(messages, messageStore: messageStore)
+            }
+        }
+    }
+
+    private static func persistMessages(
+        _ rows: [AgentChannelStoredMessage],
+        messageStore: AgentChannelMessageStore
+    ) {
+        do {
+            try messageStore.openIfNeeded()
+            _ = try messageStore.recordMessages(rows)
+        } catch {
+            NSLog("[Telegram] Failed to record Agent Channel messages: \(error.localizedDescription)")
+        }
+    }
+
+    private static func storedMessage(
+        _ message: TelegramMessage,
+        roomId: String? = nil,
+        direction: AgentChannelStoredMessageDirection
+    ) -> AgentChannelStoredMessage {
+        AgentChannelStoredMessage(
+            connectionId: connectionId,
+            roomId: roomId ?? message.chat.stableId,
+            providerMessageId: "\(message.messageId)",
+            direction: direction,
+            threadId: message.replyToMessage.map { "\($0.messageId)" },
+            authorId: message.from.map { "\($0.id)" } ?? message.senderChat.map { "\($0.id)" },
+            authorName: message.from?.displayName ?? message.senderChat?.displayName,
+            content: message.contentText,
+            payloadJSON: encodedPayload(message),
+            providerTimestamp: TelegramUpdateNormalizer.iso8601TimestampForService(message.date)
+        )
+    }
+
+    private static func encodedPayload(_ message: TelegramMessage) -> String {
+        guard let data = try? JSONEncoder().encode(message),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func storedMessageDictionary(_ message: AgentChannelStoredMessage) -> [String: Any] {
+        [
+            "id": message.providerMessageId,
+            "chat_id": message.roomId,
+            "content": message.content,
+            "timestamp": message.providerTimestamp ?? "",
+            "author": [
+                "id": message.authorId ?? "",
+                "display_name": message.authorName ?? "",
+            ],
+            "direction": message.direction.rawValue,
+            "raw": message.payloadJSON,
+        ]
+    }
+
+    private static func messageDictionary(_ message: TelegramMessage) -> [String: Any] {
+        [
+            "id": "\(message.messageId)",
+            "chat_id": message.chat.stableId,
+            "content": message.contentText,
+            "timestamp": TelegramUpdateNormalizer.iso8601TimestampForService(message.date),
+            "author": [
+                "id": message.from.map { "\($0.id)" } ?? "",
+                "display_name": message.from?.displayName ?? "",
+                "is_bot": message.from?.isBot ?? false,
+            ],
+        ]
+    }
+}
+
+private extension TelegramUpdateNormalizer {
+    static func iso8601TimestampForService(_ date: Int) -> String {
+        ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: TimeInterval(date)))
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelNativeCoexistenceTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelNativeCoexistenceTests.swift
@@ -45,6 +45,7 @@ struct AgentChannelNativeCoexistenceTests {
                     configuredTeamIds: ["T12345"],
                     readableChannelIds: ["C23456"],
                     writableChannelIds: ["C34567"],
+                    senderAllowlist: ["U55555"],
                     writeEnabled: true
                 )
             )
@@ -83,6 +84,7 @@ struct AgentChannelNativeCoexistenceTests {
             #expect(!rendered.contains("xapp-slack-app-token-super-secret"))
             #expect(!rendered.contains("123456:telegram-bot-token-super-secret"))
             #expect(nativeRows["slack"]?["app_token_saved"] as? Bool == true)
+            #expect(nativeRows["slack"]?["sender_allowlist"] as? [String] == ["U55555"])
 
             let slackPolicies = nativeRows["slack"]?["action_policies"] as? [[String: Any]] ?? []
             #expect(!slackPolicies.contains { $0["status"] as? String == "configured_only" })
@@ -111,6 +113,76 @@ struct AgentChannelNativeCoexistenceTests {
                     )
                 )
             }
+        }
+    }
+
+    @Test func globalWriteKillSwitchBlocksNativeProviderSends() async throws {
+        try await withIsolatedNativeChannelStores { stores in
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-native-channel-write-gate-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let killSwitch = ChannelWriteKillSwitch(fileURL: root.appendingPathComponent("write-gate.json"))
+            _ = try killSwitch.disableWrites(now: Date(timeIntervalSince1970: 1))
+
+            let slack = SlackConnectionService(
+                client: SlackAPIClient(baseURL: URL(string: "https://slack.test/api")!),
+                credentialStore: stores.slackCredentials
+            )
+            let telegram = TelegramConnectionService(
+                client: TelegramAPIClient(baseURL: URL(string: "https://telegram.test")!),
+                credentialStore: stores.telegramCredentials
+            )
+            try slack.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            try telegram.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    writableChatIds: ["-100111222333"],
+                    writeEnabled: true
+                )
+            )
+
+            let service = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: DiscordAPIClient(baseURL: URL(string: "https://discord.test/api/v10")!),
+                    credentialStore: stores.discordCredentials
+                ),
+                slackService: slack,
+                telegramService: telegram,
+                writeKillSwitch: killSwitch
+            )
+
+            await #expect(throws: AgentChannelConnectionServiceError.globalWritesDisabled(generation: 1)) {
+                _ = try await service.sendMessage(
+                    connectionId: "slack",
+                    roomId: "C34567",
+                    content: "blocked",
+                    confirmSend: true
+                )
+            }
+            await #expect(throws: AgentChannelConnectionServiceError.globalWritesDisabled(generation: 1)) {
+                _ = try await service.sendMessage(
+                    connectionId: "telegram",
+                    roomId: "-100111222333",
+                    content: "blocked",
+                    confirmSend: true
+                )
+            }
+
+            let slackRow = try #require(
+                service.listConnections().first { $0["id"] as? String == "slack" }
+            )
+            let slackPolicies = slackRow["action_policies"] as? [[String: Any]] ?? []
+            let sendPolicy = try #require(
+                slackPolicies.first { $0["action"] as? String == "send_message" }
+            )
+            #expect(sendPolicy["status"] as? String == "unavailable")
+            #expect(sendPolicy["reason"] as? String == "Global Agent Channel writes are disabled.")
         }
     }
 

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelNativeCoexistenceTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelNativeCoexistenceTests.swift
@@ -39,6 +39,7 @@ struct AgentChannelNativeCoexistenceTests {
             )
             try slack.saveBotToken("xoxb-slack-bot-token-super-secret")
             try slack.saveSigningSecret("slack-signing-secret-super-secret")
+            try slack.saveAppToken("xapp-slack-app-token-super-secret")
             try slack.saveConfiguration(
                 SlackConnectionConfiguration(
                     configuredTeamIds: ["T12345"],
@@ -79,7 +80,9 @@ struct AgentChannelNativeCoexistenceTests {
             #expect(!rendered.contains("discord-bot-token-super-secret"))
             #expect(!rendered.contains("xoxb-slack-bot-token-super-secret"))
             #expect(!rendered.contains("slack-signing-secret-super-secret"))
+            #expect(!rendered.contains("xapp-slack-app-token-super-secret"))
             #expect(!rendered.contains("123456:telegram-bot-token-super-secret"))
+            #expect(nativeRows["slack"]?["app_token_saved"] as? Bool == true)
 
             let slackPolicies = nativeRows["slack"]?["action_policies"] as? [[String: Any]] ?? []
             #expect(!slackPolicies.contains { $0["status"] as? String == "configured_only" })
@@ -112,28 +115,30 @@ struct AgentChannelNativeCoexistenceTests {
     }
 
     private func withIsolatedNativeChannelStores(
-        _ body: (NativeChannelCredentialStores) async throws -> Void
+        _ body: @Sendable (NativeChannelCredentialStores) async throws -> Void
     ) async throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("osaurus-native-channel-coexistence-\(UUID().uuidString)", isDirectory: true)
-        let previousAgentChannelDirectory = AgentChannelConfigurationStore.overrideDirectory
-        let previousDiscordDirectory = DiscordConnectionConfigurationStore.overrideDirectory
-        let previousSlackDirectory = SlackConnectionConfigurationStore.overrideDirectory
-        let previousTelegramDirectory = TelegramConnectionConfigurationStore.overrideDirectory
+        try await AgentChannelConfigurationTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-native-channel-coexistence-\(UUID().uuidString)", isDirectory: true)
+            let previousAgentChannelDirectory = AgentChannelConfigurationStore.overrideDirectory
+            let previousDiscordDirectory = DiscordConnectionConfigurationStore.overrideDirectory
+            let previousSlackDirectory = SlackConnectionConfigurationStore.overrideDirectory
+            let previousTelegramDirectory = TelegramConnectionConfigurationStore.overrideDirectory
 
-        AgentChannelConfigurationStore.overrideDirectory = root.appendingPathComponent("agent-channels")
-        DiscordConnectionConfigurationStore.overrideDirectory = root.appendingPathComponent("discord")
-        SlackConnectionConfigurationStore.overrideDirectory = root.appendingPathComponent("slack")
-        TelegramConnectionConfigurationStore.overrideDirectory = root.appendingPathComponent("telegram")
-        defer {
-            AgentChannelConfigurationStore.overrideDirectory = previousAgentChannelDirectory
-            DiscordConnectionConfigurationStore.overrideDirectory = previousDiscordDirectory
-            SlackConnectionConfigurationStore.overrideDirectory = previousSlackDirectory
-            TelegramConnectionConfigurationStore.overrideDirectory = previousTelegramDirectory
-            try? FileManager.default.removeItem(at: root)
+            AgentChannelConfigurationStore.overrideDirectory = root.appendingPathComponent("agent-channels")
+            DiscordConnectionConfigurationStore.overrideDirectory = root.appendingPathComponent("discord")
+            SlackConnectionConfigurationStore.overrideDirectory = root.appendingPathComponent("slack")
+            TelegramConnectionConfigurationStore.overrideDirectory = root.appendingPathComponent("telegram")
+            defer {
+                AgentChannelConfigurationStore.overrideDirectory = previousAgentChannelDirectory
+                DiscordConnectionConfigurationStore.overrideDirectory = previousDiscordDirectory
+                SlackConnectionConfigurationStore.overrideDirectory = previousSlackDirectory
+                TelegramConnectionConfigurationStore.overrideDirectory = previousTelegramDirectory
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try await body(NativeChannelCredentialStores())
         }
-
-        try await body(NativeChannelCredentialStores())
     }
 }
 
@@ -170,6 +175,7 @@ private final class NativeSlackCredentialStore: SlackCredentialStorage, @uncheck
     private let lock = NSLock()
     private var botTokenValue: String?
     private var signingSecretValue: String?
+    private var appTokenValue: String?
 
     func saveBotToken(_ token: String) -> Bool {
         lock.withLock { botTokenValue = token }
@@ -204,6 +210,24 @@ private final class NativeSlackCredentialStore: SlackCredentialStorage, @uncheck
 
     func deleteSigningSecret() -> Bool {
         lock.withLock { signingSecretValue = nil }
+        return true
+    }
+
+    func saveAppToken(_ token: String) -> Bool {
+        lock.withLock { appTokenValue = token }
+        return true
+    }
+
+    func appToken() -> String? {
+        lock.withLock { appTokenValue }
+    }
+
+    func hasAppToken() -> Bool {
+        appToken() != nil
+    }
+
+    func deleteAppToken() -> Bool {
+        lock.withLock { appTokenValue = nil }
         return true
     }
 }

--- a/Packages/OsaurusCore/Tests/Configuration/ManagementTabTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ManagementTabTests.swift
@@ -5,9 +5,9 @@
 //  Guardrails for the management sidebar's information architecture:
 //  every tab must belong to exactly one labeled section, the flattened
 //  section order must cover every tab, and legacy deep-link raw values
-//  (`"dashboard"`, `"channels"`) must keep resolving after their cases
-//  were removed. These pin the Settings IA cleanup so a future tab
-//  addition can't silently fall out of the sidebar.
+//  (`"dashboard"`, `"channels"`) must keep resolving as their destinations
+//  move. These pin the Settings IA cleanup so a future tab addition can't
+//  silently fall out of the sidebar.
 //
 
 import Foundation
@@ -59,7 +59,9 @@ struct ManagementTabTests {
 
     @Test func resolvedMapsLegacyRawValues() {
         #expect(ManagementTab.resolved(from: "dashboard") == .credits)
-        #expect(ManagementTab.resolved(from: "channels") == .agents)
+        #expect(ManagementTab.resolved(from: "channels") == .agentChannels)
+        #expect(ManagementTab.resolved(from: "integrations") == .agentChannels)
+        #expect(ManagementTab.resolved(from: "agent-channels") == .agentChannels)
     }
 
     @Test func resolvedRoundTripsCurrentRawValues() {

--- a/Packages/OsaurusCore/Tests/Configuration/SettingsSearchIndexTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/SettingsSearchIndexTests.swift
@@ -98,4 +98,18 @@ struct SettingsSearchIndexTests {
         let encryptionHits = SettingsSearchIndex.search("sqlcipher")
         #expect(encryptionHits.contains { $0.id == "storage.encryption" && $0.tab == .storage })
     }
+
+    @Test func searchFindsAgentChannelIntegrationEntries() {
+        let integrationHits = SettingsSearchIndex.search("integrations")
+        #expect(integrationHits.contains { $0.id == "agentChannels.overview" && $0.tab == .agentChannels })
+
+        let slackHits = SettingsSearchIndex.search("slack signing secret")
+        #expect(slackHits.contains { $0.id == "agentChannels.slack" && $0.tab == .agentChannels })
+
+        let telegramHits = SettingsSearchIndex.search("telegram bot token")
+        #expect(telegramHits.contains { $0.id == "agentChannels.telegram" && $0.tab == .agentChannels })
+
+        let killSwitchHits = SettingsSearchIndex.search("kill switch")
+        #expect(killSwitchHits.contains { $0.id == "agentChannels.globalWrites" && $0.tab == .agentChannels })
+    }
 }

--- a/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
@@ -1842,25 +1842,28 @@ struct DiscordConnectionTests {
             "discord_send_message",
             "discord_reply_to_thread",
         ]
-        let (registeredNames, builtInNames, runtimeNames, pluginNames, alwaysLoadedNames, phantomNames) = await MainActor.run {
-            (
-                Set(ToolRegistry.shared.listTools().map(\.name)),
-                ToolRegistry.shared.builtInToolNames,
-                ToolRegistry.shared.runtimeManagedToolNames,
-                names.filter { ToolRegistry.shared.isPluginTool($0) },
-                Set(ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)),
-                phantomDiscordNames.filter { ToolRegistry.shared.entry(named: $0) != nil }
+        let snapshot = await MainActor.run {
+            let registered = Set(ToolRegistry.shared.listTools().map(\.name))
+            return AgentChannelRegistrySnapshot(
+                registeredNames: registered,
+                registeredChannelNames: Set(registered.filter { $0.hasPrefix("agent_channel_") }),
+                builtInNames: ToolRegistry.shared.builtInToolNames,
+                runtimeNames: ToolRegistry.shared.runtimeManagedToolNames,
+                pluginNames: Set(names.filter { ToolRegistry.shared.isPluginTool($0) }),
+                alwaysLoadedNames: Set(ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)),
+                phantomNames: Set(phantomDiscordNames.filter { ToolRegistry.shared.entry(named: $0) != nil })
             )
         }
         // Agent Channel actions are provider-neutral native dynamic tools:
         // callable by the app runtime, but not injected into the always-loaded
         // prompt baseline.
-        #expect(Set(names).isSubset(of: registeredNames))
-        #expect(pluginNames.isEmpty)
-        #expect(Set(names).isDisjoint(with: builtInNames))
-        #expect(Set(names).isDisjoint(with: runtimeNames))
-        #expect(Set(names).isDisjoint(with: alwaysLoadedNames))
-        #expect(phantomNames.isEmpty)
+        #expect(Set(names).isSubset(of: snapshot.registeredNames))
+        #expect(snapshot.registeredChannelNames == Set(names))
+        #expect(snapshot.pluginNames.isEmpty)
+        #expect(Set(names).isDisjoint(with: snapshot.builtInNames))
+        #expect(Set(names).isDisjoint(with: snapshot.runtimeNames))
+        #expect(Set(names).isDisjoint(with: snapshot.alwaysLoadedNames))
+        #expect(snapshot.phantomNames.isEmpty)
 
         // The native action vocabulary stays restricted to the app surface.
         // External HTTP/MCP callers must not be able to send channel messages
@@ -2133,6 +2136,16 @@ private final class DiscordHTTPStubProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+}
+
+private struct AgentChannelRegistrySnapshot {
+    let registeredNames: Set<String>
+    let registeredChannelNames: Set<String>
+    let builtInNames: Set<String>
+    let runtimeNames: Set<String>
+    let pluginNames: Set<String>
+    let alwaysLoadedNames: Set<String>
+    let phantomNames: Set<String>
 }
 
 private extension DiscordMessage {

--- a/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
@@ -1829,7 +1829,7 @@ struct DiscordConnectionTests {
         }
     }
 
-    @Test func nativeAgentChannelToolsAreDisabledButRemainExternallyDenied() async throws {
+    @Test func nativeAgentChannelToolsAreRegisteredAsDynamicNativeToolsAndRemainExternallyDenied() async throws {
         let names = ToolRegistry.agentChannelToolNames.sorted()
         let phantomDiscordNames: Set<String> = [
             "discord_diagnostics",
@@ -1842,28 +1842,31 @@ struct DiscordConnectionTests {
             "discord_send_message",
             "discord_reply_to_thread",
         ]
-        let (registeredNames, builtInNames, pluginNames, phantomNames) = await MainActor.run {
+        let (registeredNames, builtInNames, runtimeNames, pluginNames, alwaysLoadedNames, phantomNames) = await MainActor.run {
             (
                 Set(ToolRegistry.shared.listTools().map(\.name)),
                 ToolRegistry.shared.builtInToolNames,
+                ToolRegistry.shared.runtimeManagedToolNames,
                 names.filter { ToolRegistry.shared.isPluginTool($0) },
+                Set(ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)),
                 phantomDiscordNames.filter { ToolRegistry.shared.entry(named: $0) != nil }
             )
         }
-        // Agent Channel tool registration is intentionally disabled in
-        // `ToolRegistry.registerBuiltInTools`, so none of the native action
-        // tools are live in the registry. They must also never leak in as
-        // plugin-owned tools or collide with the phantom Discord vocabulary.
-        #expect(Set(names).isDisjoint(with: registeredNames))
+        // Agent Channel actions are provider-neutral native dynamic tools:
+        // callable by the app runtime, but not injected into the always-loaded
+        // prompt baseline.
+        #expect(Set(names).isSubset(of: registeredNames))
         #expect(pluginNames.isEmpty)
+        #expect(Set(names).isDisjoint(with: builtInNames))
+        #expect(Set(names).isDisjoint(with: runtimeNames))
+        #expect(Set(names).isDisjoint(with: alwaysLoadedNames))
         #expect(phantomNames.isEmpty)
 
-        // Even while the tools are disabled, their names stay on the
-        // external-surface deny list (defense in depth) and must never be
-        // promoted to built-ins.
+        // The native action vocabulary stays restricted to the app surface.
+        // External HTTP/MCP callers must not be able to send channel messages
+        // through these tools.
         for name in names {
             #expect(ToolRegistry.externallyDeniedToolNames.contains(name))
-            #expect(!builtInNames.contains(name))
             #expect(!ToolRegistry.isDeniedForCurrentSurface(name))
             let denied = ChatExecutionContext.$isExternalSurface.withValue(true) {
                 ToolRegistry.isDeniedForCurrentSurface(name)

--- a/Packages/OsaurusCore/Tests/Helpers/AgentChannelConfigurationTestLock.swift
+++ b/Packages/OsaurusCore/Tests/Helpers/AgentChannelConfigurationTestLock.swift
@@ -1,0 +1,48 @@
+//
+//  AgentChannelConfigurationTestLock.swift
+//  OsaurusCoreTests
+//
+//  Process-wide serialization for tests that mutate native Agent Channel
+//  configuration override directories. `@Suite(.serialized)` only serializes
+//  tests inside one suite, while Discord/Slack/Telegram tests share globals.
+//
+
+import Foundation
+
+actor AgentChannelConfigurationTestLock {
+    static let shared = AgentChannelConfigurationTestLock()
+
+    private var holder = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquire() async {
+        if !holder {
+            holder = true
+            return
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            holder = false
+        }
+    }
+
+    func run<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T {
+        await acquire()
+        do {
+            let value = try await body()
+            release()
+            return value
+        } catch {
+            release()
+            throw error
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -206,6 +206,44 @@ struct MCPHTTPHandlerTests {
         }
     }
 
+    @Test func stdio_mcp_policy_hides_externally_denied_tools() {
+        #expect(MCPServerManager.isToolVisibleToExternalMCP(name: EchoTool.nameStatic, enabled: true))
+        #expect(!MCPServerManager.isToolVisibleToExternalMCP(name: EchoTool.nameStatic, enabled: false))
+
+        for name in ["file_write", "shell_run", "agent_channel_send_message"] {
+            #expect(!MCPServerManager.isToolVisibleToExternalMCP(name: name, enabled: true))
+            let denial = MCPServerManager.externalMCPDenialMessage(for: name)
+            #expect(denial?.contains("App-only tools") == true)
+        }
+    }
+
+    @Test func stdio_mcp_execution_binds_external_surface() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            ToolRegistry.shared.register(ExternalSurfaceProbeTool())
+            ToolRegistry.shared.setEnabled(true, for: ExternalSurfaceProbeTool.nameStatic)
+            defer { ToolRegistry.shared.unregister(names: [ExternalSurfaceProbeTool.nameStatic]) }
+
+            let text = try await MCPServerManager.executeToolAsExternalMCP(
+                name: ExternalSurfaceProbeTool.nameStatic,
+                argumentsJSON: "{}"
+            )
+            let envelope =
+                try JSONSerialization.jsonObject(
+                    with: Data(text.utf8)
+                ) as? [String: Any]
+            #expect(envelope?["ok"] as? Bool == true)
+            let result = envelope?["result"] as? [String: Any]
+            #expect(result?["text"] as? String == "external")
+        }
+    }
+
     @Test func mcp_call_with_missing_required_arg_returns_error() async throws {
         try await DynamicCatalogTestLock.shared.run {
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -265,6 +303,17 @@ private struct NamedEchoTool: OsaurusTool {
     let parameters: JSONValue? = nil
     func execute(argumentsJSON: String) async throws -> String {
         return argumentsJSON
+    }
+}
+
+private struct ExternalSurfaceProbeTool: OsaurusTool {
+    static let nameStatic: String = "external_surface_probe"
+    let name: String = ExternalSurfaceProbeTool.nameStatic
+    let description: String = "Reports whether the current execution surface is external"
+    let parameters: JSONValue? = nil
+
+    func execute(argumentsJSON: String) async throws -> String {
+        ChatExecutionContext.isExternalSurface ? "external" : "internal"
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -141,7 +141,7 @@ struct MCPHTTPHandlerTests {
         let server = try await startTestServer()
         defer { Task { await server.shutdown() } }
 
-        for tool in ["file_write", "file_edit", "shell_run", "git_commit"] {
+        for tool in ["file_write", "file_edit", "shell_run", "git_commit", "agent_channel_send_message"] {
             var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)/mcp/call")!)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -155,6 +155,43 @@ struct MCPHTTPHandlerTests {
             #expect(status == 403, "expected 403 for \(tool), got \(status)")
             #expect(body.contains("tool_not_exposable"))
         }
+    }
+
+    @Test func remote_dispatch_surface_binding_denies_agent_channel_tools() {
+        #expect(!HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: true))
+        #expect(HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false))
+
+        let local = ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: true)
+        ) {
+            ToolRegistry.isDeniedForCurrentSurface("agent_channel_send_message")
+        }
+        #expect(!local)
+
+        let remote = ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false)
+        ) {
+            ToolRegistry.isDeniedForCurrentSurface("agent_channel_send_message")
+        }
+        #expect(remote)
+
+        let remoteHostWrite = ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false)
+        ) {
+            ToolRegistry.isDeniedForCurrentSurface("file_write")
+        }
+        #expect(remoteHostWrite)
+    }
+
+    @Test func remote_dispatch_surface_binding_propagates_to_unstructured_tasks() async {
+        let inherited = await ChatExecutionContext.$isExternalSurface.withValue(
+            HTTPHandler.shouldBindExternalSurfaceForDispatch(isLoopback: false)
+        ) {
+            await Task {
+                ToolRegistry.isDeniedForCurrentSurface("agent_channel_send_message")
+            }.value
+        }
+        #expect(inherited)
     }
 
     @Test func mcp_call_rejects_malformed_agent_header() async throws {

--- a/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
@@ -1,0 +1,652 @@
+//
+//  SlackConnectionTests.swift
+//  osaurusTests
+//
+//  Unit and security coverage for the native Slack Agent Channel adapter.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SlackConnectionTests {
+
+    @Test func configurationPersistsAllowlistsButNeverSecrets() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let botToken = "xoxb-slack-bot-token-super-secret"
+            let signingSecret = "slack-signing-secret-super-secret"
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveBotToken(botToken)
+            try service.saveSigningSecret(signingSecret)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: [" T12345 ", "T12345"],
+                    readableChannelIds: ["C23456"],
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true,
+                    defaultReadLimit: 250
+                )
+            )
+
+            let saved = SlackConnectionConfigurationStore.load()
+            #expect(saved.configuredTeamIds == ["T12345"])
+            #expect(saved.defaultReadLimit == 100)
+            #expect(!SlackConnectionConfiguration.isValidSlackId("T١٢٣"))
+
+            let disk = try String(
+                contentsOf: SlackConnectionConfigurationStore.configurationFileURL(),
+                encoding: .utf8
+            )
+            #expect(disk.contains("C23456"))
+            #expect(!disk.contains(botToken))
+            #expect(!disk.contains(signingSecret))
+            #expect(!disk.localizedCaseInsensitiveContains("bot_token"))
+            #expect(!disk.localizedCaseInsensitiveContains("signing_secret"))
+        }
+    }
+
+    @Test func diagnosticsRedactsSavedSecretsEchoedByTransportError() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let botToken = "xoxb-slack-bot-token-super-secret"
+            let signingSecret = "slack-signing-secret-super-secret"
+            let fake = FakeSlackAPIClient()
+            await fake.setAuthFailureEchoingSecrets(botToken: botToken, signingSecret: signingSecret)
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken(botToken)
+            try service.saveSigningSecret(signingSecret)
+
+            let diagnostics = await service.diagnostics()
+
+            #expect(diagnostics.botTokenSaved)
+            #expect(diagnostics.signingSecretSaved)
+            #expect(diagnostics.status == "token_invalid_or_unavailable")
+            let failures = diagnostics.failures.joined(separator: " ")
+            #expect(failures.contains("[REDACTED:SLACK_BOT_TOKEN]"))
+            #expect(failures.contains("[REDACTED:SLACK_SIGNING_SECRET]"))
+            #expect(!failures.contains(botToken))
+            #expect(!failures.contains(signingSecret))
+            #expect(!String(describing: diagnostics.dictionary).contains(botToken))
+            #expect(!String(describing: diagnostics.dictionary).contains(signingSecret))
+        }
+    }
+
+    @Test func apiClientRedactsTokenEchoedBySlackErrorBody() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 200,
+            body: #"{"ok":false,"error":"invalid_auth \#(token)"}"#
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.authTest(token: token)
+            Issue.record("Slack request should have failed")
+        } catch let error as SlackAPIError {
+            #expect(error.localizedDescription.contains("[REDACTED:SLACK_BOT_TOKEN]"))
+            #expect(!error.localizedDescription.contains(token))
+        }
+    }
+
+    @Test func apiClientUsesConservativeMentionControlsWhenSendingMessage() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 200,
+            body: """
+            {
+              "ok": true,
+              "channel": "C34567",
+              "ts": "1718800000.000100",
+              "message": {
+                "type": "message",
+                "user": "U12345",
+                "text": "Hello @channel <@U23456>",
+                "ts": "1718800000.000100"
+              }
+            }
+            """
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        _ = try await client.sendMessage(
+            channelId: "C34567",
+            content: "Hello @channel <@U23456>",
+            threadTs: nil,
+            token: token
+        )
+
+        let body = try #require(SlackHTTPStubProtocol.lastRequestJSONBody())
+        #expect(body["parse"] as? String == "none")
+        #expect(body["link_names"] as? Bool == false)
+        #expect(body["reply_broadcast"] as? Bool == false)
+        #expect(body["unfurl_links"] as? Bool == false)
+        #expect(body["unfurl_media"] as? Bool == false)
+    }
+
+    @Test func apiClientHonorsBoundedConversationListLimit() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 200,
+            body: #"{"ok":true,"channels":[]}"#
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        _ = try await client.conversations(token: token, limit: 10)
+
+        let form = SlackHTTPStubProtocol.lastRequestFormBody()
+        #expect(form["limit"] == "10")
+        #expect(form["exclude_archived"] == "true")
+    }
+
+    @Test func readChannelReturnsBoundedMessagesForAllowlistedSlackChannel() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            await fake.setMessages([
+                "C23456": [
+                    .fixture(ts: "1718800000.000100", text: "eval reports landed"),
+                    .fixture(ts: "1718800001.000200", text: "review requested"),
+                ],
+            ])
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["T12345"],
+                    readableChannelIds: ["C23456"],
+                    defaultReadLimit: 2
+                )
+            )
+
+            let result = try await service.readChannel(channelId: "C23456", limit: nil)
+            #expect(result["channel_id"] as? String == "C23456")
+            #expect(result["partial"] as? Bool == true)
+            let messages = try #require(result["messages"] as? [[String: Any]])
+            #expect(messages.count == 2)
+            #expect(messages.first?["content"] as? String == "eval reports landed")
+            #expect(messages.first?["thread_id"] as? String == "C23456:1718800000.000100")
+        }
+    }
+
+    @Test func agentChannelReadToolDispatchesThroughSlackConnection() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            await fake.setMessages([
+                "C23456": [.fixture(ts: "1718800000.000100", text: "hello from Slack")],
+            ])
+            let slackService = SlackConnectionService(client: fake, credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelReadMessagesTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON: #"{"connection_id":"slack","room_id":"C23456"}"#
+            )
+
+            let payload = try #require(EnvelopeAssertions.successPayload(result))
+            #expect(payload["connection_id"] as? String == "slack")
+            #expect(payload["standard_kind"] as? String == "channel_messages")
+            #expect(payload["kind"] as? String == "slack_recent_messages")
+        }
+    }
+
+    @Test func agentChannelReadToolRejectsRoomsOutsideSlackReadAllowlist() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let slackService = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelReadMessagesTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON: #"{"connection_id":"slack","room_id":"C99999"}"#
+            )
+            #expect(EnvelopeAssertions.failureKind(result) == "rejected")
+            #expect(EnvelopeAssertions.failureMessage(result)?.contains("not allowlisted") == true)
+        }
+    }
+
+    @Test func agentChannelSendToolRequiresConfirmSendForSlack() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let slackService = SlackConnectionService(client: fake, credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelSendMessageTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON:
+                    #"{"connection_id":"slack","room_id":"C34567","content":"Ship it","confirm_send":false}"#
+            )
+            #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+            #expect(await fake.sentMessageCount() == 0)
+        }
+    }
+
+    @Test func agentChannelSendToolPostsOnlyWhenSlackWriteEnabledAllowlistedAndConfirmed() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let slackService = SlackConnectionService(client: fake, credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+            let tool = AgentChannelSendMessageTool(service: channelService)
+
+            let result = try await tool.execute(
+                argumentsJSON:
+                    #"{"connection_id":"slack","room_id":"C34567","content":"Ship it","confirm_send":true}"#
+            )
+            let payload = try #require(EnvelopeAssertions.successPayload(result))
+            #expect(payload["standard_kind"] as? String == "message_sent")
+            #expect(payload["kind"] as? String == "slack_message_sent")
+            #expect(await fake.sentMessageCount() == 1)
+            #expect(await fake.lastSentContent() == "Ship it")
+        }
+    }
+
+    @Test func slackSendRejectsBroadcastMentionByDefaultBeforeNetworkCall() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+
+            #expect(throws: SlackConnectionServiceError.broadcastMentionDenied) {
+                try service.draftMessage(channelId: "C34567", content: "Heads up <!channel>")
+            }
+            #expect(await fake.sentMessageCount() == 0)
+        }
+    }
+
+    @Test func slackThreadReplyUsesChannelAndThreadTimestamp() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let fake = FakeSlackAPIClient()
+            let service = SlackConnectionService(client: fake, credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+
+            let result = try await service.replyToThread(
+                threadId: "C34567:1718800000.000100",
+                content: "Thread reply",
+                confirmSend: true
+            )
+
+            #expect(result["kind"] as? String == "slack_thread_reply_sent")
+            #expect(result["thread_ts"] as? String == "1718800000.000100")
+            #expect(await fake.lastThreadTs() == "1718800000.000100")
+        }
+    }
+
+    @Test func nativeSlackConnectionIsListedAndReserved() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let slackService = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try slackService.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try slackService.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    writableChannelIds: ["C34567"],
+                    writeEnabled: true
+                )
+            )
+            let channelService = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForSlackTests(),
+                    credentialStore: FakeDiscordCredentialStoreForSlackTests()
+                ),
+                slackService: slackService
+            )
+
+            let slackRow = try #require(
+                channelService.listConnections().first { $0["id"] as? String == "slack" }
+            )
+            #expect(slackRow["kind"] as? String == "slack")
+            #expect(slackRow["configured"] as? Bool == true)
+            #expect(slackRow["secret_names"] as? [String] == ["bot_token", "signing_secret"])
+
+            let manager = AgentChannelConnectionManager()
+            #expect(throws: AgentChannelConnectionManagerError.reservedConnectionId("slack")) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "slack",
+                        name: "Shadow Slack",
+                        kind: .customHTTP,
+                        supportedActions: [.diagnostics],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [String: AgentChannelCustomHTTPAction]()
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    private func withIsolatedSlackStores(
+        _ body: (any SlackCredentialStorage) async throws -> Void
+    ) async throws {
+        let previousDirectory = SlackConnectionConfigurationStore.overrideDirectory
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-slack-tests-\(UUID().uuidString)", isDirectory: true)
+        let credentials = FakeSlackCredentialStore()
+        SlackConnectionConfigurationStore.overrideDirectory = directory
+        defer {
+            SlackConnectionConfigurationStore.overrideDirectory = previousDirectory
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try await body(credentials)
+    }
+}
+
+private final class FakeSlackCredentialStore: SlackCredentialStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedBotToken: String?
+    private var storedSigningSecret: String?
+
+    func saveBotToken(_ token: String) -> Bool {
+        save(token, assign: { storedBotToken = $0 })
+    }
+
+    func botToken() -> String? {
+        lock.withLock { storedBotToken }
+    }
+
+    func hasBotToken() -> Bool {
+        botToken() != nil
+    }
+
+    func deleteBotToken() -> Bool {
+        lock.withLock { storedBotToken = nil }
+        return true
+    }
+
+    func saveSigningSecret(_ secret: String) -> Bool {
+        save(secret, assign: { storedSigningSecret = $0 })
+    }
+
+    func signingSecret() -> String? {
+        lock.withLock { storedSigningSecret }
+    }
+
+    func hasSigningSecret() -> Bool {
+        signingSecret() != nil
+    }
+
+    func deleteSigningSecret() -> Bool {
+        lock.withLock { storedSigningSecret = nil }
+        return true
+    }
+
+    private func save(_ value: String, assign: (String) -> Void) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        lock.withLock { assign(trimmed) }
+        return true
+    }
+}
+
+private actor FakeSlackAPIClient: SlackAPIClientProtocol {
+    private var authFailureMessage: String?
+    private var messagesByChannel: [String: [SlackMessage]] = [:]
+    private var sentMessages: [(channelId: String, content: String, threadTs: String?)] = []
+
+    func setAuthFailureEchoingSecrets(botToken: String, signingSecret: String) {
+        authFailureMessage = "transport included token \(botToken) and signing secret \(signingSecret)"
+    }
+
+    func setMessages(_ messagesByChannel: [String: [SlackMessage]]) {
+        self.messagesByChannel = messagesByChannel
+    }
+
+    func sentMessageCount() -> Int {
+        sentMessages.count
+    }
+
+    func lastSentContent() -> String? {
+        sentMessages.last?.content
+    }
+
+    func lastThreadTs() -> String? {
+        sentMessages.last?.threadTs
+    }
+
+    func authTest(token: String) async throws -> SlackAuthIdentity {
+        if let authFailureMessage {
+            throw SlackAPIError.requestFailed(authFailureMessage)
+        }
+        return SlackAuthIdentity(
+            url: "https://example.slack.com/",
+            team: "Example",
+            user: "osaurus",
+            teamId: "T12345",
+            userId: "U12345",
+            botId: "B12345"
+        )
+    }
+
+    func conversations(token: String, limit: Int) async throws -> [SlackConversation] {
+        [
+            SlackConversation(
+                id: "C23456",
+                name: "dev",
+                isChannel: true,
+                isGroup: false,
+                isIM: false,
+                isMPIM: false,
+                isPrivate: false,
+                isArchived: false,
+                isMember: true
+            ),
+            SlackConversation(
+                id: "C34567",
+                name: "maintainers",
+                isChannel: true,
+                isGroup: false,
+                isIM: false,
+                isMPIM: false,
+                isPrivate: false,
+                isArchived: false,
+                isMember: true
+            ),
+        ]
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        Array((messagesByChannel[channelId] ?? []).prefix(limit))
+    }
+
+    func threadMessages(channelId: String, threadTs: String, token: String, limit: Int) async throws -> [SlackMessage] {
+        Array((messagesByChannel[channelId] ?? []).filter { ($0.threadTs ?? $0.ts) == threadTs }.prefix(limit))
+    }
+
+    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
+        sentMessages.append((channelId: channelId, content: content, threadTs: threadTs))
+        return .fixture(
+            ts: "171880000\(sentMessages.count).000100",
+            text: content,
+            threadTs: threadTs
+        )
+    }
+}
+
+private final class FakeDiscordCredentialStoreForSlackTests: DiscordCredentialStorage, @unchecked Sendable {
+    func saveBotToken(_ token: String) -> Bool { true }
+    func botToken() -> String? { nil }
+    func hasBotToken() -> Bool { false }
+    func deleteBotToken() -> Bool { true }
+}
+
+private actor FakeDiscordAPIClientForSlackTests: DiscordAPIClientProtocol {
+    func currentUser(token: String) async throws -> DiscordBotIdentity {
+        throw DiscordAPIError.invalidToken
+    }
+
+    func guild(id: String, token: String) async throws -> DiscordGuild {
+        throw DiscordAPIError.notFound("unused")
+    }
+
+    func channels(guildId: String, token: String) async throws -> [DiscordChannel] {
+        []
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [DiscordMessage] {
+        []
+    }
+
+    func sendMessage(channelId: String, content: String, token: String) async throws -> DiscordMessage {
+        throw DiscordAPIError.requestFailed("unused")
+    }
+}
+
+private final class SlackHTTPStubProtocol: URLProtocol {
+    nonisolated(unsafe) private static var statusCode: Int = 200
+    nonisolated(unsafe) private static var body = Data()
+    nonisolated(unsafe) private static var requestBody = Data()
+
+    static func session(statusCode: Int, body: String) -> URLSession {
+        self.statusCode = statusCode
+        self.body = Data(body.utf8)
+        requestBody = Data()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SlackHTTPStubProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    static func lastRequestJSONBody() -> [String: Any]? {
+        guard !requestBody.isEmpty else { return nil }
+        return try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+    }
+
+    static func lastRequestFormBody() -> [String: String] {
+        guard let body = String(data: requestBody, encoding: .utf8) else { return [:] }
+        return body
+            .split(separator: "&")
+            .reduce(into: [String: String]()) { result, pair in
+                let parts = pair.split(separator: "=", maxSplits: 1)
+                guard let name = parts.first else { return }
+                let value = parts.dropFirst().first.map(String.init) ?? ""
+                result[String(name)] = value.removingPercentEncoding ?? value
+            }
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let data = request.httpBody {
+            return data
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestBody = Self.bodyData(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private extension SlackMessage {
+    static func fixture(
+        ts: String,
+        text: String,
+        threadTs: String? = nil,
+        user: String = "U55555"
+    ) -> SlackMessage {
+        SlackMessage(
+            type: "message",
+            user: user,
+            username: "mike",
+            botId: nil,
+            text: text,
+            ts: ts,
+            threadTs: threadTs,
+            replyCount: nil
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
@@ -28,6 +28,7 @@ struct SlackConnectionTests {
                     configuredTeamIds: [" T12345 ", "T12345"],
                     readableChannelIds: ["C23456"],
                     writableChannelIds: ["C34567"],
+                    senderAllowlist: [" U55555 ", "U55555"],
                     writeEnabled: true,
                     defaultReadLimit: 250
                 )
@@ -35,6 +36,7 @@ struct SlackConnectionTests {
 
             let saved = SlackConnectionConfigurationStore.load()
             #expect(saved.configuredTeamIds == ["T12345"])
+            #expect(saved.senderAllowlist == ["U55555"])
             #expect(saved.defaultReadLimit == 100)
             #expect(!SlackConnectionConfiguration.isValidSlackId("T١٢٣"))
 
@@ -102,6 +104,50 @@ struct SlackConnectionTests {
             #expect(diagnostics.identity?.botId == "B12345")
             #expect(saved.botUserId == "U12345")
             #expect(saved.botId == "B12345")
+        }
+    }
+
+    @Test func saveConfigurationPreservesPersistedBotIdentity() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT",
+                    botId: "BOSABOT",
+                    apiAppId: "AOSABOT"
+                )
+            )
+
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"]
+                )
+            )
+
+            let saved = SlackConnectionConfigurationStore.load()
+            #expect(saved.botUserId == "UOSABOT")
+            #expect(saved.botId == "BOSABOT")
+            #expect(saved.apiAppId == "AOSABOT")
+        }
+    }
+
+    @Test func diagnosticsWarnWhenReceiveCredentialsHaveNoSenderAllowlist() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveAppToken("xapp-slack-app-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+
+            let diagnostics = await service.diagnostics()
+
+            #expect(diagnostics.status == "connected_receive_needs_sender_allowlist")
+            #expect(diagnostics.failures.contains {
+                $0.localizedCaseInsensitiveContains("no authorized sender IDs")
+            })
         }
     }
 
@@ -325,6 +371,7 @@ struct SlackConnectionTests {
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT"
                 )
             )
@@ -377,6 +424,7 @@ struct SlackConnectionTests {
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT"
                 )
             )
@@ -444,6 +492,7 @@ struct SlackConnectionTests {
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     readableChannelIds: ["C99999"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT"
                 )
             )
@@ -482,12 +531,60 @@ struct SlackConnectionTests {
         }
     }
 
+    @Test func slackInboundEventRequiresSenderAllowlistBeforeStorage() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    senderAllowlist: ["UAUTHORIZED"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> should not dispatch",
+                    ts: "1718800001.000400",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSenderDenied12345",
+                eventTime: 1_718_800_001
+            )
+
+            #expect(try service.recordInboundEvent(envelope) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 0)
+            let audits = try store.recentAuditEvents(connectionId: "slack", roomId: "C23456", limit: 10)
+            let denied = try #require(audits.first)
+            #expect(denied.authorizationDecision == "deny")
+            #expect(denied.reason == "sender_not_allowlisted")
+        }
+    }
+
     @Test func slackInboundEventMentionAndSelfMessagePolicyAvoidsOverTriggering() async throws {
         try await withIsolatedSlackStores { credentials in
             let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT",
                     botId: "BOSABOT",
                     apiAppId: "AOSABOT"
@@ -588,6 +685,7 @@ struct SlackConnectionTests {
                 SlackConnectionConfiguration(
                     configuredTeamIds: ["T12345"],
                     readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT"
                 )
             )
@@ -617,6 +715,7 @@ struct SlackConnectionTests {
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT"
                 )
             )
@@ -665,6 +764,158 @@ struct SlackConnectionTests {
         }
     }
 
+    @Test func socketModeRuntimeAcksAuthorizedEnvelopeAndStoresMessage() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeSlackAPIClient()
+            let service = SlackConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveAppToken("xapp-slack-app-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["T12345"],
+                    readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
+                    botUserId: "UOSABOT",
+                    botId: "BOSABOT",
+                    apiAppId: "A12345"
+                )
+            )
+            let socket = FakeSlackSocketModeWebSocket(messages: [
+                Self.socketModeEnvelope(
+                    envelopeId: "env-1",
+                    eventId: "EvSOCKET1",
+                    userId: "U55555",
+                    text: "<@UOSABOT> eval report ready"
+                ),
+            ])
+            let runtime = SlackSocketModeTransportRuntime(
+                service: service,
+                client: fake,
+                webSocketFactory: FakeSlackSocketModeWebSocketFactory(socket: socket)
+            )
+
+            let result = await runtime.runStep(maxMessages: 1)
+
+            #expect(result.disposition == .succeeded)
+            #expect(result.received == 1)
+            #expect(result.stored == 1)
+            #expect(await fake.lastOpenedAppToken() == "xapp-slack-app-token-super-secret")
+            #expect(await socket.sentTexts().contains(#"{"envelope_id":"env-1"}"#))
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+        }
+    }
+
+    @Test func socketModeRuntimePersistsMissingBotIdentityBeforeReceiving() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeSlackAPIClient()
+            let service = SlackConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveAppToken("xapp-slack-app-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["T12345"],
+                    readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"]
+                )
+            )
+            let socket = FakeSlackSocketModeWebSocket(messages: [
+                Self.socketModeEnvelope(
+                    envelopeId: "env-identity",
+                    eventId: "EvSOCKETIDENTITY",
+                    userId: "U55555",
+                    text: "<@U12345> first setup event"
+                ),
+            ])
+            let runtime = SlackSocketModeTransportRuntime(
+                service: service,
+                client: fake,
+                webSocketFactory: FakeSlackSocketModeWebSocketFactory(socket: socket)
+            )
+
+            let result = await runtime.runStep(maxMessages: 1)
+
+            #expect(result.disposition == .succeeded)
+            #expect(result.stored == 1)
+            let saved = SlackConnectionConfigurationStore.load()
+            #expect(saved.botUserId == "U12345")
+            #expect(saved.botId == "B12345")
+            #expect(await fake.lastOpenedAppToken() == "xapp-slack-app-token-super-secret")
+            #expect(await socket.sentTexts().contains(#"{"envelope_id":"env-identity"}"#))
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+        }
+    }
+
+    @Test func transportSupervisorStopsSlackRuntimeWhenBotTokenIsRemoved() async {
+        let runtime = SlackReceiveTransportRuntimeSpy()
+        let hasBotToken = SlackTokenPresenceBox(true)
+        let supervisor = AgentChannelTransportSupervisor(
+            slackConfiguration: {
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C12345"],
+                    senderAllowlist: ["U12345"]
+                )
+            },
+            slackHasBotToken: { hasBotToken.value() },
+            slackHasAppToken: { true },
+            slackRuntime: runtime,
+            telegramConfiguration: { TelegramConnectionConfiguration() },
+            telegramHasBotToken: { false },
+            telegramRuntime: SlackReceiveTransportRuntimeSpy()
+        )
+        let stopDate = Date(timeIntervalSince1970: 1_800_001_000)
+
+        await supervisor.startFromLaunch()
+        hasBotToken.set(false)
+        await supervisor.refreshSlackRuntime(now: stopDate)
+
+        #expect(await runtime.startCount() == 1)
+        #expect(await runtime.stopCount() == 1)
+        #expect(await runtime.lastStopDate() == stopDate)
+    }
+
+    @Test func transportSupervisorStopsSlackRuntimeWhenAppTokenIsRemoved() async {
+        let runtime = SlackReceiveTransportRuntimeSpy()
+        let hasAppToken = SlackTokenPresenceBox(true)
+        let supervisor = AgentChannelTransportSupervisor(
+            slackConfiguration: {
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C12345"],
+                    senderAllowlist: ["U12345"]
+                )
+            },
+            slackHasBotToken: { true },
+            slackHasAppToken: { hasAppToken.value() },
+            slackRuntime: runtime,
+            telegramConfiguration: { TelegramConnectionConfiguration() },
+            telegramHasBotToken: { false },
+            telegramRuntime: SlackReceiveTransportRuntimeSpy()
+        )
+        let stopDate = Date(timeIntervalSince1970: 1_800_001_200)
+
+        await supervisor.startFromLaunch()
+        hasAppToken.set(false)
+        await supervisor.refreshSlackRuntime(now: stopDate)
+
+        #expect(await runtime.startCount() == 1)
+        #expect(await runtime.stopCount() == 1)
+        #expect(await runtime.lastStopDate() == stopDate)
+    }
+
     @Test func slackInboundDispatchSurvivesPassiveSnapshotCollision() async throws {
         try await withIsolatedSlackStores { credentials in
             let store = AgentChannelMessageStore()
@@ -679,6 +930,7 @@ struct SlackConnectionTests {
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     readableChannelIds: ["C23456"],
+                    senderAllowlist: ["U55555"],
                     botUserId: "UOSABOT"
                 )
             )
@@ -927,6 +1179,35 @@ struct SlackConnectionTests {
         }
     }
 
+    private static func socketModeEnvelope(
+        envelopeId: String,
+        eventId: String,
+        userId: String,
+        text: String
+    ) -> String {
+        """
+        {
+          "envelope_id": "\(envelopeId)",
+          "type": "events_api",
+          "payload": {
+            "team_id": "T12345",
+            "api_app_id": "A12345",
+            "event_id": "\(eventId)",
+            "event_time": 1782427200,
+            "type": "event_callback",
+            "event": {
+              "type": "app_mention",
+              "channel": "C23456",
+              "user": "\(userId)",
+              "text": "\(text)",
+              "ts": "1718800000.000100",
+              "channel_type": "channel"
+            }
+          }
+        }
+        """
+    }
+
     private func withIsolatedSlackStores(
         _ body: @Sendable (any SlackCredentialStorage) async throws -> Void
     ) async throws {
@@ -1018,10 +1299,59 @@ private final class FakeSlackCredentialStore: SlackCredentialStorage, @unchecked
     }
 }
 
+private final class SlackTokenPresenceBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Bool
+
+    init(_ value: Bool) {
+        self.stored = value
+    }
+
+    func value() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func set(_ value: Bool) {
+        lock.lock()
+        stored = value
+        lock.unlock()
+    }
+}
+
+private actor SlackReceiveTransportRuntimeSpy: AgentChannelReceiveTransportRuntime {
+    private var starts = 0
+    private var stops = 0
+    private var stoppedAt: Date?
+
+    func start(pollInterval: TimeInterval) async {
+        starts += 1
+    }
+
+    func stop(now: Date) async {
+        stops += 1
+        stoppedAt = now
+    }
+
+    func startCount() -> Int {
+        starts
+    }
+
+    func stopCount() -> Int {
+        stops
+    }
+
+    func lastStopDate() -> Date? {
+        stoppedAt
+    }
+}
+
 private actor FakeSlackAPIClient: SlackAPIClientProtocol {
     private var authFailureMessage: String?
     private var messagesByChannel: [String: [SlackMessage]] = [:]
     private var sentMessages: [(channelId: String, content: String, threadTs: String?)] = []
+    private var openedAppToken: String?
 
     func setAuthFailureEchoingSecrets(botToken: String, signingSecret: String, appToken: String) {
         authFailureMessage = """
@@ -1057,6 +1387,15 @@ private actor FakeSlackAPIClient: SlackAPIClientProtocol {
             userId: "U12345",
             botId: "B12345"
         )
+    }
+
+    func openSocketModeConnection(appToken: String) async throws -> URL {
+        openedAppToken = appToken
+        return URL(string: "wss://socket-mode.slack.test/link")!
+    }
+
+    func lastOpenedAppToken() -> String? {
+        openedAppToken
     }
 
     func conversations(token: String, limit: Int) async throws -> [SlackConversation] {
@@ -1101,6 +1440,57 @@ private actor FakeSlackAPIClient: SlackAPIClientProtocol {
             text: request.content,
             threadTs: request.threadTs
         )
+    }
+}
+
+private final class FakeSlackSocketModeWebSocketFactory: SlackSocketModeWebSocketFactory, @unchecked Sendable {
+    private let socket: FakeSlackSocketModeWebSocket
+
+    init(socket: FakeSlackSocketModeWebSocket) {
+        self.socket = socket
+    }
+
+    func connect(to url: URL) -> any SlackSocketModeWebSocket {
+        socket
+    }
+}
+
+private final class FakeSlackSocketModeWebSocket: SlackSocketModeWebSocket, @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [String]
+    private var sent: [String] = []
+    private var cancelled = false
+
+    init(messages: [String]) {
+        self.messages = messages
+    }
+
+    func receiveText() async throws -> String {
+        try lock.withLock {
+            if cancelled {
+                throw CancellationError()
+            }
+            guard !messages.isEmpty else {
+                throw CancellationError()
+            }
+            return messages.removeFirst()
+        }
+    }
+
+    func sendText(_ text: String) async throws {
+        lock.withLock {
+            sent.append(text)
+        }
+    }
+
+    func cancel() {
+        lock.withLock {
+            cancelled = true
+        }
+    }
+
+    func sentTexts() async -> [String] {
+        lock.withLock { sent }
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
@@ -18,9 +18,11 @@ struct SlackConnectionTests {
         try await withIsolatedSlackStores { credentials in
             let botToken = "xoxb-slack-bot-token-super-secret"
             let signingSecret = "slack-signing-secret-super-secret"
+            let appToken = "xapp-slack-app-token-super-secret"
             let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
             try service.saveBotToken(botToken)
             try service.saveSigningSecret(signingSecret)
+            try service.saveAppToken(appToken)
             try service.saveConfiguration(
                 SlackConnectionConfiguration(
                     configuredTeamIds: [" T12345 ", "T12345"],
@@ -43,8 +45,10 @@ struct SlackConnectionTests {
             #expect(disk.contains("C23456"))
             #expect(!disk.contains(botToken))
             #expect(!disk.contains(signingSecret))
+            #expect(!disk.contains(appToken))
             #expect(!disk.localizedCaseInsensitiveContains("bot_token"))
             #expect(!disk.localizedCaseInsensitiveContains("signing_secret"))
+            #expect(!disk.localizedCaseInsensitiveContains("app_token"))
         }
     }
 
@@ -52,24 +56,34 @@ struct SlackConnectionTests {
         try await withIsolatedSlackStores { credentials in
             let botToken = "xoxb-slack-bot-token-super-secret"
             let signingSecret = "slack-signing-secret-super-secret"
+            let appToken = "xapp-slack-app-token-super-secret"
             let fake = FakeSlackAPIClient()
-            await fake.setAuthFailureEchoingSecrets(botToken: botToken, signingSecret: signingSecret)
+            await fake.setAuthFailureEchoingSecrets(
+                botToken: botToken,
+                signingSecret: signingSecret,
+                appToken: appToken
+            )
             let service = SlackConnectionService(client: fake, credentialStore: credentials)
             try service.saveBotToken(botToken)
             try service.saveSigningSecret(signingSecret)
+            try service.saveAppToken(appToken)
 
             let diagnostics = await service.diagnostics()
 
             #expect(diagnostics.botTokenSaved)
             #expect(diagnostics.signingSecretSaved)
+            #expect(diagnostics.appTokenSaved)
             #expect(diagnostics.status == "token_invalid_or_unavailable")
             let failures = diagnostics.failures.joined(separator: " ")
             #expect(failures.contains("[REDACTED:SLACK_BOT_TOKEN]"))
             #expect(failures.contains("[REDACTED:SLACK_SIGNING_SECRET]"))
+            #expect(failures.contains("[REDACTED:SLACK_APP_TOKEN]"))
             #expect(!failures.contains(botToken))
             #expect(!failures.contains(signingSecret))
+            #expect(!failures.contains(appToken))
             #expect(!String(describing: diagnostics.dictionary).contains(botToken))
             #expect(!String(describing: diagnostics.dictionary).contains(signingSecret))
+            #expect(!String(describing: diagnostics.dictionary).contains(appToken))
         }
     }
 
@@ -893,7 +907,7 @@ struct SlackConnectionTests {
             )
             #expect(slackRow["kind"] as? String == "slack")
             #expect(slackRow["configured"] as? Bool == true)
-            #expect(slackRow["secret_names"] as? [String] == ["bot_token", "signing_secret"])
+            #expect(slackRow["secret_names"] as? [String] == ["bot_token", "signing_secret", "app_token"])
 
             let manager = AgentChannelConnectionManager()
             #expect(throws: AgentChannelConnectionManagerError.reservedConnectionId("slack")) {
@@ -914,18 +928,20 @@ struct SlackConnectionTests {
     }
 
     private func withIsolatedSlackStores(
-        _ body: (any SlackCredentialStorage) async throws -> Void
+        _ body: @Sendable (any SlackCredentialStorage) async throws -> Void
     ) async throws {
-        let previousDirectory = SlackConnectionConfigurationStore.overrideDirectory
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("osaurus-slack-tests-\(UUID().uuidString)", isDirectory: true)
-        let credentials = FakeSlackCredentialStore()
-        SlackConnectionConfigurationStore.overrideDirectory = directory
-        defer {
-            SlackConnectionConfigurationStore.overrideDirectory = previousDirectory
-            try? FileManager.default.removeItem(at: directory)
+        try await AgentChannelConfigurationTestLock.shared.run {
+            let previousDirectory = SlackConnectionConfigurationStore.overrideDirectory
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-slack-tests-\(UUID().uuidString)", isDirectory: true)
+            let credentials = FakeSlackCredentialStore()
+            SlackConnectionConfigurationStore.overrideDirectory = directory
+            defer {
+                SlackConnectionConfigurationStore.overrideDirectory = previousDirectory
+                try? FileManager.default.removeItem(at: directory)
+            }
+            try await body(credentials)
         }
-        try await body(credentials)
     }
 
     private func slackSignature(secret: String, timestamp: String, body: Data) -> String {
@@ -941,6 +957,7 @@ private final class FakeSlackCredentialStore: SlackCredentialStorage, @unchecked
     private let lock = NSLock()
     private var storedBotToken: String?
     private var storedSigningSecret: String?
+    private var storedAppToken: String?
 
     func saveBotToken(_ token: String) -> Bool {
         save(token, assign: { storedBotToken = $0 })
@@ -976,6 +993,23 @@ private final class FakeSlackCredentialStore: SlackCredentialStorage, @unchecked
         return true
     }
 
+    func saveAppToken(_ token: String) -> Bool {
+        save(token, assign: { storedAppToken = $0 })
+    }
+
+    func appToken() -> String? {
+        lock.withLock { storedAppToken }
+    }
+
+    func hasAppToken() -> Bool {
+        appToken() != nil
+    }
+
+    func deleteAppToken() -> Bool {
+        lock.withLock { storedAppToken = nil }
+        return true
+    }
+
     private func save(_ value: String, assign: (String) -> Void) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
@@ -989,8 +1023,10 @@ private actor FakeSlackAPIClient: SlackAPIClientProtocol {
     private var messagesByChannel: [String: [SlackMessage]] = [:]
     private var sentMessages: [(channelId: String, content: String, threadTs: String?)] = []
 
-    func setAuthFailureEchoingSecrets(botToken: String, signingSecret: String) {
-        authFailureMessage = "transport included token \(botToken) and signing secret \(signingSecret)"
+    func setAuthFailureEchoingSecrets(botToken: String, signingSecret: String, appToken: String) {
+        authFailureMessage = """
+        transport included token \(botToken), signing secret \(signingSecret), and app token \(appToken)
+        """
     }
 
     func setMessages(_ messagesByChannel: [String: [SlackMessage]]) {

--- a/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CryptoKit
 import Testing
 
 @testable import OsaurusCore
@@ -72,6 +73,57 @@ struct SlackConnectionTests {
         }
     }
 
+    @Test func diagnosticsPersistsBotIdentityForInboundSelfFiltering() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(readableChannelIds: ["C23456"])
+            )
+
+            let diagnostics = await service.diagnostics()
+            let saved = SlackConnectionConfigurationStore.load()
+
+            #expect(diagnostics.identity?.userId == "U12345")
+            #expect(diagnostics.identity?.botId == "B12345")
+            #expect(saved.botUserId == "U12345")
+            #expect(saved.botId == "B12345")
+        }
+    }
+
+    @Test func signatureVerifierAuthorizesSlackSignedRequestOnlyWithinTolerance() throws {
+        let signingSecret = "8f742231b10e8888abcd99yyyzzz85a5"
+        let timestamp = "1531420618"
+        let body = Data(
+            """
+            token=xyzz0WbapA4vBCDEFasx0Fqz&team_id=T1DC2J9E1&team_domain=testteamnow&channel_id=C2147483705&channel_name=test&user_id=U2147483697&user_name=Steve&command=/weather&text=94070&response_url=https://hooks.slack.com/commands/1234/5678&trigger_id=13345224609.738474920.8088930838d88f008e0
+            """.utf8
+        )
+        let signature = "v0=4d19b371acb8c24626ae294d086e5dc1513e8e0c04781438c439143315cb807e"
+
+        #expect(SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: body,
+            signature: signature,
+            now: Date(timeIntervalSince1970: 1_531_420_618)
+        ))
+        #expect(!SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: body,
+            signature: signature,
+            now: Date(timeIntervalSince1970: 1_531_421_000)
+        ))
+        #expect(!SlackSignatureVerifier.isAuthorized(
+            signingSecret: signingSecret,
+            timestamp: timestamp,
+            body: Data("tampered".utf8),
+            signature: signature,
+            now: Date(timeIntervalSince1970: 1_531_420_618)
+        ))
+    }
+
     @Test func apiClientRedactsTokenEchoedBySlackErrorBody() async throws {
         let token = "xoxb-slack-bot-token-super-secret"
         let session = SlackHTTPStubProtocol.session(
@@ -116,9 +168,11 @@ struct SlackConnectionTests {
         )
 
         _ = try await client.sendMessage(
-            channelId: "C34567",
-            content: "Hello @channel <@U23456>",
-            threadTs: nil,
+            SlackOutboundMessageRequest(
+                channelId: "C34567",
+                content: "Hello @channel <@U23456>",
+                threadTs: nil
+            ),
             token: token
         )
 
@@ -146,6 +200,28 @@ struct SlackConnectionTests {
         let form = SlackHTTPStubProtocol.lastRequestFormBody()
         #expect(form["limit"] == "10")
         #expect(form["exclude_archived"] == "true")
+        #expect(SlackHTTPStubProtocol.lastRawRequestBody()
+            .contains("types=public_channel%2Cprivate_channel%2Cmpim%2Cim"))
+    }
+
+    @Test func apiClientMapsSlackRateLimitWithRetryAfterHint() async throws {
+        let token = "xoxb-slack-bot-token-super-secret"
+        let session = SlackHTTPStubProtocol.session(
+            statusCode: 429,
+            body: #"{"ok":false,"error":"ratelimited"}"#,
+            headers: ["Retry-After": "7"]
+        )
+        let client = SlackAPIClient(
+            baseURL: URL(string: "https://slack.test/api")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.messages(channelId: "C23456", token: token, limit: 1)
+            Issue.record("Slack request should have been rate limited")
+        } catch let error as SlackAPIError {
+            #expect(error == .rateLimited("Slack rate limited this request. Retry after 7 seconds."))
+        }
     }
 
     @Test func readChannelReturnsBoundedMessagesForAllowlistedSlackChannel() async throws {
@@ -174,6 +250,460 @@ struct SlackConnectionTests {
             #expect(messages.count == 2)
             #expect(messages.first?["content"] as? String == "eval reports landed")
             #expect(messages.first?["thread_id"] as? String == "C23456:1718800000.000100")
+        }
+    }
+
+    @Test func readAndSendRecordSlackMessagesInAgentChannelStore() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeSlackAPIClient()
+            await fake.setMessages([
+                "C23456": [
+                    .fixture(ts: "1718800000.000100", text: "eval reports landed"),
+                    .fixture(ts: "1718800001.000200", text: "review requested"),
+                ],
+            ])
+            let service = SlackConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("xoxb-slack-bot-token-super-secret")
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    writableChannelIds: ["C23456"],
+                    writeEnabled: true,
+                    defaultReadLimit: 2
+                )
+            )
+
+            _ = try await service.readChannel(channelId: "C23456", limit: nil)
+            _ = try await service.readChannel(channelId: "C23456", limit: nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 2)
+
+            _ = try await service.sendMessage(
+                channelId: "C23456",
+                content: "Ship it",
+                confirmSend: true
+            )
+            let rows = try store.recentMessages(connectionId: "slack", roomId: "C23456", limit: 10)
+            #expect(rows.contains { $0.providerMessageId == "1718800001.000100" && $0.direction == .outbound })
+            #expect(rows.allSatisfy { !$0.payloadJSON.localizedCaseInsensitiveContains("xoxb-slack") })
+        }
+    }
+
+    @Test func slackInboundEventNormalizationCapturesMentionThreadAndStoreDedupe() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: "legacy-verification-secret",
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> can you check this?",
+                    ts: "1718800001.000200",
+                    threadTs: "1718800000.000100",
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "Ev12345",
+                eventTime: 1_718_800_001
+            )
+
+            let normalized = try #require(try service.recordInboundEvent(envelope))
+            #expect(normalized.providerEventId == "Ev12345")
+            #expect(normalized.roomId == "C23456")
+            #expect(normalized.threadId == "C23456:1718800000.000100")
+            #expect(normalized.isThreadReply)
+            #expect(normalized.isMention)
+            #expect(normalized.mentionedUserIds == ["UOSABOT"])
+            #expect(!normalized.payloadJSON.contains("legacy-verification-secret"))
+            #expect(try service.recordInboundEvent(envelope) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+        }
+    }
+
+    @Test func slackInboundEventRequiresSignedBodyForWebhookEntryPoint() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let signingSecret = "slack-signing-secret-super-secret"
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveSigningSecret(signingSecret)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: "legacy-verification-secret",
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> signed event",
+                    ts: "1718800001.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSigned12345",
+                eventTime: 1_718_800_001
+            )
+            let body = try JSONEncoder().encode(envelope)
+            let timestamp = "1718800001"
+            let signature = slackSignature(secret: signingSecret, timestamp: timestamp, body: body)
+
+            let normalized = try #require(try service.recordVerifiedInboundEvent(
+                body: body,
+                timestamp: timestamp,
+                signature: signature,
+                now: Date(timeIntervalSince1970: 1_718_800_001)
+            ))
+
+            #expect(normalized.providerEventId == "EvSigned12345")
+            #expect(!normalized.payloadJSON.contains("legacy-verification-secret"))
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+
+            do {
+                _ = try service.recordVerifiedInboundEvent(
+                    body: body,
+                    timestamp: timestamp,
+                    signature: "v0=bad",
+                    now: Date(timeIntervalSince1970: 1_718_800_001)
+                )
+                Issue.record("Slack webhook entry should reject invalid signatures")
+            } catch let error as SlackConnectionServiceError {
+                #expect(error == .signatureVerificationFailed)
+            }
+        }
+    }
+
+    @Test func signedSlackInboundEventRequiresReadableChannelAllowlistBeforeStorage() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let signingSecret = "slack-signing-secret-super-secret"
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveSigningSecret(signingSecret)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C99999"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> signed but not allowlisted",
+                    ts: "1718800001.000300",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSignedDenied12345",
+                eventTime: 1_718_800_001
+            )
+            let body = try JSONEncoder().encode(envelope)
+            let timestamp = "1718800001"
+            let signature = slackSignature(secret: signingSecret, timestamp: timestamp, body: body)
+
+            let normalized = try service.recordVerifiedInboundEvent(
+                body: body,
+                timestamp: timestamp,
+                signature: signature,
+                now: Date(timeIntervalSince1970: 1_718_800_001)
+            )
+
+            #expect(normalized == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 0)
+        }
+    }
+
+    @Test func slackInboundEventMentionAndSelfMessagePolicyAvoidsOverTriggering() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT",
+                    botId: "BOSABOT",
+                    apiAppId: "AOSABOT"
+                )
+            )
+
+            let thirdPartyMention = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "cc <@UOTHER|teammate>",
+                    ts: "1718800002.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvOtherMention",
+                eventTime: 1_718_800_002
+            )
+            let normalized = try #require(service.normalizeInboundEvent(thirdPartyMention))
+            #expect(normalized.mentionedUserIds == ["UOTHER"])
+            #expect(!normalized.isMention)
+
+            let ownBotDirectMessage = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "AOSABOT",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: nil,
+                    botId: "BOSABOT",
+                    text: "self echo without subtype",
+                    ts: "1718800003.000100",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSelfBotDirect",
+                eventTime: 1_718_800_003
+            )
+            #expect(service.normalizeInboundEvent(ownBotDirectMessage) == nil)
+
+            let ownBotMessage = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "AOSABOT",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: "bot_message",
+                    channel: "C23456",
+                    user: nil,
+                    botId: "BOSABOT",
+                    text: "self echo",
+                    ts: "1718800003.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvSelfBot",
+                eventTime: 1_718_800_003
+            )
+            #expect(service.normalizeInboundEvent(ownBotMessage) == nil)
+        }
+    }
+
+    @Test func slackInboundEventRejectsUnconfiguredTeamAndMissingBotIdentity() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let service = SlackConnectionService(client: FakeSlackAPIClient(), credentialStore: credentials)
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "TOTHER",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> hello",
+                    ts: "1718800003.000400",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvWrongTeam",
+                eventTime: 1_718_800_003
+            )
+
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["T12345"],
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            #expect(service.normalizeInboundEvent(envelope) == nil)
+
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    configuredTeamIds: ["TOTHER"],
+                    readableChannelIds: ["C23456"]
+                )
+            )
+            #expect(service.normalizeInboundEvent(envelope) == nil)
+        }
+    }
+
+    @Test func slackInboundEventDedupesMessageAndAppMentionForSameSlackMessage() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            let appMention = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> same message",
+                    ts: "1718800004.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvAppMention",
+                eventTime: 1_718_800_004
+            )
+            let messageEcho = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "message",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> same message",
+                    ts: "1718800004.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvMessageEcho",
+                eventTime: 1_718_800_004
+            )
+
+            #expect(try service.recordInboundEvent(appMention) != nil)
+            #expect(try service.recordInboundEvent(messageEcho) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
+        }
+    }
+
+    @Test func slackInboundDispatchSurvivesPassiveSnapshotCollision() async throws {
+        try await withIsolatedSlackStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = SlackConnectionService(
+                client: FakeSlackAPIClient(),
+                credentialStore: credentials,
+                messageStore: store
+            )
+            try service.saveConfiguration(
+                SlackConnectionConfiguration(
+                    readableChannelIds: ["C23456"],
+                    botUserId: "UOSABOT"
+                )
+            )
+            _ = try store.recordMessages([
+                AgentChannelStoredMessage(
+                    connectionId: "slack",
+                    roomId: "C23456",
+                    providerMessageId: "1718800005.000200",
+                    direction: .inbound,
+                    threadId: "C23456:1718800005.000200",
+                    authorId: "U55555",
+                    authorName: "Mika",
+                    content: "<@UOSABOT> cached before event",
+                    providerTimestamp: "1718800005.000200"
+                ),
+            ])
+            let envelope = SlackEventEnvelope(
+                token: nil,
+                teamId: "T12345",
+                apiAppId: "A12345",
+                event: SlackEventMessage(
+                    type: "app_mention",
+                    subtype: nil,
+                    channel: "C23456",
+                    user: "U55555",
+                    botId: nil,
+                    text: "<@UOSABOT> cached before event",
+                    ts: "1718800005.000200",
+                    threadTs: nil,
+                    channelType: "channel"
+                ),
+                type: "event_callback",
+                eventId: "EvPassiveCollision",
+                eventTime: 1_718_800_005
+            )
+
+            #expect(try service.recordInboundEvent(envelope) != nil)
+            #expect(try service.recordInboundEvent(envelope) == nil)
+            #expect(try store.messageCount(connectionId: "slack", roomId: "C23456") == 1)
         }
     }
 
@@ -308,6 +838,9 @@ struct SlackConnectionTests {
             #expect(throws: SlackConnectionServiceError.broadcastMentionDenied) {
                 try service.draftMessage(channelId: "C34567", content: "Heads up <!channel>")
             }
+            #expect(throws: SlackConnectionServiceError.broadcastMentionDenied) {
+                try service.draftMessage(channelId: "C34567", content: "Heads up <!subteam^S12345|@ops>")
+            }
             #expect(await fake.sentMessageCount() == 0)
         }
     }
@@ -393,6 +926,14 @@ struct SlackConnectionTests {
             try? FileManager.default.removeItem(at: directory)
         }
         try await body(credentials)
+    }
+
+    private func slackSignature(secret: String, timestamp: String, body: Data) -> String {
+        var base = Data("v0:\(timestamp):".utf8)
+        base.append(body)
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let digest = HMAC<SHA256>.authenticationCode(for: base, using: key)
+        return "v0=" + digest.map { String(format: "%02x", $0) }.joined()
     }
 }
 
@@ -517,12 +1058,12 @@ private actor FakeSlackAPIClient: SlackAPIClientProtocol {
         Array((messagesByChannel[channelId] ?? []).filter { ($0.threadTs ?? $0.ts) == threadTs }.prefix(limit))
     }
 
-    func sendMessage(channelId: String, content: String, threadTs: String?, token: String) async throws -> SlackMessage {
-        sentMessages.append((channelId: channelId, content: content, threadTs: threadTs))
+    func sendMessage(_ request: SlackOutboundMessageRequest, token: String) async throws -> SlackMessage {
+        sentMessages.append((channelId: request.channelId, content: request.content, threadTs: request.threadTs))
         return .fixture(
             ts: "171880000\(sentMessages.count).000100",
-            text: content,
-            threadTs: threadTs
+            text: request.content,
+            threadTs: request.threadTs
         )
     }
 }
@@ -559,11 +1100,13 @@ private actor FakeDiscordAPIClientForSlackTests: DiscordAPIClientProtocol {
 private final class SlackHTTPStubProtocol: URLProtocol {
     nonisolated(unsafe) private static var statusCode: Int = 200
     nonisolated(unsafe) private static var body = Data()
+    nonisolated(unsafe) private static var headers: [String: String] = [:]
     nonisolated(unsafe) private static var requestBody = Data()
 
-    static func session(statusCode: Int, body: String) -> URLSession {
+    static func session(statusCode: Int, body: String, headers: [String: String] = [:]) -> URLSession {
         self.statusCode = statusCode
         self.body = Data(body.utf8)
+        self.headers = headers
         requestBody = Data()
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [SlackHTTPStubProtocol.self]
@@ -573,6 +1116,10 @@ private final class SlackHTTPStubProtocol: URLProtocol {
     static func lastRequestJSONBody() -> [String: Any]? {
         guard !requestBody.isEmpty else { return nil }
         return try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+    }
+
+    static func lastRawRequestBody() -> String {
+        String(data: requestBody, encoding: .utf8) ?? ""
     }
 
     static func lastRequestFormBody() -> [String: String] {
@@ -621,7 +1168,7 @@ private final class SlackHTTPStubProtocol: URLProtocol {
             url: request.url!,
             statusCode: Self.statusCode,
             httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"]
+            headerFields: ["Content-Type": "application/json"].merging(Self.headers) { _, new in new }
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Self.body)

--- a/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
@@ -25,7 +25,8 @@ struct TelegramConnectionTests {
                         writableChatIds: ["-100444555666"],
                         senderAllowlist: [" 7 ", "7"],
                         writeEnabled: true,
-                        defaultReadLimit: 250
+                        defaultReadLimit: 250,
+                        longPollingTimeoutSeconds: 0
                     )
                 )
 
@@ -33,6 +34,7 @@ struct TelegramConnectionTests {
             #expect(saved.readableChatIds == ["-100111222333", "@ops_channel"])
             #expect(saved.senderAllowlist == ["7"])
             #expect(saved.defaultReadLimit == 100)
+            #expect(saved.longPollingTimeoutSeconds == 1)
             #expect(!TelegramConnectionConfiguration.isValidChatId("١٢٣٤"))
 
             let disk = try String(
@@ -86,6 +88,30 @@ struct TelegramConnectionTests {
         }
     }
 
+    @Test func apiClientMapsLongPollConflictToTypedError() async throws {
+        let token = "123456:telegram-bot-token-super-secret"
+        let session = TelegramHTTPStubProtocol.session(
+            statusCode: 409,
+            body: #"{"ok":false,"error_code":409,"description":"Conflict: terminated by other getUpdates request"}"#
+        )
+        let client = TelegramAPIClient(
+            baseURL: URL(string: "https://telegram.test")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.getUpdates(offset: 99, limit: 250, timeout: 99, token: token)
+            Issue.record("Telegram getUpdates should have failed with conflict")
+        } catch let error as TelegramAPIError {
+            #expect(error == .conflict("Conflict: terminated by other getUpdates request"))
+        }
+
+        let body = try #require(TelegramHTTPStubProtocol.lastRequestJSONBody())
+        #expect(body["offset"] as? Int == 99)
+        #expect(body["limit"] as? Int == 100)
+        #expect(body["timeout"] as? Int == 50)
+    }
+
     @Test func apiClientSendsPlainTextWithoutParseMode() async throws {
         let token = "123456:telegram-bot-token-super-secret"
         let session = TelegramHTTPStubProtocol.session(
@@ -120,6 +146,27 @@ struct TelegramConnectionTests {
         #expect(body["text"] as? String == "Hello <b>ops</b>")
         #expect(body["reply_to_message_id"] as? Int == 12)
         #expect(body["parse_mode"] == nil)
+    }
+
+    @Test func diagnosticsWarnWhenLongPollingHasNoSenderAllowlist() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let service = TelegramConnectionService(client: FakeTelegramAPIClient(), credentialStore: credentials)
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            )
+
+            let diagnostics = await service.diagnostics()
+
+            #expect(diagnostics.status == "connected_receive_needs_sender_allowlist")
+            #expect(diagnostics.failures.contains {
+                $0.localizedCaseInsensitiveContains("no authorized sender IDs")
+            })
+        }
     }
 
     @Test func webhookPayloadNormalizesStoresAndDeduplicatesUpdates() async throws {
@@ -197,6 +244,293 @@ struct TelegramConnectionTests {
             #expect(await fake.lastUpdateOffset() == 42)
             #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == "43")
         }
+    }
+
+    @Test func transportRuntimeUsesStoredOffsetBoundedPollingAndHealth() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+            try store.upsertCursor(
+                connectionId: "telegram",
+                roomId: "__telegram_updates__",
+                cursor: "42"
+            )
+
+            let fake = FakeTelegramAPIClient()
+            await fake.setUpdates([
+                .fixture(updateId: 42, messageId: 10, chatId: -100111222333, text: "from runtime")
+            ])
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true,
+                    longPollingLimit: 250,
+                    longPollingTimeoutSeconds: 99
+                )
+            )
+            let healthCenter = AgentChannelTransportHealthCenter()
+            let runtime = TelegramLongPollTransportRuntime(
+                service: service,
+                healthCenter: healthCenter
+            )
+
+            let now = Date(timeIntervalSince1970: 1_800_000_000)
+            let result = await runtime.runStep(now: now, jitter: 0.5)
+
+            #expect(result.disposition == .succeeded)
+            #expect(result.received == 1)
+            #expect(result.stored == 1)
+            #expect(result.dispatchAttempted == 0)
+            #expect(result.dispatchSuppressed == 1)
+            #expect(result.health.status == .healthy)
+            #expect(result.health.lastSuccessAt == now)
+            #expect(await fake.lastUpdateOffset() == 42)
+            #expect(await fake.lastUpdateLimit() == 100)
+            #expect(await fake.lastUpdateTimeout() == 50)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == "43")
+            let published = await healthCenter.state(
+                connectionId: "telegram",
+                transportId: TelegramLongPollTransportRuntime.transportId
+            )
+            #expect(published == result.health)
+        }
+    }
+
+    @Test func transportRuntimeSurfacesTelegram409ConflictAsHealthState() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            await fake.failGetUpdatesWithConflict("Conflict: terminated by other getUpdates request")
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            )
+            let healthCenter = AgentChannelTransportHealthCenter()
+            let runtime = TelegramLongPollTransportRuntime(
+                service: service,
+                healthCenter: healthCenter,
+                backoffPolicy: AgentChannelTransportBackoffPolicy(
+                    initialDelay: 4,
+                    multiplier: 2,
+                    maxDelay: 30,
+                    jitterFraction: 0.25
+                )
+            )
+
+            let now = Date(timeIntervalSince1970: 1_800_000_100)
+            let result = await runtime.runStep(now: now, jitter: 0.5)
+
+            #expect(result.disposition == .conflict)
+            #expect(result.received == 0)
+            #expect(result.stored == 0)
+            #expect(result.dispatchAttempted == 0)
+            #expect(result.retryDelay == 4)
+            #expect(result.health.status == .conflict)
+            #expect(result.health.severity == .error)
+            #expect(result.health.nextRetryAt == now.addingTimeInterval(4))
+            #expect(result.health.detail?.contains("Conflict") == true)
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == nil)
+            let published = await healthCenter.state(
+                connectionId: "telegram",
+                transportId: TelegramLongPollTransportRuntime.transportId
+            )
+            #expect(published == result.health)
+        }
+    }
+
+    @Test func transportRuntimeStoresReceiveOnlyMessagesWithoutDispatch() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            await fake.setUpdates([
+                .fixture(updateId: 51, messageId: 501, chatId: -100111222333, text: "store only")
+            ])
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    writeEnabled: false,
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            )
+            let runtime = TelegramLongPollTransportRuntime(
+                service: service,
+                healthCenter: AgentChannelTransportHealthCenter()
+            )
+
+            let result = await runtime.runStep(now: Date(timeIntervalSince1970: 1_800_000_200), jitter: 0.5)
+
+            #expect(result.disposition == .succeeded)
+            #expect(result.stored == 1)
+            #expect(result.dispatchAttempted == 0)
+            #expect(result.dispatchSuppressed == 1)
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 1)
+            let stored = try #require(
+                try store.recentMessages(
+                    connectionId: "telegram",
+                    roomId: "-100111222333",
+                    limit: 1
+                ).first
+            )
+            #expect(stored.direction == .inbound)
+            #expect(stored.content == "store only")
+        }
+    }
+
+    @Test func transportSupervisorStartsTelegramRuntimeOnlyWhenLongPollingIsEnabled() async {
+        let runtime = SpyReceiveTransportRuntime()
+        let supervisor = AgentChannelTransportSupervisor(
+            telegramConfiguration: {
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            },
+            telegramHasBotToken: { true },
+            telegramRuntime: runtime
+        )
+
+        await supervisor.startFromLaunch()
+        await supervisor.startFromLaunch()
+
+        #expect(await runtime.startCount() == 1)
+        #expect(await runtime.stopCount() == 0)
+    }
+
+    @Test func transportSupervisorDoesNotStartTelegramRuntimeWithoutSenderAllowlist() async {
+        let runtime = SpyReceiveTransportRuntime()
+        let supervisor = AgentChannelTransportSupervisor(
+            telegramConfiguration: {
+                TelegramConnectionConfiguration(
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            },
+            telegramHasBotToken: { true },
+            telegramRuntime: runtime
+        )
+
+        await supervisor.startFromLaunch()
+
+        #expect(await runtime.startCount() == 0)
+        #expect(await runtime.stopCount() == 0)
+    }
+
+    @Test func transportSupervisorDoesNotStartTelegramRuntimeWithoutReadableChats() async {
+        let runtime = SpyReceiveTransportRuntime()
+        let supervisor = AgentChannelTransportSupervisor(
+            telegramConfiguration: {
+                TelegramConnectionConfiguration(
+                    senderAllowlist: ["7"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            },
+            telegramHasBotToken: { true },
+            telegramRuntime: runtime
+        )
+
+        await supervisor.startFromLaunch()
+
+        #expect(await runtime.startCount() == 0)
+        #expect(await runtime.stopCount() == 0)
+    }
+
+    @Test func transportSupervisorStopsTelegramRuntimeWhenLongPollingIsDisabled() async {
+        let runtime = SpyReceiveTransportRuntime()
+        let configuration = TelegramConfigurationBox(
+            TelegramConnectionConfiguration(
+                readableChatIds: ["-100111222333"],
+                senderAllowlist: ["7"],
+                receiveStorageEnabled: true,
+                longPollingEnabled: true
+            )
+        )
+        let supervisor = AgentChannelTransportSupervisor(
+            telegramConfiguration: { configuration.value() },
+            telegramHasBotToken: { true },
+            telegramRuntime: runtime
+        )
+        let stopDate = Date(timeIntervalSince1970: 1_800_000_500)
+
+        await supervisor.startFromLaunch()
+        configuration.set(
+            TelegramConnectionConfiguration(
+                readableChatIds: ["-100111222333"],
+                senderAllowlist: ["7"],
+                receiveStorageEnabled: true,
+                longPollingEnabled: false
+            )
+        )
+        await supervisor.refreshTelegramRuntime(now: stopDate)
+
+        #expect(await runtime.startCount() == 1)
+        #expect(await runtime.stopCount() == 1)
+        #expect(await runtime.lastStopDate() == stopDate)
+    }
+
+    @Test func transportSupervisorStopsTelegramRuntimeWhenBotTokenIsRemoved() async {
+        let runtime = SpyReceiveTransportRuntime()
+        let hasToken = TelegramTokenPresenceBox(true)
+        let supervisor = AgentChannelTransportSupervisor(
+            telegramConfiguration: {
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            },
+            telegramHasBotToken: { hasToken.value() },
+            telegramRuntime: runtime
+        )
+        let stopDate = Date(timeIntervalSince1970: 1_800_000_700)
+
+        await supervisor.startFromLaunch()
+        hasToken.set(false)
+        await supervisor.refreshTelegramRuntime(now: stopDate)
+
+        #expect(await runtime.startCount() == 1)
+        #expect(await runtime.stopCount() == 1)
+        #expect(await runtime.lastStopDate() == stopDate)
     }
 
     @Test func normalizationSkipsUnauthorizedSelfAndBotMessages() async throws {
@@ -628,6 +962,58 @@ struct TelegramConnectionTests {
             )
             let messages = try #require(read["messages"] as? [[String: Any]])
             #expect(messages.first?["content"] as? String == "ops ready")
+
+            await AgentChannelTransportHealthCenter.shared.clear(connectionId: "telegram")
+            await AgentChannelTransportHealthCenter.shared.update(
+                AgentChannelTransportHealthState(
+                    connectionId: "telegram",
+                    transportId: TelegramLongPollTransportRuntime.transportId,
+                    provider: .telegram,
+                    status: .healthy,
+                    severity: .info,
+                    summary: "Telegram long polling is healthy.",
+                    isRunning: true,
+                    receiveEnabled: true,
+                    lastReceivedCount: 1,
+                    lastStoredCount: 1
+                )
+            )
+            let diagnostics = await service.diagnostics(connectionId: "telegram")
+            let healthRows = try #require(diagnostics["transport_health"] as? [[String: Any]])
+            #expect(healthRows.first?["transport_id"] as? String == TelegramLongPollTransportRuntime.transportId)
+            #expect(healthRows.first?["status"] as? String == "healthy")
+            await AgentChannelTransportHealthCenter.shared.clear(connectionId: "telegram")
+        }
+    }
+
+    @Test func agentChannelReadToolRejectsChatsOutsideTelegramReadAllowlist() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let telegram = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials
+            )
+            try telegram.saveBotToken("123456:telegram-bot-token-super-secret")
+            try telegram.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"]
+                )
+            )
+            let service = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForTelegramTests(),
+                    credentialStore: FakeDiscordCredentialStoreForTelegramTests()
+                ),
+                telegramService: telegram
+            )
+            let tool = AgentChannelReadMessagesTool(service: service)
+
+            let result = try await tool.execute(
+                argumentsJSON: #"{"connection_id":"telegram","room_id":"-100999888777"}"#
+            )
+
+            #expect(EnvelopeAssertions.failureKind(result) == "rejected")
+            #expect(EnvelopeAssertions.failureMessage(result)?.contains("not allowlisted") == true)
         }
     }
 
@@ -647,18 +1033,20 @@ struct TelegramConnectionTests {
     }
 
     private func withIsolatedTelegramStores(
-        _ body: (any TelegramCredentialStorage) async throws -> Void
+        _ body: @Sendable (any TelegramCredentialStorage) async throws -> Void
     ) async throws {
-        let previousTelegramDirectory = TelegramConnectionConfigurationStore.overrideDirectory
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("osaurus-telegram-tests-\(UUID().uuidString)", isDirectory: true)
-        let credentials = FakeTelegramCredentialStore()
-        TelegramConnectionConfigurationStore.overrideDirectory = directory
-        defer {
-            TelegramConnectionConfigurationStore.overrideDirectory = previousTelegramDirectory
-            try? FileManager.default.removeItem(at: directory)
+        try await AgentChannelConfigurationTestLock.shared.run {
+            let previousTelegramDirectory = TelegramConnectionConfigurationStore.overrideDirectory
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-telegram-tests-\(UUID().uuidString)", isDirectory: true)
+            let credentials = FakeTelegramCredentialStore()
+            TelegramConnectionConfigurationStore.overrideDirectory = directory
+            defer {
+                TelegramConnectionConfigurationStore.overrideDirectory = previousTelegramDirectory
+                try? FileManager.default.removeItem(at: directory)
+            }
+            try await body(credentials)
         }
-        try await body(credentials)
     }
 }
 
@@ -690,11 +1078,18 @@ private final class FakeTelegramCredentialStore: TelegramCredentialStorage, @unc
 private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
     private var updates: [TelegramUpdate] = []
     private var lastOffset: Int64?
+    private var lastLimit: Int?
+    private var lastTimeout: Int?
     private var sentMessages: [(chatId: String, text: String, replyToMessageId: Int?)] = []
     private var getMeFailuresRemaining = 0
+    private var getUpdatesConflictMessage: String?
 
     func setUpdates(_ updates: [TelegramUpdate]) {
         self.updates = updates
+    }
+
+    func failGetUpdatesWithConflict(_ message: String) {
+        getUpdatesConflictMessage = message
     }
 
     func failNextGetMe() {
@@ -703,6 +1098,14 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
 
     func lastUpdateOffset() -> Int64? {
         lastOffset
+    }
+
+    func lastUpdateLimit() -> Int? {
+        lastLimit
+    }
+
+    func lastUpdateTimeout() -> Int? {
+        lastTimeout
     }
 
     func lastSentText() -> String? {
@@ -734,6 +1137,12 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
 
     func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate] {
         lastOffset = offset
+        lastLimit = limit
+        lastTimeout = timeout
+        if let getUpdatesConflictMessage {
+            self.getUpdatesConflictMessage = nil
+            throw TelegramAPIError.conflict(getUpdatesConflictMessage)
+        }
         return Array(updates.prefix(limit))
     }
 
@@ -788,6 +1197,75 @@ private final class FakeDiscordCredentialStoreForTelegramTests: DiscordCredentia
     func botToken() -> String? { nil }
     func hasBotToken() -> Bool { false }
     func deleteBotToken() -> Bool { true }
+}
+
+private final class TelegramConfigurationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: TelegramConnectionConfiguration
+
+    init(_ configuration: TelegramConnectionConfiguration) {
+        self.stored = configuration
+    }
+
+    func value() -> TelegramConnectionConfiguration {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func set(_ configuration: TelegramConnectionConfiguration) {
+        lock.lock()
+        stored = configuration
+        lock.unlock()
+    }
+}
+
+private final class TelegramTokenPresenceBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Bool
+
+    init(_ value: Bool) {
+        self.stored = value
+    }
+
+    func value() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+
+    func set(_ value: Bool) {
+        lock.lock()
+        stored = value
+        lock.unlock()
+    }
+}
+
+private actor SpyReceiveTransportRuntime: AgentChannelReceiveTransportRuntime {
+    private var starts = 0
+    private var stops = 0
+    private var stoppedAt: Date?
+
+    func start(pollInterval: TimeInterval) async {
+        starts += 1
+    }
+
+    func stop(now: Date) async {
+        stops += 1
+        stoppedAt = now
+    }
+
+    func startCount() -> Int {
+        starts
+    }
+
+    func stopCount() -> Int {
+        stops
+    }
+
+    func lastStopDate() -> Date? {
+        stoppedAt
+    }
 }
 
 private final class TelegramHTTPStubProtocol: URLProtocol {

--- a/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
@@ -1,0 +1,920 @@
+//
+//  TelegramConnectionTests.swift
+//  osaurusTests
+//
+//  Fixture coverage for the native Telegram agent channel.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct TelegramConnectionTests {
+
+    @Test func configurationPersistsAllowlistsButNeverBotToken() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let token = "123456:telegram-bot-token-super-secret"
+            try TelegramConnectionService(client: FakeTelegramAPIClient(), credentialStore: credentials)
+                .saveBotToken(token)
+            try TelegramConnectionService(client: FakeTelegramAPIClient(), credentialStore: credentials)
+                .saveConfiguration(
+                    TelegramConnectionConfiguration(
+                        readableChatIds: [" -100111222333 ", "-100111222333", "@Ops_Channel"],
+                        writableChatIds: ["-100444555666"],
+                        senderAllowlist: [" 7 ", "7"],
+                        writeEnabled: true,
+                        defaultReadLimit: 250
+                    )
+                )
+
+            let saved = TelegramConnectionConfigurationStore.load()
+            #expect(saved.readableChatIds == ["-100111222333", "@ops_channel"])
+            #expect(saved.senderAllowlist == ["7"])
+            #expect(saved.defaultReadLimit == 100)
+            #expect(!TelegramConnectionConfiguration.isValidChatId("١٢٣٤"))
+
+            let disk = try String(
+                contentsOf: TelegramConnectionConfigurationStore.configurationFileURL(),
+                encoding: .utf8
+            )
+            #expect(disk.contains("-100111222333"))
+            #expect(!disk.contains(token))
+            #expect(!disk.localizedCaseInsensitiveContains("bot_token"))
+        }
+    }
+
+    @Test func connectionManagerRejectsNativeTelegramId() async throws {
+        try await withIsolatedTelegramStores { _ in
+            let manager = AgentChannelConnectionManager()
+
+            #expect(throws: AgentChannelConnectionManagerError.reservedConnectionId("telegram")) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "telegram",
+                        name: "Shadow Telegram",
+                        kind: .customHTTP,
+                        supportedActions: [.diagnostics],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [:]
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test func apiClientRedactsTokenEchoedByTelegramErrorBody() async throws {
+        let token = "123456:telegram-bot-token-super-secret"
+        let session = TelegramHTTPStubProtocol.session(
+            statusCode: 403,
+            body: #"{"ok":false,"error_code":403,"description":"Telegram echoed \#(token)"}"#
+        )
+        let client = TelegramAPIClient(
+            baseURL: URL(string: "https://telegram.test")!,
+            sessionProvider: { session }
+        )
+
+        do {
+            _ = try await client.getChat(chatId: "-100111222333", token: token)
+            Issue.record("Telegram request should have failed")
+        } catch let error as TelegramAPIError {
+            #expect(error.localizedDescription.contains("[REDACTED:TELEGRAM_BOT_TOKEN]"))
+            #expect(!error.localizedDescription.contains(token))
+        }
+    }
+
+    @Test func apiClientSendsPlainTextWithoutParseMode() async throws {
+        let token = "123456:telegram-bot-token-super-secret"
+        let session = TelegramHTTPStubProtocol.session(
+            statusCode: 200,
+            body: """
+                {
+                  "ok": true,
+                  "result": {
+                    "message_id": 77,
+                    "date": 1782427200,
+                    "chat": { "id": -100111222333, "type": "group", "title": "Ops" },
+                    "from": { "id": 42, "is_bot": true, "first_name": "Osaurus", "username": "osaurus_bot" },
+                    "text": "Hello <b>ops</b>"
+                  }
+                }
+                """
+        )
+        let client = TelegramAPIClient(
+            baseURL: URL(string: "https://telegram.test")!,
+            sessionProvider: { session }
+        )
+
+        _ = try await client.sendMessage(
+            chatId: "-100111222333",
+            text: "Hello <b>ops</b>",
+            replyToMessageId: 12,
+            token: token
+        )
+
+        let body = try #require(TelegramHTTPStubProtocol.lastRequestJSONBody())
+        #expect(body["chat_id"] as? String == "-100111222333")
+        #expect(body["text"] as? String == "Hello <b>ops</b>")
+        #expect(body["reply_to_message_id"] as? Int == 12)
+        #expect(body["parse_mode"] == nil)
+    }
+
+    @Test func webhookPayloadNormalizesStoresAndDeduplicatesUpdates() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let data = Data(Self.updateJSON(updateId: 9001, messageId: 501, text: "deploy finished").utf8)
+            let first = try await service.processWebhookPayload(
+                data,
+                secretTokenHeader: "hook-secret",
+                expectedSecretToken: "hook-secret"
+            )
+            await #expect(throws: TelegramConnectionServiceError.invalidWebhookSecret) {
+                _ = try await service.processWebhookPayload(
+                    data,
+                    secretTokenHeader: "wrong-secret",
+                    expectedSecretToken: "hook-secret"
+                )
+            }
+            let duplicate = try await service.processWebhookPayload(data)
+
+            #expect(first.source == "webhook")
+            #expect(first.stored == 1)
+            #expect(first.results.first?.status == .accepted)
+            #expect(duplicate.stored == 0)
+            #expect(duplicate.results.first?.status == .duplicate)
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 1)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == nil)
+        }
+    }
+
+    @Test func longPollUsesStoredOffsetAndUpdatesCursor() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+            try store.upsertCursor(
+                connectionId: "telegram",
+                roomId: "__telegram_updates__",
+                cursor: "42"
+            )
+
+            let fake = FakeTelegramAPIClient()
+            await fake.setUpdates([
+                .fixture(updateId: 42, messageId: 10, chatId: -100111222333, text: "from poll")
+            ])
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let result = try await service.pollUpdates(limit: 10, timeout: 0)
+
+            #expect(result.source == "long_poll")
+            #expect(result.stored == 1)
+            #expect(await fake.lastUpdateOffset() == 42)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == "43")
+        }
+    }
+
+    @Test func normalizationSkipsUnauthorizedSelfAndBotMessages() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let result = try await service.processUpdates(
+                [
+                    .fixture(updateId: 1, messageId: 1, chatId: -100999888777, text: "blocked"),
+                    .fixture(
+                        updateId: 2,
+                        messageId: 2,
+                        chatId: -100111222333,
+                        text: "self",
+                        from: .fixture(id: 42, isBot: true)
+                    ),
+                    .fixture(
+                        updateId: 3,
+                        messageId: 3,
+                        chatId: -100111222333,
+                        text: "another bot",
+                        from: .fixture(id: 99, isBot: true)
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.map(\.status) == [.unauthorized, .ignored, .ignored])
+            #expect(result.results.map(\.reason) == [
+                "room_not_allowlisted",
+                "self_message_denied",
+                "bot_message_denied",
+            ])
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+        }
+    }
+
+    @Test func inboundReceiveRequiresSenderAllowlistBeforeStorage() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["99"])
+            )
+
+            let result = try await service.processUpdates(
+                [.fixture(updateId: 9, messageId: 9, chatId: -100111222333, text: "do the thing")],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.first?.status == .unauthorized)
+            #expect(result.results.first?.reason == "sender_not_allowlisted")
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "9") == false)
+        }
+    }
+
+    @Test func inboundReceiveDeniesWhenSenderAllowlistIsEmpty() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"])
+            )
+
+            let result = try await service.processUpdates(
+                [.fixture(updateId: 10, messageId: 10, chatId: -100111222333, text: "no sender policy")],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.first?.status == .unauthorized)
+            #expect(result.results.first?.reason == "sender_not_allowlisted")
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "10") == false)
+        }
+    }
+
+    @Test func cachedBotIdentityPreservesSelfDenialWhenGetMeFails() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7", "42"]
+                )
+            )
+
+            let warm = try await service.processUpdates(
+                [.fixture(updateId: 21, messageId: 21, chatId: -100111222333, text: "warm cache")],
+                source: "fixture"
+            )
+            await fake.failNextGetMe()
+            let selfMessage = try await service.processUpdates(
+                [
+                    .fixture(
+                        updateId: 22,
+                        messageId: 22,
+                        chatId: -100111222333,
+                        text: "self echo",
+                        from: .fixture(id: 42, isBot: false)
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(warm.stored == 1)
+            #expect(selfMessage.stored == 0)
+            #expect(selfMessage.results.first?.status == .ignored)
+            #expect(selfMessage.results.first?.reason == "self_message_denied")
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 1)
+        }
+    }
+
+    @Test func inboundReceiveDropsEmptyAndOversizedContentBeforeStorage() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+
+            let twoCodeUnitScalar = String(UnicodeScalar(0x1F600)!)
+            let result = try await service.processUpdates(
+                [
+                    .fixture(updateId: 31, messageId: 31, chatId: -100111222333, text: ""),
+                    .fixture(
+                        updateId: 32,
+                        messageId: 32,
+                        chatId: -100111222333,
+                        text: String(repeating: "x", count: 4097)
+                    ),
+                    .fixture(
+                        updateId: 33,
+                        messageId: 33,
+                        chatId: -100111222333,
+                        text: String(repeating: twoCodeUnitScalar, count: 2049)
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(result.stored == 0)
+            #expect(result.results.map(\.status) == [.ignored, .ignored, .ignored])
+            #expect(result.results.map(\.reason) == [
+                "empty_message_content",
+                "message_too_long",
+                "message_too_long",
+            ])
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "31") == false)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "32") == false)
+            #expect(try store.isEventSeen(connectionId: "telegram", providerEventId: "33") == false)
+        }
+    }
+
+    @Test func readAndSearchUseSQLiteBackedTelegramMessages() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(readableChatIds: ["-100111222333"], senderAllowlist: ["7"])
+            )
+            _ = try await service.processUpdates(
+                [
+                    .fixture(updateId: 10, messageId: 1, chatId: -100111222333, text: "eval reports landed"),
+                    .fixture(updateId: 11, messageId: 2, chatId: -100111222333, text: "ordinary update"),
+                ],
+                source: "fixture"
+            )
+
+            let read = try service.readChat(TelegramReadRequest(chatId: "-100111222333", limit: 5))
+            let messages = try #require(read["messages"] as? [[String: Any]])
+            #expect(messages.count == 2)
+
+            let search = try service.searchMessages(
+                query: "eval",
+                chatIds: ["-100111222333"],
+                limitPerChat: 10,
+                maxMatches: 10
+            )
+            #expect(search["match_count"] as? Int == 1)
+        }
+    }
+
+    @Test func usernameAllowlistStoresAndReadsByConfiguredHandle() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["@Ops_Channel"],
+                    writableChatIds: ["@Ops_Channel"],
+                    senderAllowlist: ["7"],
+                    writeEnabled: true
+                )
+            )
+            _ = try await service.processUpdates(
+                [
+                    .fixture(
+                        updateId: 20,
+                        messageId: 3,
+                        chatId: -100111222333,
+                        text: "eval report ready",
+                        chatUsername: "Ops_Channel"
+                    ),
+                ],
+                source: "fixture"
+            )
+
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "@ops_channel") == 1)
+
+            let listed = try await service.listChats()
+            let room = try #require(listed.first)
+            #expect(room["id"] as? String == "@ops_channel")
+            #expect(room["provider_chat_id"] as? String == "-100111222333")
+            _ = try await service.sendMessage(
+                TelegramWriteRequest(
+                    chatId: "@OPS_CHANNEL",
+                    text: "ack",
+                    replyToMessageId: nil,
+                    confirmSend: true
+                )
+            )
+
+            let read = try service.readChat(TelegramReadRequest(chatId: "@OPS_CHANNEL", limit: 5))
+            let messages = try #require(read["messages"] as? [[String: Any]])
+            #expect(messages.count == 2)
+            #expect(messages.contains { $0["direction"] as? String == "outbound" })
+
+            let search = try service.searchMessages(
+                query: "eval",
+                chatIds: ["@OPS_CHANNEL"],
+                limitPerChat: 10,
+                maxMatches: 10
+            )
+            #expect(search["match_count"] as? Int == 1)
+        }
+    }
+
+    @Test func sendMessageRequiresConfirmationMapsStatusAndRecordsOutbound() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    writableChatIds: ["-100111222333"],
+                    writeEnabled: true
+                )
+            )
+
+            await #expect(throws: TelegramConnectionServiceError.sendConfirmationRequired) {
+                _ = try await service.sendMessage(
+                    TelegramWriteRequest(
+                        chatId: "-100111222333",
+                        text: "ship it",
+                        replyToMessageId: nil,
+                        confirmSend: false
+                    )
+                )
+            }
+            await #expect(throws: TelegramConnectionServiceError.messageTooLong) {
+                let twoCodeUnitScalar = String(UnicodeScalar(0x1F600)!)
+                _ = try await service.sendMessage(
+                    TelegramWriteRequest(
+                        chatId: "-100111222333",
+                        text: String(repeating: twoCodeUnitScalar, count: 2049),
+                        replyToMessageId: nil,
+                        confirmSend: true
+                    )
+                )
+            }
+
+            let sent = try await service.sendMessage(
+                TelegramWriteRequest(
+                    chatId: "-100111222333",
+                    text: "ship it",
+                    replyToMessageId: 99,
+                    confirmSend: true
+                )
+            )
+
+            #expect(sent["delivery_status"] as? String == TelegramDeliveryStatus.sent.rawValue)
+            #expect(await fake.lastSentText() == "ship it")
+            #expect(await fake.lastReplyToMessageId() == 99)
+            let row = try #require(
+                try store.recentMessages(
+                    connectionId: "telegram",
+                    roomId: "-100111222333",
+                    limit: 1
+                ).first
+            )
+            #expect(row.direction == .outbound)
+            #expect(row.content == "ship it")
+            #expect(!row.payloadJSON.localizedCaseInsensitiveContains("telegram-bot-token-super-secret"))
+        }
+    }
+
+    @Test func standardAgentChannelServiceRoutesTelegramConnection() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let telegram = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try telegram.saveBotToken("123456:telegram-bot-token-super-secret")
+            try telegram.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    writableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    writeEnabled: true
+                )
+            )
+            _ = try await telegram.processUpdates(
+                [.fixture(updateId: 700, messageId: 17, chatId: -100111222333, text: "ops ready")],
+                source: "fixture"
+            )
+
+            let service = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForTelegramTests(),
+                    credentialStore: FakeDiscordCredentialStoreForTelegramTests()
+                ),
+                telegramService: telegram
+            )
+
+            let telegramRow = try #require(
+                service.listConnections().first { $0["id"] as? String == "telegram" }
+            )
+            #expect(telegramRow["configured"] as? Bool == true)
+            #expect(telegramRow["credential_saved"] as? Bool == true)
+            let inboundAuthorization = try #require(
+                telegramRow["inbound_authorization"] as? [String: Any]
+            )
+            #expect(inboundAuthorization["sender_allowlist"] as? [String] == ["7"])
+            #expect(inboundAuthorization["room_allowlist"] as? [String] == ["-100111222333"])
+            #expect(
+                inboundAuthorization["dispatch_contract"] as? String
+                    == "authorize_before_agent_context_or_tool_input"
+            )
+
+            let read = try await service.readMessages(
+                connectionId: "telegram",
+                roomId: "-100111222333",
+                limit: 5
+            )
+            let messages = try #require(read["messages"] as? [[String: Any]])
+            #expect(messages.first?["content"] as? String == "ops ready")
+        }
+    }
+
+    private static func updateJSON(updateId: Int64, messageId: Int, text: String) -> String {
+        """
+        {
+          "update_id": \(updateId),
+          "message": {
+            "message_id": \(messageId),
+            "date": 1782427200,
+            "chat": { "id": -100111222333, "type": "group", "title": "Ops" },
+            "from": { "id": 7, "is_bot": false, "first_name": "Mika", "username": "mika" },
+            "text": "\(text)"
+          }
+        }
+        """
+    }
+
+    private func withIsolatedTelegramStores(
+        _ body: (any TelegramCredentialStorage) async throws -> Void
+    ) async throws {
+        let previousTelegramDirectory = TelegramConnectionConfigurationStore.overrideDirectory
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-telegram-tests-\(UUID().uuidString)", isDirectory: true)
+        let credentials = FakeTelegramCredentialStore()
+        TelegramConnectionConfigurationStore.overrideDirectory = directory
+        defer {
+            TelegramConnectionConfigurationStore.overrideDirectory = previousTelegramDirectory
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try await body(credentials)
+    }
+}
+
+private final class FakeTelegramCredentialStore: TelegramCredentialStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedToken: String?
+
+    func saveBotToken(_ token: String) -> Bool {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        lock.withLock { storedToken = trimmed }
+        return true
+    }
+
+    func botToken() -> String? {
+        lock.withLock { storedToken }
+    }
+
+    func hasBotToken() -> Bool {
+        botToken() != nil
+    }
+
+    func deleteBotToken() -> Bool {
+        lock.withLock { storedToken = nil }
+        return true
+    }
+}
+
+private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
+    private var updates: [TelegramUpdate] = []
+    private var lastOffset: Int64?
+    private var sentMessages: [(chatId: String, text: String, replyToMessageId: Int?)] = []
+    private var getMeFailuresRemaining = 0
+
+    func setUpdates(_ updates: [TelegramUpdate]) {
+        self.updates = updates
+    }
+
+    func failNextGetMe() {
+        getMeFailuresRemaining += 1
+    }
+
+    func lastUpdateOffset() -> Int64? {
+        lastOffset
+    }
+
+    func lastSentText() -> String? {
+        sentMessages.last?.text
+    }
+
+    func lastReplyToMessageId() -> Int? {
+        sentMessages.last?.replyToMessageId
+    }
+
+    func getMe(token: String) async throws -> TelegramUser {
+        if getMeFailuresRemaining > 0 {
+            getMeFailuresRemaining -= 1
+            throw TelegramAPIError.requestFailed("temporary getMe failure")
+        }
+        return TelegramUser.fixture(id: 42, isBot: true)
+    }
+
+    func getChat(chatId: String, token: String) async throws -> TelegramChat {
+        TelegramChat(
+            id: Int64(chatId) ?? -100111222333,
+            type: "group",
+            title: "Ops",
+            username: chatId.hasPrefix("@") ? String(chatId.dropFirst()) : nil,
+            firstName: nil,
+            lastName: nil
+        )
+    }
+
+    func getUpdates(offset: Int64?, limit: Int, timeout: Int, token: String) async throws -> [TelegramUpdate] {
+        lastOffset = offset
+        return Array(updates.prefix(limit))
+    }
+
+    func sendMessage(
+        chatId: String,
+        text: String,
+        replyToMessageId: Int?,
+        token: String
+    ) async throws -> TelegramMessage {
+        sentMessages.append((chatId: chatId, text: text, replyToMessageId: replyToMessageId))
+        return TelegramMessage.fixture(
+            messageId: 800 + sentMessages.count,
+            chatId: Int64(chatId) ?? -100111222333,
+            text: text,
+            from: .fixture(id: 42, isBot: true),
+            replyToMessageId: replyToMessageId
+        )
+    }
+}
+
+private actor FakeDiscordAPIClientForTelegramTests: DiscordAPIClientProtocol {
+    func currentUser(token: String) async throws -> DiscordBotIdentity {
+        DiscordBotIdentity(id: "1", username: "bot", globalName: "Bot", bot: true)
+    }
+
+    func guild(id: String, token: String) async throws -> DiscordGuild {
+        DiscordGuild(id: id, name: "Guild")
+    }
+
+    func channels(guildId: String, token: String) async throws -> [DiscordChannel] {
+        []
+    }
+
+    func messages(channelId: String, token: String, limit: Int) async throws -> [DiscordMessage] {
+        []
+    }
+
+    func sendMessage(channelId: String, content: String, token: String) async throws -> DiscordMessage {
+        DiscordMessage(
+            id: "1",
+            channelId: channelId,
+            content: content,
+            timestamp: "2026-06-25T00:00:00Z",
+            author: DiscordMessageAuthor(id: "1", username: "bot", globalName: "Bot", bot: true),
+            attachments: []
+        )
+    }
+}
+
+private final class FakeDiscordCredentialStoreForTelegramTests: DiscordCredentialStorage, @unchecked Sendable {
+    func saveBotToken(_ token: String) -> Bool { true }
+    func botToken() -> String? { nil }
+    func hasBotToken() -> Bool { false }
+    func deleteBotToken() -> Bool { true }
+}
+
+private final class TelegramHTTPStubProtocol: URLProtocol {
+    nonisolated(unsafe) private static var statusCode: Int = 200
+    nonisolated(unsafe) private static var body = Data()
+    nonisolated(unsafe) private static var requestBody = Data()
+
+    static func session(statusCode: Int, body: String) -> URLSession {
+        self.statusCode = statusCode
+        self.body = Data(body.utf8)
+        requestBody = Data()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TelegramHTTPStubProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    static func lastRequestJSONBody() -> [String: Any]? {
+        guard !requestBody.isEmpty else { return nil }
+        return try? JSONSerialization.jsonObject(with: requestBody) as? [String: Any]
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let data = request.httpBody {
+            return data
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestBody = Self.bodyData(from: request)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private extension TelegramUser {
+    static func fixture(id: Int64, isBot: Bool) -> TelegramUser {
+        TelegramUser(
+            id: id,
+            isBot: isBot,
+            firstName: isBot ? "Bot" : "Mika",
+            lastName: nil,
+            username: isBot ? "bot" : "mika"
+        )
+    }
+}
+
+private extension TelegramUpdate {
+    static func fixture(
+        updateId: Int64,
+        messageId: Int,
+        chatId: Int64,
+        text: String,
+        from: TelegramUser = .fixture(id: 7, isBot: false),
+        chatUsername: String? = nil
+    ) -> TelegramUpdate {
+        TelegramUpdate(
+            updateId: updateId,
+            message: .fixture(
+                messageId: messageId,
+                chatId: chatId,
+                text: text,
+                from: from,
+                chatUsername: chatUsername
+            ),
+            editedMessage: nil,
+            channelPost: nil,
+            editedChannelPost: nil
+        )
+    }
+}
+
+private extension TelegramMessage {
+    static func fixture(
+        messageId: Int,
+        chatId: Int64,
+        text: String,
+        from: TelegramUser?,
+        replyToMessageId: Int? = nil,
+        chatUsername: String? = nil
+    ) -> TelegramMessage {
+        TelegramMessage(
+            messageId: messageId,
+            date: 1_782_427_200,
+            chat: TelegramChat(
+                id: chatId,
+                type: "group",
+                title: "Ops",
+                username: chatUsername,
+                firstName: nil,
+                lastName: nil
+            ),
+            from: from,
+            senderChat: nil,
+            text: text,
+            caption: nil,
+            replyToMessage: replyToMessageId.map { TelegramMessageReference(messageId: $0) }
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tools/AgentChannelTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentChannelTools.swift
@@ -147,6 +147,69 @@ private extension OsaurusTool {
             }
         }
 
+        if let error = error as? SlackConnectionServiceError {
+            switch error {
+            case .invalidId, .sendConfirmationRequired, .messageTooLong, .emptyMessage, .invalidThreadId:
+                return ToolEnvelope.failure(kind: .invalidArgs, message: error.localizedDescription, tool: tool)
+            case .teamNotConfigured, .channelNotReadable, .channelNotWritable, .writeDisabled, .broadcastMentionDenied:
+                return ToolEnvelope.failure(kind: .rejected, message: error.localizedDescription, tool: tool)
+            case .notConfigured:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .configurationSaveFailed, .api:
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            }
+        }
+
+        if let error = error as? SlackAPIError {
+            switch error {
+            case .invalidToken:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .missingPermissions:
+                return ToolEnvelope.failure(
+                    kind: .rejected,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .notFound:
+                return ToolEnvelope.failure(
+                    kind: .notFound,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .rateLimited:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: true
+                )
+            case .invalidResponse, .requestFailed:
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            }
+        }
+
         return ToolEnvelope.failure(
             kind: .executionError,
             message: error.localizedDescription,

--- a/Packages/OsaurusCore/Tools/AgentChannelTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentChannelTools.swift
@@ -28,7 +28,7 @@ private extension OsaurusTool {
                     tool: tool,
                     retryable: false
                 )
-            case .unsupportedKind, .unsupportedAction, .customExecutionNotImplemented:
+            case .globalWritesDisabled, .unsupportedKind, .unsupportedAction, .customExecutionNotImplemented:
                 return ToolEnvelope.failure(
                     kind: .rejected,
                     message: error.localizedDescription,
@@ -203,6 +203,69 @@ private extension OsaurusTool {
                     retryable: false
                 )
             case .rateLimited:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: true
+                )
+            case .invalidResponse, .requestFailed:
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            }
+        }
+
+        if let error = error as? TelegramConnectionServiceError {
+            switch error {
+            case .invalidChatId, .sendConfirmationRequired, .messageTooLong, .emptyMessage, .invalidWebhookSecret:
+                return ToolEnvelope.failure(kind: .invalidArgs, message: error.localizedDescription, tool: tool)
+            case .chatNotReadable, .chatNotWritable, .writeDisabled:
+                return ToolEnvelope.failure(kind: .rejected, message: error.localizedDescription, tool: tool)
+            case .notConfigured, .messageStoreUnavailable:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .configurationSaveFailed, .api:
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            }
+        }
+
+        if let error = error as? TelegramAPIError {
+            switch error {
+            case .invalidToken:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .forbidden:
+                return ToolEnvelope.failure(
+                    kind: .rejected,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .notFound:
+                return ToolEnvelope.failure(
+                    kind: .notFound,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .conflict, .rateLimited:
                 return ToolEnvelope.failure(
                     kind: .unavailable,
                     message: error.localizedDescription,

--- a/Packages/OsaurusCore/Tools/AgentChannelTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentChannelTools.swift
@@ -160,6 +160,15 @@ private extension OsaurusTool {
                     tool: tool,
                     retryable: false
                 )
+            case .signingSecretNotConfigured:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: false
+                )
+            case .signatureVerificationFailed, .invalidInboundPayload:
+                return ToolEnvelope.failure(kind: .invalidArgs, message: error.localizedDescription, tool: tool)
             case .configurationSaveFailed, .api:
                 return ToolEnvelope.failure(
                     kind: .executionError,

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -284,9 +284,9 @@ public final class ToolRegistry: ObservableObject {
             ToolConfigurationStore.save(configuration)
         }
 
-        // for tool in Self.agentChannelTools {
-        //     registerNativeDynamicTool(tool)
-        // }
+        for tool in Self.agentChannelTools {
+            registerNativeDynamicTool(tool)
+        }
     }
 
     private static let agentChannelTools: [OsaurusTool] = [

--- a/Packages/OsaurusCore/Views/Management/ManagementView.swift
+++ b/Packages/OsaurusCore/Views/Management/ManagementView.swift
@@ -188,6 +188,8 @@ private extension ManagementView {
             RemoteProvidersView()
         case .agents:
             AgentsView(deeplinkAgentId: deeplinkAgentId)
+        case .agentChannels:
+            AgentChannelConnectionCenterView()
         case .plugins:
             PluginsView()
         case .sandbox:

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
@@ -26,10 +26,15 @@ struct AgentChannelConnectionCenterView: View {
     @State private var auditIsError = false
     @State private var isLoadingAudit = false
     @State private var auditLoadID = UUID()
+    @State private var globalWriteSnapshot = ChannelWriteKillSwitchSnapshot()
+    @State private var globalWritesEnabled = true
+    @State private var writeGateMessage: String?
+    @State private var writeGateIsError = false
 
     private let manager = AgentChannelConnectionManager.shared
     private let service = AgentChannelConnectionService.shared
     private let auditWorkbench = AgentChannelAuditWorkbenchService()
+    private let writeKillSwitch = ChannelWriteKillSwitch.shared
 
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
@@ -38,7 +43,8 @@ struct AgentChannelConnectionCenterView: View {
             VStack(alignment: .leading, spacing: 22) {
                 header
                 overview
-                DiscordSettingsView()
+                globalWriteGateSection
+                nativeIntegrationsSection
                 auditWorkbenchSection
                 channelEditorSection
             }
@@ -46,6 +52,7 @@ struct AgentChannelConnectionCenterView: View {
         }
         .background(theme.primaryBackground)
         .onAppear {
+            reloadWriteGate()
             reloadConnections()
             reloadAuditWorkbench()
         }
@@ -63,7 +70,7 @@ struct AgentChannelConnectionCenterView: View {
             }
 
             Text(
-                "Configure communication channels agents can inspect or write to through one standard action surface.",
+                "Configure native Discord, Slack, and Telegram integrations plus custom JSON channels agents can inspect or write to through one standard action surface.",
                 bundle: .module
             )
             .font(.system(size: 13))
@@ -75,21 +82,21 @@ struct AgentChannelConnectionCenterView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 12) {
                 ChannelMetricCard(
-                    title: "Configured",
-                    value: "\(connections.count + 1)",
-                    caption: "including Discord",
+                    title: "Native Providers",
+                    value: "3",
+                    caption: "Discord, Slack, Telegram",
                     icon: "link"
                 )
                 ChannelMetricCard(
-                    title: "Enabled",
-                    value: "\(connections.filter(\.enabled).count + 1)",
-                    caption: "available to diagnose",
-                    icon: "checkmark.seal.fill"
+                    title: "Global Writes",
+                    value: globalWritesEnabled ? "On" : "Off",
+                    caption: "remote write gate",
+                    icon: globalWritesEnabled ? "checkmark.seal.fill" : "hand.raised.fill"
                 )
                 ChannelMetricCard(
-                    title: "JSON Channels",
+                    title: "Custom JSON",
                     value: "\(connections.count)",
-                    caption: "from agent-channels.json",
+                    caption: "custom HTTP definitions",
                     icon: "curlybraces"
                 )
             }
@@ -117,8 +124,58 @@ struct AgentChannelConnectionCenterView: View {
         }
     }
 
+    private var globalWriteGateSection: some View {
+        SettingsSubsection(label: "Global Channel Safety", anchorId: "agentChannels.globalWrites") {
+            VStack(alignment: .leading, spacing: 12) {
+                SettingsToggle(
+                    title: "Global Channel Writes",
+                    description:
+                        "Master remote/channel write gate used by channel safety checks. Provider write toggles below must also allow the destination.",
+                    isOn: Binding(
+                        get: { globalWritesEnabled },
+                        set: { setGlobalWritesEnabled($0) }
+                    )
+                )
+
+                HStack(spacing: 10) {
+                    Label {
+                        Text("Generation \(globalWriteSnapshot.generation)", bundle: .module)
+                    } icon: {
+                        Image(systemName: "number")
+                    }
+                    if globalWriteSnapshot.updatedAt.timeIntervalSince1970 > 0 {
+                        Label {
+                            Text(globalWriteSnapshot.updatedAt.formatted(date: .abbreviated, time: .shortened))
+                        } icon: {
+                            Image(systemName: "clock")
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+
+                if let writeGateMessage {
+                    AgentChannelInlineStatusMessage(message: writeGateMessage, isError: writeGateIsError)
+                }
+            }
+        }
+    }
+
+    private var nativeIntegrationsSection: some View {
+        SettingsSubsection(label: "Native Integrations", anchorId: "agentChannels.native") {
+            VStack(alignment: .leading, spacing: 20) {
+                DiscordSettingsView()
+                SettingsDivider()
+                SlackSettingsView()
+                SettingsDivider()
+                TelegramSettingsView()
+            }
+        }
+    }
+
     private var channelEditorSection: some View {
-        SettingsSubsection(label: "JSON Channel Connections") {
+        SettingsSubsection(label: "Custom JSON Connections") {
             VStack(alignment: .leading, spacing: 14) {
                 HStack(alignment: .top, spacing: 16) {
                     connectionList
@@ -261,7 +318,7 @@ struct AgentChannelConnectionCenterView: View {
             HStack(spacing: 8) {
                 Button(action: newCustomHTTPConnection) {
                     Label {
-                        Text("New Custom", bundle: .module)
+                        Text("New Custom HTTP", bundle: .module)
                     } icon: {
                         Image(systemName: "plus")
                     }
@@ -280,7 +337,7 @@ struct AgentChannelConnectionCenterView: View {
 
             if connections.isEmpty {
                 Text(
-                    "No JSON-backed channels yet. Add a custom HTTP, Slack, or Telegram connection definition to prepare agent communication without storing secrets in the file.",
+                    "No custom JSON channels yet. Add a custom HTTP connection definition when a provider does not have a native section above.",
                     bundle: .module
                 )
                 .font(.system(size: 12))
@@ -313,7 +370,7 @@ struct AgentChannelConnectionCenterView: View {
                 Text(draft.isNew ? "New Connection" : "Edit Connection", bundle: .module)
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(theme.primaryText)
-                ServerSettingsStatusBadge(status: draft.kind == .customHTTP ? .partial : .future)
+                ServerSettingsStatusBadge(status: draft.kind == .customHTTP ? .engineReady : .partial)
                 Spacer()
             }
 
@@ -328,7 +385,7 @@ struct AgentChannelConnectionCenterView: View {
                     label: "Connection ID",
                     text: $draft.id,
                     placeholder: "ops-webhook",
-                    help: "Stable id used by agent_channel tools. The native Discord id is reserved."
+                    help: "Stable id used by agent_channel tools. Native provider ids are reserved."
                 )
                 StyledSettingsTextField(
                     label: "Display Name",
@@ -413,14 +470,27 @@ struct AgentChannelConnectionCenterView: View {
             Text("Kind", bundle: .module)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(theme.primaryText)
-            Picker("", selection: $draft.kind) {
-                Text("Custom HTTP", bundle: .module).tag(AgentChannelKind.customHTTP)
-                Text("Slack", bundle: .module).tag(AgentChannelKind.slack)
-                Text("Telegram", bundle: .module).tag(AgentChannelKind.telegram)
+            HStack(spacing: 8) {
+                Image(systemName: draft.kind.icon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text(draft.kind.displayName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                Spacer(minLength: 0)
             }
-            .pickerStyle(.segmented)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(theme.inputBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(theme.inputBorder, lineWidth: 1)
+                    )
+            )
             Text(
-                "Slack and Telegram definitions can be prepared now; native execution lands in their adapter PRs.",
+                "Use the native Discord, Slack, and Telegram sections above for first-party providers. New custom connections use the reviewed HTTP runner.",
                 bundle: .module
             )
             .font(.system(size: 11))
@@ -568,6 +638,29 @@ struct AgentChannelConnectionCenterView: View {
             select(first)
         } else {
             newCustomHTTPConnection()
+        }
+    }
+
+    private func reloadWriteGate() {
+        let snapshot = writeKillSwitch.snapshot()
+        globalWriteSnapshot = snapshot
+        globalWritesEnabled = snapshot.writeEnabled
+    }
+
+    private func setGlobalWritesEnabled(_ enabled: Bool) {
+        let previousEnabled = globalWritesEnabled
+        globalWritesEnabled = enabled
+        do {
+            globalWriteSnapshot = try writeKillSwitch.setWriteEnabled(enabled)
+            writeGateMessage = enabled
+                ? "Global channel writes enabled"
+                : "Global channel writes disabled"
+            writeGateIsError = false
+        } catch {
+            globalWritesEnabled = previousEnabled
+            reloadWriteGate()
+            writeGateMessage = error.localizedDescription
+            writeGateIsError = true
         }
     }
 
@@ -932,7 +1025,7 @@ private struct ChannelConnectionRow: View {
                         .lineLimit(1)
                 }
                 Spacer()
-                ServerSettingsStatusBadge(status: connection.enabled ? .engineReady : .future)
+                ServerSettingsStatusBadge(status: connection.enabled ? .engineReady : .partial)
             }
 
             HStack(spacing: 6) {

--- a/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
@@ -99,23 +99,23 @@ struct DiscordSettingsView: View {
                 multilineField(
                     title: "Server IDs",
                     text: $guildIdsText,
-                    help: "Numeric Discord server IDs Osaurus may inspect for channel discovery."
+                    help: "Numeric Discord server IDs Osaurus may inspect for channel discovery. At least one server is required for diagnostics to report connected."
                 )
                 multilineField(
                     title: "Readable Channel IDs",
                     text: $readableChannelIdsText,
-                    help: "Numeric channel or thread IDs Osaurus may read. Recent reads are bounded."
+                    help: "Numeric channel or thread IDs Osaurus may read, search, or inspect. Recent reads are bounded."
                 )
                 SettingsToggle(
                     title: "Enable Discord Writes",
                     description:
-                        "Allow send/reply tools for write-allowlisted destinations. Tool calls still require approval.",
+                        "Allow send/reply tools for write-allowlisted Discord destinations. The global channel write switch must also be on.",
                     isOn: $writeEnabled
                 )
                 multilineField(
                     title: "Writable Channel IDs",
                     text: $writableChannelIdsText,
-                    help: "Numeric channel or thread IDs Osaurus may post to when writes are enabled."
+                    help: "Numeric channel or thread IDs Osaurus may post to when Discord writes are enabled."
                 )
                 StyledSettingsTextField(
                     label: "Default Read Limit",
@@ -190,7 +190,7 @@ struct DiscordSettingsView: View {
         writableChannelIdsText = configuration.writableChannelIds.joined(separator: "\n")
         writeEnabled = configuration.writeEnabled
         defaultReadLimit = "\(configuration.defaultReadLimit)"
-        tokenSaved = DiscordCredentialStore.hasBotToken()
+        tokenSaved = DiscordConnectionService.shared.hasBotToken()
     }
 
     private func saveToken() {

--- a/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
@@ -1,0 +1,415 @@
+//
+//  SlackSettingsView.swift
+//  osaurus
+//
+//  Manual configuration for the native Slack connection.
+//
+
+import SwiftUI
+
+struct SlackSettingsView: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    @State private var botToken: String = ""
+    @State private var signingSecret: String = ""
+    @State private var appToken: String = ""
+    @State private var configuredTeamIdsText: String = ""
+    @State private var readableChannelIdsText: String = ""
+    @State private var writableChannelIdsText: String = ""
+    @State private var senderAllowlistText: String = ""
+    @State private var writeEnabled: Bool = false
+    @State private var allowBroadcastMentions: Bool = false
+    @State private var defaultReadLimit: String = "50"
+    @State private var botTokenSaved: Bool = false
+    @State private var signingSecretSaved: Bool = false
+    @State private var appTokenSaved: Bool = false
+    @State private var statusMessage: String?
+    @State private var statusIsError = false
+    @State private var isTesting = false
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        SettingsSubsection(label: "Slack") {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(
+                    "Connect a Slack bot so Osaurus can inspect allowlisted channels and post only to write-allowlisted destinations.",
+                    bundle: .module
+                )
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+
+                credentialsSection
+                SettingsDivider()
+                allowlistSection
+                SettingsDivider()
+                actionsSection
+            }
+        }
+        .onAppear(perform: loadConfiguration)
+    }
+
+    private var credentialsSection: some View {
+        SettingsSubsection(label: "Credentials") {
+            VStack(alignment: .leading, spacing: 12) {
+                secretRow(
+                    title: "Slack bot token",
+                    text: $botToken,
+                    saved: botTokenSaved,
+                    savedMessage: "Bot token saved in Keychain",
+                    missingMessage: "No Slack bot token saved",
+                    saveTitle: "Save Bot Token",
+                    saveAction: saveBotToken,
+                    removeAction: removeBotToken
+                )
+
+                secretRow(
+                    title: "Slack signing secret",
+                    text: $signingSecret,
+                    saved: signingSecretSaved,
+                    savedMessage: "Signing secret saved in Keychain",
+                    missingMessage: "No Slack signing secret saved",
+                    saveTitle: "Save Signing Secret",
+                    saveAction: saveSigningSecret,
+                    removeAction: removeSigningSecret
+                )
+
+                secretRow(
+                    title: "Socket Mode app token",
+                    text: $appToken,
+                    saved: appTokenSaved,
+                    savedMessage: "Socket Mode app token saved in Keychain",
+                    missingMessage: "No Slack Socket Mode app token saved",
+                    saveTitle: "Save App Token",
+                    saveAction: saveAppToken,
+                    removeAction: removeAppToken
+                )
+
+                Text(
+                    "Slack secrets are stored in Keychain and are never written to the Slack configuration file.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+            }
+        }
+    }
+
+    private var allowlistSection: some View {
+        SettingsSubsection(label: "Access") {
+            VStack(alignment: .leading, spacing: 12) {
+                AgentChannelMultilineSettingsField(
+                    title: "Workspace IDs",
+                    text: $configuredTeamIdsText,
+                    help:
+                        "Optional Slack team IDs, such as T0123ABC. Leave empty only when the saved bot token's workspace is the entire allowed space."
+                )
+                AgentChannelMultilineSettingsField(
+                    title: "Readable Channel IDs",
+                    text: $readableChannelIdsText,
+                    help: "Slack channel IDs Osaurus may list, read, or search, such as C0123ABC."
+                )
+                AgentChannelMultilineSettingsField(
+                    title: "Authorized Sender IDs",
+                    text: $senderAllowlistText,
+                    help:
+                        "Slack user IDs allowed to trigger inbound Agent Channel handling. Keep this explicit for group channels."
+                )
+                SettingsToggle(
+                    title: "Enable Slack Writes",
+                    description:
+                        "Allow send/reply tools for write-allowlisted Slack channels. The global channel write switch must also be on.",
+                    isOn: $writeEnabled
+                )
+                AgentChannelMultilineSettingsField(
+                    title: "Writable Channel IDs",
+                    text: $writableChannelIdsText,
+                    help: "Slack channel IDs Osaurus may post to when Slack writes are enabled."
+                )
+                SettingsToggle(
+                    title: "Allow Broadcast Mentions",
+                    description:
+                        "Permit @channel, @here, and <!subteam> mentions in outgoing Slack messages. Leave off unless the workspace expects that behavior.",
+                    isOn: $allowBroadcastMentions
+                )
+                StyledSettingsTextField(
+                    label: "Default Read Limit",
+                    text: $defaultReadLimit,
+                    placeholder: "50",
+                    help: "Default recent-message count for Slack reads. Clamped to 1-100."
+                )
+            }
+        }
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Button(action: saveConfiguration) {
+                    Text("Save Slack Settings", bundle: .module)
+                }
+                .buttonStyle(SettingsButtonStyle(isPrimary: true))
+
+                Button(action: testConnection) {
+                    Text(isTesting ? "Testing..." : "Test Connection", bundle: .module)
+                }
+                .buttonStyle(SettingsButtonStyle())
+                .disabled(isTesting || !botTokenSaved)
+
+                Spacer(minLength: 0)
+            }
+
+            if let statusMessage {
+                AgentChannelInlineStatusMessage(message: statusMessage, isError: statusIsError)
+            }
+        }
+    }
+
+    private func secretRow(
+        title: String,
+        text: Binding<String>,
+        saved: Bool,
+        savedMessage: String,
+        missingMessage: String,
+        saveTitle: String,
+        saveAction: @escaping () -> Void,
+        removeAction: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                SecureField(title, text: text)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundColor(theme.primaryText)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(theme.inputBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(theme.inputBorder, lineWidth: 1)
+                            )
+                    )
+
+                Button(action: saveAction) {
+                    Text(LocalizedStringKey(saveTitle), bundle: .module)
+                }
+                .buttonStyle(SettingsButtonStyle(isPrimary: true))
+                .disabled(text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                Button(action: removeAction) {
+                    Text("Remove", bundle: .module)
+                }
+                .buttonStyle(SettingsButtonStyle(isDestructive: true))
+                .disabled(!saved)
+            }
+
+            AgentChannelSecretStatusRow(
+                saved: saved,
+                savedMessage: savedMessage,
+                missingMessage: missingMessage
+            )
+        }
+    }
+
+    private func loadConfiguration() {
+        let configuration = SlackConnectionConfigurationStore.load()
+        configuredTeamIdsText = configuration.configuredTeamIds.joined(separator: "\n")
+        readableChannelIdsText = configuration.readableChannelIds.joined(separator: "\n")
+        writableChannelIdsText = configuration.writableChannelIds.joined(separator: "\n")
+        senderAllowlistText = configuration.senderAllowlist.joined(separator: "\n")
+        writeEnabled = configuration.writeEnabled
+        allowBroadcastMentions = configuration.allowBroadcastMentions
+        defaultReadLimit = "\(configuration.defaultReadLimit)"
+        botTokenSaved = SlackConnectionService.shared.hasBotToken()
+        signingSecretSaved = SlackConnectionService.shared.hasSigningSecret()
+        appTokenSaved = SlackConnectionService.shared.hasAppToken()
+    }
+
+    private func saveBotToken() {
+        do {
+            try SlackConnectionService.shared.saveBotToken(botToken)
+            botToken = ""
+            botTokenSaved = true
+            Task {
+                await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
+            }
+            showStatus("Slack bot token saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func removeBotToken() {
+        _ = SlackConnectionService.shared.deleteBotToken()
+        botToken = ""
+        botTokenSaved = false
+        Task {
+            await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
+        }
+        showStatus("Slack bot token removed", isError: false)
+    }
+
+    private func saveSigningSecret() {
+        do {
+            try SlackConnectionService.shared.saveSigningSecret(signingSecret)
+            signingSecret = ""
+            signingSecretSaved = true
+            showStatus("Slack signing secret saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func removeSigningSecret() {
+        _ = SlackConnectionService.shared.deleteSigningSecret()
+        signingSecret = ""
+        signingSecretSaved = false
+        showStatus("Slack signing secret removed", isError: false)
+    }
+
+    private func saveAppToken() {
+        do {
+            try SlackConnectionService.shared.saveAppToken(appToken)
+            appToken = ""
+            appTokenSaved = true
+            Task {
+                await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
+            }
+            showStatus("Slack Socket Mode app token saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func removeAppToken() {
+        _ = SlackConnectionService.shared.deleteAppToken()
+        appToken = ""
+        appTokenSaved = false
+        Task {
+            await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
+        }
+        showStatus("Slack Socket Mode app token removed", isError: false)
+    }
+
+    private func saveConfiguration() {
+        let configuration = SlackConnectionConfiguration(
+            configuredTeamIds: parseIds(configuredTeamIdsText),
+            readableChannelIds: parseIds(readableChannelIdsText),
+            writableChannelIds: parseIds(writableChannelIdsText),
+            senderAllowlist: parseIds(senderAllowlistText),
+            writeEnabled: writeEnabled,
+            defaultReadLimit: Int(defaultReadLimit) ?? 50,
+            allowBroadcastMentions: allowBroadcastMentions
+        )
+        do {
+            try SlackConnectionService.shared.saveConfiguration(configuration)
+            loadConfiguration()
+            Task {
+                await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
+            }
+            showStatus("Slack settings saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func testConnection() {
+        isTesting = true
+        Task {
+            let diagnostics = await SlackConnectionService.shared.diagnostics()
+            await MainActor.run {
+                isTesting = false
+                if diagnostics.failures.isEmpty {
+                    showStatus("Slack connection status: \(diagnostics.status)", isError: false)
+                } else {
+                    showStatus(diagnostics.failures.joined(separator: " "), isError: true)
+                }
+            }
+        }
+    }
+
+    private func showStatus(_ message: String, isError: Bool) {
+        statusMessage = message
+        statusIsError = isError
+    }
+
+    private func parseIds(_ text: String) -> [String] {
+        let separators = CharacterSet(charactersIn: ", \n\t")
+        return SlackConnectionConfiguration.normalizedIds(
+            text.components(separatedBy: separators)
+        )
+    }
+}
+
+struct AgentChannelMultilineSettingsField: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let title: String
+    @Binding var text: String
+    let help: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(themeManager.currentTheme.primaryText)
+            TextEditor(text: $text)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(themeManager.currentTheme.primaryText)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 58)
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(themeManager.currentTheme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
+                        )
+                )
+            Text(LocalizedStringKey(help), bundle: .module)
+                .font(.system(size: 11))
+                .foregroundColor(themeManager.currentTheme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+struct AgentChannelSecretStatusRow: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let saved: Bool
+    let savedMessage: String
+    let missingMessage: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: saved ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 12))
+            Text(LocalizedStringKey(saved ? savedMessage : missingMessage), bundle: .module)
+                .font(.system(size: 11))
+        }
+        .foregroundColor(saved ? themeManager.currentTheme.successColor : themeManager.currentTheme.tertiaryText)
+    }
+}
+
+struct AgentChannelInlineStatusMessage: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let message: String
+    let isError: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: isError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+            Text(message)
+                .font(.system(size: 12))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .foregroundColor(isError ? themeManager.currentTheme.warningColor : themeManager.currentTheme.successColor)
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
@@ -1,0 +1,296 @@
+//
+//  TelegramSettingsView.swift
+//  osaurus
+//
+//  Manual configuration for the native Telegram connection.
+//
+
+import SwiftUI
+
+struct TelegramSettingsView: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    @State private var botToken: String = ""
+    @State private var readableChatIdsText: String = ""
+    @State private var writableChatIdsText: String = ""
+    @State private var senderAllowlistText: String = ""
+    @State private var writeEnabled: Bool = false
+    @State private var defaultReadLimit: String = "50"
+    @State private var ignoreSelfMessages: Bool = true
+    @State private var ignoreBotMessages: Bool = true
+    @State private var receiveStorageEnabled: Bool = true
+    @State private var longPollingEnabled: Bool = false
+    @State private var longPollingLimit: String = "100"
+    @State private var longPollingTimeoutSeconds: String = "20"
+    @State private var tokenSaved: Bool = false
+    @State private var statusMessage: String?
+    @State private var statusIsError = false
+    @State private var isTesting = false
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        SettingsSubsection(label: "Telegram") {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(
+                    "Connect a Telegram bot so Osaurus can read allowlisted chats and post only to write-allowlisted destinations.",
+                    bundle: .module
+                )
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+
+                credentialsSection
+                SettingsDivider()
+                allowlistSection
+                SettingsDivider()
+                receiveSection
+                SettingsDivider()
+                actionsSection
+            }
+        }
+        .onAppear(perform: loadConfiguration)
+    }
+
+    private var credentialsSection: some View {
+        SettingsSubsection(label: "Credentials") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    SecureField("Telegram bot token", text: $botToken)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundColor(theme.primaryText)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(theme.inputBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(theme.inputBorder, lineWidth: 1)
+                                )
+                        )
+
+                    Button(action: saveToken) {
+                        Text("Save Token", bundle: .module)
+                    }
+                    .buttonStyle(SettingsButtonStyle(isPrimary: true))
+                    .disabled(botToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    Button(action: removeToken) {
+                        Text("Remove", bundle: .module)
+                    }
+                    .buttonStyle(SettingsButtonStyle(isDestructive: true))
+                    .disabled(!tokenSaved)
+                }
+
+                AgentChannelSecretStatusRow(
+                    saved: tokenSaved,
+                    savedMessage: "Bot token saved in Keychain",
+                    missingMessage: "No Telegram bot token saved"
+                )
+
+                Text(
+                    "The token is stored in Keychain and is never written to the Telegram configuration file.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+            }
+        }
+    }
+
+    private var allowlistSection: some View {
+        SettingsSubsection(label: "Access") {
+            VStack(alignment: .leading, spacing: 12) {
+                AgentChannelMultilineSettingsField(
+                    title: "Readable Chat IDs",
+                    text: $readableChatIdsText,
+                    help:
+                        "Telegram chat IDs, supergroup IDs, or public @channel usernames Osaurus may read. Example: -1001234567890 or @release_notes."
+                )
+                AgentChannelMultilineSettingsField(
+                    title: "Sender Allowlist",
+                    text: $senderAllowlistText,
+                    help:
+                        "Telegram user IDs allowed to trigger inbound handling. Required for inbound receive when message storage or long polling is enabled."
+                )
+                SettingsToggle(
+                    title: "Enable Telegram Writes",
+                    description:
+                        "Allow send tools for write-allowlisted Telegram chats. The global channel write switch must also be on.",
+                    isOn: $writeEnabled
+                )
+                AgentChannelMultilineSettingsField(
+                    title: "Writable Chat IDs",
+                    text: $writableChatIdsText,
+                    help: "Telegram chats Osaurus may post to when Telegram writes are enabled."
+                )
+                StyledSettingsTextField(
+                    label: "Default Read Limit",
+                    text: $defaultReadLimit,
+                    placeholder: "50",
+                    help: "Default recent-message count for Telegram reads. Clamped to 1-100."
+                )
+                SettingsToggle(
+                    title: "Ignore Self Messages",
+                    description: "Ignore updates sent by this bot identity when inbound updates are handled.",
+                    isOn: $ignoreSelfMessages
+                )
+                SettingsToggle(
+                    title: "Ignore Bot Messages",
+                    description: "Ignore Telegram updates from bot accounts unless you explicitly trust bot senders.",
+                    isOn: $ignoreBotMessages
+                )
+            }
+        }
+    }
+
+    private var receiveSection: some View {
+        SettingsSubsection(label: "Receive") {
+            VStack(alignment: .leading, spacing: 12) {
+                SettingsToggle(
+                    title: "Store Incoming Messages",
+                    description:
+                        "Persist authorized Telegram updates in the local Agent Channel inbox for read/search and audit proof.",
+                    isOn: $receiveStorageEnabled
+                )
+                SettingsToggle(
+                    title: "Enable Long Polling",
+                    description:
+                        "Use Telegram getUpdates as the local desktop receive path. Only enable this when no other consumer is polling the same bot.",
+                    isOn: $longPollingEnabled
+                )
+                HStack(alignment: .top, spacing: 12) {
+                    StyledSettingsTextField(
+                        label: "Long Poll Limit",
+                        text: $longPollingLimit,
+                        placeholder: "100",
+                        help: "Maximum updates per poll. Clamped to 1-100."
+                    )
+                    StyledSettingsTextField(
+                        label: "Long Poll Timeout Seconds",
+                        text: $longPollingTimeoutSeconds,
+                        placeholder: "20",
+                        help: "Telegram long-poll timeout. Clamped to 1-50 seconds."
+                    )
+                }
+            }
+        }
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Button(action: saveConfiguration) {
+                    Text("Save Telegram Settings", bundle: .module)
+                }
+                .buttonStyle(SettingsButtonStyle(isPrimary: true))
+
+                Button(action: testConnection) {
+                    Text(isTesting ? "Testing..." : "Test Connection", bundle: .module)
+                }
+                .buttonStyle(SettingsButtonStyle())
+                .disabled(isTesting || !tokenSaved)
+
+                Spacer(minLength: 0)
+            }
+
+            if let statusMessage {
+                AgentChannelInlineStatusMessage(message: statusMessage, isError: statusIsError)
+            }
+        }
+    }
+
+    private func loadConfiguration() {
+        let configuration = TelegramConnectionConfigurationStore.load()
+        readableChatIdsText = configuration.readableChatIds.joined(separator: "\n")
+        writableChatIdsText = configuration.writableChatIds.joined(separator: "\n")
+        senderAllowlistText = configuration.senderAllowlist.joined(separator: "\n")
+        writeEnabled = configuration.writeEnabled
+        defaultReadLimit = "\(configuration.defaultReadLimit)"
+        ignoreSelfMessages = configuration.ignoreSelfMessages
+        ignoreBotMessages = configuration.ignoreBotMessages
+        receiveStorageEnabled = configuration.receiveStorageEnabled
+        longPollingEnabled = configuration.longPollingEnabled
+        longPollingLimit = "\(configuration.longPollingLimit)"
+        longPollingTimeoutSeconds = "\(configuration.longPollingTimeoutSeconds)"
+        tokenSaved = TelegramConnectionService.shared.hasBotToken()
+    }
+
+    private func saveToken() {
+        do {
+            try TelegramConnectionService.shared.saveBotToken(botToken)
+            botToken = ""
+            tokenSaved = true
+            Task {
+                await AgentChannelTransportSupervisor.shared.refreshTelegramRuntime()
+            }
+            showStatus("Telegram bot token saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func removeToken() {
+        _ = TelegramConnectionService.shared.deleteBotToken()
+        botToken = ""
+        tokenSaved = false
+        Task {
+            await AgentChannelTransportSupervisor.shared.refreshTelegramRuntime()
+        }
+        showStatus("Telegram bot token removed", isError: false)
+    }
+
+    private func saveConfiguration() {
+        let configuration = TelegramConnectionConfiguration(
+            readableChatIds: parseIds(readableChatIdsText),
+            writableChatIds: parseIds(writableChatIdsText),
+            senderAllowlist: parseIds(senderAllowlistText),
+            writeEnabled: writeEnabled,
+            defaultReadLimit: Int(defaultReadLimit) ?? 50,
+            ignoreSelfMessages: ignoreSelfMessages,
+            ignoreBotMessages: ignoreBotMessages,
+            receiveStorageEnabled: receiveStorageEnabled,
+            longPollingEnabled: longPollingEnabled,
+            longPollingLimit: Int(longPollingLimit) ?? 100,
+            longPollingTimeoutSeconds: Int(longPollingTimeoutSeconds) ?? 20
+        )
+        do {
+            try TelegramConnectionService.shared.saveConfiguration(configuration)
+            loadConfiguration()
+            Task {
+                await AgentChannelTransportSupervisor.shared.refreshTelegramRuntime()
+            }
+            showStatus("Telegram settings saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func testConnection() {
+        isTesting = true
+        Task {
+            let diagnostics = await TelegramConnectionService.shared.diagnostics()
+            await MainActor.run {
+                isTesting = false
+                if diagnostics.failures.isEmpty {
+                    showStatus("Telegram connection status: \(diagnostics.status)", isError: false)
+                } else {
+                    showStatus(diagnostics.failures.joined(separator: " "), isError: true)
+                }
+            }
+        }
+    }
+
+    private func showStatus(_ message: String, isError: Bool) {
+        statusMessage = message
+        statusIsError = isError
+    }
+
+    private func parseIds(_ text: String) -> [String] {
+        let separators = CharacterSet(charactersIn: ", \n\t")
+        return TelegramConnectionConfiguration.normalizedIds(
+            text.components(separatedBy: separators)
+        )
+    }
+}

--- a/Packages/OsaurusEvals/Suites/AgentChannels/README.md
+++ b/Packages/OsaurusEvals/Suites/AgentChannels/README.md
@@ -1,0 +1,36 @@
+# Agent Channels Eval Checklist
+
+This is a docs-only checklist for Slack and Telegram Agent Channel release
+proof. Runnable JSON cases are intentionally deferred because the current eval
+harness does not provide a fixture hook to seed native Slack/Telegram
+connection config, inject fake provider clients, or pre-populate the Agent
+Channel message store without adding harness/source wiring outside this release
+asset task.
+
+## Deterministic Cases To Add When Harness Support Exists
+
+| Case | Fixture setup | Expected result |
+| --- | --- | --- |
+| `agent_channels.unauthorized-room` | Seed native Slack/Telegram connections with one readable room/chat and one denied room/chat. | `agent_channel_read_messages` against denied targets returns rejected/not-allowlisted and no store row is written. |
+| `agent_channels.unauthorized-sender` | Seed Slack/Telegram sender allowlists and feed one allowed event plus one denied event per provider. | Allowed sender stores one snapshot; denied sender returns `sender_not_allowlisted` and stores nothing. |
+| `agent_channels.no-unapproved-send` | Seed writable destinations and fake provider send clients. | `confirm_send: false` or omitted returns invalid-args before provider dispatch; provider sent count stays zero. |
+| `agent_channels.external-mcp-denial` | Start the local MCP test surface with Agent Channel tools registered. | `/mcp/tools` omits `agent_channel_*`; `/mcp/call` returns `403 tool_not_exposable`. |
+
+## Proof To Run Now
+
+Use the no-secret smoke script:
+
+```bash
+scripts/live-proof/run-slack-telegram-channel-smoke.sh
+```
+
+For focused source-backed fixtures:
+
+```bash
+OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1 \
+scripts/live-proof/run-slack-telegram-channel-smoke.sh
+```
+
+For provider setup and live disposable-room proof, follow
+`docs/AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md` and
+`docs/CHANNEL_RELEASE_RUNBOOK_SLACK_TELEGRAM.md`.

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -19,6 +19,12 @@ The model-facing tools use these standard verbs through `agent_channel_*`
 tools. Provider-specific adapters translate the standard action into the
 provider API. Discord is the first executable adapter.
 
+The `agent_channel_*` tools are native dynamic tools. They are available to the
+app runtime and can be loaded through the capability flow, but they are not part
+of the always-loaded prompt baseline. They are also denied to external HTTP/MCP
+surfaces; channel reads and writes must originate from the Osaurus app surface
+where connection policy, confirmations, and local credentials are available.
+
 Each connection also reports provider-neutral action policy metadata in
 `agent_channel_list_connections` and `agent_channel_diagnostics`:
 
@@ -54,6 +60,31 @@ but no space allowlist is configured, unless the connection explicitly opts into
 `allowUnscopedSpaces`. Each decision carries an `audit_decision_reason` so
 denied relays can be logged without exposing secrets or external message
 content.
+
+## Service-Level Smoke Boundary
+
+Agent Channels are ready for provider smoke testing when a disposable connection
+can exercise the standard app-surface tools without exposing unfinished settings
+UI or external caller access. A smoke pass should use a disposable workspace,
+server, bot, or chat and prove:
+
+1. `agent_channel_list_connections` reports the connection with readable action
+   policy, write confirmation requirements, and no raw secrets.
+2. `agent_channel_diagnostics` reports missing credentials, disabled writes,
+   denied rooms/chats, and provider auth failures as explicit failure states.
+3. `agent_channel_read_messages` or `agent_channel_search_messages` returns
+   only allowlisted rooms/chats and treats provider message content as external
+   data.
+4. `agent_channel_draft_message` returns a redacted local preview and never
+   dispatches to the provider.
+5. `agent_channel_send_message` or `agent_channel_reply_thread` succeeds only
+   with `confirm_send: true`, a write-allowlisted destination, and a provider
+   response that can be mapped to a confirmed delivery.
+6. External HTTP/MCP surfaces reject the same `agent_channel_*` tool names.
+
+The smoke boundary does not require final visible settings placement,
+production webhook hosting, or background polling. Those remain integration
+work layered on top of the shared action vocabulary and policy gates.
 
 ## Configuration
 

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -17,7 +17,7 @@ definitions.
 
 The model-facing tools use these standard verbs through `agent_channel_*`
 tools. Provider-specific adapters translate the standard action into the
-provider API. Native adapters currently include Discord and Slack.
+provider API. Native adapters currently include Discord, Slack, and Telegram.
 
 The `agent_channel_*` tools are native dynamic tools. They are available to the
 app runtime and can be loaded through the capability flow, but they are not part
@@ -82,20 +82,27 @@ server, bot, or chat and prove:
    response that can be mapped to a confirmed delivery.
 6. External HTTP/MCP surfaces reject the same `agent_channel_*` tool names.
 
-The smoke boundary does not require final visible settings placement,
-production webhook hosting, or background polling. Those remain integration
-work layered on top of the shared action vocabulary and policy gates.
+The smoke boundary uses the visible Agent Channels settings surface and, for
+Telegram, the app-managed long-poll receive path. It does not require
+production webhook hosting. Slack Socket Mode background receive wiring remains
+the follow-up needed for full Slack desktop inbound proof.
+
+Slack/Telegram release proof uses
+[`AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md`](AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md)
+and
+[`CHANNEL_RELEASE_RUNBOOK_SLACK_TELEGRAM.md`](CHANNEL_RELEASE_RUNBOOK_SLACK_TELEGRAM.md).
+Primary desktop transports are Slack Socket Mode and Telegram long-poll; public
+webhooks are advanced/future proof paths.
 
 ## Configuration
 
 Non-secret channel definitions live in `agent-channels.json`. Secrets should be
 stored separately in Keychain and referenced by name.
 
-The connection center implementation can create, edit, delete, export, import,
-and diagnose JSON-backed channel definitions, but the management entry remains
-hidden while Agent Channels are still WIP. This keeps unfinished Discord/channel
-settings out of the normal app surface while preserving the reviewable
-configuration foundation.
+The connection center can create, edit, delete, export, import, and diagnose
+JSON-backed channel definitions. It also hosts native Discord, Slack, and
+Telegram credential and allowlist settings so users do not need to hand-edit
+provider configuration files.
 
 ```json
 {
@@ -318,9 +325,10 @@ Slack is a native Agent Channel connection. It is addressed through
 `connection_id: "slack"` on the `agent_channel_*` tools rather than through a
 separate Slack-specific model-facing tool set.
 
-The Slack bot token and optional signing secret are stored in Keychain under
-the native Slack credential reference names `bot_token` and `signing_secret`.
-The JSON configuration stores only non-secret IDs and policy in `slack.json`:
+The Slack bot token, optional signing secret, and optional Socket Mode app
+token are stored in Keychain under the native Slack credential reference names
+`bot_token`, `signing_secret`, and `app_token`. The JSON configuration stores
+only non-secret IDs and policy in `slack.json`:
 
 - `configuredTeamIds` limits which workspace can be inspected. Leave it empty
   to allow the workspace authenticated by the saved bot token.
@@ -328,6 +336,9 @@ The JSON configuration stores only non-secret IDs and policy in `slack.json`:
   `search_messages` can read.
 - `writableChannelIds` limits rooms that `draft_message`, `send_message`, and
   `reply_thread` can target.
+- `senderAllowlist` limits which Slack user IDs may trigger inbound Agent
+  Channel handling from group channels. Leave it empty to disable inbound Slack
+  dispatch until explicit users are configured.
 - `writeEnabled` must be true, and send/reply actions still require
   `confirm_send: true`.
 - `allowBroadcastMentions` defaults to false. When false, outbound messages
@@ -352,13 +363,20 @@ room id, message timestamp, canonical `channel_id:thread_ts`, mention user ids,
 and payload JSON for the shared Agent Channel store. A repeated Slack event id
 is recorded once through `channel_seen_events`, and message snapshots from
 read/search/send paths are keyed as `slack + channel_id + message_ts`.
-Inbound event storage is also gated by `readableChannelIds`; a valid Slack
-signature does not authorize events from non-allowlisted channels. Inbound
-normalization also requires the saved bot identity (`botUserId` or `botId`) so
-the adapter can suppress self/echo messages before dispatch.
+Inbound event storage is also gated by `readableChannelIds` and
+`senderAllowlist`; a valid Slack signature does not authorize events from
+non-allowlisted channels or users. Inbound normalization also requires the saved
+bot identity (`botUserId` or `botId`) so the adapter can suppress self/echo
+messages before dispatch.
 Webhook receivers should use `SlackSignatureVerifier` with the saved
 `signing_secret` to validate `X-Slack-Request-Timestamp`,
 `X-Slack-Signature`, and the exact raw request body before normalizing content.
+For desktop release proof, Socket Mode is the inbound transport. The app opens
+Slack Socket Mode with the saved app token, ACKs envelopes, and routes event
+payloads through the same normalization, authorization, storage, and audit path
+used by signed webhook fixtures. Public Events API webhooks remain an
+advanced/future transport that still must use the same signature verifier
+before parsing user-visible content.
 
 ## Message State And Dedupe
 
@@ -392,8 +410,9 @@ remain readable until they age out or are pruned.
 Telegram is native as well. The Bot API does not expose arbitrary prior chat
 history to bots, so Telegram `read_messages` and `search_messages` read from the
 local Agent Channel message store. The adapter exposes webhook and long-poll
-service entry points for populating that store; a production HTTP receiver,
-background poller, and visible settings surface are separate integration work.
+service entry points for populating that store, and the app lifecycle starts the
+long-poll runtime when receive storage and long polling are enabled in Agent
+Channels settings.
 The native Telegram adapter:
 
 - stores non-secret allowlists in `telegram.json` and keeps the bot token in
@@ -426,6 +445,9 @@ the public HTTP receiver contract. Because Telegram bot tokens are part of Bot
 API request paths, any future network proxy, crash-report, or HTTP-diagnostics
 surface must redact full request URLs with the same token-redaction policy used
 for provider errors.
+For desktop release proof, Bot API long-poll is the primary inbound transport.
+Public webhooks remain an advanced/future transport and require the Telegram
+secret-token header check before update decoding.
 
 Relay or webhook receivers should follow the same sequence used by the Telegram
 plugin pattern:

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -252,6 +252,7 @@ requests.
 The connection center validates channel definitions before saving:
 
 - `discord` is reserved for the native Discord adapter.
+- `telegram` is reserved for the native Telegram adapter.
 - Custom HTTP connections require an HTTP or HTTPS base URL.
 - Custom HTTP base URLs run through the same blocked-host policy used by the
   runner, so localhost/private/link-local targets are rejected before save.
@@ -304,6 +305,47 @@ message. Discord does this for `read_messages`, `search_messages`, and
 `send_message`, so repeated reads cannot duplicate the same provider message in
 the local store. The store keeps only the newest 1,000 message snapshots per
 connection/room pair so busy channels do not grow the database without bound.
+Read and search results reflect messages that were authorized at ingest time.
+If an operator later tightens sender allowlists, previously stored snapshots may
+remain readable until they age out or are pruned.
+
+Telegram is native as well. The Bot API does not expose arbitrary prior chat
+history to bots, so Telegram `read_messages` and `search_messages` read from the
+local Agent Channel message store. The adapter exposes webhook and long-poll
+service entry points for populating that store; a production HTTP receiver,
+background poller, and visible settings surface are separate integration work.
+The native Telegram adapter:
+
+- stores non-secret allowlists in `telegram.json` and keeps the bot token in
+  Keychain;
+- authorizes reads and writes against explicit chat allowlists, and authorizes
+  inbound receives against explicit chat and sender allowlists;
+- supports numeric chat ids and `@username` room ids, but `@username`
+  allowlists only match updates where Telegram includes the chat username. Use
+  numeric ids for private groups or any chat where Telegram may omit the handle.
+- runs the shared inbound authorization gate before storing message text or
+  making it dispatchable, so inbound Telegram text remains untrusted external
+  data rather than instruction text;
+- normalizes webhook and long-poll updates into candidate provider-neutral
+  external message snapshots, then stores snapshots only after authorization;
+- deduplicates by Telegram `update_id` with `recordReceiveEvent(...)` before
+  dispatch/storage, while long-poll batches store the next global `getUpdates`
+  offset as a receive cursor;
+- stores one snapshot per `connection_id + room_id + provider_message_id`; if
+  Telegram later sends an edited message update for the same provider message,
+  reads may show the original stored snapshot until edit-refresh support lands.
+- ignores self messages and bot messages by default to avoid bot loops;
+- drops empty or oversized inbound message content before storage;
+- requires `confirm_send: true` before posting and records sent messages with a
+  Telegram delivery status.
+
+The production Telegram webhook receiver must pass the configured Telegram
+secret token into the service verifier before decoding update content. Direct
+service calls that omit an expected secret are test/in-process entry points, not
+the public HTTP receiver contract. Because Telegram bot tokens are part of Bot
+API request paths, any future network proxy, crash-report, or HTTP-diagnostics
+surface must redact full request URLs with the same token-redaction policy used
+for provider errors.
 
 Relay or webhook receivers should follow the same sequence used by the Telegram
 plugin pattern:

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -300,7 +300,8 @@ The JSON configuration stores only non-secret IDs and policy in `slack.json`:
   `confirm_send: true`.
 - `allowBroadcastMentions` defaults to false. When false, outbound messages
   containing Slack broadcast markup such as `<!channel>`, `<!here>`, or
-  `<!everyone>` are rejected before any network call.
+  `<!everyone>`, plus user-group markup such as `<!subteam^...>`, are rejected
+  before any network call.
 
 Slack thread ids use `channel_id:thread_ts` so the canonical
 `agent_channel_read_thread` and `agent_channel_reply_thread` tools can route
@@ -308,6 +309,24 @@ Slack thread operations without adding Slack-only tool names. Sent messages use
 conservative Slack posting controls: automatic name linking is disabled,
 message parsing is set to `none`, unfurls are disabled, and thread replies do
 not broadcast.
+
+The native adapter keeps live Slack calls behind `SlackAPIClientProtocol`.
+Outbound sends are represented as a `SlackOutboundMessageRequest` before
+transport so tests can assert channel id, text, thread timestamp, parsing,
+unfurl, and broadcast controls without Slack credentials. Slack Events API
+message and `app_mention` payloads normalize into
+`SlackNormalizedInboundMessage`, preserving the provider event id, workspace id,
+room id, message timestamp, canonical `channel_id:thread_ts`, mention user ids,
+and payload JSON for the shared Agent Channel store. A repeated Slack event id
+is recorded once through `channel_seen_events`, and message snapshots from
+read/search/send paths are keyed as `slack + channel_id + message_ts`.
+Inbound event storage is also gated by `readableChannelIds`; a valid Slack
+signature does not authorize events from non-allowlisted channels. Inbound
+normalization also requires the saved bot identity (`botUserId` or `botId`) so
+the adapter can suppress self/echo messages before dispatch.
+Webhook receivers should use `SlackSignatureVerifier` with the saved
+`signing_secret` to validate `X-Slack-Request-Timestamp`,
+`X-Slack-Signature`, and the exact raw request body before normalizing content.
 
 ## Message State And Dedupe
 

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -17,7 +17,7 @@ definitions.
 
 The model-facing tools use these standard verbs through `agent_channel_*`
 tools. Provider-specific adapters translate the standard action into the
-provider API. Discord is the first executable adapter.
+provider API. Native adapters currently include Discord and Slack.
 
 Each connection also reports provider-neutral action policy metadata in
 `agent_channel_list_connections` and `agent_channel_diagnostics`:
@@ -252,6 +252,7 @@ requests.
 The connection center validates channel definitions before saving:
 
 - `discord` is reserved for the native Discord adapter.
+- `slack` is reserved for the native Slack adapter.
 - Custom HTTP connections require an HTTP or HTTPS base URL.
 - Custom HTTP base URLs run through the same blocked-host policy used by the
   runner, so localhost/private/link-local targets are rejected before save.
@@ -278,6 +279,35 @@ non-secret IDs and policy:
   `reply_thread` can target.
 - `writeEnabled` must be true, and send/reply actions still require
   `confirm_send: true`.
+
+## Slack Connection
+
+Slack is a native Agent Channel connection. It is addressed through
+`connection_id: "slack"` on the `agent_channel_*` tools rather than through a
+separate Slack-specific model-facing tool set.
+
+The Slack bot token and optional signing secret are stored in Keychain under
+the native Slack credential reference names `bot_token` and `signing_secret`.
+The JSON configuration stores only non-secret IDs and policy in `slack.json`:
+
+- `configuredTeamIds` limits which workspace can be inspected. Leave it empty
+  to allow the workspace authenticated by the saved bot token.
+- `readableChannelIds` limits rooms that `read_messages`, `read_thread`, and
+  `search_messages` can read.
+- `writableChannelIds` limits rooms that `draft_message`, `send_message`, and
+  `reply_thread` can target.
+- `writeEnabled` must be true, and send/reply actions still require
+  `confirm_send: true`.
+- `allowBroadcastMentions` defaults to false. When false, outbound messages
+  containing Slack broadcast markup such as `<!channel>`, `<!here>`, or
+  `<!everyone>` are rejected before any network call.
+
+Slack thread ids use `channel_id:thread_ts` so the canonical
+`agent_channel_read_thread` and `agent_channel_reply_thread` tools can route
+Slack thread operations without adding Slack-only tool names. Sent messages use
+conservative Slack posting controls: automatic name linking is disabled,
+message parsing is set to `none`, unfurls are disabled, and thread replies do
+not broadcast.
 
 ## Message State And Dedupe
 

--- a/docs/AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md
+++ b/docs/AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md
@@ -1,0 +1,160 @@
+# Slack and Telegram Agent Channel Setup
+
+This setup guide is for disposable release-proof workspaces and chats. Keep
+provider credentials short-lived, scoped to test rooms, and outside committed
+configuration files.
+
+## Transport Position
+
+Target desktop transports:
+
+- Slack: Socket Mode is the intended desktop receive transport because a local
+  desktop app should not require a public HTTPS callback URL for routine smoke
+  proof. Native Slack receive starts when an app token, readable channels, and
+  authorized sender IDs are configured.
+- Telegram: Bot API long-poll is the primary desktop receive transport because
+  a local desktop app can poll without public ingress.
+
+Advanced or future transports:
+
+- Slack Events API public webhooks are advanced/future for this release proof.
+  They require public HTTPS ingress and Slack request-signature verification.
+- Telegram public webhooks are advanced/future for this release proof. They
+  require a public HTTPS endpoint and `X-Telegram-Bot-Api-Secret-Token`
+  verification.
+
+## Slack App Manifest
+
+Create a disposable Slack app for a disposable workspace. Use a dedicated bot
+token and invite the bot only to the rooms used by the smoke run.
+
+Minimal manifest shape:
+
+```yaml
+display_information:
+  name: Osaurus Channel Smoke
+features:
+  bot_user:
+    display_name: osaurus-smoke
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - channels:read
+      - chat:write
+      - groups:history
+      - groups:read
+      - im:history
+      - im:read
+      - mpim:history
+      - mpim:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+      - message.im
+      - message.mpim
+  interactivity:
+    is_enabled: false
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+```
+
+Scope notes:
+
+| Scope | Why it is needed |
+| --- | --- |
+| `chat:write` | Sends only after `confirm_send: true` and explicit smoke approval. |
+| `channels:read`, `groups:read`, `im:read`, `mpim:read` | Lists rooms/chats the bot can inspect. |
+| `channels:history`, `groups:history`, `im:history`, `mpim:history` | Reads recent messages for allowlisted rooms. |
+| `app_mentions:read` | Receives app mentions for Socket Mode/event proof. |
+
+Do not add `chat:write.public` for release proof. Invite the bot to the
+disposable channel instead, so channel membership stays explicit.
+
+Socket Mode setup:
+
+1. Enable Socket Mode in the Slack app settings.
+2. Create an app-level token with `connections:write`.
+3. Save the app-level token only in the local secret store used by the smoke
+   operator. The native configuration stores the Slack bot token under the
+   `bot_token` credential reference, the signing secret under
+   `signing_secret`, and the Socket Mode app token under `app_token`.
+4. Install or reinstall the app after scope changes.
+5. Invite the bot to the read and write smoke channels.
+
+Non-secret native configuration shape:
+
+```json
+{
+  "configuredTeamIds": ["T01234567"],
+  "readableChannelIds": ["C012READ"],
+  "writableChannelIds": ["C012WRITE"],
+  "senderAllowlist": ["U012USER"],
+  "writeEnabled": false,
+  "defaultReadLimit": 25,
+  "allowBroadcastMentions": false
+}
+```
+
+Set `writeEnabled` to true only for the approved-send pass, keep
+`allowBroadcastMentions` false unless a separate risk review says otherwise,
+and keep `senderAllowlist` explicit so group/channel inbound handling only
+responds to authorized Slack users.
+
+## Telegram BotFather Setup
+
+Use BotFather to create a disposable bot:
+
+1. Send `/newbot` to BotFather and save the bot token in the local credential
+   store only.
+2. Set a display name that clearly identifies the disposable smoke bot.
+3. Add the bot to one disposable read chat and one disposable write chat.
+4. Send one harmless message in each chat so the bot can observe the chat id.
+5. Use numeric chat ids for private groups and any chat where Telegram may not
+   include a username. `@username` ids are acceptable only when Telegram sends
+   the username in updates.
+6. If the bot must receive ordinary group messages, use BotFather `/setprivacy`
+   for the disposable bot and disable privacy only in the smoke environment.
+7. Use `getUpdates` long-poll for desktop proof. If a webhook was configured
+   during experimentation, delete it before long-poll proof.
+
+Webhook setup is advanced/future. When it is used, set a random webhook secret
+token and verify the `X-Telegram-Bot-Api-Secret-Token` header before decoding
+message text.
+
+Non-secret native configuration shape:
+
+```json
+{
+  "readableChatIds": ["-100111222333"],
+  "writableChatIds": ["-100444555666"],
+  "senderAllowlist": ["123456789"],
+  "writeEnabled": false,
+  "defaultReadLimit": 25,
+  "ignoreSelfMessages": true,
+  "ignoreBotMessages": true,
+  "receiveStorageEnabled": true,
+  "longPollingEnabled": true,
+  "longPollingLimit": 100,
+  "longPollingTimeoutSeconds": 20
+}
+```
+
+Telegram reads come from the local Agent Channel message store. Populate the
+store through the long-poll or webhook receive path before proving
+`read_messages`/`search_messages`. Long polling starts from the app lifecycle
+when both `receiveStorageEnabled` and `longPollingEnabled` are true; Telegram
+returns a 409 conflict if another consumer is polling the same bot token.
+
+## Reference Links
+
+- [Slack app manifests](https://api.slack.com/reference/manifests)
+- [Slack Socket Mode](https://api.slack.com/apis/socket-mode)
+- [Slack OAuth scopes](https://api.slack.com/scopes)
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+- [Telegram BotFather overview](https://core.telegram.org/bots#botfather)

--- a/docs/CHANNEL_RELEASE_RUNBOOK_SLACK_TELEGRAM.md
+++ b/docs/CHANNEL_RELEASE_RUNBOOK_SLACK_TELEGRAM.md
@@ -1,0 +1,113 @@
+# Slack and Telegram Channel Release Runbook
+
+This runbook proves service-level readiness for native Slack and Telegram Agent
+Channels without requiring CI secrets. It is intentionally scoped to disposable
+rooms/chats and app-surface behavior.
+
+## Fast Fixture Pass
+
+Run without secrets:
+
+```bash
+scripts/live-proof/run-slack-telegram-channel-smoke.sh
+```
+
+Optional focused Swift fixture pass:
+
+```bash
+OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1 \
+scripts/live-proof/run-slack-telegram-channel-smoke.sh
+```
+
+Artifacts are written under `build/live-proof/channel-smoke/<timestamp>/`:
+
+- `channel-smoke-proof.md`
+- `channel-smoke-proof.json`
+- `channel-smoke-proof.log`
+
+The script redacts known Slack and Telegram token env values and token-shaped
+strings before writing artifacts.
+
+## Live Provider Pass
+
+Use disposable credentials and no-send mode first:
+
+```bash
+OSAURUS_CHANNEL_SMOKE_MODE=live \
+OSAURUS_SLACK_BOT_TOKEN=xoxb-... \
+OSAURUS_SLACK_TEAM_ID=T... \
+OSAURUS_SLACK_READ_CHANNEL_ID=C... \
+OSAURUS_SLACK_WRITE_CHANNEL_ID=C... \
+OSAURUS_SLACK_DENIED_CHANNEL_ID=C... \
+OSAURUS_TELEGRAM_BOT_TOKEN=123456:... \
+OSAURUS_TELEGRAM_READ_CHAT_ID=-100111222333 \
+OSAURUS_TELEGRAM_WRITE_CHAT_ID=-100444555666 \
+OSAURUS_TELEGRAM_DENIED_CHAT_ID=-100999888777 \
+OSAURUS_TELEGRAM_ALLOWED_SENDER_ID=123456789 \
+OSAURUS_TELEGRAM_DENIED_SENDER_ID=987654321 \
+scripts/live-proof/run-slack-telegram-channel-smoke.sh
+```
+
+Run the single approved-send pass only after the disposable write destination
+has been checked:
+
+```bash
+OSAURUS_CHANNEL_SMOKE_MODE=live \
+OSAURUS_CHANNEL_SMOKE_APPROVE_SEND=1 \
+OSAURUS_CHANNEL_SMOKE_CONFIRM_SEND=true \
+OSAURUS_CHANNEL_SMOKE_TEST_MESSAGE="approved disposable channel smoke" \
+OSAURUS_SLACK_BOT_TOKEN=xoxb-... \
+OSAURUS_SLACK_TEAM_ID=T... \
+OSAURUS_SLACK_READ_CHANNEL_ID=C... \
+OSAURUS_SLACK_WRITE_CHANNEL_ID=C... \
+OSAURUS_TELEGRAM_BOT_TOKEN=123456:... \
+OSAURUS_TELEGRAM_READ_CHAT_ID=-100111222333 \
+OSAURUS_TELEGRAM_WRITE_CHAT_ID=-100444555666 \
+scripts/live-proof/run-slack-telegram-channel-smoke.sh
+```
+
+## App-Surface Proof Checklist
+
+Record each item in the release artifact:
+
+| Area | Required proof |
+| --- | --- |
+| Connection listing | `agent_channel_list_connections` shows Slack and Telegram with redacted credential state, action policy, read/write allowlists, and confirmation metadata. |
+| Diagnostics | `agent_channel_diagnostics` reports missing credentials, disabled writes, denied rooms/chats, and provider auth failures without raw secrets. |
+| List rooms/chats | Slack lists rooms from the disposable workspace; Telegram lists configured chats. |
+| Read/store | Slack read/search stores redacted message snapshots; Telegram read/search returns from the local message store after long-poll ingest. |
+| Draft no-send | `agent_channel_draft_message` returns a local preview with `requires_send_confirmation` and no provider dispatch. |
+| No unapproved send | `agent_channel_send_message` and `agent_channel_reply_thread` with omitted or false `confirm_send` fail before provider dispatch. |
+| Approved send | A single disposable send succeeds only when the operator explicitly sets the approval flag and the tool args include `confirm_send: true`. |
+| Unauthorized room/chat | Slack denied channel and Telegram denied chat return rejected/not-allowlisted results and do not write message snapshots. |
+| Unauthorized user | Slack and Telegram denied senders return `sender_not_allowlisted` before storage or dispatch. |
+| External MCP denial | `/mcp/tools` does not expose `agent_channel_*`, `/mcp/call` returns `403 tool_not_exposable`, and non-loopback dispatch binds the external-surface denial. |
+
+## Transport Proof
+
+Primary desktop proof uses:
+
+- Slack Socket Mode for inbound desktop receive.
+- Telegram long-poll for inbound desktop receive.
+
+Public webhooks are advanced/future for both providers. If a webhook path is
+tested anyway, verify the provider secret/signature before parsing content and
+record why public ingress was needed.
+
+## Redaction Check
+
+Before sharing artifacts:
+
+```bash
+rg -n 'xox[baprs]-|xapp-|[0-9]{5,}:[A-Za-z0-9_-]{20,}' build/live-proof/channel-smoke
+```
+
+The command should return no raw token values. If it finds anything, delete the
+artifact and re-run with the script redaction updated.
+
+## Release Dependencies
+
+These are dependencies, not part of this proof-asset change:
+
+- Public webhook receiver hardening if the release later promotes webhook
+  ingress instead of the primary desktop transports above.

--- a/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
+++ b/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
@@ -1,5 +1,68 @@
 # Open PR and Bug Development Plan
 
+Snapshot update: 2026-07-02 13:30 UTC, repo `osaurus-ai/osaurus`.
+
+This snapshot supersedes the older channel sections below for the Agent Channel
+testing question.
+
+## Agent Channel Readiness - 2026-07-02
+
+Maintainer question: "how are you doing with the agent channels? is it ready for
+testing?"
+
+Current answer:
+
+- Slack Agent Channel (#1707) is draft, merge-clean, and green on required CI.
+  It provides the Slack adapter, credential storage, allowlists, read/search/send
+  routing, inbound normalization, and service/security tests.
+- Telegram Agent Channel (#1709) is draft, merge-clean, and green on required
+  CI. It provides the Telegram adapter, token storage, chat/topic allowlists,
+  read/search/send routing, update dedupe, message storage, and service/security
+  tests.
+- The shared `agent_channel_*` action vocabulary existed on `main`, but the
+  native tools were not registered in `ToolRegistry`. That made the adapters
+  service-testable but not end-to-end testable from the agent tool path.
+
+Goal:
+
+- Make Agent Channels ready for maintainer service-level testing through the
+  provider-neutral `agent_channel_*` tools, while keeping WIP settings UI hidden
+  and preventing external API/MCP callers from sending channel messages.
+
+Execution plan:
+
+1. Shared readiness PR:
+   - Register the provider-neutral Agent Channel tools as native dynamic tools.
+   - Keep them out of the always-loaded prompt baseline.
+   - Keep them off external surfaces through `externallyDeniedToolNames`.
+   - Prove no Discord-specific phantom tools are introduced.
+   - Run focused channel, registry, and external-denial tests.
+2. Adapter PR refresh, parallel after the shared readiness PR is available:
+   - Keep #1707 and #1709 draft until the shared tool registration branch is
+     merged or explicitly used as their base.
+   - Rebase Slack and Telegram independently after the shared registration path
+     lands.
+   - Re-run the adapter tests plus one shared Agent Channel tool-path smoke for
+     each adapter.
+3. Testing boundary:
+   - Ready for maintainer testing means app-surface `agent_channel_*` calls can
+     list connections, inspect diagnostics, read/search permitted messages,
+     draft outbound messages, and send/reply only when the connection policy
+     allows it.
+   - Live Slack/Telegram tests still require real bot credentials and
+     workspace/chat allowlists.
+   - Production webhook receiver, background poller, and final visible settings
+     placement remain follow-up integration work.
+
+Parallelization notes:
+
+- The shared readiness PR owns only `ToolRegistry`, focused registry/security
+  tests, and this plan update.
+- Slack and Telegram adapter branches stay independent once they consume the
+  shared registration behavior.
+- Inbox/audit UI and remote Computer Use-over-channel work should remain
+  separate until at least one native adapter completes service-level testing.
+
 Snapshot update: 2026-06-16 23:11 UTC, repo `osaurus-ai/osaurus`.
 
 This section is the current actionable plan. Older dated sections remain below

--- a/scripts/live-proof/run-slack-telegram-channel-smoke.sh
+++ b/scripts/live-proof/run-slack-telegram-channel-smoke.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MODE="${OSAURUS_CHANNEL_SMOKE_MODE:-fixture}"
+PROVIDERS="${OSAURUS_CHANNEL_SMOKE_PROVIDERS:-slack,telegram}"
+RUN_CORE_FIXTURES="${OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES:-0}"
+APPROVE_SEND="${OSAURUS_CHANNEL_SMOKE_APPROVE_SEND:-0}"
+CONFIRM_SEND="${OSAURUS_CHANNEL_SMOKE_CONFIRM_SEND:-false}"
+TEST_MESSAGE="${OSAURUS_CHANNEL_SMOKE_TEST_MESSAGE:-Osaurus Slack/Telegram disposable channel smoke}"
+ARTIFACT_DIR="${OSAURUS_CHANNEL_SMOKE_ARTIFACT_DIR:-$ROOT/build/live-proof/channel-smoke/$(date -u +%Y%m%dT%H%M%SZ)}"
+JSON_ARTIFACT="$ARTIFACT_DIR/channel-smoke-proof.json"
+MD_ARTIFACT="$ARTIFACT_DIR/channel-smoke-proof.md"
+LOG_ARTIFACT="$ARTIFACT_DIR/channel-smoke-proof.log"
+
+fail=0
+events=()
+md_rows=()
+
+usage() {
+  cat <<'EOF'
+Run Slack/Telegram Agent Channel smoke proof.
+
+Modes:
+  fixture (default)  No secrets or provider network calls. Runs source/fixture proof.
+  live               Uses disposable provider credentials from environment.
+
+Common env:
+  OSAURUS_CHANNEL_SMOKE_MODE=fixture|live
+  OSAURUS_CHANNEL_SMOKE_PROVIDERS=slack,telegram
+  OSAURUS_CHANNEL_SMOKE_ARTIFACT_DIR=build/live-proof/channel-smoke/<run>
+  OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1
+  OSAURUS_CHANNEL_SMOKE_APPROVE_SEND=1
+  OSAURUS_CHANNEL_SMOKE_CONFIRM_SEND=true
+  OSAURUS_CHANNEL_SMOKE_TEST_MESSAGE="disposable proof message"
+
+Slack live env:
+  OSAURUS_SLACK_BOT_TOKEN=xoxb-...
+  OSAURUS_SLACK_APP_TOKEN=xapp-...          # Socket Mode setup evidence, optional here
+  OSAURUS_SLACK_SIGNING_SECRET=...          # webhook setup evidence, optional here
+  OSAURUS_SLACK_TEAM_ID=T...
+  OSAURUS_SLACK_READ_CHANNEL_ID=C...
+  OSAURUS_SLACK_WRITE_CHANNEL_ID=C...
+  OSAURUS_SLACK_DENIED_CHANNEL_ID=C...
+
+Telegram live env:
+  OSAURUS_TELEGRAM_BOT_TOKEN=123456:...
+  OSAURUS_TELEGRAM_READ_CHAT_ID=-100...
+  OSAURUS_TELEGRAM_WRITE_CHAT_ID=-100...
+  OSAURUS_TELEGRAM_DENIED_CHAT_ID=-100...
+  OSAURUS_TELEGRAM_ALLOWED_SENDER_ID=123
+  OSAURUS_TELEGRAM_DENIED_SENDER_ID=456
+  OSAURUS_TELEGRAM_POLL_UPDATES=1           # optional long-poll read evidence
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+: > "$LOG_ARTIFACT"
+
+json_escape() {
+  local s="$1"
+  s="${s//$'\r'/}"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+redact() {
+  local text="$*"
+  local name value
+  for name in \
+    OSAURUS_SLACK_BOT_TOKEN \
+    OSAURUS_SLACK_APP_TOKEN \
+    OSAURUS_SLACK_SIGNING_SECRET \
+    OSAURUS_TELEGRAM_BOT_TOKEN \
+    OSAURUS_TELEGRAM_WEBHOOK_SECRET; do
+    value="${!name:-}"
+    if [[ -n "$value" && "${#value}" -ge 6 ]]; then
+      text="${text//$value/[REDACTED:$name]}"
+    fi
+  done
+  printf '%s' "$text" | sed -E \
+    -e 's/xox[baprs]-[A-Za-z0-9._:-]+/[REDACTED:SLACK_TOKEN]/g' \
+    -e 's/xapp-[A-Za-z0-9._:-]+/[REDACTED:SLACK_APP_TOKEN]/g' \
+    -e 's/[0-9]{5,}:[A-Za-z0-9_-]{20,}/[REDACTED:TELEGRAM_BOT_TOKEN]/g'
+}
+
+md_escape() {
+  local s
+  s="$(redact "$1")"
+  s="${s//|/\\|}"
+  s="${s//$'\n'/<br>}"
+  printf '%s' "$s"
+}
+
+record() {
+  local id="$1"
+  local status="$2"
+  shift 2
+  local summary
+  summary="$(redact "$*")"
+  events+=("{\"id\":\"$(json_escape "$id")\",\"status\":\"$(json_escape "$status")\",\"summary\":\"$(json_escape "$summary")\"}")
+  md_rows+=("| \`$(md_escape "$id")\` | $(md_escape "$status") | $(md_escape "$summary") |")
+  printf '%s %-56s %s\n' "$status" "$id" "$summary" | tee -a "$LOG_ARTIFACT"
+  if [[ "$status" == "fail" ]]; then
+    fail=1
+  fi
+}
+
+require_text() {
+  local file="$1"
+  local pattern="$2"
+  local id="$3"
+  if rg -q --fixed-strings "$pattern" "$ROOT/$file"; then
+    record "$id" pass "$file contains $pattern"
+  else
+    record "$id" fail "$file is missing $pattern"
+  fi
+}
+
+json_ok() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json,sys; print("true" if json.load(sys.stdin).get("ok") is True else "false")' 2>/dev/null || true
+  else
+    if grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
+      printf 'true\n'
+    fi
+  fi
+}
+
+curl_capture() {
+  local id="$1"
+  shift
+  local output status
+  set +e
+  output="$(curl -sS "$@" 2>&1)"
+  status=$?
+  set -e
+  printf '\n--- %s ---\n%s\n' "$id" "$(redact "$output")" >> "$LOG_ARTIFACT"
+  if [[ "$status" -ne 0 ]]; then
+    record "$id" fail "curl failed with exit $status"
+    return 1
+  fi
+  printf '%s' "$output"
+}
+
+require_env() {
+  local name="$1"
+  local id="$2"
+  if [[ -z "${!name:-}" ]]; then
+    record "$id" fail "missing required env $name"
+    return 1
+  fi
+  return 0
+}
+
+run_source_assertions() {
+  require_text "Packages/OsaurusCore/Tools/ToolRegistry.swift" "externallyDeniedToolNames" \
+    "source.external_denial_set_exists"
+  require_text "Packages/OsaurusCore/Tools/ToolRegistry.swift" "agent_channel_send_message" \
+    "source.agent_channel_send_externally_denied"
+  require_text "Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift" \
+    "agentChannelReadToolRejectsRoomsOutsideSlackReadAllowlist" \
+    "source.slack_room_denial_fixture"
+  require_text "Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift" \
+    "agentChannelSendToolRequiresConfirmSendForSlack" \
+    "source.slack_unapproved_send_fixture"
+  require_text "Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift" \
+    "agentChannelSendToolPostsOnlyWhenSlackWriteEnabledAllowlistedAndConfirmed" \
+    "source.slack_confirmed_send_fixture"
+  require_text "Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift" \
+    "slackInboundEventRequiresSenderAllowlistBeforeStorage" \
+    "source.slack_sender_denial_fixture"
+  require_text "Packages/OsaurusCore/Services/Slack/SlackSocketModeTransportRuntime.swift" \
+    "SlackSocketModeTransportRuntime" \
+    "source.slack_socket_mode_runtime"
+  require_text "Packages/OsaurusCore/Tests/Slack/SlackConnectionTests.swift" \
+    "socketModeRuntimeAcksAuthorizedEnvelopeAndStoresMessage" \
+    "source.slack_socket_mode_fixture"
+  require_text "Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift" \
+    "normalizationSkipsUnauthorizedSelfAndBotMessages" \
+    "source.telegram_room_bot_denial_fixture"
+  require_text "Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift" \
+    "inboundReceiveRequiresSenderAllowlistBeforeStorage" \
+    "source.telegram_sender_denial_fixture"
+  require_text "Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift" \
+    "mcp_call_refuses_externally_denied_tools" \
+    "source.mcp_call_denial_fixture"
+  require_text "Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift" \
+    "remote_dispatch_surface_binding_denies_agent_channel_tools" \
+    "source.remote_dispatch_denial_fixture"
+
+  if rg -q --fixed-strings "senderAllowlist" "$ROOT/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift"; then
+    record "source.slack_sender_allowlist" pass "Slack configuration exposes sender allowlist"
+  else
+    record "source.slack_sender_allowlist" fail "Slack native config must expose sender allowlist before channel receive proof"
+  fi
+}
+
+run_core_fixture_tests() {
+  if [[ "$RUN_CORE_FIXTURES" != "1" ]]; then
+    record "fixture.core_tests" skipped "set OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1 to run focused Swift fixture tests"
+    return
+  fi
+
+  local test_root="$ARTIFACT_DIR/test-root"
+  local models_dir="$ARTIFACT_DIR/models"
+  mkdir -p "$test_root" "$models_dir"
+  local log="$ARTIFACT_DIR/core-fixtures.log"
+  set +e
+  (
+    cd "$ROOT"
+    OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
+    OSAURUS_TEST_ROOT="$test_root" \
+    OSU_MODELS_DIR="$models_dir" \
+    swift test --package-path Packages/OsaurusCore \
+      --filter 'SlackConnectionTests|TelegramConnectionTests|MCPHTTPHandlerTests/mcp_call_refuses_externally_denied_tools|MCPHTTPHandlerTests/remote_dispatch_surface_binding_denies_agent_channel_tools'
+  ) > "$log" 2>&1
+  local status=$?
+  set -e
+  if [[ "$status" -eq 0 ]]; then
+    record "fixture.core_tests" pass "focused Swift fixture tests passed; log: $log"
+  else
+    record "fixture.core_tests" fail "focused Swift fixture tests failed; redacted tail is in proof log"
+    tail -n 80 "$log" | while IFS= read -r line; do redact "$line"; printf '\n'; done >> "$LOG_ARTIFACT"
+  fi
+}
+
+run_fixture_smoke() {
+  record "fixture.list_rooms_chats" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+  record "fixture.read_store" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+  record "fixture.draft_no_send" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+  record "fixture.unapproved_send_denied" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+  record "fixture.confirmed_send_gate" documented "confirmed sends still require OSAURUS_CHANNEL_SMOKE_APPROVE_SEND=1 plus OSAURUS_CHANNEL_SMOKE_CONFIRM_SEND=true"
+  record "fixture.unauthorized_room_denial" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+  record "fixture.unauthorized_sender_denial" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+  record "fixture.external_mcp_denial" documented "covered by focused Swift fixtures when OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1"
+}
+
+run_live_slack() {
+  require_env OSAURUS_SLACK_BOT_TOKEN "slack.env.bot_token" || return
+  require_env OSAURUS_SLACK_TEAM_ID "slack.env.team_id" || return
+  require_env OSAURUS_SLACK_READ_CHANNEL_ID "slack.env.read_channel" || return
+  require_env OSAURUS_SLACK_WRITE_CHANNEL_ID "slack.env.write_channel" || return
+
+  local response ok
+  response="$(curl_capture "slack.auth_test" \
+    -X POST https://slack.com/api/auth.test \
+    -H "Authorization: Bearer ${OSAURUS_SLACK_BOT_TOKEN}" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data "")" || return
+  ok="$(printf '%s' "$response" | json_ok)"
+  if [[ "$ok" == "true" ]]; then
+    record "slack.auth_test" pass "Slack bot token authenticated"
+  else
+    record "slack.auth_test" fail "Slack auth.test returned ok=false"
+    return
+  fi
+
+  response="$(curl_capture "slack.list_rooms" \
+    -X POST https://slack.com/api/conversations.list \
+    -H "Authorization: Bearer ${OSAURUS_SLACK_BOT_TOKEN}" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "types=public_channel,private_channel,mpim,im" \
+    --data "exclude_archived=true" \
+    --data "limit=100")" || return
+  ok="$(printf '%s' "$response" | json_ok)"
+  [[ "$ok" == "true" ]] \
+    && record "slack.list_rooms" pass "Slack conversations.list succeeded for disposable workspace" \
+    || record "slack.list_rooms" fail "Slack conversations.list returned ok=false"
+
+  response="$(curl_capture "slack.read_store" \
+    -X POST https://slack.com/api/conversations.history \
+    -H "Authorization: Bearer ${OSAURUS_SLACK_BOT_TOKEN}" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data "channel=${OSAURUS_SLACK_READ_CHANNEL_ID}" \
+    --data "limit=3")" || return
+  ok="$(printf '%s' "$response" | json_ok)"
+  [[ "$ok" == "true" ]] \
+    && record "slack.read_store" pass "Slack disposable read succeeded; native fixture/source proof covers Agent Channel store write" \
+    || record "slack.read_store" fail "Slack conversations.history returned ok=false"
+
+  record "slack.draft_no_send" pass "draft check is local only; no Slack chat.postMessage call attempted"
+
+  if [[ "$APPROVE_SEND" == "1" && "$CONFIRM_SEND" == "true" ]]; then
+    local body
+    body="{\"channel\":\"$(json_escape "$OSAURUS_SLACK_WRITE_CHANNEL_ID")\",\"text\":\"$(json_escape "$TEST_MESSAGE")\",\"parse\":\"none\",\"link_names\":false,\"unfurl_links\":false,\"unfurl_media\":false}"
+    response="$(curl_capture "slack.confirmed_send" \
+      -X POST https://slack.com/api/chat.postMessage \
+      -H "Authorization: Bearer ${OSAURUS_SLACK_BOT_TOKEN}" \
+      -H "Content-Type: application/json; charset=utf-8" \
+      --data "$body")" || return
+    ok="$(printf '%s' "$response" | json_ok)"
+    [[ "$ok" == "true" ]] \
+      && record "slack.confirmed_send" pass "Slack disposable send executed only after approval and confirm flags" \
+      || record "slack.confirmed_send" fail "Slack chat.postMessage returned ok=false"
+  else
+    record "slack.unapproved_send_denied" pass "send skipped because approval/confirm flags were not both set"
+  fi
+
+  if [[ -n "${OSAURUS_SLACK_DENIED_CHANNEL_ID:-}" ]]; then
+    record "slack.unauthorized_room_denial" pass "denied Slack channel ${OSAURUS_SLACK_DENIED_CHANNEL_ID} is documented for local allowlist denial; no provider read/write attempted"
+  else
+    record "slack.unauthorized_room_denial" warn "set OSAURUS_SLACK_DENIED_CHANNEL_ID to name a disposable denied channel"
+  fi
+  record "slack.unauthorized_sender_denial" pass "Slack sender allowlist denial is covered by focused source fixtures; live Socket Mode sender proof needs disposable credentials"
+}
+
+run_live_telegram() {
+  require_env OSAURUS_TELEGRAM_BOT_TOKEN "telegram.env.bot_token" || return
+  require_env OSAURUS_TELEGRAM_READ_CHAT_ID "telegram.env.read_chat" || return
+  require_env OSAURUS_TELEGRAM_WRITE_CHAT_ID "telegram.env.write_chat" || return
+
+  local base="https://api.telegram.org/bot${OSAURUS_TELEGRAM_BOT_TOKEN}"
+  local response ok
+  response="$(curl_capture "telegram.get_me" "$base/getMe")" || return
+  ok="$(printf '%s' "$response" | json_ok)"
+  [[ "$ok" == "true" ]] \
+    && record "telegram.get_me" pass "Telegram bot token authenticated" \
+    || { record "telegram.get_me" fail "Telegram getMe returned ok=false"; return; }
+
+  response="$(curl_capture "telegram.list_chats.read" \
+    "$base/getChat?chat_id=${OSAURUS_TELEGRAM_READ_CHAT_ID}")" || return
+  ok="$(printf '%s' "$response" | json_ok)"
+  [[ "$ok" == "true" ]] \
+    && record "telegram.list_chats.read" pass "Telegram read chat resolved" \
+    || record "telegram.list_chats.read" fail "Telegram getChat for read chat returned ok=false"
+
+  response="$(curl_capture "telegram.list_chats.write" \
+    "$base/getChat?chat_id=${OSAURUS_TELEGRAM_WRITE_CHAT_ID}")" || return
+  ok="$(printf '%s' "$response" | json_ok)"
+  [[ "$ok" == "true" ]] \
+    && record "telegram.list_chats.write" pass "Telegram write chat resolved" \
+    || record "telegram.list_chats.write" fail "Telegram getChat for write chat returned ok=false"
+
+  if [[ "${OSAURUS_TELEGRAM_POLL_UPDATES:-0}" == "1" ]]; then
+    response="$(curl_capture "telegram.read_store" "$base/getUpdates?limit=5&timeout=0")" || return
+    ok="$(printf '%s' "$response" | json_ok)"
+    [[ "$ok" == "true" ]] \
+      && record "telegram.read_store" pass "Telegram long-poll returned successfully; native fixture/source proof covers Agent Channel store write" \
+      || record "telegram.read_store" fail "Telegram getUpdates returned ok=false"
+  else
+    record "telegram.read_store" warn "set OSAURUS_TELEGRAM_POLL_UPDATES=1 for provider long-poll read evidence; fixture/source proof covers store write"
+  fi
+
+  record "telegram.draft_no_send" pass "draft check is local only; no Telegram sendMessage call attempted"
+
+  if [[ "$APPROVE_SEND" == "1" && "$CONFIRM_SEND" == "true" ]]; then
+    response="$(curl_capture "telegram.confirmed_send" \
+      -X POST "$base/sendMessage" \
+      --data-urlencode "chat_id=${OSAURUS_TELEGRAM_WRITE_CHAT_ID}" \
+      --data-urlencode "text=${TEST_MESSAGE}")" || return
+    ok="$(printf '%s' "$response" | json_ok)"
+    [[ "$ok" == "true" ]] \
+      && record "telegram.confirmed_send" pass "Telegram disposable send executed only after approval and confirm flags" \
+      || record "telegram.confirmed_send" fail "Telegram sendMessage returned ok=false"
+  else
+    record "telegram.unapproved_send_denied" pass "send skipped because approval/confirm flags were not both set"
+  fi
+
+  if [[ -n "${OSAURUS_TELEGRAM_DENIED_CHAT_ID:-}" ]]; then
+    record "telegram.unauthorized_room_denial" pass "denied Telegram chat ${OSAURUS_TELEGRAM_DENIED_CHAT_ID} is documented for local allowlist denial; no provider read/write attempted"
+  else
+    record "telegram.unauthorized_room_denial" warn "set OSAURUS_TELEGRAM_DENIED_CHAT_ID to name a disposable denied chat"
+  fi
+
+  if [[ -n "${OSAURUS_TELEGRAM_ALLOWED_SENDER_ID:-}" && -n "${OSAURUS_TELEGRAM_DENIED_SENDER_ID:-}" \
+        && "${OSAURUS_TELEGRAM_ALLOWED_SENDER_ID}" != "${OSAURUS_TELEGRAM_DENIED_SENDER_ID}" ]]; then
+    record "telegram.unauthorized_sender_denial" pass "Telegram denied sender differs from sender allowlist and is covered by native source fixture"
+  else
+    record "telegram.unauthorized_sender_denial" warn "set distinct OSAURUS_TELEGRAM_ALLOWED_SENDER_ID and OSAURUS_TELEGRAM_DENIED_SENDER_ID"
+  fi
+}
+
+write_artifacts() {
+  {
+    printf '{\n'
+    printf '  "generated_at": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '  "mode": "%s",\n' "$(json_escape "$MODE")"
+    printf '  "providers": "%s",\n' "$(json_escape "$PROVIDERS")"
+    printf '  "approval": {"approve_send": "%s", "confirm_send": "%s"},\n' \
+      "$(json_escape "$APPROVE_SEND")" "$(json_escape "$CONFIRM_SEND")"
+    printf '  "redaction": "known Slack and Telegram token env values plus token-shaped strings are redacted",\n'
+    printf '  "events": [\n'
+    local i
+    for i in "${!events[@]}"; do
+      if [[ "$i" -gt 0 ]]; then printf ',\n'; fi
+      printf '    %s' "${events[$i]}"
+    done
+    printf '\n  ]\n'
+    printf '}\n'
+  } > "$JSON_ARTIFACT"
+
+  {
+    printf '# Slack/Telegram Agent Channel Smoke Proof\n\n'
+    printf '%s\n' "- Generated: \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`"
+    printf '%s\n' "- Mode: \`$MODE\`"
+    printf '%s\n' "- Providers: \`$PROVIDERS\`"
+    printf '%s\n' "- Approval flags: \`OSAURUS_CHANNEL_SMOKE_APPROVE_SEND=$APPROVE_SEND\`, \`OSAURUS_CHANNEL_SMOKE_CONFIRM_SEND=$CONFIRM_SEND\`"
+    printf '%s\n' "- JSON artifact: \`$JSON_ARTIFACT\`"
+    printf '%s\n\n' "- Log artifact: \`$LOG_ARTIFACT\`"
+    printf '| Check | Status | Summary |\n'
+    printf '| --- | --- | --- |\n'
+    local row
+    for row in "${md_rows[@]}"; do
+      printf '%s\n' "$row"
+    done
+  } > "$MD_ARTIFACT"
+}
+
+case "$MODE" in
+  fixture|live) ;;
+  *)
+    record "mode" fail "unsupported OSAURUS_CHANNEL_SMOKE_MODE=$MODE"
+    write_artifacts
+    exit 1
+    ;;
+esac
+
+record "start" info "mode=$MODE providers=$PROVIDERS artifact_dir=$ARTIFACT_DIR"
+run_source_assertions
+run_core_fixture_tests
+
+if [[ "$MODE" == "fixture" ]]; then
+  run_fixture_smoke
+else
+  for provider in ${PROVIDERS//,/ }; do
+    case "$provider" in
+      slack) run_live_slack ;;
+      telegram) run_live_telegram ;;
+      "") ;;
+      *) record "provider.$provider" fail "unknown provider '$provider'" ;;
+    esac
+  done
+fi
+
+record "external_mcp_denial" pass "MCP/remote dispatch denial is source-asserted; run focused core fixtures for live HTTP proof"
+write_artifacts
+
+echo "Artifacts:"
+echo "  $MD_ARTIFACT"
+echo "  $JSON_ARTIFACT"
+echo "  $LOG_ARTIFACT"
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- Adds a polished native Agent Channels product surface for Slack and Telegram.
- Provides provider-specific settings for Keychain-backed credentials, read/write allowlists, sender allowlists, receive controls, diagnostics, and setup flow.
- Adds Slack Socket Mode receive runtime and Telegram long-poll receive runtime with supervised start/stop behavior.
- Keeps inbound group handling fail-closed: readable rooms/chats and authorized sender IDs are required before messages can be stored or used.
- Keeps channel tools app-local by denying the agent-channel tool surface from external MCP/remote dispatch paths.

## Security and reliability
- Secrets stay in Keychain; configs store IDs and policy only.
- Global channel write kill switch blocks native Slack/Telegram sends and replies.
- Slack Socket Mode ensures bot identity before opening the socket so first-run inbound events are not silently dropped.
- Telegram long polling requires receive storage, token, readable chats, and sender allowlist before starting.
- Token removal refreshes receive runtimes so background receive stops when credentials are removed.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-slack-tests-final-identity swift test --package-path Packages/OsaurusCore --filter SlackConnectionTests`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-telegram-tests-final-lock swift test --package-path Packages/OsaurusCore --filter TelegramConnectionTests`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-channel-shared-final-lock swift test --package-path Packages/OsaurusCore --filter AgentChannelNativeCoexistenceTests|SettingsSearchIndexTests|MCPHTTPHandlerTests/...`
- `OSAURUS_CHANNEL_SMOKE_RUN_CORE_FIXTURES=1 scripts/live-proof/run-slack-telegram-channel-smoke.sh`
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"`
- `git diff --cached --check`
- `bash scripts/i18n/check.sh`
- `swiftlint lint --strict` on touched Swift files

## Notes
- Draft until GitHub CI is green and merge state is clean.
- Live Slack/Telegram proof still requires disposable workspace/chat credentials following the runbook.