### PR TITLE
Handle empty voice transcriptions

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -85716,6 +85716,74 @@
         }
       }
     },
+    "No speech detected" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No speech detected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No speech detected"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No speech detected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No speech detected"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No speech detected"
+          }
+        }
+      }
+    },
+    "No Speech Detected" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No Speech Detected"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No Speech Detected"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No Speech Detected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No Speech Detected"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No Speech Detected"
+          }
+        }
+      }
+    },
     "No model card available." : {
       "localizations" : {
         "de" : {
@@ -89733,6 +89801,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "這裡沒有內容可顯示"
+          }
+        }
+      }
+    },
+    "Nothing was inserted." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was inserted."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was inserted."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was inserted."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was inserted."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was inserted."
+          }
+        }
+      }
+    },
+    "Nothing was sent." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was sent."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was sent."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was sent."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was sent."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nothing was sent."
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionModeService.swift
@@ -162,19 +162,33 @@ public final class TranscriptionModeService: ObservableObject {
         Task {
             _ = await speechService.stopStreamingTranscription()
 
-            let rawText = speechService.confirmedTranscription
+            let rawText = TranscriptionTextNormalizer.combined([
+                speechService.confirmedTranscription,
+                speechService.currentTranscription,
+            ])
             speechService.clearTranscription()
 
             if !discard, !rawText.isEmpty {
-                let finalText =
+                let cleanedText =
                     SpeechConfigurationStore.load().postProcessTranscription
                     ? await TranscriptionCleanupService.shared.clean(rawText)
                     : rawText
-                keyboardService.pasteText(finalText)
+                let finalText = TranscriptionTextNormalizer.visibleText(cleanedText)
+                if finalText.isEmpty {
+                    showNoSpeechDetectedFeedback()
+                } else {
+                    keyboardService.pasteText(finalText)
+                }
+            } else if !discard {
+                showNoSpeechDetectedFeedback()
             }
 
             overlayService.hide()
-            state = .idle
+            if case .error = state {
+                // Keep the error visible in Status/Settings until the next toggle.
+            } else {
+                state = .idle
+            }
             print("[TranscriptionMode] Stopped transcription (discard: \(discard))")
         }
     }
@@ -262,19 +276,21 @@ public final class TranscriptionModeService: ObservableObject {
         else { return }
 
         // Reset the pause timer on any real voice activity.
-        let confirmedLength = speechService.confirmedTranscription.count
+        let confirmedText = TranscriptionTextNormalizer.visibleText(speechService.confirmedTranscription)
+        let currentText = TranscriptionTextNormalizer.visibleText(speechService.currentTranscription)
+        let confirmedLength = confirmedText.count
         let hasNewConfirmedText = confirmedLength > lastConfirmedLength
         if hasNewConfirmedText { lastConfirmedLength = confirmedLength }
         if speechService.isSpeechDetected || hasNewConfirmedText
-            || !speechService.currentTranscription.isEmpty
+            || !currentText.isEmpty
         {
             lastSpeechActivityTime = Date()
         }
 
         // Only auto-stop once we've actually captured something to paste.
         let hasContent =
-            !speechService.confirmedTranscription.isEmpty
-            || !speechService.currentTranscription.isEmpty
+            !confirmedText.isEmpty
+            || !currentText.isEmpty
         guard hasContent else { return }
 
         let silenceDuration = Date().timeIntervalSince(lastSpeechActivityTime)
@@ -284,6 +300,14 @@ public final class TranscriptionModeService: ObservableObject {
             )
             stopTranscription()
         }
+    }
+
+    private func showNoSpeechDetectedFeedback() {
+        state = .error(L("No speech detected"))
+        ToastManager.shared.infoLocalized(
+            "No Speech Detected",
+            message: "Nothing was inserted."
+        )
     }
 
     // MARK: - Esc Key Monitoring

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionTextNormalizer.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionTextNormalizer.swift
@@ -1,0 +1,46 @@
+//
+//  TranscriptionTextNormalizer.swift
+//  osaurus
+//
+//  Normalizes voice transcription text before insertion or send.
+//
+
+import Foundation
+
+public enum TranscriptionTextNormalizer {
+    private static let invisibleScalars = CharacterSet(charactersIn: "\u{00AD}\u{034F}\u{061C}\u{180E}\u{200B}\u{200C}\u{200D}\u{200E}\u{200F}\u{202A}\u{202B}\u{202C}\u{202D}\u{202E}\u{2060}\u{2061}\u{2062}\u{2063}\u{2064}\u{2066}\u{2067}\u{2068}\u{2069}\u{FEFF}\u{FFFE}")
+
+    public static func visibleText(_ text: String) -> String {
+        let scalars = text.unicodeScalars.filter { scalar in
+            if invisibleScalars.contains(scalar) { return false }
+            if CharacterSet.controlCharacters.contains(scalar),
+                scalar != "\n",
+                scalar != "\t"
+            {
+                return false
+            }
+            return true
+        }
+        return String(String.UnicodeScalarView(scalars))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static func hasVisibleText(_ text: String) -> Bool {
+        !visibleText(text).isEmpty
+    }
+
+    public static func combined(_ parts: [String]) -> String {
+        parts
+            .map(visibleText)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    public static func merged(existing: String, transcript: String) -> String {
+        let existing = visibleText(existing)
+        let transcript = visibleText(transcript)
+        if existing.isEmpty { return transcript }
+        if transcript.isEmpty { return existing }
+        return "\(existing) \(transcript)"
+    }
+}

--- a/Packages/OsaurusCore/Tests/Voice/TranscriptionTextNormalizerTests.swift
+++ b/Packages/OsaurusCore/Tests/Voice/TranscriptionTextNormalizerTests.swift
@@ -1,0 +1,48 @@
+//
+//  TranscriptionTextNormalizerTests.swift
+//  osaurus
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+struct TranscriptionTextNormalizerTests {
+    @Test
+    func visibleTextDropsInvisibleOnlyTranscripts() {
+        let hidden = "\u{200B}\u{200C}\u{200D}\u{2060}\u{FEFF}\u{FFFE}\n\t "
+
+        #expect(TranscriptionTextNormalizer.visibleText(hidden).isEmpty)
+        #expect(!TranscriptionTextNormalizer.hasVisibleText(hidden))
+    }
+
+    @Test
+    func visibleTextPreservesVisibleWords() {
+        let text = "\u{200B}  hello\u{2060} world  \n"
+
+        #expect(TranscriptionTextNormalizer.visibleText(text) == "hello world")
+        #expect(TranscriptionTextNormalizer.hasVisibleText(text))
+    }
+
+    @Test
+    func combinedSkipsHiddenSegments() {
+        let combined = TranscriptionTextNormalizer.combined([
+            "\u{200B}",
+            " first ",
+            "\u{FFFE}",
+            "second",
+        ])
+
+        #expect(combined == "first second")
+    }
+
+    @Test
+    func mergedDoesNotAddHiddenTranscript() {
+        let merged = TranscriptionTextNormalizer.merged(
+            existing: " existing ",
+            transcript: "\u{200B}\u{2060}"
+        )
+
+        #expect(merged == "existing")
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -737,7 +737,7 @@ struct FloatingInputCard: View {
             .onChange(of: speechService.currentTranscription) { _, newValue in
                 // When new transcription arrives, user is speaking
                 // Only reset silence timer if there is also active audio detection or meaningful level
-                if voiceInputState == .recording && !newValue.isEmpty {
+                if voiceInputState == .recording && TranscriptionTextNormalizer.hasVisibleText(newValue) {
                     if speechService.isSpeechDetected || speechService.audioLevel > 0.05 {
                         hasDetectedSpeechThisTurn = true
                         lastSpeechTime = Date()
@@ -746,7 +746,7 @@ struct FloatingInputCard: View {
             }
             .onChange(of: speechService.confirmedTranscription) { _, newValue in
                 // When confirmed transcription changes, user was speaking
-                if voiceInputState == .recording && !newValue.isEmpty {
+                if voiceInputState == .recording && TranscriptionTextNormalizer.hasVisibleText(newValue) {
                     if speechService.isSpeechDetected || speechService.audioLevel > 0.05 {
                         hasDetectedSpeechThisTurn = true
                         lastSpeechTime = Date()
@@ -1123,7 +1123,8 @@ extension FloatingInputCard {
             voiceConfig.pauseDuration > 0
         else { return }
 
-        let hasContent = !speechService.currentTranscription.isEmpty || !speechService.confirmedTranscription.isEmpty
+        let hasContent = TranscriptionTextNormalizer.hasVisibleText(speechService.currentTranscription)
+            || TranscriptionTextNormalizer.hasVisibleText(speechService.confirmedTranscription)
         let silenceDuration = Date().timeIntervalSince(lastSpeechTime)
 
         guard hasContent else {
@@ -1159,13 +1160,15 @@ extension FloatingInputCard {
         }
 
         // Reset timer when there's real-time voice activity (not cumulative text)
-        let currentConfirmedLen = speechService.confirmedTranscription.count
+        let confirmedText = TranscriptionTextNormalizer.visibleText(speechService.confirmedTranscription)
+        let currentText = TranscriptionTextNormalizer.visibleText(speechService.currentTranscription)
+        let currentConfirmedLen = confirmedText.count
         let hasNewConfirmedText = currentConfirmedLen > lastConfirmedLength
         if hasNewConfirmedText {
             lastConfirmedLength = currentConfirmedLen
         }
 
-        if speechService.isSpeechDetected || hasNewConfirmedText || !speechService.currentTranscription.isEmpty {
+        if speechService.isSpeechDetected || hasNewConfirmedText || !currentText.isEmpty {
             lastVoiceActivityTime = Date()
         }
 
@@ -1176,7 +1179,8 @@ extension FloatingInputCard {
         // Check if timeout exceeded
         if silenceDuration >= voiceConfig.silenceTimeoutSeconds {
             let hasContent =
-                !speechService.currentTranscription.isEmpty || !speechService.confirmedTranscription.isEmpty
+                !currentText.isEmpty
+                || !confirmedText.isEmpty
 
             if hasContent && voiceConfig.transcriptionStopMode == .automatic {
                 print("[FloatingInputCard] Silence timeout with content - triggering auto-send")
@@ -1196,17 +1200,19 @@ extension FloatingInputCard {
 
         if newRemaining <= 0 {
             // Countdown finished, send message
-            let transcribedText = [
+            let transcribedText = TranscriptionTextNormalizer.combined([
                 speechService.confirmedTranscription,
                 speechService.currentTranscription,
-            ]
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
+            ])
 
             if !transcribedText.isEmpty {
                 sendVoiceMessage(transcribedText)
             } else {
                 stopVoiceInputFromTimeout()
+                ToastManager.shared.infoLocalized(
+                    "No Speech Detected",
+                    message: "Nothing was sent."
+                )
             }
         } else {
             // Update remaining time
@@ -1227,6 +1233,22 @@ extension FloatingInputCard {
     private func sendVoiceMessage(_ message: String) {
         print("[FloatingInputCard] Sending voice message. Continuous mode: \(isContinuousVoiceMode)")
         logVoiceState(trigger: "sendVoiceMessage-start")
+        let visibleInputMessage = TranscriptionTextNormalizer.visibleText(message)
+        guard !visibleInputMessage.isEmpty else {
+            cancelLiveVoicePreencodeSession(removeRegistryEntry: true)
+            Task {
+                _ = await speechService.stopStreamingTranscription()
+                speechService.clearTranscription()
+            }
+            voiceInputState = .idle
+            showVoiceOverlay = false
+            ToastManager.shared.infoLocalized(
+                "No Speech Detected",
+                message: "Nothing was sent."
+            )
+            return
+        }
+
         let voiceCaptureStart = CFAbsoluteTimeGetCurrent()
         let voiceSnapshot = mediaCapabilities.supportsAudio ? speechService.currentLiveAudioSnapshot() : nil
         let snapshotMs = Int((CFAbsoluteTimeGetCurrent() - voiceCaptureStart) * 1000)
@@ -1259,12 +1281,27 @@ extension FloatingInputCard {
             speechService.clearTranscription()
             logVoiceState(trigger: "sendVoiceMessage-afterStop")
 
-            print("[FloatingInputCard] Invoking cleanup for voice message (\(message.count) chars)")
+            print("[FloatingInputCard] Invoking cleanup for voice message (\(visibleInputMessage.count) chars)")
             let cleanedMessage =
                 SpeechConfigurationStore.load().postProcessTranscription
-                ? await TranscriptionCleanupService.shared.clean(message)
-                : message
+                ? await TranscriptionCleanupService.shared.clean(visibleInputMessage)
+                : visibleInputMessage
+            let visibleMessage = TranscriptionTextNormalizer.visibleText(cleanedMessage)
             print("[FloatingInputCard] Cleanup done. Original: \(message) | Cleaned: \(cleanedMessage)")
+
+            guard !visibleMessage.isEmpty else {
+                await MainActor.run {
+                    voiceInputState = .idle
+                    showVoiceOverlay = false
+                    cancelLiveVoicePreencodeSession(removeRegistryEntry: true)
+                    ToastManager.shared.infoLocalized(
+                        "No Speech Detected",
+                        message: "Nothing was sent."
+                    )
+                }
+                return
+            }
+
             await finalPreencodeTask?.value
 
             await MainActor.run {
@@ -1272,7 +1309,7 @@ extension FloatingInputCard {
                 showVoiceOverlay = false
 
                 let existing = localText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let fullMessage = existing.isEmpty ? cleanedMessage : "\(existing) \(cleanedMessage)"
+                let fullMessage = TranscriptionTextNormalizer.merged(existing: existing, transcript: visibleMessage)
 
                 if let voiceAudioData {
                     let voiceAttachment = Attachment(
@@ -1293,7 +1330,7 @@ extension FloatingInputCard {
                 }
 
                 // try to paste. if it fails (permissions), we fall back to direct text setting
-                if KeyboardSimulationService.shared.pasteText(cleanedMessage) {
+                if KeyboardSimulationService.shared.pasteText(visibleMessage) {
                     // success: clear UI state immediately
                     localText = ""
                     text = ""
@@ -1317,12 +1354,10 @@ extension FloatingInputCard {
     private func transferToTextInput() {
         print("[FloatingInputCard] Transferring to text input - disabling continuous mode")
         // Transfer transcription to text input and close overlay
-        let transcribedText = [
+        let transcribedText = TranscriptionTextNormalizer.combined([
             speechService.confirmedTranscription,
             speechService.currentTranscription,
-        ]
-        .filter { !$0.isEmpty }
-        .joined(separator: " ")
+        ])
 
         voiceInputState = .sending
         // exit continuous mode when switching to text
@@ -1336,15 +1371,24 @@ extension FloatingInputCard {
                 SpeechConfigurationStore.load().postProcessTranscription
                 ? await TranscriptionCleanupService.shared.clean(transcribedText)
                 : transcribedText
+            let visibleText = TranscriptionTextNormalizer.visibleText(cleaned)
 
             await MainActor.run {
                 voiceInputState = .idle
                 showVoiceOverlay = false
 
-                let existing = localText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let fullCombined = existing.isEmpty ? cleaned : "\(existing) \(cleaned)"
+                guard !visibleText.isEmpty else {
+                    ToastManager.shared.infoLocalized(
+                        "No Speech Detected",
+                        message: "Nothing was inserted."
+                    )
+                    return
+                }
 
-                if KeyboardSimulationService.shared.pasteText(cleaned) {
+                let existing = localText.trimmingCharacters(in: .whitespacesAndNewlines)
+                let fullCombined = TranscriptionTextNormalizer.merged(existing: existing, transcript: visibleText)
+
+                if KeyboardSimulationService.shared.pasteText(visibleText) {
                     isFocused = true
                 } else {
                     // Fallback if paste fails

--- a/Packages/OsaurusCore/Views/Voice/VoiceInputOverlay.swift
+++ b/Packages/OsaurusCore/Views/Voice/VoiceInputOverlay.swift
@@ -105,6 +105,10 @@ public struct VoiceInputOverlay: View {
         }
     }
 
+    private var visibleFullText: String {
+        TranscriptionTextNormalizer.visibleText(fullText)
+    }
+
     public var body: some View {
         VStack(spacing: 0) {
             // Main content card
@@ -204,13 +208,13 @@ public struct VoiceInputOverlay: View {
                         .font(.system(size: 15))
                         .foregroundColor(theme.tertiaryText)
                         .italic()
-                } else if fullText.isEmpty {
+                } else if visibleFullText.isEmpty {
                     Text("Listening...", bundle: .module)
                         .font(.system(size: 15))
                         .foregroundColor(theme.tertiaryText)
                         .italic()
                 } else {
-                    Text(fullText)
+                    Text(visibleFullText)
                         .font(.system(size: 15))
                         .foregroundColor(theme.primaryText)
                         .lineLimit(nil)
@@ -276,8 +280,8 @@ public struct VoiceInputOverlay: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .opacity(fullText.isEmpty ? 0.5 : 1)
-                .disabled(fullText.isEmpty)
+                .opacity(visibleFullText.isEmpty ? 0.5 : 1)
+                .disabled(visibleFullText.isEmpty)
 
                 Spacer()
 
@@ -298,8 +302,8 @@ public struct VoiceInputOverlay: View {
                         )
                     }
                     .buttonStyle(.plain)
-                    .opacity(fullText.isEmpty ? 0.5 : 1)
-                    .disabled(fullText.isEmpty)
+                    .opacity(visibleFullText.isEmpty ? 0.5 : 1)
+                    .disabled(visibleFullText.isEmpty)
                 } else {
                     // wrap only the ring in an animated container so its
                     // appearance/disappearance transition is scoped. also prevents
@@ -420,11 +424,10 @@ public struct VoiceInputOverlay: View {
     }
 
     private func sendMessage() {
+        let message = visibleFullText
+        guard !message.isEmpty else { return }
         state = .sending
-        let message = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !message.isEmpty {
-            onSend?(message)
-        }
+        onSend?(message)
         // FloatingInputCard.sendVoiceMessage owns the rest of the
         // lifecycle. It runs cleanup, then resets state/dismisses the overlay.
         // We intentionally do not auto reset here as doing so caused a visible


### PR DESCRIPTION
## Summary
- add a shared transcription normalizer for invisible/control-only ASR output
- block empty-visible voice sends, paste/transfer, memo dictation paste, and overlay actions
- skip live voice preencode work on empty-visible sends and surface no-speech feedback
- add string catalog entries and focused normalizer tests

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter TranscriptionTextNormalizerTests`

## Reviews
- Fable medium review: no blocking findings
- Grok review: no blocking findings

Draft until CI is green.
