### PR TITLE
Repin vmlx-swift to merged main (class-killer #116 + norm #117 + Theme 3) — fixes Metal concurrency crash class

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "92a07217295b4237a99fd77a41b498c3505c9993"
+        "revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc"
+        "revision" : "92a07217295b4237a99fd77a41b498c3505c9993"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc"
+        "revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         // producers are off the GPU; restores can't race input tokenization).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8dffa0a8e69d7617d68f0843635158684120a3dc"
+            revision: "92a07217295b4237a99fd77a41b498c3505c9993"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -39,9 +39,14 @@ let package = Package(
         // serialized disk-restore evals (#113) — together closing the
         // client-disconnect crash train (engine teardown returns only after
         // producers are off the GPU; restores can't race input tokenization).
+        // Now also carries #116 (serialize GPU-stream drivers — re-locks
+        // eval/asyncEval/item + synchronize/clearCache to kill the Metal
+        // concurrent-encoder crash class) and #117 (NormConventionResolver:
+        // an unrecognized norm_convention defers to the vote instead of
+        // silently disabling the (1+weight) shift).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "92a07217295b4237a99fd77a41b498c3505c9993"
+            revision: "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
-        #expect(packageResolved.contains(#""revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
-        #expect(workspaceResolved.contains(#""revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
-        #expect(appResolved.contains(#""revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc""#))
+        #expect(packageSwift.contains(#"revision: "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
+        #expect(packageResolved.contains(#""revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
+        #expect(workspaceResolved.contains(#""revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
+        #expect(appResolved.contains(#""revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -658,8 +658,16 @@ struct RuntimePolicySourceTests {
         // plus the orphan tool-call closer strip (vmlx-swift#115) that
         // removes stray `</parameter></function></zyphra_tool_call>`
         // closer runs from the visible stream in ZAYA / Gemma-4
-        // AppleScript agent-loop rows.
-        let expectedRuntimeHardenedRevision = "8dffa0a8e69d7617d68f0843635158684120a3dc"
+        // AppleScript agent-loop rows,
+        // plus the GPU-stream-driver serialization (vmlx-swift#116) that
+        // re-locks eval/asyncEval/item + synchronize/clearCache to kill the
+        // Metal concurrent-encoder crash class (Sentry: end_encoding,
+        // "encoder already encoding", addCompletedHandler-after-commit,
+        // set_input_array double-free), and the NormConventionResolver
+        // fallback (vmlx-swift#117) so an unrecognized norm_convention
+        // declaration defers to the order-independent vote instead of
+        // silently disabling the (1+weight) RMSNorm shift.
+        let expectedRuntimeHardenedRevision = "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "92a07217295b4237a99fd77a41b498c3505c9993"
+        "revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8dffa0a8e69d7617d68f0843635158684120a3dc"
+        "revision" : "92a07217295b4237a99fd77a41b498c3505c9993"
       }
     },
     {


### PR DESCRIPTION
## What

Repins the consolidated vmlx-swift dependency from the `#116` branch tip onto **merged vmlx main `53840914`**, which now carries:

- **#116 — serialize GPU-stream drivers** (the class-killer): re-locks `eval`/`asyncEval`/`item` + `synchronize`/`clearCache` on a per-stream driver lock. Kills the Metal concurrent-encoder crash class (Sentry Theme 2: `end_encoding`, `encoder already encoding`, `addCompletedHandler after commit`, `set_input_array` double-free, etc.).
- **#117 — NormConventionResolver**: an unrecognized `norm_convention` declaration defers to the order-independent vote instead of silently disabling the `(1+weight)` RMSNorm shift (prevents a converter typo from stranding a raw bundle's norms unshifted).
- **Theme 3 (already on main)**: SM hadamard threadgroup sizing (fixed `shmem[8192]`=32 KB per-block rewrite) and PD Mistral3 `rope_theta` typed flat-rope fallback.

## Live validation (dev build, this pin)

Built Release against `53840914`, launched, ran the multiturn matrix on `:1337`:
- Text multiturn (gemma-4-e2b, qwen3-0.6b): coherent, no crash.
- VL multiturn (gemma-4 Gemma4 arch + qwen2.5-vl different mrope/vision arch): correct image reads, no crash.
- **4 concurrent requests on one model: 4/4 clean** — directly exercises the class-killer GPU serialization.

## Not included (deliberate)

Sentry Theme 1 (Qwen3VL RotaryEmbedding OOB / Gemma4 Array OOB) are `EXC_BREAKPOINT` shape/index traps seen only on RAM-starved devices, unreproducible on healthy hardware and without a proven root cause. No speculative guard was added — they remain flagged for a symbolicated-build / low-RAM repro.