### PR TITLE
Fix task progress overlay menu bar placement

### DIFF
--- a/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
+++ b/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
@@ -1,0 +1,99 @@
+//
+//  NotchPanelPlacementTests.swift
+//  osaurusTests
+//
+//  Regression tests for task-progress notch overlay placement. API-dispatched
+//  background tasks render here; the panel must stay below the macOS menu bar.
+//
+
+import CoreGraphics
+import Testing
+
+@testable import OsaurusCore
+
+struct NotchPanelPlacementTests {
+    @Test func panelAnchorsToVisibleFrameBelowMenuBar() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1440, height: 868)
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame,
+            preferredSize: CGSize(width: 600, height: 500)
+        )
+
+        #expect(placement.frame.maxY == visibleFrame.maxY)
+        #expect(placement.frame.maxY < screenFrame.maxY)
+        #expect(placement.frame.origin.y == 368)
+        #expect(placement.frame.midX == visibleFrame.midX)
+    }
+
+    @Test func panelHandlesDisplaysWithNegativeOrigin() {
+        let screenFrame = CGRect(x: -1920, y: 0, width: 1920, height: 1080)
+        let visibleFrame = CGRect(x: -1920, y: 0, width: 1920, height: 1040)
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame,
+            preferredSize: CGSize(width: 600, height: 500)
+        )
+
+        #expect(placement.frame.maxY == visibleFrame.maxY)
+        #expect(placement.frame.midX == visibleFrame.midX)
+        #expect(placement.frame.minX >= visibleFrame.minX)
+        #expect(placement.frame.maxX <= visibleFrame.maxX)
+        #expect(placement.frame.minY >= visibleFrame.minY)
+        #expect(placement.frame.maxY <= visibleFrame.maxY)
+    }
+
+    @Test func panelConstrainsToNarrowVisibleFrame() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 500, height: 800)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 500, height: 778)
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame,
+            preferredSize: CGSize(width: 600, height: 900)
+        )
+
+        #expect(placement.frame.width == visibleFrame.width)
+        #expect(placement.frame.height == visibleFrame.height)
+        #expect(placement.frame.minX == visibleFrame.minX)
+        #expect(placement.frame.maxX == visibleFrame.maxX)
+        #expect(placement.frame.maxY == visibleFrame.maxY)
+    }
+
+    @Test func emptyVisibleFrameFallsBackToScreenFrame() {
+        let screenFrame = CGRect(x: 100, y: -900, width: 1200, height: 900)
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: .zero,
+            preferredSize: CGSize(width: 600, height: 500)
+        )
+
+        #expect(placement.frame.maxY == screenFrame.maxY)
+        #expect(placement.frame.midX == screenFrame.midX)
+    }
+
+    @Test func alertContentTopPaddingMatchesMenuBarGap() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1440, height: 868)
+
+        let padding = NotchPanelPlacement.alertContentTopPadding(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(padding == 32)
+    }
+
+    @Test func alertContentTopPaddingFallsBackToZeroForEmptyVisibleFrame() {
+        let padding = NotchPanelPlacement.alertContentTopPadding(
+            screenFrame: CGRect(x: 100, y: -900, width: 1200, height: 900),
+            visibleFrame: .zero
+        )
+
+        #expect(padding == 0)
+    }
+}

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -247,6 +247,7 @@ struct NotchView: View {
                     )
             }
         }
+        .padding(.top, windowController.alertContentTopPadding)
         .animation(swingSpring, value: expansion)
         .animation(swingSpring, value: sortedTasks.map(\.id))
         .animation(swingSpring, value: activeTaskIndex)
@@ -379,8 +380,6 @@ struct NotchView: View {
 
     private var expandedContent: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Color.clear.frame(height: metrics.notchHeight)
-
             VStack(alignment: .leading, spacing: 8) {
                 expandedHeader
 
@@ -571,14 +570,6 @@ struct NotchView: View {
                     endPoint: .bottom
                 ),
                 lineWidth: 1
-            )
-            .mask(
-                VStack(spacing: 0) {
-                    Color.clear.frame(height: max(metrics.notchHeight - 6, 0))
-                    LinearGradient(colors: [Color.white.opacity(0), .white], startPoint: .top, endPoint: .bottom)
-                        .frame(height: 10)
-                    Color.white
-                }
             )
     }
 

--- a/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
@@ -3,8 +3,8 @@
 //  osaurus
 //
 //  Manages the dedicated NSPanel for the notch UI.
-//  Positions the panel at the very top of the screen, flush with the
-//  display edge, and detects hardware notch dimensions.
+//  Positions the panel at the top of the visible display area and detects
+//  hardware notch dimensions for compact sizing.
 //
 
 import AppKit
@@ -47,10 +47,41 @@ public struct NotchScreenMetrics: Equatable {
     }
 }
 
+// MARK: - Notch Panel Placement
+
+struct NotchPanelPlacement: Equatable {
+    let frame: CGRect
+
+    static func panelRect(
+        screenFrame: CGRect,
+        visibleFrame: CGRect,
+        preferredSize: CGSize
+    ) -> NotchPanelPlacement {
+        let safeFrame = visibleFrame.isEmpty ? screenFrame : visibleFrame
+        let width = min(preferredSize.width, max(1, safeFrame.width))
+        let height = min(preferredSize.height, max(1, safeFrame.height))
+        let centeredX = safeFrame.midX - width / 2
+        let minX = safeFrame.minX
+        let maxX = safeFrame.maxX - width
+        let x = min(max(centeredX, minX), maxX)
+        let y = safeFrame.maxY - height
+
+        return NotchPanelPlacement(frame: CGRect(x: x, y: y, width: width, height: height))
+    }
+
+    static func alertContentTopPadding(
+        screenFrame: CGRect,
+        visibleFrame: CGRect
+    ) -> CGFloat {
+        guard !visibleFrame.isEmpty else { return 0 }
+        return max(0, screenFrame.maxY - visibleFrame.maxY)
+    }
+}
+
 // MARK: - Notch Window Controller
 
 /// Displays the notch background task indicator at the top center of the screen,
-/// flush with the display's top edge so it blends with the hardware notch.
+/// inside the screen's visible frame so task progress never covers the menu bar.
 @MainActor
 public final class NotchWindowController: NSObject, ObservableObject {
     public static let shared = NotchWindowController()
@@ -66,6 +97,11 @@ public final class NotchWindowController: NSObject, ObservableObject {
         notchWidth: 200,
         notchHeight: 32
     )
+
+    /// Extra top inset applied only while the alert dimming layer expands the
+    /// panel to the whole display. Keeps the visible notch content below the
+    /// menu bar even though the panel itself covers the full screen.
+    @Published public private(set) var alertContentTopPadding: CGFloat = 0
 
     /// Panel width – generous to allow expansion + shadow.
     private static let panelWidth: CGFloat = 600
@@ -96,8 +132,9 @@ public final class NotchWindowController: NSObject, ObservableObject {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
-        // Sit above the menu bar so the notch overlaps the bezel area
-        panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 3)
+        // Keep task progress above regular app windows without covering macOS
+        // menu-bar/status-item windows.
+        panel.level = .floating
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
         panel.isReleasedWhenClosed = false
         panel.hidesOnDeactivate = false
@@ -209,8 +246,6 @@ public final class NotchWindowController: NSObject, ObservableObject {
         guard let panel = notchPanel else { return }
         let alertActive = ThemedAlertCenter.shared.active(for: .notchOverlay) != nil
 
-        guard alertActive != isExpandedForAlert else { return }
-
         guard let screen = panel.screen ?? NSScreen.main ?? NSScreen.screens.first else {
             // No attached display; nothing to resize against. Leave
             // `isExpandedForAlert` unchanged so the panel frame and the flag
@@ -220,17 +255,36 @@ public final class NotchWindowController: NSObject, ObservableObject {
             return
         }
         let targetFrame = alertActive ? screen.frame : panelRect(for: screen)
-        panel.setFrame(targetFrame, display: true)
+        let targetLevel = alertActive ? Self.alertPanelLevel : NSWindow.Level.floating
+        let targetPadding = alertActive
+            ? NotchPanelPlacement.alertContentTopPadding(
+                screenFrame: screen.frame,
+                visibleFrame: screen.visibleFrame
+            )
+            : 0
+
+        if panel.level != targetLevel {
+            panel.level = targetLevel
+        }
+        if alertContentTopPadding != targetPadding {
+            alertContentTopPadding = targetPadding
+        }
+        if panel.frame != targetFrame {
+            panel.setFrame(targetFrame, display: true)
+        }
         isExpandedForAlert = alertActive
     }
 
-    /// Panel positioned at the very top of the screen (using full frame, not visibleFrame).
+    /// Panel positioned at the top of the usable display area, below the menu bar.
     private func panelRect(for screen: NSScreen) -> NSRect {
-        let screenFrame = screen.frame
-        let x = screenFrame.origin.x + (screenFrame.width / 2) - Self.panelWidth / 2
-        let y = screenFrame.origin.y + screenFrame.height - Self.panelHeight
-        return NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight)
+        NotchPanelPlacement.panelRect(
+            screenFrame: screen.frame,
+            visibleFrame: screen.visibleFrame,
+            preferredSize: CGSize(width: Self.panelWidth, height: Self.panelHeight)
+        ).frame
     }
+
+    private static let alertPanelLevel = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 3)
 }
 
 // MARK: - Pass-Through View


### PR DESCRIPTION
## Summary
- Fixes task progress notch overlay placement so API-dispatched background tasks stay below the macOS menu bar/status items.
- Anchors normal notch panel placement to the active screen's visible frame instead of the full display frame.
- Keeps full-screen alert dimming by expanding the panel only during notch-scoped alerts, while applying a top content inset so the visible pill does not jump into the menu-bar/notch region.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter NotchPanelPlacementTests` (6 tests)
- `git diff --check`
- Fable review: safe to push after alert-mode padding fix
- Grok review: safe to push; high-effort flag was unavailable for the installed Grok models, so review ran on the available model without an explicit effort flag

## Manual follow-up
- CI app build should provide the release build signal; local `make app` is blocked by the missing Mac Development signing certificate on this machine.
- Manual UI smoke recommended before ready: dispatch a background task through the API and confirm the task progress overlay stays below the menu bar on the active display.
