### PR TITLE
Cap sandbox plugin tool expansion

### DIFF
--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2435,6 +2435,43 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("Tools settings caps expanded tool groups to avoid eager scroll layout")
+    func toolsSettingsCapsExpandedToolGroups() throws {
+        let toolsView = try Self.source("Views/Plugin/ToolsManagerView.swift")
+
+        #expect(
+            toolsView.contains("let toolGroupRenderCapValue = 20"),
+            "Tools settings must keep a shared per-group render cap so large plugin/provider catalogs do not eagerly lay out every row while scrolling."
+        )
+        #expect(
+            toolsView.contains("private func cappedGroup<Row: View>"),
+            "Flat built-in/runtime tool groups should use the shared capped renderer."
+        )
+        #expect(
+            toolsView.contains("private var visibleTools: [ToolRegistry.ToolEntry]")
+                && toolsView.contains("ShowAllToolsButton("),
+            "Plugin and remote provider cards should cap expanded rows and expose an explicit show-all control."
+        )
+
+        let sandboxCardStart = try #require(toolsView.range(of: "private struct SandboxPluginToolCard"))
+        let hoverBackgroundStart = try #require(
+            toolsView.range(
+                of: "private struct HoverableCardBackground",
+                range: sandboxCardStart.upperBound ..< toolsView.endIndex
+            )
+        )
+        let sandboxCard = String(toolsView[sandboxCardStart.lowerBound ..< hoverBackgroundStart.lowerBound])
+
+        #expect(
+            sandboxCard.contains("@State private var showAllTools = false")
+                && sandboxCard.contains("private var visibleToolSpecs: [SandboxToolSpec]")
+                && sandboxCard.contains("toolGroupRenderCapValue")
+                && sandboxCard.contains("ForEach(visibleToolSpecs, id: \\.id)")
+                && sandboxCard.contains("ShowAllToolsButton("),
+            "Sandbox plugin cards must use the same capped expansion path as other tool cards; otherwise a large JSON tool recipe can freeze the Tools page."
+        )
+    }
+
     @Test("local decode loop keeps tool schemas for parser-side argument validation")
     func localDecodeLoopKeepsToolSchemasForParserValidation() throws {
         let chatEngine = try Self.source("Services/Chat/ChatEngine.swift")

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -1339,13 +1339,16 @@ private struct SandboxPluginToolCard: View {
 
     @State private var isExpanded = false
     @State private var isMenuHovering = false
+    @State private var showAllTools = false
 
     private var toolCount: Int {
         plugin.tools?.count ?? 0
     }
 
-    private var toolNames: [String] {
-        plugin.tools?.map { "\(plugin.id)_\($0.id)" } ?? []
+    private var visibleToolSpecs: [SandboxToolSpec] {
+        guard let tools = plugin.tools else { return [] }
+        let cap = toolGroupRenderCapValue
+        return (showAllTools || tools.count <= cap) ? tools : Array(tools.prefix(cap))
     }
 
     var body: some View {
@@ -1452,10 +1455,19 @@ private struct SandboxPluginToolCard: View {
 
                 if let tools = plugin.tools, !tools.isEmpty {
                     VStack(spacing: 8) {
-                        ForEach(tools, id: \.id) { spec in
+                        ForEach(visibleToolSpecs, id: \.id) { spec in
                             let toolName = "\(plugin.id)_\(spec.id)"
                             let entry = ToolRegistry.shared.entry(named: toolName)
                             sandboxToolRow(spec: spec, entry: entry)
+                        }
+
+                        if tools.count > toolGroupRenderCapValue {
+                            ShowAllToolsButton(
+                                hiddenCount: tools.count - toolGroupRenderCapValue,
+                                isExpanded: showAllTools
+                            ) {
+                                showAllTools.toggle()
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
## Summary

Caps expanded sandbox plugin tool rows using the shared Tools-page render cap, matching the existing plugin/provider card behavior.

This prevents a large JSON sandbox plugin from eagerly laying out every tool row when a user expands the card, which hardens the R011 Tools page scroll/freeze path.

Adds a source-policy regression test covering the shared Tools-page render-cap contract, including the sandbox plugin card.

## Validation

- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-tools-scroll-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests`
  - Passed: 87 tests in 1 suite after 1.317s test execution; full cold build completed successfully first.

## Review

- Fable/Claude review: no blockers; confirmed the sandbox card now mirrors the existing capped plugin/provider card pattern.
- Grok review: no blockers; `--effort high` was unsupported by installed `grok-composer-2.5-fast`, so fallback review without effort was used.

## Notes

Wave 2C R011 Tools page scroll/freeze hardening. Main already had prior fixes for the global Tools page and plugin/provider cards; this closes the analogous sandbox plugin expansion path.