### PR TITLE
Repin vmlx-swift: strip orphan tool-call closer tags (#115)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "37a68bc2d053f8cdc70a07660d92f54aadb0c2f504cea16d72f073edaeac05c2",
+  "originHash" : "632c51bdb2a9440f255783101d40efa41ce30bc0a883054309278e3454b84fa8",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
+        "revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "785a98ab5e9fcb21e8612a325228d51adac584eaecbc14cf3d7d7998eb9f8865",
+  "originHash" : "bdf6a1555ee0a71c299e2868bd776a37046bed4b32bd2a923dda5a9558799da7",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
+        "revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         // producers are off the GPU; restores can't race input tokenization).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
+            revision: "8dffa0a8e69d7617d68f0843635158684120a3dc"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
-        #expect(packageResolved.contains(#""revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
-        #expect(workspaceResolved.contains(#""revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
-        #expect(appResolved.contains(#""revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238""#))
+        #expect(packageSwift.contains(#"revision: "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
+        #expect(packageResolved.contains(#""revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
+        #expect(workspaceResolved.contains(#""revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
+        #expect(appResolved.contains(#""revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -654,8 +654,12 @@ struct RuntimePolicySourceTests {
         // (vmlx-swift#107) that honors the bundle's longest_edge instead of
         // crushing images to 336px, and the stop-string fix (vmlx-swift#109)
         // that discards post-stop buffers at end-of-stream so text after a
-        // matched stop string can no longer leak into responses.
-        let expectedRuntimeHardenedRevision = "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
+        // matched stop string can no longer leak into responses,
+        // plus the orphan tool-call closer strip (vmlx-swift#115) that
+        // removes stray `</parameter></function></zyphra_tool_call>`
+        // closer runs from the visible stream in ZAYA / Gemma-4
+        // AppleScript agent-loop rows.
+        let expectedRuntimeHardenedRevision = "8dffa0a8e69d7617d68f0843635158684120a3dc"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8f00718690528ee7f37876b2ebc767c22ffaf84686b201530873bb4e91965632",
+  "originHash" : "3e1ff0bda2fb40739fd509af946f74d76ed517e42acde77a162d8fe185909d2d",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cee0f8e234a352fcc6d09fba9a78dd24c0b15238"
+        "revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc"
       }
     },
     {


### PR DESCRIPTION
Bumps vmlx-swift `cee0f8e2` → `8dffa0a8` — exactly [osaurus-ai/vmlx-swift#115](https://github.com/osaurus-ai/vmlx-swift/pull/115) (one squashed commit on top of the prior pin).

## What #115 fixes
Live ZAYA / Gemma-4 AppleScript rows emit stray `</parameter></function></zyphra_tool_call>` closer runs with no matching opener after several agent-loop steps. The tool-call state machine only entered collection on an OPEN tag, so those protocol closers streamed to the user as literal visible text. #115 adds an opt-in `orphanStripTags` registry (XMLFunctionParser + Gemma4ToolCallParser) and strips registered orphan closers from the visible stream — runs, chunk-split, partial-at-EOS, embedded — scoped strictly to each format's own closers so ordinary prose (`</div>`) still flushes verbatim. Default empty ⇒ no behavior change for non-opted formats.

## Verification (live, on this app built against 8dffa0a8's tree)
- **vmlx unit tests:** orphan-strip suite 8/8 pass (all streaming shapes). 1 unrelated pre-existing `.lfm2` test failure — provably orthogonal (LFM2 uses the empty-default `orphanStripTags`, new path skipped).
- **Live matrix, 3 models / 3 tool formats** (ZAYA JANG6M zayaXml opt-in, Gemma-4 gemma4 opt-in, Qwen non-opted):
  - streaming + non-stream `run_applescript` tool calls — no closer leak in visible stream
  - over-strip guard: `</div>`/`</span>` survive verbatim on every format
  - coherence, system prompt, long-context needle (4.7k) all pass
  - prefix cache intact (Gemma 1.83×, Qwen 1.53×)

No runtime/cache/tokenizer changes beyond the tool-call text path.