### PR TITLE
Persist user turns before chat streaming

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -41,6 +41,7 @@ enum ChatSessionStore {
 
     /// Save a session (creates or updates)
     static func save(_ session: ChatSessionData) {
+        guard !pendingDeletes.contains(session.id) else { return }
         ensureOpen()
         // When the chat-history DB is deferred (storage key not yet resident or
         // a key rotation is in flight), `ensureOpen()` leaves `didOpen` false.
@@ -62,17 +63,21 @@ enum ChatSessionStore {
     /// open yet. Keyed by id so repeated saves of the same session collapse to
     /// the latest snapshot. Drained by `flushPendingSaves()`.
     private static var pendingSaves: [UUID: ChatSessionData] = [:]
+    private static var pendingDeletes: Set<UUID> = []
 
     /// Re-attempt any saves that were deferred while the chat-history DB was
     /// closed. Call when storage becomes ready (e.g. on the rotation-complete
     /// notification). No-op when nothing is pending or the DB is still deferred.
     static func flushPendingSaves() {
-        guard !pendingSaves.isEmpty else { return }
+        guard !pendingSaves.isEmpty || !pendingDeletes.isEmpty else { return }
         ensureOpen()
         guard didOpen else { return }
+        flushPendingDeletes()
+        guard !pendingSaves.isEmpty else { return }
         let drained = pendingSaves
         pendingSaves.removeAll()
         for (id, session) in drained {
+            guard !pendingDeletes.contains(id) else { continue }
             do {
                 try ChatHistoryDatabase.shared.saveSession(session)
             } catch {
@@ -86,12 +91,40 @@ enum ChatSessionStore {
     /// Delete a session by ID. Also removes the session's artifacts dir
     /// on disk (best-effort) so old shared artifacts don't accumulate.
     static func delete(id: UUID) {
+        pendingSaves.removeValue(forKey: id)
         ensureOpen()
+        guard didOpen else {
+            pendingDeletes.insert(id)
+            removeArtifacts(for: id)
+            return
+        }
         do {
             try ChatHistoryDatabase.shared.deleteSession(id: id)
+            pendingDeletes.remove(id)
         } catch {
+            pendingDeletes.insert(id)
             print("[ChatSessionStore] Failed to delete session \(id): \(error)")
         }
+        removeArtifacts(for: id)
+    }
+
+    private static func flushPendingDeletes() {
+        guard !pendingDeletes.isEmpty else { return }
+        let drained = pendingDeletes
+        pendingDeletes.removeAll()
+        for id in drained {
+            do {
+                try ChatHistoryDatabase.shared.deleteSession(id: id)
+            } catch {
+                pendingDeletes.insert(id)
+                print("[ChatSessionStore] Failed to flush deferred delete \(id): \(error)")
+                continue
+            }
+            removeArtifacts(for: id)
+        }
+    }
+
+    private static func removeArtifacts(for id: UUID) {
         let artifactsDir = OsaurusPaths.contextArtifactsDir(contextId: id.uuidString)
         try? FileManager.default.removeItem(at: artifactsDir)
     }
@@ -214,6 +247,7 @@ enum ChatSessionStore {
         static func _resetForTesting() {
             didOpen = false
             pendingSaves.removeAll()
+            pendingDeletes.removeAll()
             ChatHistoryDatabase.shared.close()
         }
 
@@ -227,6 +261,12 @@ enum ChatSessionStore {
             pendingSaves[session.id] = session
         }
 
+        static func _enqueuePendingDeleteForTesting(_ id: UUID) {
+            pendingSaves.removeValue(forKey: id)
+            pendingDeletes.insert(id)
+        }
+
         static var _pendingSaveCountForTesting: Int { pendingSaves.count }
+        static var _pendingDeleteCountForTesting: Int { pendingDeletes.count }
     #endif
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -190,6 +190,247 @@ struct ChatSessionQueuedSendTests {
         }
     }
 
+    @Test
+    func send_attachmentOnlyTurnPersistsBeforeAssistantCompletes() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+            let attachment = Attachment.document(
+                filename: "assessment.txt",
+                content: "rubric details",
+                fileSize: 13
+            )
+
+            session.send("   ", attachments: [attachment])
+
+            let sessionId = try #require(session.sessionId)
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(persisted.turns.count == 1)
+            #expect(persisted.turns[0].role == .user)
+            #expect(persisted.turns[0].content == "")
+            #expect(persisted.turns[0].attachments.count == 1)
+            #expect(persisted.turns[0].attachments[0].filename == "assessment.txt")
+            #expect(persisted.turns[0].attachments[0].documentContent == "rubric details")
+
+            session.stop()
+            try await waitUntil(timeout: .seconds(1)) { !session.isStreaming }
+        }
+    }
+
+    @Test
+    func privacyCancelRemovesPersistedTransientUserTurn() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+
+            session.send("review will cancel")
+
+            let transientId = try #require(session.sessionId)
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.turns.isEmpty && session.sessionId == nil
+            }
+
+            #expect(ChatSessionStore.load(id: transientId) == nil)
+            #expect(ChatSessionsManager.shared.session(for: transientId) == nil)
+            #expect(session.input == "review will cancel")
+        }
+    }
+
+    @Test
+    func privacyCancelRemovesPersistedTurnFromPremintedEmptySession() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let premintedId = UUID()
+            session.sessionId = premintedId
+            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+
+            session.send("review will cancel")
+
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.turns.isEmpty && session.sessionId == nil
+            }
+
+            #expect(ChatSessionStore.load(id: premintedId) == nil)
+            #expect(ChatSessionsManager.shared.session(for: premintedId) == nil)
+            #expect(session.input == "review will cancel")
+        }
+    }
+
+    @Test
+    func privacyCancelOnExistingSessionKeepsPersistedHistory() async throws {
+        try await ChatHistoryTestStorage.run {
+            let existingId = UUID()
+            let existing = ChatSessionData(
+                id: existingId,
+                title: "Existing chat",
+                turns: [ChatTurnData(role: .user, content: "previous question")]
+            )
+            ChatSessionsManager.shared.save(existing)
+
+            let session = ChatSession()
+            session.load(from: existing)
+            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+
+            session.send("review will cancel")
+
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.sessionId == existingId && session.turns.count == 1
+            }
+
+            let persisted = try #require(ChatSessionStore.load(id: existingId))
+            #expect(persisted.turns.map(\.content) == ["previous question"])
+            #expect(session.turns.map(\.content) == ["previous question"])
+            #expect(session.input == "review will cancel")
+        }
+    }
+
+    @Test
+    func privacyCancelLeavesQueuedSendPending() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { DelayedCancellingBeforeDeltaChatEngine(delayMs: 120) }
+
+            session.send("review will cancel")
+            try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+
+            let queuedAttachment = Attachment.document(
+                filename: "follow-up.txt",
+                content: "queued context",
+                fileSize: 14
+            )
+            session.enqueueSend("queued follow-up", attachments: [queuedAttachment])
+
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.turns.isEmpty && session.queuedSend != nil
+            }
+
+            #expect(session.sessionId == nil)
+            #expect(session.input == "review will cancel")
+            #expect(session.queuedSend?.text == "queued follow-up")
+            #expect(session.queuedSend?.attachments.first?.filename == "follow-up.txt")
+        }
+    }
+
+    @Test
+    func stopBeforeFirstDeltaKeepsPersistedUserTurn() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+
+            session.send("keep this after stop")
+            try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+            let sessionId = try #require(session.sessionId)
+
+            session.stop()
+
+            try await waitUntil(timeout: .seconds(1)) { !session.isStreaming }
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(persisted.turns.count == 1)
+            #expect(persisted.turns[0].role == .user)
+            #expect(persisted.turns[0].content == "keep this after stop")
+        }
+    }
+
+    @Test
+    func privacyCancelDuringRegenerationRestoresHistoricalTurns() async throws {
+        try await ChatHistoryTestStorage.run {
+            let sessionId = UUID()
+            let existing = ChatSessionData(
+                id: sessionId,
+                title: "Regenerate chat",
+                turns: [
+                    ChatTurnData(role: .user, content: "original question"),
+                    ChatTurnData(role: .assistant, content: "original answer"),
+                ]
+            )
+            ChatSessionsManager.shared.save(existing)
+
+            let session = ChatSession()
+            session.load(from: existing)
+            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            let assistantId = try #require(session.turns.last?.id)
+
+            session.regenerate(turnId: assistantId)
+
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.sessionId == sessionId && session.turns.count == 2
+            }
+
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(session.turns.map(\.content) == ["original question", "original answer"])
+            #expect(persisted.turns.map(\.content) == ["original question", "original answer"])
+        }
+    }
+
+    @Test
+    func privacyCancelDuringEditRegenerationRestoresEditedHistory() async throws {
+        try await ChatHistoryTestStorage.run {
+            let sessionId = UUID()
+            let existing = ChatSessionData(
+                id: sessionId,
+                title: "Edit regenerate chat",
+                turns: [
+                    ChatTurnData(role: .user, content: "original question"),
+                    ChatTurnData(role: .assistant, content: "original answer"),
+                ]
+            )
+            ChatSessionsManager.shared.save(existing)
+
+            let session = ChatSession()
+            session.load(from: existing)
+            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            let userId = try #require(session.turns.first?.id)
+
+            session.editAndRegenerate(turnId: userId, newContent: "edited question")
+
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.sessionId == sessionId && session.turns.count == 2
+            }
+
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(session.turns.map(\.content) == ["original question", "original answer"])
+            #expect(persisted.turns.map(\.content) == ["original question", "original answer"])
+        }
+    }
+
+    @Test
+    func abortedRegenerationDoesNotPoisonLaterPrivacyCancel() async throws {
+        try await ChatHistoryTestStorage.run {
+            let sessionId = UUID()
+            let existing = ChatSessionData(
+                id: sessionId,
+                title: "Aborted regenerate chat",
+                turns: [
+                    ChatTurnData(role: .user, content: "original question"),
+                    ChatTurnData(role: .assistant, content: "original answer"),
+                ]
+            )
+            ChatSessionsManager.shared.save(existing)
+
+            let session = ChatSession()
+            session.load(from: existing)
+            let assistantId = try #require(session.turns.last?.id)
+
+            session.isStreaming = true
+            session.regenerate(turnId: assistantId)
+            session.isStreaming = false
+
+            #expect(session.turns.map(\.content) == ["original question", "original answer"])
+
+            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.send("later normal message")
+
+            try await waitUntil(timeout: .seconds(2)) {
+                !session.isStreaming && session.sessionId == sessionId && session.turns.count == 2
+            }
+
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(session.turns.map(\.content) == ["original question", "original answer"])
+            #expect(persisted.turns.map(\.content) == ["original question", "original answer"])
+            #expect(session.input == "later normal message")
+        }
+    }
+
     // MARK: - Mid-run steering (iteration-boundary injection)
 
     @Test
@@ -276,6 +517,40 @@ private actor SlowFinishingChatEngine: ChatEngineProtocol {
 
     func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
         throw NSError(domain: "ChatSessionQueuedSendTests", code: 1)
+    }
+}
+
+private actor CancellingBeforeDeltaChatEngine: ChatEngineProtocol {
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: CancellationError())
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionQueuedSendTests", code: 3)
+    }
+}
+
+private actor DelayedCancellingBeforeDeltaChatEngine: ChatEngineProtocol {
+    let delayMs: Int
+
+    init(delayMs: Int) {
+        self.delayMs = delayMs
+    }
+
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        let delay = delayMs
+        return AsyncThrowingStream { continuation in
+            Task {
+                try? await Task.sleep(for: .milliseconds(delay))
+                continuation.finish(throwing: CancellationError())
+            }
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionQueuedSendTests", code: 4)
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
@@ -50,6 +50,60 @@ struct ChatSessionStoreDeferredSaveTests {
         }
     }
 
+    @Test func deleteDropsQueuedSaveForSession() throws {
+        try withOpenStores {
+            let session = ChatSessionData(
+                id: UUID(),
+                title: "Cancelled deferred chat",
+                turns: [ChatTurnData(role: .user, content: "cancelled before review")]
+            )
+            ChatSessionStore._enqueuePendingSaveForTesting(session)
+            #expect(ChatSessionStore._pendingSaveCountForTesting == 1)
+
+            ChatSessionStore.delete(id: session.id)
+            ChatSessionStore.flushPendingSaves()
+
+            #expect(ChatSessionStore._pendingSaveCountForTesting == 0)
+            #expect(ChatHistoryDatabase.shared.loadSession(id: session.id) == nil)
+        }
+    }
+
+    @Test func flushDeletesQueuedDeleteFromDatabase() throws {
+        try withOpenStores {
+            let session = ChatSessionData(
+                id: UUID(),
+                title: "Persisted before deferred delete",
+                turns: [ChatTurnData(role: .user, content: "remove me later")]
+            )
+            try ChatHistoryDatabase.shared.saveSession(session)
+            ChatSessionStore._enqueuePendingDeleteForTesting(session.id)
+            #expect(ChatSessionStore._pendingDeleteCountForTesting == 1)
+
+            ChatSessionStore.flushPendingSaves()
+
+            #expect(ChatSessionStore._pendingDeleteCountForTesting == 0)
+            #expect(ChatHistoryDatabase.shared.loadSession(id: session.id) == nil)
+        }
+    }
+
+    @Test func pendingDeleteWinsOverQueuedSaveForSession() throws {
+        try withOpenStores {
+            let session = ChatSessionData(
+                id: UUID(),
+                title: "Cancelled deferred chat",
+                turns: [ChatTurnData(role: .user, content: "do not restore")]
+            )
+            ChatSessionStore._enqueuePendingSaveForTesting(session)
+            ChatSessionStore._enqueuePendingDeleteForTesting(session.id)
+
+            ChatSessionStore.flushPendingSaves()
+
+            #expect(ChatSessionStore._pendingSaveCountForTesting == 0)
+            #expect(ChatSessionStore._pendingDeleteCountForTesting == 0)
+            #expect(ChatHistoryDatabase.shared.loadSession(id: session.id) == nil)
+        }
+    }
+
     @Test func loadHealsOrphanedTurnsBackToDisk() throws {
         try withOpenStores(memory: true) {
             let sessionId = UUID(uuidString: "44444444-5555-6666-7777-888888888888")!

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -203,6 +203,19 @@ final class ChatSession: ObservableObject {
 
     /// Tracks if session has unsaved content changes
     private var isDirty: Bool = false
+    /// Session id whose first persisted turn belongs to the active send.
+    /// Used to undo transient rows on privacy-review cancels, including
+    /// pre-minted empty session ids.
+    private var transientSessionIdForCurrentRun: UUID?
+    /// Whether this run appended a new user turn. Regeneration sends reuse
+    /// historical user turns and must not pop one during privacy-cancel rollback.
+    private var appendedUserTurnForCurrentRun = false
+    /// Full transcript snapshot to restore when privacy review cancels a
+    /// regeneration/edit-regeneration before the request leaves the device.
+    private var turnsRollbackOnCancel: [ChatTurn]?
+    /// Privacy review cancel restores the draft instead of committing the run;
+    /// it must not auto-dispatch a queued follow-up during cleanup.
+    private var suppressQueuedSendFlushForCurrentRun = false
 
     // MARK: - Memoization Cache
     private let blockMemoizer = BlockMemoizer()
@@ -1530,6 +1543,10 @@ final class ChatSession: ObservableObject {
         queuedSend = nil
         voiceInputState = .idle
         showVoiceOverlay = false
+        transientSessionIdForCurrentRun = nil
+        appendedUserTurnForCurrentRun = false
+        turnsRollbackOnCancel = nil
+        suppressQueuedSendFlushForCurrentRun = false
         // Clear session identity for new chat
         if let prev = sessionId {
             let key = sessionStateKey(prev)
@@ -1865,6 +1882,10 @@ final class ChatSession: ObservableObject {
         showVoiceOverlay = false
         input = ""
         pendingAttachments = []
+        transientSessionIdForCurrentRun = nil
+        appendedUserTurnForCurrentRun = false
+        turnsRollbackOnCancel = nil
+        suppressQueuedSendFlushForCurrentRun = false
         isDirty = false  // Fresh load, not dirty
         // Clear caches to force a clean block rebuild for the new session
         blockMemoizer.clear()
@@ -2027,6 +2048,8 @@ final class ChatSession: ObservableObject {
         guard let index = turns.firstIndex(where: { $0.id == turnId }) else { return }
         guard turns[index].role == .user else { return }
 
+        turnsRollbackOnCancel = snapshotTurnsForCancelRollback()
+
         // Update the content
         turns[index].content = newContent
 
@@ -2053,6 +2076,8 @@ final class ChatSession: ObservableObject {
     func regenerate(turnId: UUID) {
         guard let index = turns.firstIndex(where: { $0.id == turnId }) else { return }
         guard turns[index].role == .assistant else { return }
+
+        turnsRollbackOnCancel = snapshotTurnsForCancelRollback()
 
         // Remove this turn and all subsequent turns
         turns = Array(turns.prefix(index))
@@ -2475,6 +2500,9 @@ final class ChatSession: ObservableObject {
         // unrelated cancel doesn't accidentally repopulate the input
         // with a turn the user already sent.
         savedDraftOnCancel = nil
+        transientSessionIdForCurrentRun = nil
+        appendedUserTurnForCurrentRun = false
+        turnsRollbackOnCancel = nil
         budgetTracker.clear()
         ServerController.signalGenerationEnd()
         // Finalize ledger outcomes before trimming so the classification sees
@@ -2485,7 +2513,10 @@ final class ChatSession: ObservableObject {
         markUnfinishedToolCallsInterrupted()
         rebuildVisibleBlocks()
         save()
-        flushQueuedSendIfEligible()
+        if !suppressQueuedSendFlushForCurrentRun {
+            flushQueuedSendIfEligible()
+        }
+        suppressQueuedSendFlushForCurrentRun = false
     }
 
     /// A stopped (or errored) run can leave an assistant tool call that never
@@ -3255,7 +3286,10 @@ final class ChatSession: ObservableObject {
         let hasContent = !trimmed.isEmpty || !attachments.isEmpty
         let isRegeneration = !hasContent && !turns.isEmpty
         guard hasContent || isRegeneration else { return }
-        guard activeRunId == nil, !isStreaming else { return }
+        guard activeRunId == nil, !isStreaming else {
+            restoreTurnsRollbackAfterAbortedRegeneration()
+            return
+        }
 
         // Authoritative guard for every send path (interactive, regeneration,
         // queued, VAD, programmatic): never start a local generation while
@@ -3263,13 +3297,20 @@ final class ChatSession: ObservableObject {
         // first so the draft survives; this backstops the rest.
         if localModelBusyInOtherWindow {
             windowState?.showLocalModelBusyAlert = true
+            restoreTurnsRollbackAfterAbortedRegeneration()
             return
+        }
+        if hasContent {
+            turnsRollbackOnCancel = nil
         }
 
         // Fresh run: a previous stop() may have left the flag true. The
         // auto-flush in completeRunCleanup keys off this, so clear it
         // before the new run can finalize.
         stopRequested = false
+        transientSessionIdForCurrentRun = nil
+        appendedUserTurnForCurrentRun = false
+        suppressQueuedSendFlushForCurrentRun = false
 
         // Any new user input clears a prior completion banner — we're
         // moving on to a follow-up. Clarify prompts (when active) live
@@ -3291,12 +3332,14 @@ final class ChatSession: ObservableObject {
         awaitingClarify = nil
 
         if hasContent {
+            let sendIntroducesFirstTurn = turns.isEmpty
             // One-shot activation signal — the install's first ever chat-UI
             // message. Inside the `hasContent` branch so a contentless
             // regeneration doesn't count as "used".
             FeatureTelemetry.firstTimeChatUsed()
 
             turns.append(ChatTurn(role: .user, content: trimmed, attachments: attachments))
+            appendedUserTurnForCurrentRun = true
             // Stash the draft so we can put it back if the user cancels
             // out of the privacy review sheet. The text and attachments
             // arrive cleared (the input bar wipes them as part of its
@@ -3306,18 +3349,12 @@ final class ChatSession: ObservableObject {
             isDirty = true
             rebuildVisibleBlocks()
 
-            // Immediately save new session so it appears in sidebar
-            if sessionId == nil {
-                sessionId = UUID()
-                createdAt = Date()
-                updatedAt = Date()
-                isDirty = false  // Already set updatedAt
-                // Auto-generate title from first user message
-                let turnData = turns.map { ChatTurnData(from: $0) }
-                title = ChatSessionData.generateTitle(from: turnData)
-                let data = toSessionData()
-                ChatSessionsManager.shared.save(data)
-                onSessionChanged?()
+            // Persist the user turn before inference starts. Final cleanup will
+            // save the assistant turn, but the user's text/attachments must
+            // survive a crash, quit, or long-running stream too.
+            save()
+            if sendIntroducesFirstTurn {
+                transientSessionIdForCurrentRun = sessionId
             }
         }
 
@@ -3354,8 +3391,12 @@ final class ChatSession: ObservableObject {
                 lastStreamError = nil
                 isStreaming = true
                 ServerController.signalGenerationStart()
+                var shouldPersistConversationArtifacts = true
                 defer {
-                    finalizeRun(runId: runId, persistConversationArtifacts: true)
+                    finalizeRun(
+                        runId: runId,
+                        persistConversationArtifacts: shouldPersistConversationArtifacts
+                    )
                 }
 
                 var assistantTurn = ChatTurn(role: .assistant, content: "")
@@ -4657,6 +4698,8 @@ final class ChatSession: ObservableObject {
                         debugLog("send: stop() cancelled mid-prepare — keeping user turn")
                     } else {
                         debugLog("send: cancelled before any delta — restoring draft")
+                        shouldPersistConversationArtifacts = false
+                        suppressQueuedSendFlushForCurrentRun = true
                         handleCancelledBeforeFirstDelta()
                     }
                 } catch let pfError as PrivacyFilterPipelineError {
@@ -4711,13 +4754,23 @@ final class ChatSession: ObservableObject {
         if let last = turns.last, last.role == .assistant, last.contentIsEmpty {
             turns.removeLast()
         }
+        if let rollback = turnsRollbackOnCancel {
+            turns = rollback
+            turnsRollbackOnCancel = nil
+            appendedUserTurnForCurrentRun = false
+            rebuildVisibleBlocks()
+            savedDraftOnCancel = nil
+            persistAfterCancelledBeforeFirstDelta()
+            return
+        }
         // Remove the user turn this run was attached to, if it's the
         // current trailing turn. Don't blindly drop the last turn —
         // queued sends or auxiliary turns might have landed between
         // the append and the cancel.
-        if let last = turns.last, last.role == .user {
+        if appendedUserTurnForCurrentRun, let last = turns.last, last.role == .user {
             turns.removeLast()
         }
+        appendedUserTurnForCurrentRun = false
         rebuildVisibleBlocks()
         // Restore the typed draft. Concatenating onto whatever the
         // user has half-typed since hitting Send would be surprising,
@@ -4729,6 +4782,44 @@ final class ChatSession: ObservableObject {
             pendingAttachments = draft.attachments
         }
         savedDraftOnCancel = nil
+        persistAfterCancelledBeforeFirstDelta()
+    }
+
+    private func snapshotTurnsForCancelRollback() -> [ChatTurn] {
+        turns.map { ChatTurn(from: ChatTurnData(from: $0)) }
+    }
+
+    private func restoreTurnsRollbackAfterAbortedRegeneration() {
+        guard let rollback = turnsRollbackOnCancel else { return }
+        turns = rollback
+        turnsRollbackOnCancel = nil
+        appendedUserTurnForCurrentRun = false
+        transientSessionIdForCurrentRun = nil
+        rebuildVisibleBlocks()
+        isDirty = false
+        save()
+    }
+
+    private func persistAfterCancelledBeforeFirstDelta() {
+        let transientId = transientSessionIdForCurrentRun
+        transientSessionIdForCurrentRun = nil
+
+        if turns.isEmpty, let id = transientId, sessionId == id {
+            sessionId = nil
+            title = "New Chat"
+            createdAt = Date()
+            updatedAt = createdAt
+            isDirty = false
+            ChatSessionsManager.shared.delete(id: id)
+            let key = sessionStateKey(id)
+            Task { await SessionToolStateStore.shared.invalidate(key) }
+            Task { await SessionRedactionStore.shared.invalidate(id.uuidString) }
+            onSessionChanged?()
+            return
+        }
+
+        guard !turns.isEmpty else { return }
+        save()
     }
 }
 


### PR DESCRIPTION
## Summary
- persist user turns and attachments immediately before chat streaming starts, so crash/quit/long-running streams do not lose the user turn
- roll back privacy-review cancels without leaving chat rows, queued sends, memory artifacts, redaction/tool state, or deferred-save ghosts
- preserve existing and regeneration histories on privacy cancel, including aborted-regeneration rollback cleanup
- make chat-session deletes win over deferred saves and drain deferred deletes before queued saves

## Validation
- git diff --check
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ChatSessionQueuedSendTests (23 tests passed)
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ChatSessionStoreDeferredSaveTests (5 tests passed)

## Review Evidence
- Fable final verification: no blocking correctness/data-loss/privacy issues; stale rollback fix verified
- Grok final verification: no blocking correctness/data-loss/privacy issues; 28 focused tests confirmed

## Notes
- make pr-ready-check is not available in this checkout, so readiness will be gated through GitHub checks and PR metadata before leaving draft.