### PR TITLE
Recover bare capability load ids

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -262,7 +262,10 @@ struct CapabilitiesDiscoverToolTests {
                 let previousOverride = ToolConfigurationStore.overrideDirectory
                 ToolConfigurationStore.overrideDirectory = tempDir
                 try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-                defer { ToolConfigurationStore.overrideDirectory = previousOverride }
+                defer {
+                    ToolConfigurationStore.overrideDirectory = previousOverride
+                    try? FileManager.default.removeItem(at: tempDir)
+                }
 
                 let dbWasOpen = ToolDatabase.shared.isOpen
                 if !dbWasOpen {
@@ -422,15 +425,289 @@ struct CapabilitiesLoadToolTests {
     }
 
     @Test func handlesInvalidIdFormat() async throws {
-        // All-failed contract: a load where NOTHING succeeded returns a
-        // real failure envelope (kind: invalid_args, field: ids), not
-        // "Warning" prose inside a success envelope.
-        let tool = CapabilitiesLoadTool()
-        let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"no-slash\"]}")
-        #expect(ToolEnvelope.isError(result))
-        #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
-        #expect(EnvelopeAssertions.failureField(result) == "ids")
-        #expect(result.contains("Invalid ID format"))
+        try await StoragePathsTestLock.shared.run {
+            try await DynamicCatalogTestLock.shared.run {
+                // All-failed contract: a load where NOTHING succeeded returns a
+                // real failure envelope (kind: invalid_args, field: ids), not
+                // "Warning" prose inside a success envelope.
+                let tool = CapabilitiesLoadTool()
+                let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"no-slash\"]}")
+                #expect(ToolEnvelope.isError(result))
+                #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+                #expect(EnvelopeAssertions.failureField(result) == "ids")
+                #expect(result.contains("Invalid ID format"))
+            }
+        }
+    }
+
+    @Test @MainActor
+    func bareRegisteredToolIdLoadsAsToolId() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-capability-load-bare-id-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousOverride = ToolConfigurationStore.overrideDirectory
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                ToolConfigurationStore.overrideDirectory = previousOverride
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let toolName =
+                "bare_search_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+            let fixture = CapabilityPolicyFixtureTool(
+                name: toolName,
+                description: "Search the web for current headlines and online results"
+            )
+            ToolRegistry.shared.registerPluginTool(fixture)
+            ToolRegistry.shared.setEnabled(true, for: fixture.name)
+            defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+            _ = await CapabilityLoadBuffer.shared.drain()
+
+            let tool = CapabilitiesLoadTool()
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"\(toolName)\"]}")
+            }
+
+            #expect(!ToolEnvelope.isError(result))
+            #expect(result.contains("Tool '\(toolName)' loaded"))
+            #expect(result.contains("Schema for `\(toolName)`"))
+            let buffered = await CapabilityLoadBuffer.shared.drain()
+            #expect(buffered.map(\.function.name) == [toolName])
+        }
+    }
+
+    @Test @MainActor
+    func bareToolIdResolutionPreservesRegisteredCasingAndTrimsFullIds() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-capability-load-bare-id-fallback-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousOverride = ToolConfigurationStore.overrideDirectory
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                ToolConfigurationStore.overrideDirectory = previousOverride
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let toolName =
+                "Bare_Case_Tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+            let fixture = CapabilityPolicyFixtureTool(
+                name: toolName,
+                description: "Search the web for current headlines and online results"
+            )
+            ToolRegistry.shared.registerPluginTool(fixture)
+            ToolRegistry.shared.setEnabled(true, for: fixture.name)
+            defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+            _ = await CapabilityLoadBuffer.shared.drain()
+
+            let tool = CapabilitiesLoadTool()
+            let lowercasedResult = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"\(toolName.lowercased())\"]}")
+            }
+            #expect(!ToolEnvelope.isError(lowercasedResult))
+            #expect(lowercasedResult.contains("Tool '\(toolName)' loaded"))
+            #expect(await CapabilityLoadBuffer.shared.drain().map(\.function.name) == [toolName])
+
+            let trimmedResult = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"  tool/\(toolName)  \"]}")
+            }
+            #expect(!ToolEnvelope.isError(trimmedResult))
+            #expect(trimmedResult.contains("Tool '\(toolName)' loaded"))
+            #expect(await CapabilityLoadBuffer.shared.drain().map(\.function.name) == [toolName])
+        }
+    }
+
+    @Test @MainActor
+    func barePluginGroupIdLoadsPluginTools() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await DynamicCatalogTestLock.shared.run {
+                try await withTemporaryOsaurusRoot("osaurus-capability-load-bare-plugin-root") {
+                    let plugin = SandboxPlugin(
+                        name: "Bare Plugin \(UUID().uuidString.prefix(6))",
+                        description: "Bare plugin load fixture"
+                    )
+                    let groupTool = SandboxPluginTool(
+                        spec: SandboxToolSpec(
+                            id: "probe",
+                            description: "Probe tool loaded through a bare plugin id",
+                            parameters: [
+                                "query": SandboxParameterSpec(
+                                    type: "string",
+                                    description: "Search query"
+                                )
+                            ],
+                            run: "echo hi"
+                        ),
+                        plugin: plugin
+                    )
+                    ToolRegistry.shared.registerPluginTool(groupTool)
+                    ToolRegistry.shared.setEnabled(true, for: groupTool.name)
+                    defer { ToolRegistry.shared.unregister(names: [groupTool.name]) }
+
+                    let agent = Agent(
+                        name: "BarePluginLoad-\(UUID().uuidString.prefix(6))",
+                        agentAddress: "bare-plugin-load-\(UUID().uuidString)",
+                        manualToolNames: [groupTool.name]
+                    )
+                    AgentManager.shared.add(agent)
+                    _ = await CapabilityLoadBuffer.shared.drain()
+
+                    do {
+                        let tool = CapabilitiesLoadTool()
+                        let result = try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
+                            try await tool.execute(argumentsJSON: "{\"ids\": [\"\(plugin.id)\"]}")
+                        }
+
+                        #expect(!ToolEnvelope.isError(result))
+                        #expect(result.contains("Auto-loaded tools"))
+                        #expect(result.contains(groupTool.name))
+                        let buffered = await CapabilityLoadBuffer.shared.drain()
+                        #expect(buffered.contains(where: { $0.function.name == groupTool.name }))
+
+                        _ = await AgentManager.shared.delete(id: agent.id)
+                    } catch {
+                        _ = await AgentManager.shared.delete(id: agent.id)
+                        throw error
+                    }
+                }
+            }
+        }
+    }
+
+    @Test @MainActor
+    func bareRegisteredSkillIdLoadsAsSkillId() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot("osaurus-capability-load-bare-skill-root") {
+                let suffix = String(UUID().uuidString.prefix(8)).lowercased()
+                let titleSuffix = suffix.prefix(1).uppercased() + suffix.dropFirst()
+                let skillName = "Bare Skill \(titleSuffix)"
+                let skill = Skill(
+                    id: UUID(),
+                    name: skillName,
+                    description: "Bare skill fixture",
+                    version: "1.0.0",
+                    keywords: [],
+                    enabled: true,
+                    instructions: "Use the bare skill fixture.",
+                    isBuiltIn: false,
+                    pluginId: nil
+                )
+                await SkillStore.save(skill)
+                await SkillManager.shared.refresh()
+
+                let tool = CapabilitiesLoadTool()
+                let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                    try await tool.execute(argumentsJSON: "{\"ids\": [\"\(skillName)\"]}")
+                }
+
+                #expect(!ToolEnvelope.isError(result))
+                #expect(result.contains("## Skill: \(skillName)"))
+                #expect(result.contains("Bare skill fixture"))
+                #expect(result.contains("Use the bare skill fixture."))
+            }
+        }
+    }
+
+    @Test @MainActor
+    func bareDisabledSkillIdReportsDisabled() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot("osaurus-capability-load-disabled-skill-root") {
+                let suffix = String(UUID().uuidString.prefix(8)).lowercased()
+                let titleSuffix = suffix.prefix(1).uppercased() + suffix.dropFirst()
+                let skillName = "Disabled Skill \(titleSuffix)"
+                let skill = Skill(
+                    id: UUID(),
+                    name: skillName,
+                    description: "Disabled skill fixture",
+                    version: "1.0.0",
+                    keywords: [],
+                    enabled: false,
+                    instructions: "Do not load this disabled skill.",
+                    isBuiltIn: false,
+                    pluginId: nil
+                )
+                await SkillStore.save(skill)
+                await SkillManager.shared.refresh()
+
+                let tool = CapabilitiesLoadTool()
+                let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                    try await tool.execute(argumentsJSON: "{\"ids\": [\"\(skillName)\"]}")
+                }
+
+                #expect(ToolEnvelope.isError(result))
+                #expect(EnvelopeAssertions.failureKind(result) == "rejected")
+                #expect(result.contains("Skill '\(skillName)' is disabled"))
+                #expect(!result.contains("No registered tool, skill, or plugin matched"))
+            }
+        }
+    }
+
+    @Test @MainActor
+    func ambiguousBareIdRequiresFullCapabilityId() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await DynamicCatalogTestLock.shared.run {
+                try await withTemporaryOsaurusRoot("osaurus-capability-load-ambiguous-root") {
+                    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                        "osaurus-capability-load-ambiguous-\(UUID().uuidString)",
+                        isDirectory: true
+                    )
+                    let previousOverride = ToolConfigurationStore.overrideDirectory
+                    ToolConfigurationStore.overrideDirectory = tempDir
+                    try? FileManager.default.createDirectory(
+                        at: tempDir,
+                        withIntermediateDirectories: true
+                    )
+                    defer {
+                        ToolConfigurationStore.overrideDirectory = previousOverride
+                        try? FileManager.default.removeItem(at: tempDir)
+                    }
+
+                    let suffix = String(UUID().uuidString.prefix(8)).lowercased()
+                    let titleSuffix = suffix.prefix(1).uppercased() + suffix.dropFirst()
+                    let sharedName = "Ambiguous Capability \(titleSuffix)"
+                    let fixture = CapabilityPolicyFixtureTool(
+                        name: sharedName,
+                        description: "Search the web for current headlines and online results"
+                    )
+                    ToolRegistry.shared.registerPluginTool(fixture)
+                    ToolRegistry.shared.setEnabled(true, for: fixture.name)
+                    defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+                    let skill = Skill(
+                        id: UUID(),
+                        name: sharedName,
+                        description: "Ambiguous skill fixture",
+                        version: "1.0.0",
+                        keywords: [],
+                        enabled: true,
+                        instructions: "Use the ambiguous skill.",
+                        isBuiltIn: false,
+                        pluginId: nil
+                    )
+                    await SkillStore.save(skill)
+                    await SkillManager.shared.refresh()
+
+                    let tool = CapabilitiesLoadTool()
+                    let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                        try await tool.execute(argumentsJSON: "{\"ids\": [\"\(sharedName)\"]}")
+                    }
+
+                    #expect(ToolEnvelope.isError(result))
+                    #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+                    #expect(EnvelopeAssertions.failureField(result) == "ids")
+                    #expect(result.contains("Ambiguous bare capability id"))
+                    #expect(result.contains("tool/\(sharedName)"))
+                    #expect(result.contains("skill/\(sharedName)"))
+                }
+            }
+        }
     }
 
     @Test func handlesUnknownTypePrefix() async throws {
@@ -790,6 +1067,39 @@ struct CapabilitiesLoadToolTests {
             #expect(result.contains("non-object parameter schema"))
             #expect(await CapabilityLoadBuffer.shared.drain().isEmpty)
         }
+    }
+}
+
+@MainActor
+private func withTemporaryOsaurusRoot<T>(
+    _ prefix: String,
+    operation: () async throws -> T
+) async throws -> T {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "\(prefix)-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+    let previousRoot = OsaurusPaths.overrideRoot
+    OsaurusPaths.overrideRoot = root
+    AgentManager.shared.refresh()
+    await SkillManager.shared.refresh()
+
+    func cleanup() async {
+        OsaurusPaths.overrideRoot = previousRoot
+        AgentManager.shared.refresh()
+        try? FileManager.default.removeItem(at: root)
+        await SkillManager.shared.refresh()
+    }
+
+    do {
+        let result = try await operation()
+        await cleanup()
+        return result
+    } catch {
+        await cleanup()
+        throw error
     }
 }
 

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -633,38 +633,31 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         var failures: [LoadFailure] = []
 
         for id in ids {
-            guard let slashIdx = id.firstIndex(of: "/") else {
-                failures.append(
-                    LoadFailure(
-                        kind: .invalidArgs,
-                        message:
-                            "Invalid ID format '\(id)' — expected `<type>/<id>` "
-                            + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). Use IDs from the Enabled capabilities list or `capabilities_discover`.",
-                        field: "ids"
-                    )
-                )
+            let resolvedId: LoadId
+            switch await resolveLoadId(id) {
+            case .resolved(let value):
+                resolvedId = value
+            case .failed(let failure):
+                failures.append(failure)
                 continue
             }
 
-            let typePrefix = String(id[id.startIndex ..< slashIdx])
-            let rawId = String(id[id.index(after: slashIdx)...])
-
             let outcome: LoadOutcome
-            switch typePrefix {
+            switch resolvedId.typePrefix {
             case "method":
-                outcome = await loadMethod(rawId)
+                outcome = await loadMethod(resolvedId.rawId)
             case "tool":
-                outcome = await loadTool(rawId)
+                outcome = await loadTool(resolvedId.rawId)
             case "skill":
-                outcome = await loadSkill(rawId)
+                outcome = await loadSkill(resolvedId.rawId)
             case "plugin":
-                outcome = await loadPlugin(rawId)
+                outcome = await loadPlugin(resolvedId.rawId)
             default:
                 outcome = .failure(
                     LoadFailure(
                         kind: .invalidArgs,
                         message:
-                            "Unknown type '\(typePrefix)' in ID '\(id)' "
+                            "Unknown type '\(resolvedId.typePrefix)' in ID '\(id)' "
                             + "(expected `tool`, `skill`, `plugin`, or `method`)."
                     )
                 )
@@ -718,6 +711,125 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     private enum LoadOutcome {
         case success(String)
         case failure(LoadFailure)
+    }
+
+    private struct LoadId {
+        let typePrefix: String
+        let rawId: String
+
+        var canonical: String { "\(typePrefix)/\(rawId)" }
+    }
+
+    private enum LoadIdResolution {
+        case resolved(LoadId)
+        case failed(LoadFailure)
+    }
+
+    private func resolveLoadId(_ id: String) async -> LoadIdResolution {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .failed(
+                LoadFailure(
+                    kind: .invalidArgs,
+                    message:
+                        "Invalid ID format '\(id)' — expected `<type>/<id>` "
+                        + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). Use IDs from the Enabled capabilities list or `capabilities_discover`.",
+                    field: "ids",
+                    expected: "non-empty `<type>/<id>` capability id"
+                )
+            )
+        }
+        if let slashIdx = trimmed.firstIndex(of: "/") {
+            return .resolved(
+                LoadId(
+                    typePrefix: String(trimmed[trimmed.startIndex ..< slashIdx]),
+                    rawId: String(trimmed[trimmed.index(after: slashIdx)...])
+                )
+            )
+        }
+        return await resolveBareLoadId(trimmed)
+    }
+
+    /// Tolerate the most common model/user copy error: passing a bare registered
+    /// capability name (`search`) instead of its manifest id (`tool/search`).
+    /// The closed vocabulary remains intact: only a single clear live match is
+    /// accepted; ambiguous names are rejected with exact ids to retry.
+    @MainActor
+    private func resolveBareLoadId(_ id: String) async -> LoadIdResolution {
+        let toolNames = ToolRegistry.shared.listTools().map(\.name)
+        let skillNames = SkillManager.shared.skills.map(\.name)
+        let pluginIds = Array(
+            Set(
+                ToolRegistry.shared.listDynamicTools()
+                    .compactMap { ToolRegistry.shared.groupName(for: $0.name) }
+                    .filter { !$0.isEmpty }
+            )
+        )
+
+        func pluginDisplayNameMatches(_ pluginId: String, _ candidate: String, exact: Bool) -> Bool {
+            guard let display = PluginManager.shared.loadedPlugin(for: pluginId)?.plugin.manifest.name else {
+                return false
+            }
+            if exact { return display == candidate }
+            return display.caseInsensitiveCompare(candidate) == .orderedSame
+        }
+
+        func matches(exact: Bool) -> [LoadId] {
+            var result: [LoadId] = []
+
+            func same(_ lhs: String, _ rhs: String) -> Bool {
+                exact ? lhs == rhs : lhs.caseInsensitiveCompare(rhs) == .orderedSame
+            }
+
+            result.append(
+                contentsOf: toolNames
+                    .filter { same($0, id) }
+                    .map { LoadId(typePrefix: "tool", rawId: $0) }
+            )
+            result.append(
+                contentsOf: skillNames
+                    .filter { same($0, id) }
+                    .map { LoadId(typePrefix: "skill", rawId: $0) }
+            )
+            result.append(
+                contentsOf: pluginIds
+                    .filter { same($0, id) || pluginDisplayNameMatches($0, id, exact: exact) }
+                    .map { LoadId(typePrefix: "plugin", rawId: $0) }
+            )
+
+            var seen: Set<String> = []
+            return result.filter { seen.insert($0.canonical).inserted }
+        }
+
+        let exactMatches = matches(exact: true)
+        let candidates = exactMatches.isEmpty ? matches(exact: false) : exactMatches
+
+        guard !candidates.isEmpty else {
+            return .failed(
+                LoadFailure(
+                    kind: .invalidArgs,
+                    message:
+                        "Invalid ID format '\(id)' — expected `<type>/<id>` "
+                        + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). No registered tool, skill, or plugin matched this bare id. Use IDs from the Enabled capabilities list or `capabilities_discover`.",
+                    field: "ids",
+                    expected: "full capability id such as `tool/\(id)`, `skill/<name>`, or `plugin/<id>`"
+                )
+            )
+        }
+        guard candidates.count == 1, let candidate = candidates.first else {
+            let choices = candidates.map(\.canonical).sorted().joined(separator: ", ")
+            return .failed(
+                LoadFailure(
+                    kind: .invalidArgs,
+                    message:
+                        "Ambiguous bare capability id '\(id)' matched multiple capabilities: \(choices). "
+                        + "Use the full id exactly as shown in the Enabled capabilities list or `capabilities_discover`.",
+                    field: "ids",
+                    expected: "one of: \(choices)"
+                )
+            )
+        }
+        return .resolved(candidate)
     }
 
     // MARK: - Loaders
@@ -1023,6 +1135,11 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         guard let skill = skill else {
             return .failure(
                 LoadFailure(kind: .notFound, message: "Skill '\(skillName)' not found.")
+            )
+        }
+        guard skill.enabled else {
+            return .failure(
+                LoadFailure(kind: .rejected, message: "Skill '\(skill.name)' is disabled.")
             )
         }
         var output = "## Skill: \(skill.name)\n"


### PR DESCRIPTION
## Summary
- allow `capabilities_load` to recover a bare live tool, skill, or plugin id when it has exactly one match
- preserve closed-vocabulary behavior by rejecting ambiguous bare ids with exact retry ids
- reject disabled skills consistently through the normal skill loader path
- add focused coverage for bare tool, skill, plugin, ambiguity, case-insensitive, and whitespace id handling

## Validation
- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter CapabilityToolsTests` (38 tests passed)
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test make test` was attempted locally but the full-suite runner stopped making progress after `queryTemplateEscapesInputWithoutAddingSiblingParameters`; run was interrupted and CI remains the required full-suite gate.

## Reviews
- Grok review completed after retry without unsupported effort flag and with a prompt-file diff: no blocking correctness or actor-isolation issues.
- Fable/Claude reviewed an earlier revision and found no blocking implementation issues; actionable test-isolation findings were addressed. Final Fable retry stalled twice at the 5-minute limit, so it was recorded as unavailable for the final diff rather than blocking this draft.

## Support Context
Addresses Wave 0 capability-load recovery from the Discord support plan for reports where agents could not successfully load Search/capabilities after discovery.