### PR TITLE
Backfill compatibility leaderboard with previously tested models

### DIFF
--- a/reports/COMPATIBILITY.json
+++ b/reports/COMPATIBILITY.json
@@ -1,6 +1,6 @@
 {
-  "contributions" : 4,
-  "generatedAt" : "2026-07-06T02:32:37.896Z",
+  "contributions" : 6,
+  "generatedAt" : "2026-07-06T04:20:09.751Z",
   "models" : [
     {
       "builds" : [
@@ -22,6 +22,30 @@
       "model" : "OsaurusAI/Ornith-1.0-9B-MXFP4",
       "passed" : 188,
       "peakPhysFootprintMb" : 20613.585746765137,
+      "scored" : 247,
+      "skipped" : 5,
+      "verdict" : "works"
+    },
+    {
+      "builds" : [
+
+      ],
+      "catalogHashes" : [
+        "137408f3cdba4838"
+      ],
+      "chips" : [
+        "Apple M4 Pro"
+      ],
+      "contributions" : 1,
+      "decodeTokensPerSecondMax" : 13.46734269025956,
+      "decodeTokensPerSecondMin" : 13.46734269025956,
+      "errored" : 0,
+      "hasSelfJudged" : false,
+      "maxRamMb" : 49152,
+      "minRamMb" : 49152,
+      "model" : "OsaurusAI/gemma-4-12B-it-MXFP8",
+      "passed" : 223,
+      "peakPhysFootprintMb" : 20535.99245452881,
       "scored" : 247,
       "skipped" : 5,
       "verdict" : "works"
@@ -94,6 +118,30 @@
       "model" : "mlx-community/Qwen3.5-4B-OptiQ-4bit",
       "passed" : 212,
       "peakPhysFootprintMb" : 20487.085746765137,
+      "scored" : 247,
+      "skipped" : 5,
+      "verdict" : "works"
+    },
+    {
+      "builds" : [
+
+      ],
+      "catalogHashes" : [
+        "137408f3cdba4838"
+      ],
+      "chips" : [
+        "Apple M4 Pro"
+      ],
+      "contributions" : 1,
+      "decodeTokensPerSecondMax" : 10.33938140350877,
+      "decodeTokensPerSecondMin" : 10.33938140350877,
+      "errored" : 0,
+      "hasSelfJudged" : true,
+      "maxRamMb" : 49152,
+      "minRamMb" : 49152,
+      "model" : "xai/grok-4.3",
+      "passed" : 228,
+      "peakPhysFootprintMb" : 19637.49208831787,
       "scored" : 247,
       "skipped" : 5,
       "verdict" : "works"

--- a/reports/COMPATIBILITY.md
+++ b/reports/COMPATIBILITY.md
@@ -1,10 +1,16 @@
 # Osaurus Model Compatibility (community)
 
-Crowdsourced from 4 contribution(s). Verdicts: **works** (runs cleanly), **partial** (runs with errors or low pass-rate), **broken** (error-dominated / never scored).
+Crowdsourced from 6 contribution(s). Verdicts: **works** (runs cleanly), **partial** (runs with errors or low pass-rate), **broken** (error-dominated / never scored).
 
 | Model | Verdict | Pass | Contrib | Chips | RAM band | peak RAM | decode tok/s | builds |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `Ornith-1.0-9B-MXFP4` | works | 76% (188/247) | 1 | Apple M4 Pro | 48GB | 20614MB | 23 | — |
+| `gemma-4-12B-it-MXFP8` | works | 90% (223/247) | 1 | Apple M4 Pro | 48GB | 20536MB | 13 | — |
 | `gemma-4-E4B-it-4bit` | works | 77% (188/245) | 1 | Apple M4 Pro | 48GB | 19798MB | 21 | — |
 | `Qwen3-4B-4bit` | works | 80% (198/246) | 1 | Apple M4 Pro | 48GB | 20583MB | 53 | — |
 | `Qwen3.5-4B-OptiQ-4bit` | works | 86% (212/247) | 1 | Apple M4 Pro | 48GB | 20487MB | 35 | — |
+| `grok-4.3` | works | 92% (228/247) | 1 | Apple M4 Pro | 48GB | 19637MB | 10 | — |
+
+## Caveats
+
+- `grok-4.3`: at least one contribution self-judged an LLM-judged suite — those rubric grades are weaker.

--- a/reports/community/apple-m4-pro-OsaurusAI-gemma-4-12B-it-MXFP8-20260704.json
+++ b/reports/community/apple-m4-pro-OsaurusAI-gemma-4-12B-it-MXFP8-20260704.json
@@ -1,0 +1,88 @@
+{
+  "domains" : [
+    "agent_loop",
+    "apple_script",
+    "capability_claims",
+    "computer_use_loop",
+    "default_agent",
+    "micro_perf",
+    "subagent"
+  ],
+  "generatedAt" : "2026-07-06T04:18:31.542Z",
+  "models" : [
+    {
+      "chatModelPassed" : 211,
+      "chatModelScored" : 228,
+      "environment" : {
+        "caseCount" : 12,
+        "catalogHash" : "137408f3cdba4838",
+        "chip" : "Apple M4 Pro",
+        "cpuCores" : 14,
+        "judge" : "xai/grok-4.3",
+        "lowPowerMode" : false,
+        "osVersion" : "26.2.0",
+        "powerSource" : "AC",
+        "runModel" : "OsaurusAI/gemma-4-12B-it-MXFP8",
+        "thermalState" : "fair",
+        "totalRamMb" : 49152
+      },
+      "meanCpuPercent" : 66.84375354583517,
+      "meanDecodeTokensPerSecond" : 13.46734269025956,
+      "meanPromptTokensPerTask" : 25350.417582417584,
+      "meanTotalTokensPerTask" : 21928.645454545454,
+      "meanTtftMs" : 87.38914322345815,
+      "modelId" : "OsaurusAI/gemma-4-12B-it-MXFP8",
+      "peakCpuPercent" : 524.7043178852887,
+      "peakPhysFootprintMb" : 20535.99245452881,
+      "perDomain" : {
+        "agent_loop" : {
+          "errored" : 0,
+          "passed" : 79,
+          "scored" : 92,
+          "skipped" : 3
+        },
+        "apple_script" : {
+          "errored" : 0,
+          "passed" : 28,
+          "scored" : 35,
+          "skipped" : 0
+        },
+        "capability_claims" : {
+          "errored" : 0,
+          "passed" : 10,
+          "scored" : 11,
+          "skipped" : 0
+        },
+        "computer_use_loop" : {
+          "errored" : 0,
+          "passed" : 23,
+          "scored" : 23,
+          "skipped" : 0
+        },
+        "default_agent" : {
+          "errored" : 0,
+          "passed" : 37,
+          "scored" : 38,
+          "skipped" : 0
+        },
+        "micro_perf" : {
+          "errored" : 0,
+          "passed" : 3,
+          "scored" : 3,
+          "skipped" : 0
+        },
+        "subagent" : {
+          "errored" : 0,
+          "passed" : 43,
+          "scored" : 45,
+          "skipped" : 2
+        }
+      },
+      "startedAt" : "2026-07-04T03:35:10Z",
+      "subsystemPassed" : 12,
+      "subsystemScored" : 19,
+      "totalPassed" : 223,
+      "totalScored" : 247
+    }
+  ]
+}

--- a/reports/community/apple-m4-pro-xai-grok-4.3-20260705.json
+++ b/reports/community/apple-m4-pro-xai-grok-4.3-20260705.json
@@ -1,0 +1,88 @@
+{
+  "domains" : [
+    "agent_loop",
+    "apple_script",
+    "capability_claims",
+    "computer_use_loop",
+    "default_agent",
+    "micro_perf",
+    "subagent"
+  ],
+  "generatedAt" : "2026-07-06T04:19:06.440Z",
+  "models" : [
+    {
+      "chatModelPassed" : 218,
+      "chatModelScored" : 228,
+      "environment" : {
+        "caseCount" : 12,
+        "catalogHash" : "137408f3cdba4838",
+        "chip" : "Apple M4 Pro",
+        "cpuCores" : 14,
+        "judge" : "self-judge",
+        "lowPowerMode" : false,
+        "osVersion" : "26.2.0",
+        "powerSource" : "AC",
+        "runModel" : "xai/grok-4.3",
+        "thermalState" : "fair",
+        "totalRamMb" : 49152
+      },
+      "meanCpuPercent" : 32.995194582527496,
+      "meanDecodeTokensPerSecond" : 10.33938140350877,
+      "meanPromptTokensPerTask" : 32286.923076923078,
+      "meanTotalTokensPerTask" : 27458.045454545456,
+      "meanTtftMs" : 675.729790900616,
+      "modelId" : "xai/grok-4.3",
+      "peakCpuPercent" : 517.2388282920834,
+      "peakPhysFootprintMb" : 19637.49208831787,
+      "perDomain" : {
+        "agent_loop" : {
+          "errored" : 0,
+          "passed" : 89,
+          "scored" : 92,
+          "skipped" : 3
+        },
+        "apple_script" : {
+          "errored" : 0,
+          "passed" : 26,
+          "scored" : 35,
+          "skipped" : 0
+        },
+        "capability_claims" : {
+          "errored" : 0,
+          "passed" : 11,
+          "scored" : 11,
+          "skipped" : 0
+        },
+        "computer_use_loop" : {
+          "errored" : 0,
+          "passed" : 22,
+          "scored" : 23,
+          "skipped" : 0
+        },
+        "default_agent" : {
+          "errored" : 0,
+          "passed" : 34,
+          "scored" : 38,
+          "skipped" : 0
+        },
+        "micro_perf" : {
+          "errored" : 0,
+          "passed" : 3,
+          "scored" : 3,
+          "skipped" : 0
+        },
+        "subagent" : {
+          "errored" : 0,
+          "passed" : 43,
+          "scored" : 45,
+          "skipped" : 2
+        }
+      },
+      "startedAt" : "2026-07-05T18:46:28Z",
+      "subsystemPassed" : 10,
+      "subsystemScored" : 19,
+      "totalPassed" : 228,
+      "totalScored" : 247
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `gemma-4-12B-it-MXFP8` to the community compatibility leaderboard, built from its best recorded full-coverage run (Jul 4 frontier-parity push, 223/247 on catalog `137408f3cdba4838`) — no retest needed.
- Add the `xai/grok-4.3` frontier reference lane (Jul 5, 228/247, same catalog) so the leaderboard shows how close each local model gets to a frontier baseline. Its self-judged rubric rows are flagged as a caveat by the tooling.
- Rebuild `COMPATIBILITY.md` / `COMPATIBILITY.json`; both contributions pass `compat --validate` provenance checks.

## Test plan
- [x] `osaurus-evals compat --validate` passes on `reports/community/`
- [x] `make evals-compat` regenerates the leaderboard deterministically