### PR TITLE
Harden model compatibility preflight diagnostics

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "" : {
       "shouldTranslate" : false
     },
+    "%@ %@ \"%@\"" : {
+      "shouldTranslate" : false
+    },
     " — %@" : {
       "localizations" : {
         "de" : {
@@ -68859,6 +68862,24 @@
           }
         }
       }
+    },
+    "JANGTQ sidecar label mismatch" : {
+      "shouldTranslate" : false
+    },
+    "JANGTQ sidecar missing" : {
+      "shouldTranslate" : false
+    },
+    "Unsupported OCR model family" : {
+      "shouldTranslate" : false
+    },
+    "model id contains \"jangtq\"" : {
+      "shouldTranslate" : false
+    },
+    "model name contains \"jangtq\"" : {
+      "shouldTranslate" : false
+    },
+    "no JANGTQ routing stamp" : {
+      "shouldTranslate" : false
     },
     "JSON object keyed by standard action names. Values define method, path, optional query, headers, and bodyTemplate." : {
       "comment" : "Help text for the \"Action Map JSON\" field in the custom HTTP section of the agent channel custom connection sheet.",

--- a/Packages/OsaurusCore/Services/ModelCompatibilityDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/ModelCompatibilityDiagnostics.swift
@@ -59,6 +59,11 @@ enum ModelCompatibilityDiagnostics {
         let hasVisionConfig: Bool
         let hasJANGConfig: Bool
         let hasJANGTQSidecar: Bool
+        let configWeightFormat: String?
+        let configFormat: String?
+        let jangWeightFormat: String?
+        let jangFormat: String?
+        let jangProfile: String?
         let tokenizer: TokenizerSummary?
         let generation: GenerationSummary?
         let toolCalling: ToolCallingSummary?
@@ -111,6 +116,9 @@ enum ModelCompatibilityDiagnostics {
             case incompleteBundle
             case unsupportedHunyuanDense
             case unsupportedLongCat
+            case unsupportedDeepSeekOCR
+            case missingJANGTQSidecar
+            case mislabeledJANGTQSidecar
             case notMLXFormat
             case partialDFlashSpeculativeDecoding
         }
@@ -370,6 +378,13 @@ enum ModelCompatibilityDiagnostics {
                 detail: localBundle.detail ?? L("The local directory does not have the required MLX files.")
             )
         case .available:
+            if let sidecarStatus = jangtqSidecarStatus(
+                modelId: modelId,
+                modelName: modelName,
+                config: config
+            ) {
+                return sidecarStatus
+            }
             // A bundle can have every required file yet still be a non-MLX
             // (e.g. PyTorch / transformers) safetensors export co-mingled in a
             // shared model store — it passes discovery but vmlx cannot load it.
@@ -572,11 +587,200 @@ enum ModelCompatibilityDiagnostics {
                 detail:
                     L(
                         "LongCat local bundles require native vmlx architecture, processor, cache, and media-path support before Osaurus should offer them as runnable."
+                )
+            )
+        }
+
+        let hasOCRArchitecture = architectures.contains { $0.contains("ocr") }
+        let hasOCRName = names.contains { $0.contains("ocr") }
+        let isDeepSeekOCR =
+            modelTypes.contains(where: { $0.contains("deepseek") && $0.contains("ocr") })
+            || architectures.contains(where: { $0.contains("deepseek") && $0.contains("ocr") })
+            || names.contains(where: { $0.contains("deepseekocr") || $0.contains("deepseek-ocr") })
+            || names.contains(where: { $0.contains("unlimited") && $0.contains("ocr") })
+            || (modelTypes.contains("deepseek_vl_v2") && (hasOCRArchitecture || hasOCRName))
+        if isDeepSeekOCR {
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .unsupportedDeepSeekOCR,
+                title: L("Unsupported OCR model family"),
+                detail:
+                    L(
+                        "DeepSeek-OCR / Unlimited-OCR bundles require a dedicated OCR/VL processor and runtime contract that this Osaurus build does not ship. Use a supported MLX text or vision model instead."
                     )
             )
         }
 
         return nil
+    }
+
+    private static func jangtqSidecarStatus(
+        modelId: String,
+        modelName: String,
+        config: ConfigSummary?
+    ) -> RuntimeStatus? {
+        guard let config else { return nil }
+        let jangWeightFormat = normalizedJANGRoutingValueIfPresent(config.jangWeightFormat)
+        let configWeightFormat = normalizedJANGRoutingValueIfPresent(config.configWeightFormat)
+        let jangFormat = normalizedJANGRoutingValueIfPresent(config.jangFormat)
+        let configFormat = normalizedJANGRoutingValueIfPresent(config.configFormat)
+        let profile = normalizedJANGRoutingValueIfPresent(config.jangProfile)
+        let modelDeclaresJANGTQ = [modelId, modelName].contains { value in
+            value.lowercased().contains("jangtq")
+        }
+        // Keep top-level JANGTQ stamps aligned with the host preflight. Profile,
+        // config.json, and name fallbacks can prove a missing sidecar, but an
+        // existing sidecar plus jang_config.json must still have a real stamp.
+        let jangConfigValidatorDeclaresJANGTQ =
+            declaresJANGTQWeightFormat(jangWeightFormat)
+            || declaresJANGTQFormat(jangFormat)
+        let jangConfigDeclaresJANGTQ =
+            jangConfigValidatorDeclaresJANGTQ
+            || profile?.lowercased().contains("jangtq") == true
+        let fallbackDeclaresJANGTQ =
+            declaresJANGTQWeightFormat(configWeightFormat)
+            || declaresJANGTQFormat(configFormat)
+            || modelDeclaresJANGTQ
+        let declaresJANGTQ = jangConfigDeclaresJANGTQ || fallbackDeclaresJANGTQ
+        guard config.hasJANGConfig || config.hasJANGTQSidecar || declaresJANGTQ else { return nil }
+
+        if declaresJANGTQ, !config.hasJANGTQSidecar {
+            let declaration = jangRoutingDeclaration(
+                config: config,
+                modelId: modelId,
+                modelName: modelName
+            )
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .missingJANGTQSidecar,
+                title: L("JANGTQ sidecar missing"),
+                detail: String(
+                    format:
+                        L(
+                            "%@ declares JANGTQ via %@, but the required jangtq_runtime.safetensors sidecar is missing. Re-download the full model or obtain the sidecar from the publisher."
+                        ),
+                    modelName,
+                    declaration
+                )
+            )
+        }
+
+        if config.hasJANGTQSidecar, config.hasJANGConfig, !jangConfigValidatorDeclaresJANGTQ {
+            let declaration = jangRoutingDeclaration(
+                config: config,
+                modelId: modelId,
+                modelName: modelName
+            )
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .mislabeledJANGTQSidecar,
+                title: L("JANGTQ sidecar label mismatch"),
+                detail: String(
+                    format:
+                        L(
+                            "%@ ships jangtq_runtime.safetensors, but jang_config.json declares %@. Re-download from a corrected source or set a JANGTQ routing stamp (weight_format \"mxtq\" or format \"jangtq\") before loading."
+                        ),
+                    modelName,
+                    declaration
+                )
+            )
+        }
+
+        if config.hasJANGTQSidecar, !declaresJANGTQ {
+            let declaration = jangRoutingDeclaration(
+                config: config,
+                modelId: modelId,
+                modelName: modelName
+            )
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .mislabeledJANGTQSidecar,
+                title: L("JANGTQ sidecar label mismatch"),
+                detail: String(
+                    format:
+                        L(
+                            "%@ ships jangtq_runtime.safetensors, but routing metadata declares %@. Re-download from a corrected source or set a JANGTQ routing stamp (weight_format \"mxtq\", format \"jangtq\", profile \"jangtq\", or a JANGTQ model name) before loading."
+                        ),
+                    modelName,
+                    declaration
+                )
+            )
+        }
+
+        return nil
+    }
+
+    private static func declaresJANGTQWeightFormat(_ value: String?) -> Bool {
+        guard let value else { return false }
+        let normalized = value.lowercased()
+        return normalized == "mxtq" || normalized.contains("jangtq")
+    }
+
+    private static func declaresJANGTQFormat(_ value: String?) -> Bool {
+        guard let value else { return false }
+        let normalized = value.lowercased()
+        return normalized == "mxtq" || normalized.contains("jangtq")
+    }
+
+    private static func jangRoutingDeclaration(
+        config: ConfigSummary,
+        modelId: String,
+        modelName: String
+    ) -> String {
+        var fields: [String] = []
+        appendJANGRoutingField(
+            &fields,
+            source: "jang_config.json",
+            key: "weight_format",
+            value: config.jangWeightFormat
+        )
+        appendJANGRoutingField(
+            &fields,
+            source: "config.json",
+            key: "weight_format",
+            value: config.configWeightFormat
+        )
+        appendJANGRoutingField(
+            &fields,
+            source: "jang_config.json",
+            key: "format",
+            value: config.jangFormat
+        )
+        appendJANGRoutingField(
+            &fields,
+            source: "config.json",
+            key: "format",
+            value: config.configFormat
+        )
+        appendJANGRoutingField(
+            &fields,
+            source: "jang_config.json",
+            key: "profile",
+            value: config.jangProfile
+        )
+        if modelId.lowercased().contains("jangtq") {
+            fields.append(L("model id contains \"jangtq\""))
+        }
+        if modelName.lowercased().contains("jangtq") {
+            fields.append(L("model name contains \"jangtq\""))
+        }
+        return fields.isEmpty ? L("no JANGTQ routing stamp") : fields.joined(separator: ", ")
+    }
+
+    private static func appendJANGRoutingField(
+        _ fields: inout [String],
+        source: String,
+        key: String,
+        value: String?
+    ) {
+        guard let value = normalizedJANGRoutingValueIfPresent(value) else { return }
+        fields.append(String(format: L("%@ %@ \"%@\""), source, key, value))
+    }
+
+    private static func normalizedJANGRoutingValueIfPresent(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private static func isDFlashStyleBundle(
@@ -700,6 +904,36 @@ enum ModelCompatibilityDiagnostics {
                 value: config.hasJANGTQSidecar ? "present" : "absent"
             )
         )
+        appendOptional(
+            &rows,
+            source: "jang_config.json",
+            key: "weight_format",
+            value: config.jangWeightFormat
+        )
+        appendOptional(
+            &rows,
+            source: "config.json",
+            key: "weight_format",
+            value: config.configWeightFormat
+        )
+        appendOptional(
+            &rows,
+            source: "jang_config.json",
+            key: "format",
+            value: config.jangFormat
+        )
+        appendOptional(
+            &rows,
+            source: "config.json",
+            key: "format",
+            value: config.configFormat
+        )
+        appendOptional(
+            &rows,
+            source: "jang_config.json",
+            key: "profile",
+            value: config.jangProfile
+        )
 
         if let tokenizer = config.tokenizer {
             appendOptional(
@@ -822,6 +1056,7 @@ enum ModelCompatibilityDiagnostics {
         let architectures =
             (object["architectures"] as? [Any])?
             .compactMap { $0 as? String } ?? []
+        let jangRouting = readJANGRoutingSummary(at: bundleURL)
         return ConfigSummary(
             modelType: stringValue(object["model_type"]),
             textModelType: stringValue(textConfig?["model_type"]),
@@ -833,9 +1068,27 @@ enum ModelCompatibilityDiagnostics {
             hasJANGTQSidecar: FileManager.default.fileExists(
                 atPath: bundleURL.appendingPathComponent("jangtq_runtime.safetensors").path
             ),
+            configWeightFormat: stringValue(object["weight_format"]),
+            configFormat: stringValue(object["format"]),
+            jangWeightFormat: jangRouting.weightFormat,
+            jangFormat: jangRouting.format,
+            jangProfile: jangRouting.profile,
             tokenizer: readTokenizerSummary(at: bundleURL),
             generation: readGenerationSummary(at: bundleURL),
             toolCalling: readToolCallingSummary(at: bundleURL)
+        )
+    }
+
+    private static func readJANGRoutingSummary(
+        at bundleURL: URL
+    ) -> (weightFormat: String?, format: String?, profile: String?) {
+        let url = bundleURL.appendingPathComponent("jang_config.json")
+        guard let object = readJSONObject(at: url) else { return (nil, nil, nil) }
+        let quantization = object["quantization"] as? [String: Any]
+        return (
+            stringValue(object["weight_format"]),
+            stringValue(object["format"]),
+            stringValue(quantization?["profile"]) ?? stringValue(object["profile"])
         )
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3693,20 +3693,23 @@ public actor ModelRuntime {
         let normalizedStamp = (probe.weight_format ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        let isMxtq = normalizedStamp == "mxtq"
         let normalizedFormat = (probe.format ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        let declaresJANGTQFormat = normalizedFormat == "jangtq"
+        let declaresJANGTQ =
+            normalizedStamp == "mxtq"
+            || normalizedStamp.contains("jangtq")
+            || normalizedFormat == "mxtq"
+            || normalizedFormat.contains("jangtq")
 
         // Forward mismatch: declared JANGTQ, sidecar missing.
-        if isMxtq && !sidecarPresent {
+        if declaresJANGTQ && !sidecarPresent {
             throw NSError(
                 domain: "ModelRuntime",
                 code: 2,
                 userInfo: [
                     NSLocalizedDescriptionKey:
-                        "Model '\(name)' declares JANGTQ (weight_format: \"mxtq\") but is missing "
+                        "Model '\(name)' declares JANGTQ but is missing "
                         + "required sidecar file 'jangtq_runtime.safetensors'. "
                         + "Re-download the full model or obtain the sidecar from the original publisher."
                 ]
@@ -3716,8 +3719,15 @@ public actor ModelRuntime {
         // Inverse mismatch: sidecar present but stamp says non-JANGTQ. The
         // safetensors carry `tq_norms` / `tq_packed` keys vmlx's base class
         // can't decode → "Unhandled keys" runtime error. Catch it here.
-        if sidecarPresent && !isMxtq && !declaresJANGTQFormat {
-            let actualStamp = (probe.weight_format?.isEmpty == false) ? probe.weight_format! : "absent"
+        if sidecarPresent && !declaresJANGTQ {
+            let actualStamp: String
+            if probe.weight_format?.isEmpty == false {
+                actualStamp = "weight_format: \"\(probe.weight_format!)\""
+            } else if probe.format?.isEmpty == false {
+                actualStamp = "format: \"\(probe.format!)\""
+            } else {
+                actualStamp = "absent"
+            }
             throw NSError(
                 domain: "ModelRuntime",
                 code: 3,
@@ -3725,10 +3735,10 @@ public actor ModelRuntime {
                     NSLocalizedDescriptionKey:
                         "Model '\(name)' ships the JANGTQ runtime sidecar "
                         + "('jangtq_runtime.safetensors') but its jang_config.json "
-                        + "declares weight_format: \"\(actualStamp)\". This is a mislabeled "
+                        + "declares \(actualStamp). This is a mislabeled "
                         + "bundle — the safetensors carry TurboQuant tensors (tq_norms / "
                         + "tq_packed) that vmlx's base model class cannot decode. "
-                        + "Fix: set weight_format to \"mxtq\" in jang_config.json, "
+                        + "Fix: set weight_format to \"mxtq\" or format to \"jangtq\" in jang_config.json, "
                         + "or re-download from a corrected source."
                 ]
             )

--- a/Packages/OsaurusCore/Tests/Service/ModelCompatibilityDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelCompatibilityDiagnosticsTests.swift
@@ -22,6 +22,7 @@ struct ModelCompatibilityDiagnosticsTests {
         tokenizerConfig: String? = nil,
         generationConfig: String? = nil,
         jangConfig: String? = nil,
+        jangtqSidecar: Bool = false,
         tokenizer: Bool = true,
         weights: Bool = true
     ) {
@@ -48,6 +49,9 @@ struct ModelCompatibilityDiagnosticsTests {
         }
         if weights {
             try? Data("w".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+        }
+        if jangtqSidecar {
+            try? Data("sidecar".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
         }
     }
 
@@ -349,6 +353,408 @@ struct ModelCompatibilityDiagnosticsTests {
         #expect(report.runtime.reason == .unsupportedLongCat)
         #expect(report.preflight.status == .unsupported)
         #expect(report.preflight.blocksRuntimeLoad)
+    }
+
+    @Test func deepSeekOCRConfig_reportsUnsupportedFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config:
+                #"{"model_type":"deepseek_ocr","architectures":["DeepseekOCRForConditionalGeneration"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "deepseek-ai/DeepSeek-OCR",
+            modelName: "DeepSeek OCR",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .unsupportedDeepSeekOCR)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+        #expect(report.toolUse.status == .failed)
+    }
+
+    @Test func unlimitedOCRName_reportsUnsupportedFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"qwen2_vl","architectures":["Qwen2VLForConditionalGeneration"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "osaurus-ai/Unlimited-OCR-Qwen",
+            modelName: "Unlimited OCR Qwen",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .unsupportedDeepSeekOCR)
+        #expect(report.preflight.status == .unsupported)
+    }
+
+    @Test func deepSeekVLV2OCRName_reportsUnsupportedOCRFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_vl_v2","architectures":["AutoModelForVision2Seq"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "local/custom-ocr-import",
+            modelName: "Custom OCR Import",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .unsupportedDeepSeekOCR)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+    }
+
+    @Test func deepSeekVLV2WithoutOCRHint_doesNotReportUnsupportedOCRFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_vl_v2","architectures":["AutoModelForVision2Seq"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "deepseek-ai/deepseek-vl2",
+            modelName: "DeepSeek VL2",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.reason == .localBundleReady)
+        #expect(report.preflight.status == .supported)
+    }
+
+    @Test func jangtqMxtqMissingSidecar_reportsRuntimeBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"minimax_m2"}"#,
+            jangConfig: #"{"weight_format":"mxtq"}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/MiniMax-M2.7-JANGTQ",
+            modelName: "MiniMax M2.7 JANGTQ",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .missingJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+        #expect(report.toolUse.status == .failed)
+        #expect(
+            report.evidence.contains {
+                $0.source == "jang_config.json" && $0.key == "weight_format" && $0.value == "mxtq"
+            }
+        )
+        #expect(
+            report.evidence.contains {
+                $0.source == "jangtq_runtime.safetensors" && $0.key == "file" && $0.value == "absent"
+            }
+        )
+    }
+
+    @Test func jangtqFormatMissingSidecar_reportsRuntimeBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"step3"}"#,
+            jangConfig: #"{"format":"jangtq"}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "JANGQ-AI/Step-3.7-Flash-JANGTQ_K",
+            modelName: "Step 3.7 Flash JANGTQ_K",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .missingJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+        #expect(
+            report.evidence.contains {
+                $0.source == "jang_config.json" && $0.key == "format" && $0.value == "jangtq"
+            }
+        )
+    }
+
+    @Test func jangtqVariantWeightFormatMissingSidecar_reportsRuntimeBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4"}"#,
+            jangConfig: #"{"weight_format":"jangtq4"}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash",
+            modelName: "DeepSeek V4 Flash",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .missingJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+    }
+
+    @Test func jangtqMxtqWithSidecar_allowsRuntimePreflight() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"minimax_m2"}"#,
+            jangConfig: #"{"weight_format":"mxtq"}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/MiniMax-M2.7-JANGTQ",
+            modelName: "MiniMax M2.7 JANGTQ",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.reason == .localBundleReady)
+        #expect(report.preflight.status == .supported)
+        #expect(
+            report.evidence.contains {
+                $0.source == "jang_config.json" && $0.key == "weight_format" && $0.value == "mxtq"
+            }
+        )
+    }
+
+    @Test func jangtqNameWithSidecarWithoutJANGConfig_allowsRuntimePreflight() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4"}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+            modelName: "DeepSeek V4 Flash JANGTQ2",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.reason == .localBundleReady)
+        #expect(report.preflight.status == .supported)
+    }
+
+    @Test func jangtqSidecarWithoutRoutingStamp_reportsMislabeledBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4"}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash",
+            modelName: "DeepSeek V4 Flash",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .mislabeledJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+    }
+
+    @Test func jangtqSidecarWithBf16Stamp_reportsMislabeledBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4"}"#,
+            jangConfig: #"{"weight_format":"bf16","quantization":{"profile":"JANGTQ_1L"}}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash-JANGTQ2",
+            modelName: "DeepSeek V4 Flash JANGTQ2",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .mislabeledJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.toolUse.status == .failed)
+    }
+
+    @Test func jangtqProfileMissingSidecar_reportsRuntimeBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4"}"#,
+            jangConfig: #"{"quantization":{"profile":"JANGTQ_1L"}}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash",
+            modelName: "DeepSeek V4 Flash",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .missingJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+        #expect(
+            report.evidence.contains {
+                $0.source == "jang_config.json" && $0.key == "profile" && $0.value == "JANGTQ_1L"
+            }
+        )
+    }
+
+    @Test func jangtqFormatStampWithSidecar_allowsRuntimePreflight() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"step3"}"#,
+            jangConfig: #"{"format":"jangtq"}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "JANGQ-AI/Step-3.7-Flash-JANGTQ_K",
+            modelName: "Step 3.7 Flash JANGTQ_K",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.reason == .localBundleReady)
+        #expect(report.preflight.status == .supported)
+        #expect(
+            report.evidence.contains {
+                $0.source == "jang_config.json" && $0.key == "format" && $0.value == "jangtq"
+            }
+        )
+    }
+
+    @Test func jangtqVariantFormatStampWithSidecar_allowsRuntimePreflight() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4"}"#,
+            jangConfig: #"{"format":"jangtq2"}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash",
+            modelName: "DeepSeek V4 Flash",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.reason == .localBundleReady)
+        #expect(report.preflight.status == .supported)
+        #expect(
+            report.evidence.contains {
+                $0.source == "jang_config.json" && $0.key == "format" && $0.value == "jangtq2"
+            }
+        )
+    }
+
+    @Test func jangtqConfigWeightFormatMissingSidecar_reportsRuntimeBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4","weight_format":"mxtq"}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash",
+            modelName: "DeepSeek V4 Flash",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .missingJANGTQSidecar)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+        #expect(
+            report.evidence.contains {
+                $0.source == "config.json" && $0.key == "weight_format" && $0.value == "mxtq"
+            }
+        )
+    }
+
+    @Test func jangtqConfigWeightFormatWithSidecarWithoutJANGConfig_allowsRuntimePreflight() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"deepseek_v4","weight_format":"mxtq"}"#,
+            jangtqSidecar: true
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "OsaurusAI/DeepSeek-V4-Flash",
+            modelName: "DeepSeek V4 Flash",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.reason == .localBundleReady)
+        #expect(report.preflight.status == .supported)
+        #expect(
+            report.evidence.contains {
+                $0.source == "config.json" && $0.key == "weight_format" && $0.value == "mxtq"
+            }
+        )
     }
 
     @Test func dflashConfig_reportsPartialAndBlocksRuntimeLoad() {

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -477,6 +477,23 @@ struct ModelRuntimeFindDirectoryTests {
         try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "MiniMax-JANGTQ-OK")
     }
 
+    @Test("Sidecar present on variant JANGTQ stamp passes")
+    func jangtq_variantStampWithSidecar_passes() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "jangtq4", at: dir)
+        try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+        try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "Nemotron-JANGTQ4")
+    }
+
+    @Test("Missing sidecar on variant JANGTQ stamp throws")
+    func jangtq_variantStampMissingSidecar_throws() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "jangtq4", at: dir)
+        #expect(throws: Error.self) {
+            try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "Nemotron-JANGTQ4")
+        }
+    }
+
     @Test("MiMo and N2 JANGTQ app load preflight requires sidecar without reading bundle JSON")
     func mimoAndN2JANGTQSidecarFastPathAvoidsBundleJSONRead() async throws {
         for name in ["MiMo-V2.5-JANGTQ_2", "Nex-N2-Pro-JANGTQ2"] {


### PR DESCRIPTION
## Disposition

**Deferred as an intentional draft. Do not merge or rebase this branch yet.**

## Unique scope

The branch contains useful typed diagnostics for unsupported OCR bundles and missing or mislabeled JANGTQ sidecars. It does not change prompts, samplers, chat templates, or generated output.

## Blocker

PR #2044 currently owns the adjacent model-runtime and compatibility boundary. Rebasing this branch before that ownership settles risks duplicating or contradicting the canonical runtime policy and diagnostics path.

## Required next action

After #2044 reaches a terminal state, compare its final runtime diagnostics against this branch. Port only diagnostic cases that remain absent, then run exact-bundle live preflight proof, focused compatibility tests, localization checks, app build, and current GitHub CI.

No remote branch has been deleted.