### PR TITLE
Handle empty voice transcriptions

### DIFF
--- a/Packages/OsaurusCore/Services/Voice/TranscriptionTextNormalizer.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionTextNormalizer.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 public enum TranscriptionTextNormalizer {
-    private static let invisibleScalars = CharacterSet(charactersIn: "\u{00AD}\u{034F}\u{061C}\u{180E}\u{200B}\u{200C}\u{200D}\u{200E}\u{200F}\u{202A}\u{202B}\u{202C}\u{202D}\u{202E}\u{2060}\u{2061}\u{2062}\u{2063}\u{2064}\u{2066}\u{2067}\u{2068}\u{2069}\u{FEFF}\u{FFFE}")
+    private static let noiseScalars = CharacterSet(charactersIn: "\u{00AD}\u{034F}\u{180E}\u{200B}\u{2060}\u{2061}\u{2062}\u{2063}\u{2064}\u{FEFF}\u{FFFE}")
+    private static let formatOnlyScalars = CharacterSet(charactersIn: "\u{061C}\u{200C}\u{200D}\u{200E}\u{200F}\u{202A}\u{202B}\u{202C}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{2069}")
 
     public static func visibleText(_ text: String) -> String {
         let scalars = text.unicodeScalars.filter { scalar in
-            if invisibleScalars.contains(scalar) { return false }
+            if noiseScalars.contains(scalar) { return false }
+            if formatOnlyScalars.contains(scalar) { return true }
             if CharacterSet.controlCharacters.contains(scalar),
                 scalar != "\n",
                 scalar != "\t"
@@ -21,8 +23,10 @@ public enum TranscriptionTextNormalizer {
             }
             return true
         }
-        return String(String.UnicodeScalarView(scalars))
+        let cleaned = String(String.UnicodeScalarView(scalars))
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard containsVisibleScalar(cleaned) else { return "" }
+        return cleaned
     }
 
     public static func hasVisibleText(_ text: String) -> Bool {
@@ -42,5 +46,14 @@ public enum TranscriptionTextNormalizer {
         if existing.isEmpty { return transcript }
         if transcript.isEmpty { return existing }
         return "\(existing) \(transcript)"
+    }
+
+    private static func containsVisibleScalar(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) { return false }
+            if noiseScalars.contains(scalar) || formatOnlyScalars.contains(scalar) { return false }
+            if CharacterSet.controlCharacters.contains(scalar) { return false }
+            return true
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Voice/TranscriptionTextNormalizerTests.swift
+++ b/Packages/OsaurusCore/Tests/Voice/TranscriptionTextNormalizerTests.swift
@@ -25,6 +25,30 @@ struct TranscriptionTextNormalizerTests {
     }
 
     @Test
+    func visibleTextPreservesJoinersWhenTextIsVisible() {
+        let text = "a\u{200D}b c\u{200C}d"
+
+        #expect(TranscriptionTextNormalizer.visibleText(text) == "a\u{200D}b c\u{200C}d")
+        #expect(TranscriptionTextNormalizer.hasVisibleText(text))
+    }
+
+    @Test
+    func visibleTextPreservesDirectionMarksWhenTextIsVisible() {
+        let text = "\u{200F}right-to-left\u{200E}"
+
+        #expect(TranscriptionTextNormalizer.visibleText(text) == "\u{200F}right-to-left\u{200E}")
+        #expect(TranscriptionTextNormalizer.hasVisibleText(text))
+    }
+
+    @Test
+    func visibleTextDropsDirectionMarksWithoutVisibleText() {
+        let text = "\u{200F}\u{200E}\u{202A}\u{202C}"
+
+        #expect(TranscriptionTextNormalizer.visibleText(text).isEmpty)
+        #expect(!TranscriptionTextNormalizer.hasVisibleText(text))
+    }
+
+    @Test
     func combinedSkipsHiddenSegments() {
         let combined = TranscriptionTextNormalizer.combined([
             "\u{200B}",
@@ -44,5 +68,15 @@ struct TranscriptionTextNormalizerTests {
         )
 
         #expect(merged == "existing")
+    }
+
+    @Test
+    func mergedJoinsVisibleExistingTextAndTranscript() {
+        let merged = TranscriptionTextNormalizer.merged(
+            existing: " existing ",
+            transcript: "\u{200B} transcript "
+        )
+
+        #expect(merged == "existing transcript")
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1188,6 +1188,10 @@ extension FloatingInputCard {
             } else if !hasContent {
                 print("[FloatingInputCard] Silence timeout without content - closing voice input")
                 stopVoiceInputFromTimeout()
+                ToastManager.shared.infoLocalized(
+                    "No Speech Detected",
+                    message: "Nothing was sent."
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- normalize voice transcription text before insertion/send so invisible-only ASR output is treated as no speech
- preserve meaningful joiners and direction marks when visible text exists
- show no-speech feedback for empty memo/chat voice outcomes, including silence timeout

## Validation
- `git diff --check HEAD~1..HEAD`
- `scripts/i18n/check.sh`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-memo swift test --disable-index-store --package-path Packages/OsaurusCore --filter TranscriptionTextNormalizerTests` — 8 tests in 1 suite passed

## Review evidence
- Fable medium review attempted; blocked by quota (`You've reached your Fable 5 limit`).
- Claude Opus medium final review: no merge blockers.
- Grok final review: no merge blockers.
