### PR TITLE
Discover custom external model folders

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -255,7 +255,7 @@ final class ModelManager: NSObject, ObservableObject {
         if !Self.skipBackgroundOrgFetchForTests {
             Task { [weak self] in await self?.loadOsaurusAIOrgModels() }
 
-            // Discover external bundles (HF cache, LM Studio) off the main
+            // Discover external bundles (HF cache, LM Studio, custom folders) off the main
             // thread. `rescan()` posts `.localModelsChanged` when the set
             // changes, which re-runs `refreshDownloadStates()` to merge them.
             Task.detached(priority: .utility) {
@@ -1770,7 +1770,7 @@ extension ModelManager {
     }
 
     private nonisolated static func mergeExternalModels(into scanned: [MLXModel]) -> [MLXModel] {
-        // Append externally-discovered bundles (HF cache, LM Studio). Read
+        // Append externally-discovered bundles (HF cache, LM Studio, custom folders). Read
         // fresh from the locator's in-memory registry each call (cheap) so a
         // background rescan is reflected without invalidating the disk-scan
         // cache above. Locally-present models win on id collision.

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -23753,6 +23753,16 @@
         }
       }
     },
+    "Cache or model folder path" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cache or model folder path"
+          }
+        }
+      }
+    },
     "Cache directory" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -27984,6 +27994,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇 Hugging Face 緩存文件夾"
+          }
+        }
+      }
+    },
+    "Choose Hugging Face cache or model folder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose Hugging Face cache or model folder"
           }
         }
       }
@@ -63002,6 +63022,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hugging Face 緩存"
+          }
+        }
+      }
+    },
+    "Hugging Face cache and model folder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hugging Face cache and model folder"
           }
         }
       }
@@ -152217,6 +152247,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用來自 ~/.cache/huggingface（以及 HF_HOME / HF_HUB_CACHE）的 MLX 模型。"
+          }
+        }
+      }
+    },
+    "Use MLX models from ~/.cache/huggingface, HF_HOME / HF_HUB_CACHE, or a custom folder." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MLX models from ~/.cache/huggingface, HF_HOME / HF_HUB_CACHE, or a custom folder."
           }
         }
       }

--- a/Packages/OsaurusCore/Services/ExternalModelLocator.swift
+++ b/Packages/OsaurusCore/Services/ExternalModelLocator.swift
@@ -3,8 +3,8 @@
 //  osaurus
 //
 //  Read-only discovery of MLX/safetensors model bundles that live outside
-//  Osaurus's own models directory — the Hugging Face Hub cache and LM
-//  Studio. Discovered bundles are surfaced in the catalog and made
+//  Osaurus's own models directory — the Hugging Face Hub cache, LM
+//  Studio, and user-selected model folders. Discovered bundles are surfaced in the catalog and made
 //  runnable in place via an id -> absolute-path registry the runtime path
 //  resolvers consult; nothing is ever copied, symlinked, or mutated in the
 //  source location.
@@ -35,7 +35,8 @@ enum ExternalModelLocator {
         let bundlePath: String
         /// Source revision when known (HF commit hash from `refs/main`).
         let revision: String?
-        /// Human-readable provenance ("Hugging Face cache", "LM Studio").
+        /// Human-readable provenance ("Hugging Face cache", "LM Studio",
+        /// "Custom model folder").
         let source: String
     }
 
@@ -142,6 +143,7 @@ enum ExternalModelLocator {
     enum Source: String {
         case huggingFaceCache = "Hugging Face cache"
         case lmStudio = "LM Studio"
+        case customModelFolder = "Custom model folder"
     }
 
     // MARK: - Public read API (hot path)
@@ -293,6 +295,8 @@ enum ExternalModelLocator {
                     reports.append(scanHuggingFaceCacheReport(root: root))
                 case .lmStudio:
                     reports.append(scanReport(root: root, source: .lmStudio))
+                case .customModelFolder:
+                    reports.append(scanCustomModelFolderReport(root: root))
                 }
             }
             return ScanReport(sources: reports)
@@ -302,6 +306,11 @@ enum ExternalModelLocator {
             reports.append(
                 contentsOf: huggingFaceCacheRoots().map(scanHuggingFaceCacheReport(root:))
             )
+            if let customRoot = customModelFolderRoot(),
+                FileManager.default.fileExists(atPath: customRoot.path)
+            {
+                reports.append(scanCustomModelFolderReport(root: customRoot))
+            }
         }
         if isLMStudioImportEnabled {
             reports.append(contentsOf: lmStudioRoots().map { scanReport(root: $0, source: .lmStudio) })
@@ -310,6 +319,14 @@ enum ExternalModelLocator {
     }
 
     // MARK: - Roots
+
+    static func customModelFolderRoot(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        customPath: String? = ExternalModelLocator.customHFCachePath
+    ) -> URL? {
+        guard let customPath else { return nil }
+        return Self.fileURL(fromUserPath: customPath, homeDirectory: homeDirectory)
+    }
 
     static func huggingFaceCacheRoots(
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -514,6 +531,48 @@ enum ExternalModelLocator {
 
     // MARK: - Generic nested-layout scanner (LM Studio + tests)
 
+    static func scanCustomModelFolderReport(root: URL) -> SourceScanReport {
+        let rootDiagnostic = bundleDiagnostic(at: root, root: root)
+        if rootDiagnostic.isValid {
+            return SourceScanReport(
+                source: .customModelFolder,
+                rootPath: root.path,
+                discovered: [
+                    Discovered(
+                        id: root.lastPathComponent,
+                        bundlePath: root.standardizedFileURL.path,
+                        revision: nil,
+                        source: Source.customModelFolder.rawValue
+                    )
+                ],
+                skipped: []
+            )
+        }
+
+        var report = scanReport(
+            root: root,
+            source: .customModelFolder,
+            skipTopLevelHuggingFaceCacheFolders: true
+        )
+        if rootDiagnostic.isCandidate, let reason = rootDiagnostic.reason {
+            report = SourceScanReport(
+                source: report.source,
+                rootPath: report.rootPath,
+                discovered: report.discovered,
+                skipped: [
+                    Skipped(
+                        repoId: root.lastPathComponent,
+                        path: root.path,
+                        reason: reason,
+                        detail: rootDiagnostic.detail
+                            ?? "The selected folder is not a complete MLX safetensors bundle."
+                    )
+                ] + report.skipped
+            )
+        }
+        return report
+    }
+
     /// Scan a root with a nested `publisher/repo/` layout, registering any
     /// directory that validates as an MLX bundle. Bounded depth keeps the
     /// scan cheap on large model libraries.
@@ -521,7 +580,11 @@ enum ExternalModelLocator {
         scanReport(root: root, source: source).discovered
     }
 
-    static func scanReport(root: URL, source: Source) -> SourceScanReport {
+    static func scanReport(
+        root: URL,
+        source: Source,
+        skipTopLevelHuggingFaceCacheFolders: Bool = false
+    ) -> SourceScanReport {
         let fm = FileManager.default
         var results: [Discovered] = []
         var skipped: [Skipped] = []
@@ -535,6 +598,11 @@ enum ExternalModelLocator {
                 )
             else { return }
             for entry in entries {
+                if skipTopLevelHuggingFaceCacheFolders, prefix.isEmpty,
+                    entry.lastPathComponent.hasPrefix("models--")
+                {
+                    continue
+                }
                 let resolved = entry.resolvingSymlinksInPath()
                 var isDir: ObjCBool = false
                 guard fm.fileExists(atPath: resolved.path, isDirectory: &isDir), isDir.boolValue

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -221,6 +221,82 @@ struct ExternalModelLocatorTests {
         )
     }
 
+    @Test func scanCustomModelFolder_findsDirectAndNestedBundles() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let direct = root.appendingPathComponent("Direct-Model", isDirectory: true)
+        let nested = root.appendingPathComponent("publisher/repo", isDirectory: true)
+        let hfSnapshot = root
+            .appendingPathComponent("models--org--cached", isDirectory: true)
+            .appendingPathComponent("snapshots/abc123", isDirectory: true)
+        writeBundle(at: direct)
+        writeBundle(at: nested)
+        writeBundle(at: hfSnapshot)
+
+        let report = ExternalModelLocator.scanCustomModelFolderReport(root: root)
+        let ids = Set(report.discovered.map(\.id))
+
+        #expect(ids.contains("Direct-Model"))
+        #expect(ids.contains("publisher/repo"))
+        #expect(!ids.contains("models--org--cached/snapshots/abc123"))
+        #expect(report.discovered.allSatisfy { $0.source == "Custom model folder" })
+    }
+
+    @Test func scanCustomModelFolder_acceptsSelectedBundleRoot() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(at: root)
+
+        let report = ExternalModelLocator.scanCustomModelFolderReport(root: root)
+
+        #expect(report.discovered.map(\.id) == [root.lastPathComponent])
+        #expect(report.discovered.first?.bundlePath == root.standardizedFileURL.path)
+        #expect(report.discovered.first?.source == "Custom model folder")
+        #expect(report.skipped.isEmpty)
+    }
+
+    @Test func rescan_resolvesCustomModelFolderPath() async {
+        await OsaurusTestGlobals.withPathsLock {
+            rescan_resolvesCustomModelFolderPath_body()
+        }
+    }
+
+    private func rescan_resolvesCustomModelFolderPath_body() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        let previousOverride = ExternalModelLocator.testRootsOverride
+        let manifestRoot = makeTempDir()
+        let customRoot = makeTempDir()
+        OsaurusPaths.overrideRoot = manifestRoot
+        ExternalModelLocator.invalidateInMemory()
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            ExternalModelLocator.testRootsOverride = previousOverride
+            ExternalModelLocator.invalidateInMemory()
+            try? FileManager.default.removeItem(at: manifestRoot)
+            try? FileManager.default.removeItem(at: customRoot)
+        }
+
+        let bundle = customRoot.appendingPathComponent("publisher/repo", isDirectory: true)
+        writeBundle(at: bundle)
+
+        ExternalModelLocator.testRootsOverride = [(root: customRoot, source: .customModelFolder)]
+        ExternalModelLocator.rescan()
+
+        let resolved = ExternalModelLocator.path(forId: "publisher/repo")
+        #expect(resolved?.standardizedFileURL.path == bundle.standardizedFileURL.path)
+
+        let models = ExternalModelLocator.models()
+        #expect(
+            models.contains {
+                $0.id == "publisher/repo" && $0.externalSource == "Custom model folder"
+            }
+        )
+
+        let report = ExternalModelLocator.lastScanReport()
+        #expect(report?.discovered.contains { $0.id == "publisher/repo" } == true)
+        #expect(report?.skipped.isEmpty == true)
+    }
+
     // MARK: - HF cache scan + resolution (via test override)
 
     @Test func rescan_resolvesHFCacheSnapshotAndPath() async {

--- a/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
@@ -3,9 +3,10 @@
 //  osaurus
 //
 //  Settings controls for discovering and running models that already live
-//  on this Mac via other tools — the Hugging Face Hub cache and LM Studio.
-//  Toggling a source on/off triggers a background rescan; discovered models
-//  appear in the catalog and run in place (never copied or modified).
+//  on this Mac via other tools: the Hugging Face Hub cache, LM Studio, and
+//  user-selected model folders. Toggling a source on/off triggers a
+//  background rescan; discovered models appear in the catalog and run in
+//  place (never copied or modified).
 //
 
 import SwiftUI
@@ -24,8 +25,11 @@ struct ExternalModelsSettingsView: View {
 
     @State private var hfCount: Int = 0
     @State private var lmStudioCount: Int = 0
+    @State private var customFolderCount: Int = 0
     @State private var scanReport: ExternalModelLocator.ScanReport?
     @State private var isScanning: Bool = false
+    @State private var needsRescanAfterCurrent: Bool = false
+    @State private var pathRescanTask: Task<Void, Never>?
     @State private var showHFCachePicker: Bool = false
 
     var body: some View {
@@ -39,10 +43,12 @@ struct ExternalModelsSettingsView: View {
             .fixedSize(horizontal: false, vertical: true)
 
             SettingsToggle(
-                title: L("Hugging Face cache"),
+                title: L("Hugging Face cache and model folder"),
                 description:
-                    "Use MLX models from ~/.cache/huggingface (and HF_HOME / HF_HUB_CACHE).",
-                badge: importHFCache && hfCount > 0 ? "\(hfCount)" : nil,
+                    "Use MLX models from ~/.cache/huggingface, HF_HOME / HF_HUB_CACHE, or a custom folder.",
+                badge:
+                    importHFCache && hfCount + customFolderCount > 0
+                    ? "\(hfCount + customFolderCount)" : nil,
                 isOn: $importHFCache
             )
 
@@ -67,7 +73,10 @@ struct ExternalModelsSettingsView: View {
                         .font(.system(size: 11))
                         .foregroundColor(theme.tertiaryText)
                 } else {
-                    Text("\(hfCount + lmStudioCount) external models found", bundle: .module)
+                    Text(
+                        "\(hfCount + lmStudioCount + customFolderCount) external models found",
+                        bundle: .module
+                    )
                         .font(.system(size: 11))
                         .foregroundColor(theme.tertiaryText)
                 }
@@ -114,7 +123,7 @@ struct ExternalModelsSettingsView: View {
         .onAppear { refreshCounts() }
         .onChange(of: importHFCache) { _, _ in rescan() }
         .onChange(of: importLMStudio) { _, _ in rescan() }
-        .onChange(of: customHFCachePath) { _, _ in refreshCounts() }
+        .onChange(of: customHFCachePath) { _, _ in schedulePathRescan() }
         .onReceive(NotificationCenter.default.publisher(for: .localModelsChanged)) { _ in
             refreshCounts()
         }
@@ -125,14 +134,13 @@ struct ExternalModelsSettingsView: View {
         ) { result in
             if case .success(let urls) = result, let url = urls.first {
                 customHFCachePath = url.path
-                rescan()
             }
         }
     }
 
     private var hfCachePathControl: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("HF cache path", bundle: .module)
+            Text("Cache or model folder path", bundle: .module)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(theme.secondaryText)
 
@@ -152,13 +160,12 @@ struct ExternalModelsSettingsView: View {
                     }
                 )
                 .buttonStyle(.plain)
-                .localizedHelp("Choose Hugging Face cache folder")
+                .localizedHelp("Choose Hugging Face cache or model folder")
 
                 if !customHFCachePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Button(
                         action: {
                             customHFCachePath = ""
-                            rescan()
                         },
                         label: {
                             Image(systemName: "arrow.counterclockwise")
@@ -203,17 +210,40 @@ struct ExternalModelsSettingsView: View {
             models.filter {
                 $0.externalSource == ExternalModelLocator.Source.lmStudio.rawValue
             }.count
+        customFolderCount =
+            models.filter {
+                $0.externalSource == ExternalModelLocator.Source.customModelFolder.rawValue
+            }.count
     }
 
     private func rescan() {
-        guard !isScanning else { return }
+        pathRescanTask?.cancel()
+        guard !isScanning else {
+            needsRescanAfterCurrent = true
+            return
+        }
+
         isScanning = true
         Task.detached(priority: .utility) {
             ExternalModelLocator.rescan()
             await MainActor.run {
                 self.isScanning = false
                 self.refreshCounts()
+                if self.needsRescanAfterCurrent {
+                    self.needsRescanAfterCurrent = false
+                    self.rescan()
+                }
             }
+        }
+    }
+
+    private func schedulePathRescan() {
+        refreshCounts()
+        pathRescanTask?.cancel()
+        pathRescanTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            guard !Task.isCancelled else { return }
+            rescan()
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a Custom model folder external source for user-selected model libraries, while keeping HF cache snapshot discovery intact.
- Scan the selected path as both an HF cache and a custom model folder; the custom scan skips top-level `models--*` cache folders to avoid duplicate HF cache discovery.
- Update the external-model settings UI, counts, path copy, debounced typed-path rescans, and localization entries.

## Tests
- `git diff --check`
- `scripts/i18n/check.sh`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --disable-index-store --package-path Packages/OsaurusCore --filter ExternalModelLocatorTests` (18 tests)

## Reviews
- Fable medium: quota-blocked (`You've reached your Fable 5 limit`).
- Claude Opus medium fallback: no blocking issues.
- Grok review (`--no-subagents --disable-web-search`; no effort flag because this installed model rejects the effort parameter): no blocking issues.

## Notes
- The custom folder intentionally shares the existing HF cache path setting and toggle; turning off the combined setting disables both HF cache and custom-folder discovery.
- Selecting or typing a path can include either a Hugging Face cache, a direct MLX bundle, or a directory containing nested MLX bundles.
