### PR TITLE
Fix self-scheduled runs not auto-starting; fresh chat per wake

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -486,6 +486,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         Task { @MainActor in
             guard StorageKeyManager.shared.isStorageReadyForWrites else {
                 NSLog("[Osaurus] Scheduler disabled: storage key is not already unlocked")
+                // Arm a one-shot start for when the key becomes resident,
+                // so slots persisted from a previous session still fire
+                // once the user unlocks encrypted storage.
+                NextRunScheduler.shared.startWhenStorageBecomesReady()
                 return
             }
             NextRunScheduler.shared.start()

--- a/Packages/OsaurusCore/Identity/StorageKeyManager.swift
+++ b/Packages/OsaurusCore/Identity/StorageKeyManager.swift
@@ -70,6 +70,15 @@ public final class StorageKeyManager: @unchecked Sendable {
     static let keyAccount = "data-encryption-key"
     static let saltAccount = "data-encryption-salt"
 
+    /// Posted the first time the DEK becomes resident in this process
+    /// (nil -> non-nil cache transition). Subsystems that were gated off
+    /// at launch because storage wasn't ready (e.g. `NextRunScheduler`)
+    /// observe this to start once the key is unlocked. Posted from
+    /// whatever thread performed the unlock; observers must hop as needed.
+    public static let storageKeyDidBecomeResident = Notification.Name(
+        "OsaurusStorageKeyDidBecomeResident"
+    )
+
     /// Domain-separation tag used in HKDF for v1 of the storage key
     /// derivation. Bumping requires a key rotation.
     static let hkdfInfo = Data("osaurus-storage-v1".utf8)
@@ -150,11 +159,24 @@ public final class StorageKeyManager: @unchecked Sendable {
                 markProvisioned()
             }
 
-            os_unfair_lock_lock(&lock)
-            cachedKey = key
-            cachedReadFailureStatus = nil
-            os_unfair_lock_unlock(&lock)
+            cacheResidentKey(key)
             return key
+        }
+    }
+
+    /// Cache a freshly resolved key, posting `storageKeyDidBecomeResident`
+    /// on the nil -> non-nil transition (outside the lock).
+    private func cacheResidentKey(_ key: SymmetricKey) {
+        os_unfair_lock_lock(&lock)
+        let wasResident = cachedKey != nil
+        cachedKey = key
+        cachedReadFailureStatus = nil
+        os_unfair_lock_unlock(&lock)
+        if !wasResident {
+            NotificationCenter.default.post(
+                name: Self.storageKeyDidBecomeResident,
+                object: nil
+            )
         }
     }
 
@@ -222,10 +244,7 @@ public final class StorageKeyManager: @unchecked Sendable {
     /// `.osec` files. The cached key is updated atomically.
     public func rotate() throws -> SymmetricKey {
         let key = try generateAndPersistKey(forceFresh: true)
-        os_unfair_lock_lock(&lock)
-        cachedKey = key
-        cachedReadFailureStatus = nil
-        os_unfair_lock_unlock(&lock)
+        cacheResidentKey(key)
         return key
     }
 
@@ -239,10 +258,7 @@ public final class StorageKeyManager: @unchecked Sendable {
         if !Self.disablesKeychainForProcess {
             try persistKeychain(data: bytes)
         }
-        os_unfair_lock_lock(&lock)
-        cachedKey = key
-        cachedReadFailureStatus = nil
-        os_unfair_lock_unlock(&lock)
+        cacheResidentKey(key)
     }
 
     /// Replace the current DEK with one deterministically derived from
@@ -254,10 +270,7 @@ public final class StorageKeyManager: @unchecked Sendable {
     public func deriveFromMasterKey(context: LAContext) throws -> SymmetricKey {
         if Self.disablesKeychainForProcess {
             let key = try generateInMemoryKey()
-            os_unfair_lock_lock(&lock)
-            cachedKey = key
-            cachedReadFailureStatus = nil
-            os_unfair_lock_unlock(&lock)
+            cacheResidentKey(key)
             return key
         }
         guard MasterKey.exists() else {
@@ -283,10 +296,7 @@ public final class StorageKeyManager: @unchecked Sendable {
         try persistKeychain(data: derivedBytes)
 
         let key = SymmetricKey(data: derivedBytes)
-        os_unfair_lock_lock(&lock)
-        cachedKey = key
-        cachedReadFailureStatus = nil
-        os_unfair_lock_unlock(&lock)
+        cacheResidentKey(key)
         log.info("Storage key re-derived from master key (HKDF-SHA256)")
         return key
     }

--- a/Packages/OsaurusCore/Managers/NextRunScheduler.swift
+++ b/Packages/OsaurusCore/Managers/NextRunScheduler.swift
@@ -55,6 +55,7 @@ public final class NextRunScheduler {
 
     private var tickerTask: Task<Void, Never>?
     private var earlyWakeContinuation: CheckedContinuation<Void, Never>?
+    private var storageUnlockObserver: NSObjectProtocol?
 
     /// `(agent_id, trigger_kind) -> last dispatch wall time`. Used for
     /// coalescing. Lives in-process; not persisted because spec defines
@@ -94,19 +95,65 @@ public final class NextRunScheduler {
         print("[Osaurus] NextRunScheduler started")
     }
 
+    /// Arm a one-shot start for when the storage key becomes resident.
+    /// Called from the app-delegate launch path when the storage gate
+    /// fails (opt-in encryption, key not yet unlocked): the scheduler
+    /// can't open `scheduler.sqlite` without the key, but must come up
+    /// as soon as some other subsystem unlocks it — otherwise slots
+    /// persisted from a previous session sit due forever.
+    public func startWhenStorageBecomesReady() {
+        guard tickerTask == nil, storageUnlockObserver == nil else { return }
+        storageUnlockObserver = NotificationCenter.default.addObserver(
+            forName: StorageKeyManager.storageKeyDidBecomeResident,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                NextRunScheduler.shared.handleStorageUnlocked()
+            }
+        }
+    }
+
+    private func handleStorageUnlocked() {
+        removeStorageUnlockObserver()
+        start()
+    }
+
+    private func removeStorageUnlockObserver() {
+        guard let observer = storageUnlockObserver else { return }
+        NotificationCenter.default.removeObserver(observer)
+        storageUnlockObserver = nil
+    }
+
     /// Stop the loop. Used by tests and (theoretically) the in-process
     /// dispatcher shutdown.
     public func stop() {
         tickerTask?.cancel()
         tickerTask = nil
+        removeStorageUnlockObserver()
         fireEarlyWake()
     }
+
+    /// True while the dispatch loop is alive. The Next Run panel uses this
+    /// to warn when a due row can't fire because the loop never started
+    /// (e.g. encrypted storage was still locked at launch).
+    public var isRunning: Bool { tickerTask != nil }
 
     /// Wake the loop early — call this from `LocalAgentBridge`
     /// `scheduleNextRun` / `cancelNextRun` so the next sleep cycle picks
     /// up the new row immediately rather than waiting for the 60s
     /// fallback. Safe to call when the loop is asleep, awake, or stopped.
+    ///
+    /// If the loop was never started (the launch-time storage gate failed)
+    /// but storage is ready now, start it lazily: the caller just wrote a
+    /// row to the (possibly encrypted) scheduler DB, so the key must be
+    /// resident. Without this, a slot scheduled mid-session would sit due
+    /// forever showing "Now" until a manual Run now.
     public func notifyRowChanged() {
+        if tickerTask == nil, StorageKeyManager.shared.isStorageReadyForWrites {
+            start()
+            return
+        }
         fireEarlyWake()
     }
 
@@ -213,20 +260,20 @@ public final class NextRunScheduler {
             source: "scheduler/NextRun"
         ) {
             print("[NextRunScheduler] dispatch skipped: \(rejection.message)")
+            // The slot was already cleared; leave a cancelled row so the
+            // Activity tab shows why the wake never produced a session.
+            await recordSkippedRun(entry: entry, reason: "builtin-agent-rejected")
             return
         }
 
-        let request = DispatchRequest(
-            prompt: entry.instructions,
-            agentId: entry.agentId,
-            title: "Self-scheduled run",
-            source: .selfSchedule,
-            externalSessionKey: entry.agentId.uuidString
-        )
+        let request = await Self.makeDispatchRequest(for: entry)
         guard let handle = await TaskDispatcher.shared.dispatch(request) else {
             print(
                 "[NextRunScheduler] dispatch failed for agent \(entry.agentId.uuidString.prefix(8))"
             )
+            // The slot was cleared before dispatch; without this row the
+            // run would vanish without a trace (e.g. concurrency limit hit).
+            await recordSkippedRun(entry: entry, reason: "dispatch-failed")
             return
         }
         // Fire-and-forget the await — we don't need to block the
@@ -235,6 +282,95 @@ public final class NextRunScheduler {
         // existing run-hook in Phase 1.
         Task.detached {
             _ = await TaskDispatcher.shared.awaitCompletion(handle)
+        }
+    }
+
+    // MARK: - Dispatch request composition
+    //
+    // Every self-scheduled wake runs in a FRESH chat session
+    // (`externalSessionKey: nil`, so `BackgroundTaskManager` never
+    // reattaches to a prior `.selfSchedule` session). Continuity across
+    // wakes is the agent's job via `schedule_next_run` instructions and
+    // its agent DB — accreting every run into one shared chat grew the
+    // context window without bound. Because the fresh chat has no prior
+    // turns, the prompt carries a preamble explaining why the run exists.
+    // Shared with `NextRunPanelView.runNow` so manual and automatic wakes
+    // produce identical sessions.
+
+    /// Build the dispatch request for a wake, including the previous-run
+    /// pointer looked up from `agent_runs`.
+    public static func makeDispatchRequest(for entry: NextRunEntry) async -> DispatchRequest {
+        let previousRun = await latestCompletedRun(for: entry.agentId)
+        return DispatchRequest(
+            prompt: composeDispatchPrompt(entry: entry, previousRun: previousRun),
+            agentId: entry.agentId,
+            title: sessionTitle(for: entry),
+            source: .selfSchedule,
+            externalSessionKey: nil
+        )
+    }
+
+    /// Most recent `agent_runs` row that reached a terminal state, used
+    /// as the previous-run pointer in the fresh-chat preamble.
+    public static func latestCompletedRun(for agentId: UUID) async -> AgentRunRecord? {
+        await Task.detached(priority: .utility) { () -> AgentRunRecord? in
+            do {
+                try SchedulerDatabase.shared.open()
+                let recent = try SchedulerDatabase.shared.runs(agentId: agentId, limit: 8)
+                return recent.first { $0.endedAt != nil }
+            } catch {
+                return nil
+            }
+        }.value
+    }
+
+    /// Prompt preamble + verbatim instructions for a self-scheduled wake.
+    public static func composeDispatchPrompt(
+        entry: NextRunEntry,
+        previousRun: AgentRunRecord?
+    ) -> String {
+        var lines: [String] = [
+            "[Self-scheduled run] This chat was started automatically for a "
+                + "scheduled wake. It is a fresh session with no prior "
+                + "conversation context.",
+            "Scheduled by: \(entry.scheduledBy.rawValue), "
+                + "for \(promptTimestamp(entry.scheduledAt)).",
+        ]
+        if let previousRun, let ended = previousRun.endedAt {
+            lines.append(
+                "Your previous run \(statusPhrase(previousRun.status)) at "
+                    + "\(promptTimestamp(ended)). Consult your agent database "
+                    + "or notes for any state you saved."
+            )
+        }
+        lines.append("")
+        lines.append("Instructions for this run:")
+        lines.append(entry.instructions)
+        return lines.joined(separator: "\n")
+    }
+
+    /// Session title for a self-scheduled wake, e.g.
+    /// "Self-scheduled run — Jul 4, 2:42 PM".
+    public static func sessionTitle(for entry: NextRunEntry) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, h:mm a"
+        return "Self-scheduled run — \(formatter.string(from: entry.scheduledAt))"
+    }
+
+    private static func promptTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private static func statusPhrase(_ status: AgentRunStatus) -> String {
+        switch status {
+        case .success: return "completed"
+        case .error: return "failed"
+        case .cancelled: return "was cancelled"
+        case .clamped: return "was clamped"
+        case .running: return "was still running"
         }
     }
 

--- a/Packages/OsaurusCore/Tools/Database/SchedulerTools.swift
+++ b/Packages/OsaurusCore/Tools/Database/SchedulerTools.swift
@@ -62,7 +62,10 @@ final class ScheduleNextRunTool: OsaurusTool, @unchecked Sendable {
     let name = "schedule_next_run"
     let description =
         "Ask the host to wake you again at a future time, with a short "
-        + "instruction describing what to do then. The host clamps your "
+        + "instruction describing what to do then. The wake runs in a "
+        + "FRESH chat with no prior conversation context, so make "
+        + "`instructions` self-contained (persist any state you'll need "
+        + "in your agent database first). The host clamps your "
         + "request against the agent's schedule bounds (min interval, "
         + "max horizon, quiet hours, daily cap); the result tells you "
         + "the actual scheduled time and whether any clamp applied. "

--- a/Packages/OsaurusCore/Views/Agent/NextRunPanelView.swift
+++ b/Packages/OsaurusCore/Views/Agent/NextRunPanelView.swift
@@ -127,6 +127,19 @@ public struct NextRunPanelView: View {
                             .foregroundColor(theme.secondaryText.opacity(0.85))
                             .lineLimit(1)
                     }
+                    // A due row with a dead dispatch loop would otherwise
+                    // look like a working "Now" state forever (e.g. the
+                    // storage key wasn't unlocked at launch). Tell the user
+                    // why nothing fired and that Run now is the escape hatch.
+                    if entry.scheduledAt <= nowTick, !NextRunScheduler.shared.isRunning {
+                        Label(
+                            "Scheduler inactive — waiting for storage unlock. Use Run now to start manually.",
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.warningColor)
+                        .lineLimit(2)
+                    }
                 }
                 Spacer(minLength: 8)
 
@@ -397,14 +410,11 @@ public struct NextRunPanelView: View {
         // then dispatch with `selfSchedule` so the audit trail still shows
         // the run was triggered by the next-run plumbing.
         try? LocalAgentBridge.shared.cancelNextRun(agentId: agentId)
-        let request = DispatchRequest(
-            prompt: entry.instructions,
-            agentId: agentId,
-            title: "Self-scheduled run",
-            source: .selfSchedule,
-            externalSessionKey: agentId.uuidString
-        )
         Task {
+            // Same builder as the automatic path: fresh chat per run,
+            // preamble prompt with the previous-run pointer, timestamped
+            // session title.
+            let request = await NextRunScheduler.makeDispatchRequest(for: entry)
             _ = await TaskDispatcher.shared.dispatch(request)
             await reload()
             onRunNow()

--- a/docs/AGENT_DB.md
+++ b/docs/AGENT_DB.md
@@ -192,6 +192,10 @@ Writes use SQLite `ON CONFLICT` upsert — **last write wins**. The runtime [`Ne
 
 Because the slot is cleared on wake, **wakeups are single-shot**. If an agent wants to wake again it has to call `schedule_next_run` from inside the run. This is intentional — it's how the agent expresses "keep me alive" vs. "I'm done".
 
+**Every wake runs in a fresh chat session.** The dispatcher does not reattach to the chat from a previous self-scheduled run, so the context window never accretes across wakes. Continuity is the agent's job: carry state forward through the `instructions` on the next `schedule_next_run` call and through the agent DB. The dispatched prompt carries a host-composed preamble — who scheduled the wake, when, and a pointer to the previous run's completion time/status from `agent_runs` — followed by the stored instructions verbatim (see `NextRunScheduler.composeDispatchPrompt`).
+
+If dispatch fails after the slot is cleared (e.g. host concurrency is saturated), the scheduler records a `cancelled` row in `agent_runs` (`dispatch-failed`) so the miss is visible in the Activity tab instead of vanishing.
+
 Every slot carries `NextRunScheduledBy` (`.agent` / `.user` / `.system`) so the audit trail and the Next Run banner can show "scheduled by you" vs. "scheduled by the agent".
 
 ---
@@ -204,7 +208,7 @@ From [`SchedulerTools.swift`](../Packages/OsaurusCore/Tools/Database/SchedulerTo
 | ---------------- | --------------- | -------- | ----------------------------------------------------------------------------- |
 | `scheduled_at`   | ISO-8601 string | one of   | Absolute wake-up time.                                                        |
 | `in_seconds`     | integer         | one of   | Relative offset from now.                                                     |
-| `instructions`   | string          | yes      | The "wake-up brief" the agent reads when it fires. Becomes the user turn.     |
+| `instructions`   | string          | yes      | The "wake-up brief" the agent reads when it fires. Becomes the user turn in a fresh chat session, prefixed by the host's wake preamble. |
 | `context_views`  | string[]        | no       | Saved-view names to prefetch into the system prompt before the run starts.    |
 | `priority`       | `normal` \| `low` | no     | `low` means "skip if the user is mid-conversation when due". Default `normal`. |
 | `on_miss`        | `skip` \| `run_once` \| `run_catchup` | no | What to do when the wake-up time has already passed (e.g. laptop was asleep). Default `skip`. |


### PR DESCRIPTION
## Summary

Fixes two user-reported self-scheduling issues:

**1. Due next-run slots never auto-start.** `NextRunScheduler.start()` was only called once at launch, gated on `StorageKeyManager.isStorageReadyForWrites`. With opt-in encryption and the key not yet resident, the loop never started and nothing retried — the slot sat at "Now" until a manual Run now.
- `notifyRowChanged()` now lazily starts the loop when storage is ready (the bridge just wrote the scheduler DB, so the key is resident).
- `StorageKeyManager` posts `storageKeyDidBecomeResident` on the first nil→resident key transition; the launch gate arms a one-shot observer (`startWhenStorageBecomesReady()`) so slots from a previous session fire once storage unlocks.
- Dispatch failures after the slot is cleared (concurrency saturated, built-in-agent rejection) now record a `cancelled` row in `agent_runs` instead of vanishing silently.
- The Next Run panel shows a warning when a row is due but the loop is inactive, so the stuck state is diagnosable.

**2. All self-scheduled runs shared one chat.** Dispatch passed `externalSessionKey: agentId.uuidString`, reattaching every wake to the same `.selfSchedule` session and growing the context window without bound.
- Each wake now runs in a fresh chat session (`externalSessionKey: nil`), via a shared `NextRunScheduler.makeDispatchRequest(for:)` used by both the scheduler loop and the panel's Run now.
- The prompt carries a host-composed preamble: fresh-session notice, scheduled-by + time, a previous-run pointer from `agent_runs`, then the stored instructions verbatim. Session titles are timestamped.
- The `schedule_next_run` tool description now tells the model to write self-contained instructions.

Recurring `ScheduleManager` schedules are untouched. Docs updated in `docs/AGENT_DB.md`.

## Test plan

- [x] `RuntimePolicySourceTests`, `StorageOptInEncryptionTests`, scheduler DB suites pass (114 tests) — including the AppDelegate source-text assertions around the scheduler launch gate.
- [x] Full `make test` (keychain-disabled mode): remaining failures are the documented keychain-gated suites and pre-existing parallel-run timeout flakes, each passing in isolation.
- [ ] Live proof: with encrypted storage locked at launch, schedule a run mid-session and confirm it fires without manual start; confirm each wake opens a new sidebar session with the preamble.