### PR TITLE
Agent DB: sandbox file paths, db_export, and token-efficiency fixes

### DIFF
--- a/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
+++ b/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
@@ -119,6 +119,11 @@ public enum ChatExecutionContext {
     /// untouched.
     @TaskLocal public static var sandboxReadBridge: SandboxReadBridge?
 
+    /// Linux sandbox agent name for the current execution. Bound alongside
+    /// `sandboxReadBridge` so Agent DB file tools can resolve paths under
+    /// `/workspace/...` even in plain sandbox mode (no host folder).
+    @TaskLocal public static var sandboxAgentName: String?
+
     /// Default idle-timeout (seconds) for `shell_run`, applied ONLY when the
     /// model passed no `timeout` argument. Bound by headless drivers
     /// (`AgentLoopEvaluator`) where no user [Terminate] button exists, so a

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -54739,6 +54739,40 @@
         }
       }
     },
+    "Exported data from the database" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daten aus der Datenbank exportiert"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터베이스에서 데이터를 내보냈습니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Данные экспортированы из базы данных"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已从数据库导出数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已從數據庫導出數據"
+          }
+        }
+      }
+    },
     "Exported on %@" : {
       "comment" : "Auto-extracted format-string key (Apple String.LocalizationValue canonical form).",
       "extractionState" : "manual",
@@ -54813,6 +54847,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將路由器支持捆綁包導出到%@。"
+          }
+        }
+      }
+    },
+    "Exporting data from the database" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportiert Daten aus der Datenbank"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터베이스에서 데이터 내보내는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Экспорт данных из базы данных"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在从数据库导出数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在從數據庫導出數據"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/AgentBridge/LocalAgentBridge.swift
+++ b/Packages/OsaurusCore/Services/AgentBridge/LocalAgentBridge.swift
@@ -376,6 +376,32 @@ public final class LocalAgentBridge: @unchecked Sendable, AgentRuntimeBridge {
         }
     }
 
+    /// Stream a read-only query to a file on disk (used by `db_export`).
+    func exportQueryToFile(
+        agentId: UUID,
+        sql: String,
+        params: [AgentSQLValue],
+        url: URL,
+        format: DatabaseExport.Format,
+        maxBytes: Int
+    ) throws -> DatabaseExport.Result {
+        try serialized(agentId) {
+            let database = try AgentDatabaseStore.shared.database(for: agentId)
+            try AgentDatabase.validateReadOnlyQuery(sql)
+            let probe = try database.query(sql: sql, params: params, limit: 1, offset: 0)
+            return try DatabaseExport.streamWrite(
+                url: url,
+                format: format,
+                maxBytes: maxBytes,
+                headerColumns: probe.columns
+            ) { emit in
+                _ = try database.forEachQueryRow(sql: sql, params: params) { columns, row in
+                    try emit(columns, row)
+                }
+            }
+        }
+    }
+
     // MARK: - AgentRuntimeBridge (saved views, spec §6.3)
 
     @discardableResult

--- a/Packages/OsaurusCore/Services/AgentBridge/OnboardingPrompt.swift
+++ b/Packages/OsaurusCore/Services/AgentBridge/OnboardingPrompt.swift
@@ -16,7 +16,7 @@ import Foundation
 
 public enum OnboardingPrompt {
     /// Monotonic integer. Bump for any text change.
-    public static let version: Int = 2
+    public static let version: Int = 3
 
     /// Block appended to the system prompt after the agent's persistent
     /// prompt and before per-run instructions (spec §5.5.3). The schema
@@ -44,9 +44,10 @@ public enum OnboardingPrompt {
         5. Before creating a new table, briefly confirm the columns with the user. Agent-authored schemas without user input tend to be over-engineered or wrong-shaped.
 
         Moving data at scale (do NOT insert large data one row at a time):
-        - If the data is in a file in your working folder, call `db_import(table, path)`. The host reads, parses (CSV/TSV/JSON/JSONL), and bulk-loads it — no row data passes through your tokens and you spend one tool call, not one per row. It creates the table from the file's columns when needed.
+        - If the data is in a file in your sandbox workspace or working folder, call `db_import(table, path)`. The host reads, parses (CSV/TSV/JSON/JSONL), and bulk-loads it — no row data passes through your tokens and you spend one tool call, not one per row. It creates the table from the file's columns when needed.
+        - To extract a large result set without paging `db_query`, call `db_export(sql, path)` — the host writes CSV/JSON/JSONL to disk and returns a summary only.
         - If the rows are already in your context (e.g. JSON you just fetched), pass them as `db_insert(table, rows=[...])` / `db_upsert(table, key_columns, rows=[...])` in a single call.
-        - `db_execute` runs first-class SQL, including multi-statement transform scripts (e.g. `INSERT … SELECT`, CTEs, window functions) inside one transaction. Use it to aggregate/derive instead of pulling rows into context and computing by hand. `ATTACH`/`DETACH`, `PRAGMA` writes, `load_extension`, `DROP TABLE`/`TRUNCATE`, unconstrained `DELETE`, and writes to system tables are rejected.
+        - `db_execute` runs first-class SQL, including multi-statement transform scripts (e.g. `INSERT … SELECT`, CTEs, window functions) inside one transaction. Pass `path` instead of `sql` to run a `.sql` script from disk without loading it into tokens. Use `db_import` for CSV/JSON ingestion. `ATTACH`/`DETACH`, `PRAGMA` writes, `load_extension`, `DROP TABLE`/`TRUNCATE`, unconstrained `DELETE`, and writes to system tables are rejected.
 
         Schema discipline:
         - Tables should have clear, narrow purposes. One thing per table.

--- a/Packages/OsaurusCore/Services/AgentBridge/SchemaSnapshot.swift
+++ b/Packages/OsaurusCore/Services/AgentBridge/SchemaSnapshot.swift
@@ -150,7 +150,8 @@ public enum SchemaSnapshot {
 
         lines.append("System columns on every user table: _created_at, _updated_at, _deleted_at.")
         lines.append(
-            "Queries via db.query() auto-filter `_deleted_at IS NULL` unless you pass include_deleted=true."
+            "Soft-deleted rows have a non-null `_deleted_at`. Typed tools hide them by default; "
+            + "add `_deleted_at IS NULL` in your `db_query` SQL when you want the same filter."
         )
         return lines.joined(separator: "\n")
     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -1584,7 +1584,7 @@ public struct SystemPromptComposer: Sendable {
     /// users who never enable the feature.
     static let agentDBToolNames: Set<String> = [
         "db_schema", "db_create_table", "db_alter_table", "db_migrate",
-        "db_insert", "db_upsert", "db_import", "db_update", "db_delete", "db_restore",
+        "db_insert", "db_upsert", "db_import", "db_export", "db_update", "db_delete", "db_restore",
         "db_query", "db_execute",
         // Saved views (spec §6.3 / phase 2).
         "db_define_view", "db_run_view", "db_list_views", "db_drop_view",

--- a/Packages/OsaurusCore/Storage/AgentDatabase.swift
+++ b/Packages/OsaurusCore/Storage/AgentDatabase.swift
@@ -18,8 +18,10 @@
 //    - Every table gets `_created_at`, `_updated_at`, `_deleted_at`.
 //    - Soft delete is the default; `softDelete` writes `_deleted_at`.
 //    - Triggers auto-update `_updated_at` on UPDATE.
-//    - All `query()` calls auto-filter `_deleted_at IS NULL` unless the
-//      caller passes `includeDeleted = true`.
+//    - Typed mutation paths (`update`, `softDelete`, …) auto-filter
+//      `_deleted_at IS NULL` unless `includeDeleted = true`. Raw
+//      `query()` / `db_query` SQL does not rewrite the statement — add
+//      `_deleted_at IS NULL` yourself when you want to hide tombstones.
 //
 //  Concurrency: one serial queue per `AgentDatabase`. The
 //  `LocalAgentBridge` further serializes all mutations across this
@@ -271,10 +273,14 @@ public struct AgentQueryResult: Codable, Sendable, Equatable {
 public struct AgentExecuteResult: Codable, Sendable, Equatable {
     public var rowsAffected: Int
     public var warning: String?
+    /// When `execute()` drains a SELECT result set, this counts the rows
+    /// that were not returned — callers should use `query()` instead.
+    public var selectRowsDrained: Int?
 
-    public init(rowsAffected: Int, warning: String? = nil) {
+    public init(rowsAffected: Int, warning: String? = nil, selectRowsDrained: Int? = nil) {
         self.rowsAffected = rowsAffected
         self.warning = warning
+        self.selectRowsDrained = selectRowsDrained
     }
 }
 
@@ -1495,6 +1501,73 @@ public final class AgentDatabase: @unchecked Sendable {
         }
     }
 
+    /// Validate that SQL is a read-only SELECT/WITH suitable for export
+    /// or saved views. Reuses the same guardrails as `defineView`.
+    public static func validateReadOnlyQuery(_ sql: String) throws {
+        guard !sql.isEmpty else {
+            throw AgentDatabaseError.invalidArgument("SQL must not be empty")
+        }
+        if let reason = forbiddenReason(in: sql) {
+            throw AgentDatabaseError.forbidden(reason)
+        }
+        let head = collapseWhitespace(stripComments(sql))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        guard head.hasPrefix("SELECT") || head.hasPrefix("WITH") else {
+            throw AgentDatabaseError.invalidArgument(
+                "Read-only export/query SQL must be SELECT or WITH ... SELECT only."
+            )
+        }
+    }
+
+    /// Stream every row from a read-only query without the `query()` row
+    /// cap. The handler receives column names once, then each row; return
+    /// `false` from the handler to stop early (e.g. export byte budget).
+    public func forEachQueryRow(
+        sql: String,
+        params: [AgentSQLValue] = [],
+        handler: (_ columns: [String], _ row: [AgentSQLValue]) throws -> Bool
+    ) throws -> Int {
+        try Self.validateReadOnlyQuery(sql)
+        return try queue.sync {
+            guard let connection = db else { throw AgentDatabaseError.notOpen }
+            try Self.executeRawOn(connection: connection, sql: "BEGIN DEFERRED")
+            defer { try? Self.executeRawOn(connection: connection, sql: "ROLLBACK") }
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(connection, sql, -1, &stmt, nil) == SQLITE_OK,
+                let prepared = stmt
+            else {
+                throw AgentDatabaseError.failedToPrepare(String(cString: sqlite3_errmsg(connection)))
+            }
+            defer { sqlite3_finalize(prepared) }
+
+            for (i, value) in params.enumerated() {
+                Self.bind(prepared, index: i + 1, value: value)
+            }
+
+            let colCount = Int(sqlite3_column_count(prepared))
+            var columns: [String] = []
+            columns.reserveCapacity(colCount)
+            for c in 0 ..< colCount {
+                let name = sqlite3_column_name(prepared, Int32(c)).map { String(cString: $0) } ?? ""
+                columns.append(name)
+            }
+
+            var count = 0
+            while sqlite3_step(prepared) == SQLITE_ROW {
+                var row: [AgentSQLValue] = []
+                row.reserveCapacity(colCount)
+                for c in 0 ..< colCount {
+                    row.append(Self.readColumn(prepared, index: c))
+                }
+                count += 1
+                if try !handler(columns, row) { break }
+            }
+            return count
+        }
+    }
+
     /// Raw SQL escape hatch (spec §6.2). Rejects the absolute-disaster
     /// statements (`DROP TABLE`, `TRUNCATE`, `DELETE` with no WHERE on
     /// any user table) and logs everything else to `_changelog` with
@@ -1528,6 +1601,7 @@ public final class AgentDatabase: @unchecked Sendable {
             // deltas so non-DML statements (CREATE/PRAGMA) don't inflate the
             // total.
             let before = Int(sqlite3_total_changes(connection))
+            var selectRowsDrained = 0
             try sql.withCString { (base: UnsafePointer<CChar>) in
                 var cursor: UnsafePointer<CChar>? = base
                 while let current = cursor, current.pointee != 0 {
@@ -1559,7 +1633,10 @@ public final class AgentDatabase: @unchecked Sendable {
                     // surface the rows (`query` exists for that); drain to
                     // DONE so the transaction can commit cleanly.
                     if step == SQLITE_ROW {
-                        while sqlite3_step(prepared) == SQLITE_ROW { /* drain */  }
+                        selectRowsDrained += 1
+                        while sqlite3_step(prepared) == SQLITE_ROW {
+                            selectRowsDrained += 1
+                        }
                     } else if step != SQLITE_DONE {
                         throw AgentDatabaseError.failedToExecute(
                             "execute: step returned \(step): "
@@ -1581,7 +1658,19 @@ public final class AgentDatabase: @unchecked Sendable {
                 sql: sql
             )
 
-            return AgentExecuteResult(rowsAffected: affected, warning: warning)
+            if selectRowsDrained > 0 {
+                let selectHint =
+                    "SELECT returned \(selectRowsDrained) row(s) that were not included "
+                    + "in this result. Use `db_query` to read rows."
+                warning =
+                    warning.map { $0 + " " + selectHint }
+                    ?? selectHint
+            }
+            return AgentExecuteResult(
+                rowsAffected: affected,
+                warning: warning,
+                selectRowsDrained: selectRowsDrained > 0 ? selectRowsDrained : nil
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Storage/AgentDatabaseTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/AgentDatabaseTests.swift
@@ -238,7 +238,8 @@ struct AgentDatabaseTests {
         // The bulk-ingestion guidance must be present so the model reaches
         // for db_import instead of looping single-row writes.
         #expect(OnboardingPrompt.block.contains("db_import"))
-        // And it still calls out the soft-delete contract explicitly.
+        #expect(OnboardingPrompt.block.contains("db_export"))
+        // Soft-delete guidance: typed tools hide tombstones; raw SQL does not.
         #expect(
             OnboardingPrompt.block.lowercased().contains("soft delete")
         )
@@ -459,6 +460,43 @@ struct AgentDatabaseTests {
         #expect(page3.rows.first?[0] == .integer(21))
         #expect(page3.rows.last?[0] == .integer(25))
         #expect(page3.truncated == false)
+    }
+
+    @Test
+    func executeReportsDrainedSelectRows() throws {
+        let db = try makeDB()
+        try db.createTable(
+            name: "rows",
+            purpose: "select drain",
+            columns: [AgentColumnSpec(name: "n", type: "INTEGER", nullable: false)],
+            indexes: [],
+            actor: .agent,
+            runId: nil
+        )
+        _ = try db.insert(table: "rows", row: ["n": .integer(1)], actor: .agent, runId: nil)
+        _ = try db.insert(table: "rows", row: ["n": .integer(2)], actor: .agent, runId: nil)
+
+        let result = try db.execute(sql: "SELECT n FROM rows ORDER BY n", actor: .agent, runId: nil)
+        #expect(result.selectRowsDrained == 2)
+        #expect(result.warning?.contains("db_query") == true)
+    }
+
+    @Test
+    func queryDoesNotAutoFilterSoftDeletedRows() throws {
+        let db = try makeDB()
+        try db.createTable(
+            name: "notes",
+            purpose: "soft delete visibility",
+            columns: [AgentColumnSpec(name: "title", type: "TEXT", nullable: false)],
+            indexes: [],
+            actor: .agent,
+            runId: nil
+        )
+        let id = try db.insert(table: "notes", row: ["title": .text("gone")], actor: .agent, runId: nil)
+        _ = try db.softDelete(table: "notes", whereClause: ["id": .integer(id)], actor: .agent, runId: nil)
+
+        let all = try db.query(sql: "SELECT COUNT(*) FROM notes")
+        #expect(all.rows[0][0] == .integer(1))
     }
 
     // MARK: - Typed tools on raw-SQL tables (no host-managed columns)

--- a/Packages/OsaurusCore/Tests/Storage/DatabaseToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/DatabaseToolsTests.swift
@@ -81,6 +81,12 @@ struct DatabaseToolsTests {
 
     @Test
     func pathResolverUnavailableWhenNoRoot() async {
+        // The whole test bundle runs suites in parallel, and sibling suites
+        // may leave a folder context registered in the process-global
+        // `FolderToolManager` (or an active sandbox agent context). The
+        // durable invariant is that resolution FAILS when the file exists
+        // nowhere — the exact envelope ("unavailable" vs "No file at")
+        // depends on whether a root happened to be visible.
         let result = await DatabaseFilePathResolver.resolveForRead(
             path: "missing.csv",
             tool: "db_import"
@@ -89,7 +95,10 @@ struct DatabaseToolsTests {
             Issue.record("expected failure")
             return
         }
-        #expect(envelope.contains("unavailable") || envelope.contains("db_insert"))
+        #expect(
+            envelope.contains("unavailable") || envelope.contains("db_insert")
+                || envelope.contains("missing.csv")
+        )
     }
 
     @Test
@@ -192,22 +201,44 @@ struct DatabaseToolsTests {
     }
 
     @Test
-    @MainActor
     func exportOverwriteGuard() async throws {
-        try await withHostFolder { root in
-            let dest = root.appendingPathComponent("out.csv")
-            try "old\n".write(to: dest, atomically: true, encoding: .utf8)
+        // Pin the resolver to a sandbox root via the TaskLocal (checked
+        // before any process-global state), so parallel sibling suites
+        // can't redirect the write candidate mid-test.
+        let agentName = "test-agent-\(UUID().uuidString.prefix(8))"
+        let agentDir = OsaurusPaths.containerAgentDir(agentName)
+        try FileManager.default.createDirectory(at: agentDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: agentDir) }
 
-            let result = await DatabaseFilePathResolver.resolveForWrite(
+        let dest = agentDir.appendingPathComponent("out.csv")
+        try "old\n".write(to: dest, atomically: true, encoding: .utf8)
+
+        let result = await ChatExecutionContext.$sandboxAgentName.withValue(agentName) {
+            await DatabaseFilePathResolver.resolveForWrite(
                 path: "out.csv",
                 tool: "db_export",
                 overwrite: false
             )
-            guard case .failed(let envelope) = result else {
-                Issue.record("expected overwrite failure")
-                return
-            }
-            #expect(envelope.contains("overwrite"))
         }
+        guard case .failed(let envelope) = result else {
+            Issue.record("expected overwrite failure")
+            return
+        }
+        #expect(envelope.contains("overwrite"))
+
+        // Same path with overwrite: true must resolve to the sandbox file.
+        let allowed = await ChatExecutionContext.$sandboxAgentName.withValue(agentName) {
+            await DatabaseFilePathResolver.resolveForWrite(
+                path: "out.csv",
+                tool: "db_export",
+                overwrite: true
+            )
+        }
+        guard case .resolved(let resolved) = allowed else {
+            Issue.record("expected overwrite:true to resolve")
+            return
+        }
+        #expect(resolved.scope == .sandbox)
+        #expect(resolved.url.path == dest.path)
     }
 }

--- a/Packages/OsaurusCore/Tests/Storage/DatabaseToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/DatabaseToolsTests.swift
@@ -1,0 +1,213 @@
+//
+//  DatabaseToolsTests.swift
+//  osaurusTests
+//
+//  Path resolution, export, and tool-surface tests for Agent DB file tools.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct DatabaseToolsTests {
+
+    @MainActor
+    private func withHostFolder<T>(
+        _ body: (URL) async throws -> T
+    ) async throws -> T {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-db-tools-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let context = FolderContext(
+            rootPath: root,
+            projectType: .unknown,
+            tree: "",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false
+        )
+        FolderToolManager.shared.registerFolderTools(for: context)
+        defer { FolderToolManager.shared.unregisterFolderTools() }
+        return try await body(root)
+    }
+
+    @Test
+    @MainActor
+    func pathResolverReadsFromHostWorkingFolder() async throws {
+        try await withHostFolder { root in
+            let file = root.appendingPathComponent("data.csv")
+            try "a,b\n1,2\n".write(to: file, atomically: true, encoding: .utf8)
+
+            let agentId = UUID()
+            let result = await ChatExecutionContext.$currentAgentId.withValue(agentId) {
+                await DatabaseFilePathResolver.resolveForRead(path: "data.csv", tool: "db_import")
+            }
+            guard case .resolved(let resolved) = result else {
+                Issue.record("expected success, got \(result)")
+                return
+            }
+            #expect(resolved.scope == .hostFolder)
+            #expect(resolved.url.path == file.path)
+        }
+    }
+
+    @Test
+    func pathResolverReadsFromSandboxAgentDir() async throws {
+        let agentName = "test-agent-\(UUID().uuidString.prefix(8))"
+        let agentDir = OsaurusPaths.containerAgentDir(agentName)
+        try FileManager.default.createDirectory(at: agentDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: agentDir) }
+
+        let file = agentDir.appendingPathComponent("output.csv")
+        try "x\n1\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let agentId = UUID()
+        let result = await ChatExecutionContext.$sandboxAgentName.withValue(agentName) {
+            await ChatExecutionContext.$currentAgentId.withValue(agentId) {
+                await DatabaseFilePathResolver.resolveForRead(path: "output.csv", tool: "db_import")
+            }
+        }
+        guard case .resolved(let resolved) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(resolved.scope == .sandbox)
+        #expect(resolved.url.path == file.path)
+    }
+
+    @Test
+    func pathResolverUnavailableWhenNoRoot() async {
+        let result = await DatabaseFilePathResolver.resolveForRead(
+            path: "missing.csv",
+            tool: "db_import"
+        )
+        guard case .failed(let envelope) = result else {
+            Issue.record("expected failure")
+            return
+        }
+        #expect(envelope.contains("unavailable") || envelope.contains("db_insert"))
+    }
+
+    @Test
+    @MainActor
+    func dbExecutePathModeRunsSqlScript() async throws {
+        try await withHostFolder { root in
+            let script = root.appendingPathComponent("seed.sql")
+            try """
+            CREATE TABLE IF NOT EXISTS seed_test (label TEXT);
+            INSERT INTO seed_test (label) VALUES ('from-file');
+            """.write(to: script, atomically: true, encoding: .utf8)
+
+            let agentId = UUID()
+            let db = AgentDatabase(agentId: agentId)
+            try db.openInMemory()
+            defer { db.close() }
+
+            let read = await DatabaseFilePathResolver.loadTextScript(path: "seed.sql", tool: "db_execute")
+            guard case .text(let sql) = read else {
+                Issue.record("path resolve/read failed")
+                return
+            }
+            _ = try db.execute(sql: sql, actor: .agent, runId: nil)
+            let count = try db.query(sql: "SELECT COUNT(*) FROM seed_test")
+            #expect(count.rows[0][0] == .integer(1))
+        }
+    }
+
+    @Test
+    @MainActor
+    func dbExecutePathModeRejectsForbiddenScript() async throws {
+        try await withHostFolder { root in
+            let script = root.appendingPathComponent("evil.sql")
+            try "DROP TABLE notes;".write(to: script, atomically: true, encoding: .utf8)
+
+            let load = await DatabaseFilePathResolver.loadTextScript(path: "evil.sql", tool: "db_execute")
+            guard case .text(let sql) = load else {
+                Issue.record("expected script load")
+                return
+            }
+            let db = AgentDatabase(agentId: UUID())
+            try db.openInMemory()
+            defer { db.close() }
+            #expect(throws: AgentDatabaseError.self) {
+                _ = try db.execute(sql: sql, actor: .agent, runId: nil)
+            }
+        }
+    }
+
+    @Test
+    func exportImportCsvRoundTrip() throws {
+        let db = AgentDatabase(agentId: UUID())
+        try db.openInMemory()
+        defer { db.close() }
+
+        try db.createTable(
+            name: "items",
+            purpose: "export test",
+            columns: [AgentColumnSpec(name: "name", type: "TEXT", nullable: false)],
+            indexes: [],
+            actor: .agent,
+            runId: nil
+        )
+        _ = try db.insert(table: "items", row: ["name": .text("alpha")], actor: .agent, runId: nil)
+        _ = try db.insert(table: "items", row: ["name": .text("beta")], actor: .agent, runId: nil)
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export-\(UUID().uuidString).csv")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let probe = try db.query(sql: "SELECT name FROM items ORDER BY id")
+        let exported = try DatabaseExport.streamWrite(
+            url: tempURL,
+            format: .csv,
+            maxBytes: DatabaseImport.maxBytes,
+            headerColumns: probe.columns
+        ) { emit in
+            _ = try db.forEachQueryRow(sql: "SELECT name FROM items ORDER BY id") { columns, row in
+                try emit(columns, row)
+            }
+        }
+        #expect(exported.rowsExported == 2)
+        #expect(!exported.truncated)
+
+        let parsed = try AgentImportRunner.parse(
+            url: tempURL,
+            explicitFormat: "csv",
+            hasHeader: true,
+            explicitColumns: nil,
+            maxRows: nil
+        )
+        #expect(parsed.rows.count == 2)
+    }
+
+    @Test
+    func validateReadOnlyQueryRejectsInsert() {
+        #expect(throws: AgentDatabaseError.self) {
+            try AgentDatabase.validateReadOnlyQuery("INSERT INTO t VALUES (1)")
+        }
+    }
+
+    @Test
+    @MainActor
+    func exportOverwriteGuard() async throws {
+        try await withHostFolder { root in
+            let dest = root.appendingPathComponent("out.csv")
+            try "old\n".write(to: dest, atomically: true, encoding: .utf8)
+
+            let result = await DatabaseFilePathResolver.resolveForWrite(
+                path: "out.csv",
+                tool: "db_export",
+                overwrite: false
+            )
+            guard case .failed(let envelope) = result else {
+                Issue.record("expected overwrite failure")
+                return
+            }
+            #expect(envelope.contains("overwrite"))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/Database/DatabaseExport.swift
+++ b/Packages/OsaurusCore/Tools/Database/DatabaseExport.swift
@@ -1,0 +1,275 @@
+//
+//  DatabaseExport.swift
+//  osaurus
+//
+//  Host-side writer for `db_export`. Streams query rows to CSV / JSON /
+//  JSONL on disk so large result sets never pass through model tokens.
+//
+
+import Foundation
+
+enum DatabaseExport {
+    enum Format: String, Sendable {
+        case csv
+        case json
+        case jsonl
+
+        static func detect(path: String, explicit: String?) -> Format? {
+            if let explicit {
+                let lower = explicit.lowercased()
+                switch lower {
+                case "csv": return .csv
+                case "json": return .json
+                case "jsonl", "ndjson": return .jsonl
+                default: return nil
+                }
+            }
+            let ext = (path as NSString).pathExtension.lowercased()
+            switch ext {
+            case "csv": return .csv
+            case "json": return .json
+            case "jsonl", "ndjson": return .jsonl
+            default: return nil
+            }
+        }
+    }
+
+    struct Result: Sendable {
+        var rowsExported: Int
+        var bytesWritten: Int
+        var truncated: Bool
+        var columns: [String]
+    }
+
+    enum ExportError: LocalizedError {
+        case unsupportedFormat(String)
+        case writeFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedFormat(let f):
+                return "Unsupported export format `\(f)`. Use csv, json, or jsonl."
+            case .writeFailed(let m):
+                return m
+            }
+        }
+    }
+
+    /// Stream rows from `rowSource` to `url`, stopping when `maxBytes` is
+    /// reached. `headerColumns` is written even when zero rows are emitted
+    /// (CSV/JSON array open). Return false from `emit` to stop early.
+    static func streamWrite(
+        url: URL,
+        format: Format,
+        maxBytes: Int,
+        headerColumns: [String] = [],
+        rowSource: (_ emit: (_ columns: [String], _ row: [AgentSQLValue]) throws -> Bool) throws -> Void
+    ) throws -> Result {
+        switch format {
+        case .csv:
+            return try streamCSV(
+                url: url,
+                maxBytes: maxBytes,
+                headerColumns: headerColumns,
+                rowSource: rowSource
+            )
+        case .json:
+            return try streamJSON(
+                url: url,
+                maxBytes: maxBytes,
+                headerColumns: headerColumns,
+                rowSource: rowSource
+            )
+        case .jsonl:
+            return try streamJSONL(url: url, maxBytes: maxBytes, rowSource: rowSource)
+        }
+    }
+
+    private static func streamCSV(
+        url: URL,
+        maxBytes: Int,
+        headerColumns: [String],
+        rowSource: (_ emit: (_ columns: [String], _ row: [AgentSQLValue]) throws -> Bool) throws -> Void
+    ) throws -> Result {
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+
+        var columns = headerColumns
+        var exported = 0
+        var bytesWritten = 0
+        var truncated = false
+        var headerWritten = false
+
+        func writeHeaderIfNeeded(_ cols: [String]) throws -> Bool {
+            guard !headerWritten, !cols.isEmpty else { return true }
+            columns = cols
+            let header = csvLine(columns) + "\n"
+            let headerData = Data(header.utf8)
+            if headerData.count > maxBytes {
+                truncated = true
+                return false
+            }
+            try handle.write(contentsOf: headerData)
+            bytesWritten += headerData.count
+            headerWritten = true
+            return true
+        }
+
+        if !headerColumns.isEmpty {
+            guard try writeHeaderIfNeeded(headerColumns) else {
+                return Result(rowsExported: 0, bytesWritten: bytesWritten, truncated: true, columns: columns)
+            }
+        }
+
+        try rowSource { cols, row in
+            guard try writeHeaderIfNeeded(cols) else { return false }
+            let line = csvLine(row.map { sqlValueToExportString($0) }) + "\n"
+            let lineData = Data(line.utf8)
+            if bytesWritten + lineData.count > maxBytes {
+                truncated = true
+                return false
+            }
+            try handle.write(contentsOf: lineData)
+            bytesWritten += lineData.count
+            exported += 1
+            return true
+        }
+
+        return Result(
+            rowsExported: exported,
+            bytesWritten: bytesWritten,
+            truncated: truncated,
+            columns: columns
+        )
+    }
+
+    private static func streamJSON(
+        url: URL,
+        maxBytes: Int,
+        headerColumns: [String],
+        rowSource: (_ emit: (_ columns: [String], _ row: [AgentSQLValue]) throws -> Bool) throws -> Void
+    ) throws -> Result {
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+
+        var columns: [String] = headerColumns
+        var exported = 0
+        var bytesWritten = 0
+        var truncated = false
+        var started = false
+
+        try handle.write(contentsOf: Data("[".utf8))
+        bytesWritten += 1
+
+        try rowSource { cols, row in
+            columns = cols
+            var object: [String: Any] = [:]
+            for (index, column) in columns.enumerated() {
+                let value = index < row.count ? row[index] : .null
+                object[column] = sqlValueToJSON(value)
+            }
+            let prefix = started ? Data(",".utf8) : Data()
+            let rowData = (try JSONSerialization.data(withJSONObject: object))
+            let chunk = prefix + rowData
+            if bytesWritten + chunk.count + 1 > maxBytes {
+                truncated = true
+                return false
+            }
+            try handle.write(contentsOf: chunk)
+            bytesWritten += chunk.count
+            started = true
+            exported += 1
+            return true
+        }
+
+        let suffix = Data("]".utf8)
+        if bytesWritten + suffix.count <= maxBytes {
+            try handle.write(contentsOf: suffix)
+            bytesWritten += suffix.count
+        } else {
+            truncated = true
+        }
+
+        return Result(
+            rowsExported: exported,
+            bytesWritten: bytesWritten,
+            truncated: truncated,
+            columns: columns
+        )
+    }
+
+    private static func streamJSONL(
+        url: URL,
+        maxBytes: Int,
+        rowSource: (_ emit: (_ columns: [String], _ row: [AgentSQLValue]) throws -> Bool) throws -> Void
+    ) throws -> Result {
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+
+        var columns: [String] = []
+        var exported = 0
+        var bytesWritten = 0
+        var truncated = false
+
+        try rowSource { cols, row in
+            columns = cols
+            var object: [String: Any] = [:]
+            for (index, column) in columns.enumerated() {
+                let value = index < row.count ? row[index] : .null
+                object[column] = sqlValueToJSON(value)
+            }
+            let rowData = try JSONSerialization.data(withJSONObject: object) + Data([0x0A])
+            if bytesWritten + rowData.count > maxBytes {
+                truncated = true
+                return false
+            }
+            try handle.write(contentsOf: rowData)
+            bytesWritten += rowData.count
+            exported += 1
+            return true
+        }
+
+        return Result(
+            rowsExported: exported,
+            bytesWritten: bytesWritten,
+            truncated: truncated,
+            columns: columns
+        )
+    }
+
+    private static func csvLine(_ fields: [String]) -> String {
+        fields.map(csvEscape).joined(separator: ",")
+    }
+
+    private static func csvEscape(_ field: String) -> String {
+        if field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r") {
+            return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        }
+        return field
+    }
+
+    private static func sqlValueToExportString(_ value: AgentSQLValue) -> String {
+        switch value {
+        case .null: return ""
+        case .integer(let n): return String(n)
+        case .double(let d): return String(d)
+        case .text(let s): return s
+        case .bool(let b): return b ? "true" : "false"
+        case .blob(let data): return data.base64EncodedString()
+        }
+    }
+
+    private static func sqlValueToJSON(_ value: AgentSQLValue) -> Any {
+        switch value {
+        case .null: return NSNull()
+        case .integer(let n): return NSNumber(value: n)
+        case .double(let d): return NSNumber(value: d)
+        case .text(let s): return s
+        case .bool(let b): return NSNumber(value: b)
+        case .blob(let data): return data.base64EncodedString()
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/Database/DatabaseFilePathResolver.swift
+++ b/Packages/OsaurusCore/Tools/Database/DatabaseFilePathResolver.swift
@@ -1,0 +1,333 @@
+//
+//  DatabaseFilePathResolver.swift
+//  osaurus
+//
+//  Dual-root path resolution for Agent DB file tools (`db_import`,
+//  `db_export`, `db_execute` path mode). Reads and writes may target
+//  files under the Linux sandbox agent dir (host-visible at
+//  `OsaurusPaths.containerAgentDir`) or the bound host working folder.
+//
+
+import Foundation
+
+enum DatabaseFilePathResolver {
+    enum Scope: String, Sendable {
+        case sandbox
+        case hostFolder
+    }
+
+    struct Resolved: Sendable {
+        let url: URL
+        let scope: Scope
+    }
+
+    enum Outcome: Sendable {
+        case resolved(Resolved)
+        case failed(envelope: String)
+    }
+
+    /// Resolve a path for reading an existing file (import / SQL script).
+    static func resolveForRead(path: String, tool: String) async -> Outcome {
+        var rootsChecked: [String] = []
+        var candidates: [(URL, Scope)] = []
+
+        if let agentName = await currentSandboxAgentName() {
+            rootsChecked.append("sandbox workspace for agent `\(agentName)`")
+            candidates.append(contentsOf: sandboxCandidates(path: path, agentName: agentName))
+        }
+
+        if let root = await hostWorkingFolderRoot() {
+            rootsChecked.append("host working folder `\(root.path)`")
+            if let url = try? FolderToolHelpers.resolvePath(path, rootPath: root) {
+                candidates.append((url, .hostFolder))
+            }
+        }
+
+        guard !rootsChecked.isEmpty else {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message:
+                        "`\(tool)` reads files from your sandbox workspace or host "
+                        + "working folder, but neither is available in this session. "
+                        + "Run in sandbox mode or ask the user to pick a working folder, "
+                        + "then retry. Fallback for tabular data: one `db_insert` with "
+                        + "a `rows` array instead of row-by-row inserts.",
+                    tool: tool,
+                    retryable: false
+                )
+            )
+        }
+
+        for (url, scope) in candidates {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return .resolved(Resolved(url: url, scope: scope))
+            }
+        }
+
+        let tried = candidates.map(\.0.path).joined(separator: ", ")
+        return .failed(
+            envelope: ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "No file at `\(path)`. Checked: \(rootsChecked.joined(separator: "; "))."
+                    + (tried.isEmpty ? "" : " Candidate paths: \(tried)."),
+                field: "path",
+                tool: tool,
+                retryable: false
+            )
+        )
+    }
+
+    /// Resolve a destination path for writing (export). Creates parent
+    /// directories when `createParents` is true.
+    static func resolveForWrite(
+        path: String,
+        tool: String,
+        overwrite: Bool,
+        createParents: Bool = true
+    ) async -> Outcome {
+        var rootsChecked: [String] = []
+        var candidates: [(URL, Scope)] = []
+
+        if let agentName = await currentSandboxAgentName() {
+            rootsChecked.append("sandbox workspace for agent `\(agentName)`")
+            if let url = primarySandboxCandidate(path: path, agentName: agentName) {
+                candidates.append((url, .sandbox))
+            }
+        }
+
+        if let root = await hostWorkingFolderRoot() {
+            rootsChecked.append("host working folder `\(root.path)`")
+            if let url = try? FolderToolHelpers.resolvePath(path, rootPath: root) {
+                candidates.append((url, .hostFolder))
+            }
+        }
+
+        guard !rootsChecked.isEmpty else {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message:
+                        "`\(tool)` writes files to your sandbox workspace or host "
+                        + "working folder, but neither is available in this session. "
+                        + "Run in sandbox mode or ask the user to pick a working folder, "
+                        + "then retry.",
+                    tool: tool,
+                    retryable: false
+                )
+            )
+        }
+
+        guard let (url, scope) = candidates.first else {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "Path `\(path)` is outside every checked root "
+                        + "(\(rootsChecked.joined(separator: "; "))).",
+                    field: "path",
+                    tool: tool,
+                    retryable: false
+                )
+            )
+        }
+
+        if FileManager.default.fileExists(atPath: url.path), !overwrite {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "File already exists at `\(path)`. Pass `overwrite: true` "
+                        + "to replace it, or choose a different path.",
+                    field: "overwrite",
+                    tool: tool,
+                    retryable: false
+                )
+            )
+        }
+
+        if createParents {
+            let parent = url.deletingLastPathComponent()
+            do {
+                try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            } catch {
+                return .failed(
+                    envelope: ToolEnvelope.failure(
+                        kind: .executionError,
+                        message: "Could not create directory `\(parent.path)`: \(error.localizedDescription)",
+                        tool: tool
+                    )
+                )
+            }
+        }
+
+        return .resolved(Resolved(url: url, scope: scope))
+    }
+
+    /// Read file bytes with the shared 64 MiB cap used by import paths.
+    enum ReadTextOutcome: Sendable {
+        case text(String)
+        case failed(envelope: String)
+    }
+
+    static func readTextFile(at url: URL, tool: String) -> ReadTextOutcome {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "No file at `\(url.path)`.",
+                    field: "path",
+                    tool: tool,
+                    retryable: false
+                )
+            )
+        }
+        let attrs = try? fm.attributesOfItem(atPath: url.path)
+        let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        if size > DatabaseImport.maxBytes {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "File is \(size) bytes; limit is \(DatabaseImport.maxBytes). "
+                        + "Split the file or run smaller chunks.",
+                    field: "path",
+                    tool: tool,
+                    retryable: false
+                )
+            )
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            guard let text = String(data: data, encoding: .utf8) else {
+                return .failed(
+                    envelope: ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message: "File is not valid UTF-8 text.",
+                        field: "path",
+                        tool: tool,
+                        retryable: false
+                    )
+                )
+            }
+            return .text(text)
+        } catch {
+            return .failed(
+                envelope: ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: "Could not read `\(url.path)`: \(error.localizedDescription)",
+                    tool: tool
+                )
+            )
+        }
+    }
+
+    /// Resolve `path` and read a UTF-8 text script (SQL, CSV, etc.).
+    static func loadTextScript(path: String, tool: String) async -> ReadTextOutcome {
+        switch await resolveForRead(path: path, tool: tool) {
+        case .failed(let envelope):
+            return .failed(envelope: envelope)
+        case .resolved(let resolved):
+            return readTextFile(at: resolved.url, tool: tool)
+        }
+    }
+
+    // MARK: - Sandbox identity
+
+    static func currentSandboxAgentName() async -> String? {
+        if let bridge = ChatExecutionContext.sandboxReadBridge {
+            return bridge.agentName
+        }
+        if let name = ChatExecutionContext.sandboxAgentName {
+            return name
+        }
+        let captured: String? = await MainActor.run {
+            ToolRegistry.shared.activeSandboxAgentContext?.agentName
+        }
+        if let captured { return captured }
+        if let agentId = ChatExecutionContext.currentAgentId {
+            return await MainActor.run {
+                SandboxAgentProvisioner.linuxName(for: agentId.uuidString)
+            }
+        }
+        return nil
+    }
+
+    private static func hostWorkingFolderRoot() async -> URL? {
+        await MainActor.run {
+            FolderToolManager.shared.registeredContext?.rootPath
+        }
+    }
+
+    // MARK: - Path mapping (mirrors SharedArtifact sandbox resolution)
+
+    private static func sandboxCandidates(path: String, agentName: String) -> [(URL, Scope)] {
+        var out: [(URL, Scope)] = []
+        if let primary = primarySandboxCandidate(path: path, agentName: agentName) {
+            out.append((primary, .sandbox))
+        }
+        if let basename = extractPathComponent(path) {
+            let agentDir = OsaurusPaths.containerAgentDir(agentName)
+            for sub in ["output", "out", "build", "dist"] {
+                if let attempt = resolveContainedPath("\(sub)/\(basename)", within: agentDir) {
+                    out.append((attempt, .sandbox))
+                }
+            }
+        }
+        return out
+    }
+
+    private static func primarySandboxCandidate(path: String, agentName: String) -> URL? {
+        let agentDir = OsaurusPaths.containerAgentDir(agentName)
+        let containerHome = OsaurusPaths.inContainerAgentHome(agentName)
+
+        var relativePath = path
+        if relativePath.hasPrefix(containerHome + "/") {
+            relativePath = String(relativePath.dropFirst(containerHome.count + 1))
+        } else if relativePath.hasPrefix("/workspace/") {
+            let stripped = String(relativePath.dropFirst("/workspace/".count))
+            return resolveContainedPath(stripped, within: OsaurusPaths.containerWorkspace())
+        }
+        if relativePath.hasPrefix("./") {
+            relativePath = String(relativePath.dropFirst(2))
+        }
+        guard !relativePath.hasPrefix("/") else { return nil }
+        return resolveContainedPath(relativePath, within: agentDir)
+    }
+
+    private static func resolveContainedPath(_ rawPath: String, within root: URL) -> URL? {
+        let trimmedPath = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else { return nil }
+
+        let rootURL = canonicalizedURL(root)
+        let candidate =
+            trimmedPath.hasPrefix("/")
+            ? URL(fileURLWithPath: trimmedPath)
+            : rootURL.appendingPathComponent(trimmedPath)
+        let resolved = canonicalizedURL(candidate)
+
+        guard isContained(resolved, in: rootURL) else { return nil }
+        return resolved
+    }
+
+    private static func extractPathComponent(_ rawPath: String) -> String? {
+        let normalized = rawPath.replacingOccurrences(of: "\\", with: "/")
+        let basename = (normalized as NSString).lastPathComponent
+        let sanitized = basename.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) }
+        let cleaned = String(String.UnicodeScalarView(sanitized)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty, cleaned != ".", cleaned != ".." else { return nil }
+        return cleaned
+    }
+
+    private static func canonicalizedURL(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private static func isContained(_ candidate: URL, in root: URL) -> Bool {
+        let candidatePath = candidate.path
+        let rootPath = root.path
+        return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
+    }
+}

--- a/Packages/OsaurusCore/Tools/Database/DatabaseFilePathResolver.swift
+++ b/Packages/OsaurusCore/Tools/Database/DatabaseFilePathResolver.swift
@@ -247,9 +247,18 @@ enum DatabaseFilePathResolver {
             ToolRegistry.shared.activeSandboxAgentContext?.agentName
         }
         if let captured { return captured }
+        // Last-resort fallback for entry points that bypass the registry
+        // TaskLocal binding. Only trust it when the agent actually has a
+        // provisioned sandbox dir — deriving a name from a bare agent id
+        // in host-folder mode would fabricate a sandbox root and hijack
+        // writes away from the working folder.
         if let agentId = ChatExecutionContext.currentAgentId {
-            return await MainActor.run {
+            let name = await MainActor.run {
                 SandboxAgentProvisioner.linuxName(for: agentId.uuidString)
+            }
+            let agentDir = OsaurusPaths.containerAgentDir(name)
+            if FileManager.default.fileExists(atPath: agentDir.path) {
+                return name
             }
         }
         return nil

--- a/Packages/OsaurusCore/Tools/Database/DatabaseTools.swift
+++ b/Packages/OsaurusCore/Tools/Database/DatabaseTools.swift
@@ -152,6 +152,46 @@ enum DatabaseToolHelpers {
             tool: tool
         )
     }
+
+    /// JSON-schema fragment for positional SQL bind parameters.
+    static let sqlParamsProperty: JSONValue = .object([
+        "type": .string("array"),
+        "description": .string(
+            "Positional bind parameters (optional). Each item may be string, number, boolean, or null."
+        ),
+    ])
+
+    /// Soft ceiling on encoded row payloads returned by read tools.
+    static let maxEncodedRowBytes = 80_000
+
+    /// Trim trailing rows so the JSON payload stays under the soft cap.
+    static func trimQueryRows(
+        _ rows: inout [[Any]],
+        offset: Int?,
+        maxBytes: Int = maxEncodedRowBytes
+    ) -> (sizeTruncated: Bool, pagingHint: String?) {
+        var sizeTruncated = false
+        if let data = try? JSONSerialization.data(withJSONObject: rows),
+            data.count > maxBytes, !rows.isEmpty
+        {
+            let avg = max(1, data.count / rows.count)
+            let keep = max(1, (maxBytes * 9 / 10) / avg)
+            if keep < rows.count {
+                rows = Array(rows.prefix(keep))
+                sizeTruncated = true
+            }
+        }
+        let hint: String?
+        if sizeTruncated {
+            let nextOffset = (offset ?? 0) + rows.count
+            hint =
+                "Result truncated at \(rows.count) rows. Page with `offset: \(nextOffset)`, "
+                + "or aggregate in SQL (COUNT/SUM/GROUP BY) instead of returning raw rows."
+        } else {
+            hint = nil
+        }
+        return (sizeTruncated, hint)
+    }
 }
 
 // MARK: - db_schema
@@ -902,14 +942,10 @@ final class DBQueryTool: OsaurusTool, @unchecked Sendable {
         "Run a read-only SQL query. Returns up to `limit` rows (default "
         + "1000, hard cap 5000); page through larger results with "
         + "`limit`/`offset`. `truncated` is true when more rows existed. For "
-        + "big tables, prefer aggregating in SQL (COUNT/SUM/GROUP BY) over "
-        + "returning raw rows. Queries auto-filter `_deleted_at IS NULL` on "
-        + "user tables unless you pass `include_deleted=true` in the WHERE."
-
-    /// Soft ceiling on the encoded row payload (chars), kept under the
-    /// universal 100K tool-result cap so the model gets a clean
-    /// `truncated` + paging hint instead of a hard string cut.
-    private static let maxEncodedRowBytes = 80_000
+        + "big tables, prefer aggregating in SQL (COUNT/SUM/GROUP BY) or "
+        + "`db_export` over returning raw rows. On user tables, add "
+        + "`_deleted_at IS NULL` to your WHERE when you want to hide "
+        + "soft-deleted rows — `db_query` runs your SQL as written."
 
     let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -921,11 +957,7 @@ final class DBQueryTool: OsaurusTool, @unchecked Sendable {
                     "SELECT statement. May reference `?1`, `?2`, … bound from `params`."
                 ),
             ]),
-            "params": .object([
-                "type": .string("array"),
-                "description": .string("Positional bind parameters (optional)."),
-                "items": .object(["type": .string("string")]),
-            ]),
+            "params": DatabaseToolHelpers.sqlParamsProperty,
             "limit": .object([
                 "type": .string("integer"),
                 "description": .string(
@@ -970,29 +1002,15 @@ final class DBQueryTool: OsaurusTool, @unchecked Sendable {
                 row.map { DatabaseToolHelpers.toJSONAny($0) }
             }
 
-            // Encoded-size guard: trim trailing rows so the payload stays
-            // under the soft cap, surfacing a paging hint rather than a hard
-            // truncation of the JSON string downstream.
-            var sizeTruncated = false
-            if let data = try? JSONSerialization.data(withJSONObject: rows),
-                data.count > Self.maxEncodedRowBytes, !rows.isEmpty
-            {
-                let avg = max(1, data.count / rows.count)
-                let keep = max(1, (Self.maxEncodedRowBytes * 9 / 10) / avg)
-                if keep < rows.count {
-                    rows = Array(rows.prefix(keep))
-                    sizeTruncated = true
-                }
-            }
+            let (sizeTruncated, pagingHint) = DatabaseToolHelpers.trimQueryRows(
+                &rows,
+                offset: offset
+            )
 
             let truncated = result.truncated || sizeTruncated
             var warnings: [String] = []
-            if truncated {
-                let nextOffset = (offset ?? 0) + rows.count
-                warnings.append(
-                    "Result truncated at \(rows.count) rows. Page with `offset: \(nextOffset)`, "
-                        + "or aggregate in SQL (COUNT/SUM/GROUP BY) instead of returning raw rows."
-                )
+            if truncated, let pagingHint {
+                warnings.append(pagingHint)
             }
             return ToolEnvelope.success(
                 tool: name,
@@ -1018,9 +1036,11 @@ final class DBExecuteTool: OsaurusTool, @unchecked Sendable {
         + "multi-statement transform scripts (`INSERT … SELECT`, CTEs, "
         + "window functions, index/trigger DDL) which run inside one "
         + "transaction. Prefer this over pulling rows into context to "
-        + "compute by hand, and use `db_import` for file ingestion. Logged "
-        + "with `op='raw'`. Rejected: DROP TABLE, TRUNCATE, DROP DATABASE, "
-        + "unconstrained DELETE, ATTACH/DETACH, PRAGMA writes, "
+        + "compute by hand. Pass `path` (instead of `sql`) to run a `.sql` "
+        + "script from your sandbox workspace or working folder without "
+        + "loading it into tokens. Use `db_import` for CSV/JSON ingestion. "
+        + "Logged with `op='raw'`. Rejected: DROP TABLE, TRUNCATE, DROP "
+        + "DATABASE, unconstrained DELETE, ATTACH/DETACH, PRAGMA writes, "
         + "load_extension, and writes to system tables."
 
     let parameters: JSONValue? = .object([
@@ -1029,14 +1049,19 @@ final class DBExecuteTool: OsaurusTool, @unchecked Sendable {
         "properties": .object([
             "sql": .object([
                 "type": .string("string"),
-                "description": .string("Statement to execute."),
+                "description": .string(
+                    "Statement to execute. Mutually exclusive with `path`."
+                ),
             ]),
-            "params": .object([
-                "type": .string("array"),
-                "items": .object(["type": .string("string")]),
+            "path": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Path to a `.sql` script under your sandbox workspace or "
+                        + "working folder. Mutually exclusive with `sql`."
+                ),
             ]),
+            "params": DatabaseToolHelpers.sqlParamsProperty,
         ]),
-        "required": .array([.string("sql")]),
     ])
 
     func execute(argumentsJSON: String) async throws -> String {
@@ -1045,8 +1070,32 @@ final class DBExecuteTool: OsaurusTool, @unchecked Sendable {
         let agentReq = DatabaseToolHelpers.requireAgentId(tool: name)
         guard case .value(let agentId) = agentReq else { return agentReq.failureEnvelope ?? "" }
 
-        let sqlReq = requireString(args, "sql", expected: "SQL statement", tool: name)
-        guard case .value(let sql) = sqlReq else { return sqlReq.failureEnvelope ?? "" }
+        let inlineSQL = (args["sql"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pathArg = (args["path"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasSQL = !(inlineSQL ?? "").isEmpty
+        let hasPath = !(pathArg ?? "").isEmpty
+        guard hasSQL != hasPath else {
+            let field = (hasSQL && hasPath) ? "sql" : nil
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Pass exactly one of `sql` or `path`.",
+                field: field,
+                expected: "sql XOR path",
+                tool: name
+            )
+        }
+
+        let sql: String
+        if hasPath, let pathArg {
+            switch await DatabaseFilePathResolver.loadTextScript(path: pathArg, tool: name) {
+            case .failed(let envelope):
+                return envelope
+            case .text(let text):
+                sql = text
+            }
+        } else {
+            sql = inlineSQL ?? ""
+        }
 
         let params: [AgentSQLValue]
         if let raw = args["params"] {
@@ -1064,6 +1113,9 @@ final class DBExecuteTool: OsaurusTool, @unchecked Sendable {
             var resultDict: [String: Any] = ["rows_affected": result.rowsAffected]
             if let warning = result.warning {
                 resultDict["warning"] = warning
+            }
+            if let drained = result.selectRowsDrained {
+                resultDict["select_rows_drained"] = drained
             }
             return ToolEnvelope.success(
                 tool: name,
@@ -1086,10 +1138,11 @@ final class DBExecuteTool: OsaurusTool, @unchecked Sendable {
 final class DBImportTool: OsaurusTool, @unchecked Sendable {
     let name = "db_import"
     let description =
-        "Bulk-load a file from your working folder straight into a table. "
-        + "The host reads and parses it, so no row data passes through your "
-        + "tokens and you don't spend a tool call per row — use this instead "
-        + "of looping `db_insert` whenever the data already lives in a file. "
+        "Bulk-load a file from your sandbox workspace or host working "
+        + "folder straight into a table. The host reads and parses it, so "
+        + "no row data passes through your tokens and you don't spend a tool "
+        + "call per row — use this instead of looping `db_insert` whenever "
+        + "the data already lives in a file (e.g. `/workspace/output/data.csv`). "
         + "Supports CSV, TSV, JSON (array or object), and JSONL/NDJSON; the "
         + "format is auto-detected from the extension/content. Creates the "
         + "table from the file's columns when it doesn't exist (set "
@@ -1107,8 +1160,9 @@ final class DBImportTool: OsaurusTool, @unchecked Sendable {
             "path": .object([
                 "type": .string("string"),
                 "description": .string(
-                    "Path to the data file, relative to your working folder "
-                        + "(e.g. `data/today.csv`)."
+                    "Path to the data file under your sandbox workspace or "
+                        + "host working folder (e.g. `output/today.csv` or "
+                        + "`/workspace/output/today.csv`)."
                 ),
             ]),
             "format": .object([
@@ -1170,7 +1224,7 @@ final class DBImportTool: OsaurusTool, @unchecked Sendable {
         let pathReq = requireString(
             args,
             "path",
-            expected: "path under your working folder",
+            expected: "path under sandbox workspace or working folder",
             tool: name
         )
         guard case .value(let path) = pathReq else { return pathReq.failureEnvelope ?? "" }
@@ -1222,104 +1276,210 @@ final class DBImportTool: OsaurusTool, @unchecked Sendable {
             }
         }
 
-        // Resolve the working-folder root the same way `file_read` does.
-        let root: URL? = await MainActor.run {
-            FolderToolManager.shared.registeredContext?.rootPath
-        }
-        guard let rootPath = root else {
-            return ToolEnvelope.failure(
-                kind: .unavailable,
-                message:
-                    "db_import reads from your working folder, but no folder is bound to "
-                    + "this session. Ask the user to pick a working folder, then retry.",
-                tool: name,
-                retryable: false
-            )
-        }
-
-        let fileURL: URL
-        do {
-            fileURL = try FolderToolHelpers.resolvePath(path, rootPath: rootPath)
-        } catch {
-            return ToolEnvelope.fromError(error, tool: name)
-        }
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message: "No file at `\(path)` in the working folder.",
-                field: "path",
-                tool: name,
-                retryable: false
-            )
-        }
-        let parsed: DatabaseImport.Parsed
-        do {
-            parsed = try AgentImportRunner.parse(
-                url: fileURL,
-                explicitFormat: args["format"] as? String,
-                hasHeader: hasHeader,
-                explicitColumns: explicitColumnNames,
-                maxRows: maxRows
-            )
-        } catch {
-            return ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription,
-                tool: name,
-                retryable: false
-            )
-        }
-
-        let mode: AgentImportRunner.Mode =
-            (modeRaw == "upsert") ? .upsert(keyColumns: keyColumns) : .insert
-        do {
-            let outcome = try AgentImportRunner.run(
-                agentId: agentId,
-                table: table,
-                parsed: parsed,
-                mode: mode,
-                createTable: createTable,
-                typeOverrides: typeOverrides,
-                sourceLabel: (path as NSString).lastPathComponent
-            )
-
-            var resultDict: [String: Any] = [
-                "table": outcome.table,
-                "rows_imported": outcome.rowsImported,
-                "rows_skipped": outcome.rowsSkipped,
-                "created_table": outcome.createdTable,
-                "columns": outcome.columns,
-                "truncated": outcome.truncated,
-            ]
-            if !outcome.droppedColumns.isEmpty {
-                resultDict["dropped_columns"] = outcome.droppedColumns
-            }
-            if !outcome.sampleErrors.isEmpty { resultDict["sample_errors"] = outcome.sampleErrors }
-
-            var warnings: [String] = []
-            if outcome.truncated {
-                warnings.append("Import stopped at max_rows; not all rows were loaded.")
-            }
-            if !outcome.droppedColumns.isEmpty {
-                warnings.append(
-                    "Ignored columns not on `\(table)`: "
-                        + outcome.droppedColumns.joined(separator: ", ") + "."
+        switch await DatabaseFilePathResolver.resolveForRead(path: path, tool: name) {
+        case .failed(let envelope):
+            return envelope
+        case .resolved(let resolved):
+            let parsed: DatabaseImport.Parsed
+            do {
+                parsed = try AgentImportRunner.parse(
+                    url: resolved.url,
+                    explicitFormat: args["format"] as? String,
+                    hasHeader: hasHeader,
+                    explicitColumns: explicitColumnNames,
+                    maxRows: maxRows
+                )
+            } catch {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription,
+                    tool: name,
+                    retryable: false
                 )
             }
-            return ToolEnvelope.success(
-                tool: name,
-                result: resultDict,
-                warnings: warnings.isEmpty ? nil : warnings
-            )
-        } catch let error as AgentImportRunner.RunError {
+
+            let mode: AgentImportRunner.Mode =
+                (modeRaw == "upsert") ? .upsert(keyColumns: keyColumns) : .insert
+            do {
+                let outcome = try AgentImportRunner.run(
+                    agentId: agentId,
+                    table: table,
+                    parsed: parsed,
+                    mode: mode,
+                    createTable: createTable,
+                    typeOverrides: typeOverrides,
+                    sourceLabel: (path as NSString).lastPathComponent
+                )
+
+                var resultDict: [String: Any] = [
+                    "table": outcome.table,
+                    "rows_imported": outcome.rowsImported,
+                    "rows_skipped": outcome.rowsSkipped,
+                    "created_table": outcome.createdTable,
+                    "columns": outcome.columns,
+                    "truncated": outcome.truncated,
+                    "source_scope": resolved.scope.rawValue,
+                ]
+                if !outcome.droppedColumns.isEmpty {
+                    resultDict["dropped_columns"] = outcome.droppedColumns
+                }
+                if !outcome.sampleErrors.isEmpty { resultDict["sample_errors"] = outcome.sampleErrors }
+
+                var warnings: [String] = []
+                if outcome.truncated {
+                    warnings.append("Import stopped at max_rows; not all rows were loaded.")
+                }
+                if !outcome.droppedColumns.isEmpty {
+                    warnings.append(
+                        "Ignored columns not on `\(table)`: "
+                            + outcome.droppedColumns.joined(separator: ", ") + "."
+                    )
+                }
+                return ToolEnvelope.success(
+                    tool: name,
+                    result: resultDict,
+                    warnings: warnings.isEmpty ? nil : warnings
+                )
+            } catch let error as AgentImportRunner.RunError {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: error.errorDescription ?? "Import failed.",
+                    tool: name,
+                    retryable: false
+                )
+            } catch {
+                return DatabaseToolHelpers.envelope(for: error, tool: name)
+            }
+        }
+    }
+}
+
+// MARK: - db_export
+
+/// Host-mediated bulk exporter. Runs a read-only SELECT and writes rows
+/// to CSV/JSON/JSONL on disk — the mirror of `db_import`.
+final class DBExportTool: OsaurusTool, @unchecked Sendable {
+    let name = "db_export"
+    let description =
+        "Run a read-only SELECT and write the rows to a file in your "
+        + "sandbox workspace or host working folder. No row data passes "
+        + "through your tokens — use this instead of paging `db_query` when "
+        + "you need a large extract. Supports CSV (default), JSON, and "
+        + "JSONL/NDJSON (auto-detected from the path extension). Returns a "
+        + "small summary only."
+
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "sql": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Read-only SELECT or WITH … SELECT statement."
+                ),
+            ]),
+            "params": DatabaseToolHelpers.sqlParamsProperty,
+            "path": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Destination file under sandbox workspace or working folder."
+                ),
+            ]),
+            "format": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Optional override: `csv`, `json`, `jsonl`/`ndjson`. "
+                        + "Auto-detected from extension when omitted."
+                ),
+            ]),
+            "overwrite": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Replace an existing file at `path`. Default false."
+                ),
+            ]),
+        ]),
+        "required": .array([.string("sql"), .string("path")]),
+    ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+        let agentReq = DatabaseToolHelpers.requireAgentId(tool: name)
+        guard case .value(let agentId) = agentReq else { return agentReq.failureEnvelope ?? "" }
+
+        let sqlReq = requireString(args, "sql", expected: "read-only SELECT statement", tool: name)
+        guard case .value(let sql) = sqlReq else { return sqlReq.failureEnvelope ?? "" }
+        let pathReq = requireString(
+            args,
+            "path",
+            expected: "destination path under sandbox workspace or working folder",
+            tool: name
+        )
+        guard case .value(let path) = pathReq else { return pathReq.failureEnvelope ?? "" }
+
+        guard let format = DatabaseExport.Format.detect(
+            path: path,
+            explicit: args["format"] as? String
+        ) else {
             return ToolEnvelope.failure(
                 kind: .invalidArgs,
-                message: error.errorDescription ?? "Import failed.",
-                tool: name,
-                retryable: false
+                message:
+                    "Could not detect export format from `\(path)`. "
+                    + "Pass `format`: csv, json, or jsonl.",
+                field: "format",
+                tool: name
             )
-        } catch {
-            return DatabaseToolHelpers.envelope(for: error, tool: name)
+        }
+
+        let overwrite = coerceBool(args["overwrite"]) ?? false
+        switch await DatabaseFilePathResolver.resolveForWrite(
+            path: path,
+            tool: name,
+            overwrite: overwrite
+        ) {
+        case .failed(let envelope):
+            return envelope
+        case .resolved(let resolved):
+            let params: [AgentSQLValue]
+            if let raw = args["params"] {
+                params = DatabaseToolHelpers.toSQLValueArray(raw)
+            } else {
+                params = []
+            }
+
+            do {
+                let outcome = try LocalAgentBridge.shared.exportQueryToFile(
+                    agentId: agentId,
+                    sql: sql,
+                    params: params,
+                    url: resolved.url,
+                    format: format,
+                    maxBytes: DatabaseImport.maxBytes
+                )
+                var warnings: [String] = []
+                if outcome.truncated {
+                    warnings.append(
+                        "Export stopped at the \(DatabaseImport.maxBytes)-byte file cap; "
+                            + "not all rows were written. Narrow the query or export in chunks."
+                    )
+                }
+                return ToolEnvelope.success(
+                    tool: name,
+                    result: [
+                        "path": path,
+                        "format": format.rawValue,
+                        "rows_exported": outcome.rowsExported,
+                        "bytes": outcome.bytesWritten,
+                        "truncated": outcome.truncated,
+                        "columns": outcome.columns,
+                        "destination_scope": resolved.scope.rawValue,
+                    ],
+                    warnings: warnings.isEmpty ? nil : warnings
+                )
+            } catch {
+                return DatabaseToolHelpers.envelope(for: error, tool: name)
+            }
         }
     }
 }
@@ -1457,16 +1617,26 @@ final class DBRunViewTool: OsaurusTool, @unchecked Sendable {
                 agentId: agentId,
                 name: viewName
             )
-            let rows: [[Any]] = result.rows.map { row in
+            var rows: [[Any]] = result.rows.map { row in
                 row.map { DatabaseToolHelpers.toJSONAny($0) }
+            }
+            let (sizeTruncated, pagingHint) = DatabaseToolHelpers.trimQueryRows(
+                &rows,
+                offset: nil
+            )
+            let truncated = result.truncated || sizeTruncated
+            var warnings: [String] = []
+            if truncated, let pagingHint {
+                warnings.append(pagingHint)
             }
             return ToolEnvelope.success(
                 tool: name,
                 result: [
                     "columns": result.columns,
                     "rows": rows,
-                    "truncated": result.truncated,
-                ]
+                    "truncated": truncated,
+                ],
+                warnings: warnings.isEmpty ? nil : warnings
             )
         } catch {
             return DatabaseToolHelpers.envelope(for: error, tool: name)

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -223,6 +223,7 @@ public final class ToolRegistry: ObservableObject {
             DBInsertTool(),
             DBUpsertTool(),
             DBImportTool(),
+            DBExportTool(),
             DBUpdateTool(),
             DBDeleteTool(),
             DBRestoreTool(),
@@ -728,26 +729,29 @@ public final class ToolRegistry: ObservableObject {
             // relying on each caller to remember. Inert outside combined
             // mode, leaving plain folder + plain sandbox modes untouched.
             let policy = combinedHostReadPolicy
+            let sandboxAgent = activeSandboxAgentName
             let result = try await ChatExecutionContext.$hostReadOnlyScope.withValue(policy.scope) {
                 try await ChatExecutionContext.$allowHostSecretReads.withValue(policy.allowSecretReads) {
                     try await ChatExecutionContext.$sandboxReadBridge.withValue(combinedSandboxReadBridge) {
-                        if tool.bypassRegistryTimeout {
+                        try await ChatExecutionContext.$sandboxAgentName.withValue(sandboxAgent) {
+                            if tool.bypassRegistryTimeout {
+                                return Self.normalizeToolResult(
+                                    try await Self.runToolBodyUntimed(
+                                        tool,
+                                        argumentsJSON: effectiveArgumentsJSON
+                                    ),
+                                    tool: name
+                                )
+                            }
                             return Self.normalizeToolResult(
-                                try await Self.runToolBodyUntimed(
+                                try await Self.runToolBody(
                                     tool,
-                                    argumentsJSON: effectiveArgumentsJSON
+                                    argumentsJSON: effectiveArgumentsJSON,
+                                    timeoutSeconds: Self.defaultToolTimeoutSeconds
                                 ),
                                 tool: name
                             )
                         }
-                        return Self.normalizeToolResult(
-                            try await Self.runToolBody(
-                                tool,
-                                argumentsJSON: effectiveArgumentsJSON,
-                                timeoutSeconds: Self.defaultToolTimeoutSeconds
-                            ),
-                            tool: name
-                        )
                     }
                 }
             }
@@ -799,6 +803,19 @@ public final class ToolRegistry: ObservableObject {
             agentName: agentName,
             home: OsaurusPaths.inContainerAgentHome(agentName)
         )
+    }
+
+    /// Sandbox agent name bound for Agent DB file tools. Same resolution
+    /// order as `combinedSandboxReadBridge`, but also set in plain sandbox
+    /// mode when only sandbox built-ins are registered.
+    private var activeSandboxAgentName: String? {
+        if let captured = activeSandboxAgentContext?.agentName { return captured }
+        if let bridge = combinedSandboxReadBridge { return bridge.agentName }
+        guard toolsByName.keys.contains("sandbox_exec")
+            || toolsByName.keys.contains("sandbox_read_file"),
+            let agentId = ChatExecutionContext.currentAgentId
+        else { return nil }
+        return SandboxAgentProvisioner.linuxName(for: agentId.uuidString)
     }
 
     /// The effective autonomous-exec config for the agent driving the

--- a/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
+++ b/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
@@ -142,6 +142,7 @@ enum ToolDisplayName {
         "db_insert": ToolLabel(L("Inserting into the database"), L("Inserted into the database")),
         "db_upsert": ToolLabel(L("Saving to the database"), L("Saved to the database")),
         "db_import": ToolLabel(L("Importing data into the database"), L("Imported data into the database")),
+        "db_export": ToolLabel(L("Exporting data from the database"), L("Exported data from the database")),
         "db_update": ToolLabel(L("Updating the database"), L("Updated the database")),
         "db_delete": ToolLabel(L("Deleting from the database"), L("Deleted from the database")),
         "db_query": ToolLabel(L("Querying the database"), L("Queried the database")),

--- a/Packages/OsaurusEvals/Suites/AgentDB/README.md
+++ b/Packages/OsaurusEvals/Suites/AgentDB/README.md
@@ -23,6 +23,9 @@ the flow is reachable end-to-end from existing tools.
 | `sql-guardrails` | Destructive SQL is rejected and data survives | `forbiddenReason` (`DROP TABLE`) | table still holds its 3 rows after a rejected `DROP` |
 | `softdelete-restore` | The soft-delete contract round-trips | `db_delete` → `db_restore` | delete-before-restore ordering, 3 active / 3 total rows |
 | `daily-github-analyst` | The full reference flow, from existing tools | `db_import` → `db_define_view` → `db_run_view` → `share_artifact` | `repo_stats` has 4 rows, today total 175, trend view (day,total) rows, artifact named `*trend*` shared |
+| `export-csv` | A full result set lands on disk in **one** host-mediated call | `db_export` (streamed file write) | CSV header + last row on disk, `file_write` **not** called, source table untouched |
+| `execute-sql-script` | A `.sql` script runs from disk, its SQL never entering tokens | `db_execute` path mode | args contain `transform.sql` but **no** `select`, `file_read` **not** called, derived table shape + busiest-day row |
+| `sandbox-import` | A file generated **inside the sandbox** bulk-loads (the original gap) | dual-root path resolution (`DatabaseFilePathResolver`) | rowCount 6, `SUM(additions)=105`, `db_insert`/`db_upsert` **not** called; SKIPs on hosts without a sandbox |
 
 Fixtures live in [`../../Fixtures/AgentDB`](../../Fixtures/AgentDB):
 `commits-500.csv` (500 deterministic commit rows) and `stars-today.csv`
@@ -91,6 +94,12 @@ there is no local generation rate to record (that metric belongs to local-MLX
 runtime proof). The meaningful frontier metrics are wall latency, model
 round-trips (`steps`), and total model tokens (prompt + completion across
 steps), pulled from each case's `telemetry`.
+
+The three file-surface cases added with the Agent DB file-tool upgrade
+(`export-csv`, `execute-sql-script`, `sandbox-import`) postdate this recorded
+run; they pass on the local baseline (`mlx-community/Qwen3.5-4B-OptiQ-4bit`,
+2026-07-05 — `sandbox-import` SKIPs on hosts whose container can't boot) and
+still need a frontier row recorded when an `XAI_API_KEY` is next available.
 
 | Case | Result | Latency | Steps | Model tokens |
 |------|--------|---------|-------|--------------|

--- a/Packages/OsaurusEvals/Suites/AgentDB/execute-sql-script.json
+++ b/Packages/OsaurusEvals/Suites/AgentDB/execute-sql-script.json
@@ -1,0 +1,61 @@
+{
+  "id": "agentdb.execute-sql-script",
+  "domain": "agent_loop",
+  "label": "agentdb • run a .sql script from disk via db_execute path mode",
+  "query": "Your working folder contains a SQL script named transform.sql that builds a daily_totals table from the raw_events table already in your agent database. Run the script with a single db_execute call by passing its path — do NOT read the file into your context or paste its SQL inline. Then tell me the total for the busiest day.",
+  "notes": "db_execute path-mode proof: the script must run from disk (path arg) without its SQL passing through tokens. argsMustContain pins the path was passed; argsMustNotContain 'select' (case-insensitive audit) fails any trajectory that inlined the script's SQL instead; mustNotCallTools forbids the file_read-then-paste fallback and the per-row db_insert fallback. dbState pins the derived table's shape and busiest-day row, so a pass means the on-disk script really executed.",
+  "fixtures": {
+    "agentCapabilities": {
+      "dbEnabled": true
+    },
+    "workspaceFiles": [
+      {
+        "path": "transform.sql",
+        "contents": "CREATE TABLE daily_totals (day TEXT, total INTEGER);\nINSERT INTO daily_totals (day, total) SELECT day, SUM(amount) FROM raw_events GROUP BY day;\n"
+      }
+    ],
+    "seedSql": [
+      "CREATE TABLE raw_events (day TEXT, amount INTEGER); INSERT INTO raw_events (day, amount) VALUES ('2026-06-20',10),('2026-06-20',20),('2026-06-20',30),('2026-06-21',5),('2026-06-21',5);"
+    ]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 10,
+      "mustCallTools": [
+        "db_execute"
+      ],
+      "mustNotCallTools": [
+        "file_read",
+        "db_insert"
+      ],
+      "toolUsageAudit": [
+        {
+          "tool": "db_execute",
+          "maxCalls": 1,
+          "argsMustContain": "transform.sql",
+          "argsMustNotContain": "select"
+        }
+      ],
+      "dbState": [
+        {
+          "sql": "SELECT COUNT(*) FROM daily_totals",
+          "expectFirstValue": "2"
+        },
+        {
+          "sql": "SELECT day, total FROM daily_totals ORDER BY total DESC",
+          "expectColumns": [
+            "day",
+            "total"
+          ],
+          "expectValues": [
+            "2026-06-20",
+            "60"
+          ]
+        }
+      ],
+      "finalTextContains": [
+        "60"
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/AgentDB/export-csv.json
+++ b/Packages/OsaurusEvals/Suites/AgentDB/export-csv.json
@@ -1,0 +1,52 @@
+{
+  "id": "agentdb.export-csv",
+  "domain": "agent_loop",
+  "label": "agentdb • export a result set to CSV via one host-mediated db_export",
+  "query": "Your agent database has a table named orders with columns item (TEXT) and amount (INTEGER) holding 8 rows. Export the item and amount columns of every order, ordered by amount ascending, to a CSV file named orders.csv in your working folder using db_export — do not page the rows through db_query and do not write the file yourself. Then tell me exactly how many rows were exported.",
+  "notes": "db_export proof: a full result set must land on disk via the host-mediated export path (one tool call, no row data through tokens), NOT a db_query page loop plus file_write. mustNotCallTools pins that the model didn't hand-write the file; the files assertions verify the CSV header (from the SELECT's columns) and the last data row landed in the working folder; dbState pins the source table untouched. seedSql shapes the table like a real db_create_table table (id PK + system columns) so db_schema composes with it.",
+  "fixtures": {
+    "agentCapabilities": {
+      "dbEnabled": true
+    },
+    "seedSql": [
+      "CREATE TABLE orders (id INTEGER PRIMARY KEY AUTOINCREMENT, item TEXT, amount INTEGER, _created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')), _updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')), _deleted_at INTEGER);",
+      "INSERT INTO orders (item, amount) VALUES ('alpha',10),('bravo',20),('charlie',30),('delta',40),('echo',50),('foxtrot',60),('golf',70),('hotel',80);"
+    ]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 10,
+      "mustCallTools": [
+        "db_export"
+      ],
+      "mustNotCallTools": [
+        "file_write"
+      ],
+      "toolUsageAudit": [
+        {
+          "tool": "db_export",
+          "argsMustContain": "orders.csv"
+        }
+      ],
+      "files": [
+        {
+          "path": "orders.csv",
+          "contains": "item,amount"
+        },
+        {
+          "path": "orders.csv",
+          "contains": "hotel,80"
+        }
+      ],
+      "dbState": [
+        {
+          "sql": "SELECT COUNT(*) FROM orders",
+          "expectFirstValue": "8"
+        }
+      ],
+      "finalTextContains": [
+        "8"
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/AgentDB/sandbox-import.json
+++ b/Packages/OsaurusEvals/Suites/AgentDB/sandbox-import.json
@@ -1,0 +1,45 @@
+{
+  "id": "agentdb.sandbox-import",
+  "domain": "agent_loop",
+  "label": "agentdb • db_import from a file generated in the sandbox workspace",
+  "query": "Earlier you generated a CSV file at exports/report.csv in your sandbox home (columns: sha, author, additions, deletions). Load it into your agent database as a table named commits using db_import, then tell me exactly how many rows the table has.",
+  "notes": "Regression case for the original sandbox gap: db_import used to require a bound host working folder, so files the agent generated INSIDE its sandbox were unreachable and models fell back to token-burning per-row inserts. The dual-root resolver now reads the VM home through the host-visible mount. seedFiles stages the CSV guest-side (real ownership); mustNotCallTools pins that no per-row fallback happened; dbState reads the isolated per-eval-agent DB after the run. Skips (not fails) on hosts without a working sandbox, matching the SandboxFrontier suites.",
+  "fixtures": {
+    "agentCapabilities": {
+      "dbEnabled": true
+    },
+    "sandbox": {
+      "seedFiles": [
+        {
+          "path": "exports/report.csv",
+          "contents": "sha,author,additions,deletions\nsha001,alice,5,1\nsha002,bob,10,2\nsha003,carol,15,3\nsha004,dave,20,4\nsha005,erin,25,5\nsha006,frank,30,6\n"
+        }
+      ]
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 10,
+      "mustCallTools": [
+        "db_import"
+      ],
+      "mustNotCallTools": [
+        "db_insert",
+        "db_upsert"
+      ],
+      "dbState": [
+        {
+          "sql": "SELECT COUNT(*) FROM commits",
+          "expectFirstValue": "6"
+        },
+        {
+          "sql": "SELECT SUM(additions) FROM commits",
+          "expectFirstValue": "105"
+        }
+      ],
+      "finalTextContains": [
+        "6"
+      ]
+    }
+  }
+}

--- a/docs/AGENT_DB.md
+++ b/docs/AGENT_DB.md
@@ -64,9 +64,9 @@ Every table the agent creates via `db_create_table` is augmented with three rese
 | `_updated_at`  | `TEXT` ISO  | host         | Refreshed on `db_update` / `db_upsert` writes. |
 | `_deleted_at`  | `TEXT` ISO  | host         | `NULL` for live rows; ISO timestamp once soft-deleted. |
 
-`db_delete` is a **soft delete**: it stamps `_deleted_at` rather than removing the row. `db_restore` clears the stamp. `db_query` filters out rows with a non-null `_deleted_at` by default — pass `includeDeleted: true` to see them.
+`db_delete` is a **soft delete**: it stamps `_deleted_at` rather than removing the row. `db_restore` clears the stamp. Typed mutation tools (`db_update`, etc.) hide soft-deleted rows by default. **`db_query` runs your SQL as written** — add `_deleted_at IS NULL` to the WHERE when you want to exclude tombstones.
 
-The Data tab's `Active` / `Deleted` / `All` segmented control (in [`AgentDBTabViews.swift`](../Packages/OsaurusCore/Views/Agent/AgentDBTabViews.swift)) maps directly to that flag: `Active` hides tombstones (the agent's default), `Deleted` only shows tombstones, `All` shows both with the soft-deleted rows dimmed.
+The Data tab's `Active` / `Deleted` / `All` segmented control (in [`AgentDBTabViews.swift`](../Packages/OsaurusCore/Views/Agent/AgentDBTabViews.swift)) maps to that filter in the UI: `Active` hides tombstones, `Deleted` only shows tombstones, `All` shows both with the soft-deleted rows dimmed.
 
 There is **no hard-delete tool**. If you need to actually purge a row, do it from the host (the migrator or a developer console) — the model can't.
 
@@ -91,7 +91,8 @@ All `db_*` tools live in [`Tools/Database/DatabaseTools.swift`](../Packages/Osau
 | ------------ | --------------------------------------------------------------------- |
 | `db_insert`  | Insert one row (`row`) **or many** (`rows[]`) in a single call.       |
 | `db_upsert`  | Insert-or-update keyed by an explicit conflict column set; also accepts `rows[]`. |
-| `db_import`  | Host-mediated bulk load from a working-folder file (CSV/TSV/JSON/JSONL). See [Bulk Ingestion at Scale](#bulk-ingestion-at-scale). |
+| `db_import`  | Host-mediated bulk load from a sandbox-workspace or working-folder file (CSV/TSV/JSON/JSONL). See [Bulk Ingestion at Scale](#bulk-ingestion-at-scale). |
+| `db_export`  | Host-mediated bulk export: run a read-only SELECT and write CSV/JSON/JSONL to a sandbox-workspace or working-folder file. Mirror of `db_import`. |
 | `db_update`  | Update rows matching a typed `where` clause.                          |
 | `db_delete`  | **Soft-delete** — stamp `_deleted_at`. Restorable via `db_restore`.   |
 | `db_restore` | Clear `_deleted_at` to bring a row back into the live set.            |
@@ -101,7 +102,7 @@ All `db_*` tools live in [`Tools/Database/DatabaseTools.swift`](../Packages/Osau
 | Tool             | Role                                                                                      |
 | ---------------- | ----------------------------------------------------------------------------------------- |
 | `db_query`       | Run a read-only SELECT. Accepts `limit` / `offset` for paging; rows are capped (hard max **5000**) and a `truncated` flag flips when the cap or an oversized payload kicks in. |
-| `db_execute`     | First-class SQL, including **multi-statement** transform scripts (`INSERT … SELECT`, CTEs, window functions) inside one transaction. Restricted by host policy (see below); reach for the typed tools first. |
+| `db_execute`     | First-class SQL, including **multi-statement** transform scripts (`INSERT … SELECT`, CTEs, window functions) inside one transaction. Pass `path` instead of `sql` to run a `.sql` script from disk. Restricted by host policy (see below); reach for the typed tools first. |
 | `db_define_view` | Save a parameterised SELECT under a name. Surfaces in the Views tab.                       |
 | `db_run_view`    | Execute a saved view with arguments.                                                       |
 | `db_list_views`  | Enumerate saved views.                                                                     |
@@ -124,13 +125,13 @@ The agent DB's first wall used to be data movement: a model that needed to load 
 
 ### Three ways to load data
 
-1. **`db_import(table, path, …)` — host-mediated file load.** When the data already lives in a file in the agent's working folder, this is the right tool. The host resolves the path (same root as `file_read`, via [`FolderToolManager`](../Packages/OsaurusCore/Services/Folder/FolderToolManager.swift)), reads and parses it (CSV/TSV/JSON/JSONL, auto-detected), creates the table from the file's columns when needed, and bulk-loads every row — in **one** tool call, with **zero** row bytes in the model context. Pass `keyColumns` to upsert instead of append. Parsing and schema resolution are shared with the UI importer through [`AgentImportRunner`](../Packages/OsaurusCore/Tools/Database/AgentImportRunner.swift).
+1. **`db_import(table, path, …)` — host-mediated file load.** When the data already lives in a file in the agent's sandbox workspace (`/workspace/...`) or host working folder, this is the right tool. The host resolves the path (sandbox agent dir or [`FolderToolManager`](../Packages/OsaurusCore/Services/Folder/FolderToolManager.swift) root), reads and parses it (CSV/TSV/JSON/JSONL, auto-detected), creates the table from the file's columns when needed, and bulk-loads every row — in **one** tool call, with **zero** row bytes in the model context. Pass `keyColumns` to upsert instead of append. Parsing and schema resolution are shared with the UI importer through [`AgentImportRunner`](../Packages/OsaurusCore/Tools/Database/AgentImportRunner.swift).
 2. **`db_insert` / `db_upsert` with `rows[]` — in-context bulk write.** When the rows are something the model *computed* (not a file), it can hand the whole batch over in a single call instead of looping. Backed by [`AgentDatabase.insertMany` / `upsertMany`](../Packages/OsaurusCore/Storage/AgentDatabase.swift), which chunk the write and run it inside one transaction.
 3. **`db_execute` multi-statement transforms — don't move the data at all.** For aggregation/derivation, the most efficient path is to compute *in SQL* (`INSERT INTO totals SELECT … GROUP BY …`) rather than pulling rows into context. The whole script runs in one transaction.
 
 ### Reading back without blowing the budget
 
-`db_query` takes `limit` and `offset` so the model can page through a large result set instead of slurping it. Results are capped at a hard maximum of **5000** rows, and the tool independently trims the response when the encoded JSON would be too large — in both cases the result's `truncated` flag is set and a paging hint is returned so the model knows to ask for the next page.
+`db_query` takes `limit` and `offset` so the model can page through a large result set instead of slurping it. Results are capped at a hard maximum of **5000** rows, and the tool independently trims the response when the encoded JSON would be too large — in both cases the result's `truncated` flag is set and a paging hint is returned so the model knows to ask for the next page. For large extracts to a file, use **`db_export(sql, path)`** instead — the host streams rows to CSV/JSON/JSONL on disk and returns a summary only.
 
 ### The data-movement budget refund
 


### PR DESCRIPTION
## Summary

- **`db_import` / `db_export` / `db_execute(path=…)`** now resolve files from both the Linux sandbox workspace (`/workspace/...`) and the host working folder via a shared `DatabaseFilePathResolver`, fixing the case where sandbox-generated CSV/SQL files could not be bulk-loaded without token-expensive row-by-row inserts.
- **New `db_export` tool** streams read-only SELECT results to CSV/JSON/JSONL on disk and returns a summary only — the mirror of `db_import` for large extracts.
- **`db_execute` path mode** runs `.sql` scripts from disk through existing guardrails without loading them into model context.
- **Doc honesty + token fixes**: corrected misleading `db_query` soft-delete claims; shared 80KB payload trim for `db_run_view`; `db_execute` reports drained SELECT row counts with a `db_query` hint; widened `params` schema.

## Test plan

- [x] `make test` (with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`)
- [x] New `DatabaseToolsTests`: sandbox/host path resolution, SQL script path mode, export/import round-trip, overwrite guard, forbidden SQL rejection
- [x] `AgentDatabaseTests`: SELECT drain reporting, soft-delete visibility on raw `db_query`
- [ ] Manual: agent in sandbox generates `output/data.csv`, calls `db_import(table, path="/workspace/.../data.csv")` without a host working folder bound
- [ ] Manual: `db_export(sql, path="output/report.csv")` then read file from sandbox