### PR TITLE
Add agent chat generation settings regression

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionAgentSettingsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionAgentSettingsTests.swift
@@ -1,0 +1,82 @@
+//
+//  ChatSessionAgentSettingsTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the agent-bound chat sampling contract: a ChatSession running under a
+//  custom agent must pass the agent's temperature and max-token settings into
+//  the model request. This guards the "agent mode ignores custom temperature"
+//  support report without changing the remote-agent Mode 2 boundary, where the
+//  host agent intentionally resolves its own sampling settings server-side.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ChatSessionAgentSettingsTests {
+    private static let asyncTimeout: Duration = .seconds(10)
+
+    @Test
+    func sendUsesCustomAgentGenerationSettings() async throws {
+        try await ChatHistoryTestStorage.run {
+            let manager = AgentManager.shared
+            let agent = Agent(
+                name: "Sampling Agent \(UUID().uuidString)",
+                temperature: 0.23,
+                maxTokens: 321
+            )
+            manager.add(agent)
+
+            let engine = AgentSettingsCaptureEngine()
+            let session = ChatSession()
+            session.agentId = agent.id
+            session.chatEngineFactory = { engine }
+
+            session.send("Use the configured sampling values.")
+
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await engine.request != nil
+            }
+
+            let request = try #require(await engine.request)
+            #expect(request.temperature == 0.23)
+            #expect(request.max_tokens == 321)
+
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                !session.isStreaming
+            }
+        }
+    }
+}
+
+private actor AgentSettingsCaptureEngine: ChatEngineProtocol {
+    private(set) var request: ChatCompletionRequest?
+
+    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        self.request = request
+        return AsyncThrowingStream { continuation in
+            continuation.yield("ok")
+            continuation.finish()
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionAgentSettingsTests", code: 1)
+    }
+}
+
+@MainActor
+private func waitUntilAsync(
+    timeout: Duration,
+    _ predicate: @escaping () async -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await predicate() { return }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    throw NSError(domain: "ChatSessionAgentSettingsTests", code: 2)
+}


### PR DESCRIPTION
## Summary

Adds a focused regression test for the R080 support report that interactive agent chat can ignore custom generation settings.

This lane is intentionally test-only: it pins the `ChatSession.send()` request-construction boundary for a custom agent's `temperature` and `max_tokens`. It does not claim runtime sampler enforcement or remote Mode 2 behavior, which remains server-owned and covered separately.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter ChatSessionAgentSettingsTests`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter AgentRunSamplingResolutionTests`

## Review

- Fable final review: no blockers.
- Grok final review: no blockers. Grok rejected `--effort high` for the installed model, so the review was rerun without the effort flag per repo guidance.