### PR TITLE
Bound skill archive subprocesses

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
+++ b/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
@@ -239,17 +239,58 @@ struct SkillArchiveProcessResult: Sendable, Equatable {
     let timedOut: Bool
 }
 
+enum SkillArchiveProcessRunnerError: Error, Sendable, Equatable {
+    case outputDrainIncomplete
+}
+
+protocol SkillArchiveProcessOutputStreaming: Sendable {
+    func start(
+        onChunk: @escaping @Sendable (Data) -> Void,
+        onCompletion: @escaping @Sendable ((any Error)?) -> Void
+    )
+    func cancel()
+}
+
+struct SkillArchiveProcessConfiguration: Sendable {
+    static let `default` = SkillArchiveProcessConfiguration()
+
+    let outputLimitBytes: Int
+    let chunkBytes: Int
+    let cleanupGraceSeconds: TimeInterval
+    let outputStream: (any SkillArchiveProcessOutputStreaming)?
+
+    init(
+        outputLimitBytes: Int = 256 * 1024,
+        chunkBytes: Int = 16 * 1024,
+        cleanupGraceSeconds: TimeInterval = 2,
+        outputStream: (any SkillArchiveProcessOutputStreaming)? = nil
+    ) {
+        self.outputLimitBytes = outputLimitBytes
+        self.chunkBytes = chunkBytes
+        self.cleanupGraceSeconds = cleanupGraceSeconds
+        self.outputStream = outputStream
+    }
+}
+
 enum SkillArchiveProcessRunner {
-    private static let outputLimitBytes = 256 * 1024
-    private static let chunkBytes = 16 * 1024
-    private static let forcedKillGraceSeconds: TimeInterval = 2
+    private static let waitPollNanoseconds = 50_000_000
+
+    private enum WaitOutcome {
+        case exited
+        case timedOut
+        case cancelled
+        case outputReadFailed
+    }
 
     static func run(
         executablePath: String,
         arguments: [String],
         currentDirectoryURL: URL? = nil,
-        timeoutSeconds: TimeInterval
+        timeoutSeconds: TimeInterval,
+        configuration: SkillArchiveProcessConfiguration = .default
     ) throws -> SkillArchiveProcessResult {
+        if Task.isCancelled { throw CancellationError() }
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
@@ -265,34 +306,112 @@ enum SkillArchiveProcessRunner {
         }
 
         try process.run()
+        try? pipe.fileHandleForWriting.close()
 
+        let outputStream = configuration.outputStream
+            ?? SkillArchiveDispatchOutputStream(
+                fileHandle: pipe.fileHandleForReading,
+                chunkBytes: configuration.chunkBytes
+            )
         let reader = SkillArchiveProcessOutputReader(
-            fileHandle: pipe.fileHandleForReading,
-            maxBytes: outputLimitBytes,
-            chunkBytes: chunkBytes
+            outputStream: outputStream,
+            maxBytes: configuration.outputLimitBytes
         )
         reader.start()
 
-        let deadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(timeoutSeconds))
-        let timedOut = terminated.wait(timeout: deadline) == .timedOut
-        if timedOut {
-            process.terminate()
-            let graceDeadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(forcedKillGraceSeconds))
-            if terminated.wait(timeout: graceDeadline) == .timedOut {
-                Darwin.kill(process.processIdentifier, SIGKILL)
-                _ = terminated.wait(timeout: DispatchTime.now() + .nanoseconds(Self.nanoseconds(forcedKillGraceSeconds)))
+        let waitOutcome = Self.waitForProcess(
+            terminated: terminated,
+            reader: reader,
+            timeoutSeconds: timeoutSeconds
+        )
+        switch waitOutcome {
+        case .exited:
+            process.waitUntilExit()
+        case .timedOut, .cancelled, .outputReadFailed:
+            Self.stopAndReap(
+                process,
+                terminated: terminated,
+                graceSeconds: configuration.cleanupGraceSeconds
+            )
+        }
+        process.terminationHandler = nil
+
+        let completion: SkillArchiveProcessOutputCompletion
+        if let drained = reader.waitForEnd(timeoutSeconds: configuration.cleanupGraceSeconds) {
+            completion = drained
+        } else {
+            // DispatchIO cancellation waits for its cleanup callback, so no
+            // descriptor callback can race deletion of an extraction directory.
+            _ = reader.cancelAndWait()
+            if waitOutcome == .cancelled || Task.isCancelled {
+                throw CancellationError()
+            }
+            throw SkillArchiveProcessRunnerError.outputDrainIncomplete
+        }
+
+        if waitOutcome == .cancelled || Task.isCancelled {
+            throw CancellationError()
+        }
+        if let readError = completion.readError {
+            throw readError
+        }
+
+        return SkillArchiveProcessResult(
+            terminationStatus: process.terminationStatus,
+            output: completion.output,
+            outputTruncated: completion.outputWasTruncated,
+            timedOut: waitOutcome == .timedOut
+        )
+    }
+
+    private static func waitForProcess(
+        terminated: DispatchSemaphore,
+        reader: SkillArchiveProcessOutputReader,
+        timeoutSeconds: TimeInterval
+    ) -> WaitOutcome {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        let timeoutNanoseconds = UInt64(Self.nanoseconds(timeoutSeconds))
+        let (candidateDeadline, overflow) = startedAt.addingReportingOverflow(timeoutNanoseconds)
+        let deadline = overflow ? UInt64.max : candidateDeadline
+
+        while true {
+            if Task.isCancelled { return .cancelled }
+            if reader.readErrorDetected { return .outputReadFailed }
+            if terminated.wait(timeout: .now()) == .success { return .exited }
+
+            let now = DispatchTime.now().uptimeNanoseconds
+            guard now < deadline else { return .timedOut }
+            let remaining = deadline - now
+            let waitNanoseconds = Int(min(remaining, UInt64(Self.waitPollNanoseconds)))
+            if terminated.wait(timeout: .now() + .nanoseconds(waitNanoseconds)) == .success {
+                return .exited
+            }
+        }
+    }
+
+    private static func stopAndReap(
+        _ process: Process,
+        terminated: DispatchSemaphore,
+        graceSeconds: TimeInterval
+    ) {
+        if terminated.wait(timeout: .now()) == .timedOut {
+            if process.isRunning {
+                process.terminate()
+            }
+
+            let graceDeadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(graceSeconds))
+            if terminated.wait(timeout: graceDeadline) == .timedOut,
+                terminated.wait(timeout: .now()) == .timedOut,
+                process.isRunning {
+                // The termination latch is checked immediately before SIGKILL
+                // so Foundation has not announced and reaped this child PID.
+                _ = Darwin.kill(process.processIdentifier, SIGKILL)
             }
         }
 
-        _ = reader.waitForEnd(timeoutSeconds: forcedKillGraceSeconds)
-
-        let status = process.isRunning ? Int32(-1) : process.terminationStatus
-        return SkillArchiveProcessResult(
-            terminationStatus: status,
-            output: reader.outputString,
-            outputTruncated: reader.outputWasTruncated,
-            timedOut: timedOut
-        )
+        // Cleanup callers may remove process inputs and outputs as soon as run
+        // returns, so a bounded post-kill wait is not sufficient here.
+        process.waitUntilExit()
     }
 
     private static func nanoseconds(_ seconds: TimeInterval) -> Int {
@@ -303,55 +422,62 @@ enum SkillArchiveProcessRunner {
     }
 }
 
+private struct SkillArchiveProcessOutputCompletion {
+    let output: String
+    let outputWasTruncated: Bool
+    let readError: (any Error)?
+}
+
 private final class SkillArchiveProcessOutputReader: @unchecked Sendable {
-    private let fileHandle: FileHandle
+    private let outputStream: any SkillArchiveProcessOutputStreaming
     private let maxBytes: Int
-    private let chunkBytes: Int
     private let lock = NSLock()
     private let done = DispatchSemaphore(value: 0)
     private var data = Data()
     private var truncated = false
+    private var readError: (any Error)?
+    private var finished = false
 
-    init(fileHandle: FileHandle, maxBytes: Int, chunkBytes: Int) {
-        self.fileHandle = fileHandle
+    init(outputStream: any SkillArchiveProcessOutputStreaming, maxBytes: Int) {
+        self.outputStream = outputStream
         self.maxBytes = maxBytes
-        self.chunkBytes = chunkBytes
     }
 
     func start() {
-        DispatchQueue.global(qos: .utility).async {
-            defer { self.done.signal() }
-            while true {
-                let chunk = (try? self.fileHandle.read(upToCount: self.chunkBytes)) ?? Data()
-                if chunk.isEmpty { return }
-                self.append(chunk)
-            }
-        }
+        outputStream.start(
+            onChunk: { [self] chunk in append(chunk) },
+            onCompletion: { [self] error in finish(with: error) }
+        )
     }
 
-    func waitForEnd(timeoutSeconds: TimeInterval) -> Bool {
+    func waitForEnd(timeoutSeconds: TimeInterval) -> SkillArchiveProcessOutputCompletion? {
         let deadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(timeoutSeconds))
-        return done.wait(timeout: deadline) == .success
+        guard done.wait(timeout: deadline) == .success else { return nil }
+        return completionSnapshot()
     }
 
-    var outputString: String {
-        lock.lock()
-        let snapshot = data
-        let wasTruncated = truncated
-        lock.unlock()
+    func cancelAndWait() -> SkillArchiveProcessOutputCompletion {
+        outputStream.cancel()
+        done.wait()
+        return completionSnapshot()
+    }
 
-        var output = String(data: snapshot, encoding: .utf8) ?? ""
-        if wasTruncated {
-            output += "\n[output truncated]"
+    var readErrorDetected: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return readError != nil
+    }
+
+    private func finish(with error: (any Error)?) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
         }
-        return output
-    }
-
-    var outputWasTruncated: Bool {
-        lock.lock()
-        let wasTruncated = truncated
+        readError = error
+        finished = true
         lock.unlock()
-        return wasTruncated
+        done.signal()
     }
 
     private func append(_ chunk: Data) {
@@ -372,10 +498,136 @@ private final class SkillArchiveProcessOutputReader: @unchecked Sendable {
         }
     }
 
+    private func completionSnapshot() -> SkillArchiveProcessOutputCompletion {
+        lock.lock()
+        let snapshot = data
+        let wasTruncated = truncated
+        let error = readError
+        lock.unlock()
+
+        var output = String(data: snapshot, encoding: .utf8) ?? ""
+        if wasTruncated {
+            output += "\n[output truncated]"
+        }
+        return SkillArchiveProcessOutputCompletion(
+            output: output,
+            outputWasTruncated: wasTruncated,
+            readError: error
+        )
+    }
+
     private static func nanoseconds(_ seconds: TimeInterval) -> Int {
         guard seconds.isFinite, seconds > 0 else { return 0 }
         let maxSafeSeconds = TimeInterval(Int.max / 1_000_000_000)
         if seconds >= maxSafeSeconds { return Int.max }
         return Int(seconds * 1_000_000_000)
+    }
+}
+
+/// DispatchIO owns descriptor access until its cleanup callback runs. Retaining
+/// the FileHandle prevents ARC from closing that descriptor before the join.
+private final class SkillArchiveDispatchOutputStream: SkillArchiveProcessOutputStreaming, @unchecked Sendable {
+    private let state: SkillArchiveDispatchOutputState
+    private let channel: DispatchIO
+    private let fileHandle: FileHandle
+    private let chunkBytes: Int
+    private let queue = DispatchQueue(label: "ai.osaurus.skill-archive-output", qos: .utility)
+
+    init(fileHandle: FileHandle, chunkBytes: Int) {
+        let state = SkillArchiveDispatchOutputState()
+        self.state = state
+        self.fileHandle = fileHandle
+        self.chunkBytes = chunkBytes
+        self.channel = DispatchIO(
+            type: .stream,
+            fileDescriptor: fileHandle.fileDescriptor,
+            queue: queue
+        ) { errorCode in
+            state.finishCleanup(errorCode: errorCode)
+        }
+    }
+
+    func start(
+        onChunk: @escaping @Sendable (Data) -> Void,
+        onCompletion: @escaping @Sendable ((any Error)?) -> Void
+    ) {
+        state.installCompletion(onCompletion)
+        channel.setLimit(lowWater: chunkBytes)
+        channel.read(offset: 0, length: Int.max, queue: queue) { [weak self] done, dispatchData, errorCode in
+            guard let self else { return }
+            if let dispatchData, !dispatchData.isEmpty {
+                onChunk(Data(dispatchData))
+            }
+
+            guard done || errorCode != 0 else { return }
+            if state.requestClose(errorCode: errorCode) {
+                channel.close(flags: errorCode == 0 ? [] : .stop)
+            }
+        }
+    }
+
+    func cancel() {
+        if state.requestClose(errorCode: ECANCELED) {
+            channel.close(flags: .stop)
+        }
+    }
+}
+
+private final class SkillArchiveDispatchOutputState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completionHandler: (@Sendable ((any Error)?) -> Void)?
+    private var pendingError: (any Error)?
+    private var closeRequested = false
+    private var cleanupFinished = false
+    private var completionDelivered = false
+
+    func installCompletion(_ handler: @escaping @Sendable ((any Error)?) -> Void) {
+        lock.lock()
+        completionHandler = handler
+        let shouldDeliver = cleanupFinished && !completionDelivered
+        if shouldDeliver {
+            completionDelivered = true
+            completionHandler = nil
+        }
+        let error = pendingError
+        lock.unlock()
+
+        if shouldDeliver {
+            handler(error)
+        }
+    }
+
+    func requestClose(errorCode: Int32) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !closeRequested else { return false }
+
+        closeRequested = true
+        if errorCode != 0 {
+            pendingError = Self.posixError(errorCode)
+        }
+        return true
+    }
+
+    func finishCleanup(errorCode: Int32) {
+        lock.lock()
+        if pendingError == nil, errorCode != 0 {
+            pendingError = Self.posixError(errorCode)
+        }
+        cleanupFinished = true
+        guard let handler = completionHandler, !completionDelivered else {
+            lock.unlock()
+            return
+        }
+
+        completionDelivered = true
+        let error = pendingError
+        completionHandler = nil
+        lock.unlock()
+        handler(error)
+    }
+
+    private static func posixError(_ code: Int32) -> any Error {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(code))
     }
 }

--- a/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
+++ b/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
@@ -6,6 +6,7 @@
 //  persisted skill store.
 //
 
+import Darwin
 import Foundation
 
 /// Import limits for a third-party skill bundle. The defaults are intentionally
@@ -177,23 +178,29 @@ public struct SkillImportPolicy: Sendable, Equatable {
     }
 
     private static func listArchiveEntries(in zipURL: URL) throws -> [SkillArchiveEntry] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        process.arguments = ["-l", zipURL.path]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-
-        try process.run()
-        process.waitUntilExit()
-
-        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        guard process.terminationStatus == 0 else {
-            throw SkillFileError.archiveListingFailed(output.trimmingCharacters(in: .whitespacesAndNewlines))
+        let result: SkillArchiveProcessResult
+        do {
+            result = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/unzip",
+                arguments: ["-l", zipURL.path],
+                timeoutSeconds: 30
+            )
+        } catch {
+            throw SkillFileError.archiveListingFailed(error.localizedDescription)
         }
 
-        return output.split(separator: "\n").compactMap { line -> SkillArchiveEntry? in
+        if result.timedOut {
+            throw SkillFileError.archiveListingFailed(L("inspection timed out after 30 seconds"))
+        }
+
+        guard result.terminationStatus == 0 else {
+            throw SkillFileError.archiveListingFailed(result.output.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        if result.outputTruncated {
+            throw SkillFileError.archiveListingFailed(L("inspection output exceeded the supported limit"))
+        }
+
+        return result.output.split(separator: "\n").compactMap { line -> SkillArchiveEntry? in
             let parts = line.split(separator: " ", omittingEmptySubsequences: true)
             guard parts.count >= 4, let size = Int64(parts[0]) else {
                 return nil
@@ -223,4 +230,152 @@ public struct SkillImportPlan: Sendable, Equatable {
 public struct SkillImportResult: Sendable, Equatable {
     public let skill: Skill
     public let notes: [String]
+}
+
+struct SkillArchiveProcessResult: Sendable, Equatable {
+    let terminationStatus: Int32
+    let output: String
+    let outputTruncated: Bool
+    let timedOut: Bool
+}
+
+enum SkillArchiveProcessRunner {
+    private static let outputLimitBytes = 256 * 1024
+    private static let chunkBytes = 16 * 1024
+    private static let forcedKillGraceSeconds: TimeInterval = 2
+
+    static func run(
+        executablePath: String,
+        arguments: [String],
+        currentDirectoryURL: URL? = nil,
+        timeoutSeconds: TimeInterval
+    ) throws -> SkillArchiveProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectoryURL
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        let terminated = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            terminated.signal()
+        }
+
+        try process.run()
+
+        let reader = SkillArchiveProcessOutputReader(
+            fileHandle: pipe.fileHandleForReading,
+            maxBytes: outputLimitBytes,
+            chunkBytes: chunkBytes
+        )
+        reader.start()
+
+        let deadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(timeoutSeconds))
+        let timedOut = terminated.wait(timeout: deadline) == .timedOut
+        if timedOut {
+            process.terminate()
+            let graceDeadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(forcedKillGraceSeconds))
+            if terminated.wait(timeout: graceDeadline) == .timedOut {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                _ = terminated.wait(timeout: DispatchTime.now() + .nanoseconds(Self.nanoseconds(forcedKillGraceSeconds)))
+            }
+        }
+
+        _ = reader.waitForEnd(timeoutSeconds: forcedKillGraceSeconds)
+
+        let status = process.isRunning ? Int32(-1) : process.terminationStatus
+        return SkillArchiveProcessResult(
+            terminationStatus: status,
+            output: reader.outputString,
+            outputTruncated: reader.outputWasTruncated,
+            timedOut: timedOut
+        )
+    }
+
+    private static func nanoseconds(_ seconds: TimeInterval) -> Int {
+        guard seconds.isFinite, seconds > 0 else { return 0 }
+        let maxSafeSeconds = TimeInterval(Int.max / 1_000_000_000)
+        if seconds >= maxSafeSeconds { return Int.max }
+        return Int(seconds * 1_000_000_000)
+    }
+}
+
+private final class SkillArchiveProcessOutputReader: @unchecked Sendable {
+    private let fileHandle: FileHandle
+    private let maxBytes: Int
+    private let chunkBytes: Int
+    private let lock = NSLock()
+    private let done = DispatchSemaphore(value: 0)
+    private var data = Data()
+    private var truncated = false
+
+    init(fileHandle: FileHandle, maxBytes: Int, chunkBytes: Int) {
+        self.fileHandle = fileHandle
+        self.maxBytes = maxBytes
+        self.chunkBytes = chunkBytes
+    }
+
+    func start() {
+        DispatchQueue.global(qos: .utility).async {
+            defer { self.done.signal() }
+            while true {
+                let chunk = (try? self.fileHandle.read(upToCount: self.chunkBytes)) ?? Data()
+                if chunk.isEmpty { return }
+                self.append(chunk)
+            }
+        }
+    }
+
+    func waitForEnd(timeoutSeconds: TimeInterval) -> Bool {
+        let deadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(timeoutSeconds))
+        return done.wait(timeout: deadline) == .success
+    }
+
+    var outputString: String {
+        lock.lock()
+        let snapshot = data
+        let wasTruncated = truncated
+        lock.unlock()
+
+        var output = String(data: snapshot, encoding: .utf8) ?? ""
+        if wasTruncated {
+            output += "\n[output truncated]"
+        }
+        return output
+    }
+
+    var outputWasTruncated: Bool {
+        lock.lock()
+        let wasTruncated = truncated
+        lock.unlock()
+        return wasTruncated
+    }
+
+    private func append(_ chunk: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let remaining = maxBytes - data.count
+        if remaining <= 0 {
+            truncated = true
+            return
+        }
+
+        if chunk.count <= remaining {
+            data.append(chunk)
+        } else {
+            data.append(contentsOf: chunk.prefix(remaining))
+            truncated = true
+        }
+    }
+
+    private static func nanoseconds(_ seconds: TimeInterval) -> Int {
+        guard seconds.isFinite, seconds > 0 else { return 0 }
+        let maxSafeSeconds = TimeInterval(Int.max / 1_000_000_000)
+        if seconds >= maxSafeSeconds { return Int.max }
+        return Int(seconds * 1_000_000_000)
+    }
 }

--- a/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
+++ b/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
@@ -182,9 +182,11 @@ public struct SkillImportPolicy: Sendable, Equatable {
         do {
             result = try SkillArchiveProcessRunner.run(
                 executablePath: "/usr/bin/unzip",
-                arguments: ["-l", zipURL.path],
+                arguments: ["-l", "--", zipURL.path],
                 timeoutSeconds: 30
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw SkillFileError.archiveListingFailed(error.localizedDescription)
         }
@@ -241,6 +243,7 @@ struct SkillArchiveProcessResult: Sendable, Equatable {
 
 enum SkillArchiveProcessRunnerError: Error, Sendable, Equatable {
     case outputDrainIncomplete
+    case processTerminationIncomplete
 }
 
 protocol SkillArchiveProcessOutputStreaming: Sendable {
@@ -258,17 +261,30 @@ struct SkillArchiveProcessConfiguration: Sendable {
     let chunkBytes: Int
     let cleanupGraceSeconds: TimeInterval
     let outputStream: (any SkillArchiveProcessOutputStreaming)?
+    let deferredCleanupURL: URL?
 
     init(
         outputLimitBytes: Int = 256 * 1024,
         chunkBytes: Int = 16 * 1024,
         cleanupGraceSeconds: TimeInterval = 2,
-        outputStream: (any SkillArchiveProcessOutputStreaming)? = nil
+        outputStream: (any SkillArchiveProcessOutputStreaming)? = nil,
+        deferredCleanupURL: URL? = nil
     ) {
         self.outputLimitBytes = outputLimitBytes
         self.chunkBytes = chunkBytes
         self.cleanupGraceSeconds = cleanupGraceSeconds
         self.outputStream = outputStream
+        self.deferredCleanupURL = deferredCleanupURL
+    }
+
+    func withDeferredCleanupURL(_ url: URL) -> Self {
+        Self(
+            outputLimitBytes: outputLimitBytes,
+            chunkBytes: chunkBytes,
+            cleanupGraceSeconds: cleanupGraceSeconds,
+            outputStream: outputStream,
+            deferredCleanupURL: url
+        )
     }
 }
 
@@ -280,6 +296,11 @@ enum SkillArchiveProcessRunner {
         case timedOut
         case cancelled
         case outputReadFailed
+    }
+
+    private enum ReapOutcome {
+        case reaped
+        case incomplete
     }
 
     static func run(
@@ -300,23 +321,33 @@ enum SkillArchiveProcessRunner {
         process.standardOutput = pipe
         process.standardError = pipe
 
-        let terminated = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            terminated.signal()
-        }
-
-        try process.run()
-        try? pipe.fileHandleForWriting.close()
-
-        let outputStream = configuration.outputStream
-            ?? SkillArchiveDispatchOutputStream(
+        let outputStream: any SkillArchiveProcessOutputStreaming
+        if let configuredStream = configuration.outputStream {
+            try? pipe.fileHandleForReading.close()
+            outputStream = configuredStream
+        } else {
+            outputStream = try SkillArchiveDispatchOutputStream(
                 fileHandle: pipe.fileHandleForReading,
                 chunkBytes: configuration.chunkBytes
             )
+        }
         let reader = SkillArchiveProcessOutputReader(
             outputStream: outputStream,
             maxBytes: configuration.outputLimitBytes
         )
+
+        let terminated = SkillArchiveProcessTerminationLatch()
+        process.terminationHandler = { _ in
+            terminated.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            process.terminationHandler = nil
+            throw error
+        }
+        try? pipe.fileHandleForWriting.close()
         reader.start()
 
         let waitOutcome = Self.waitForProcess(
@@ -324,31 +355,54 @@ enum SkillArchiveProcessRunner {
             reader: reader,
             timeoutSeconds: timeoutSeconds
         )
+        let reapOutcome: ReapOutcome
         switch waitOutcome {
         case .exited:
-            process.waitUntilExit()
+            reapOutcome = .reaped
         case .timedOut, .cancelled, .outputReadFailed:
-            Self.stopAndReap(
+            reapOutcome = Self.stopAndReap(
                 process,
                 terminated: terminated,
                 graceSeconds: configuration.cleanupGraceSeconds
             )
         }
-        process.terminationHandler = nil
+
+        let terminationStatus: Int32?
+        switch reapOutcome {
+        case .reaped:
+            terminationStatus = process.terminationStatus
+            process.terminationHandler = nil
+        case .incomplete:
+            terminationStatus = nil
+            SkillArchiveDeferredProcessReaper.shared.adopt(
+                process,
+                terminated: terminated,
+                cleanupURL: configuration.deferredCleanupURL
+            )
+        }
 
         let completion: SkillArchiveProcessOutputCompletion
         if let drained = reader.waitForEnd(timeoutSeconds: configuration.cleanupGraceSeconds) {
             completion = drained
         } else {
-            // DispatchIO cancellation waits for its cleanup callback, so no
-            // descriptor callback can race deletion of an extraction directory.
-            _ = reader.cancelAndWait()
+            let cancelledDrain = reader.cancelAndWait(
+                timeoutSeconds: configuration.cleanupGraceSeconds
+            )
+            if reapOutcome == .incomplete {
+                throw SkillArchiveProcessRunnerError.processTerminationIncomplete
+            }
+            guard cancelledDrain != nil else {
+                throw SkillArchiveProcessRunnerError.outputDrainIncomplete
+            }
             if waitOutcome == .cancelled || Task.isCancelled {
                 throw CancellationError()
             }
             throw SkillArchiveProcessRunnerError.outputDrainIncomplete
         }
 
+        guard let terminationStatus else {
+            throw SkillArchiveProcessRunnerError.processTerminationIncomplete
+        }
         if waitOutcome == .cancelled || Task.isCancelled {
             throw CancellationError()
         }
@@ -357,7 +411,7 @@ enum SkillArchiveProcessRunner {
         }
 
         return SkillArchiveProcessResult(
-            terminationStatus: process.terminationStatus,
+            terminationStatus: terminationStatus,
             output: completion.output,
             outputTruncated: completion.outputWasTruncated,
             timedOut: waitOutcome == .timedOut
@@ -365,7 +419,7 @@ enum SkillArchiveProcessRunner {
     }
 
     private static func waitForProcess(
-        terminated: DispatchSemaphore,
+        terminated: SkillArchiveProcessTerminationLatch,
         reader: SkillArchiveProcessOutputReader,
         timeoutSeconds: TimeInterval
     ) -> WaitOutcome {
@@ -377,13 +431,13 @@ enum SkillArchiveProcessRunner {
         while true {
             if Task.isCancelled { return .cancelled }
             if reader.readErrorDetected { return .outputReadFailed }
-            if terminated.wait(timeout: .now()) == .success { return .exited }
+            if terminated.wait(timeout: .now()) { return .exited }
 
             let now = DispatchTime.now().uptimeNanoseconds
             guard now < deadline else { return .timedOut }
             let remaining = deadline - now
             let waitNanoseconds = Int(min(remaining, UInt64(Self.waitPollNanoseconds)))
-            if terminated.wait(timeout: .now() + .nanoseconds(waitNanoseconds)) == .success {
+            if terminated.wait(timeout: .now() + .nanoseconds(waitNanoseconds)) {
                 return .exited
             }
         }
@@ -391,27 +445,22 @@ enum SkillArchiveProcessRunner {
 
     private static func stopAndReap(
         _ process: Process,
-        terminated: DispatchSemaphore,
+        terminated: SkillArchiveProcessTerminationLatch,
         graceSeconds: TimeInterval
-    ) {
-        if terminated.wait(timeout: .now()) == .timedOut {
-            if process.isRunning {
-                process.terminate()
-            }
+    ) -> ReapOutcome {
+        if terminated.wait(timeout: .now()) { return .reaped }
 
-            let graceDeadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(graceSeconds))
-            if terminated.wait(timeout: graceDeadline) == .timedOut,
-                terminated.wait(timeout: .now()) == .timedOut,
-                process.isRunning {
-                // The termination latch is checked immediately before SIGKILL
-                // so Foundation has not announced and reaped this child PID.
-                _ = Darwin.kill(process.processIdentifier, SIGKILL)
-            }
+        if process.isRunning {
+            process.terminate()
         }
+        let terminationDeadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(graceSeconds))
+        if terminated.wait(timeout: terminationDeadline) { return .reaped }
 
-        // Cleanup callers may remove process inputs and outputs as soon as run
-        // returns, so a bounded post-kill wait is not sufficient here.
-        process.waitUntilExit()
+        if !terminated.isTerminated, process.isRunning {
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        }
+        let killDeadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(graceSeconds))
+        return terminated.wait(timeout: killDeadline) ? .reaped : .incomplete
     }
 
     private static func nanoseconds(_ seconds: TimeInterval) -> Int {
@@ -419,6 +468,95 @@ enum SkillArchiveProcessRunner {
         let maxSafeSeconds = TimeInterval(Int.max / 1_000_000_000)
         if seconds >= maxSafeSeconds { return Int.max }
         return Int(seconds * 1_000_000_000)
+    }
+}
+
+private final class SkillArchiveProcessTerminationLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var terminated = false
+    private var observers: [@Sendable () -> Void] = []
+
+    var isTerminated: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return terminated
+    }
+
+    func signal() {
+        lock.lock()
+        guard !terminated else {
+            lock.unlock()
+            return
+        }
+        terminated = true
+        let pendingObservers = observers
+        observers.removeAll()
+        lock.unlock()
+
+        semaphore.signal()
+        for observer in pendingObservers {
+            observer()
+        }
+    }
+
+    func wait(timeout: DispatchTime) -> Bool {
+        if isTerminated { return true }
+        return semaphore.wait(timeout: timeout) == .success
+    }
+
+    func whenTerminated(_ observer: @escaping @Sendable () -> Void) {
+        lock.lock()
+        if terminated {
+            lock.unlock()
+            observer()
+        } else {
+            observers.append(observer)
+            lock.unlock()
+        }
+    }
+}
+
+/// Keeps Foundation's process source alive after the bounded caller contract
+/// expires, and removes process-owned output only after Foundation confirms
+/// termination.
+private final class SkillArchiveDeferredProcessReaper: @unchecked Sendable {
+    static let shared = SkillArchiveDeferredProcessReaper()
+
+    private struct Entry {
+        let process: Process
+        let cleanupURL: URL?
+    }
+
+    private let lock = NSLock()
+    private let cleanupQueue = DispatchQueue(label: "ai.osaurus.skill-archive-reaper", qos: .utility)
+    private var entries: [UUID: Entry] = [:]
+
+    func adopt(
+        _ process: Process,
+        terminated: SkillArchiveProcessTerminationLatch,
+        cleanupURL: URL?
+    ) {
+        let id = UUID()
+        lock.lock()
+        entries[id] = Entry(process: process, cleanupURL: cleanupURL)
+        lock.unlock()
+
+        terminated.whenTerminated { [weak self] in
+            self?.finish(id: id)
+        }
+    }
+
+    private func finish(id: UUID) {
+        cleanupQueue.async { [self] in
+            lock.lock()
+            let entry = entries.removeValue(forKey: id)
+            lock.unlock()
+
+            if let cleanupURL = entry?.cleanupURL {
+                try? FileManager.default.removeItem(at: cleanupURL)
+            }
+        }
     }
 }
 
@@ -456,9 +594,10 @@ private final class SkillArchiveProcessOutputReader: @unchecked Sendable {
         return completionSnapshot()
     }
 
-    func cancelAndWait() -> SkillArchiveProcessOutputCompletion {
+    func cancelAndWait(timeoutSeconds: TimeInterval) -> SkillArchiveProcessOutputCompletion? {
         outputStream.cancel()
-        done.wait()
+        let deadline = DispatchTime.now() + .nanoseconds(Self.nanoseconds(timeoutSeconds))
+        guard done.wait(timeout: deadline) == .success else { return nil }
         return completionSnapshot()
     }
 
@@ -524,26 +663,40 @@ private final class SkillArchiveProcessOutputReader: @unchecked Sendable {
     }
 }
 
-/// DispatchIO owns descriptor access until its cleanup callback runs. Retaining
-/// the FileHandle prevents ARC from closing that descriptor before the join.
-private final class SkillArchiveDispatchOutputStream: SkillArchiveProcessOutputStreaming, @unchecked Sendable {
+/// DispatchIO exclusively controls a duplicated descriptor and closes it only
+/// after the cleanup callback says no operation can still use it.
+final class SkillArchiveDispatchOutputStream: SkillArchiveProcessOutputStreaming, @unchecked Sendable {
     private let state: SkillArchiveDispatchOutputState
     private let channel: DispatchIO
-    private let fileHandle: FileHandle
     private let chunkBytes: Int
     private let queue = DispatchQueue(label: "ai.osaurus.skill-archive-output", qos: .utility)
 
-    init(fileHandle: FileHandle, chunkBytes: Int) {
+    init(fileHandle: FileHandle, chunkBytes: Int) throws {
+        let duplicatedDescriptor = fcntl(fileHandle.fileDescriptor, F_DUPFD_CLOEXEC, 0)
+        guard duplicatedDescriptor >= 0 else {
+            let duplicationError = errno
+            try? fileHandle.close()
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(duplicationError))
+        }
+
+        do {
+            try fileHandle.close()
+        } catch {
+            _ = Darwin.close(duplicatedDescriptor)
+            throw error
+        }
+
         let state = SkillArchiveDispatchOutputState()
         self.state = state
-        self.fileHandle = fileHandle
         self.chunkBytes = chunkBytes
         self.channel = DispatchIO(
             type: .stream,
-            fileDescriptor: fileHandle.fileDescriptor,
+            fileDescriptor: duplicatedDescriptor,
             queue: queue
         ) { errorCode in
-            state.finishCleanup(errorCode: errorCode)
+            let closeResult = Darwin.close(duplicatedDescriptor)
+            let closeError = closeResult == 0 ? 0 : errno
+            state.finishCleanup(errorCode: errorCode == 0 ? closeError : errorCode)
         }
     }
 

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -402,12 +402,21 @@ public final class SkillManager {
     // MARK: - ZIP Export/Import
 
     public func exportSkillAsZip(_ skill: Skill) async throws -> URL {
+        try Task.checkCancellation()
         let skillDir = SkillStore.skillDirectory(for: skill)
         let zipURL = FileManager.default.temporaryDirectory.appendingPathComponent(
             "\(skill.xplaceholder_agentSkillsNamex).zip"
         )
         try? FileManager.default.removeItem(at: zipURL)
-        try await FileManager.default.zipItem(at: skillDir, to: zipURL)
+        do {
+            try await FileManager.default.zipItem(at: skillDir, to: zipURL)
+            try Task.checkCancellation()
+        } catch {
+            if (error as? SkillArchiveProcessRunnerError) != .processTerminationIncomplete {
+                try? FileManager.default.removeItem(at: zipURL)
+            }
+            throw error
+        }
         guard FileManager.default.fileExists(atPath: zipURL.path) else {
             throw SkillFileError.exportFailed
         }
@@ -426,57 +435,81 @@ public final class SkillManager {
         overwriteExisting: Bool,
         policy: SkillImportPolicy = .default
     ) async throws -> SkillImportResult {
-        // All filesystem work (unzip, SKILL.md read, nested file copies) runs
-        // off the main actor — a large bundle would otherwise block the UI and
-        // trip an app-hang. Only the trailing `refresh()` (which mutates
-        // observed state) hops back to the main actor.
-        let result = try await Task.detached(priority: .userInitiated) {
-            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-                UUID().uuidString
-            )
-            defer { try? FileManager.default.removeItem(at: tempDir) }
-
-            try policy.validateArchiveBeforeExtraction(zipURL)
-            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-            try await FileManager.default.unzipItem(at: zipURL, to: tempDir)
-
-            let importPlan = try policy.scanExtractedTree(at: tempDir)
-            let content = try String(contentsOf: importPlan.skillMarkdownURL, encoding: .utf8)
-            let parsed = try Skill.parseAnyFormat(from: content)
-
-            let skill = Skill(
-                name: parsed.name,
-                description: parsed.description,
-                version: parsed.version,
-                author: parsed.author,
-                category: parsed.category,
-                instructions: parsed.instructions,
-                directoryName: parsed.xplaceholder_agentSkillsNamex
-            )
-
-            try Self.installImportedSkill(
-                skill,
-                from: importPlan.skillRootURL,
-                overwriteExisting: overwriteExisting,
-                stagingBase: tempDir
-            )
-
-            let notes: [String]
-            if importPlan.ignoredSkillMarkdownPaths.isEmpty {
-                notes = []
-            } else {
-                let ignored = importPlan.ignoredSkillMarkdownPaths.joined(separator: ", ")
-                notes = [
-                    L("Imported \(importPlan.selectedSkillMarkdownPath); ignored additional SKILL.md files: \(ignored)")
-                ]
-            }
-            return SkillImportResult(skill: skill, notes: notes)
-        }.value
+        let result = try await Self.performZipImport(
+            zipURL,
+            overwriteExisting: overwriteExisting,
+            policy: policy
+        )
 
         await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(result.skill) }
         return result
+    }
+
+    /// Nonisolated async work runs off the main actor while preserving the
+    /// caller task's cancellation state through validation and extraction.
+    nonisolated private static func performZipImport(
+        _ zipURL: URL,
+        overwriteExisting: Bool,
+        policy: SkillImportPolicy
+    ) async throws -> SkillImportResult {
+        try Task.checkCancellation()
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString
+        )
+        var cleanupTransferredToReaper = false
+        defer {
+            if !cleanupTransferredToReaper {
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+        }
+
+        try policy.validateArchiveBeforeExtraction(zipURL)
+        try Task.checkCancellation()
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        do {
+            try await FileManager.default.unzipItem(at: zipURL, to: tempDir)
+        } catch {
+            if (error as? SkillArchiveProcessRunnerError) == .processTerminationIncomplete {
+                cleanupTransferredToReaper = true
+            }
+            throw error
+        }
+
+        try Task.checkCancellation()
+        let importPlan = try policy.scanExtractedTree(at: tempDir)
+        let content = try String(contentsOf: importPlan.skillMarkdownURL, encoding: .utf8)
+        let parsed = try Skill.parseAnyFormat(from: content)
+        try Task.checkCancellation()
+
+        let skill = Skill(
+            name: parsed.name,
+            description: parsed.description,
+            version: parsed.version,
+            author: parsed.author,
+            category: parsed.category,
+            instructions: parsed.instructions,
+            directoryName: parsed.xplaceholder_agentSkillsNamex
+        )
+
+        try Self.installImportedSkill(
+            skill,
+            from: importPlan.skillRootURL,
+            overwriteExisting: overwriteExisting,
+            stagingBase: tempDir
+        )
+
+        let notes: [String]
+        if importPlan.ignoredSkillMarkdownPaths.isEmpty {
+            notes = []
+        } else {
+            let ignored = importPlan.ignoredSkillMarkdownPaths.joined(separator: ", ")
+            notes = [
+                L("Imported \(importPlan.selectedSkillMarkdownPath); ignored additional SKILL.md files: \(ignored)")
+            ]
+        }
+        return SkillImportResult(skill: skill, notes: notes)
     }
 
     nonisolated private static func installImportedSkill(
@@ -759,56 +792,66 @@ public final class SkillManager {
 // MARK: - FileManager ZIP Extension
 
 extension FileManager {
-    func unzipItem(at sourceURL: URL, to destinationURL: URL) async throws {
-        try await Task.detached(priority: .userInitiated) {
-            let result = try SkillArchiveProcessRunner.run(
-                executablePath: "/usr/bin/unzip",
-                arguments: ["-o", "-q", sourceURL.path, "-d", destinationURL.path],
-                timeoutSeconds: 60
+    func unzipItem(
+        at sourceURL: URL,
+        to destinationURL: URL,
+        configuration: SkillArchiveProcessConfiguration = .default
+    ) async throws {
+        try Task.checkCancellation()
+        let result = try SkillArchiveProcessRunner.run(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-o", "-q", "-d", destinationURL.path, "--", sourceURL.path],
+            timeoutSeconds: 60,
+            configuration: configuration.withDeferredCleanupURL(destinationURL)
+        )
+        try Task.checkCancellation()
+
+        if result.timedOut {
+            throw NSError(
+                domain: "FileManager",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unzip timed out after 60 seconds"]
             )
+        }
 
-            if result.timedOut {
-                throw NSError(
-                    domain: "FileManager",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Unzip timed out after 60 seconds"]
-                )
-            }
-
-            if result.terminationStatus != 0 {
-                throw NSError(
-                    domain: "FileManager",
-                    code: Int(result.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: "Unzip failed: \(result.output)"]
-                )
-            }
-        }.value
+        if result.terminationStatus != 0 {
+            throw NSError(
+                domain: "FileManager",
+                code: Int(result.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "Unzip failed: \(result.output)"]
+            )
+        }
     }
 
-    func zipItem(at sourceURL: URL, to destinationURL: URL) async throws {
-        try await Task.detached(priority: .userInitiated) {
-            let result = try SkillArchiveProcessRunner.run(
-                executablePath: "/usr/bin/zip",
-                arguments: ["-r", "-q", destinationURL.path, sourceURL.lastPathComponent],
-                currentDirectoryURL: sourceURL.deletingLastPathComponent(),
-                timeoutSeconds: 120
+    func zipItem(
+        at sourceURL: URL,
+        to destinationURL: URL,
+        configuration: SkillArchiveProcessConfiguration = .default
+    ) async throws {
+        try Task.checkCancellation()
+        let result = try SkillArchiveProcessRunner.run(
+            executablePath: "/usr/bin/zip",
+            arguments: ["-r", "-q", "-nw", destinationURL.path, "--", sourceURL.lastPathComponent],
+            currentDirectoryURL: sourceURL.deletingLastPathComponent(),
+            timeoutSeconds: 120,
+            configuration: configuration.withDeferredCleanupURL(destinationURL)
+        )
+        try Task.checkCancellation()
+
+        if result.timedOut {
+            throw NSError(
+                domain: "FileManager",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Zip timed out after 120 seconds"]
             )
+        }
 
-            if result.timedOut {
-                throw NSError(
-                    domain: "FileManager",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Zip timed out after 120 seconds"]
-                )
-            }
-
-            if result.terminationStatus != 0 {
-                throw NSError(
-                    domain: "FileManager",
-                    code: Int(result.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: "Zip failed: \(result.output)"]
-                )
-            }
-        }.value
+        if result.terminationStatus != 0 {
+            throw NSError(
+                domain: "FileManager",
+                code: Int(result.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "Zip failed: \(result.output)"]
+            )
+        }
     }
 }

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -761,23 +761,25 @@ public final class SkillManager {
 extension FileManager {
     func unzipItem(at sourceURL: URL, to destinationURL: URL) async throws {
         try await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-            process.arguments = ["-o", "-q", sourceURL.path, "-d", destinationURL.path]
+            let result = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/unzip",
+                arguments: ["-o", "-q", sourceURL.path, "-d", destinationURL.path],
+                timeoutSeconds: 60
+            )
 
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
-
-            try process.run()
-            process.waitUntilExit()
-
-            if process.terminationStatus != 0 {
-                let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            if result.timedOut {
                 throw NSError(
                     domain: "FileManager",
-                    code: Int(process.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: "Unzip failed: \(output)"]
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Unzip timed out after 60 seconds"]
+                )
+            }
+
+            if result.terminationStatus != 0 {
+                throw NSError(
+                    domain: "FileManager",
+                    code: Int(result.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: "Unzip failed: \(result.output)"]
                 )
             }
         }.value
@@ -785,24 +787,26 @@ extension FileManager {
 
     func zipItem(at sourceURL: URL, to destinationURL: URL) async throws {
         try await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-            process.currentDirectoryURL = sourceURL.deletingLastPathComponent()
-            process.arguments = ["-r", "-q", destinationURL.path, sourceURL.lastPathComponent]
+            let result = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/zip",
+                arguments: ["-r", "-q", destinationURL.path, sourceURL.lastPathComponent],
+                currentDirectoryURL: sourceURL.deletingLastPathComponent(),
+                timeoutSeconds: 120
+            )
 
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
-
-            try process.run()
-            process.waitUntilExit()
-
-            if process.terminationStatus != 0 {
-                let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            if result.timedOut {
                 throw NSError(
                     domain: "FileManager",
-                    code: Int(process.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: "Zip failed: \(output)"]
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Zip timed out after 120 seconds"]
+                )
+            }
+
+            if result.terminationStatus != 0 {
+                throw NSError(
+                    domain: "FileManager",
+                    code: Int(result.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: "Zip failed: \(result.output)"]
                 )
             }
         }.value

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -122819,6 +122819,12 @@
         }
       }
     },
+    "inspection output exceeded the supported limit" : {
+      "shouldTranslate" : false
+    },
+    "inspection timed out after 30 seconds" : {
+      "shouldTranslate" : false
+    },
     "Preparing…" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Tests/Skill/SkillArchiveProcessRunnerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillArchiveProcessRunnerTests.swift
@@ -27,6 +27,42 @@ struct SkillArchiveProcessRunnerTests {
         #expect(!result.timedOut)
     }
 
+    @Test func dispatchStreamReadsThroughDuplicateAfterClosingOriginalHandle() throws {
+        let pipe = Pipe()
+        let originalDescriptor = pipe.fileHandleForReading.fileDescriptor
+        let capture = SkillArchiveStreamCapture()
+        let stream = try SkillArchiveDispatchOutputStream(
+            fileHandle: pipe.fileHandleForReading,
+            chunkBytes: 64
+        )
+
+        #expect(fcntl(originalDescriptor, F_GETFD) == -1)
+        #expect(errno == EBADF)
+
+        stream.start(
+            onChunk: { capture.append($0) },
+            onCompletion: { capture.finish(error: $0) }
+        )
+        try pipe.fileHandleForWriting.write(contentsOf: Data("duplicated descriptor".utf8))
+        try pipe.fileHandleForWriting.close()
+
+        #expect(capture.waitForCompletion(timeoutSeconds: 1))
+        #expect(capture.output == "duplicated descriptor")
+        #expect(capture.error == nil)
+    }
+
+    @Test func repeatedRunsKeepDescriptorLifecycleStable() throws {
+        for _ in 0..<100 {
+            let result = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/printf",
+                arguments: ["x"],
+                timeoutSeconds: 2
+            )
+            #expect(result.output == "x")
+            #expect(result.terminationStatus == 0)
+        }
+    }
+
     @Test func outputLimitKeepsDrainingUntilProcessExits() throws {
         let fixtureURL = FileManager.default.temporaryDirectory.appendingPathComponent(
             "osaurus-runner-output-\(UUID().uuidString)"
@@ -52,42 +88,61 @@ struct SkillArchiveProcessRunnerTests {
     }
 
     @Test func timeoutForceKillsAndReapsTermIgnoringProcess() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "osaurus-runner-timeout-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let scriptURL = root.appendingPathComponent("ignore-term.sh")
-        let readyURL = root.appendingPathComponent("ready")
-        try """
-        #!/bin/sh
-        trap '' TERM
-        printf 'ready\n' > "$1"
-        while :; do :; done
-        """
-        .write(to: scriptURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o700],
-            ofItemAtPath: scriptURL.path
-        )
+        let fixture = try Self.makeTermIgnoringFixture(prefix: "timeout")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let clock = ContinuousClock()
+        let startedAt = clock.now
 
         let task = Task.detached {
             try SkillArchiveProcessRunner.run(
-                executablePath: scriptURL.path,
-                arguments: [readyURL.path],
+                executablePath: fixture.script.path,
+                arguments: [fixture.pidFile.path],
                 timeoutSeconds: 1,
                 configuration: SkillArchiveProcessConfiguration(cleanupGraceSeconds: 0.1)
             )
         }
 
-        let fixtureBecameReady = await Self.waitForFile(at: readyURL)
+        let fixtureBecameReady = await Self.waitForFile(at: fixture.pidFile)
         let result = try await task.value
 
         #expect(fixtureBecameReady)
         #expect(result.timedOut)
         #expect(result.terminationStatus == SIGKILL)
+        #expect(startedAt.duration(to: clock.now) < .seconds(3))
+    }
+
+    @Test func cancellationForceKillsTermIgnoringProcessWithinBound() async throws {
+        let fixture = try Self.makeTermIgnoringFixture(prefix: "cancellation")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let task = Task.detached {
+            try SkillArchiveProcessRunner.run(
+                executablePath: fixture.script.path,
+                arguments: [fixture.pidFile.path],
+                timeoutSeconds: 30,
+                configuration: SkillArchiveProcessConfiguration(cleanupGraceSeconds: 0.1)
+            )
+        }
+
+        guard let processID = await Self.waitForProcessID(at: fixture.pidFile) else {
+            task.cancel()
+            _ = try? await task.value
+            Issue.record("TERM-hostile fixture did not publish its process ID")
+            return
+        }
+        let clock = ContinuousClock()
+        let cancelledAt = clock.now
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            #expect(cancelledAt.duration(to: clock.now) < .seconds(2))
+            #expect(await Self.waitForProcessExit(processID))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     @Test func outputReadErrorIsPropagatedInsteadOfBecomingEOF() throws {
@@ -135,6 +190,32 @@ struct SkillArchiveProcessRunnerTests {
         #expect(stream.completionDelivered)
     }
 
+    @Test func neverCompletingDrainCancellationFailsWithinBound() throws {
+        let stream = NeverCompletingSkillArchiveOutputStream()
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+
+        do {
+            _ = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/true",
+                arguments: [],
+                timeoutSeconds: 2,
+                configuration: SkillArchiveProcessConfiguration(
+                    cleanupGraceSeconds: 0.05,
+                    outputStream: stream
+                )
+            )
+            Issue.record("Expected an incomplete output drain error")
+        } catch let error as SkillArchiveProcessRunnerError {
+            #expect(error == .outputDrainIncomplete)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(stream.cancelRequested)
+        #expect(startedAt.duration(to: clock.now) < .seconds(1))
+    }
+
     @Test func cancellationReapsProcessAndJoinsReaderBeforeThrowing() async {
         let stream = StalledSkillArchiveOutputStream()
         let task = Task.detached {
@@ -171,6 +252,86 @@ struct SkillArchiveProcessRunnerTests {
         }
         return false
     }
+
+    private static func waitForProcessExit(_ processID: pid_t) async -> Bool {
+        for _ in 0..<100 {
+            if Darwin.kill(processID, 0) == -1, errno == ESRCH { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return false
+    }
+
+    private static func waitForProcessID(at url: URL) async -> pid_t? {
+        for _ in 0..<200 {
+            if let contents = try? String(contentsOf: url, encoding: .utf8),
+                let processID = pid_t(contents.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return processID
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return nil
+    }
+
+    private static func makeTermIgnoringFixture(
+        prefix: String
+    ) throws -> (root: URL, script: URL, pidFile: URL) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-runner-\(prefix)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let script = root.appendingPathComponent("ignore-term.sh")
+        let pidFile = root.appendingPathComponent("pid")
+        try """
+        #!/bin/sh
+        trap '' TERM
+        printf '%s\n' "$$" > "$1"
+        while :; do :; done
+        """
+        .write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: script.path
+        )
+        return (root, script, pidFile)
+    }
+}
+
+private final class SkillArchiveStreamCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private let completed = DispatchSemaphore(value: 0)
+    private var data = Data()
+    private var completionError: NSError?
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func finish(error: (any Error)?) {
+        lock.lock()
+        completionError = error as NSError?
+        lock.unlock()
+        completed.signal()
+    }
+
+    func waitForCompletion(timeoutSeconds: TimeInterval) -> Bool {
+        completed.wait(timeout: .now() + timeoutSeconds) == .success
+    }
+
+    var output: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    var error: NSError? {
+        lock.lock()
+        defer { lock.unlock() }
+        return completionError
+    }
 }
 
 private enum InjectedSkillArchiveReadError: Error, Equatable {
@@ -187,6 +348,28 @@ private final class FailingSkillArchiveOutputStream: SkillArchiveProcessOutputSt
     }
 
     func cancel() {}
+}
+
+private final class NeverCompletingSkillArchiveOutputStream: SkillArchiveProcessOutputStreaming, @unchecked Sendable {
+    private let lock = NSLock()
+    private var didRequestCancel = false
+
+    func start(
+        onChunk: @escaping @Sendable (Data) -> Void,
+        onCompletion: @escaping @Sendable ((any Error)?) -> Void
+    ) {}
+
+    func cancel() {
+        lock.lock()
+        didRequestCancel = true
+        lock.unlock()
+    }
+
+    var cancelRequested: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didRequestCancel
+    }
 }
 
 /// Models DispatchIO's asynchronous cleanup callback: cancellation schedules

--- a/Packages/OsaurusCore/Tests/Skill/SkillArchiveProcessRunnerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillArchiveProcessRunnerTests.swift
@@ -1,0 +1,245 @@
+//
+//  SkillArchiveProcessRunnerTests.swift
+//  OsaurusCoreTests
+//
+//  Exercises subprocess completion, bounded output, and cleanup failure paths
+//  independently from ZIP archive contents.
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SkillArchiveProcessRunnerTests {
+    @Test func normalCompletionCollectsOutput() throws {
+        let result = try SkillArchiveProcessRunner.run(
+            executablePath: "/usr/bin/printf",
+            arguments: ["normal output"],
+            timeoutSeconds: 2
+        )
+
+        #expect(result.terminationStatus == 0)
+        #expect(result.output == "normal output")
+        #expect(!result.outputTruncated)
+        #expect(!result.timedOut)
+    }
+
+    @Test func outputLimitKeepsDrainingUntilProcessExits() throws {
+        let fixtureURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-runner-output-\(UUID().uuidString)"
+        )
+        try Data(repeating: 0x78, count: 128 * 1024).write(to: fixtureURL)
+        defer { try? FileManager.default.removeItem(at: fixtureURL) }
+
+        let result = try SkillArchiveProcessRunner.run(
+            executablePath: "/bin/cat",
+            arguments: [fixtureURL.path],
+            timeoutSeconds: 2,
+            configuration: SkillArchiveProcessConfiguration(
+                outputLimitBytes: 64,
+                chunkBytes: 4 * 1024,
+                cleanupGraceSeconds: 0.5
+            )
+        )
+
+        #expect(result.terminationStatus == 0)
+        #expect(result.output == String(repeating: "x", count: 64) + "\n[output truncated]")
+        #expect(result.outputTruncated)
+        #expect(!result.timedOut)
+    }
+
+    @Test func timeoutForceKillsAndReapsTermIgnoringProcess() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-runner-timeout-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let scriptURL = root.appendingPathComponent("ignore-term.sh")
+        let readyURL = root.appendingPathComponent("ready")
+        try """
+        #!/bin/sh
+        trap '' TERM
+        printf 'ready\n' > "$1"
+        while :; do :; done
+        """
+        .write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: scriptURL.path
+        )
+
+        let task = Task.detached {
+            try SkillArchiveProcessRunner.run(
+                executablePath: scriptURL.path,
+                arguments: [readyURL.path],
+                timeoutSeconds: 1,
+                configuration: SkillArchiveProcessConfiguration(cleanupGraceSeconds: 0.1)
+            )
+        }
+
+        let fixtureBecameReady = await Self.waitForFile(at: readyURL)
+        let result = try await task.value
+
+        #expect(fixtureBecameReady)
+        #expect(result.timedOut)
+        #expect(result.terminationStatus == SIGKILL)
+    }
+
+    @Test func outputReadErrorIsPropagatedInsteadOfBecomingEOF() throws {
+        let stream = FailingSkillArchiveOutputStream()
+
+        do {
+            _ = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/true",
+                arguments: [],
+                timeoutSeconds: 2,
+                configuration: SkillArchiveProcessConfiguration(
+                    cleanupGraceSeconds: 0.1,
+                    outputStream: stream
+                )
+            )
+            Issue.record("Expected the injected output read error")
+        } catch let error as InjectedSkillArchiveReadError {
+            #expect(error == .failed)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func incompleteDrainCancelsAndJoinsReaderBeforeThrowing() throws {
+        let stream = StalledSkillArchiveOutputStream()
+
+        do {
+            _ = try SkillArchiveProcessRunner.run(
+                executablePath: "/usr/bin/true",
+                arguments: [],
+                timeoutSeconds: 2,
+                configuration: SkillArchiveProcessConfiguration(
+                    cleanupGraceSeconds: 0.05,
+                    outputStream: stream
+                )
+            )
+            Issue.record("Expected an incomplete output drain error")
+        } catch let error as SkillArchiveProcessRunnerError {
+            #expect(error == .outputDrainIncomplete)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(stream.cancelRequested)
+        #expect(stream.completionDelivered)
+    }
+
+    @Test func cancellationReapsProcessAndJoinsReaderBeforeThrowing() async {
+        let stream = StalledSkillArchiveOutputStream()
+        let task = Task.detached {
+            try SkillArchiveProcessRunner.run(
+                executablePath: "/bin/sleep",
+                arguments: ["30"],
+                timeoutSeconds: 30,
+                configuration: SkillArchiveProcessConfiguration(
+                    cleanupGraceSeconds: 0.05,
+                    outputStream: stream
+                )
+            )
+        }
+
+        let readerStarted = stream.waitUntilStarted(timeoutSeconds: 2)
+        task.cancel()
+
+        #expect(readerStarted)
+        do {
+            _ = try await task.value
+            Issue.record("Expected CancellationError")
+        } catch is CancellationError {
+            #expect(stream.cancelRequested)
+            #expect(stream.completionDelivered)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    private static func waitForFile(at url: URL) async -> Bool {
+        for _ in 0..<200 {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return false
+    }
+}
+
+private enum InjectedSkillArchiveReadError: Error, Equatable {
+    case failed
+}
+
+private final class FailingSkillArchiveOutputStream: SkillArchiveProcessOutputStreaming, @unchecked Sendable {
+    func start(
+        onChunk: @escaping @Sendable (Data) -> Void,
+        onCompletion: @escaping @Sendable ((any Error)?) -> Void
+    ) {
+        onChunk(Data("partial output".utf8))
+        onCompletion(InjectedSkillArchiveReadError.failed)
+    }
+
+    func cancel() {}
+}
+
+/// Models DispatchIO's asynchronous cleanup callback: cancellation schedules
+/// completion, and the runner must wait for that completion before returning.
+private final class StalledSkillArchiveOutputStream: SkillArchiveProcessOutputStreaming, @unchecked Sendable {
+    private let lock = NSLock()
+    private let started = DispatchSemaphore(value: 0)
+    private var completion: (@Sendable ((any Error)?) -> Void)?
+    private var didRequestCancel = false
+    private var didDeliverCompletion = false
+
+    func start(
+        onChunk: @escaping @Sendable (Data) -> Void,
+        onCompletion: @escaping @Sendable ((any Error)?) -> Void
+    ) {
+        lock.lock()
+        completion = onCompletion
+        lock.unlock()
+        started.signal()
+    }
+
+    func cancel() {
+        lock.lock()
+        guard !didRequestCancel else {
+            lock.unlock()
+            return
+        }
+        didRequestCancel = true
+        let handler = completion
+        completion = nil
+        lock.unlock()
+
+        DispatchQueue.global(qos: .utility).async { [self] in
+            lock.lock()
+            didDeliverCompletion = true
+            lock.unlock()
+            handler?(nil)
+        }
+    }
+
+    func waitUntilStarted(timeoutSeconds: TimeInterval) -> Bool {
+        started.wait(timeout: .now() + timeoutSeconds) == .success
+    }
+
+    var cancelRequested: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didRequestCancel
+    }
+
+    var completionDelivered: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didDeliverCompletion
+    }
+}

--- a/Packages/OsaurusCore/Tests/Skill/SkillImportPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillImportPolicyTests.swift
@@ -6,6 +6,7 @@
 //  persisted skill directory.
 //
 
+import Darwin
 import Foundation
 import Testing
 
@@ -370,6 +371,105 @@ struct SkillImportPolicyTests {
         }
     }
 
+    @Test func importCancellationReachesBlockedArchiveInspection() async throws {
+        try await Self.withTempRoot { root in
+            let fifoURL = root.appendingPathComponent("blocked-archive.zip")
+            try #require(mkfifo(fifoURL.path, 0o600) == 0)
+
+            let task = Task {
+                try await SkillManager.shared.importSkillFromZip(
+                    fifoURL,
+                    overwriteExisting: false,
+                    policy: .test
+                )
+            }
+            guard let writerDescriptor = await Self.waitForFIFOReader(at: fifoURL) else {
+                task.cancel()
+                _ = try? await task.value
+                Issue.record("Archive inspection did not open the FIFO")
+                return
+            }
+
+            task.cancel()
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            _ = Darwin.close(writerDescriptor)
+
+            do {
+                _ = try await task.value
+                Issue.record("Expected CancellationError")
+            } catch is CancellationError {
+                // Cancellation must survive policy wrapping and reach the archive subprocess.
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test func exportCancellationReachesZipProcessAndRemovesPartialArchive() async throws {
+        try await Self.withTempRoot { _ in
+            let identifier = UUID().uuidString
+            let skill = Skill(
+                name: "Cancellation Export \(identifier)",
+                directoryName: "cancellation-export-\(identifier)"
+            )
+            let skillDirectory = SkillStore.skillDirectory(for: skill)
+            try FileManager.default.createDirectory(at: skillDirectory, withIntermediateDirectories: true)
+            try "# Cancellation Export".write(
+                to: skillDirectory.appendingPathComponent("SKILL.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let sparsePayload = skillDirectory.appendingPathComponent("payload.bin")
+            _ = FileManager.default.createFile(atPath: sparsePayload.path, contents: nil)
+            let payloadHandle = try FileHandle(forWritingTo: sparsePayload)
+            try payloadHandle.truncate(atOffset: 512 * 1024 * 1024)
+            try payloadHandle.close()
+
+            let archiveURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "\(skill.xplaceholder_agentSkillsNamex).zip"
+            )
+            defer { try? FileManager.default.removeItem(at: archiveURL) }
+
+            let task = Task {
+                try await SkillManager.shared.exportSkillAsZip(skill)
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            task.cancel()
+
+            do {
+                _ = try await task.value
+                Issue.record("Expected CancellationError")
+            } catch is CancellationError {
+                #expect(!FileManager.default.fileExists(atPath: archiveURL.path))
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test func archiveUtilitiesTreatLeadingDashSourceAsPath() async throws {
+        try await Self.withTempRoot { root in
+            let source = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "-leading-dash-bundle",
+                skillName: "Leading Dash"
+            )
+            let archiveURL = root.appendingPathComponent("leading-dash.zip")
+            let extractionURL = root.appendingPathComponent("leading-dash-extracted", isDirectory: true)
+
+            try await FileManager.default.zipItem(at: source, to: archiveURL)
+            try SkillImportPolicy.test.validateArchiveBeforeExtraction(archiveURL)
+            try await FileManager.default.unzipItem(at: archiveURL, to: extractionURL)
+
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: extractionURL.appendingPathComponent("-leading-dash-bundle/SKILL.md").path
+                )
+            )
+        }
+    }
+
     private static func withTempRoot<T: Sendable>(
         _ body: @Sendable (URL) async throws -> T
     ) async throws -> T {
@@ -388,6 +488,16 @@ struct SkillImportPolicyTests {
             }
             return try await body(root)
         }
+    }
+
+    private static func waitForFIFOReader(at url: URL) async -> Int32? {
+        for _ in 0..<200 {
+            let descriptor = Darwin.open(url.path, O_WRONLY | O_NONBLOCK)
+            if descriptor >= 0 { return descriptor }
+            guard errno == ENXIO else { return nil }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return nil
     }
 
     private static func makeSkillBundle(
@@ -451,7 +561,7 @@ struct SkillImportPolicyTests {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
         process.currentDirectoryURL = source.deletingLastPathComponent()
-        process.arguments = ["-r", "-q", zipURL.path, source.lastPathComponent]
+        process.arguments = ["-r", "-q", "-nw", zipURL.path, "--", source.lastPathComponent]
 
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/Packages/OsaurusCore/Tests/Skill/SkillImportPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillImportPolicyTests.swift
@@ -133,6 +133,81 @@ struct SkillImportPolicyTests {
         }
     }
 
+    @Test func archiveEntryLimitRejectsHighEntryListingWithoutStalling() async throws {
+        try await Self.withTempRoot { root in
+            let source = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "many-entry-bundle",
+                skillName: "Many Entry Skill"
+            )
+            let references = source.appendingPathComponent("references", isDirectory: true)
+            try FileManager.default.createDirectory(at: references, withIntermediateDirectories: true)
+
+            for index in 0..<2_000 {
+                _ = FileManager.default.createFile(
+                    atPath: references.appendingPathComponent("entry-\(index).txt").path,
+                    contents: Data(),
+                    attributes: nil
+                )
+            }
+
+            let zipURL = try Self.makeZip(from: source, in: root)
+            let startedAt = Date()
+
+            try Self.expectSkillFileError(matching: { error in
+                if case .archiveEntryLimitExceeded(40) = error { return true }
+                return false
+            }) {
+                try SkillImportPolicy.test.validateArchiveBeforeExtraction(zipURL)
+            }
+
+            #expect(Date().timeIntervalSince(startedAt) < 10)
+        }
+    }
+
+    @Test func archiveListingFailsClosedWhenOutputIsTruncated() async throws {
+        try await Self.withTempRoot { root in
+            let source = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "long-listing-bundle",
+                skillName: "Long Listing Skill"
+            )
+            var longDirectory = source.appendingPathComponent("references", isDirectory: true)
+            for segment in 0..<4 {
+                longDirectory = longDirectory.appendingPathComponent(
+                    "segment-\(segment)-" + String(repeating: "x", count: 120),
+                    isDirectory: true
+                )
+            }
+            try FileManager.default.createDirectory(at: longDirectory, withIntermediateDirectories: true)
+
+            for index in 0..<700 {
+                _ = FileManager.default.createFile(
+                    atPath: longDirectory.appendingPathComponent("entry-\(index).txt").path,
+                    contents: Data(),
+                    attributes: nil
+                )
+            }
+
+            let zipURL = try Self.makeZip(from: source, in: root)
+            let policy = SkillImportPolicy(
+                maxArchiveBytes: 10_000_000,
+                maxEntryBytes: 1_000_000,
+                maxEntryCount: 512,
+                maxPathDepth: 8
+            )
+
+            try Self.expectSkillFileError(matching: { error in
+                if case .archiveListingFailed(let details) = error {
+                    return details.contains("exceeded the supported limit")
+                }
+                return false
+            }) {
+                try policy.validateArchiveBeforeExtraction(zipURL)
+            }
+        }
+    }
+
     @Test func extractedTreeRejectsSymlinksAndOversizedFiles() async throws {
         try await Self.withTempRoot { root in
             let symlinkBundle = try Self.makeSkillBundle(


### PR DESCRIPTION
## Summary
- Prevents skill import and export from freezing when archive tools produce large output, resist termination, or leave output pipes open.
- Drains archive output concurrently, applies bounded termination and cleanup, and preserves cancellation through import and export.
- Fails closed on truncated archive listings and validates archive arguments that begin with a dash.
- Uses duplicated close-on-exec descriptors so output readers and process cleanup cannot race over the same descriptor.

## Security and reliability
- Archive limits remain enforced before extraction.
- Truncated or untrusted listings cannot undercount entries.
- Process termination and output draining are bounded; unconfirmed termination retains resources for deferred cleanup instead of racing deletion.
- Import and export cancellation propagates to the archive process.

## Validation
- 23 focused skill archive and import-policy tests, including repeated stress, hostile TERM handling, a reader that never finishes, FIFO and sparse-file cancellation, and leading-dash paths.
- Scoped SwiftLint: 0 violations.
- Localization check passed.
- `git diff --check origin/main...HEAD` passed.
- Rebased on current `main` containing #2078; the final four commits remain patch-identical.

## Known risk
A pathological Foundation process that never signals termination can retain its process and output resources for deferred cleanup. This is deliberate fail-safe behavior to avoid a freeze or use-after-close race.
