### PR TITLE
Fix ExternalPlugin shutdown teardown race and recurring app-side hangs

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -1819,7 +1819,12 @@ extension AppDelegate {
                 )
                 alert.alertStyle = .warning
                 alert.addButton(withTitle: "OK")
-                alert.runModal()
+                // `runModal` intentionally blocks the main run loop until the
+                // user dismisses the alert; pause the hang watchdog so the
+                // wait isn't reported as an app hang (Sentry APPLE-MACOS-VE).
+                CrashReportingService.shared.withAppHangTrackingPaused {
+                    _ = alert.runModal()
+                }
                 return
             }
 

--- a/Packages/OsaurusCore/ComputerUse/Perception/FrontmostAppTracker.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/FrontmostAppTracker.swift
@@ -70,6 +70,14 @@ public final class FrontmostAppTracker: ObservableObject {
         if app.processIdentifier == selfPid { return }
         if let bundleId = app.bundleIdentifier, bundleId == selfBundleId { return }
         lastNonSelfPid = app.processIdentifier
-        lastNonSelfAppName = app.localizedName ?? app.bundleIdentifier
+        // Skip the no-op publish: assigning an unchanged `@Published` value
+        // still fires the whole Combine/SwiftUI fan-out synchronously inside
+        // this NSWorkspace notification callback, which showed up as a
+        // main-thread hang under load (Sentry APPLE-MACOS-RQ). Re-activating
+        // the same app (the common case) shouldn't redo any downstream work.
+        let name = app.localizedName ?? app.bundleIdentifier
+        if lastNonSelfAppName != name {
+            lastNonSelfAppName = name
+        }
     }
 }

--- a/Packages/OsaurusCore/Managers/WatcherManager.swift
+++ b/Packages/OsaurusCore/Managers/WatcherManager.swift
@@ -56,6 +56,15 @@ public final class WatcherManager {
     /// Last known fingerprint per watcher (convergence anchor)
     private var lastKnownFingerprints: [UUID: DirectoryFingerprint] = [:]
 
+    /// Memoized results of `resolveWatchPath`. Resolving a security-scoped
+    /// bookmark does a synchronous IPC round-trip to `scopedbookmarksagent`
+    /// that can stall for seconds, and `handleFSEvent` used to re-resolve
+    /// every enabled watcher's bookmark on every FSEvent batch — on the main
+    /// queue — which tripped the app-hang watchdog (Sentry APPLE-MACOS-CB).
+    /// The resolved path is stable for the app session, so resolve once per
+    /// watcher and invalidate whenever the watcher set reloads (`refresh()`).
+    private var resolvedWatchPaths: [UUID: String] = [:]
+
     // MARK: - Initialization
 
     private init() {
@@ -86,6 +95,9 @@ public final class WatcherManager {
     public func refresh() {
         watchers = WatcherStore.loadAll()
         recomputeAgentCounts()
+        // Bookmarks may have changed with the reload; drop memoized paths so
+        // the next resolve re-reads them (see `resolvedWatchPaths`).
+        resolvedWatchPaths.removeAll()
     }
 
     /// Number of watchers linked to the given agent.
@@ -354,8 +366,20 @@ public final class WatcherManager {
         eventStream = nil
     }
 
-    /// Resolve the watch path from a watcher's bookmark
+    /// Resolve the watch path from a watcher's bookmark. Memoized per
+    /// watcher for the app session — see `resolvedWatchPaths` for why.
     private func resolveWatchPath(for watcher: Watcher) -> String? {
+        if let cached = resolvedWatchPaths[watcher.id] {
+            return cached
+        }
+        let resolved = resolveWatchPathUncached(for: watcher)
+        if let resolved {
+            resolvedWatchPaths[watcher.id] = resolved
+        }
+        return resolved
+    }
+
+    private func resolveWatchPathUncached(for watcher: Watcher) -> String? {
         guard let bookmark = watcher.watchBookmark else {
             return watcher.watchPath
         }

--- a/Packages/OsaurusCore/Managers/WindowManager.swift
+++ b/Packages/OsaurusCore/Managers/WindowManager.swift
@@ -132,8 +132,13 @@ public final class WindowManager: NSObject, ObservableObject {
             return
         }
 
-        // Unhide app if hidden
-        NSApp.unhide(nil)
+        // Unhide app if hidden. Guarded because `unhide:` always makes a
+        // synchronous mach round-trip to the WindowServer (SLSSetFrontProcess),
+        // which can stall for seconds when the system is under memory pressure
+        // (Sentry APPLE-MACOS-P9) — skip it in the common not-hidden case.
+        if NSApp.isHidden {
+            NSApp.unhide(nil)
+        }
 
         // Deminiaturize if needed
         if window.isMiniaturized {

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import os
 
 /// Represents an MLX-compatible LLM that can be downloaded and used
 struct MLXModel: Identifiable, Codable {
@@ -158,15 +159,24 @@ struct MLXModel: Identifiable, Codable {
         return result.isEmpty ? name : result
     }
 
+    /// Memoized byte-count strings keyed by size. `ByteCountFormatStyle.format`
+    /// walks ICU/attributed-string machinery on every call, and the model grid
+    /// reads `formattedDownloadSize` for every card on every SwiftUI update —
+    /// enough aggregate work to trip the app-hang watchdog on slow machines
+    /// (Sentry APPLE-MACOS-VM). Sizes come from a small curated catalog, so
+    /// the cache stays tiny. Stale only if the system locale changes
+    /// mid-session, which the rest of the formatted UI doesn't survive either.
+    private static let formattedSizeCache = OSAllocatedUnfairLock<[Int64: String]>(initialState: [:])
+
     /// Formatted download size string (e.g., "3.9 GB").
-    ///
-    /// Uses the value-type `ByteCountFormatStyle` rather than allocating a
-    /// `ByteCountFormatter` per call: the size string is read from SwiftUI body
-    /// getters once per model row, and the format style is cheap and
-    /// concurrency-safe.
     var formattedDownloadSize: String? {
         guard let bytes = totalSizeEstimateBytes else { return nil }
-        return bytes.formatted(.byteCount(style: .file, allowedUnits: [.gb, .mb]))
+        return Self.formattedSizeCache.withLock { cache in
+            if let cached = cache[bytes] { return cached }
+            let formatted = bytes.formatted(.byteCount(style: .file, allowedUnits: [.gb, .mb]))
+            cache[bytes] = formatted
+            return formatted
+        }
     }
 
     /// Abbreviated HF Hub download (popularity) count for the card footer

--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -563,6 +563,24 @@ final class ExternalPlugin: @unchecked Sendable {
     /// the winner of this latch frees `ctx`.
     private let didDestroy = OSAllocatedUnfairLock<Bool>(initialState: false)
 
+    /// Tracks plugin callbacks that can run OUTSIDE the queues `shutdown()`
+    /// drains: main-actor invocations (`dispatchPluginCallOnMainActor` never
+    /// touches `invokeQueue`) and task-event deliveries whose per-task queue
+    /// was created after `shutdown()` took its snapshot (or whose body read
+    /// `isShutDown == false` just before the mid-drain flip). Either could
+    /// still be executing plugin code when the drain group completed, so
+    /// `destroy(ctx)` freed the context under a live callback — the
+    /// use-after-free behind production crash APPLE-MACOS-9T (EXC_BAD_ACCESS
+    /// inside the plugin's destroy/teardown path).
+    ///
+    /// Contract: callers `enter()` BEFORE reading the `isShutDown` latch and
+    /// `leave()` when the callback returns. `shutdown()` flips the latch
+    /// (inside the drain), then waits on this group before `destroy`. The
+    /// enter-before-check ordering makes that sound: a callback either
+    /// entered before the wait began (so the wait covers it) or observes the
+    /// flipped latch and bails without touching `ctx`.
+    private let inFlightCallbacks = DispatchGroup()
+
     /// Per-plugin concurrent queue for C ABI calls. Each plugin gets its own
     /// queue so that long-running operations (e.g. agentic inference) in one
     /// plugin don't block other plugins or additional requests to the same plugin.
@@ -646,6 +664,13 @@ final class ExternalPlugin: @unchecked Sendable {
     var hasTaskEventHandler: Bool { abiVersion >= 2 && api.on_task_event != nil }
 
     #if DEBUG
+        /// Test-only: flipped once `shutdown()` has captured its task-event
+        /// queue snapshot. Lets `PluginShutdownRaceTests` deterministically
+        /// deliver a task event on a queue created AFTER the snapshot — the
+        /// exact window where only `inFlightCallbacks` (not the drain group)
+        /// keeps `destroy(ctx)` from freeing the context under the callback.
+        let shutdownSnapshotTakenForTesting = OSAllocatedUnfairLock<Bool>(initialState: false)
+
         /// Test-only: synchronously drains every per-task event queue and the
         /// config event queue, then returns. Intended to be called from the
         /// matched `removeLoadedPluginForTesting` cleanup so that any
@@ -693,6 +718,9 @@ final class ExternalPlugin: @unchecked Sendable {
         let queues: [DispatchQueue] = taskEventQueuesLock.withLock {
             Array(taskEventQueues.values)
         }
+        #if DEBUG
+            shutdownSnapshotTakenForTesting.withLock { $0 = true }
+        #endif
 
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             let group = DispatchGroup()
@@ -718,6 +746,16 @@ final class ExternalPlugin: @unchecked Sendable {
                 group.leave()
             }
             group.notify(flags: .barrier, queue: self.invokeQueue) { [self] in
+                // Wait for callbacks the drain above cannot see: main-actor
+                // invocations and task-event deliveries on queues created
+                // after the snapshot. `isShutDown` is already true here (the
+                // configEventQueue marker flipped it before the group
+                // completed), so no NEW callback can pass its latch check —
+                // this wait only covers ones already inside plugin code.
+                // Safe to block: we're on an invokeQueue worker (never the
+                // main thread), and the waited-on callbacks never dispatch
+                // to invokeQueue themselves.
+                self.inFlightCallbacks.wait()
                 // Destroy exactly once. Concurrent shutdown attempts (re-entry
                 // from PluginManager hot reload, etc.) all drain and await here,
                 // but only the winner of `didDestroy` frees `ctx`.
@@ -734,7 +772,17 @@ final class ExternalPlugin: @unchecked Sendable {
                 // same plugin path does not see stale "already delivered"
                 // entries against a fresh ctx pointer.
                 self.lastDeliveredConfig.withLock { $0.removeAll(keepingCapacity: false) }
-                self.api.destroy?(self.ctx)
+                // Scope TLS to this plugin for the duration of `destroy`:
+                // plugin teardown code routinely calls host trampolines
+                // (config_get("api_key"), http_request for a final webhook
+                // delete, ...) and without TLS those resolve through the
+                // global `lastDispatchedPluginId` fallback — potentially a
+                // DIFFERENT plugin's context, or none at all — giving the
+                // dying plugin values it never wrote (or nil where it always
+                // saw a value), which some plugins dereference and crash on.
+                PluginHostContext.withTLSScope(pluginId: self.id, agentId: nil) {
+                    self.api.destroy?(self.ctx)
+                }
                 continuation.resume()
             }
         }
@@ -805,6 +853,12 @@ final class ExternalPlugin: @unchecked Sendable {
         errorMessage: String,
         _ call: @Sendable (osr_plugin_ctx_t) -> UnsafePointer<CChar>?
     ) throws -> String {
+        // Main-actor invocations never touch `invokeQueue`, so `shutdown()`'s
+        // barrier drain cannot see them. Enter the in-flight group BEFORE the
+        // latch check (see `inFlightCallbacks`) so `destroy(ctx)` waits for
+        // this call instead of freeing the context under it.
+        inFlightCallbacks.enter()
+        defer { inFlightCallbacks.leave() }
         guard !isShutDown.withLock({ $0 }) else {
             throw NSError(
                 domain: "ExternalPlugin",
@@ -1084,6 +1138,12 @@ final class ExternalPlugin: @unchecked Sendable {
         let isTerminal = eventType == .completed || eventType == .failed || eventType == .cancelled
 
         eventQueue(for: taskId).async { [self] in
+            // Enter BEFORE the latch check (see `inFlightCallbacks`): this
+            // queue may not be in `shutdown()`'s drain snapshot (created
+            // after it), so the group is what keeps `destroy(ctx)` from
+            // running while this delivery is inside plugin code.
+            self.inFlightCallbacks.enter()
+            defer { self.inFlightCallbacks.leave() }
             guard !self.isShutDown.withLock({ $0 }) else { return }
             PluginHostContext.withTLSScope(pluginId: pluginId, agentId: agentId) {
                 taskId.withCString { taskIdPtr in

--- a/Packages/OsaurusCore/Tests/Plugin/PluginShutdownRaceTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginShutdownRaceTests.swift
@@ -1,0 +1,249 @@
+//
+//  PluginShutdownRaceTests.swift
+//  OsaurusCoreTests
+//
+//  Regresses the production crash class behind Sentry APPLE-MACOS-9T
+//  (EXC_BAD_ACCESS during `ExternalPlugin.shutdown` → `destroy(ctx)`).
+//
+//  `shutdown()` drains the per-task event queues (snapshot), the config
+//  event queue, and the invoke queue (barrier) before calling `destroy`.
+//  Two callback paths escaped that drain:
+//
+//  1. Main-actor invocations (`dispatchPluginCallOnMainActor`) never touch
+//     `invokeQueue`, so the barrier could not see them — `destroy(ctx)`
+//     could free the context while the main thread was inside plugin code.
+//  2. Task events delivered on a per-task queue created AFTER the snapshot
+//     (or whose body read `isShutDown == false` just before the mid-drain
+//     flip) ran concurrently with `destroy`.
+//
+//  Both are now covered by `inFlightCallbacks` (enter-before-latch-check,
+//  `shutdown()` waits on the group before `destroy`). These tests block a
+//  callback inside plugin code, run a full `shutdown()` concurrently, and
+//  pin that `destroy` fired exactly once and never while the callback was
+//  still executing.
+//
+//  Also pins that `destroy` runs inside a plugin TLS scope: plugin teardown
+//  code routinely calls host trampolines (e.g. `config_get("api_key")`),
+//  and without TLS those resolve through the racy global fallback —
+//  potentially another plugin's context, or none at all.
+//
+
+import Foundation
+import Testing
+import os
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct PluginShutdownRaceTests {
+
+    /// Shared with the C callbacks via the plugin's opaque `ctx` pointer.
+    final class Recorder: @unchecked Sendable {
+        // Signaled by the blocked callback once it is inside plugin code.
+        let callbackStarted = DispatchSemaphore(value: 0)
+        // The blocked callback waits on this before returning.
+        let releaseCallback = DispatchSemaphore(value: 0)
+        // Signaled by the blocked on_config_changed delivery (test 2 only).
+        let configStarted = DispatchSemaphore(value: 0)
+        // The blocked on_config_changed waits on this (test 2 only).
+        let releaseConfig = DispatchSemaphore(value: 0)
+
+        private let lock = NSLock()
+        private var _insidePluginCode = false
+        private var _destroyCount = 0
+        private var _destroyedWhileInsidePluginCode = false
+        private var _tlsPluginIdAtDestroy: String?
+
+        var insidePluginCode: Bool {
+            get { lock.withLock { _insidePluginCode } }
+            set { lock.withLock { _insidePluginCode = newValue } }
+        }
+        var destroyCount: Int { lock.withLock { _destroyCount } }
+        var destroyedWhileInsidePluginCode: Bool {
+            lock.withLock { _destroyedWhileInsidePluginCode }
+        }
+        var tlsPluginIdAtDestroy: String? { lock.withLock { _tlsPluginIdAtDestroy } }
+
+        func recordDestroy(tlsPluginId: String?) {
+            lock.withLock {
+                _destroyCount += 1
+                if _insidePluginCode { _destroyedWhileInsidePluginCode = true }
+                _tlsPluginIdAtDestroy = tlsPluginId
+            }
+        }
+    }
+
+    /// Async-safe semaphore wait: Swift 6 forbids `DispatchSemaphore.wait`
+    /// on a concurrency-pool thread, so hop to a GCD global queue for the
+    /// blocking wait and resume with whether it was signaled in time.
+    private func signaled(_ sem: DispatchSemaphore, within timeout: TimeInterval = 5) async -> Bool {
+        await withCheckedContinuation { cont in
+            DispatchQueue.global().async {
+                cont.resume(returning: sem.wait(timeout: .now() + timeout) == .success)
+            }
+        }
+    }
+
+    /// Mirrors the private TLS key in `PluginHostContext` — the destroy
+    /// callback reads it to prove `destroy` ran inside a plugin TLS scope.
+    /// If the key is ever renamed in the host, this test fails loudly
+    /// instead of the contract silently regressing.
+    private static let pluginTLSKey = "ai.osaurus.plugin.active"
+
+    private static let blockingDestroy: osr_destroy_t = { ctxPtr in
+        guard let ctxPtr else { return }
+        let recorder = Unmanaged<Recorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+        recorder.recordDestroy(
+            tlsPluginId: Thread.current.threadDictionary[PluginShutdownRaceTests.pluginTLSKey] as? String
+        )
+    }
+
+    private func makePlugin(
+        recorder: Recorder,
+        pluginId: String
+    ) -> (plugin: ExternalPlugin, retain: Unmanaged<Recorder>) {
+        let retain = Unmanaged.passRetained(recorder)
+        let ctx = retain.toOpaque()
+        let api = osr_plugin_api(
+            free_string: { ptr in
+                guard let ptr else { return }
+                free(UnsafeMutableRawPointer(mutating: ptr))
+            },
+            init: nil,
+            destroy: Self.blockingDestroy,
+            get_manifest: nil,
+            invoke: { ctxPtr, _, _, _ in
+                guard let ctxPtr else { return nil }
+                let recorder = Unmanaged<Recorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+                recorder.insidePluginCode = true
+                recorder.callbackStarted.signal()
+                recorder.releaseCallback.wait()
+                recorder.insidePluginCode = false
+                return UnsafePointer(strdup(#"{"ok":true}"#))
+            },
+            version: 6,
+            handle_route: nil,
+            on_config_changed: { ctxPtr, _, _ in
+                guard let ctxPtr else { return }
+                let recorder = Unmanaged<Recorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+                recorder.configStarted.signal()
+                recorder.releaseConfig.wait()
+            },
+            on_task_event: { ctxPtr, _, _, _ in
+                guard let ctxPtr else { return }
+                let recorder = Unmanaged<Recorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+                recorder.insidePluginCode = true
+                recorder.callbackStarted.signal()
+                recorder.releaseCallback.wait()
+                recorder.insidePluginCode = false
+            }
+        )
+        let manifest = PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(tools: nil, routes: nil, config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+        let plugin = ExternalPlugin(
+            handle: ctx,
+            api: api,
+            ctx: ctx,
+            manifest: manifest,
+            path: "/tmp/shutdown-race-\(pluginId)",
+            abiVersion: 6
+        )
+        return (plugin, retain)
+    }
+
+    /// A main-actor invocation (accessibility-style plugin call) blocked
+    /// inside plugin code must delay `destroy(ctx)` until it returns —
+    /// `invokeQueue`'s barrier drain cannot see main-actor calls, so only
+    /// `inFlightCallbacks` prevents the use-after-free.
+    @Test
+    func shutdownWaitsForInFlightMainActorInvocation() async throws {
+        let recorder = Recorder()
+        let (plugin, retain) = makePlugin(
+            recorder: recorder,
+            pluginId: "com.test.shutdown-race.mainactor.\(UUID().uuidString)"
+        )
+        defer { retain.release() }
+
+        let invokeTask = Task {
+            try await plugin.invoke(type: "tool", id: "t", payload: "{}", isolation: .mainActor)
+        }
+        #expect(await signaled(recorder.callbackStarted))
+
+        let shutdownTask = Task.detached { await plugin.shutdown() }
+        // Give shutdown time to finish every drain it CAN see. Before the
+        // fix, destroy fired inside this window while the main thread was
+        // still executing plugin code.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(recorder.destroyCount == 0, "destroy must wait for the in-flight main-actor call")
+
+        recorder.releaseCallback.signal()
+        let result = try await invokeTask.value
+        #expect(result == #"{"ok":true}"#)
+        await shutdownTask.value
+
+        #expect(recorder.destroyCount == 1)
+        #expect(!recorder.destroyedWhileInsidePluginCode)
+        #expect(recorder.tlsPluginIdAtDestroy == plugin.id, "destroy must run inside this plugin's TLS scope")
+    }
+
+    /// A task event delivered on a per-task queue created AFTER `shutdown()`
+    /// took its drain snapshot must still delay `destroy(ctx)`. The config
+    /// event queue is deliberately kept busy so the `isShutDown` latch flips
+    /// late — reproducing the exact interleaving where the drain group
+    /// completed while the event callback was still inside plugin code.
+    @Test
+    func shutdownWaitsForTaskEventOnQueueCreatedAfterSnapshot() async throws {
+        let recorder = Recorder()
+        let (plugin, retain) = makePlugin(
+            recorder: recorder,
+            pluginId: "com.test.shutdown-race.taskevent.\(UUID().uuidString)"
+        )
+        defer { retain.release() }
+
+        // Occupy the config event queue so shutdown's drain marker (which
+        // flips `isShutDown`) queues behind it.
+        plugin.notifyConfigBatch([(key: "k", value: "v")], agentId: UUID())
+        #expect(await signaled(recorder.configStarted))
+
+        let shutdownTask = Task.detached { await plugin.shutdown() }
+        // Wait until the drain snapshot exists — the event queue created
+        // below is then provably invisible to the drain group.
+        let deadline = Date().addingTimeInterval(5)
+        while !plugin.shutdownSnapshotTakenForTesting.withLock({ $0 }) {
+            try #require(Date() < deadline, "shutdown never took its drain snapshot")
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        // Fresh task id → fresh queue, post-snapshot. The latch is still
+        // false (config marker blocked), so delivery proceeds into plugin
+        // code and blocks there.
+        plugin.notifyTaskEvent(taskId: "post-snapshot-task", eventType: .started, eventJSON: "{}")
+        #expect(await signaled(recorder.callbackStarted))
+
+        // Unblock the config queue: the latch flips, the drain group
+        // completes, and shutdown reaches the destroy step — which must
+        // now wait for the blocked event delivery.
+        recorder.releaseConfig.signal()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(recorder.destroyCount == 0, "destroy must wait for the in-flight task event")
+
+        recorder.releaseCallback.signal()
+        await shutdownTask.value
+
+        #expect(recorder.destroyCount == 1)
+        #expect(!recorder.destroyedWhileInsidePluginCode)
+        #expect(recorder.tlsPluginIdAtDestroy == plugin.id, "destroy must run inside this plugin's TLS scope")
+    }
+}

--- a/docs/SENTRY_VMLX_CRASH_TRIAGE_2026_07_05.md
+++ b/docs/SENTRY_VMLX_CRASH_TRIAGE_2026_07_05.md
@@ -1,0 +1,57 @@
+# Sentry VMLX Crash Triage — 0.21.6 (2026-07-05)
+
+Handoff list for the VMLX workstream. These crash groups were triaged from the
+`osaurus-inc/apple-macos` Sentry project for release
+`com.dinoki.osaurus@0.21.6+0.21.6` (production). Every stack bottoms out in
+`vmlx-swift` frames (`BatchEngine.swift`, `Evaluate.swift`, model files) or
+MLX core / Metal — none of the crashing files exist in the Osaurus repo, so
+**no Osaurus-side code changes were made for these rows**. Flagged only, per
+triage instruction.
+
+The one app-side crash from the same triage (APPLE-MACOS-9T,
+`ExternalPlugin.shutdown` teardown use-after-free) was fixed in Osaurus — see
+`Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift` and
+`PluginShutdownRaceTests`.
+
+## Theme 1 — Indexing / precondition failures in model forward passes
+
+| Issue | Events | Status | Signature |
+|---|---|---|---|
+| [APPLE-MACOS-WV](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-WV) | 27, **escalating**, new in 0.21.6 window | unresolved | `MLXArray` indexing precondition in `Qwen3VLLanguage.RotaryEmbedding` via `BatchEngine.stepBatchDecode` (BatchEngine.swift:2375, Qwen3VL.swift:1110, MLXArray+Indexing.swift:696) |
+| [APPLE-MACOS-1A](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-1A) | 31 since Jun 4 | unresolved | `Array._checkSubscript` OOB in `Gemma4.prepare` → `maskedScatter` (Gemma4.swift:1104) during solo fast-path prefill |
+| [APPLE-MACOS-EJ](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-EJ) | 13 since Jun 16 | unresolved | `Array._checkSubscript` OOB in Gemma4 `TextMLP` inside the compiled decode trace (Gemma4Text.swift:376, Transforms+Compile.swift) |
+| [APPLE-MACOS-CA](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-CA) | 15, last on 0.21.2 (Jul 1) | resolved as stale | `MiniMaxJANGTQAttention` MLXArray ellipsis indexing (MiniMaxJANGTQ.swift:119, MLXArray+Indexing.swift:517). Auto-reopens on regression |
+
+## Theme 2 — Metal command-encoder / command-buffer lifecycle races
+
+Common thread: encoder/buffer state races in `mlx::core::metal` under
+concurrent load (BatchEngine + chunked VLM prefill). Likely one underlying
+lifecycle bug with several surfaces.
+
+| Issue | Events | Status | Signature |
+|---|---|---|---|
+| [APPLE-MACOS-6H](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-6H) | 27 (16 in 0.21.6) | **reopened as regressed** | `addCompletedHandler: provided after commit call` assertion during `Mistral3VLMJANGTQ.prepare` → `chunkedPrefillEmbedding` (ChunkedPrefillVLM.swift:71) |
+| [APPLE-MACOS-PE](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-PE) (+ siblings 12, T2) | 4 | unresolved | `EXC_BAD_ACCESS` creating a compute command encoder in the same Mistral3VLMJANGTQ chunked-prefill path (device.cpp:537). Same user/machine as 6H |
+| [APPLE-MACOS-33](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-33) / KY / WZ | 8 / 2 / 1 | unresolved | AGX driver assertion "a command encoder is already encoding" across G16/G17 GPU families |
+| [APPLE-MACOS-1Z](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-1Z) / K1 | 3 / 2 | unresolved | malloc "pointer being freed was not allocated" in `CommandEncoder::set_input_array` / `maybeInsertBarrier` |
+| [APPLE-MACOS-T1](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-T1) | 4 | unresolved | `_status < MTLCommandBufferStatusCommitted` assertion |
+| [APPLE-MACOS-11](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-11) / XT | 6 / 1, last 6h ago | unresolved | `EXC_BAD_ACCESS` in `mlx::core::metal::Device::end_encoding` |
+| [APPLE-MACOS-XY](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-XY) | 1, brand new | unresolved | `EXC_BAD_ACCESS` in `mlx::core::Reduce::eval_gpu` → `setComputePipelineState:`. Watch for growth |
+| [APPLE-MACOS-3T](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-3T) | 18 | ignored | C++ `runtime_error`: Metal command buffer OOM (`kIOGPUCommandBufferCallbackErrorOutOfMemory`). Related to RAM-gate policy work |
+| [APPLE-MACOS-4](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-4) | 10 | ignored, assigned Eric Jang | `commit command buffer with uncommitted encoder` assertion |
+
+## Theme 3 — Deterministic config / kernel bugs (100% repro for affected users)
+
+| Issue | Events | Status | Signature |
+|---|---|---|---|
+| [APPLE-MACOS-SM](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-SM) | 4 | unresolved | `custom_kernel_jangtq_hadamard_multiblock` requests 65536 B threadgroup memory on a GPU with a 32768 B limit — deterministic abort for JANGTQ models on lower-tier chips. Kernel must size to the device limit |
+| [APPLE-MACOS-PD](https://osaurus-inc.sentry.io/issues/APPLE-MACOS-PD) | 4 | unresolved | `fatalError` at MLXVLM/Mistral3.swift:342: `rope_parameters['rope_theta'] is required` — hard crash on loading a Mistral3 bundle missing the key. Should be a typed load error, not `fatalError` (per the memory-safety contract: fail before unsafe allocation with a clear typed error) |
+
+## Notes
+
+- All rows above report 0 "users impacted" only because `sendDefaultPii`
+  is off and `event.user` is stripped in `beforeSend`; event counts and
+  distinct `app.device` hashes are the real impact signal.
+- The high-volume `OsaurusMain.main` app-hang group (APPLE-MACOS-5, 1153
+  events) and SwiftUI/CoreText framework hang groups remain ignored as
+  non-actionable sample points.


### PR DESCRIPTION
## Summary

Output of the 0.21.6 Sentry crash/hang triage. One production crash fix, five hang fixes, and the VMLX crash-list handoff doc.

### Crash: APPLE-MACOS-9T — `ExternalPlugin.shutdown` use-after-free (17 events)

`shutdown()` drained the invoke queue (barrier), the config queue, and a **snapshot** of the per-task event queues before calling `destroy(ctx)`. Two callback paths escaped that drain, so `destroy` could free the plugin context while a callback was still executing plugin code:

- **Main-actor invocations** (`dispatchPluginCallOnMainActor`, used by accessibility plugins) never touch `invokeQueue`, so the barrier drain couldn't see them.
- **Task events** delivered on a per-task queue created *after* the snapshot (or whose body read `isShutDown == false` just before the mid-drain flip) ran concurrently with `destroy`.

Fix: a new `inFlightCallbacks` DispatchGroup with an enter-before-latch-check contract on both paths; `shutdown()` waits on it before `destroy`. `destroy` also now runs inside `PluginHostContext.withTLSScope` — teardown code calling host trampolines (e.g. `config_get("api_key")`, matching the crash symbol) previously resolved through the racy global fallback, potentially getting a different plugin's context or none.

Regression coverage: `PluginShutdownRaceTests` deterministically blocks a callback inside plugin code, runs a full concurrent `shutdown()`, and pins that `destroy` fires exactly once, never mid-callback, and with the right TLS. A DEBUG-only seam (`shutdownSnapshotTakenForTesting`) makes the post-snapshot task-event window reproducible.

### Hangs (Sentry AppHang groups, all recurring on 0.21.6)

- **APPLE-MACOS-VM** — `MLXModel.formattedDownloadSize` now memoizes the `ByteCountFormatStyle` output; the model grid re-formatted every card on every SwiftUI update.
- **APPLE-MACOS-RQ** — `FrontmostAppTracker.record` skips the `@Published` assignment when the app name is unchanged, avoiding the synchronous Combine/SwiftUI fan-out inside every NSWorkspace activation callback.
- **APPLE-MACOS-CB** — `WatcherManager.resolveWatchPath` results are memoized per session; security-scoped bookmark resolution (synchronous IPC to `scopedbookmarksagent`) previously re-ran for every enabled watcher on every FSEvent batch on the main queue.
- **APPLE-MACOS-P9** — `WindowManager.show` only calls `NSApp.unhide(nil)` when actually hidden, skipping a synchronous WindowServer round-trip in the common case.
- **APPLE-MACOS-VE** — the HuggingFace deep-link "Unsupported model" `NSAlert.runModal()` is wrapped in `withAppHangTrackingPaused` (intentional modal wait).

APPLE-MACOS-X4 / S2 / XG were triaged as not-actionable (old releases, memory-pressure machines, paths already off-main) and resolved in Sentry with rationale.

### VMLX handoff

`docs/SENTRY_VMLX_CRASH_TRIAGE_2026_07_05.md` lists the ~15 flagged VMLX/MLX runtime crash groups by theme (indexing/precondition, Metal encoder lifecycle, deterministic config/kernel bugs) for the VMLX workstream. No VMLX code touched.

## Test plan

- [x] `PluginShutdownRaceTests` (2 new tests) pass in isolation and in the full parallel run
- [x] Related plugin suites (`PluginAbiHandshakeTests`, `PluginAccessibilityInvocationTests`, `PluginClarifyEventTests`, `PluginAgentScopingTests`, etc.) pass
- [x] Full `make test`-equivalent run: 26 scattered failures reproduced as parallel-run environment flakiness; every affected suite passes when rerun in isolation, and the trailing MLX metallib abort reproduces on a clean tree (documented SwiftPM-harness limitation in AGENTS.md)
- [x] `swift-format` / `swiftlint` clean on changed lines (remaining warnings are pre-existing)