### PR TITLE
Add favorite model pins to catalog

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -630,6 +630,15 @@ struct MLXModel: Identifiable, Codable {
     }()
 }
 
+extension MLXModel {
+    /// Cross-surface favourite key for the local model catalog. The picker
+    /// uses the same `source + id` key shape, so a local model favourited from
+    /// the picker is also recognised on the model management page.
+    var favoriteKey: String {
+        FavoriteModelsStore.key(sourceKey: ModelPickerItem.Source.local.uniqueKey, modelId: id)
+    }
+}
+
 /// Hardware compatibility assessment for a model.
 enum ModelCompatibility {
     case compatible

--- a/Packages/OsaurusCore/Tests/Model/FavoriteModelsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/FavoriteModelsStoreTests.swift
@@ -1,0 +1,67 @@
+//
+//  FavoriteModelsStoreTests.swift
+//  osaurusTests
+//
+//  Verifies persisted favourite model keys used by both the model picker and
+//  model management grid.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FavoriteModelsStoreTests {
+
+    @Test @MainActor func addToggleAndRemoveMaintainOrderedUniqueKeys() {
+        let (store, _, cleanup) = makeStore()
+        defer { cleanup() }
+
+        let first = FavoriteModelsStore.key(sourceKey: "local", modelId: "OsaurusAI/a")
+        let second = FavoriteModelsStore.key(sourceKey: "remote-provider", modelId: "openai/gpt")
+
+        store.add(first)
+        store.add(first)
+        store.add(second)
+
+        #expect(store.favoriteKeys == [first, second])
+        #expect(store.isFavorite(first))
+        #expect(store.isFavorite(second))
+
+        store.toggle(first)
+
+        #expect(store.favoriteKeys == [second])
+        #expect(!store.isFavorite(first))
+        #expect(store.isFavorite(second))
+
+        store.remove(second)
+
+        #expect(store.favoriteKeys.isEmpty)
+    }
+
+    @Test @MainActor func reloadPreservesFavoritesFromUserDefaults() {
+        let (store, defaults, cleanup) = makeStore()
+        defer { cleanup() }
+
+        let key = FavoriteModelsStore.key(sourceKey: "local", modelId: "OsaurusAI/gemma")
+        store.add(key)
+
+        let reloaded = FavoriteModelsStore(userDefaults: defaults)
+
+        #expect(reloaded.favoriteKeys == [key])
+        #expect(reloaded.isFavorite(key))
+    }
+
+    @MainActor
+    private func makeStore() -> (FavoriteModelsStore, UserDefaults, () -> Void) {
+        let suite = "favorite-models-store-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return (
+            FavoriteModelsStore(userDefaults: defaults),
+            defaults,
+            { defaults.removePersistentDomain(forName: suite) }
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelDownloadViewFamilyGroupingTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelDownloadViewFamilyGroupingTests.swift
@@ -20,7 +20,8 @@ struct ModelDownloadViewFamilyGroupingTests {
         id: String,
         sizeGB: Int64? = nil,
         isTopSuggestion: Bool = false,
-        releasedAt: Date? = nil
+        releasedAt: Date? = nil,
+        rootDirectory: URL? = nil
     ) -> MLXModel {
         MLXModel(
             id: id,
@@ -33,7 +34,26 @@ struct ModelDownloadViewFamilyGroupingTests {
             // Pin to a directory that never exists so `isDownloaded` is
             // deterministically false — otherwise a dev machine that
             // actually has one of these repos on disk skews the ranking.
-            rootDirectory: URL(fileURLWithPath: "/nonexistent/osaurus-grouping-tests")
+            rootDirectory: rootDirectory
+                ?? URL(fileURLWithPath: "/nonexistent/osaurus-grouping-tests")
+        )
+    }
+
+    private func makeTempModelRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-model-grid-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func markDownloaded(_ model: MLXModel) throws {
+        let directory = model.localDirectory
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: directory.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: directory.appendingPathComponent("tokenizer.json"))
+        _ = FileManager.default.createFile(
+            atPath: directory.appendingPathComponent("model.safetensors").path,
+            contents: Data()
         )
     }
 
@@ -121,6 +141,7 @@ struct ModelDownloadViewFamilyGroupingTests {
             filterState: ModelManager.ModelFilterState(),
             selectedTab: .all,
             sortOption: .recommended,
+            favoriteKeys: [],
             totalMemoryGB: 48
         )
         let lists = ModelDownloadView.makeGridLists(input)
@@ -145,5 +166,78 @@ struct ModelDownloadViewFamilyGroupingTests {
             downloadStates: [:]
         )
         #expect(pick.id == curated.id)
+    }
+
+    @Test func makeGridLists_pinsFavouriteCatalogFamiliesAheadOfTopPicks() {
+        let favorite = model(
+            id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
+            sizeGB: 8,
+            releasedAt: Date(timeIntervalSince1970: 1)
+        )
+        let topPick = model(
+            id: "OsaurusAI/Qwen3.6-27B-MXFP4",
+            sizeGB: 15,
+            isTopSuggestion: true,
+            releasedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        let input = ModelDownloadView.GridListInput(
+            availableModels: [],
+            suggestedModels: [topPick, favorite],
+            deduplicatedModels: [],
+            downloadStates: [:],
+            searchText: "",
+            filterState: ModelManager.ModelFilterState(),
+            selectedTab: .all,
+            sortOption: .recommended,
+            favoriteKeys: [favorite.favoriteKey],
+            totalMemoryGB: 48
+        )
+
+        let lists = ModelDownloadView.makeGridLists(input)
+
+        #expect(lists.favorites.map(\.id) == [favorite.id])
+        #expect(lists.suggested.map(\.id) == [topPick.id])
+        #expect(lists.displayed.prefix(2).map(\.id) == [favorite.id, topPick.id])
+    }
+
+    @Test func makeGridLists_pinsDownloadedFavouritesAfterActiveDownloads() throws {
+        let root = try makeTempModelRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let active = model(id: "OsaurusAI/active-download", sizeGB: 4)
+        let favoriteDownloaded = model(
+            id: "OsaurusAI/zzz-favorite-downloaded",
+            sizeGB: 4,
+            rootDirectory: root
+        )
+        let otherDownloaded = model(
+            id: "OsaurusAI/aaa-other-downloaded",
+            sizeGB: 4,
+            rootDirectory: root
+        )
+        try markDownloaded(favoriteDownloaded)
+        try markDownloaded(otherDownloaded)
+
+        let input = ModelDownloadView.GridListInput(
+            availableModels: [],
+            suggestedModels: [],
+            deduplicatedModels: [otherDownloaded, favoriteDownloaded, active],
+            downloadStates: [active.id: .downloading(progress: 0.5)],
+            searchText: "",
+            filterState: ModelManager.ModelFilterState(),
+            selectedTab: .downloaded,
+            sortOption: .nameAsc,
+            favoriteKeys: [favoriteDownloaded.favoriteKey],
+            totalMemoryGB: 48
+        )
+
+        let lists = ModelDownloadView.makeGridLists(input)
+
+        #expect(lists.downloaded.map(\.id) == [
+            active.id,
+            favoriteDownloaded.id,
+            otherDownloaded.id,
+        ])
     }
 }

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -58,6 +58,9 @@ struct ModelDownloadView: View {
     /// Shared model manager for handling downloads and model state
     @ObservedObject private var modelManager = ModelManager.shared
 
+    /// Shared favourites so the model picker and model management grid stay in sync.
+    @ObservedObject private var favoritesStore = FavoriteModelsStore.shared
+
     /// System resource monitor for hardware info. Deliberately NOT
     /// `@ObservedObject`: observing it here re-evaluated the entire model
     /// grid on every 2s monitor tick (each card re-reading `totalMemoryGB`
@@ -135,6 +138,7 @@ struct ModelDownloadView: View {
     /// selected tab, debounced search text, or a throttled
     /// `modelManager` publish).
     @State private var gridListsSnapshot = GridLists(
+        favorites: [],
         suggested: [],
         others: [],
         downloaded: [],
@@ -208,6 +212,7 @@ struct ModelDownloadView: View {
         .onChange(of: sortOption) { _, _ in refreshGridLists() }
         .onChange(of: filterState) { _, _ in refreshGridLists() }
         .onChange(of: debouncedSearchText) { _, _ in refreshGridLists() }
+        .onChange(of: favoritesStore.favoriteKeys) { _, _ in refreshGridLists() }
         .onReceive(
             modelManager.objectWillChange
                 .throttle(for: .milliseconds(200), scheduler: DispatchQueue.main, latest: true)
@@ -702,8 +707,10 @@ struct ModelDownloadView: View {
             ),
             downloadState: modelManager.effectiveDownloadState(for: model),
             metrics: modelManager.downloadMetrics[model.id],
+            isFavorite: favoritesStore.isFavorite(model.favoriteKey),
             onViewDetails: { modelToShowDetails = model },
             onUnsupportedTap: { unsupportedModelName = model.name },
+            onToggleFavorite: { favoritesStore.toggle(model.favoriteKey) },
             onCancel: { modelManager.cancelDownload(model.id) },
             onPause: { modelManager.pauseDownload(model.id) },
             onResume: { modelManager.resumeDownload(model.id) }
@@ -846,15 +853,26 @@ struct ModelDownloadView: View {
             && !filterState.isActive
         if isBrowsing {
             VStack(alignment: .leading, spacing: 16) {
-                if lists.suggested.isEmpty {
+                if lists.favorites.isEmpty, lists.suggested.isEmpty {
                     modelGrid(models: lists.others)
                 } else {
-                    topPicksCarousel(lists.suggested)
-                    modelGridSection(
-                        title: L("Our Curated Models"),
-                        models: lists.others,
-                        isFirst: true
-                    )
+                    if !lists.favorites.isEmpty {
+                        modelGridSection(
+                            title: L("Favourites"),
+                            models: lists.favorites,
+                            isFirst: true
+                        )
+                    }
+                    if !lists.suggested.isEmpty {
+                        topPicksCarousel(lists.suggested)
+                    }
+                    if !lists.others.isEmpty {
+                        modelGridSection(
+                            title: L("Our Curated Models"),
+                            models: lists.others,
+                            isFirst: lists.favorites.isEmpty
+                        )
+                    }
                 }
                 imageModelsLinkRow
             }
@@ -1312,6 +1330,7 @@ struct ModelDownloadView: View {
     /// pass to avoid running `applySort` / `SearchService.filterModels` /
     /// `filterState.apply` 4–6 times during animation frames.
     struct GridLists {
+        let favorites: [MLXModel]
         let suggested: [MLXModel]
         let others: [MLXModel]
         let downloaded: [MLXModel]
@@ -1327,7 +1346,7 @@ struct ModelDownloadView: View {
     /// `.animation(_:value:)` modifier (rather than `withAnimation`) gives
     /// `LazyVGrid` reliable reorder animations — same path search uses.
     private var gridChangeToken: String {
-        "\(selectedTab.rawValue)|\(sortOption.rawValue)|\(debouncedSearchText)|\(filterStateToken)"
+        "\(selectedTab.rawValue)|\(sortOption.rawValue)|\(debouncedSearchText)|\(filterStateToken)|\(favoritesStore.favoriteKeys.joined(separator: ","))"
     }
 
     /// Compact label for the active filter selection. `nil` when no
@@ -1375,6 +1394,7 @@ struct ModelDownloadView: View {
         let filterState: ModelManager.ModelFilterState
         let selectedTab: ModelListTab
         let sortOption: ModelSortOption
+        let favoriteKeys: [String]
         let totalMemoryGB: Double
     }
 
@@ -1389,6 +1409,7 @@ struct ModelDownloadView: View {
             filterState: filterState,
             selectedTab: selectedTab,
             sortOption: sortOption,
+            favoriteKeys: favoritesStore.favoriteKeys,
             totalMemoryGB: systemMonitor.totalMemoryGB
         )
     }
@@ -1403,7 +1424,8 @@ struct ModelDownloadView: View {
     nonisolated static func groupIntoFamilyCards(
         _ models: [MLXModel],
         totalMemoryGB: Double,
-        downloadStates: [String: DownloadState]
+        downloadStates: [String: DownloadState],
+        favoriteKeys: Set<String> = []
     ) -> [MLXModel] {
         var order: [String] = []
         var buckets: [String: [MLXModel]] = [:]
@@ -1417,7 +1439,8 @@ struct ModelDownloadView: View {
                 defaultFamilyVariant(
                     among: $0,
                     totalMemoryGB: totalMemoryGB,
-                    downloadStates: downloadStates
+                    downloadStates: downloadStates,
+                    favoriteKeys: favoriteKeys
                 )
             }
         }
@@ -1432,7 +1455,8 @@ struct ModelDownloadView: View {
     nonisolated static func defaultFamilyVariant(
         among variants: [MLXModel],
         totalMemoryGB: Double,
-        downloadStates: [String: DownloadState]
+        downloadStates: [String: DownloadState],
+        favoriteKeys: Set<String> = []
     ) -> MLXModel {
         func isActive(_ m: MLXModel) -> Bool {
             switch downloadStates[m.id] ?? .notStarted {
@@ -1452,6 +1476,9 @@ struct ModelDownloadView: View {
         let best = variants.min { lhs, rhs in
             if isActive(lhs) != isActive(rhs) { return isActive(lhs) }
             if lhs.isDownloaded != rhs.isDownloaded { return lhs.isDownloaded }
+            let lhsFavorite = favoriteKeys.contains(lhs.favoriteKey)
+            let rhsFavorite = favoriteKeys.contains(rhs.favoriteKey)
+            if lhsFavorite != rhsFavorite { return lhsFavorite }
             let lc = compatRank(lhs)
             let rc = compatRank(rhs)
             if lc != rc { return lc < rc }
@@ -1482,6 +1509,7 @@ struct ModelDownloadView: View {
         let filterState = input.filterState
         let searchText = input.searchText
         let downloadStates = input.downloadStates
+        let favoriteKeys = Set(input.favoriteKeys)
 
         func isActive(_ m: MLXModel) -> Bool {
             switch downloadStates[m.id] ?? .notStarted {
@@ -1493,6 +1521,9 @@ struct ModelDownloadView: View {
         // imported/non-curated models visible in the All tab.
         func isUserModel(_ m: MLXModel) -> Bool {
             m.isDownloaded || isActive(m)
+        }
+        func isFavorite(_ m: MLXModel) -> Bool {
+            favoriteKeys.contains(m.favoriteKey)
         }
         func compatibilityRank(_ m: MLXModel) -> Int {
             switch m.compatibility(totalMemoryGB: mem) {
@@ -1516,6 +1547,10 @@ struct ModelDownloadView: View {
                 break
             }
             return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        func stableFavoritesFirst(_ models: [MLXModel]) -> [MLXModel] {
+            guard !favoriteKeys.isEmpty else { return models }
+            return models.filter(isFavorite) + models.filter { !isFavorite($0) }
         }
         func applySort(_ models: [MLXModel]) -> [MLXModel] {
             switch sortOption {
@@ -1565,14 +1600,14 @@ struct ModelDownloadView: View {
         // Catalog default ordering is newest-first; an explicit sort choice
         // takes over via `applySort`, matching `sortedSuggested`'s convention.
         func sortedCatalog(_ models: [MLXModel]) -> [MLXModel] {
-            sortOption == .recommended ? models.sorted(by: newestFirst) : applySort(models)
+            stableFavoritesFirst(sortOption == .recommended ? models.sorted(by: newestFirst) : applySort(models))
         }
         func sortedSuggested(_ filtered: [MLXModel]) -> [MLXModel] {
             if sortOption != .recommended {
-                return applySort(filtered)
+                return stableFavoritesFirst(applySort(filtered))
             }
             let curatedIds = ModelManager.curatedSuggestedIds
-            return filtered.sorted { lhs, rhs in
+            return stableFavoritesFirst(filtered.sorted { lhs, rhs in
                 let lhsCurated = curatedIds.contains(lhs.id.lowercased())
                 let rhsCurated = curatedIds.contains(rhs.id.lowercased())
                 if lhsCurated != rhsCurated { return lhsCurated }
@@ -1582,7 +1617,7 @@ struct ModelDownloadView: View {
                 }
 
                 return newestFirst(lhs, rhs)
-            }
+            })
         }
         func computeDownloadedList() -> [MLXModel] {
             let all = input.deduplicatedModels
@@ -1599,8 +1634,8 @@ struct ModelDownloadView: View {
             }
             let searched = SearchService.filterModels(merged, with: searchText)
             let filtered = filterState.apply(to: searched, totalMemoryGB: mem)
-            let activeGroup = applySort(filtered.filter(isActive))
-            let restGroup = applySort(filtered.filter { !isActive($0) })
+            let activeGroup = stableFavoritesFirst(applySort(filtered.filter(isActive)))
+            let restGroup = stableFavoritesFirst(applySort(filtered.filter { !isActive($0) }))
             return activeGroup + restGroup
         }
 
@@ -1631,6 +1666,15 @@ struct ModelDownloadView: View {
         let suggFiltered = filterState.apply(to: suggSearched, totalMemoryGB: mem)
         let recommended = sortedSuggested(suggFiltered)
 
+        let favoriteCandidates = sortedCatalog((recommended + allFiltered).filter(isFavorite))
+        let favorites = groupIntoFamilyCards(
+            favoriteCandidates,
+            totalMemoryGB: mem,
+            downloadStates: downloadStates,
+            favoriteKeys: favoriteKeys
+        )
+        let favoriteFamilies = Set(favorites.map { ModelMetadataParser.familyKey(from: $0.id) })
+
         // The Top Picks carousel only exists under the default Recommended
         // sort. Any explicit sort merges the picks back into the grid so they
         // sort alongside everything else. The carousel itself is newest-first,
@@ -1639,14 +1683,20 @@ struct ModelDownloadView: View {
         let topPicks =
             sortOption == .recommended
             ? groupIntoFamilyCards(
-                sortedCatalog(recommended.filter { $0.isTopSuggestion }),
+                sortedCatalog(
+                    recommended.filter {
+                        $0.isTopSuggestion
+                            && !favoriteFamilies.contains(ModelMetadataParser.familyKey(from: $0.id))
+                    }
+                ),
                 totalMemoryGB: mem,
-                downloadStates: downloadStates
+                downloadStates: downloadStates,
+                favoriteKeys: favoriteKeys
             )
             : []
         // Exclude by family, not id, so demoted precision siblings of a Top
         // Pick don't reappear as separate grid cards below the carousel.
-        let topPickFamilies = Set(topPicks.map { ModelMetadataParser.familyKey(from: $0.id) })
+        let pinnedFamilies = favoriteFamilies.union(topPicks.map { ModelMetadataParser.familyKey(from: $0.id) })
 
         // The grid is the rest of the catalog — recommended non-top picks plus
         // everything else — deduped and ordered newest-first (or by the
@@ -1655,7 +1705,7 @@ struct ModelDownloadView: View {
         var catalogRest: [MLXModel] = []
         for model in recommended + allFiltered {
             let key = model.id.lowercased()
-            if topPickFamilies.contains(ModelMetadataParser.familyKey(from: model.id)) { continue }
+            if pinnedFamilies.contains(ModelMetadataParser.familyKey(from: model.id)) { continue }
             if seenCatalog.insert(key).inserted {
                 catalogRest.append(model)
             }
@@ -1663,7 +1713,8 @@ struct ModelDownloadView: View {
         let others = groupIntoFamilyCards(
             sortedCatalog(catalogRest),
             totalMemoryGB: mem,
-            downloadStates: downloadStates
+            downloadStates: downloadStates,
+            favoriteKeys: favoriteKeys
         )
 
         let downloaded = computeDownloadedList()
@@ -1680,7 +1731,7 @@ struct ModelDownloadView: View {
 
         let displayed: [MLXModel]
         switch input.selectedTab {
-        case .all: displayed = topPicks + others
+        case .all: displayed = favorites + topPicks + others
         case .downloaded: displayed = downloaded
         }
 
@@ -1696,6 +1747,7 @@ struct ModelDownloadView: View {
         }
 
         return GridLists(
+            favorites: favorites,
             suggested: topPicks,
             others: others,
             downloaded: downloaded,
@@ -1803,7 +1855,7 @@ struct ModelDownloadView: View {
         selectedTab = hasOwnModels ? .downloaded : .all
     }
 
-    private static func isOsaurusAI(_ model: MLXModel) -> Bool {
+    nonisolated private static func isOsaurusAI(_ model: MLXModel) -> Bool {
         model.id.lowercased().hasPrefix("osaurusai/")
     }
 

--- a/Packages/OsaurusCore/Views/Model/ModelRowView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelRowView.swift
@@ -29,6 +29,9 @@ struct ModelRowView: View {
     /// Optional download metrics (speed, ETA, bytes transferred)
     let metrics: ModelDownloadService.DownloadMetrics?
 
+    /// Whether this model is pinned by the user.
+    var isFavorite: Bool = false
+
     /// Callback when user taps the Details button
     let onViewDetails: () -> Void
 
@@ -36,6 +39,9 @@ struct ModelRowView: View {
     /// card is unsupported, this fires instead of `onViewDetails` so the host
     /// can explain that the model can't be used rather than open its details.
     var onUnsupportedTap: (() -> Void)? = nil
+
+    /// Optional action for pinning/unpinning the model.
+    var onToggleFavorite: (() -> Void)? = nil
 
     /// Optional cancel action when downloading or paused
     let onCancel: (() -> Void)?
@@ -157,6 +163,7 @@ struct ModelRowView: View {
                     // shifts as state changes.
                     stateChip
                     Spacer(minLength: 0)
+                    favoriteButton
                     if content.isTopSuggestion {
                         topPickRibbon
                     }
@@ -287,6 +294,25 @@ struct ModelRowView: View {
 
     private var topPickRibbon: some View {
         headerChip(icon: "star.fill", text: L("Top Pick"))
+    }
+
+    @ViewBuilder
+    private var favoriteButton: some View {
+        if let onToggleFavorite {
+            Button(action: onToggleFavorite) {
+                Image(systemName: isFavorite ? "star.fill" : "star")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(isFavorite ? Color.yellow : Color.white)
+                    .frame(width: 24, height: 22)
+                    .background(
+                        Capsule().fill(.black.opacity(isFavorite ? 0.34 : 0.24))
+                    )
+                    .contentShape(Capsule())
+            }
+            .buttonStyle(PlainButtonStyle())
+            .localizedHelp(isFavorite ? "Remove from favourites" : "Add to favourites")
+            .accessibilityLabel(Text(isFavorite ? L("Remove from favourites") : L("Add to favourites")))
+        }
     }
 
     /// Unified download-state indicator pinned to the header's top-left.


### PR DESCRIPTION
## Summary
- extend the existing favourite-model store to local catalog/download rows via a shared local model key
- add a Favourites section ahead of Top Picks in the model management catalog and pin favourited downloaded models after active downloads
- add focused tests for favourite persistence, catalog pinning, and downloaded-tab ordering

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-favorite-models swift test --disable-index-store --package-path Packages/OsaurusCore --filter 'FavoriteModelsStoreTests|ModelDownloadViewFamilyGroupingTests'` - 11 tests passed
- `git diff --check`
- `scripts/i18n/check.sh`
