### PR TITLE
Start Sparkle update checks at app launch

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -603,6 +603,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
                 }
             }
         }
+
+        // Start Sparkle at launch so update checks run whenever the app is
+        // open, not only when the settings window is first shown. First access
+        // instantiates the lazy updater controller, which also arms Sparkle's
+        // own 24h scheduled check cycle for long-running sessions. Delayed a
+        // few seconds so it stays clear of the busy launch window (server
+        // bind, prewarms, database opens).
+        if !keychainDisabledTestMode {
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(5))
+                self?.updater.checkForUpdatesInBackground()
+            }
+        }
     }
 
     /// Fire-and-forget launch prewarm. Skipped when the last-active


### PR DESCRIPTION
## Summary

- The Sparkle updater controller was a `lazy var` that nothing touched until the settings window appeared, so despite `SUEnableAutomaticChecks = YES`, update checks never ran unless the user opened settings.
- Kick off a background update check ~5 seconds after launch in `applicationDidFinishLaunching` (delayed to stay clear of server bind / prewarms / database opens). First access instantiates the updater, which runs an immediate check and arms Sparkle's own 24h scheduled cycle for long-running sessions — so users get prompted to upgrade early, in any app state.
- Skipped in keychain-disabled test mode, matching other launch-time UI subsystems. The existing check on settings open is kept as a cheap badge refresh.

## Test plan

- [x] `make test` — 4,950/4,961 pass; the 11 failures are pre-existing (keychain-gated suites under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, plus two suites that pass in isolation)
- [x] Live smoke: built the release app (`make app`), launched it without opening settings, and confirmed `Sparkle: didNotFindUpdate` ("Osaurus 0.21.5 is currently the newest version available") in the logs ~25s after launch