### PR TITLE
Recover bare capability tool ids

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -433,6 +433,171 @@ struct CapabilitiesLoadToolTests {
         #expect(result.contains("Invalid ID format"))
     }
 
+    @Test @MainActor
+    func bareToolIdLoadsRegisteredTool() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let toolName =
+                "lane_b_bare_load_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+            let fixture = CapabilityPolicyFixtureTool(
+                name: toolName,
+                description: "Search the web for current headlines and online results"
+            )
+            ToolRegistry.shared.registerPluginTool(fixture)
+            ToolRegistry.shared.setEnabled(true, for: fixture.name)
+            defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+            _ = await CapabilityLoadBuffer.shared.drain()
+
+            let tool = CapabilitiesLoadTool()
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"\(toolName)\"]}")
+            }
+
+            #expect(!ToolEnvelope.isError(result))
+            #expect(result.contains("Tool '\(toolName)' loaded"))
+            let buffered = await CapabilityLoadBuffer.shared.drain()
+            #expect(buffered.contains(where: { $0.function.name == toolName }))
+        }
+    }
+
+    @Test @MainActor
+    func bareToolIdTrimsWhitespaceAndUsesCanonicalCase() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "_")
+            let toolName = "Lane_B_Case_Load_Tool_\(suffix)"
+            let fixture = CapabilityPolicyFixtureTool(
+                name: toolName,
+                description: "Search the web for current headlines and online results"
+            )
+            ToolRegistry.shared.registerPluginTool(fixture)
+            ToolRegistry.shared.setEnabled(true, for: fixture.name)
+            defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+            _ = await CapabilityLoadBuffer.shared.drain()
+
+            let tool = CapabilitiesLoadTool()
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"  \(toolName.lowercased())  \"]}")
+            }
+
+            #expect(!ToolEnvelope.isError(result))
+            #expect(result.contains("Tool '\(toolName)' loaded"))
+            let buffered = await CapabilityLoadBuffer.shared.drain()
+            #expect(buffered.contains(where: { $0.function.name == toolName }))
+        }
+    }
+
+    @Test @MainActor
+    func bareToolIdStillHonorsAgentGrant() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await DynamicCatalogTestLock.shared.run {
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-capability-bare-load-grant-root-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                AgentManager.shared.refresh()
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    AgentManager.shared.refresh()
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-capability-bare-load-grant-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                let previousOverride = ToolConfigurationStore.overrideDirectory
+                ToolConfigurationStore.overrideDirectory = tempDir
+                try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                defer { ToolConfigurationStore.overrideDirectory = previousOverride }
+
+                let toolName =
+                    "lane_b_bare_denied_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+                let denied = CapabilityPolicyFixtureTool(
+                    name: toolName,
+                    description: "Search the web for current headlines and online results"
+                )
+                ToolRegistry.shared.registerPluginTool(denied)
+                ToolRegistry.shared.setEnabled(true, for: denied.name)
+                defer { ToolRegistry.shared.unregister(names: [denied.name]) }
+
+                let agent = Agent(
+                    name: "CapabilityBareLoadGrant-\(UUID().uuidString.prefix(6))",
+                    agentAddress: "capability-bare-load-grant-\(UUID().uuidString)",
+                    manualToolNames: []
+                )
+                AgentManager.shared.add(agent)
+                _ = await CapabilityLoadBuffer.shared.drain()
+
+                let tool = CapabilitiesLoadTool()
+                let result = try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
+                    try await tool.execute(argumentsJSON: "{\"ids\": [\"\(denied.name)\"]}")
+                }
+
+                #expect(result.contains("not enabled for this agent"))
+                #expect(result.contains("availability: hidden_by_agent_scope"))
+                let buffered = await CapabilityLoadBuffer.shared.drain()
+                #expect(!buffered.contains(where: { $0.function.name == denied.name }))
+
+                _ = await AgentManager.shared.delete(id: agent.id)
+            }
+        }
+    }
+
+    @Test @MainActor
+    func bareToolIdReportsDisabledAvailability() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-capability-bare-load-disabled-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousOverride = ToolConfigurationStore.overrideDirectory
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                ToolConfigurationStore.overrideDirectory = previousOverride
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let toolName =
+                "lane_b_bare_disabled_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+            let disabled = CapabilityPolicyFixtureTool(
+                name: toolName,
+                description: "Search the web for current headlines and online results"
+            )
+            ToolRegistry.shared.registerPluginTool(disabled)
+            ToolRegistry.shared.setEnabled(false, for: disabled.name)
+            defer { ToolRegistry.shared.unregister(names: [disabled.name]) }
+
+            let tool = CapabilitiesLoadTool()
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(argumentsJSON: "{\"ids\": [\"\(disabled.name)\"]}")
+            }
+
+            #expect(result.contains("disabled"))
+            #expect(result.contains("availability: disabled"))
+            let buffered = await CapabilityLoadBuffer.shared.drain()
+            #expect(!buffered.contains(where: { $0.function.name == disabled.name }))
+        }
+    }
+
+    @Test @MainActor
+    func bareUnknownIdPointsBackToDiscovery() async throws {
+        let tool = CapabilitiesLoadTool()
+        let unknown = "not_a_registered_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+        let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"\(unknown)\"]}")
+
+        #expect(ToolEnvelope.isError(result))
+        #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+        #expect(EnvelopeAssertions.failureField(result) == "ids")
+        #expect(EnvelopeAssertions.failureRetryable(result) == false)
+        #expect(result.contains("Bare tool name '\(unknown)' is not registered"))
+        #expect(result.contains("capabilities_discover"))
+    }
+
     @Test func handlesUnknownTypePrefix() async throws {
         let tool = CapabilitiesLoadTool()
         let result = try await tool.execute(argumentsJSON: "{\"ids\": [\"widget/abc\"]}")

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -632,22 +632,46 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         var sections: [String] = []
         var failures: [LoadFailure] = []
 
-        for id in ids {
-            guard let slashIdx = id.firstIndex(of: "/") else {
+        for rawInputId in ids {
+            let id = rawInputId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !id.isEmpty else {
                 failures.append(
                     LoadFailure(
                         kind: .invalidArgs,
                         message:
-                            "Invalid ID format '\(id)' — expected `<type>/<id>` "
-                            + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). Use IDs from the Enabled capabilities list or `capabilities_discover`.",
-                        field: "ids"
+                            "Invalid empty capability ID — expected `<type>/<id>` "
+                            + "(e.g. `tool/sandbox_exec`, `skill/plot-data`).",
+                        field: "ids",
+                        expected: "non-empty capability ID"
                     )
                 )
                 continue
             }
 
-            let typePrefix = String(id[id.startIndex ..< slashIdx])
-            let rawId = String(id[id.index(after: slashIdx)...])
+            let typePrefix: String
+            let rawId: String
+            if let slashIdx = id.firstIndex(of: "/") {
+                typePrefix = String(id[id.startIndex ..< slashIdx])
+                rawId = String(id[id.index(after: slashIdx)...])
+            } else if let toolName = await Self.resolveBareToolName(id) {
+                typePrefix = "tool"
+                rawId = toolName
+            } else {
+                failures.append(
+                    LoadFailure(
+                        kind: .invalidArgs,
+                        message:
+                            "Invalid ID format '\(id)' — expected `<type>/<id>` "
+                            + "(e.g. `tool/sandbox_exec`, `skill/plot-data`). "
+                            + "Bare tool name '\(id)' is not registered. "
+                            + "If this is a skill, plugin, or method, include the type prefix; "
+                            + "otherwise call `capabilities_discover` and use a returned ID.",
+                        field: "ids",
+                        expected: "tool/<name>, skill/<name>, plugin/<id>, or method/<id>"
+                    )
+                )
+                continue
+            }
 
             let outcome: LoadOutcome
             switch typePrefix {
@@ -703,6 +727,12 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             text: text,
             warnings: warnings.isEmpty ? nil : warnings
         )
+    }
+
+    private static func resolveBareToolName(_ id: String) async -> String? {
+        await MainActor.run {
+            ToolRegistry.shared.canonicalToolName(matchingBareId: id)
+        }
     }
 
     /// Structured per-id failure: the `kind` drives the all-failed

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1111,6 +1111,15 @@ public final class ToolRegistry: ObservableObject {
         )
     }
 
+    /// Resolve an unqualified tool name without building the full `ToolEntry`
+    /// list. Exact registry matches win; otherwise a single case-insensitive
+    /// match is treated as the canonical tool name.
+    func canonicalToolName(matchingBareId id: String) -> String? {
+        if toolsByName.keys.contains(id) { return id }
+        let matches = toolsByName.keys.filter { $0.caseInsensitiveCompare(id) == .orderedSame }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
     /// Set enablement for a tool and persist.
     func setEnabled(_ enabled: Bool, for name: String) {
         configuration.setEnabled(enabled, for: name)


### PR DESCRIPTION
## Summary
- recover unqualified `capabilities_load` tool IDs when they match a registered tool name exactly or via a single case-insensitive match
- keep qualified `<type>/<id>` as the canonical contract, and point unknown bare IDs back to `capabilities_discover` instead of suggesting a guaranteed-failing `tool/<id>` retry
- add registry-level canonical bare-name resolution without building the full `ToolEntry` list
- add focused coverage for bare load success, whitespace/case canonicalization, agent grant enforcement, disabled availability, and unknown bare-id failure semantics

## Validation
- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter CapabilityToolsTests`

## Reviews
- Fable (`claude -p --model fable --effort medium --fallback-model opus,sonnet`): no blocking findings after correcting the unknown bare-id retry guidance
- Grok (`grok --no-subagents --disable-web-search`): no blocking findings