### PR TITLE
Publish plugin active version atomically

### DIFF
--- a/Packages/OsaurusRepository/PluginInstallManager.swift
+++ b/Packages/OsaurusRepository/PluginInstallManager.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 import CryptoKit
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 public enum PluginInstallError: Error, CustomStringConvertible, LocalizedError {
     case specNotFound(String)
@@ -387,20 +392,42 @@ public final class PluginInstallManager: @unchecked Sendable {
     }
 
     public static func updateCurrentSymlink(pluginId: String, version: SemanticVersion) throws {
+        try replaceCurrentSymlink(pluginId: pluginId, version: version) { stagedPath, currentPath in
+            if rename(stagedPath, currentPath) != 0 {
+                let code = errno
+                throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+            }
+        }
+    }
+
+    /// Publishes a prepared version pointer without exposing a missing `current` entry.
+    /// The injected commit operation keeps failure-at-the-swap-point behavior testable.
+    static func replaceCurrentSymlink(
+        pluginId: String,
+        version: SemanticVersion,
+        commit: (_ stagedPath: String, _ currentPath: String) throws -> Void
+    ) throws {
         let fm = FileManager.default
         let link = currentSymlinkURL(pluginId: pluginId)
         let dir = toolsPluginDirectory(pluginId: pluginId)
         if !fm.fileExists(atPath: dir.path) {
             try fm.createDirectory(at: dir, withIntermediateDirectories: true)
         }
-        // Remove any existing entry (regular file, live symlink, or dangling
-        // symlink). `fileExists` follows symlinks and reports a dangling link
-        // as missing, but `createSymbolicLink` would still fail with EEXIST.
-        // `try?` is intentional: nothing-to-remove is fine; if the entry truly
-        // cannot be replaced, `createSymbolicLink` will surface the error.
-        try? fm.removeItem(at: link)
+
+        // Staging beside `current` keeps the rename on one filesystem. POSIX
+        // rename then swaps the pointer atomically, so a failed commit leaves
+        // the previously active version visible to readers.
+        let stagedLink = dir.appendingPathComponent(
+            ".current.\(UUID().uuidString).tmp",
+            isDirectory: false
+        )
+        defer { try? fm.removeItem(at: stagedLink) }
         do {
-            try fm.createSymbolicLink(atPath: link.path, withDestinationPath: version.description)
+            try fm.createSymbolicLink(
+                atPath: stagedLink.path,
+                withDestinationPath: version.description
+            )
+            try commit(stagedLink.path, link.path)
         } catch {
             throw PluginInstallError.layoutInvalid(
                 "Could not refresh 'current' symlink for \(pluginId) → \(version.description): \(error). Try reinstalling the plugin."

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallManagerTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallManagerTests.swift
@@ -3,6 +3,7 @@
 //  OsaurusRepository
 //
 //  Regression coverage for the `current` symlink lifecycle:
+//    - atomic publication and rollback when the pointer swap fails
 //    - replacing dangling symlinks (the v1→v2 plugin upgrade bug)
 //    - the launch-time self-heal pass
 //
@@ -13,6 +14,10 @@ import XCTest
 @testable import OsaurusRepository
 
 final class PluginInstallManagerTests: XCTestCase {
+    private enum PublicationFailure: Error {
+        case injected
+    }
+
     private var tempRoot: URL!
     private var previousOverride: URL?
 
@@ -76,6 +81,25 @@ final class PluginInstallManagerTests: XCTestCase {
 
     private func sv(_ s: String) -> SemanticVersion { SemanticVersion.parse(s)! }
 
+    private func stagedCurrentEntries(pluginId: String) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(
+            atPath: PluginInstallManager.toolsPluginDirectory(pluginId: pluginId).path
+        ).filter { $0.hasPrefix(".current.") && $0.hasSuffix(".tmp") }
+    }
+
+    private func assertLayoutInvalid(
+        _ error: Error,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let installError = error as? PluginInstallError else {
+            return XCTFail("Expected PluginInstallError, got \(error)", file: file, line: line)
+        }
+        guard case .layoutInvalid = installError else {
+            return XCTFail("Expected layoutInvalid, got \(installError)", file: file, line: line)
+        }
+    }
+
     // MARK: - updateCurrentSymlink
 
     /// Reproduces the v1→v2 upgrade bug: `current` points at a deleted version dir
@@ -121,6 +145,7 @@ final class PluginInstallManagerTests: XCTestCase {
             fm.fileExists(atPath: v1Dir.path),
             "Old version directory must not be touched by symlink update"
         )
+        XCTAssertEqual(try stagedCurrentEntries(pluginId: pluginId), [])
     }
 
     func test_updateCurrentSymlink_createsWhenAbsent() throws {
@@ -148,6 +173,117 @@ final class PluginInstallManagerTests: XCTestCase {
         try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: sv("1.0.0"))
 
         XCTAssertEqual(try fm.destinationOfSymbolicLink(atPath: link.path), "1.0.0")
+    }
+
+    func test_updateCurrentSymlink_replacesRegularFileAtomically() throws {
+        let fm = FileManager.default
+        let pluginId = "osaurus.time"
+        _ = pluginDir(pluginId)
+        let link = PluginInstallManager.currentSymlinkURL(pluginId: pluginId)
+        try Data("stale".utf8).write(to: link)
+
+        try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: sv("1.0.0"))
+
+        XCTAssertEqual(try fm.destinationOfSymbolicLink(atPath: link.path), "1.0.0")
+        XCTAssertEqual(try stagedCurrentEntries(pluginId: pluginId), [])
+    }
+
+    func test_replaceCurrentSymlink_failedCommitPreservesLivePointer() throws {
+        let fm = FileManager.default
+        let pluginId = "osaurus.rollback"
+        let oldVersion = try makeVersionDir(pluginId: pluginId, version: "1.0.0")
+        _ = try makeVersionDir(pluginId: pluginId, version: "2.0.0")
+        let link = PluginInstallManager.currentSymlinkURL(pluginId: pluginId)
+        try fm.createSymbolicLink(atPath: link.path, withDestinationPath: "1.0.0")
+        var commitAttempted = false
+
+        XCTAssertThrowsError(
+            try PluginInstallManager.replaceCurrentSymlink(
+                pluginId: pluginId,
+                version: sv("2.0.0")
+            ) { stagedPath, currentPath in
+                commitAttempted = true
+                XCTAssertEqual(
+                    try fm.destinationOfSymbolicLink(atPath: stagedPath),
+                    "2.0.0"
+                )
+                XCTAssertEqual(currentPath, link.path)
+                throw PublicationFailure.injected
+            }
+        ) { error in
+            self.assertLayoutInvalid(error)
+        }
+
+        XCTAssertTrue(commitAttempted)
+        XCTAssertEqual(try fm.destinationOfSymbolicLink(atPath: link.path), "1.0.0")
+        XCTAssertTrue(fm.fileExists(atPath: oldVersion.path))
+        XCTAssertEqual(try stagedCurrentEntries(pluginId: pluginId), [])
+    }
+
+    func test_replaceCurrentSymlink_failedFirstCommitLeavesPointerAbsent() throws {
+        let fm = FileManager.default
+        let pluginId = "osaurus.first-publication"
+        _ = pluginDir(pluginId)
+        let link = PluginInstallManager.currentSymlinkURL(pluginId: pluginId)
+
+        XCTAssertThrowsError(
+            try PluginInstallManager.replaceCurrentSymlink(
+                pluginId: pluginId,
+                version: sv("1.0.0")
+            ) { _, _ in
+                throw PublicationFailure.injected
+            }
+        ) { error in
+            self.assertLayoutInvalid(error)
+        }
+
+        XCTAssertNil(try? fm.destinationOfSymbolicLink(atPath: link.path))
+        XCTAssertEqual(try stagedCurrentEntries(pluginId: pluginId), [])
+    }
+
+    func test_replaceCurrentSymlink_failedCommitPreservesDanglingPointer() throws {
+        let fm = FileManager.default
+        let pluginId = "osaurus.dangling-rollback"
+        _ = pluginDir(pluginId)
+        let link = PluginInstallManager.currentSymlinkURL(pluginId: pluginId)
+        try fm.createSymbolicLink(atPath: link.path, withDestinationPath: "1.0.0")
+        XCTAssertFalse(fm.fileExists(atPath: link.path))
+
+        XCTAssertThrowsError(
+            try PluginInstallManager.replaceCurrentSymlink(
+                pluginId: pluginId,
+                version: sv("2.0.0")
+            ) { _, _ in
+                throw PublicationFailure.injected
+            }
+        ) { error in
+            self.assertLayoutInvalid(error)
+        }
+
+        XCTAssertEqual(try fm.destinationOfSymbolicLink(atPath: link.path), "1.0.0")
+        XCTAssertEqual(try stagedCurrentEntries(pluginId: pluginId), [])
+    }
+
+    func test_updateCurrentSymlink_refusesToReplaceDirectory() throws {
+        let fm = FileManager.default
+        let pluginId = "osaurus.invalid-current"
+        let link = PluginInstallManager.currentSymlinkURL(pluginId: pluginId)
+        try fm.createDirectory(at: link, withIntermediateDirectories: true)
+        let marker = link.appendingPathComponent("keep.txt", isDirectory: false)
+        try Data("keep".utf8).write(to: marker)
+
+        XCTAssertThrowsError(
+            try PluginInstallManager.updateCurrentSymlink(
+                pluginId: pluginId,
+                version: sv("2.0.0")
+            )
+        ) { error in
+            self.assertLayoutInvalid(error)
+        }
+
+        XCTAssertTrue(fm.fileExists(atPath: marker.path))
+        XCTAssertNil(try? fm.destinationOfSymbolicLink(atPath: link.path))
+        XCTAssertEqual(try stagedCurrentEntries(pluginId: pluginId), [])
     }
 
     // MARK: - repairDanglingCurrentSymlinks


### PR DESCRIPTION
## Summary

- Publishes the plugin `current` symlink with a same-directory staged link and atomic rename.
- Preserves the previously active version when publication fails instead of creating a missing-pointer window.
- Fails closed when `current` is an unexpected directory and safely replaces regular-file or dangling-link entries.
- Leaves the existing fail-closed signing-key mismatch and receipt trust behavior unchanged.

## Scope

This PR now contains only the atomic active-version pointer change and its focused tests. The earlier automatic signing-key rotation and plugin UI changes were removed after comparison with the current registry trust flow.

## Validation

- 23 focused active-pointer tests passed.
- 18 existing plugin integrity and trust tests passed.
- Full `OsaurusRepository` suite: 82 tests passed.
- Scoped SwiftLint passed; three unchanged warnings remain outside edited hunks.
- `git diff --check` passed.

## Risk

Concurrent publishers are last-writer-wins, while each rename remains atomic. A process crash after staging but before rename can leave a harmless `.current.*.tmp` entry; it does not replace or remove the active pointer.