### PR TITLE
added transcription cleanup toggle and redesign the dictation overlay

### DIFF
--- a/Packages/OsaurusCore/Models/Voice/SpeechConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Voice/SpeechConfiguration.swift
@@ -82,6 +82,11 @@ public struct SpeechConfiguration: Codable, Equatable, Sendable {
     /// Seconds of silence before closing voice input (0 = disabled, 10-120 seconds)
     public var silenceTimeoutSeconds: Double
 
+    /// Whether to clean up the raw transcription with the core model
+    /// (removes filler words like "uh"/"mm", stutters, and self-corrections).
+    /// Disable to keep the natural, verbatim transcription.
+    public var postProcessTranscription: Bool
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let defaults = SpeechConfiguration.default
@@ -110,6 +115,9 @@ public struct SpeechConfiguration: Codable, Equatable, Sendable {
         self.silenceTimeoutSeconds =
             try container.decodeIfPresent(Double.self, forKey: .silenceTimeoutSeconds)
             ?? defaults.silenceTimeoutSeconds
+        self.postProcessTranscription =
+            try container.decodeIfPresent(Bool.self, forKey: .postProcessTranscription)
+            ?? defaults.postProcessTranscription
     }
 
     public init(
@@ -121,7 +129,8 @@ public struct SpeechConfiguration: Codable, Equatable, Sendable {
         transcriptionStopMode: TranscriptionStopMode = .automatic,
         pauseDuration: Double = 1.5,
         confirmationDelay: Double = 2.0,
-        silenceTimeoutSeconds: Double = 30.0
+        silenceTimeoutSeconds: Double = 30.0,
+        postProcessTranscription: Bool = true
     ) {
         self.modelVersion = modelVersion
         self.selectedInputDeviceId = selectedInputDeviceId
@@ -132,6 +141,7 @@ public struct SpeechConfiguration: Codable, Equatable, Sendable {
         self.pauseDuration = pauseDuration
         self.confirmationDelay = confirmationDelay
         self.silenceTimeoutSeconds = silenceTimeoutSeconds
+        self.postProcessTranscription = postProcessTranscription
     }
 
     public static var `default`: SpeechConfiguration {
@@ -144,7 +154,8 @@ public struct SpeechConfiguration: Codable, Equatable, Sendable {
             transcriptionStopMode: .automatic,
             pauseDuration: 1.5,
             confirmationDelay: 2.0,
-            silenceTimeoutSeconds: 30.0
+            silenceTimeoutSeconds: 30.0,
+            postProcessTranscription: true
         )
     }
 }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -19356,6 +19356,9 @@
         }
       }
     },
+    "Cancel (Esc)" : {
+
+    },
     "Cancel a running task" : {
       "localizations" : {
         "de" : {
@@ -35877,6 +35880,7 @@
       }
     },
     "Done (Esc)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -108871,6 +108875,9 @@
           }
         }
       }
+    },
+    "Stop and insert" : {
+
     },
     "Stop Mode" : {
       "localizations" : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -22663,6 +22663,9 @@
       },
       "shouldTranslate" : false
     },
+    "Clean Up Transcription" : {
+
+    },
     "Clear" : {
       "localizations" : {
         "de" : {
@@ -28468,6 +28471,9 @@
           }
         }
       }
+    },
+    "core model" : {
+
     },
     "Core model" : {
       "extractionState" : "manual",
@@ -55238,6 +55244,9 @@
           }
         }
       }
+    },
+    "Keep the natural transcription, including filler words" : {
+
     },
     "Keep this chat running?" : {
       "localizations" : {
@@ -112649,6 +112658,9 @@
           }
         }
       }
+    },
+    "The core model removes filler words like \"uh\" and \"mm\"" : {
+
     },
     "The current model is text-only." : {
       "localizations" : {

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
@@ -139,6 +139,12 @@ public final class TranscriptionModeService: ObservableObject {
     public func stopTranscription(discard: Bool = false) {
         guard state == .transcribing || state == .starting else { return }
 
+        // A cancel has nothing to clean up, so dismiss the overlay right away
+        // instead of showing a "Processing" state while the stream tears down.
+        if discard {
+            overlayService.hide()
+        }
+
         state = .stopping
         stopEscKeyMonitoring()
         stopSilenceMonitoring()

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
@@ -122,6 +122,14 @@ public final class TranscriptionModeService: ObservableObject {
         Task {
             do {
                 try await speechService.startStreamingTranscription()
+                // The user may have cancelled while the stream was starting up.
+                // If we're no longer in `.starting`, a stop is already in flight
+                // (or done) — don't resurrect the session by subscribing again,
+                // which would leave the audio stream and timers running.
+                guard state == .starting else {
+                    _ = await speechService.stopStreamingTranscription()
+                    return
+                }
                 state = .transcribing
                 subscribeToAudioLevel()
                 print("[TranscriptionMode] Started transcription")

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
@@ -134,7 +134,9 @@ public final class TranscriptionModeService: ObservableObject {
         }
     }
 
-    public func stopTranscription() {
+    /// Stops transcription. When `discard` is true the captured text is thrown
+    /// away (cancel); otherwise it is cleaned up and inserted (done).
+    public func stopTranscription(discard: Bool = false) {
         guard state == .transcribing || state == .starting else { return }
 
         state = .stopping
@@ -149,7 +151,7 @@ public final class TranscriptionModeService: ObservableObject {
             let rawText = speechService.confirmedTranscription
             speechService.clearTranscription()
 
-            if !rawText.isEmpty {
+            if !discard, !rawText.isEmpty {
                 let finalText =
                     SpeechConfigurationStore.load().postProcessTranscription
                     ? await TranscriptionCleanupService.shared.clean(rawText)
@@ -159,7 +161,7 @@ public final class TranscriptionModeService: ObservableObject {
 
             overlayService.hide()
             state = .idle
-            print("[TranscriptionMode] Stopped transcription")
+            print("[TranscriptionMode] Stopped transcription (discard: \(discard))")
         }
     }
 
@@ -190,7 +192,7 @@ public final class TranscriptionModeService: ObservableObject {
             self?.stopTranscription()
         }
         overlayService.onCancel = { [weak self] in
-            self?.stopTranscription()
+            self?.stopTranscription(discard: true)
         }
     }
 
@@ -278,7 +280,7 @@ public final class TranscriptionModeService: ObservableObject {
         escKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == 53 {  // Esc
                 Task { @MainActor in
-                    self?.stopTranscription()
+                    self?.stopTranscription(discard: true)
                 }
             }
         }

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
@@ -150,7 +150,10 @@ public final class TranscriptionModeService: ObservableObject {
             speechService.clearTranscription()
 
             if !rawText.isEmpty {
-                let finalText = await TranscriptionCleanupService.shared.clean(rawText)
+                let finalText =
+                    SpeechConfigurationStore.load().postProcessTranscription
+                    ? await TranscriptionCleanupService.shared.clean(rawText)
+                    : rawText
                 keyboardService.pasteText(finalText)
             }
 

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionOverlayWindowService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionOverlayWindowService.swift
@@ -160,12 +160,12 @@ public final class TranscriptionOverlayWindowService: ObservableObject {
 
         guard let screen = activeScreen else { return }
 
-        // Position at top-center of the screen, below menu bar
+        // Position at bottom-center of the screen, above the Dock.
         let visibleFrame = screen.visibleFrame
         let panelSize = panel.frame.size
 
         let x = visibleFrame.origin.x + (visibleFrame.width - panelSize.width) / 2
-        let y = visibleFrame.origin.y + visibleFrame.height - panelSize.height - 20
+        let y = visibleFrame.origin.y + 20
 
         panel.setFrameOrigin(NSPoint(x: x, y: y))
     }

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionOverlayWindowService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionOverlayWindowService.swift
@@ -84,7 +84,7 @@ public final class TranscriptionOverlayWindowService: ObservableObject {
     // MARK: - Private Helpers
 
     private func createPanel() {
-        let panelSize = NSSize(width: 400, height: 60)
+        let panelSize = NSSize(width: 400, height: 120)
         let initialRect = NSRect(origin: .zero, size: panelSize)
 
         // Create panel with minimal chrome
@@ -124,10 +124,17 @@ public final class TranscriptionOverlayWindowService: ObservableObject {
     }
 
     private func createOverlayView() -> some View {
-        TranscriptionOverlayView(
+        let config = SpeechConfigurationStore.load()
+        // Show a Stop button whenever transcription won't stop on its own:
+        // manual mode, or automatic mode with pause duration 0 (no auto-send).
+        let showsStopButton =
+            config.transcriptionStopMode == .manual
+            || (config.transcriptionStopMode == .automatic && config.pauseDuration == 0)
+        return TranscriptionOverlayView(
             audioLevel: audioLevel,
             isActive: isActive,
             isProcessing: isProcessing,
+            showsStopButton: showsStopButton,
             onDone: { [weak self] in
                 self?.onDone?()
             },

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1260,7 +1260,10 @@ extension FloatingInputCard {
             logVoiceState(trigger: "sendVoiceMessage-afterStop")
 
             print("[FloatingInputCard] Invoking cleanup for voice message (\(message.count) chars)")
-            let cleanedMessage = await TranscriptionCleanupService.shared.clean(message)
+            let cleanedMessage =
+                SpeechConfigurationStore.load().postProcessTranscription
+                ? await TranscriptionCleanupService.shared.clean(message)
+                : message
             print("[FloatingInputCard] Cleanup done. Original: \(message) | Cleaned: \(cleanedMessage)")
             await finalPreencodeTask?.value
 
@@ -1329,7 +1332,10 @@ extension FloatingInputCard {
             _ = await speechService.stopStreamingTranscription()
             speechService.clearTranscription()
 
-            let cleaned = await TranscriptionCleanupService.shared.clean(transcribedText)
+            let cleaned =
+                SpeechConfigurationStore.load().postProcessTranscription
+                ? await TranscriptionCleanupService.shared.clean(transcribedText)
+                : transcribedText
 
             await MainActor.run {
                 voiceInputState = .idle

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -72,6 +72,29 @@ struct TranscriptionModeSettingsTab: View {
         NotificationCenter.default.post(name: .voiceConfigurationChanged, object: nil)
     }
 
+    /// Description for the cleanup toggle. When enabled, "core model" is styled
+    /// as an underlined accent-colored link that deep-links to its setting.
+    private var cleanupDescription: AttributedString {
+        guard postProcessTranscription else {
+            var text = AttributedString(L("Keep the natural transcription, including filler words"))
+            text.foregroundColor = theme.tertiaryText
+            return text
+        }
+        var text = AttributedString(L("The core model removes filler words like \"uh\" and \"mm\""))
+        text.foregroundColor = theme.tertiaryText
+        if let range = text.range(of: L("core model")) {
+            text[range].underlineStyle = .single
+            text[range].link = URL(string: "osaurus-settings://core-model")
+        }
+        return text
+    }
+
+    /// Deep-links to the Core Model picker in the General settings tab.
+    private func navigateToCoreModelSetting() {
+        SettingsHighlightCoordinator.shared.request("settings.general.coreModel")
+        ManagementStateManager.shared.selectedTab = .settings
+    }
+
     /// Formatted display for silence timeout
     private var silenceTimeoutFormatted: String {
         if silenceTimeoutSeconds >= 60 {
@@ -423,17 +446,44 @@ struct TranscriptionModeSettingsTab: View {
                     .font(.system(size: 12))
                     .foregroundColor(theme.secondaryText)
 
-                // Post-processing toggle
-                SettingsToggle(
-                    title: L("Clean Up Transcription"),
-                    description: postProcessTranscription
-                        ? L("The core model removes filler words like \"uh\" and \"mm\"")
-                        : L("Keep the natural transcription, including filler words"),
-                    isOn: $postProcessTranscription
-                )
-                .onChange(of: postProcessTranscription) { _, _ in
-                    saveVoiceSettings()
+                // Post-processing toggle. The description highlights "core model"
+                // as a deep link into the General settings tab, since users may
+                // not know what the core model is.
+                HStack {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Clean Up Transcription", bundle: .module)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(theme.primaryText)
+                        Text(cleanupDescription)
+                            .font(.system(size: 11))
+                            .tint(theme.accentColor)
+                            .environment(
+                                \.openURL,
+                                OpenURLAction { _ in
+                                    navigateToCoreModelSetting()
+                                    return .handled
+                                }
+                            )
+                    }
+
+                    Spacer()
+
+                    Toggle("", isOn: $postProcessTranscription)
+                        .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+                        .labelsHidden()
+                        .onChange(of: postProcessTranscription) { _, _ in
+                            saveVoiceSettings()
+                        }
                 }
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(theme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
 
                 // Voice Stop Mode Picker
                 VStack(alignment: .leading, spacing: 10) {

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -302,8 +302,8 @@ struct TranscriptionModeSettingsTab: View {
                     }
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Test Area Card

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -29,6 +29,7 @@ struct TranscriptionModeSettingsTab: View {
     @State private var pauseDuration: Double = 1.5
     @State private var confirmationDelay: Double = 2.0
     @State private var silenceTimeoutSeconds: Double = 30.0
+    @State private var postProcessTranscription: Bool = true
 
     /// Polls accessibility permission while the tab is visible, since
     /// `AXIsProcessTrusted()` won't notify us when the user grants it externally.
@@ -55,6 +56,7 @@ struct TranscriptionModeSettingsTab: View {
         pauseDuration = config.pauseDuration
         confirmationDelay = config.confirmationDelay
         silenceTimeoutSeconds = config.silenceTimeoutSeconds
+        postProcessTranscription = config.postProcessTranscription
     }
 
     private func saveVoiceSettings() {
@@ -64,6 +66,7 @@ struct TranscriptionModeSettingsTab: View {
         config.pauseDuration = pauseDuration
         config.confirmationDelay = confirmationDelay
         config.silenceTimeoutSeconds = silenceTimeoutSeconds
+        config.postProcessTranscription = postProcessTranscription
         SpeechConfigurationStore.save(config)
 
         NotificationCenter.default.post(name: .voiceConfigurationChanged, object: nil)
@@ -419,6 +422,18 @@ struct TranscriptionModeSettingsTab: View {
                 Text("Applies to both chat voice input and Transcription Mode", bundle: .module)
                     .font(.system(size: 12))
                     .foregroundColor(theme.secondaryText)
+
+                // Post-processing toggle
+                SettingsToggle(
+                    title: L("Clean Up Transcription"),
+                    description: postProcessTranscription
+                        ? L("The core model removes filler words like \"uh\" and \"mm\"")
+                        : L("Keep the natural transcription, including filler words"),
+                    isOn: $postProcessTranscription
+                )
+                .onChange(of: postProcessTranscription) { _, _ in
+                    saveVoiceSettings()
+                }
 
                 // Voice Stop Mode Picker
                 VStack(alignment: .leading, spacing: 10) {

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -84,7 +84,6 @@ struct TranscriptionModeSettingsTab: View {
         text.foregroundColor = theme.tertiaryText
         if let range = text.range(of: L("core model")) {
             text[range].foregroundColor = theme.accentColor
-            text[range].underlineColor = theme.accentColor
             text[range].underlineStyle = .single
             text[range].link = URL(string: "osaurus-settings://core-model")
         }

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -303,6 +303,7 @@ struct TranscriptionModeSettingsTab: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Test Area Card

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -83,6 +83,8 @@ struct TranscriptionModeSettingsTab: View {
         var text = AttributedString(L("The core model removes filler words like \"uh\" and \"mm\""))
         text.foregroundColor = theme.tertiaryText
         if let range = text.range(of: L("core model")) {
+            text[range].foregroundColor = theme.accentColor
+            text[range].underlineColor = theme.accentColor
             text[range].underlineStyle = .single
             text[range].link = URL(string: "osaurus-settings://core-model")
         }

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
@@ -19,6 +19,10 @@ public struct TranscriptionOverlayView: View {
     /// Whether the transcript is being cleaned up by the LLM
     let isProcessing: Bool
 
+    /// Whether to show an explicit Stop button (manual mode, or automatic with
+    /// pause duration 0 — cases where transcription won't stop on its own)
+    var showsStopButton: Bool = false
+
     /// Callback when user presses Done
     var onDone: (() -> Void)?
 
@@ -35,67 +39,71 @@ public struct TranscriptionOverlayView: View {
     /// Hover state for close button
     @State private var isCloseHovered = false
 
+    /// Pulsing state for the status dot
+    @State private var dotPulse = false
+
     // MARK: - Constants
 
     private let cornerRadius: CGFloat = 14
+
+    private var statusColor: Color { isProcessing ? theme.warningColor : theme.accentColor }
+    private var statusText: LocalizedStringKey { isProcessing ? "Processing" : "Listening" }
 
     public init(
         audioLevel: Float,
         isActive: Bool,
         isProcessing: Bool = false,
+        showsStopButton: Bool = false,
         onDone: (() -> Void)? = nil,
         onCancel: (() -> Void)? = nil
     ) {
         self.audioLevel = audioLevel
         self.isActive = isActive
         self.isProcessing = isProcessing
+        self.showsStopButton = showsStopButton
         self.onDone = onDone
         self.onCancel = onCancel
     }
 
-    public var body: some View {
-        HStack(spacing: 14) {
-            // Voice status indicator
-            VoiceStatusIndicator(
-                state: isProcessing ? .processing : .listening,
-                showLabel: true,
-                compact: false
-            )
-            .fixedSize()
+    private let badgeHeight: CGFloat = 28
 
-            // Waveform visualization - compact and centered
+    public var body: some View {
+        ZStack {
+            // Live audio spectrum — the single waveform, centered in the card.
             WaveformView(
                 level: audioLevel,
                 style: .bars,
-                barCount: 8,
+                barCount: 14,
+                primaryColor: .white,
                 isActive: isActive && !isProcessing
             )
-            .frame(width: 56, height: 20)
+            .frame(width: 150, height: 26)
             .opacity(isProcessing ? 0 : 1)
 
-            // Close button
-            Button(action: { onDone?() }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(isCloseHovered ? theme.primaryText : theme.tertiaryText)
-                    .frame(width: 28, height: 28)
-                    .background(
-                        Circle()
-                            .fill(isCloseHovered ? theme.secondaryBackground : theme.tertiaryBackground)
-                    )
+            // Stop / Cancel controls share the waveform's horizontal axis,
+            // pinned to the card's left and right edges.
+            HStack(spacing: 0) {
+                if showsStopButton && !isProcessing {
+                    stopButton
+                }
+                Spacer(minLength: 0)
+                cancelButton
             }
-            .buttonStyle(.plain)
-            .scaleEffect(isCloseHovered ? 1.05 : 1.0)
-            .animation(.easeOut(duration: 0.15), value: isCloseHovered)
-            .onHover { hovering in
-                isCloseHovered = hovering
-            }
-            .localizedHelp("Done (Esc)")
         }
+        .frame(height: 30)
         .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .fixedSize()
+        // Push the row below the badge that straddles the top border.
+        .padding(.top, badgeHeight / 2 + 14)
+        .padding(.bottom, 16)
+        .frame(width: 264)
         .modifier(OverlayGlassBackground(cornerRadius: cornerRadius))
+        // The status badge straddles the top border like a notch.
+        .overlay(alignment: .top) {
+            statusBadge
+                .offset(y: -badgeHeight / 2)
+        }
+        // Reserve room above the card so the straddling badge isn't clipped.
+        .padding(.top, badgeHeight / 2)
         // Subtle entrance animation
         .scaleEffect(isAppeared ? 1.0 : 0.95)
         .opacity(isAppeared ? 1.0 : 0)
@@ -103,6 +111,92 @@ public struct TranscriptionOverlayView: View {
             withAnimation(.easeOut(duration: 0.2)) {
                 isAppeared = true
             }
+            dotPulse = true
+        }
+    }
+
+    // MARK: - Subviews
+
+    /// Pulsing dot + status label, rendered as an opaque pill so it reads
+    /// cleanly where it cuts through the card's top border.
+    private var statusBadge: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 7, height: 7)
+                .scaleEffect(dotPulse ? 1.3 : 0.85)
+                .opacity(dotPulse ? 1.0 : 0.55)
+                .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: dotPulse)
+
+            Text(statusText, bundle: .module)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.white)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: badgeHeight)
+        .modifier(BadgeGlassBackground(tint: statusColor))
+    }
+
+    /// Stop & insert — only shown when transcription won't stop on its own.
+    private var stopButton: some View {
+        Button(action: { onDone?() }) {
+            HStack(spacing: 6) {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 9, weight: .bold))
+                Text("Stop", bundle: .module)
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(theme.accentColor))
+        }
+        .buttonStyle(.plain)
+        .localizedHelp("Stop and insert")
+    }
+
+    /// Cancel — discards the transcript.
+    private var cancelButton: some View {
+        Button(action: { onCancel?() }) {
+            Image(systemName: "xmark")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.white.opacity(isCloseHovered ? 1.0 : 0.7))
+                .frame(width: 24, height: 24)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(isCloseHovered ? 0.22 : 0.12))
+                )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isCloseHovered ? 1.05 : 1.0)
+        .animation(.easeOut(duration: 0.15), value: isCloseHovered)
+        .onHover { hovering in
+            isCloseHovered = hovering
+        }
+        .localizedHelp("Cancel (Esc)")
+    }
+}
+
+// MARK: - Badge Glass Background
+
+/// Liquid Glass capsule for the status badge (macOS 26+), tinted with the
+/// state color, with a themed translucent fallback on earlier systems.
+private struct BadgeGlassBackground: ViewModifier {
+    @Environment(\.theme) private var theme
+    let tint: Color
+
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content
+                .background(Capsule().fill(Color.black.opacity(0.55)))
+                .glassEffect(.regular.tint(tint.opacity(0.28)), in: Capsule())
+                .overlay(Capsule().strokeBorder(tint.opacity(0.5), lineWidth: 1))
+        } else {
+            content
+                .background(Capsule().fill(Color.black.opacity(0.85)))
+                .background(Capsule().fill(tint.opacity(0.22)))
+                .clipShape(Capsule())
+                .overlay(Capsule().strokeBorder(tint.opacity(0.5), lineWidth: 1))
         }
     }
 }
@@ -117,29 +211,25 @@ private struct OverlayGlassBackground: ViewModifier {
 
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        // A consistent dark HUD (independent of the app theme) reads cleanly on
+        // both light and dark desktops and avoids the washed-out "outcast" that a
+        // translucent white fill produced on light themes.
         if #available(macOS 26.0, *) {
             content
-                // A translucent themed fill sits behind the glass so the overlay
-                // stays clearly legible on bright or busy backgrounds, instead of
-                // the near-invisible `.clear` glass it used before.
-                .background(
-                    shape.fill(theme.cardBackground.opacity(theme.isDark ? 0.72 : 0.82))
-                )
+                .background(shape.fill(Color.black.opacity(0.55)))
                 .glassEffect(.regular, in: shape)
                 .overlay(
                     shape.strokeBorder(theme.accentColor.opacity(0.55), lineWidth: 1)
                 )
-                .shadow(color: .black.opacity(0.38), radius: 22, x: 0, y: 8)
+                .shadow(color: .black.opacity(0.25), radius: 10, x: 0, y: 4)
         } else {
             content
-                .background(
-                    shape.fill(theme.cardBackground.opacity(theme.isDark ? 0.95 : 0.98))
-                )
+                .background(shape.fill(Color.black.opacity(0.8)))
                 .clipShape(shape)
                 .overlay(
                     shape.strokeBorder(theme.accentColor.opacity(0.55), lineWidth: 1)
                 )
-                .shadow(color: theme.shadowColor.opacity(0.25), radius: 18, x: 0, y: 6)
+                .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 3)
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
@@ -73,11 +73,11 @@ public struct TranscriptionOverlayView: View {
             WaveformView(
                 level: audioLevel,
                 style: .bars,
-                barCount: 18,
+                barCount: 22,
                 primaryColor: .white,
                 isActive: isActive && !isProcessing
             )
-            .frame(width: 200, height: 26)
+            .frame(width: 240, height: 26)
             .opacity(isProcessing ? 0 : 1)
 
             // Stop / Cancel controls share the waveform's horizontal axis,

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
@@ -73,11 +73,11 @@ public struct TranscriptionOverlayView: View {
             WaveformView(
                 level: audioLevel,
                 style: .bars,
-                barCount: 14,
+                barCount: 18,
                 primaryColor: .white,
                 isActive: isActive && !isProcessing
             )
-            .frame(width: 150, height: 26)
+            .frame(width: 200, height: 26)
             .opacity(isProcessing ? 0 : 1)
 
             // Stop / Cancel controls share the waveform's horizontal axis,
@@ -95,7 +95,7 @@ public struct TranscriptionOverlayView: View {
         // Push the row below the badge that straddles the top border.
         .padding(.top, badgeHeight / 2 + 14)
         .padding(.bottom, 16)
-        .frame(width: 264)
+        .frame(width: 320)
         .modifier(OverlayGlassBackground(cornerRadius: cornerRadius))
         // The status badge straddles the top border like a notch.
         .overlay(alignment: .top) {

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
@@ -39,6 +39,9 @@ public struct TranscriptionOverlayView: View {
     /// Hover state for close button
     @State private var isCloseHovered = false
 
+    /// Hover state for stop button
+    @State private var isStopHovered = false
+
     /// Pulsing state for the status dot
     @State private var dotPulse = false
 
@@ -140,18 +143,21 @@ public struct TranscriptionOverlayView: View {
     /// Stop & insert — only shown when transcription won't stop on its own.
     private var stopButton: some View {
         Button(action: { onDone?() }) {
-            HStack(spacing: 6) {
-                Image(systemName: "stop.fill")
-                    .font(.system(size: 9, weight: .bold))
-                Text("Stop", bundle: .module)
-                    .font(.system(size: 11, weight: .semibold))
-            }
-            .foregroundColor(.white)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Capsule().fill(theme.accentColor))
+            Image(systemName: "stop.fill")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(.white.opacity(isStopHovered ? 1.0 : 0.7))
+                .frame(width: 24, height: 24)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(isStopHovered ? 0.22 : 0.12))
+                )
         }
         .buttonStyle(.plain)
+        .scaleEffect(isStopHovered ? 1.05 : 1.0)
+        .animation(.easeOut(duration: 0.15), value: isStopHovered)
+        .onHover { hovering in
+            isStopHovered = hovering
+        }
         .localizedHelp("Stop and insert")
     }
 

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
@@ -86,11 +86,11 @@ public struct TranscriptionOverlayView: View {
             // Stop / Cancel controls share the waveform's horizontal axis,
             // pinned to the card's left and right edges.
             HStack(spacing: 0) {
+                cancelButton
+                Spacer(minLength: 0)
                 if showsStopButton && !isProcessing {
                     stopButton
                 }
-                Spacer(minLength: 0)
-                cancelButton
             }
         }
         .frame(height: 30)

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionOverlayView.swift
@@ -116,29 +116,30 @@ private struct OverlayGlassBackground: ViewModifier {
     let cornerRadius: CGFloat
 
     func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         if #available(macOS 26.0, *) {
             content
-                .glassEffect(
-                    .clear,
-                    in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                // A translucent themed fill sits behind the glass so the overlay
+                // stays clearly legible on bright or busy backgrounds, instead of
+                // the near-invisible `.clear` glass it used before.
+                .background(
+                    shape.fill(theme.cardBackground.opacity(theme.isDark ? 0.72 : 0.82))
                 )
+                .glassEffect(.regular, in: shape)
                 .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .strokeBorder(theme.cardBorder, lineWidth: 1)
+                    shape.strokeBorder(theme.accentColor.opacity(0.55), lineWidth: 1)
                 )
-                .shadow(color: .black.opacity(0.22), radius: 16, x: 0, y: 6)
+                .shadow(color: .black.opacity(0.38), radius: 22, x: 0, y: 8)
         } else {
             content
                 .background(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .fill(theme.cardBackground.opacity(theme.isDark ? 0.95 : 0.98))
+                    shape.fill(theme.cardBackground.opacity(theme.isDark ? 0.95 : 0.98))
                 )
-                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .clipShape(shape)
                 .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .strokeBorder(theme.cardBorder, lineWidth: 1)
+                    shape.strokeBorder(theme.accentColor.opacity(0.55), lineWidth: 1)
                 )
-                .shadow(color: theme.shadowColor.opacity(0.15), radius: 12, x: 0, y: 4)
+                .shadow(color: theme.shadowColor.opacity(0.25), radius: 18, x: 0, y: 6)
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Voice/VoiceComponents.swift
+++ b/Packages/OsaurusCore/Views/Voice/VoiceComponents.swift
@@ -134,7 +134,11 @@ private struct WaveformBars: View {
 
     @ViewBuilder
     private func singleBar(index: Int, timestamp: TimeInterval) -> some View {
-        let phaseOffset = phaseOffsets.indices.contains(index) ? phaseOffsets[index] : 0
+        // Before `onAppear` seeds random offsets, fall back to a per-index phase
+        // so bars start desynced. A shared 0 offset would render every bar at the
+        // same height on the first frame — a full-height flash before they settle.
+        let phaseOffset =
+            phaseOffsets.indices.contains(index) ? phaseOffsets[index] : Double(index) * 0.7
 
         // use the raw level for animation intensity
         let effectiveLevel = CGFloat(max(0.0, min(1.0, level)))


### PR DESCRIPTION
## Summary

- added a toggle in Speech To Text settings to turn off core-model post-processing
- linked the "core model" text in the toggle description to its setting in General
- redesigned the dictation overlay as a dark HUD with a status badge, a wider live waveform, and consistent legibility across light and dark themes
- added distinct Stop and Cancel controls, with Stop inserting the transcript and Cancel discarding it
- moved the overlay to the bottom centre of the screen

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
