### PR TITLE
Add recoverable agent backup restore path

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -299,6 +299,27 @@ public final class AgentManager: ObservableObject {
         )
     }
 
+    /// Restore a preserved legacy agent backup and publish it like a newly
+    /// available custom agent. `AgentStore` owns conflict-safe decoding /
+    /// re-id behavior; the manager refreshes UI state and gives recovered
+    /// conflict copies a fresh address when the local master key is available.
+    @discardableResult
+    public func restoreRecoverableAgentBackup(at url: URL) throws -> Agent {
+        let agent = try AgentStore.restoreRecoverableBackup(at: url)
+        refresh()
+        if !agent.isBuiltIn {
+            try? assignAddress(to: agent)
+            let restored = self.agent(for: agent.id) ?? agent
+            NotificationCenter.default.post(
+                name: .agentAdded,
+                object: nil,
+                userInfo: ["agentId": agent.id]
+            )
+            return restored
+        }
+        return agent
+    }
+
     /// Set or replace the custom avatar image for `agentId`. Writes the bytes
     /// to disk under `agents/avatars/`, updates the agent record, and posts
     /// `.agentUpdated`. Returns true on success.

--- a/Packages/OsaurusCore/Models/Agent/AgentStore.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentStore.swift
@@ -9,6 +9,32 @@ import Foundation
 
 @MainActor
 public enum AgentStore {
+    public struct RecoverableAgentBackup: Equatable, Sendable {
+        public let url: URL
+        public let agent: Agent
+        public let conflictsWithExistingAgent: Bool
+    }
+
+    public enum RecoveryError: Error, Equatable, LocalizedError {
+        case unreadableBackup(String)
+        case builtInAgent(String)
+        case restoreSaveFailed(String)
+        case backupConsumedFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .unreadableBackup(let name):
+                return "Could not read agent backup \(name)."
+            case .builtInAgent(let name):
+                return "Built-in agent backups cannot be restored: \(name)."
+            case .restoreSaveFailed(let name):
+                return "Could not save recovered agent \(name)."
+            case .backupConsumedFailed(let name):
+                return "Recovered agent backup could not be marked restored: \(name)."
+            }
+        }
+    }
+
     // MARK: - Public API
 
     /// Load all agents sorted by name, including built-ins
@@ -60,6 +86,81 @@ public enum AgentStore {
                 return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
             }
         }
+    }
+
+    /// Preserved legacy migration conflict copies (`<uuid>.json.bak`,
+    /// `<uuid>.json.1.bak`, ...). These are intentionally ignored by
+    /// `loadAll()` so a conflict never overwrites the canonical agent, but the
+    /// user still needs a recovery surface for the saved legacy copy.
+    public static func recoverableBackups() -> [RecoverableAgentBackup] {
+        OsaurusPaths.migrateLegacyPersonasIfNeeded()
+        let directory = OsaurusPaths.agents()
+        guard
+            let files = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            )
+        else { return [] }
+
+        return files
+            .filter(isRecoverableBackupURL)
+            .compactMap { url -> RecoverableAgentBackup? in
+                guard let agent = try? decodeAgentBackup(at: url), !agent.isBuiltIn else {
+                    return nil
+                }
+                return RecoverableAgentBackup(
+                    url: url,
+                    agent: agent,
+                    conflictsWithExistingAgent: exists(id: agent.id)
+                        || identityConflicts(with: agent)
+                )
+            }
+            .sorted { lhs, rhs in
+                lhs.url.lastPathComponent.localizedCaseInsensitiveCompare(rhs.url.lastPathComponent)
+                    == .orderedAscending
+            }
+    }
+
+    /// Restore a preserved agent backup into the canonical `agents/` store.
+    ///
+    /// If the backup's original UUID is free, the agent is restored as-is. If a
+    /// current agent already owns that UUID, the recovered copy is imported as a
+    /// new agent with a fresh UUID and cleared crypto identity so existing
+    /// agent-scoped tokens / addresses are never duplicated.
+    @discardableResult
+    public static func restoreRecoverableBackup(
+        at url: URL,
+        recoveredId: UUID = UUID(),
+        recoveredAt: Date = Date()
+    ) throws -> Agent {
+        let backup = try decodeAgentBackup(at: url)
+        guard !backup.isBuiltIn else {
+            throw RecoveryError.builtInAgent(backup.name)
+        }
+
+        let restored: Agent
+        if exists(id: backup.id) {
+            let safeRecoveredId = uniqueRecoveredId(preferred: recoveredId)
+            restored = backup.recoveredConflictCopy(id: safeRecoveredId, recoveredAt: recoveredAt)
+        } else if identityConflicts(with: backup) {
+            restored = backup.clearingRecoveredIdentity(recoveredAt: recoveredAt)
+        } else {
+            restored = backup
+        }
+        let createdRestoredAgent = !exists(id: restored.id)
+        save(restored)
+        guard exists(id: restored.id) else {
+            throw RecoveryError.restoreSaveFailed(restored.name)
+        }
+        do {
+            try consumeRecoveredBackup(at: url)
+        } catch {
+            if createdRestoredAgent {
+                removeAgentRecord(id: restored.id)
+            }
+            throw error
+        }
+        return restored
     }
 
     /// Load a specific agent by ID
@@ -197,5 +298,152 @@ public enum AgentStore {
 
     private static func avatarsDirectory() -> URL {
         OsaurusPaths.agents().appendingPathComponent("avatars", isDirectory: true)
+    }
+
+    private static func isRecoverableBackupURL(_ url: URL) -> Bool {
+        url.pathExtension.lowercased() == "bak"
+            && url.lastPathComponent.localizedCaseInsensitiveContains(".json")
+    }
+
+    private static func decodeAgentBackup(at url: URL) throws -> Agent {
+        do {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return try decoder.decode(Agent.self, from: data)
+        } catch {
+            throw RecoveryError.unreadableBackup(url.lastPathComponent)
+        }
+    }
+
+    private static func identityConflicts(with agent: Agent) -> Bool {
+        let candidateAddress = agent.agentAddress?.lowercased()
+        return loadAll().contains { existing in
+            guard !existing.isBuiltIn else { return false }
+            if let index = agent.agentIndex, existing.agentIndex == index {
+                return true
+            }
+            if let candidateAddress,
+                existing.agentAddress?.lowercased() == candidateAddress
+            {
+                return true
+            }
+            return false
+        }
+    }
+
+    private static func consumeRecoveredBackup(at url: URL) throws {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return }
+        let consumedURL = uniqueConsumedBackupURL(for: url, fileManager: fm)
+        do {
+            try fm.moveItem(at: url, to: consumedURL)
+        } catch {
+            throw RecoveryError.backupConsumedFailed(url.lastPathComponent)
+        }
+    }
+
+    private static func uniqueRecoveredId(preferred: UUID) -> UUID {
+        var candidate = preferred
+        while exists(id: candidate) {
+            candidate = UUID()
+        }
+        return candidate
+    }
+
+    private static func removeAgentRecord(id: UUID) {
+        let url = agentFileURL(for: id)
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            print("[Osaurus] Failed to roll back recovered agent record \(id): \(error)")
+        }
+    }
+
+    private static func uniqueConsumedBackupURL(for url: URL, fileManager fm: FileManager) -> URL {
+        var candidate = url.appendingPathExtension("restored")
+        var counter = 1
+        while fm.fileExists(atPath: candidate.path) {
+            candidate = url.appendingPathExtension("restored.\(counter)")
+            counter += 1
+        }
+        return candidate
+    }
+}
+
+private extension Agent {
+    func clearingRecoveredIdentity(recoveredAt: Date) -> Agent {
+        Agent(
+            id: id,
+            name: name,
+            description: description,
+            systemPrompt: systemPrompt,
+            themeId: themeId,
+            defaultModel: defaultModel,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            chatQuickActions: chatQuickActions,
+            chatGreeting: chatGreeting,
+            chatSubtitle: chatSubtitle,
+            isBuiltIn: false,
+            createdAt: createdAt,
+            updatedAt: recoveredAt,
+            agentIndex: nil,
+            agentAddress: nil,
+            autonomousExec: autonomousExec,
+            pluginInstructions: pluginInstructions,
+            bonjourEnabled: bonjourEnabled,
+            toolSelectionMode: toolSelectionMode,
+            manualToolNames: manualToolNames,
+            manualSkillNames: manualSkillNames,
+            toolsEnabled: toolsEnabled,
+            memoryEnabled: memoryEnabled,
+            avatar: avatar,
+            customAvatarFilename: customAvatarFilename,
+            autoSpeak: autoSpeak,
+            ttsVoice: ttsVoice,
+            settings: settings,
+            order: order,
+            hostWorkspaceBookmark: hostWorkspaceBookmark,
+            hostWorkspacePath: hostWorkspacePath
+        )
+    }
+
+    func recoveredConflictCopy(id: UUID, recoveredAt: Date) -> Agent {
+        Agent(
+            id: id,
+            name: "\(name) (Recovered)",
+            description: description,
+            systemPrompt: systemPrompt,
+            themeId: themeId,
+            defaultModel: defaultModel,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            chatQuickActions: chatQuickActions,
+            chatGreeting: chatGreeting,
+            chatSubtitle: chatSubtitle,
+            isBuiltIn: false,
+            createdAt: createdAt,
+            updatedAt: recoveredAt,
+            agentIndex: nil,
+            agentAddress: nil,
+            autonomousExec: autonomousExec,
+            pluginInstructions: pluginInstructions,
+            bonjourEnabled: bonjourEnabled,
+            toolSelectionMode: toolSelectionMode,
+            manualToolNames: manualToolNames,
+            manualSkillNames: manualSkillNames,
+            toolsEnabled: toolsEnabled,
+            memoryEnabled: memoryEnabled,
+            avatar: avatar,
+            customAvatarFilename: nil,
+            autoSpeak: autoSpeak,
+            ttsVoice: ttsVoice,
+            settings: settings,
+            order: nil,
+            hostWorkspaceBookmark: hostWorkspaceBookmark,
+            hostWorkspacePath: hostWorkspacePath
+        )
     }
 }

--- a/Packages/OsaurusCore/Tests/Plugin/AgentManagerLifecycleNotificationTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/AgentManagerLifecycleNotificationTests.swift
@@ -32,6 +32,14 @@ struct AgentManagerLifecycleNotificationTests {
         )
     }
 
+    private func seedAgentBackup(at url: URL, agent: Agent) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(agent)
+        try data.write(to: url, options: .atomic)
+    }
+
     /// Subscribes to `name` and returns the `agentId` from the first
     /// notification received, or nil after `timeoutMs`. We capture only
     /// the `agentId` (a `UUID`, value type) rather than the whole
@@ -99,6 +107,111 @@ struct AgentManagerLifecycleNotificationTests {
 
             let id = try #require(receivedId, "expected .agentAdded to fire after add()")
             #expect(id == agent.id)
+        }
+    }
+
+    @Test
+    func restoreRecoverableBackupPostsAgentAddedAndRefreshesManagerList() async throws {
+        try await ChatHistoryTestStorage.run {
+            let fm = FileManager.default
+            let agents = OsaurusPaths.agents()
+            try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+            let agentId = UUID()
+            let backupURL = agents.appendingPathComponent("\(agentId.uuidString).json.bak")
+            let backup = Agent(
+                id: agentId,
+                name: "RecoveredNotify",
+                systemPrompt: "Recovered through manager"
+            )
+            try self.seedAgentBackup(at: backupURL, agent: backup)
+
+            var restoreError: Error?
+            let receivedId = await self.awaitAgentIdNotification(.agentAdded) {
+                do {
+                    _ = try AgentManager.shared.restoreRecoverableAgentBackup(at: backupURL)
+                } catch {
+                    restoreError = error
+                }
+            }
+            if let restoreError {
+                throw restoreError
+            }
+
+            let notificationId = try #require(
+                receivedId,
+                "expected .agentAdded to fire after restore"
+            )
+            #expect(notificationId == agentId)
+
+            let restored = try #require(
+                AgentManager.shared.agent(for: agentId),
+                "expected restore to refresh the manager list"
+            )
+            #expect(restored.name == "RecoveredNotify")
+            #expect(!fm.fileExists(atPath: backupURL.path))
+            #expect(fm.fileExists(atPath: backupURL.appendingPathExtension("restored").path))
+        }
+    }
+
+    @Test
+    func restoreRecoverableConflictPostsRecoveredAgentIdAndRefreshesManagerList() async throws {
+        try await ChatHistoryTestStorage.run {
+            let fm = FileManager.default
+            let agents = OsaurusPaths.agents()
+            try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+            let originalId = UUID()
+            AgentStore.save(Agent(
+                id: originalId,
+                name: "CanonicalNotify",
+                systemPrompt: "canonical through manager"
+            ))
+
+            let backupURL = agents.appendingPathComponent("\(originalId.uuidString).json.bak")
+            let backup = Agent(
+                id: originalId,
+                name: "LegacyNotify",
+                systemPrompt: "legacy through manager",
+                agentIndex: 17,
+                agentAddress: "0xlegacy-manager"
+            )
+            try self.seedAgentBackup(at: backupURL, agent: backup)
+
+            var restoredAgent: Agent?
+            var restoreError: Error?
+            let receivedId = await self.awaitAgentIdNotification(.agentAdded) {
+                do {
+                    restoredAgent = try AgentManager.shared.restoreRecoverableAgentBackup(at: backupURL)
+                } catch {
+                    restoreError = error
+                }
+            }
+            if let restoreError {
+                throw restoreError
+            }
+
+            let restored = try #require(restoredAgent)
+            #expect(restored.id != originalId)
+            #expect(restored.name == "LegacyNotify (Recovered)")
+            // The store clears the backup identity before save; the manager then
+            // assigns a fresh identity for the recovered agent.
+            #expect(restored.agentIndex != backup.agentIndex)
+            #expect(restored.agentAddress != backup.agentAddress)
+
+            let notificationId = try #require(
+                receivedId,
+                "expected .agentAdded to fire after conflict restore"
+            )
+            #expect(notificationId == restored.id)
+
+            let managerRestored = try #require(
+                AgentManager.shared.agent(for: restored.id),
+                "expected restore to refresh the manager list with the recovered id"
+            )
+            #expect(managerRestored.name == "LegacyNotify (Recovered)")
+            let canonical = try #require(AgentManager.shared.agent(for: originalId))
+            #expect(canonical.name == "CanonicalNotify")
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Utils/OsaurusPersonasMigrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/OsaurusPersonasMigrationTests.swift
@@ -26,6 +26,39 @@ struct OsaurusPersonasMigrationTests {
         try data.write(to: url, options: .atomic)
     }
 
+    private func seedLoadableAgentJSON(at url: URL, agent: Agent) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(agent)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func loadableAgentDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    private func withTemporaryOsaurusRoot<T: Sendable>(
+        name: String,
+        _ body: @Sendable (URL) async throws -> T
+    ) async throws -> T {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(
+            "\(name)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        let previousRoot = OsaurusPaths.overrideRoot
+        OsaurusPaths.overrideRoot = root
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            try? fm.removeItem(at: root)
+        }
+        return try await body(root)
+    }
+
     @Test("Stranded records move into agents/ after the agents dir already exists")
     func movesStrandedRecordsAfterAgentsDirCreated() async throws {
         try await StoragePathsTestLock.shared.run {
@@ -92,17 +125,23 @@ struct OsaurusPersonasMigrationTests {
             let id = UUID()
             let agents = OsaurusPaths.agents()
             try fm.createDirectory(at: agents, withIntermediateDirectories: true)
-            try seedAgentJSON(at: agents.appendingPathComponent("\(id).json"), id: id, name: "Canonical")
+            try seedLoadableAgentJSON(
+                at: agents.appendingPathComponent("\(id).json"),
+                agent: Agent(id: id, name: "Canonical")
+            )
 
             let legacy = root.appendingPathComponent("Personas", isDirectory: true)
             try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
-            try seedAgentJSON(at: legacy.appendingPathComponent("\(id).json"), id: id, name: "Legacy")
+            try seedLoadableAgentJSON(
+                at: legacy.appendingPathComponent("\(id).json"),
+                agent: Agent(id: id, name: "Legacy")
+            )
 
             let result = OsaurusPaths.migrateLegacyPersonasIfNeeded()
             #expect(result == .migrated(moved: 0, conflicts: 1))
 
             // Canonical copy is untouched.
-            let canonical = try JSONDecoder().decode(
+            let canonical = try loadableAgentDecoder().decode(
                 Agent.self,
                 from: Data(contentsOf: agents.appendingPathComponent("\(id).json"))
             )
@@ -111,8 +150,15 @@ struct OsaurusPersonasMigrationTests {
             // Legacy copy preserved as a `.bak` sibling (ignored by loadAll).
             let backup = agents.appendingPathComponent("\(id).json.bak")
             #expect(fm.fileExists(atPath: backup.path))
-            let backed = try JSONDecoder().decode(Agent.self, from: Data(contentsOf: backup))
+            let backed = try loadableAgentDecoder().decode(Agent.self, from: Data(contentsOf: backup))
             #expect(backed.name == "Legacy")
+
+            let recoverableBackups = await MainActor.run { AgentStore.recoverableBackups() }
+            let recoverableBackup = try #require(recoverableBackups.first)
+            #expect(recoverableBackups.count == 1)
+            #expect(recoverableBackup.url.lastPathComponent == backup.lastPathComponent)
+            #expect(recoverableBackup.agent.name == "Legacy")
+            #expect(recoverableBackup.conflictsWithExistingAgent)
 
             #expect(!fm.fileExists(atPath: legacy.path))
         }
@@ -178,6 +224,338 @@ struct OsaurusPersonasMigrationTests {
 
             #expect(OsaurusPaths.migrateLegacyPersonasIfNeeded() == .migrated(moved: 1, conflicts: 0))
             #expect(OsaurusPaths.migrateLegacyPersonasIfNeeded() == .legacyDirectoryAbsent)
+        }
+    }
+
+    @Test("Migration conflict backups are discoverable and restore as safe new agents")
+    func conflictBackupRestoresAsNewAgentWithoutOverwritingCanonical() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot(name: "osaurus-personas-recover-conflict") { _ in
+                let fm = FileManager.default
+                let agents = OsaurusPaths.agents()
+                try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+                let originalId = UUID()
+                let recoveredId = UUID()
+                let recoveredAt = Date(timeIntervalSince1970: 1_800_000_000)
+
+                let canonical = Agent(
+                    id: originalId,
+                    name: "Canonical",
+                    systemPrompt: "canonical prompt"
+                )
+                try seedLoadableAgentJSON(
+                    at: agents.appendingPathComponent("\(originalId.uuidString).json"),
+                    agent: canonical
+                )
+
+                let legacy = Agent(
+                    id: originalId,
+                    name: "Legacy",
+                    systemPrompt: "legacy prompt",
+                    agentIndex: 42,
+                    agentAddress: "0xlegacy",
+                    customAvatarFilename: "\(originalId.uuidString).png",
+                    order: 7
+                )
+                let backupURL = agents.appendingPathComponent("\(originalId.uuidString).json.bak")
+                try seedLoadableAgentJSON(at: backupURL, agent: legacy)
+
+                let backups = await MainActor.run { AgentStore.recoverableBackups() }
+                let backup = try #require(backups.first)
+                #expect(backups.count == 1)
+                #expect(backup.url.lastPathComponent == backupURL.lastPathComponent)
+                #expect(backup.agent.name == "Legacy")
+                #expect(backup.conflictsWithExistingAgent)
+
+                let restored = try await MainActor.run {
+                    try AgentStore.restoreRecoverableBackup(
+                        at: backup.url,
+                        recoveredId: recoveredId,
+                        recoveredAt: recoveredAt
+                    )
+                }
+
+                #expect(restored.id == recoveredId)
+                #expect(restored.name == "Legacy (Recovered)")
+                #expect(restored.systemPrompt == "legacy prompt")
+                #expect(restored.updatedAt == recoveredAt)
+                #expect(restored.agentIndex == nil)
+                #expect(restored.agentAddress == nil)
+                #expect(restored.customAvatarFilename == nil)
+                #expect(restored.order == nil)
+
+                let stillCanonical = await MainActor.run { AgentStore.load(id: originalId) }
+                #expect(stillCanonical?.name == "Canonical")
+                #expect(stillCanonical?.systemPrompt == "canonical prompt")
+
+                let loadedRecovered = await MainActor.run { AgentStore.load(id: recoveredId) }
+                #expect(loadedRecovered?.name == "Legacy (Recovered)")
+
+                #expect(!fm.fileExists(atPath: backupURL.path))
+                #expect(fm.fileExists(atPath: backupURL.appendingPathExtension("restored").path))
+                let remainingBackups = await MainActor.run { AgentStore.recoverableBackups() }
+                #expect(remainingBackups.isEmpty)
+            }
+        }
+    }
+
+    @Test("Numbered non-conflicting backups restore under their original agent id")
+    func nonConflictingBackupRestoresOriginalId() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot(name: "osaurus-personas-recover-orphan") { _ in
+                let fm = FileManager.default
+                let agents = OsaurusPaths.agents()
+                try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+                let originalId = UUID()
+                let orphan = Agent(
+                    id: originalId,
+                    name: "Orphan",
+                    systemPrompt: "orphan prompt",
+                    agentIndex: 11,
+                    agentAddress: "0xorphan",
+                    order: 3
+                )
+                let backupURL = agents.appendingPathComponent("\(originalId.uuidString).json.1.bak")
+                try seedLoadableAgentJSON(at: backupURL, agent: orphan)
+
+                let backups = await MainActor.run { AgentStore.recoverableBackups() }
+                let backup = try #require(backups.first)
+                #expect(backups.count == 1)
+                #expect(!backup.conflictsWithExistingAgent)
+
+                let restored = try await MainActor.run {
+                    try AgentStore.restoreRecoverableBackup(at: backup.url)
+                }
+
+                #expect(restored.id == originalId)
+                #expect(restored.name == "Orphan")
+                #expect(restored.systemPrompt == "orphan prompt")
+                #expect(restored.agentIndex == 11)
+                #expect(restored.agentAddress == "0xorphan")
+                #expect(restored.order == 3)
+
+                let loaded = await MainActor.run { AgentStore.load(id: originalId) }
+                #expect(loaded?.name == "Orphan")
+                #expect(loaded?.systemPrompt == "orphan prompt")
+
+                #expect(!fm.fileExists(atPath: backupURL.path))
+                #expect(fm.fileExists(atPath: backupURL.appendingPathExtension("restored").path))
+                let remainingBackups = await MainActor.run { AgentStore.recoverableBackups() }
+                #expect(remainingBackups.isEmpty)
+            }
+        }
+    }
+
+    @Test("Conflict restores avoid explicit recovered id collisions")
+    func conflictBackupAvoidsRecoveredIdCollision() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot(name: "osaurus-personas-recover-id-collision") { _ in
+                let fm = FileManager.default
+                let agents = OsaurusPaths.agents()
+                try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+                let originalId = UUID()
+                let occupiedRecoveredId = UUID()
+                try seedLoadableAgentJSON(
+                    at: agents.appendingPathComponent("\(originalId.uuidString).json"),
+                    agent: Agent(id: originalId, name: "Canonical")
+                )
+                try seedLoadableAgentJSON(
+                    at: agents.appendingPathComponent("\(occupiedRecoveredId.uuidString).json"),
+                    agent: Agent(id: occupiedRecoveredId, name: "Occupied")
+                )
+
+                let legacy = Agent(
+                    id: originalId,
+                    name: "Legacy",
+                    systemPrompt: "legacy prompt"
+                )
+                let backupURL = agents.appendingPathComponent("\(originalId.uuidString).json.bak")
+                try seedLoadableAgentJSON(at: backupURL, agent: legacy)
+
+                let restored = try await MainActor.run {
+                    try AgentStore.restoreRecoverableBackup(
+                        at: backupURL,
+                        recoveredId: occupiedRecoveredId
+                    )
+                }
+
+                #expect(restored.id != originalId)
+                #expect(restored.id != occupiedRecoveredId)
+                #expect(restored.name == "Legacy (Recovered)")
+                let occupied = await MainActor.run { AgentStore.load(id: occupiedRecoveredId) }
+                #expect(occupied?.name == "Occupied")
+                let loadedRecovered = await MainActor.run { AgentStore.load(id: restored.id) }
+                #expect(loadedRecovered?.name == "Legacy (Recovered)")
+                #expect(!fm.fileExists(atPath: backupURL.path))
+                #expect(fm.fileExists(atPath: backupURL.appendingPathExtension("restored").path))
+            }
+        }
+    }
+
+    @Test("Built-in backups are rejected and left untouched")
+    func builtInBackupRestoreIsRejected() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot(name: "osaurus-personas-built-in-backup") { _ in
+                let fm = FileManager.default
+                let agents = OsaurusPaths.agents()
+                try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+                let builtIn = Agent(
+                    id: Agent.defaultId,
+                    name: "Osaurus",
+                    isBuiltIn: true,
+                    createdAt: Date(timeIntervalSince1970: 0),
+                    updatedAt: Date(timeIntervalSince1970: 0)
+                )
+                let backupURL = agents.appendingPathComponent("\(Agent.defaultId.uuidString).json.bak")
+                try seedLoadableAgentJSON(at: backupURL, agent: builtIn)
+
+                do {
+                    _ = try await MainActor.run {
+                        try AgentStore.restoreRecoverableBackup(at: backupURL)
+                    }
+                    Issue.record("expected built-in backup restore to fail")
+                } catch let error as AgentStore.RecoveryError {
+                    #expect(error == .builtInAgent("Osaurus"))
+                } catch {
+                    Issue.record("unexpected restore error: \(error)")
+                }
+
+                #expect(fm.fileExists(atPath: backupURL.path))
+                #expect(!fm.fileExists(atPath: backupURL.appendingPathExtension("restored").path))
+            }
+        }
+    }
+
+    @Test("Orphan backups with reused identity keep their id and clear address/index")
+    func orphanBackupWithReusedIdentityClearsAddressAndIndex() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot(name: "osaurus-personas-recover-identity") { _ in
+                let fm = FileManager.default
+                let agents = OsaurusPaths.agents()
+                try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+                let existingId = UUID()
+                let originalId = UUID()
+                let reusedAddress = "0xreused"
+                let existing = Agent(
+                    id: existingId,
+                    name: "Current",
+                    agentIndex: 5,
+                    agentAddress: reusedAddress
+                )
+                try seedLoadableAgentJSON(
+                    at: agents.appendingPathComponent("\(existingId.uuidString).json"),
+                    agent: existing
+                )
+
+                let orphan = Agent(
+                    id: originalId,
+                    name: "Orphan",
+                    systemPrompt: "orphan prompt",
+                    agentIndex: 5,
+                    agentAddress: reusedAddress,
+                    customAvatarFilename: "\(originalId.uuidString).png",
+                    order: 4
+                )
+                let backupURL = agents.appendingPathComponent("\(originalId.uuidString).json.bak")
+                try seedLoadableAgentJSON(at: backupURL, agent: orphan)
+
+                let backups = await MainActor.run { AgentStore.recoverableBackups() }
+                let backup = try #require(backups.first)
+                #expect(backups.count == 1)
+                #expect(backup.conflictsWithExistingAgent)
+
+                let restored = try await MainActor.run {
+                    try AgentStore.restoreRecoverableBackup(
+                        at: backup.url,
+                        recoveredAt: Date(timeIntervalSince1970: 1_800_000_100)
+                    )
+                }
+
+                #expect(restored.id == originalId)
+                #expect(restored.name == "Orphan")
+                #expect(restored.agentIndex == nil)
+                #expect(restored.agentAddress == nil)
+                #expect(restored.customAvatarFilename == "\(originalId.uuidString).png")
+                #expect(restored.order == 4)
+
+                let loaded = await MainActor.run { AgentStore.load(id: originalId) }
+                #expect(loaded?.agentIndex == nil)
+                #expect(loaded?.agentAddress == nil)
+
+                let stillExisting = await MainActor.run { AgentStore.load(id: existingId) }
+                #expect(stillExisting?.agentIndex == 5)
+                #expect(stillExisting?.agentAddress == reusedAddress)
+
+                #expect(!fm.fileExists(atPath: backupURL.path))
+                #expect(fm.fileExists(atPath: backupURL.appendingPathExtension("restored").path))
+            }
+        }
+    }
+
+    @Test("Failed backup consumption rolls back only the restored agent JSON")
+    func restoreConsumeFailureKeepsExistingAgentData() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withTemporaryOsaurusRoot(name: "osaurus-personas-recover-consume-failure") { root in
+                let fm = FileManager.default
+                let agents = OsaurusPaths.agents()
+                try fm.createDirectory(at: agents, withIntermediateDirectories: true)
+
+                let originalId = UUID()
+                let agentDirectory = OsaurusPaths.agentDirectory(for: originalId)
+                let databaseURL = OsaurusPaths.agentDatabaseFile(for: originalId)
+                try fm.createDirectory(
+                    at: agentDirectory,
+                    withIntermediateDirectories: true
+                )
+                try Data("existing db".utf8).write(to: databaseURL, options: .atomic)
+
+                let backupDirectory = root.appendingPathComponent(
+                    "locked-backups",
+                    isDirectory: true
+                )
+                try fm.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+                let backupURL = backupDirectory.appendingPathComponent(
+                    "\(originalId.uuidString).json.bak"
+                )
+                let orphan = Agent(
+                    id: originalId,
+                    name: "Orphan",
+                    systemPrompt: "restore should roll back JSON only"
+                )
+                try seedLoadableAgentJSON(at: backupURL, agent: orphan)
+                try fm.setAttributes(
+                    [.posixPermissions: NSNumber(value: 0o555)],
+                    ofItemAtPath: backupDirectory.path
+                )
+                defer {
+                    try? fm.setAttributes(
+                        [.posixPermissions: NSNumber(value: 0o755)],
+                        ofItemAtPath: backupDirectory.path
+                    )
+                }
+
+                do {
+                    _ = try await MainActor.run {
+                        try AgentStore.restoreRecoverableBackup(at: backupURL)
+                    }
+                    Issue.record("expected backup consumption to fail")
+                } catch let error as AgentStore.RecoveryError {
+                    #expect(error == .backupConsumedFailed(backupURL.lastPathComponent))
+                } catch {
+                    Issue.record("unexpected restore error: \(error)")
+                }
+
+                #expect(fm.fileExists(atPath: backupURL.path))
+                #expect(!fm.fileExists(
+                    atPath: agents.appendingPathComponent("\(originalId.uuidString).json").path
+                ))
+                #expect(fm.fileExists(atPath: databaseURL.path))
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a recoverable backup path for preserved legacy agent/persona migration artifacts. Agent backup files such as `<uuid>.json.bak` and numbered `<uuid>.json.1.bak` can now be discovered and restored without overwriting canonical agents.

Conflict restores are imported under a fresh UUID with identity fields cleared. Non-conflicting restores keep their original UUID, but reused crypto identities are detected and cleared before save so agent-scoped addresses are not duplicated. Successfully restored backups are moved out of the discoverable set with a `.restored` suffix.

The restore path also rolls back only the just-written agent JSON if backup consumption fails, preserving pre-existing per-agent data, rejects built-in backups without consuming them, and avoids explicit recovered-id collisions. `AgentManager.restoreRecoverableAgentBackup(at:)` refreshes the published list, assigns a fresh identity where needed, and posts `.agentAdded` with the restored id.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter OsaurusPersonasMigrationTests`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter AgentManagerLifecycleNotificationTests`

## Review

- Fable final review: stalled after the repo timeout window and was interrupted.
- Claude Opus fallback review: no blockers.
- Grok review: `--effort high` rejected by the installed `grok-composer-2.5-fast` model; rerun without `--effort` per repo guidance, no blockers.

## Notes

This is the model/manager recovery path for Wave 2D. UI wiring can call `AgentManager.restoreRecoverableAgentBackup(at:)` so the published agent list and lifecycle notifications stay aligned.