### PR TITLE
Add support diagnostics bundle scaffold

### DIFF
--- a/Packages/OsaurusCore/Services/SupportDiagnosticsBundle.swift
+++ b/Packages/OsaurusCore/Services/SupportDiagnosticsBundle.swift
@@ -1,0 +1,491 @@
+//
+//  SupportDiagnosticsBundle.swift
+//  osaurus
+//
+//  Privacy-preserving support bundle for diagnosing request/tool state without
+//  exporting prompts, responses, wire bodies, free-form error text, or raw
+//  stable identifiers.
+//
+
+import CryptoKit
+import Foundation
+
+struct SupportDiagnosticsBundle: Codable, Equatable, Sendable {
+    static let schemaVersion = 1
+
+    let schemaVersion: Int
+    let generatedAt: Date
+    let app: AppSnapshot
+    let context: ContextSnapshot
+    let tools: ToolInventorySnapshot
+    let recentRequests: [RequestSnapshot]
+    let privacy: PrivacySnapshot
+
+    struct AppSnapshot: Codable, Equatable, Sendable {
+        let name: String?
+        let version: String?
+        let build: String?
+        let osVersion: String
+
+        static func current(bundle: Bundle = .main) -> AppSnapshot {
+            let info = bundle.infoDictionary ?? [:]
+            return AppSnapshot(
+                name: info["CFBundleName"] as? String,
+                version: info["CFBundleShortVersionString"] as? String,
+                build: info["CFBundleVersion"] as? String,
+                osVersion: ProcessInfo.processInfo.operatingSystemVersionString
+            )
+        }
+    }
+
+    struct ContextSnapshot: Codable, Equatable, Sendable {
+        let sessionIdFingerprint: String?
+        let agentIdFingerprint: String?
+        let agentAddressFingerprint: String?
+        let agentName: String?
+        let modelId: String?
+        let providerIdFingerprint: String?
+        let runtime: String?
+        let toolMode: String?
+    }
+
+    struct ToolInventorySnapshot: Codable, Equatable, Sendable {
+        let registered: [ToolRecord]
+        let enabledNames: [String]
+        let dynamicNames: [String]
+        let loadedNames: [String]
+        let initialAlwaysLoadedNames: [String]
+        let sessionFingerprint: String?
+    }
+
+    struct ToolRecord: Codable, Equatable, Sendable {
+        let name: String
+        let enabled: Bool
+        let groupName: String?
+    }
+
+    struct RequestSnapshot: Codable, Equatable, Sendable {
+        let idFingerprint: String
+        let timestamp: Date
+        let source: String
+        let turnIdFingerprint: String?
+        let requestIdFingerprint: String?
+        let method: String
+        let path: String
+        let statusCode: Int
+        let durationMs: Double
+        let userAgent: String?
+        let pluginId: String?
+        let model: String?
+        let inputTokens: Int?
+        let outputTokens: Int?
+        let tokensPerSecond: Double?
+        let temperature: Float?
+        let maxTokens: Int?
+        let finishReason: String?
+        let errorMessageCaptured: Bool
+        let bodyPresence: BodyPresence
+        let toolCalls: [ToolCallSnapshot]
+        let connection: ConnectionSnapshot?
+    }
+
+    struct BodyPresence: Codable, Equatable, Sendable {
+        let localRequestCaptured: Bool
+        let localResponseCaptured: Bool
+        let wireRequestCaptured: Bool
+        let wireResponseCaptured: Bool
+    }
+
+    struct ToolCallSnapshot: Codable, Equatable, Sendable {
+        let idFingerprint: String
+        let name: String
+        let argumentKeyCount: Int
+        let argumentByteCount: Int
+        let durationMs: Double?
+        let isError: Bool
+        let resultCaptured: Bool
+    }
+
+    struct ConnectionSnapshot: Codable, Equatable, Sendable {
+        let providerIdFingerprint: String?
+        let remoteEndpoint: String?
+        let transport: String?
+        let mode: String?
+        let accessKeyIdFingerprint: String?
+        let audienceFingerprint: String?
+    }
+
+    struct PrivacySnapshot: Codable, Equatable, Sendable {
+        let redactedValue: String
+        let omittedFields: [String]
+        let notes: [String]
+
+        static let standard = PrivacySnapshot(
+            redactedValue: SupportDiagnosticsBundleBuilder.redactedValue,
+            omittedFields: [
+                "requestBody",
+                "responseBody",
+                "wireRequestBody",
+                "wireResponseBody",
+                "toolCall.arguments",
+                "toolCall.argumentKeys",
+                "toolCall.result",
+                "sessionId",
+                "turnId",
+                "logId",
+                "toolCall.id",
+                "agentId",
+                "agentAddress",
+                "providerId",
+                "connection.providerId",
+                "accessKeyId",
+                "audience",
+                "plugin.path",
+                "pluginLog.message",
+                "errorMessage",
+            ],
+            notes: [
+                "Request, response, and wire bodies are omitted.",
+                "Tool call argument names, values, and results are omitted.",
+                "Session, request, turn, log, agent, provider, access-key, and audience identifiers are SHA-256 fingerprints.",
+                "Plugin paths, console messages, and provider error text are represented only as captured/omitted state.",
+                "Endpoint metadata omits query strings and redacts identity-shaped path segments.",
+                "Short identifier metadata strings are scanned for common bearer/token secrets.",
+            ]
+        )
+    }
+}
+
+struct SupportDiagnosticsToolInput: Equatable, Sendable {
+    let name: String
+    let enabled: Bool
+    let groupName: String?
+
+    init(name: String, enabled: Bool, groupName: String? = nil) {
+        self.name = name
+        self.enabled = enabled
+        self.groupName = groupName
+    }
+}
+
+enum SupportDiagnosticsBundleBuilder {
+    static let redactedValue = "[REDACTED]"
+
+    @MainActor
+    static func buildCurrent(
+        generatedAt: Date = Date(),
+        sessionId: String? = nil,
+        agentId: UUID? = nil,
+        agentAddress: String? = nil,
+        agentName: String? = nil,
+        modelId: String? = nil,
+        providerId: String? = nil,
+        runtime: String? = nil,
+        toolMode: String? = nil,
+        recentLogLimit: Int = 50
+    ) async -> SupportDiagnosticsBundle {
+        let registry = ToolRegistry.shared
+        let registered = registry.listTools().map { entry in
+            SupportDiagnosticsToolInput(
+                name: entry.name,
+                enabled: entry.enabled,
+                groupName: registry.groupName(for: entry.name)
+            )
+        }
+        let dynamicNames = registry.listDynamicTools().map(\.name)
+        let sessionState: SessionToolState?
+        if let sessionId {
+            sessionState = await SessionToolStateStore.shared.get(sessionId)
+        } else {
+            sessionState = nil
+        }
+
+        return make(
+            generatedAt: generatedAt,
+            app: .current(),
+            sessionId: sessionId,
+            agentId: agentId,
+            agentAddress: agentAddress,
+            agentName: agentName,
+            modelId: modelId,
+            providerId: providerId,
+            runtime: runtime,
+            toolMode: toolMode,
+            registeredTools: registered,
+            dynamicToolNames: dynamicNames,
+            sessionState: sessionState,
+            logs: InsightsService.shared.logs,
+            recentLogLimit: recentLogLimit
+        )
+    }
+
+    static func make(
+        generatedAt: Date = Date(),
+        app: SupportDiagnosticsBundle.AppSnapshot = .current(),
+        sessionId: String? = nil,
+        agentId: UUID? = nil,
+        agentAddress: String? = nil,
+        agentName: String? = nil,
+        modelId: String? = nil,
+        providerId: String? = nil,
+        runtime: String? = nil,
+        toolMode: String? = nil,
+        registeredTools: [SupportDiagnosticsToolInput] = [],
+        dynamicToolNames: [String] = [],
+        sessionState: SessionToolState? = nil,
+        logs: [RequestLog] = [],
+        recentLogLimit: Int = 50
+    ) -> SupportDiagnosticsBundle {
+        // Pure constructor for tests and already-snapshotted inputs. Live app
+        // export flows should call buildCurrent so actor-owned state is read
+        // from the correct isolation domain before arriving here.
+        let context = SupportDiagnosticsBundle.ContextSnapshot(
+            sessionIdFingerprint: fingerprint(sessionId),
+            agentIdFingerprint: fingerprint(agentId),
+            agentAddressFingerprint: fingerprint(agentAddress),
+            agentName: redactedMetadata(agentName),
+            modelId: redactedMetadata(modelId),
+            providerIdFingerprint: fingerprint(providerId),
+            runtime: redactedMetadata(runtime),
+            toolMode: redactedMetadata(toolMode)
+        )
+
+        let registeredRecords = registeredTools
+            .map {
+                SupportDiagnosticsBundle.ToolRecord(
+                    name: $0.name,
+                    enabled: $0.enabled,
+                    groupName: redactedMetadata($0.groupName)
+                )
+            }
+            .sorted { compareIdentifiers($0.name, $1.name) }
+        let tools = SupportDiagnosticsBundle.ToolInventorySnapshot(
+            registered: registeredRecords,
+            enabledNames: sortedUnique(registeredTools.filter(\.enabled).map(\.name)),
+            dynamicNames: sortedUnique(dynamicToolNames),
+            loadedNames: sortedUnique(Array(sessionState?.loadedToolNames ?? [])),
+            initialAlwaysLoadedNames: sortedUnique(Array(sessionState?.initialAlwaysLoadedNames ?? [])),
+            sessionFingerprint: redactedMetadata(sessionState?.sessionFingerprint)
+        )
+
+        let limit = max(0, recentLogLimit)
+        let recentRequests = logs
+            .sorted { lhs, rhs in
+                if lhs.timestamp == rhs.timestamp {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.timestamp > rhs.timestamp
+            }
+            .prefix(limit)
+            .map(snapshot)
+
+        return SupportDiagnosticsBundle(
+            schemaVersion: SupportDiagnosticsBundle.schemaVersion,
+            generatedAt: generatedAt,
+            app: app,
+            context: context,
+            tools: tools,
+            recentRequests: recentRequests,
+            privacy: .standard
+        )
+    }
+
+    private static func snapshot(_ log: RequestLog) -> SupportDiagnosticsBundle.RequestSnapshot {
+        SupportDiagnosticsBundle.RequestSnapshot(
+            idFingerprint: fingerprint(log.id.uuidString) ?? "",
+            timestamp: log.timestamp,
+            source: log.source.rawValue,
+            turnIdFingerprint: fingerprint(log.turnId),
+            requestIdFingerprint: fingerprint(log.requestId),
+            method: redactedMetadata(log.method) ?? "",
+            path: diagnosticPath(for: log),
+            statusCode: log.statusCode,
+            durationMs: log.durationMs,
+            userAgent: redactedMetadata(log.userAgent),
+            pluginId: redactedMetadata(log.pluginId),
+            model: redactedMetadata(log.model),
+            inputTokens: log.inputTokens,
+            outputTokens: log.outputTokens,
+            tokensPerSecond: log.tokensPerSecond,
+            temperature: log.temperature,
+            maxTokens: log.maxTokens,
+            finishReason: log.finishReason?.rawValue,
+            errorMessageCaptured: hasContent(log.errorMessage),
+            bodyPresence: SupportDiagnosticsBundle.BodyPresence(
+                localRequestCaptured: log.requestBody != nil,
+                localResponseCaptured: log.responseBody != nil,
+                wireRequestCaptured: log.wireRequestBody != nil,
+                wireResponseCaptured: log.wireResponseBody != nil
+            ),
+            toolCalls: (log.toolCalls ?? []).map(snapshot),
+            connection: log.connection.map(snapshot)
+        )
+    }
+
+    private static func snapshot(_ call: ToolCallLog) -> SupportDiagnosticsBundle.ToolCallSnapshot {
+        SupportDiagnosticsBundle.ToolCallSnapshot(
+            idFingerprint: fingerprint(call.id.uuidString) ?? "",
+            name: redactedMetadata(call.name) ?? "",
+            argumentKeyCount: argumentKeyCount(from: call.arguments),
+            argumentByteCount: call.arguments.utf8.count,
+            durationMs: call.durationMs,
+            isError: call.isError,
+            resultCaptured: call.result != nil
+        )
+    }
+
+    private static func snapshot(_ connection: RequestConnectionInfo)
+        -> SupportDiagnosticsBundle.ConnectionSnapshot
+    {
+        SupportDiagnosticsBundle.ConnectionSnapshot(
+            providerIdFingerprint: fingerprint(connection.providerId),
+            remoteEndpoint: sanitizedEndpoint(connection.remoteEndpoint),
+            transport: connection.transport?.rawValue,
+            mode: connection.mode?.rawValue,
+            accessKeyIdFingerprint: fingerprint(connection.accessKeyId),
+            audienceFingerprint: fingerprint(connection.audience)
+        )
+    }
+
+    private static func argumentKeyCount(from arguments: String) -> Int {
+        guard let data = arguments.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return 0
+        }
+        return object.keys.count
+    }
+
+    private static func diagnosticPath(for log: RequestLog) -> String {
+        if log.source == .plugin {
+            return "[plugin path omitted]"
+        }
+        return sanitizedEndpoint(log.path) ?? ""
+    }
+
+    private static func sanitizedEndpoint(_ value: String?) -> String? {
+        guard let value = redactedMetadata(value) else { return nil }
+        let withoutQuery = value.split(
+            separator: "?",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        ).first.map(String.init) ?? value
+        let withoutFragment = withoutQuery.split(
+            separator: "#",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        ).first.map(String.init) ?? withoutQuery
+        return redactIdentitySegments(in: withoutFragment)
+    }
+
+    private static func redactIdentitySegments(in value: String) -> String {
+        var output = value
+        output = replacing(
+            pattern: #"\b[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\b"#,
+            in: output,
+            template: "[uuid]"
+        )
+        output = replacing(
+            pattern: #"\b0x[0-9A-Fa-f]{40}\b"#,
+            in: output,
+            template: "0x[REDACTED]"
+        )
+        output = replacing(
+            pattern: #"/[A-Za-z0-9._~%-]{32,}(?=/|$)"#,
+            in: output,
+            template: "/[id]"
+        )
+        return output
+    }
+
+    private static func fingerprint(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty
+        else {
+            return nil
+        }
+        let digest = SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "sha256:" + String(digest.prefix(16))
+    }
+
+    private static func fingerprint(_ value: UUID?) -> String? {
+        fingerprint(value?.uuidString)
+    }
+
+    private static func hasContent(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static func redactedMetadata(_ value: String?, maxLength: Int = 512) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty
+        else {
+            return nil
+        }
+        let clipped: String
+        if value.count > maxLength {
+            clipped = String(value.prefix(maxLength)) + "...[truncated]"
+        } else {
+            clipped = value
+        }
+        return redactSecretLikeSubstrings(clipped)
+    }
+
+    private static func redactSecretLikeSubstrings(_ value: String) -> String {
+        var output = value
+        output = replacing(
+            pattern: #"(?i)(bearer\s+)[^\s,;]+"#,
+            in: output,
+            template: "$1\(redactedValue)"
+        )
+        output = replacing(
+            pattern: #"(?i)(authorization\s*[:=]\s*)(?:basic|bearer|token)?\s*[^\s,;]+"#,
+            in: output,
+            template: "$1\(redactedValue)"
+        )
+        output = replacing(
+            pattern: #"(?i)((?:^|[^\w])"?(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|code)"?\s*[=:]\s*)"?[^\s"&;,}]+"?"#,
+            in: output,
+            template: "$1\(redactedValue)"
+        )
+        output = replacing(
+            pattern: #"(?i)([a-z][a-z0-9+.-]*://)[^/@:\s]+(?::[^/@\s]*)?@"#,
+            in: output,
+            template: "$1\(redactedValue)@"
+        )
+        output = replacing(
+            pattern: #"\bsk-[A-Za-z0-9._-]{8,}\b"#,
+            in: output,
+            template: redactedValue
+        )
+        return output
+    }
+
+    private static func replacing(pattern: String, in value: String, template: String) -> String {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            return value
+        }
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        return expression.stringByReplacingMatches(
+            in: value,
+            options: [],
+            range: range,
+            withTemplate: template
+        )
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted(by: compareIdentifiers)
+    }
+
+    private static func compareIdentifiers(_ lhs: String, _ rhs: String) -> Bool {
+        let order = lhs.caseInsensitiveCompare(rhs)
+        if order == .orderedSame {
+            return lhs < rhs
+        }
+        return order == .orderedAscending
+    }
+}

--- a/Packages/OsaurusCore/Tests/Support/SupportDiagnosticsBundleTests.swift
+++ b/Packages/OsaurusCore/Tests/Support/SupportDiagnosticsBundleTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Support diagnostics bundle", .serialized)
+struct SupportDiagnosticsBundleTests {
+    private static let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let app = SupportDiagnosticsBundle.AppSnapshot(
+        name: "OsaurusTests",
+        version: "1.2.3",
+        build: "456",
+        osVersion: "macOS test"
+    )
+
+    @Test func redactsSensitiveRequestAndToolPayloads() throws {
+        let sessionId = "session-raw-value-do-not-export"
+        let accessKeyId = "access-key-raw-value-do-not-export"
+        let secretToken = "live-secret-token-do-not-export"
+        let bearerToken = "sk-test-secret-token-do-not-export"
+        let basicToken = "dXNlcjpwYXNzLWRvLW5vdC1leHBvcnQ="
+        let privatePrompt = "please search the private account history"
+        let privateResponse = "private diagnosis response"
+        let wirePrompt = "wire prompt payload"
+        let wireResponse = "wire response payload"
+        let pluginMessage = "plugin log private project path"
+        let toolQueryValue = "private account lookup"
+        let argumentKeySecret = "alice@example.com"
+        let agentAddress = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let providerId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let toolCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let requestId = "router-request-secret-do-not-export"
+        let log = RequestLog(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            timestamp: Self.now,
+            source: .chatUI,
+            turnId: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+            requestId: requestId,
+            method: "POST",
+            path: "/agents/\(agentAddress)/run?token=\(secretToken)",
+            statusCode: 500,
+            durationMs: 250,
+            requestBody: #"{"prompt":"\#(privatePrompt)","api_key":"\#(secretToken)"}"#,
+            responseBody: privateResponse,
+            userAgent: "Osaurus Authorization: Basic \(basicToken)",
+            pluginId: "search-plugin",
+            model: "provider/model",
+            inputTokens: 12,
+            outputTokens: 3,
+            temperature: 0.3,
+            maxTokens: 256,
+            toolCalls: [
+                ToolCallLog(
+                    id: toolCallId,
+                    name: "web_search",
+                    arguments: #"{"query":"\#(toolQueryValue)","\#(argumentKeySecret)":true}"#,
+                    result: "result with \(secretToken)",
+                    durationMs: 10,
+                    isError: true
+                )
+            ],
+            finishReason: .error,
+            errorMessage: "provider rejected bearer \(bearerToken) token=\(secretToken)",
+            wireRequestBody: wirePrompt,
+            wireResponseBody: wireResponse,
+            connection: RequestConnectionInfo(
+                providerId: providerId,
+                remoteEndpoint: "https://user:\(secretToken)@provider.example/run?api_key=\(secretToken)",
+                transport: .direct,
+                mode: .remoteInference,
+                accessKeyId: accessKeyId,
+                audience: "agent-support"
+            )
+        )
+        let pluginLog = RequestLog(
+            id: UUID(uuidString: "77777777-7777-7777-7777-777777777777")!,
+            timestamp: Self.now.addingTimeInterval(-1),
+            source: .plugin,
+            method: "INFO",
+            path: "[info] \(pluginMessage)",
+            statusCode: 200,
+            durationMs: 1,
+            pluginId: "diagnostics-plugin"
+        )
+        let state = SessionToolState(
+            loadedToolNames: ["web_search"],
+            initialAlwaysLoadedNames: ["capabilities_load"],
+            sessionFingerprint: "sandbox/auto"
+        )
+
+        let bundle = SupportDiagnosticsBundleBuilder.make(
+            generatedAt: Self.now,
+            app: Self.app,
+            sessionId: sessionId,
+            agentId: UUID(uuidString: "88888888-8888-8888-8888-888888888888")!,
+            agentAddress: agentAddress,
+            agentName: #"Support Agent {"api_key":"\#(secretToken)"}"#,
+            modelId: "provider/model",
+            providerId: "provider token=\(secretToken)",
+            registeredTools: [
+                SupportDiagnosticsToolInput(name: "capabilities_load", enabled: true),
+                SupportDiagnosticsToolInput(name: "web_search", enabled: true, groupName: "search"),
+            ],
+            dynamicToolNames: ["web_search"],
+            sessionState: state,
+            logs: [pluginLog, log]
+        )
+
+        let payload = try encodedPayload(bundle)
+
+        #expect(!payload.contains(secretToken))
+        #expect(!payload.contains(bearerToken))
+        #expect(!payload.contains(basicToken))
+        #expect(!payload.contains(privatePrompt))
+        #expect(!payload.contains(privateResponse))
+        #expect(!payload.contains(wirePrompt))
+        #expect(!payload.contains(wireResponse))
+        #expect(!payload.contains(pluginMessage))
+        #expect(!payload.contains(toolQueryValue))
+        #expect(!payload.contains(argumentKeySecret))
+        #expect(!payload.contains(sessionId))
+        #expect(!payload.contains(accessKeyId))
+        #expect(!payload.contains(requestId))
+        #expect(!payload.contains(agentAddress))
+        #expect(payload.contains(SupportDiagnosticsBundleBuilder.redactedValue))
+        #expect(bundle.context.sessionIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.context.agentIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.context.agentAddressFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.context.providerIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.recentRequests[0].idFingerprint.hasPrefix("sha256:"))
+        #expect(bundle.recentRequests[0].turnIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.recentRequests[0].requestIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.recentRequests[0].path == "/agents/0x[REDACTED]/run")
+        #expect(bundle.recentRequests[0].errorMessageCaptured)
+        #expect(bundle.recentRequests[0].bodyPresence.localRequestCaptured)
+        #expect(bundle.recentRequests[0].bodyPresence.localResponseCaptured)
+        #expect(bundle.recentRequests[0].bodyPresence.wireRequestCaptured)
+        #expect(bundle.recentRequests[0].bodyPresence.wireResponseCaptured)
+        #expect(bundle.recentRequests[0].toolCalls[0].argumentKeyCount == 2)
+        #expect(bundle.recentRequests[0].toolCalls[0].idFingerprint.hasPrefix("sha256:"))
+        #expect(bundle.recentRequests[0].toolCalls[0].resultCaptured)
+        #expect(bundle.recentRequests[0].connection?.accessKeyIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.recentRequests[0].connection?.providerIdFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.recentRequests[0].connection?.audienceFingerprint?.hasPrefix("sha256:") == true)
+        #expect(bundle.recentRequests[1].path == "[plugin path omitted]")
+    }
+
+    @Test func summarizesToolsAndRecentRequestsDeterministically() throws {
+        let firstLog = RequestLog(
+            id: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+            timestamp: Self.now,
+            source: .httpAPI,
+            method: "POST",
+            path: "/chat/completions",
+            statusCode: 200,
+            durationMs: 100,
+            model: "model-a",
+            outputTokens: 20
+        )
+        let secondLog = RequestLog(
+            id: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!,
+            timestamp: Self.now.addingTimeInterval(-60),
+            source: .plugin,
+            method: "LOG",
+            path: "/plugin/log",
+            statusCode: 200,
+            durationMs: 1
+        )
+        let state = SessionToolState(
+            loadedToolNames: ["z_tool", "a_tool", "a_tool"],
+            initialAlwaysLoadedNames: ["capabilities_load", "todo_write"]
+        )
+
+        let bundle = SupportDiagnosticsBundleBuilder.make(
+            generatedAt: Self.now,
+            app: Self.app,
+            registeredTools: [
+                SupportDiagnosticsToolInput(name: "z_tool", enabled: false, groupName: "plugin-z"),
+                SupportDiagnosticsToolInput(name: "a_tool", enabled: true, groupName: "plugin-a"),
+                SupportDiagnosticsToolInput(name: "capabilities_load", enabled: true),
+            ],
+            dynamicToolNames: ["z_tool", "a_tool", "a_tool"],
+            sessionState: state,
+            logs: [firstLog, secondLog],
+            recentLogLimit: 1
+        )
+
+        #expect(bundle.schemaVersion == SupportDiagnosticsBundle.schemaVersion)
+        #expect(bundle.recentRequests.count == 1)
+        #expect(bundle.recentRequests[0].idFingerprint.hasPrefix("sha256:"))
+        #expect(bundle.recentRequests[0].model == "model-a")
+        #expect(bundle.tools.registered.map(\.name) == ["a_tool", "capabilities_load", "z_tool"])
+        #expect(bundle.tools.enabledNames == ["a_tool", "capabilities_load"])
+        #expect(bundle.tools.dynamicNames == ["a_tool", "z_tool"])
+        #expect(bundle.tools.loadedNames == ["a_tool", "z_tool"])
+        #expect(bundle.tools.initialAlwaysLoadedNames == ["capabilities_load", "todo_write"])
+        #expect(bundle.recentRequests[0].tokensPerSecond == 200)
+    }
+
+    private func encodedPayload(_ bundle: SupportDiagnosticsBundle) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(bundle)
+        return String(decoding: data, as: UTF8.self)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a privacy-preserving `SupportDiagnosticsBundle` scaffold for support exports.
- Snapshot app/context/tool/request metadata without serializing prompts, responses, wire bodies, tool argument names/values, tool results, raw stable identifiers, plugin paths, or provider error text.
- Add focused tests for redaction, fingerprinting, plugin-path omission, deterministic request limiting, and tool inventory summaries.

## Validation
- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter SupportDiagnosticsBundleTests`

## Review evidence
- Grok final review: no blocking issues against the prior privacy findings.
- Claude Fable final review: no remaining blocking issues; non-blocking hardening suggestions recorded locally (salted fingerprints, broader token patterns, buildCurrent smoke once integrated).

## Notes
- This is Wave 0 scaffold only. It does not add an export button yet; future UI/API integration should call `SupportDiagnosticsBundleBuilder.buildCurrent(...)` so actor-owned state is snapshotted correctly.