### PR TITLE
Harden manual plugin receipt metadata

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
@@ -48,7 +48,7 @@ public struct ToolsInstall {
     }
 
     private static func installFromRegistry(pluginId: String, args: [String]) async {
-        var preferredVersion: SemanticVersion? = nil
+        var preferredVersion: SemanticVersion?
         if let idx = args.firstIndex(of: "--version"), idx + 1 < args.count {
             let vstr = args[idx + 1]
             preferredVersion = SemanticVersion.parse(vstr)
@@ -458,7 +458,7 @@ public struct ToolsInstall {
     }
 
     /// Creates a receipt.json for manual installations
-    private static func createManualInstallReceipt(pluginId: String, version: SemanticVersion, installDir: URL) throws {
+    static func createManualInstallReceipt(pluginId: String, version: SemanticVersion, installDir: URL) throws {
         // Find the dylib in the install directory
         guard let dylibURL = findFirstDylib(in: installDir) else {
             // No dylib found - skip receipt creation (plugin might not be fully built)
@@ -480,7 +480,7 @@ public struct ToolsInstall {
             arch: "arm64",
             public_keys: nil,
             artifact: .init(
-                url: "file://" + dylibURL.path,
+                url: dylibURL.absoluteString,
                 sha256: dylibSha,
                 minisign: nil,
                 size: dylibData.count
@@ -503,10 +503,8 @@ public struct ToolsInstall {
         else {
             return nil
         }
-        for case let fileURL as URL in enumerator {
-            if fileURL.pathExtension == "dylib" {
-                return fileURL
-            }
+        for case let fileURL as URL in enumerator where fileURL.pathExtension == "dylib" {
+            return fileURL
         }
         return nil
     }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsInstallTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsInstallTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import OsaurusRepository
 import XCTest
@@ -203,5 +204,80 @@ final class ToolsInstallTests: XCTestCase {
             XCTAssertTrue(String(describing: error).contains("dev.example.other"))
             XCTAssertTrue(String(describing: error).contains("dev.example.current"))
         }
+    }
+
+    func testManualInstallReceiptIncludesArtifactMetadata() throws {
+        let dylibBytes = Data("manual-plugin-binary".utf8)
+        let dylibURL = tempDir.appendingPathComponent("ManualPlugin.dylib", isDirectory: false)
+        try dylibBytes.write(to: dylibURL)
+        let version = try XCTUnwrap(SemanticVersion.parse("1.2.3"))
+
+        try ToolsInstall.createManualInstallReceipt(
+            pluginId: "com.example.manual",
+            version: version,
+            installDir: tempDir
+        )
+
+        let receiptURL = tempDir.appendingPathComponent("receipt.json", isDirectory: false)
+        let receiptData = try Data(contentsOf: receiptURL)
+        let receipt = try JSONDecoder().decode(PluginReceipt.self, from: receiptData)
+        let expectedSha = Data(SHA256.hash(data: dylibBytes)).map { String(format: "%02x", $0) }.joined()
+
+        XCTAssertEqual(receipt.plugin_id, "com.example.manual")
+        XCTAssertEqual(receipt.version, version)
+        XCTAssertEqual(receipt.dylib_filename, "ManualPlugin.dylib")
+        XCTAssertEqual(receipt.dylib_sha256, expectedSha)
+        let artifactURL = try XCTUnwrap(URL(string: receipt.artifact.url))
+        XCTAssertEqual(artifactURL.scheme, "file")
+        XCTAssertEqual(
+            artifactURL.resolvingSymlinksInPath().path,
+            dylibURL.resolvingSymlinksInPath().path
+        )
+        XCTAssertEqual(receipt.artifact.sha256, expectedSha)
+        XCTAssertNil(receipt.artifact.minisign)
+        XCTAssertEqual(receipt.artifact.size, dylibBytes.count)
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: receiptData) as? [String: Any])
+        XCTAssertNotNil(json["artifact"], "Manual install receipts must keep the artifact object required by PluginReceipt.")
+    }
+
+    func testManualInstallReceiptEncodesArtifactURLForPathsWithSpaces() throws {
+        let installDir = tempDir.appendingPathComponent("Manual Plugin With Spaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: installDir, withIntermediateDirectories: true)
+        let dylibBytes = Data("manual-plugin-binary".utf8)
+        let dylibURL = installDir.appendingPathComponent("Manual Plugin.dylib", isDirectory: false)
+        try dylibBytes.write(to: dylibURL)
+        let version = try XCTUnwrap(SemanticVersion.parse("1.2.3"))
+
+        try ToolsInstall.createManualInstallReceipt(
+            pluginId: "com.example.manual",
+            version: version,
+            installDir: installDir
+        )
+
+        let receiptURL = installDir.appendingPathComponent("receipt.json", isDirectory: false)
+        let receiptData = try Data(contentsOf: receiptURL)
+        let receipt = try JSONDecoder().decode(PluginReceipt.self, from: receiptData)
+        let artifactURL = try XCTUnwrap(URL(string: receipt.artifact.url))
+
+        XCTAssertEqual(artifactURL.scheme, "file")
+        XCTAssertTrue(receipt.artifact.url.contains("%20"))
+        XCTAssertEqual(
+            artifactURL.resolvingSymlinksInPath().path,
+            dylibURL.resolvingSymlinksInPath().path
+        )
+    }
+
+    func testManualInstallReceiptSkipsWhenNoDylibExists() throws {
+        let version = try XCTUnwrap(SemanticVersion.parse("1.2.3"))
+
+        try ToolsInstall.createManualInstallReceipt(
+            pluginId: "com.example.empty",
+            version: version,
+            installDir: tempDir
+        )
+
+        let receiptURL = tempDir.appendingPathComponent("receipt.json", isDirectory: false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: receiptURL.path))
     }
 }


### PR DESCRIPTION
## Summary
- Adds regression coverage that manual `osaurus tools install` receipt generation writes artifact metadata that decodes as `PluginReceipt`.
- Keeps the manual receipt writer non-public but internal so CLI tests can exercise the real writer directly.
- Fixes manual receipt `artifact.url` serialization to use `URL.absoluteString`, preserving valid file URLs for paths with spaces or other escaped characters.

## Support mapping
- R035 / Wave 3B plugin authoring: CLI/manual install receipt schema hardening. Current `main` already writes the `artifact` object; this PR pins that behavior and fixes an adjacent malformed file-URL edge case.

## Validation
- `git diff --check`
- `swift test --disable-index-store --package-path Packages/OsaurusCLI --filter ToolsInstallTests`

## Reviews
- Fable medium review: no blockers. First pass found the raw `file://` concatenation URL edge case; addressed with `dylibURL.absoluteString` and a path-with-spaces test. Second pass: no blockers.
- Grok review: no blockers. First pass noted this is regression hardening rather than a new production receipt-shape fix; second pass: no blockers.
