### PR TITLE
Polish model catalog cards and promote Ornith Top Picks

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -837,6 +837,36 @@ extension ModelManager {
             useCase: .vision
         ),
 
+        // MARK: Ornith 1.0 (DeepReinforce, Qwen 3.5 hybrid backbone)
+        //
+        // Vision-language agentic-coding models on the Qwen 3.5 hybrid
+        // architecture (Gated-DeltaNet linear attention + full attention),
+        // so they reuse the existing `qwen3_5` / `qwen3_5_moe` runtime
+        // classes. MXFP8 is the curated Top Pick representative per family
+        // (precision-first, matching the Qwen 3.6 convention); the MXFP4 and
+        // JANG_4M siblings stay auto-fetched and collapse into each family
+        // card's Versions picker.
+
+        curated(
+            id: "OsaurusAI/Ornith-1.0-9B-MXFP8",
+            description:
+                "Ornith 1.0 9B vision-language model, tuned for agentic coding on a Qwen 3.5 hybrid backbone. MXFP8 — near-lossless precision. 256K context.",
+            isTopSuggestion: true,
+            modelType: "qwen3_5",
+            releasedAt: date("2026-06-26"),
+            useCase: .vision
+        ),
+
+        curated(
+            id: "OsaurusAI/Ornith-1.0-35B-MXFP8",
+            description:
+                "Ornith 1.0 35B vision-language MoE, state-of-the-art open agentic coding for its size. MXFP8 — near-lossless precision. 256K context.",
+            isTopSuggestion: true,
+            modelType: "qwen3_5_moe",
+            releasedAt: date("2026-06-26"),
+            useCase: .vision
+        ),
+
         // MARK: MiniMax M2.7 (JANGTQ MoE)
         //
         // 228.7B total / ~1.4B active MoE (256 experts, top-8) with 192K context.

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -738,10 +738,18 @@ struct ModelDownloadView: View {
 
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
-                    LazyHStack(spacing: 12) {
+                    // Non-lazy HStack: a LazyHStack lets the scroll view settle
+                    // its height from the first cards it measures, clipping any
+                    // taller card that scrolls in later. Top Picks is a small
+                    // curated set, so measuring every card up front is cheap.
+                    // `ModelRowView`'s fixed-slot body gives every card the
+                    // same natural height, and `fixedSize` guarantees each one
+                    // gets it regardless of the proposed height.
+                    HStack(alignment: .top, spacing: 12) {
                         ForEach(models, id: \.id) { model in
                             modelCard(for: model)
                                 .frame(width: 280)
+                                .fixedSize(horizontal: false, vertical: true)
                                 .id(model.id)
                         }
                     }
@@ -1598,11 +1606,20 @@ struct ModelDownloadView: View {
         // (when searching) anything matching the query. without the latter two,
         // imported/pasted repos inserted into `availableModels` are filtered
         // out and never appear
+        //
+        // AppleScript bundles only ever emit AppleScript (dedicated subagent
+        // models, not chat models), so they never surface in the Catalog tab —
+        // same rule as the chat model picker. They install and manage through
+        // Computer Use → Models instead; the On Device tab still lists an
+        // installed one so it stays deletable from here.
         let hasQuery = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let allTabBase = input.availableModels.filter { model in
-            isOsaurusAI(model) || isUserModel(model) || hasQuery
+            guard !AppleScriptModelCatalog.isAppleScriptModel(id: model.id) else { return false }
+            return isOsaurusAI(model) || isUserModel(model) || hasQuery
         }
-        let osaurusSuggested = input.suggestedModels.filter { isOsaurusAI($0) }
+        let osaurusSuggested = input.suggestedModels.filter {
+            isOsaurusAI($0) && !AppleScriptModelCatalog.isAppleScriptModel(id: $0.id)
+        }
 
         let availSearched = SearchService.filterModels(allTabBase, with: searchText)
         let availFiltered = filterState.apply(to: availSearched, totalMemoryGB: mem)

--- a/Packages/OsaurusCore/Views/Model/ModelRowView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelRowView.swift
@@ -59,6 +59,11 @@ struct ModelRowView: View {
                 onViewDetails()
             }
         }) {
+            // Fixed-slot body: every row below the header has a constant
+            // height (single-line tag row, fixed stat strip, reserved
+            // two-line description, always-present footer), so all cards
+            // share the same internal rhythm and the same natural height —
+            // rows line up across the grid and carousel by construction.
             VStack(spacing: 0) {
                 gradientHeader
 
@@ -67,15 +72,12 @@ struct ModelRowView: View {
 
                     statStrip
 
-                    if !content.description.isEmpty {
-                        Text(content.description)
-                            .font(.system(size: 12))
-                            .foregroundColor(theme.secondaryText)
-                            .lineLimit(2)
-                            .truncationMode(.tail)
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    Text(content.description)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(2, reservesSpace: true)
+                        .truncationMode(.tail)
+                        .multilineTextAlignment(.leading)
 
                     // Push the footer to the bottom so the popularity /
                     // release line sits at the same place on every card,
@@ -329,32 +331,34 @@ struct ModelRowView: View {
 
     // MARK: - Body Sections
 
-    /// Editorial / decision tags. Use-case leads (when set), followed by
-    /// the colored compatibility verdict and the LLM/VLM type so the eye
-    /// lands on "what is it / will it run" before raw specs.
+    /// Single-line decision row, capped at two pills so it can never wrap
+    /// and shift the rows below: one identity pill — the curated use case
+    /// when set (its tint + icon come from `ModelUseCase`, matching the
+    /// onboarding picker's vocabulary), otherwise the LLM/VLM type, or the
+    /// "Not MLX" warning for unsupported bundles — plus the colored
+    /// compatibility verdict, so the eye lands on "what is it / will it
+    /// run" before raw specs.
     private var leadTags: some View {
-        FlowLayout(spacing: 6) {
-            if let useCase = content.useCase {
-                // Tint + icon come from `ModelUseCase` so the vocabulary
-                // matches the onboarding picker's `.useCase(...)` chip.
-                TintedPill(
-                    icon: useCase.iconName,
-                    label: Text(useCase.displayName, bundle: .module),
-                    color: useCase.tintColor
-                )
-            }
+        HStack(spacing: 6) {
             if content.isUnsupportedFormat {
                 TintedPill(
                     icon: "exclamationmark.octagon",
                     label: Text(L("Not MLX")),
                     color: theme.errorColor
                 )
-            }
-            compatibilityBadge
-            if let type = content.type {
+            } else if let useCase = content.useCase {
+                TintedPill(
+                    icon: useCase.iconName,
+                    label: Text(useCase.displayName, bundle: .module),
+                    color: useCase.tintColor
+                )
+            } else if let type = content.type {
                 modelTypeBadge(type)
             }
+            compatibilityBadge
+            Spacer(minLength: 0)
         }
+        .frame(height: 20)
     }
 
     /// Fixed three-column spec strip. Columns stay in the same order with
@@ -390,39 +394,37 @@ struct ModelRowView: View {
     }
 
     /// Muted footer with popularity and release recency. Pinned to the
-    /// bottom of the card via a `Spacer` so it aligns across rows.
-    @ViewBuilder
+    /// bottom of the card via a `Spacer`, and always rendered at a fixed
+    /// height (even when one or both stats are missing) so the bottom
+    /// edge sits at the same place on every card.
     private var cardFooter: some View {
-        let downloads = content.downloadsText
-        let released = content.releaseText
-        if downloads != nil || released != nil {
-            HStack(spacing: 8) {
-                if let downloads {
-                    HStack(spacing: 3) {
-                        Image(systemName: "arrow.down.circle")
-                            .font(.system(size: 9, weight: .medium))
-                        Text(L("\(downloads) downloads"))
-                            .font(.system(size: 11))
-                    }
-                    .foregroundColor(theme.tertiaryText)
-                }
-
-                // Push popularity to the leading edge and release recency
-                // to the trailing edge so the two read as distinct stats.
-                Spacer(minLength: 8)
-
-                // Curated entries set `releasedAt` explicitly; HF
-                // auto-fetched ones pick it up from `lastModified` —
-                // either way the prefix is "Released".
-                if let released {
-                    Text(L("Released \(released)"))
+        HStack(spacing: 8) {
+            if let downloads = content.downloadsText {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.system(size: 9, weight: .medium))
+                    Text(L("\(downloads) downloads"))
                         .font(.system(size: 11))
-                        .foregroundColor(theme.tertiaryText)
                 }
+                .foregroundColor(theme.tertiaryText)
             }
-            .lineLimit(1)
-            .truncationMode(.tail)
+
+            // Push popularity to the leading edge and release recency
+            // to the trailing edge so the two read as distinct stats.
+            Spacer(minLength: 8)
+
+            // Curated entries set `releasedAt` explicitly; HF
+            // auto-fetched ones pick it up from `lastModified` —
+            // either way the prefix is "Released".
+            if let released = content.releaseText {
+                Text(L("Released \(released)"))
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+            }
         }
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .frame(height: 14)
     }
 
     /// Plain-language fit verdict. When the RAM estimate is known it reads
@@ -530,7 +532,10 @@ extension ModelCardContent {
             isTopSuggestion: model.isTopSuggestion,
             isDownloaded: model.isDownloaded,
             isUnsupportedFormat: model.isDownloaded && !model.isMLXFormat,
-            useCase: model.useCase,
+            // The "Runs Anywhere" (.smallest) editorial pill is dropped on
+            // cards: the compatibility pill already carries the fit verdict,
+            // so it added nothing and pushed the tag row onto a second line.
+            useCase: model.useCase == .smallest ? nil : model.useCase,
             compatibility: model.compatibility(totalMemoryGB: totalMemoryGB),
             memoryNeeded: model.formattedEstimatedMemory,
             type: model.useCase == .vision ? nil : (model.isVLM ? .vlm : .llm),
@@ -588,6 +593,8 @@ private struct TintedPill: View {
                 .font(.system(size: 8, weight: .semibold))
             label
                 .font(.system(size: 10, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
         .foregroundColor(color)
         .padding(.horizontal, 6)


### PR DESCRIPTION
## Summary

- Redesign the model card body into fixed slots so every catalog card has the same height and internal rhythm: a single-line tag row capped at two pills (identity + compatibility verdict), a reserved two-line description, and an always-present fixed-height footer. This also fixes the Top Picks carousel clipping taller cards (the strip now uses a non-lazy `HStack`, so it sizes to cards' uniform natural height).
- Drop the redundant "Runs Anywhere" pill from cards — the compatibility pill already carries the fit verdict.
- Hide AppleScript bundles (`OsaurusAI/Osaurus-AppleScript-*`) from the Catalog tab; they only emit AppleScript for the dedicated subagent and are managed in Computer Use → Models. Installed ones remain visible/deletable in On Device.
- Promote Ornith 1.0 9B and 35B to Top Picks via curated entries (`OsaurusAI/Ornith-1.0-9B-MXFP8`, `OsaurusAI/Ornith-1.0-35B-MXFP8`); MXFP4/JANG_4M siblings fold into each family card's Versions picker.

## Test plan

- [x] `make test` (keychain-disabled mode) — model catalog suites pass (`ModelDownloadViewFamilyGroupingTests`, `ModelManagerSuggestedTests`, picker/cache suites); remaining failures are the documented keychain-gated and timeout-flake suites
- [x] Visual check of Models → Catalog: uniform card heights in Top Picks and curated grid, no clipped footers, no AppleScript cards, Ornith cards present as Top Picks