### PR TITLE
Persist user turns before chat streaming

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionsManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionsManager.swift
@@ -109,8 +109,8 @@ final class ChatSessionsManager: ObservableObject {
     /// Rename a session.
     ///
     /// Pulls from the in-memory list first because new sessions are only
-    /// flushed to `ChatSessionStore` after their first turn writes, so a
-    /// rename issued before that flush would otherwise be dropped.
+    /// discoverable there until the pre-stream first-turn save reaches
+    /// `ChatSessionStore`; otherwise an early rename could be dropped.
     func rename(id: UUID, title: String) {
         guard
             var session = sessions.first(where: { $0.id == id })

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -218,6 +218,26 @@ struct ChatSessionQueuedSendTests {
     }
 
     @Test
+    func send_plainTextPersistsBeforeAssistantCompletes() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+
+            session.send("persist while streaming")
+            try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+
+            let sessionId = try #require(session.sessionId)
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(persisted.turns.count == 1)
+            #expect(persisted.turns[0].role == .user)
+            #expect(persisted.turns[0].content == "persist while streaming")
+
+            session.stop()
+            try await waitUntil(timeout: .seconds(1)) { !session.isStreaming }
+        }
+    }
+
+    @Test
     func privacyCancelRemovesPersistedTransientUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
@@ -292,6 +312,7 @@ struct ChatSessionQueuedSendTests {
 
             session.send("review will cancel")
             try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+            let transientId = try #require(session.sessionId)
 
             let queuedAttachment = Attachment.document(
                 filename: "follow-up.txt",
@@ -308,6 +329,8 @@ struct ChatSessionQueuedSendTests {
             #expect(session.input == "review will cancel")
             #expect(session.queuedSend?.text == "queued follow-up")
             #expect(session.queuedSend?.attachments.first?.filename == "follow-up.txt")
+            #expect(ChatSessionStore.load(id: transientId) == nil)
+            #expect(ChatSessionsManager.shared.session(for: transientId) == nil)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
@@ -104,6 +104,22 @@ struct ChatSessionStoreDeferredSaveTests {
         }
     }
 
+    @Test func pendingDeleteRejectsDeferredSaveWhileDatabaseClosed() throws {
+        let session = ChatSessionData(
+            id: UUID(),
+            title: "Cancelled while closed",
+            turns: [ChatTurnData(role: .user, content: "do not queue")]
+        )
+        ChatSessionStore._resetForTesting()
+        defer { ChatSessionStore._resetForTesting() }
+
+        ChatSessionStore._enqueuePendingDeleteForTesting(session.id)
+        ChatSessionStore.save(session)
+
+        #expect(ChatSessionStore._pendingSaveCountForTesting == 0)
+        #expect(ChatSessionStore._pendingDeleteCountForTesting == 1)
+    }
+
     @Test func loadHealsOrphanedTurnsBackToDisk() throws {
         try withOpenStores(memory: true) {
             let sessionId = UUID(uuidString: "44444444-5555-6666-7777-888888888888")!


### PR DESCRIPTION
## Summary
- persist user turns before chat streaming starts so crash/quit/long-running streams do not lose the prompt
- roll back transient persisted turns on privacy-review cancellation while preserving explicit Stop behavior and existing history
- harden deferred chat-history delete/save ordering so cancelled transient sessions cannot be resurrected

## Validation
- `git diff --check HEAD~1..HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-chat swift test --disable-index-store --package-path Packages/OsaurusCore --filter 'ChatSessionQueuedSendTests|ChatSessionStoreDeferredSaveTests'` — 30 tests in 2 suites passed

## Review evidence
- Fable medium review attempted; blocked by quota (`You've reached your Fable 5 limit`).
- Claude Opus medium final review: no merge blockers.
- Grok final review: no merge blockers.
