### PR TITLE
Harden plugin repository refresh diagnostics

### DIFF
--- a/Packages/OsaurusCore/Services/Plugin/PluginRepositoryService.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginRepositoryService.swift
@@ -66,6 +66,9 @@ final class PluginRepositoryService: ObservableObject {
     /// Error from last refresh attempt
     @Published private(set) var lastError: String?
 
+    /// Structured diagnostic from the last repository refresh attempt.
+    @Published private(set) var lastRefreshResult: CentralRepositoryRefreshResult?
+
     /// Plugin ID that needs secrets configuration after installation (triggers secrets sheet in UI)
     @Published var pendingSecretsPlugin: String?
 
@@ -124,13 +127,14 @@ final class PluginRepositoryService: ObservableObject {
             await loadInstalledPluginsFromDisk()
         }
 
-        // Run git operations on background thread
-        let gitSuccess = await Task.detached(priority: .utility) {
-            CentralRepositoryManager.shared.refresh()
+        // Run repository I/O on a background thread.
+        let refreshResult = await Task.detached(priority: .utility) {
+            CentralRepositoryManager.shared.refreshWithDiagnostics()
         }.value
+        lastRefreshResult = refreshResult
 
-        if !gitSuccess {
-            lastError = "Unable to reach plugin repository"
+        if !refreshResult.succeeded {
+            lastError = refreshResult.userMessage ?? "Unable to reach plugin repository"
         }
 
         // Parse specs and resolve installed state on background threads (both read

--- a/Packages/OsaurusCore/Tools/ConfigurationTools.swift
+++ b/Packages/OsaurusCore/Tools/ConfigurationTools.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import OsaurusRepository
 
 // MARK: - Provider read visibility (eval isolation)
 
@@ -74,6 +75,40 @@ enum ConfigurationProviderReadVisibility {
     }
 }
 
+private enum PluginRepositoryDiagnosticProjection {
+    static func dictionary(_ result: CentralRepositoryRefreshResult?) -> [String: Any]? {
+        guard let result else { return nil }
+        var dict: [String: Any] = [
+            "succeeded": result.succeeded,
+            "repository_url": result.repositoryURL,
+            "attempted_archive_urls": result.attemptedArchiveURLs,
+            "cache_available": result.cacheAvailable,
+        ]
+        if let refreshedAt = result.refreshedAt {
+            dict["refreshed_at"] = ISO8601DateFormatter().string(from: refreshedAt)
+        }
+        if let cacheUpdatedAt = result.cacheUpdatedAt {
+            dict["cache_updated_at"] = ISO8601DateFormatter().string(from: cacheUpdatedAt)
+        }
+        if let failure = result.failure {
+            var failureDict: [String: Any] = [
+                "kind": failure.kind.rawValue,
+                "message": failure.message,
+                "user_message": failure.userMessage,
+                "retryable": failure.retryable,
+            ]
+            if let failedURL = failure.failedArchiveURL {
+                failureDict["failed_archive_url"] = failedURL
+            }
+            if let httpStatusCode = failure.httpStatusCode {
+                failureDict["http_status_code"] = httpStatusCode
+            }
+            dict["failure"] = failureDict
+        }
+        return dict
+    }
+}
+
 // MARK: - osaurus_status
 
 public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
@@ -113,6 +148,9 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
             let plugins = PluginRepositoryService.shared.plugins
             let installedPlugins = plugins.filter { $0.installedVersion != nil }
             let failedPlugins = installedPlugins.filter { $0.loadError != nil }
+            let pluginRepositoryDiagnostic = PluginRepositoryDiagnosticProjection.dictionary(
+                PluginRepositoryService.shared.lastRefreshResult
+            )
 
             let schedules = ScheduleManager.shared.schedules
             let enabledSchedules = schedules.filter { $0.isEnabled }
@@ -177,6 +215,7 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
                 "plugins": [
                     "installed": installedPlugins.count,
                     "failed": failedPlugins.count,
+                    "repository": pluginRepositoryDiagnostic ?? [:],
                 ],
                 "schedules": [
                     "total": schedules.count,
@@ -347,7 +386,14 @@ public final class OsaurusListTool: OsaurusTool, @unchecked Sendable {
                 default:
                     filtered = items
                 }
-                payload = ["scope": "plugins", "filter": filter, "items": filtered]
+                payload = [
+                    "scope": "plugins",
+                    "filter": filter,
+                    "repository": PluginRepositoryDiagnosticProjection.dictionary(
+                        PluginRepositoryService.shared.lastRefreshResult
+                    ) ?? [:],
+                    "items": filtered,
+                ]
             case "schedules":
                 let schedules = ScheduleManager.shared.schedules.map { s -> [String: Any] in
                     return [

--- a/Packages/OsaurusRepository/CentralRepositoryManager.swift
+++ b/Packages/OsaurusRepository/CentralRepositoryManager.swift
@@ -17,9 +17,106 @@ public struct CentralRepository {
     }
 }
 
+public struct CentralRepositoryRefreshResult: Equatable, Sendable {
+    public let succeeded: Bool
+    public let repositoryURL: String
+    public let attemptedArchiveURLs: [String]
+    public let refreshedAt: Date?
+    public let cacheAvailable: Bool
+    public let cacheUpdatedAt: Date?
+    public let failure: CentralRepositoryRefreshFailure?
+
+    public var userMessage: String? {
+        failure?.userMessage
+    }
+}
+
+public struct CentralRepositoryRefreshFailure: Equatable, LocalizedError, Sendable {
+    public enum Kind: String, Sendable {
+        case unsupportedRepository
+        case notFound
+        case unauthorized
+        case rateLimited
+        case serverError
+        case networkUnavailable
+        case timedOut
+        case tlsTrust
+        case cancelled
+        case malformedArchive
+        case unzipFailed
+        case fileSystem
+        case unknown
+    }
+
+    public let kind: Kind
+    public let message: String
+    public let repositoryURL: String
+    public let attemptedArchiveURLs: [String]
+    public let failedArchiveURL: String?
+    public let httpStatusCode: Int?
+    public let retryable: Bool
+    public let cacheAvailable: Bool
+    public let cacheUpdatedAt: Date?
+
+    public var errorDescription: String? { message }
+
+    public var userMessage: String {
+        let cacheSuffix: String
+        if cacheAvailable {
+            if let cacheUpdatedAt {
+                let formattedDate = DateFormatter.localizedString(
+                    from: cacheUpdatedAt,
+                    dateStyle: .medium,
+                    timeStyle: .short
+                )
+                cacheSuffix = " Showing cached plugin list from \(formattedDate)."
+            } else {
+                cacheSuffix = " Showing cached plugin list."
+            }
+        } else {
+            cacheSuffix = " No cached plugin list is available yet."
+        }
+
+        let retrySuffix = retryable
+            ? " You can retry after the connection or service recovers."
+            : " Check the repository URL or configuration before retrying."
+
+        switch kind {
+        case .unsupportedRepository:
+            return "Plugin repository URL is unsupported. Osaurus can refresh GitHub repositories only.\(cacheSuffix)"
+        case .notFound:
+            return "Plugin repository archive was not found for the configured branch.\(cacheSuffix)\(retrySuffix)"
+        case .unauthorized:
+            return "Plugin repository rejected the request as unauthorized.\(cacheSuffix)\(retrySuffix)"
+        case .rateLimited:
+            return "Plugin repository rate limit was reached.\(cacheSuffix)\(retrySuffix)"
+        case .serverError:
+            return "Plugin repository is temporarily unavailable.\(cacheSuffix)\(retrySuffix)"
+        case .networkUnavailable:
+            return "Plugin repository is unreachable from this network.\(cacheSuffix)\(retrySuffix)"
+        case .timedOut:
+            return "Plugin repository refresh timed out.\(cacheSuffix)\(retrySuffix)"
+        case .tlsTrust:
+            return "Plugin repository connection failed certificate validation.\(cacheSuffix)\(retrySuffix)"
+        case .cancelled:
+            return "Plugin repository refresh was cancelled.\(cacheSuffix)\(retrySuffix)"
+        case .malformedArchive:
+            return "Plugin repository downloaded an invalid registry archive.\(cacheSuffix)\(retrySuffix)"
+        case .unzipFailed:
+            return "Plugin repository archive could not be unpacked.\(cacheSuffix)\(retrySuffix)"
+        case .fileSystem:
+            return "Plugin repository cache could not be updated on disk.\(cacheSuffix)\(retrySuffix)"
+        case .unknown:
+            return "Plugin repository refresh failed.\(cacheSuffix)\(retrySuffix)"
+        }
+    }
+}
+
 public final class CentralRepositoryManager: @unchecked Sendable {
     public static let shared = CentralRepositoryManager()
     private init() {}
+
+    static nonisolated(unsafe) var downloadFileOverride: (@Sendable (URL, URL) throws -> Void)?
 
     public var central: CentralRepository = .init(
         url: "https://github.com/osaurus-ai/osaurus-tools.git",
@@ -38,12 +135,52 @@ public final class CentralRepositoryManager: @unchecked Sendable {
     /// missing `plugins/` dir) the existing on-disk copy is left untouched.
     @discardableResult
     public func refresh() -> Bool {
+        refreshWithDiagnostics().succeeded
+    }
+
+    /// Refreshes the local plugin registry and returns a typed diagnostic that
+    /// callers can surface in UI/support bundles without parsing logs.
+    @discardableResult
+    public func refreshWithDiagnostics() -> CentralRepositoryRefreshResult {
         do {
-            try performRefresh()
-            return true
+            let attemptedURLs = try performRefresh()
+            return CentralRepositoryRefreshResult(
+                succeeded: true,
+                repositoryURL: Self.redactedURLString(central.url),
+                attemptedArchiveURLs: attemptedURLs.map { Self.redactedURLString($0.absoluteString) },
+                refreshedAt: Date(),
+                cacheAvailable: hasCachedSpecs(),
+                cacheUpdatedAt: cacheUpdatedAt(),
+                failure: nil
+            )
+        } catch let attemptError as RefreshAttemptError {
+            let failure = makeFailure(
+                from: attemptError.underlying,
+                attemptedURLs: attemptError.attemptedURLs,
+                failedURL: attemptError.failedURL
+            )
+            NSLog("[Osaurus] Registry refresh failed: %@", failure.message)
+            return CentralRepositoryRefreshResult(
+                succeeded: false,
+                repositoryURL: failure.repositoryURL,
+                attemptedArchiveURLs: failure.attemptedArchiveURLs,
+                refreshedAt: nil,
+                cacheAvailable: failure.cacheAvailable,
+                cacheUpdatedAt: failure.cacheUpdatedAt,
+                failure: failure
+            )
         } catch {
-            NSLog("[Osaurus] Registry refresh failed: %@", String(describing: error))
-            return false
+            let failure = makeFailure(from: error, attemptedURLs: [], failedURL: nil)
+            NSLog("[Osaurus] Registry refresh failed: %@", failure.message)
+            return CentralRepositoryRefreshResult(
+                succeeded: false,
+                repositoryURL: failure.repositoryURL,
+                attemptedArchiveURLs: failure.attemptedArchiveURLs,
+                refreshedAt: nil,
+                cacheAvailable: failure.cacheAvailable,
+                cacheUpdatedAt: failure.cacheUpdatedAt,
+                failure: failure
+            )
         }
     }
 
@@ -57,7 +194,7 @@ public final class CentralRepositoryManager: @unchecked Sendable {
 
     // MARK: - Refresh pipeline
 
-    private func performRefresh() throws {
+    private func performRefresh() throws -> [URL] {
         let fm = FileManager.default
         let root = ToolsPaths.pluginSpecsRoot()
         try fm.createDirectoryIfNeeded(at: root)
@@ -75,43 +212,58 @@ public final class CentralRepositoryManager: @unchecked Sendable {
 
         let zipURL = stagingDir.appendingPathComponent(Path.archiveZip, isDirectory: false)
 
-        // try candidates in order, falling through on 404 so a repo whose
+        // Try candidates in order, falling through on 404 so a repo whose
         // default branch is master still resolves when no branch is pinned
-        var lastError: Error?
+        var attemptedURLs: [URL] = []
         for (index, url) in archiveURLs.enumerated() {
+            attemptedURLs.append(url)
             do {
                 try downloadFile(from: url, to: zipURL)
-                lastError = nil
                 break
             } catch RefreshError.httpStatus(404) where index < archiveURLs.count - 1 {
-                lastError = RefreshError.httpStatus(404)
                 continue
             } catch {
-                throw error
+                throw RefreshAttemptError(underlying: error, attemptedURLs: attemptedURLs, failedURL: url)
             }
         }
-        if let lastError { throw lastError }
 
         let extractDir = stagingDir.appendingPathComponent(Path.extracted, isDirectory: true)
-        try fm.createDirectory(at: extractDir, withIntermediateDirectories: true)
-        try unzip(zipURL: zipURL, to: extractDir)
+        do {
+            try fm.createDirectory(at: extractDir, withIntermediateDirectories: true)
+            try unzip(zipURL: zipURL, to: extractDir)
+        } catch {
+            throw RefreshAttemptError(underlying: error, attemptedURLs: attemptedURLs, failedURL: nil)
+        }
 
         // GitHub source archives wrap their contents in a single top-level directory
         // named `<repo>-<branch>/`.
         guard let innerRoot = locateInnerArchiveRoot(in: extractDir) else {
-            throw RefreshError.malformedArchive("no inner directory inside \(extractDir.path)")
+            throw RefreshAttemptError(
+                underlying: RefreshError.malformedArchive("no inner directory inside \(extractDir.path)"),
+                attemptedURLs: attemptedURLs,
+                failedURL: nil
+            )
         }
 
         // Integrity check: the inner root must contain a `plugins/` directory with at
         // least one JSON file that decodes as a valid `PluginSpec`. Prevents accidentally
         // installing an unrelated repository as the registry.
         guard !decodeSpecs(in: pluginsDirectory(under: innerRoot)).isEmpty else {
-            throw RefreshError.malformedArchive(
-                "no decodable plugin specs under \(innerRoot.path)/\(Path.plugins)"
+            throw RefreshAttemptError(
+                underlying: RefreshError.malformedArchive(
+                    "no decodable plugin specs under \(innerRoot.path)/\(Path.plugins)"
+                ),
+                attemptedURLs: attemptedURLs,
+                failedURL: nil
             )
         }
 
-        try replaceDirectoryAtomically(at: centralCloneDirectory, with: innerRoot)
+        do {
+            try replaceDirectoryAtomically(at: centralCloneDirectory, with: innerRoot)
+        } catch {
+            throw RefreshAttemptError(underlying: error, attemptedURLs: attemptedURLs, failedURL: nil)
+        }
+        return attemptedURLs
     }
 
     // MARK: - URL derivation
@@ -125,12 +277,12 @@ public final class CentralRepositoryManager: @unchecked Sendable {
         guard let comps = URLComponents(string: central.url),
             let host = comps.host?.lowercased(),
             host == "github.com" || host.hasSuffix(".github.com")
-        else { throw RefreshError.unsupportedURL(central.url) }
+        else { throw RefreshError.unsupportedURL(Self.redactedURLString(central.url)) }
 
         var path = comps.path
         if path.hasSuffix(".git") { path = String(path.dropLast(4)) }
         let segments = path.split(separator: "/", omittingEmptySubsequences: true)
-        guard segments.count >= 2 else { throw RefreshError.unsupportedURL(central.url) }
+        guard segments.count >= 2 else { throw RefreshError.unsupportedURL(Self.redactedURLString(central.url)) }
 
         let owner = String(segments[0])
         let repo = String(segments[1])
@@ -140,7 +292,7 @@ public final class CentralRepositoryManager: @unchecked Sendable {
             let encoded = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
             return URL(string: "https://github.com/\(owner)/\(repo)/archive/refs/heads/\(encoded).zip")
         }
-        guard !urls.isEmpty else { throw RefreshError.unsupportedURL(central.url) }
+        guard !urls.isEmpty else { throw RefreshError.unsupportedURL(Self.redactedURLString(central.url)) }
         return urls
     }
 
@@ -149,6 +301,11 @@ public final class CentralRepositoryManager: @unchecked Sendable {
     /// Synchronously downloads `url` to `destination`. Callers invoke `refresh()`
     /// from a background thread (e.g. `Task.detached`) so blocking is acceptable.
     private func downloadFile(from url: URL, to destination: URL) throws {
+        if let override = Self.downloadFileOverride {
+            try override(url, destination)
+            return
+        }
+
         let outcome = SyncDownloadOutcome()
         let semaphore = DispatchSemaphore(value: 0)
         RepositoryGlobalProxySettings.sharedSession().downloadTask(with: url) { tempURL, response, error in
@@ -259,6 +416,125 @@ public final class CentralRepositoryManager: @unchecked Sendable {
         root.appendingPathComponent(Path.plugins, isDirectory: true)
     }
 
+    private func hasCachedSpecs() -> Bool {
+        !decodeSpecs(in: pluginsDirectory(under: centralCloneDirectory)).isEmpty
+    }
+
+    private func cacheUpdatedAt() -> Date? {
+        guard FileManager.default.fileExists(atPath: centralCloneDirectory.path) else { return nil }
+        return try? centralCloneDirectory.resourceValues(forKeys: [.contentModificationDateKey])
+            .contentModificationDate
+    }
+
+    private func makeFailure(from error: Error, attemptedURLs: [URL], failedURL: URL?)
+        -> CentralRepositoryRefreshFailure
+    {
+        let cacheAvailable = hasCachedSpecs()
+        let cacheUpdatedAt = cacheUpdatedAt()
+        let mapped = mapFailure(error)
+        let statusCode: Int?
+        if case .httpStatus(let code)? = error as? RefreshError {
+            statusCode = code
+        } else {
+            statusCode = nil
+        }
+
+        return CentralRepositoryRefreshFailure(
+            kind: mapped.kind,
+            message: Self.sanitizedDiagnosticMessage(mapped.message),
+            repositoryURL: Self.redactedURLString(central.url),
+            attemptedArchiveURLs: attemptedURLs.map { Self.redactedURLString($0.absoluteString) },
+            failedArchiveURL: failedURL.map { Self.redactedURLString($0.absoluteString) },
+            httpStatusCode: statusCode,
+            retryable: mapped.retryable,
+            cacheAvailable: cacheAvailable,
+            cacheUpdatedAt: cacheUpdatedAt
+        )
+    }
+
+    private func mapFailure(_ error: Error) -> (
+        kind: CentralRepositoryRefreshFailure.Kind,
+        message: String,
+        retryable: Bool
+    ) {
+        if let refreshError = error as? RefreshError {
+            switch refreshError {
+            case .unsupportedURL:
+                return (.unsupportedRepository, refreshError.description, false)
+            case .httpStatus(let code):
+                if code == 404 {
+                    return (.notFound, refreshError.description, false)
+                } else if code == 401 || code == 403 {
+                    return (.unauthorized, refreshError.description, false)
+                } else if code == 429 {
+                    return (.rateLimited, refreshError.description, true)
+                } else if code >= 500 {
+                    return (.serverError, refreshError.description, true)
+                }
+                return (.unknown, refreshError.description, false)
+            case .unzipFailed:
+                return (.unzipFailed, refreshError.description, false)
+            case .malformedArchive:
+                return (.malformedArchive, refreshError.description, false)
+            }
+        }
+
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .cannotFindHost, .cannotConnectToHost,
+                 .networkConnectionLost, .dnsLookupFailed:
+                return (.networkUnavailable, urlError.localizedDescription, true)
+            case .timedOut:
+                return (.timedOut, urlError.localizedDescription, true)
+            case .secureConnectionFailed, .serverCertificateHasBadDate,
+                 .serverCertificateUntrusted, .serverCertificateHasUnknownRoot,
+                 .serverCertificateNotYetValid, .clientCertificateRejected,
+                 .clientCertificateRequired:
+                return (.tlsTrust, urlError.localizedDescription, false)
+            case .cancelled:
+                return (.cancelled, urlError.localizedDescription, true)
+            default:
+                return (.unknown, urlError.localizedDescription, true)
+            }
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain || nsError.domain == NSPOSIXErrorDomain {
+            return (.fileSystem, nsError.localizedDescription, false)
+        }
+
+        return (.unknown, String(describing: error), true)
+    }
+
+    private static func sanitizedDiagnosticMessage(_ message: String) -> String {
+        var sanitized = message
+        for (prefix, replacement) in pathRedactionPrefixes() where !prefix.isEmpty {
+            sanitized = sanitized.replacingOccurrences(of: prefix, with: replacement)
+        }
+        if sanitized.count > 600 {
+            let end = sanitized.index(sanitized.startIndex, offsetBy: 600)
+            sanitized = String(sanitized[..<end]) + "..."
+        }
+        return sanitized
+    }
+
+    private static func pathRedactionPrefixes() -> [(String, String)] {
+        [
+            (ToolsPaths.root().path, "<osaurus-data>"),
+            (FileManager.default.homeDirectoryForCurrentUser.path, "~"),
+            (FileManager.default.temporaryDirectory.path, "<tmp>"),
+        ]
+    }
+
+    private static func redactedURLString(_ string: String) -> String {
+        guard var components = URLComponents(string: string) else { return "<repository-url>" }
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? "<repository-url>"
+    }
+
     private enum Path {
         static let central = "central"
         static let plugins = "plugins"
@@ -268,9 +544,15 @@ public final class CentralRepositoryManager: @unchecked Sendable {
     }
 }
 
+private struct RefreshAttemptError: Error {
+    let underlying: Error
+    let attemptedURLs: [URL]
+    let failedURL: URL?
+}
+
 // MARK: - Errors
 
-private enum RefreshError: Error, CustomStringConvertible {
+enum RefreshError: Error, CustomStringConvertible {
     case unsupportedURL(String)
     case httpStatus(Int)
     case unzipFailed(Int, String)

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/CentralRepositoryManagerTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/CentralRepositoryManagerTests.swift
@@ -1,0 +1,202 @@
+//
+//  CentralRepositoryManagerTests.swift
+//  OsaurusRepository
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusRepository
+
+final class CentralRepositoryManagerTests: XCTestCase {
+    private var tempRoot: URL!
+    private var previousRoot: URL?
+    private var previousRepository: CentralRepository!
+    private var previousDownloadOverride: (@Sendable (URL, URL) throws -> Void)?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-central-repo-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousRoot = ToolsPaths.overrideRoot
+        previousRepository = CentralRepositoryManager.shared.central
+        previousDownloadOverride = CentralRepositoryManager.downloadFileOverride
+        ToolsPaths.overrideRoot = tempRoot
+        CentralRepositoryManager.downloadFileOverride = nil
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousRoot
+        CentralRepositoryManager.shared.central = previousRepository
+        CentralRepositoryManager.downloadFileOverride = previousDownloadOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testRefreshWithDiagnosticsClassifiesOfflineNetworkFailure() {
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://github.com/osaurus-ai/osaurus-tools.git",
+            branch: "main"
+        )
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let result = CentralRepositoryManager.shared.refreshWithDiagnostics()
+
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.failure?.kind, .networkUnavailable)
+        XCTAssertEqual(result.failure?.retryable, true)
+        XCTAssertEqual(result.cacheAvailable, false)
+        XCTAssertEqual(
+            result.attemptedArchiveURLs,
+            ["https://github.com/osaurus-ai/osaurus-tools/archive/refs/heads/main.zip"]
+        )
+        XCTAssertEqual(result.failure?.failedArchiveURL, result.attemptedArchiveURLs.first)
+        XCTAssertTrue(result.userMessage?.contains("unreachable") == true)
+        XCTAssertTrue(result.userMessage?.contains("No cached plugin list") == true)
+    }
+
+    func testRefreshWithDiagnosticsMentionsCachedRepositoryWhenRefreshFails() throws {
+        try writeCachedSpec(pluginId: "osaurus.cached")
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://github.com/osaurus-ai/osaurus-tools.git",
+            branch: "main"
+        )
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw URLError(.timedOut)
+        }
+
+        let result = CentralRepositoryManager.shared.refreshWithDiagnostics()
+
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.failure?.kind, .timedOut)
+        XCTAssertTrue(result.cacheAvailable)
+        XCTAssertNotNil(result.cacheUpdatedAt)
+        XCTAssertTrue(result.userMessage?.contains("Showing cached plugin list") == true)
+        XCTAssertEqual(CentralRepositoryManager.shared.listAllSpecs().map(\.plugin_id), ["osaurus.cached"])
+    }
+
+    func testRefreshDiagnosticsRedactCredentialBearingRepositoryURL() {
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://token:secret@github.com/osaurus-ai/osaurus-tools.git?api_key=secret",
+            branch: "main"
+        )
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw URLError(.timedOut)
+        }
+
+        let result = CentralRepositoryManager.shared.refreshWithDiagnostics()
+        let diagnostic = [
+            result.repositoryURL,
+            result.attemptedArchiveURLs.joined(separator: " "),
+            result.failure?.repositoryURL ?? "",
+            result.failure?.failedArchiveURL ?? "",
+            result.failure?.message ?? "",
+            result.failure?.userMessage ?? "",
+        ].joined(separator: " ")
+
+        XCTAssertFalse(diagnostic.contains("secret"))
+        XCTAssertFalse(diagnostic.contains("api_key"))
+        XCTAssertEqual(result.repositoryURL, "https://github.com/osaurus-ai/osaurus-tools.git")
+    }
+
+    func testRefreshDiagnosticsFailClosedWhenRepositoryURLCannotParse() {
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://token:secret@%",
+            branch: nil
+        )
+
+        let result = CentralRepositoryManager.shared.refreshWithDiagnostics()
+        let diagnostic = [
+            result.repositoryURL,
+            result.failure?.repositoryURL ?? "",
+            result.failure?.message ?? "",
+            result.failure?.userMessage ?? "",
+        ].joined(separator: " ")
+
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.failure?.kind, .unsupportedRepository)
+        XCTAssertEqual(result.repositoryURL, "<repository-url>")
+        XCTAssertFalse(diagnostic.contains("secret"))
+        XCTAssertFalse(diagnostic.contains("token"))
+    }
+
+    func testRefreshDiagnosticsRedactsLocalPathsFromArchiveFailures() throws {
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://github.com/osaurus-ai/osaurus-tools.git",
+            branch: nil
+        )
+        CentralRepositoryManager.downloadFileOverride = { _, destination in
+            try Data("not a zip archive".utf8).write(to: destination)
+        }
+
+        let result = CentralRepositoryManager.shared.refreshWithDiagnostics()
+
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.failure?.kind, .unzipFailed)
+        XCTAssertEqual(
+            result.attemptedArchiveURLs,
+            ["https://github.com/osaurus-ai/osaurus-tools/archive/refs/heads/main.zip"]
+        )
+        XCTAssertFalse(result.failure?.message.contains(tempRoot.path) == true)
+        XCTAssertFalse(result.failure?.userMessage.contains(tempRoot.path) == true)
+        XCTAssertFalse(result.failure?.message.contains(NSHomeDirectory()) == true)
+    }
+
+    func testRefreshDiagnosticsRecordsMainMaster404FallbackChain() {
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://github.com/osaurus-ai/osaurus-tools.git",
+            branch: nil
+        )
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw RefreshError.httpStatus(404)
+        }
+
+        let result = CentralRepositoryManager.shared.refreshWithDiagnostics()
+
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.failure?.kind, .notFound)
+        XCTAssertEqual(result.failure?.httpStatusCode, 404)
+        XCTAssertEqual(result.failure?.retryable, false)
+        XCTAssertEqual(
+            result.attemptedArchiveURLs,
+            [
+                "https://github.com/osaurus-ai/osaurus-tools/archive/refs/heads/main.zip",
+                "https://github.com/osaurus-ai/osaurus-tools/archive/refs/heads/master.zip",
+            ]
+        )
+        XCTAssertEqual(result.failure?.failedArchiveURL, result.attemptedArchiveURLs.last)
+    }
+
+    func testRefreshKeepsBooleanCompatibility() {
+        CentralRepositoryManager.shared.central = CentralRepository(
+            url: "https://github.com/osaurus-ai/osaurus-tools.git",
+            branch: "main"
+        )
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw URLError(.cannotFindHost)
+        }
+
+        XCTAssertFalse(CentralRepositoryManager.shared.refresh())
+    }
+
+    private func writeCachedSpec(pluginId: String) throws {
+        let pluginsDirectory = ToolsPaths.pluginSpecsRoot()
+            .appendingPathComponent("central", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginsDirectory, withIntermediateDirectories: true)
+
+        let spec = PluginSpec(plugin_id: pluginId, name: "Cached Plugin")
+        let data = try JSONEncoder().encode(spec)
+        try data.write(
+            to: pluginsDirectory.appendingPathComponent("\(pluginId).json", isDirectory: false),
+            options: .atomic
+        )
+    }
+}


### PR DESCRIPTION
Fixes R058 / Wave 3B plugin repository unreachable diagnostics.

Summary:
- add typed central repository refresh diagnostics with retryability, attempted archive URLs, HTTP status, cache availability, and cache date
- preserve the existing Bool refresh API while exposing `refreshWithDiagnostics()` to plugin services and tools
- surface redacted repository diagnostics through plugin status/list tooling and plugin repository service errors
- redact URL credentials, query/fragment data, and local filesystem paths from support-facing diagnostics

Validation:
- `swift test --disable-index-store --package-path Packages/OsaurusRepository --filter CentralRepositoryManagerTests` passed: 7 tests
- `swift test --disable-index-store --package-path Packages/OsaurusCore --filter ConfigurationTools` passed: 12 tests in 3 suites
- `git diff --check` passed

Review evidence:
- Fable unavailable due model limit; used Claude Opus fallback at medium effort
- Opus review found no blocking issues after redaction changes; follow-up hardening requests were applied
- Grok review stale blockers were addressed before commit: fail-closed URL redaction and main/master 404 fallback coverage
