### PR TITLE
Decouple startup completion from plugin loading

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -33,6 +33,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     private var activityDot: NSView?
     private var vadDot: NSView?
     private var pendingPopoverAction: (@MainActor () -> Void)?
+    private var shouldLoadPluginsAfterFirstServerStart = false
+    private var hasCompletedFirstServerStartWork = false
+    private var launchEmbeddingInitTask: Task<Void, Never>?
     private var keychainDisabledTestMode: Bool {
         StorageKeyManager.disablesKeychainForProcess
     }
@@ -272,26 +275,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // Initialize directory access early so security-scoped bookmark is active
         _ = DirectoryPickerService.shared
 
+        let shouldLoadPluginsAtStartup = !keychainDisabledTestMode && !LaunchGuard.shouldSkip(.plugins)
+        shouldLoadPluginsAfterFirstServerStart = shouldLoadPluginsAtStartup
         if keychainDisabledTestMode {
             log.warning(
                 "Keychain disabled by OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1; stored secrets will not be readable in this process"
             )
             LaunchGuard.markStartupComplete()
-        } else if LaunchGuard.shouldSkip(.plugins) {
+        } else if !shouldLoadPluginsAtStartup {
             // Tiered safe mode: plugins are the first subsystem we drop. Other
             // tiers (sandbox / distillation / auto model-load) are gated at
             // their own start sites below via `LaunchGuard.shouldSkip(...)`.
             NotificationService.shared.postSafeModeActive()
-            LaunchGuard.markStartupComplete()
-        } else {
-            // Load external tool plugins at launch (after core is initialized)
-            Task { @MainActor in
-                await PluginManager.shared.loadAll()
-                LaunchGuard.markStartupComplete()
-            }
-
-            // Start plugin repository background refresh for update checking
-            PluginRepositoryService.shared.startBackgroundRefresh()
         }
 
         // Pre-warm cheap caches immediately for instant first window.
@@ -310,13 +305,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // emission would otherwise restart the server mid-launch (hang audit).
         Task { @MainActor in
             await serverStartupTask.value
-            serverController.markLaunchComplete()
-            // The unified prewarm builds the picker with whatever is currently
-            // available; once remote providers finish connecting below they post
-            // .remoteProviderModelsChanged and the cache rebuilds automatically.
-            // Keep this after server bind so very large local bundles cannot
-            // block `/health` and API startup while their config is inspected.
-            ModelPickerItemCache.shared.prewarm()
+            if serverController.isRunning {
+                completeFirstSuccessfulServerStart()
+            } else {
+                LaunchGuard.markStartupComplete()
+            }
         }
 
         // Only warm the storage key when the user opted in to encryption.
@@ -430,6 +423,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
 
             await ToolIndexService.shared.syncFromRegistry(rebuildVectorIndex: false)
         }
+        launchEmbeddingInitTask = embeddingInitTask
         // Start activity tracking, drain any pending sessions left over from
         // the previous launch, and arm the periodic consolidator.
         Task { @MainActor in
@@ -1349,8 +1343,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             .store(in: &cancellables)
         serverController.$isRunning
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] isRunning in
                 self?.updateStatusItemAndMenu()
+                if isRunning {
+                    self?.completeFirstSuccessfulServerStart()
+                }
             }
             .store(in: &cancellables)
         serverController.$configuration
@@ -1390,6 +1387,30 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             )
         }
         .store(in: &cancellables)
+    }
+
+    @MainActor
+    private func completeFirstSuccessfulServerStart() {
+        guard serverController.isRunning else { return }
+        guard !hasCompletedFirstServerStartWork else { return }
+        hasCompletedFirstServerStartWork = true
+
+        serverController.markLaunchComplete()
+        LaunchGuard.markStartupComplete()
+        // The unified prewarm builds the picker with whatever is currently
+        // available; once remote providers finish connecting below they post
+        // .remoteProviderModelsChanged and the cache rebuilds automatically.
+        // Keep this after server bind so very large local bundles cannot
+        // block `/health` and API startup while their config is inspected.
+        ModelPickerItemCache.shared.prewarm()
+        if shouldLoadPluginsAfterFirstServerStart {
+            // Keep plugin and repository work off the initial bind path;
+            // crashes here are handled by the plugin loading marker.
+            Task { @MainActor in
+                await PluginManager.shared.loadAll()
+            }
+            PluginRepositoryService.shared.startBackgroundRefresh()
+        }
     }
 
     private func updateStatusItemAndMenu() {
@@ -1629,9 +1650,11 @@ extension AppDelegate {
             forName: .safeModeRecoveryRequested,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] note in
+            let rawFeatures = note.userInfo?["recoveredFeatures"] as? Int ?? 0
             Task { @MainActor in
-                self?.recoverFromSafeMode()
+                let recoveredFeatures = LaunchGuard.Feature(rawValue: rawFeatures)
+                self?.recoverFromSafeMode(recoveredFeatures: recoveredFeatures)
             }
         }
     }
@@ -1639,21 +1662,36 @@ extension AppDelegate {
     /// Bring subsystems skipped by a degraded launch online after the running
     /// app proved healthy via `/health`. Idempotent and only ever runs once.
     @MainActor
-    private func recoverFromSafeMode() {
+    private func recoverFromSafeMode(recoveredFeatures: LaunchGuard.Feature) {
+        guard !recoveredFeatures.isEmpty else { return }
         guard !hasRecoveredFromSafeMode else { return }
         guard !keychainDisabledTestMode else { return }
         hasRecoveredFromSafeMode = true
         log.warning("Safe-mode recovery: starting previously skipped subsystems after clean /health")
 
-        Task { @MainActor in
-            await PluginManager.shared.loadAll()
+        if recoveredFeatures.contains(.plugins) {
+            Task { @MainActor in
+                await PluginManager.shared.loadAll()
+            }
+            PluginRepositoryService.shared.startBackgroundRefresh()
         }
-        PluginRepositoryService.shared.startBackgroundRefresh()
-        SandboxToolRegistrar.shared.start()
 
-        Task { @MainActor in
-            if MemoryDatabase.shared.isOpen {
-                await MemoryConsolidator.shared.start()
+        if recoveredFeatures.contains(.sandbox) {
+            SandboxToolRegistrar.shared.start()
+        }
+
+        if recoveredFeatures.contains(.distillation) {
+            Task { @MainActor [weak self] in
+                await self?.launchEmbeddingInitTask?.value
+                if MemoryDatabase.shared.isOpen {
+                    await MemoryConsolidator.shared.start()
+                }
+            }
+        }
+
+        if recoveredFeatures.contains(.autoModelLoad) {
+            Task { @MainActor in
+                await SpeechService.shared.autoLoadIfNeeded()
             }
         }
     }

--- a/Packages/OsaurusCore/Managers/LaunchGuard.swift
+++ b/Packages/OsaurusCore/Managers/LaunchGuard.swift
@@ -104,7 +104,6 @@ enum LaunchGuard {
         let defaults = UserDefaults.standard
         defaults.set(false, forKey: startupInProgressKey)
         defaults.set(0, forKey: crashCountKey)
-        disabledFeatures = []
     }
 
     /// Called when the running app serves a clean `/health`. Treats the

--- a/Packages/OsaurusCore/Tests/Service/LifecycleConcurrencyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LifecycleConcurrencyTests.swift
@@ -21,6 +21,7 @@ import Testing
 
 @testable import OsaurusCore
 
+@Suite(.serialized)
 struct LifecycleConcurrencyTests {
 
     // MARK: - runWithDeadline
@@ -149,5 +150,50 @@ struct LifecycleConcurrencyTests {
         #expect(combined.contains(.plugins))
         #expect(combined.contains(.sandbox))
         #expect(!combined.contains(.autoModelLoad))
+    }
+
+    @Test @MainActor func launchguard_startup_completion_preserves_safe_mode_until_health() {
+        let defaults = UserDefaults.standard
+        let startupInProgressKey = "LaunchGuard.startupInProgress"
+        let crashCountKey = "LaunchGuard.consecutiveCrashCount"
+        let previousInProgress = defaults.object(forKey: startupInProgressKey)
+        let previousCrashCount = defaults.object(forKey: crashCountKey)
+
+        defer {
+            LaunchGuard.noteHealthyHealthCheck()
+            if let previousInProgress {
+                defaults.set(previousInProgress, forKey: startupInProgressKey)
+            } else {
+                defaults.removeObject(forKey: startupInProgressKey)
+            }
+            if let previousCrashCount {
+                defaults.set(previousCrashCount, forKey: crashCountKey)
+            } else {
+                defaults.removeObject(forKey: crashCountKey)
+            }
+        }
+
+        defaults.set(true, forKey: startupInProgressKey)
+        defaults.set(4, forKey: crashCountKey)
+
+        #expect(LaunchGuard.checkOnLaunch())
+        #expect(LaunchGuard.shouldSkip(.plugins))
+        #expect(LaunchGuard.shouldSkip(.sandbox))
+        #expect(LaunchGuard.shouldSkip(.distillation))
+        #expect(LaunchGuard.shouldSkip(.autoModelLoad))
+
+        LaunchGuard.markStartupComplete()
+        #expect(LaunchGuard.shouldSkip(.plugins))
+        #expect(LaunchGuard.shouldSkip(.sandbox))
+        #expect(LaunchGuard.shouldSkip(.distillation))
+        #expect(LaunchGuard.shouldSkip(.autoModelLoad))
+        #expect(defaults.bool(forKey: startupInProgressKey) == false)
+        #expect(defaults.integer(forKey: crashCountKey) == 0)
+
+        LaunchGuard.noteHealthyHealthCheck()
+        #expect(!LaunchGuard.shouldSkip(.plugins))
+        #expect(!LaunchGuard.shouldSkip(.sandbox))
+        #expect(!LaunchGuard.shouldSkip(.distillation))
+        #expect(!LaunchGuard.shouldSkip(.autoModelLoad))
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1812,6 +1812,134 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("startup completion is tied to server bind, not plugin loading")
+    func startupCompletionIsTiedToServerBindNotPluginLoading() throws {
+        let appDelegate = try Self.source("AppDelegate.swift")
+        let launchBody = try Self.functionBody(
+            "public func applicationDidFinishLaunching(_ notification: Notification)",
+            in: appDelegate
+        )
+        let observerBody = try Self.functionBody("private func setupObservers()", in: appDelegate)
+        let successfulStartBody = try Self.functionBody(
+            "private func completeFirstSuccessfulServerStart()",
+            in: appDelegate
+        )
+
+        let startupCompleteCall = "LaunchGuard.markStartupComplete()"
+        let startupCompleteCount = appDelegate.components(separatedBy: startupCompleteCall).count - 1
+        #expect(
+            startupCompleteCount == 3,
+            "startup completion should only be cleared by the test-host branch, handled startup-error branch, and first-successful-server-start hook"
+        )
+
+        let serverBind = try #require(launchBody.range(of: "await serverStartupTask.value"))
+        let keychainBranch = try #require(launchBody.range(of: "if keychainDisabledTestMode {"))
+        let safeModeBranch = try #require(
+            launchBody.range(of: "} else if !shouldLoadPluginsAtStartup {", range: keychainBranch.upperBound ..< launchBody.endIndex)
+        )
+        let keychainStartupComplete = try #require(
+            launchBody.range(of: startupCompleteCall, range: keychainBranch.upperBound ..< safeModeBranch.lowerBound)
+        )
+        let runningCheck = try #require(launchBody.range(of: "if serverController.isRunning {"))
+        let completionHook = try #require(launchBody.range(of: "completeFirstSuccessfulServerStart()"))
+        let handledStartupErrorComplete = try #require(
+            launchBody.range(of: "LaunchGuard.markStartupComplete()", range: completionHook.upperBound ..< launchBody.endIndex)
+        )
+        let isRunningSink = try #require(observerBody.range(of: "serverController.$isRunning"))
+        let runningObserverHook = try #require(
+            observerBody.range(of: "if isRunning {\n                    self?.completeFirstSuccessfulServerStart()")
+        )
+        let configurationSink = try #require(observerBody.range(of: "serverController.$configuration"))
+        let successfulBindGuard = try #require(
+            successfulStartBody.range(of: "guard serverController.isRunning else { return }")
+        )
+        let firstSuccessGuard = try #require(
+            successfulStartBody.range(of: "guard !hasCompletedFirstServerStartWork else { return }")
+        )
+        let startupComplete = try #require(successfulStartBody.range(of: startupCompleteCall))
+        let pluginLoad = try #require(successfulStartBody.range(of: "await PluginManager.shared.loadAll()"))
+        let pluginRepositoryRefresh = try #require(
+            successfulStartBody.range(of: "PluginRepositoryService.shared.startBackgroundRefresh()")
+        )
+
+        #expect(
+            keychainBranch.lowerBound < keychainStartupComplete.lowerBound
+                && keychainStartupComplete.lowerBound < safeModeBranch.lowerBound,
+            "keychain-disabled test hosts must clear LaunchGuard without requiring a successful local bind"
+        )
+        #expect(
+            serverBind.lowerBound < runningCheck.lowerBound && runningCheck.lowerBound < completionHook.lowerBound,
+            "the initial server startup task must feed the first-successful-server-start hook only after checking bind success"
+        )
+        #expect(
+            completionHook.lowerBound < handledStartupErrorComplete.lowerBound,
+            "handled startup errors must clear LaunchGuard without running plugin or repository startup work"
+        )
+        #expect(
+            isRunningSink.lowerBound < runningObserverHook.lowerBound
+                && runningObserverHook.lowerBound < configurationSink.lowerBound,
+            "later successful starts must also feed the first-successful-server-start hook"
+        )
+        #expect(
+            successfulBindGuard.lowerBound < startupComplete.lowerBound,
+            "LaunchGuard must mark startup complete only after successful server startup"
+        )
+        #expect(
+            firstSuccessGuard.lowerBound < startupComplete.lowerBound,
+            "first-successful-server-start work must be idempotent across initial and later start notifications"
+        )
+        #expect(
+            startupComplete.lowerBound < pluginLoad.lowerBound,
+            "plugin loading must start after startup completion"
+        )
+        #expect(
+            startupComplete.lowerBound < pluginRepositoryRefresh.lowerBound,
+            "plugin repository refresh must start after startup completion"
+        )
+    }
+
+    @Test("safe-mode recovery restores all launch-skipped subsystems")
+    func safeModeRecoveryRestoresSkippedSubsystems() throws {
+        let appDelegate = try Self.source("AppDelegate.swift")
+        let observerBody = try Self.functionBody("private func setupSafeModeRecovery()", in: appDelegate)
+        let recoveryBody = try Self.functionBody(
+            "private func recoverFromSafeMode(recoveredFeatures: LaunchGuard.Feature)",
+            in: appDelegate
+        )
+
+        #expect(observerBody.contains("LaunchGuard.Feature(rawValue: rawFeatures)"))
+        #expect(
+            recoveryBody.contains("guard !recoveredFeatures.isEmpty else { return }"),
+            "safe-mode recovery must not burn its one-shot guard on a missing or empty recoveredFeatures payload"
+        )
+        #expect(
+            recoveryBody.contains(
+                "if recoveredFeatures.contains(.plugins)"
+            ) && recoveryBody.contains("await PluginManager.shared.loadAll()")
+        )
+        #expect(
+            recoveryBody.contains(
+                "if recoveredFeatures.contains(.plugins)"
+            ) && recoveryBody.contains("PluginRepositoryService.shared.startBackgroundRefresh()")
+        )
+        #expect(
+            recoveryBody.contains(
+                "if recoveredFeatures.contains(.sandbox)"
+            ) && recoveryBody.contains("SandboxToolRegistrar.shared.start()")
+        )
+        #expect(
+            recoveryBody.contains(
+                "if recoveredFeatures.contains(.distillation)"
+            ) && recoveryBody.contains("await MemoryConsolidator.shared.start()")
+                && recoveryBody.contains("await self?.launchEmbeddingInitTask?.value")
+        )
+        #expect(
+            recoveryBody.contains(
+                "if recoveredFeatures.contains(.autoModelLoad)"
+            ) && recoveryBody.contains("await SpeechService.shared.autoLoadIfNeeded()")
+        )
+    }
+
     @Test("live proof keychain-disabled mode keeps app startup off user Keychain")
     func liveProofKeychainDisabledModeKeepsStartupOffUserKeychain() throws {
         let paths = try Self.source("Utils/OsaurusPaths.swift")
@@ -1832,7 +1960,6 @@ struct RuntimePolicySourceTests {
         #expect(appDelegate.contains("OSAURUS_KEYCHAIN_FREE_SHOW_UI"))
         #expect(appDelegate.contains("Keychain disabled by OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1"))
         #expect(appDelegate.contains("if keychainDisabledTestMode {"))
-        #expect(appDelegate.contains("LaunchGuard.markStartupComplete()"))
         #expect(
             appDelegate.contains(
                 "if !keychainDisabledTestMode {\n                await MCPProviderManager.shared.connectEnabledProviders()"


### PR DESCRIPTION
## Summary

Moves post-bind startup completion, model-picker prewarm, plugin loading, and plugin repository refresh behind a one-shot first-successful-server-start hook, so plugin and repository work cannot block the local API bind or `/health` availability.

Keeps handled bind failures from being counted as startup crashes while still deferring plugin/repository/prewarm until a later successful server start.

Preserves LaunchGuard safe-mode disabled feature flags until `/health` proves the process healthy, then recovers only the tiers that were skipped, including sandbox, distillation, plugins, and speech auto-load.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter 'LifecycleConcurrencyTests|RuntimePolicySourceTests'`
  - Passed: 96 tests in 2 suites after 2.530s test execution; full rebuild completed successfully first.

## Review

- Fable/Claude review: no code blocker found at `c5d1275a5`; static cross-file contract verification passed. Fable could not run tests during review because the machine was out of disk space, then local validation was rerun and passed after freeing generated cache space.
- Grok review: ready for PR; no blockers found at `c5d1275a5`. `--effort high` was unsupported by installed `grok-composer-2.5-fast`, so fallback review without the effort flag was used.

## Notes

Wave 2C startup/network hang slice for R024/R033/R058. Plugin crashes after successful server startup are handled by the PluginManager loading marker/quarantine path; LaunchGuard persisted startup success now follows successful API startup or a handled startup error, not plugin load completion.