### PR TITLE
Pin agent run prompt injection contract

### DIFF
--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -1194,6 +1194,9 @@ struct HTTPHandlerChatStreamingTests {
             let defaultNames = Set(requests[0].tools?.map(\.function.name) ?? [])
             #expect(defaultNames == ToolRegistry.defaultAgentAllowedToolNames)
 
+            let customSystemMessage = requests[1].messages.first { $0.role == "system" }
+            #expect(customSystemMessage?.content?.contains("Test identity") == true)
+
             let customNames = Set(requests[1].tools?.map(\.function.name) ?? [])
             for configure in ToolRegistry.configureToolNames {
                 #expect(


### PR DESCRIPTION
## Summary

Adds a focused regression assertion for R063: `/agents/{id}/run` must route through the server-side agent context composer and include the selected custom agent system prompt in the model request.

This keeps the existing strict `/chat/completions` contract intact: the `X-Osaurus-Agent-Id` header remains attribution/persistence context and does not inject local agent prompt/context there.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter HTTPHandlerChatStreamingTests/agentRun_usesComposerResolvedToolSurface`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter HTTPHandlerChatStreamingTests/chatCompletions_agentHeaderDoesNotInjectAgentContext`

## Review

- Fable final review: no blockers.
- Grok final review: no blockers; `--effort high` was rejected by the installed Grok model, then rerun without `--effort` per repo guidance.

## Notes

This is a regression pin, not a production rewrite. Investigation found the strict `/chat/completions` non-injection behavior is intentional and already covered by existing tests.