### PR TITLE
Harden MCP surfaces: session recovery, OAuth single-flight, stdio death detection, external-surface enforcement

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift
@@ -19,8 +19,14 @@ public struct MCPCommand: Command {
 
         fputs("[MCP] Starting MCP command...\n", stderr)
         let credential = resolvedAccessKey(args: args)
+        let networkExposed = Configuration.resolveExposeToNetwork()
         if let credential {
             fputs("[MCP] Using access key from \(credential.source)\n", stderr)
+        } else if networkExposed {
+            fputs(
+                "[MCP] No access key configured; Server > Network exposure is enabled — provide --access-key or OSAURUS_MCP_ACCESS_KEY\n",
+                stderr
+            )
         } else {
             fputs("[MCP] No access key configured; relying on local loopback trust\n", stderr)
         }
@@ -37,26 +43,27 @@ public struct MCPCommand: Command {
         let server = MCP.Server(
             name: "Osaurus MCP Proxy",
             version: version,
-            capabilities: .init(tools: .init(listChanged: true))
+            capabilities: .init(tools: .init(listChanged: false))
         )
 
         // Register ListTools -> GET /mcp/tools
         await server.withMethodHandler(MCP.ListTools.self) { _ in
             fputs("[MCP] Handling ListTools\n", stderr)
             guard let url = URL(string: "\(baseURL)/mcp/tools") else {
-                fputs("[MCP] Invalid tools URL\n", stderr)
-                return .init(tools: [])
+                throw MCPError.internalError("Invalid tools URL")
             }
             fputs("[MCP] Fetching tools from \(url)\n", stderr)
             let request = makeProxyRequest(url: url, method: "GET", timeout: 5.0, credential: credential)
             do {
                 let (data, response) = try await URLSession.shared.data(for: request)
-                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                    fputs(
-                        "[MCP] Failed to list tools: HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)\n",
-                        stderr
+                guard let http = response as? HTTPURLResponse else {
+                    throw MCPError.internalError("Failed to list tools: non-HTTP response")
+                }
+                guard http.statusCode == 200 else {
+                    let body = String(bytes: data, encoding: .utf8) ?? ""
+                    throw MCPError.internalError(
+                        "Failed to list tools: HTTP \(http.statusCode)\(body.isEmpty ? "" : ": \(body)")"
                     )
-                    return .init(tools: [])
                 }
                 fputs("[MCP] Tools fetched successfully\n", stderr)
                 let tools: [MCP.Tool]
@@ -71,12 +78,14 @@ public struct MCPCommand: Command {
                         return MCP.Tool(name: name, description: description, inputSchema: schema)
                     }
                 } else {
-                    tools = []
+                    throw MCPError.internalError("Failed to list tools: unexpected response shape")
                 }
                 return .init(tools: tools)
+            } catch let error as MCPError {
+                throw error
             } catch {
                 fputs("[MCP] Error fetching tools: \(error)\n", stderr)
-                return .init(tools: [])
+                throw MCPError.internalError("Failed to list tools: \(error.localizedDescription)")
             }
         }
 

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/Configuration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/Configuration.swift
@@ -42,13 +42,41 @@ public struct Configuration {
             return nil
         }
 
-        struct PartialConfig: Decodable { let port: Int? }
+        struct PartialConfig: Decodable {
+            let port: Int?
+            let exposeToNetwork: Bool?
+        }
         do {
             let data = try Data(contentsOf: configURL)
             let cfg = try JSONDecoder().decode(PartialConfig.self, from: data)
             return cfg.port
         } catch {
             return nil
+        }
+    }
+
+    /// Whether the Osaurus HTTP server is exposed beyond loopback. Used by
+    /// `osaurus mcp` to avoid printing a misleading loopback-trust message.
+    public static func resolveExposeToNetwork() -> Bool {
+        let fm = FileManager.default
+        let root = root()
+        let oldRoot = legacyRoot()
+        let candidates: [URL] = [
+            root.appendingPathComponent("config/server.json"),
+            root.appendingPathComponent("ServerConfiguration.json"),
+            oldRoot.appendingPathComponent("config/server.json"),
+            oldRoot.appendingPathComponent("ServerConfiguration.json"),
+        ]
+        guard let configURL = candidates.first(where: { fm.fileExists(atPath: $0.path) }) else {
+            return false
+        }
+        struct PartialConfig: Decodable { let exposeToNetwork: Bool? }
+        do {
+            let data = try Data(contentsOf: configURL)
+            let cfg = try JSONDecoder().decode(PartialConfig.self, from: data)
+            return cfg.exposeToNetwork ?? false
+        } catch {
+            return false
         }
     }
 

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -193,6 +193,13 @@ public final class MCPProviderManager: ObservableObject {
         state.resourceMetadataURL = nil
         providerStates[providerId] = state
 
+        // Held outside the do/catch so the failure path can tear the
+        // half-connected client down. Without this, a failed HTTP connect
+        // leaked the transport's URLSession — and, with streaming enabled,
+        // the SDK's SSE retry loop kept reconnecting forever with stale
+        // credentials because nobody ever called `disconnect()`.
+        var attemptClient: MCP.Client?
+
         do {
             // Create authenticated transport
             let transport = try await createTransport(for: provider)
@@ -202,6 +209,7 @@ public final class MCPProviderManager: ObservableObject {
                 name: "Osaurus",
                 version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
             )
+            attemptClient = client
 
             // Connect under a timeout. Without this, a stdio subprocess that
             // spawned successfully but never speaks MCP would leave the card
@@ -212,8 +220,15 @@ public final class MCPProviderManager: ObservableObject {
                 _ = try await client.connect(transport: transport)
             }
 
-            // Store client
+            // Store client, tearing down any client we're replacing (a
+            // connect on an already-connected provider must not leak the
+            // old transport's URLSession / SSE loop).
+            if let replaced = clients[providerId], replaced !== client {
+                Task.detached { await replaced.disconnect() }
+            }
             clients[providerId] = client
+
+            await registerRemoteToolListChangedHandler(client: client, providerId: providerId)
 
             // Discover tools
             try await discoverTools(for: providerId, client: client, provider: provider)
@@ -259,6 +274,9 @@ public final class MCPProviderManager: ObservableObject {
                         try await performConnect(provider: provider, allowOAuthRetry: false)
                         return
                     } catch {
+                        if MCPOAuthService.isPermanentAuthFailure(error) {
+                            handlePermanentOAuthFailure(providerId: providerId)
+                        }
                         // Fall through and surface the original auth challenge.
                     }
                 }
@@ -282,8 +300,16 @@ public final class MCPProviderManager: ObservableObject {
                 ToolRegistry.shared.unregister(names: tools.map { $0.name })
             }
 
-            // Clean up local state
-            clients.removeValue(forKey: providerId)
+            // Clean up local state. The half-connected client from THIS
+            // attempt must be disconnected explicitly so its transport
+            // invalidates the URLSession and stops any SSE retry loop.
+            let staleClient = clients.removeValue(forKey: providerId)
+            var teardown: [MCP.Client] = []
+            if let attemptClient { teardown.append(attemptClient) }
+            if let staleClient, staleClient !== attemptClient { teardown.append(staleClient) }
+            for client in teardown {
+                Task.detached { await client.disconnect() }
+            }
             discoveredTools.removeValue(forKey: providerId)
             registeredTools.removeValue(forKey: providerId)
             // Stdio subprocesses might have been spawned successfully even
@@ -304,8 +330,13 @@ public final class MCPProviderManager: ObservableObject {
             ToolRegistry.shared.unregister(names: toolNames)
         }
 
-        // Clean up
-        clients.removeValue(forKey: providerId)
+        // Clean up. HTTP transports must be disconnected explicitly:
+        // dropping the reference alone never invalidates the transport's
+        // URLSession, and with streaming enabled the SDK's SSE retry loop
+        // keeps reconnecting every few seconds forever.
+        if let client = clients.removeValue(forKey: providerId) {
+            Task.detached { await client.disconnect() }
+        }
         discoveredTools.removeValue(forKey: providerId)
         registeredTools.removeValue(forKey: providerId)
 
@@ -381,26 +412,73 @@ public final class MCPProviderManager: ObservableObject {
 
     // MARK: - Tool Execution
 
-    /// Execute a tool on a provider
+    /// Execute a tool on a provider.
+    ///
+    /// Remote streamable-HTTP servers expire their `Mcp-Session-Id` after
+    /// idle periods or restarts, and OAuth access tokens baked into the
+    /// transport at connect time go stale. Both used to strand the provider
+    /// in a "Connected" state whose every tool call failed until the user
+    /// manually reconnected. We now reconnect once (which rebuilds the
+    /// transport with fresh auth and a fresh session) and retry the call.
     public func executeTool(providerId: UUID, toolName: String, argumentsJSON: String) async throws -> String {
-        guard let client = clients[providerId] else {
-            throw MCPProviderError.notConnected
-        }
-
         guard let provider = configuration.provider(id: providerId) else {
             throw MCPProviderError.providerNotFound
+        }
+
+        // A missing client on an enabled provider (transient connect failure
+        // at launch, earlier session loss) is recoverable — reconnect instead
+        // of failing the model's tool call outright.
+        if clients[providerId] == nil, provider.enabled {
+            try await performConnect(provider: provider, allowOAuthRetry: true)
+        }
+        guard let client = clients[providerId] else {
+            throw MCPProviderError.notConnected
         }
 
         let arguments = try MCPProviderTool.convertArgumentsToMCPValues(argumentsJSON)
         let timeout = provider.toolCallTimeout
 
         // Run the network call off MainActor so it doesn't block the UI thread.
-        let (content, isError) = try await Self.callMCPTool(
-            client: client,
-            toolName: toolName,
-            arguments: arguments,
-            timeout: timeout
-        )
+        let (content, isError): ([MCP.Tool.Content], Bool?)
+        do {
+            (content, isError) = try await Self.callMCPTool(
+                client: client,
+                toolName: toolName,
+                arguments: arguments,
+                timeout: timeout
+            )
+        } catch let error where Self.isRecoverableSessionError(error) {
+            if var reconnectState = providerStates[providerId] {
+                reconnectState.isAutoReconnecting = true
+                providerStates[providerId] = reconnectState
+                notifyStatusChanged()
+            }
+            defer {
+                if var finished = providerStates[providerId] {
+                    finished.isAutoReconnecting = false
+                    providerStates[providerId] = finished
+                }
+            }
+            // One reconnect + one retry; the rebuilt transport carries fresh
+            // OAuth/bearer credentials and negotiates a new session. If the
+            // reconnect fails we surface the reconnect error (it is the more
+            // actionable one: auth required, server down, ...).
+            try await performConnect(provider: provider, allowOAuthRetry: true)
+            guard let freshClient = clients[providerId] else {
+                throw MCPProviderError.notConnected
+            }
+            if var reconnected = providerStates[providerId] {
+                reconnected.lastAutoReconnectAt = Date()
+                providerStates[providerId] = reconnected
+                notifyStatusChanged()
+            }
+            (content, isError) = try await Self.callMCPTool(
+                client: freshClient,
+                toolName: toolName,
+                arguments: arguments,
+                timeout: timeout
+            )
+        }
 
         // Check for error
         if let isError = isError, isError {
@@ -413,6 +491,32 @@ public final class MCPProviderManager: ObservableObject {
 
         // Convert content to string
         return MCPProviderTool.convertMCPContent(content)
+    }
+
+    /// True when a tool-call failure indicates the connection/session is
+    /// stale (expired `Mcp-Session-Id`, expired auth token, closed
+    /// transport) rather than a failure of the tool itself. These are the
+    /// cases where the request was rejected before execution, so a single
+    /// reconnect + retry is safe (no double-execution risk). Timeouts are
+    /// deliberately excluded: the server may have executed the tool.
+    ///
+    /// The MCP SDK exposes these conditions only as `internalError`
+    /// message strings, so we match the exact strings it produces
+    /// (`HTTPClientTransport.processHTTPResponse` / `send`).
+    nonisolated static func isRecoverableSessionError(_ error: Error) -> Bool {
+        guard let mcpError = error as? MCPError else { return false }
+        switch mcpError {
+        case .connectionClosed:
+            return true
+        case .internalError(let message):
+            guard let message else { return false }
+            return message == "Session expired"
+                || message == "Authentication required"
+                || message == "Access forbidden"
+                || message == "Transport not connected"
+        default:
+            return false
+        }
     }
 
     /// Trampoline that runs the MCP network call outside MainActor isolation.
@@ -497,21 +601,17 @@ public final class MCPProviderManager: ObservableObject {
         }
 
         // Create temporary transport
-        let configuration = GlobalProxySettings.makeConfiguration(base: .default)
         var allHeaders: [String: String] = headers
         if let token = token, !token.isEmpty {
             allHeaders["Authorization"] = "Bearer \(token)"
         }
-        if !allHeaders.isEmpty {
-            configuration.httpAdditionalHeaders = allHeaders
-        }
-        configuration.timeoutIntervalForRequest = 10
-        configuration.timeoutIntervalForResource = 20
 
-        let transport = HTTPClientTransport(
+        let transport = MCPHTTPTransportBuilder.makeTransport(
             endpoint: endpoint,
-            configuration: configuration,
-            streaming: false
+            headers: allHeaders,
+            streaming: false,
+            discoveryTimeout: 10,
+            toolCallTimeout: 10
         )
 
         let client = MCP.Client(
@@ -519,13 +619,21 @@ public final class MCPProviderManager: ObservableObject {
             version: "1.0.0"
         )
 
-        // Connect
-        _ = try await client.connect(transport: transport)
+        // Probe clients are short-lived: always tear the transport down so
+        // the test URLSession doesn't outlive the sheet that triggered it.
+        do {
+            // Connect
+            _ = try await client.connect(transport: transport)
 
-        // List tools to verify connection
-        let (tools, _) = try await client.listTools()
+            // List tools to verify connection
+            let (tools, _) = try await client.listTools()
 
-        return tools.count
+            await client.disconnect()
+            return tools.count
+        } catch {
+            await client.disconnect()
+            throw error
+        }
     }
 
     // MARK: - OAuth
@@ -627,6 +735,18 @@ public final class MCPProviderManager: ObservableObject {
         switch provider.executionHost {
         case .host:
             let runner = try MCPStdioHostRunner(provider: provider)
+            let providerId = provider.id
+            await runner.setProcessExitHandler { [weak self] exitCode in
+                Task { @MainActor in
+                    guard let self else { return }
+                    let tail = await runner.lastStderrTail()
+                    self.handleStdioProcessExit(
+                        providerId: providerId,
+                        exitCode: exitCode,
+                        stderrTail: tail
+                    )
+                }
+            }
             try await runner.start()
             hostStdioRunners[provider.id] = runner
             return runner.transport
@@ -655,6 +775,18 @@ public final class MCPProviderManager: ObservableObject {
                     }
                 }
                 let runner = try SandboxStdioRunner(provider: provider)
+                let providerId = provider.id
+                await runner.setProcessExitHandler { [weak self] exitCode in
+                    Task { @MainActor in
+                        guard let self else { return }
+                        let tail = await runner.lastStderrTail()
+                        self.handleStdioProcessExit(
+                            providerId: providerId,
+                            exitCode: exitCode,
+                            stderrTail: tail
+                        )
+                    }
+                }
                 try await runner.start()
                 sandboxStdioRunners[provider.id] = runner
                 return runner.transport
@@ -664,15 +796,19 @@ public final class MCPProviderManager: ObservableObject {
         }
     }
 
-    /// Build the `URLSessionConfiguration` for a provider, including any cached
-    /// auth headers. OAuth refresh-before-connect happens inside this method so
+    /// Build the HTTP transport for a provider, including any cached auth
+    /// headers. OAuth refresh-before-connect happens inside this method so
     /// every entrypoint (connect / testConnection) goes through the same gate.
+    ///
+    /// Headers are injected per-request via the transport's request modifier
+    /// instead of `httpAdditionalHeaders` — Apple documents the latter as
+    /// unsupported for `Authorization`, and per-request injection also covers
+    /// the SDK's SSE reconnects. Timeout semantics live in
+    /// `MCPHTTPTransportBuilder`.
     private func createHTTPTransport(for provider: MCPProvider) async throws -> HTTPClientTransport {
         guard let endpoint = URL(string: provider.url) else {
             throw MCPProviderError.invalidURL
         }
-
-        let urlConfig = GlobalProxySettings.makeConfiguration(base: .default)
 
         // Build headers
         var headers = provider.resolvedHeaders()
@@ -695,17 +831,12 @@ public final class MCPProviderManager: ObservableObject {
             break
         }
 
-        if !headers.isEmpty {
-            urlConfig.httpAdditionalHeaders = headers
-        }
-
-        urlConfig.timeoutIntervalForRequest = provider.discoveryTimeout
-        urlConfig.timeoutIntervalForResource = max(provider.discoveryTimeout, provider.toolCallTimeout)
-
-        return HTTPClientTransport(
+        return MCPHTTPTransportBuilder.makeTransport(
             endpoint: endpoint,
-            configuration: urlConfig,
-            streaming: provider.streamingEnabled
+            headers: headers,
+            streaming: provider.streamingEnabled,
+            discoveryTimeout: provider.discoveryTimeout,
+            toolCallTimeout: provider.toolCallTimeout
         )
     }
 
@@ -728,9 +859,82 @@ public final class MCPProviderManager: ObservableObject {
         do {
             return try await MCPOAuthService.refresh(provider: provider, tokens: tokens)
         } catch {
+            if MCPOAuthService.isPermanentAuthFailure(error) {
+                handlePermanentOAuthFailure(providerId: provider.id)
+            }
             throw MCPProviderError.connectionFailed(
                 "Could not refresh OAuth tokens: \(error.localizedDescription)"
             )
+        }
+    }
+
+    private func handlePermanentOAuthFailure(providerId: UUID) {
+        MCPProviderKeychain.deleteOAuthTokens(for: providerId)
+        if var state = providerStates[providerId] {
+            state.requiresAuth = true
+            state.isConnected = false
+            state.isConnecting = false
+            state.lastError = "Session expired — please sign in again."
+            providerStates[providerId] = state
+        }
+        notifyStatusChanged()
+    }
+
+    private func handleStdioProcessExit(providerId: UUID, exitCode: Int32, stderrTail: String) {
+        guard providerStates[providerId]?.isConnected == true else { return }
+
+        if let tools = registeredTools[providerId] {
+            ToolRegistry.shared.unregister(names: tools.map { $0.name })
+        }
+        if let client = clients.removeValue(forKey: providerId) {
+            Task.detached { await client.disconnect() }
+        }
+        discoveredTools.removeValue(forKey: providerId)
+        registeredTools.removeValue(forKey: providerId)
+        stopStdioRunners(for: providerId)
+
+        if var state = providerStates[providerId] {
+            state.isConnected = false
+            state.isConnecting = false
+            state.discoveredToolCount = 0
+            state.discoveredToolNames = []
+            state.lastStderrTail = stderrTail.isEmpty ? nil : stderrTail
+            let codeSuffix = exitCode >= 0 ? " (exit \(exitCode))" : ""
+            if stderrTail.isEmpty {
+                state.lastError = "Stdio MCP subprocess exited unexpectedly\(codeSuffix)."
+            } else {
+                state.lastError = "Stdio MCP subprocess exited\(codeSuffix): \(stderrTail)"
+            }
+            providerStates[providerId] = state
+        }
+        NotificationCenter.default.post(name: .toolsListChanged, object: nil)
+        notifyStatusChanged()
+    }
+
+    private func registerRemoteToolListChangedHandler(client: MCP.Client, providerId: UUID) async {
+        await client.onNotification(ToolListChangedNotification.self) { [weak self] _ in
+            Task { @MainActor in
+                await self?.handleRemoteToolListChanged(providerId: providerId)
+            }
+        }
+    }
+
+    private func handleRemoteToolListChanged(providerId: UUID) async {
+        guard let provider = configuration.provider(id: providerId),
+            let client = clients[providerId]
+        else { return }
+
+        do {
+            if let oldTools = registeredTools[providerId] {
+                ToolRegistry.shared.unregister(names: oldTools.map { $0.name })
+            }
+            try await discoverTools(for: providerId, client: client, provider: provider)
+        } catch {
+            if var state = providerStates[providerId] {
+                state.lastError = "Tool list refresh failed: \(error.localizedDescription)"
+                providerStates[providerId] = state
+            }
+            notifyStatusChanged()
         }
     }
 
@@ -817,13 +1021,16 @@ public final class MCPProviderManager: ObservableObject {
         provider: MCPProvider
     ) -> [MCPProviderTool] {
         var tools: [MCPProviderTool] = []
+        var reservedNames = Set(ToolRegistry.shared.registeredToolNames())
         for mcpTool in mcpTools {
             let tool = MCPProviderTool(
                 mcpTool: mcpTool,
                 providerId: providerId,
-                providerName: provider.name
+                providerName: provider.name,
+                reservedNames: reservedNames
             )
             tools.append(tool)
+            reservedNames.insert(tool.name)
             ToolRegistry.shared.registerMCPTool(tool)
         }
         return tools

--- a/Packages/OsaurusCore/Models/Configuration/MCPProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MCPProviderConfiguration.swift
@@ -307,6 +307,12 @@ public struct MCPProviderState: Sendable {
     public var discoveredToolCount: Int
     public var discoveredToolNames: [String]
     public var lastConnectedAt: Date?
+    /// When the manager last auto-reconnected after a stale session during tool execution.
+    public var lastAutoReconnectAt: Date?
+    /// True while `executeTool` is rebuilding a stale HTTP/session connection.
+    public var isAutoReconnecting: Bool
+    /// Last stderr lines captured from a stdio subprocess before unexpected exit.
+    public var lastStderrTail: String?
     /// Set when a connection attempt yielded `401 Unauthorized` and the server advertised
     /// OAuth via `WWW-Authenticate`. UI uses this to surface a "Sign in" CTA.
     public var requiresAuth: Bool
@@ -322,6 +328,9 @@ public struct MCPProviderState: Sendable {
         self.discoveredToolCount = 0
         self.discoveredToolNames = []
         self.lastConnectedAt = nil
+        self.lastAutoReconnectAt = nil
+        self.isAutoReconnecting = false
+        self.lastStderrTail = nil
         self.requiresAuth = false
         self.resourceMetadataURL = nil
     }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9560,8 +9560,46 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 // Belt-and-braces: the registry re-checks the external deny
                 // list under this flag even if a new entry point forgets
                 // the name-based preflight above.
+                let isEnabled = await MainActor.run {
+                    ToolRegistry.shared.isGlobalEnabled(toolName)
+                }
+                if !isEnabled {
+                    let message = "Tool '\(toolName)' is disabled in Osaurus settings."
+                    let payload: [String: Any] = [
+                        "content": [["type": "text", "text": message]],
+                        "isError": true,
+                    ]
+                    let data =
+                        (try? JSONSerialization.data(withJSONObject: payload, options: .osaurusCanonical))
+                        ?? Data("{}".utf8)
+                    let body = String(decoding: data, as: UTF8.self)
+                    hop {
+                        var headers = [("Content-Type", "application/json; charset=utf-8")]
+                        headers.append(contentsOf: cors)
+                        self.sendResponse(
+                            context: ctx.value,
+                            version: head.version,
+                            status: .ok,
+                            headers: headers,
+                            body: body
+                        )
+                    }
+                    logSelf.logRequest(
+                        method: "POST",
+                        path: "/mcp/call",
+                        userAgent: logUserAgent,
+                        requestBody: logRequestBody,
+                        responseStatus: 200,
+                        startTime: logStartTime,
+                        errorMessage: message
+                    )
+                    return
+                }
+
                 let result = try await ChatExecutionContext.$isExternalSurface.withValue(true) {
-                    try await ToolRegistry.shared.execute(name: toolName, argumentsJSON: argsJSON)
+                    try await ChatExecutionContext.$denyUnapprovedToolPrompts.withValue(true) {
+                        try await ToolRegistry.shared.execute(name: toolName, argumentsJSON: argsJSON)
+                    }
                 }
                 let payload: [String: Any] = [
                     "content": [["type": "text", "text": result]],

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -198,6 +198,202 @@
         }
       }
     },
+    "Auto-reconnecting after a stale session." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Automatische Wiederverbindung nach einer veralteten Sitzung."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "세션이 만료되어 자동으로 다시 연결하는 중입니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Автоматическое переподключение после устаревшей сессии."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "会话失效，正在自动重新连接。"
+          }
+        }
+      }
+    },
+    "Connected %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verbunden %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "연결됨 %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Подключено %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已连接 %@"
+          }
+        }
+      }
+    },
+    "Currently connected, but the last probe failed." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Derzeit verbunden, aber die letzte Prüfung ist fehlgeschlagen."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "현재 연결되어 있지만 마지막 상태 확인이 실패했습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сейчас подключено, но последняя проверка не удалась."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "当前已连接，但上次探测失败。"
+          }
+        }
+      }
+    },
+    "Last auto-reconnect %@." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Letzte automatische Wiederverbindung: %@."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "마지막 자동 재연결: %@."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Последнее автоматическое переподключение: %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次自动重连：%@。"
+          }
+        }
+      }
+    },
+    "Last connected %@." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Zuletzt verbunden: %@."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "마지막 연결: %@."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Последнее подключение: %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次连接：%@。"
+          }
+        }
+      }
+    },
+    "Reconnecting…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wird erneut verbunden …"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "다시 연결하는 중…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Повторное подключение…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在重新连接…"
+          }
+        }
+      }
+    },
+    "The last probe succeeded, but the provider is not connected." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Die letzte Prüfung war erfolgreich, aber der Anbieter ist nicht verbunden."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "마지막 상태 확인은 성공했지만 공급자가 연결되어 있지 않습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Последняя проверка прошла успешно, но провайдер не подключён."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "上次探测成功，但提供方未连接。"
+          }
+        }
+      }
+    },
     "—" : {
       "comment" : "A placeholder text to indicate missing data.",
       "isCommentAutoGenerated" : true,

--- a/Packages/OsaurusCore/Services/Auth/OAuthLoopbackServer.swift
+++ b/Packages/OsaurusCore/Services/Auth/OAuthLoopbackServer.swift
@@ -23,6 +23,7 @@ public enum OAuthLoopbackError: LocalizedError, Sendable {
     case bindFailed(String)
     case stateMismatch
     case missingCode
+    case callbackTimeout
     case oauthError(error: String, description: String?)
 
     public var errorDescription: String? {
@@ -35,6 +36,8 @@ public enum OAuthLoopbackError: LocalizedError, Sendable {
             return "OAuth state mismatch — possible CSRF or stale callback"
         case .missingCode:
             return "OAuth provider returned no authorization code"
+        case .callbackTimeout:
+            return "Timed out waiting for OAuth sign-in to complete in the browser"
         case .oauthError(let error, let description):
             if let description, !description.isEmpty {
                 return "OAuth provider returned error \(error): \(description)"
@@ -103,12 +106,15 @@ public final class OAuthLoopbackServer: @unchecked Sendable {
         self.callbackPath = callbackPath.hasPrefix("/") ? callbackPath : "/" + callbackPath
         self.corsOriginAllowlist = corsOriginAllowlist
         do {
+            let parameters = NWParameters.tcp
+            // RFC 8252 §7.3: bind to the loopback interface only — never all interfaces.
+            parameters.requiredInterfaceType = .loopback
             switch port {
             case .fixed(let value):
                 let nwPort = NWEndpoint.Port(rawValue: value) ?? .any
-                self.listener = try NWListener(using: .tcp, on: nwPort)
+                self.listener = try NWListener(using: parameters, on: nwPort)
             case .ephemeral:
-                self.listener = try NWListener(using: .tcp, on: .any)
+                self.listener = try NWListener(using: parameters, on: .any)
             }
         } catch {
             throw OAuthLoopbackError.bindFailed(error.localizedDescription)
@@ -177,17 +183,25 @@ public final class OAuthLoopbackServer: @unchecked Sendable {
         }
     }
 
+    /// Await the authorization callback. Responds to task cancellation
+    /// (e.g. a sign-in timeout racing this call) by resuming with
+    /// `CancellationError` — without this, cancelling the surrounding task
+    /// would leave the continuation stranded forever.
     public func waitForCallback() async throws -> OAuthCallbackResult {
-        try await withCheckedThrowingContinuation { continuation in
-            lock.lock()
-            if let pendingResult {
-                self.pendingResult = nil
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if let pendingResult {
+                    self.pendingResult = nil
+                    lock.unlock()
+                    continuation.resume(with: pendingResult)
+                    return
+                }
+                self.continuation = continuation
                 lock.unlock()
-                continuation.resume(with: pendingResult)
-                return
             }
-            self.continuation = continuation
-            lock.unlock()
+        } onCancel: {
+            complete(.failure(CancellationError()))
         }
     }
 

--- a/Packages/OsaurusCore/Services/MCP/MCPHTTPTransportBuilder.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPHTTPTransportBuilder.swift
@@ -1,0 +1,80 @@
+//
+//  MCPHTTPTransportBuilder.swift
+//  osaurus
+//
+//  Single construction point for remote MCP HTTP transports so the
+//  connect path, the test-connection path, and the probe path all get
+//  the same timeout and header semantics.
+//
+
+import Foundation
+import MCP
+
+enum MCPHTTPTransportBuilder {
+    /// Floor for the URLSession per-request (idle) timeout. The logical MCP
+    /// timeouts (discovery / tool call) are enforced above the transport by
+    /// `withTimeout` races, so the session-level timeout only needs to catch
+    /// truly dead connections — it must never be shorter than the logical
+    /// timeouts or it wins the race and long tool calls die early.
+    static let minimumRequestTimeout: TimeInterval = 60
+
+    /// Build the URLSession configuration for a remote MCP provider.
+    ///
+    /// Two deliberate differences from the historical behavior:
+    /// - `timeoutIntervalForRequest` is the max of the logical timeouts (with
+    ///   a floor), not the discovery timeout alone. The old value (default
+    ///   20s) applied to every request in the session, so a tool call that
+    ///   produced no bytes for 20s was killed even though the tool-call
+    ///   timeout was 45s.
+    /// - `timeoutIntervalForResource` is left at the URLSession default
+    ///   (7 days). The old cap of `max(discovery, toolCall)` hard-killed the
+    ///   long-lived SSE GET stream every ~45 seconds, forcing a permanent
+    ///   reconnect churn loop for streaming providers.
+    ///
+    /// Headers are intentionally NOT set here: `httpAdditionalHeaders` is
+    /// documented by Apple as unsupported for `Authorization`, so auth and
+    /// custom headers ride on each request via `requestModifier(headers:)`.
+    static func sessionConfiguration(
+        discoveryTimeout: TimeInterval,
+        toolCallTimeout: TimeInterval
+    ) -> URLSessionConfiguration {
+        let configuration = GlobalProxySettings.makeConfiguration(base: .default)
+        configuration.timeoutIntervalForRequest = max(
+            discoveryTimeout, toolCallTimeout, minimumRequestTimeout
+        )
+        return configuration
+    }
+
+    /// Per-request header injection with `httpAdditionalHeaders` semantics:
+    /// a header already present on the request (the SDK sets Accept,
+    /// Content-Type, MCP-Session-Id, ...) is never overwritten.
+    static func requestModifier(headers: [String: String]) -> @Sendable (URLRequest) -> URLRequest {
+        guard !headers.isEmpty else { return { $0 } }
+        return { request in
+            var modified = request
+            for (key, value) in headers where modified.value(forHTTPHeaderField: key) == nil {
+                modified.setValue(value, forHTTPHeaderField: key)
+            }
+            return modified
+        }
+    }
+
+    /// Build the transport used by connect, test-connection, and HTTP probes.
+    static func makeTransport(
+        endpoint: URL,
+        headers: [String: String],
+        streaming: Bool,
+        discoveryTimeout: TimeInterval,
+        toolCallTimeout: TimeInterval
+    ) -> HTTPClientTransport {
+        HTTPClientTransport(
+            endpoint: endpoint,
+            configuration: sessionConfiguration(
+                discoveryTimeout: discoveryTimeout,
+                toolCallTimeout: toolCallTimeout
+            ),
+            streaming: streaming,
+            requestModifier: requestModifier(headers: headers)
+        )
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
@@ -48,11 +48,11 @@ public enum MCPLocalProviderDiagnostics {
             ? L("\(result.toolCount) tool(s) discovered via \(snapshot.transportSummary).")
             : result.redactedMessage
         if let state, state.isConnected != result.succeeded {
+            detail += " "
             detail +=
-                " "
-                + L(
-                    "Live connection state (\(state.isConnected ? L("connected") : L("disconnected"))) differs from the last probe (\(result.succeeded ? L("ok") : L("failed")))."
-                )
+                state.isConnected
+                ? L("Currently connected, but the last probe failed.")
+                : L("The last probe succeeded, but the provider is not connected.")
         }
         return ProviderDiagnosticRow(
             id: "local-health",

--- a/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
@@ -12,10 +12,11 @@ public enum MCPLocalProviderDiagnostics {
         report: ProviderDiagnosticReport,
         provider: MCPProvider,
         healthSnapshot: MCPProviderHealthSnapshot?,
+        state: MCPProviderState? = nil,
         captureDecision: MCPCapturePolicyDecision = MCPCaptureCapabilityPolicy.defaultScreenshotDecision
     ) -> ProviderDiagnosticReport {
         var rows = report.rows
-        rows.append(healthSnapshotRow(provider: provider, snapshot: healthSnapshot))
+        rows.append(healthSnapshotRow(provider: provider, snapshot: healthSnapshot, state: state))
         rows.append(capturePolicyRow(captureDecision))
         return ProviderDiagnosticReport(
             title: report.title,
@@ -26,7 +27,8 @@ public enum MCPLocalProviderDiagnostics {
 
     public static func healthSnapshotRow(
         provider: MCPProvider,
-        snapshot: MCPProviderHealthSnapshot?
+        snapshot: MCPProviderHealthSnapshot?,
+        state: MCPProviderState? = nil
     ) -> ProviderDiagnosticRow {
         guard let snapshot else {
             return ProviderDiagnosticRow(
@@ -41,14 +43,23 @@ public enum MCPLocalProviderDiagnostics {
         }
 
         let result = snapshot.lastProbe
+        var detail =
+            result.succeeded
+            ? L("\(result.toolCount) tool(s) discovered via \(snapshot.transportSummary).")
+            : result.redactedMessage
+        if let state, state.isConnected != result.succeeded {
+            detail +=
+                " "
+                + L(
+                    "Live connection state (\(state.isConnected ? L("connected") : L("disconnected"))) differs from the last probe (\(result.succeeded ? L("ok") : L("failed")))."
+                )
+        }
         return ProviderDiagnosticRow(
             id: "local-health",
             title: L("Last probe"),
             value: result.reasonCode.rawValue,
             severity: result.succeeded ? .ok : .blocked,
-            detail: result.succeeded
-                ? L("\(result.toolCount) tool(s) discovered via \(snapshot.transportSummary).")
-                : result.redactedMessage,
+            detail: detail,
             action: result.redactedAction
         )
     }

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -229,21 +229,17 @@ public enum MCPProviderProbeService {
             )
         }
 
-        let configuration = GlobalProxySettings.makeConfiguration(base: .default)
         var allHeaders = headers
         if let token, !token.isEmpty {
             allHeaders["Authorization"] = "Bearer \(token)"
         }
-        if !allHeaders.isEmpty {
-            configuration.httpAdditionalHeaders = allHeaders
-        }
-        configuration.timeoutIntervalForRequest = discoveryTimeout
-        configuration.timeoutIntervalForResource = max(discoveryTimeout, 20)
 
-        let transport = HTTPClientTransport(
+        let transport = MCPHTTPTransportBuilder.makeTransport(
             endpoint: endpoint,
-            configuration: configuration,
-            streaming: streamingEnabled
+            headers: allHeaders,
+            streaming: streamingEnabled,
+            discoveryTimeout: discoveryTimeout,
+            toolCallTimeout: discoveryTimeout
         )
         return await runProbe(provider: provider, transport: transport, startedAt: startedAt)
     }
@@ -306,6 +302,10 @@ public enum MCPProviderProbeService {
             let (tools, _) = try await withTimeout(seconds: provider.discoveryTimeout) {
                 try await client.listTools()
             }
+            // Probes are short-lived by contract: disconnect the client so
+            // HTTP transports invalidate their URLSession (and stop any SSE
+            // loop) instead of leaking one per Test click.
+            await client.disconnect()
             if let cleanup {
                 await cleanup()
             }
@@ -315,6 +315,7 @@ public enum MCPProviderProbeService {
                 tools: tools
             )
         } catch {
+            await client.disconnect()
             if let cleanup {
                 await cleanup()
             }

--- a/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
@@ -180,7 +180,8 @@ public enum MCPServerHub {
         let diagnostics = MCPLocalProviderDiagnostics.augment(
             report: baseReport,
             provider: provider,
-            healthSnapshot: healthSnapshot
+            healthSnapshot: healthSnapshot,
+            state: state
         )
         let severity = diagnostics.rows.map(\.severity).max(by: mcpSeverityLessThan) ?? .info
         let status = status(for: provider, state: state, highestSeverity: severity)

--- a/Packages/OsaurusCore/Services/MCP/MCPServerManager.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerManager.swift
@@ -15,7 +15,17 @@ private let mcpLog = Logger(subsystem: "ai.osaurus", category: "MCP")
 final class MCPServerManager {
     static let shared = MCPServerManager()
 
-    private init() {}
+    private var toolsChangedObserver: NSObjectProtocol?
+
+    private init() {
+        toolsChangedObserver = NotificationCenter.default.addObserver(
+            forName: .toolsListChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { await self?.notifyInboundToolListChangedIfRunning() }
+        }
+    }
 
     // MARK: - MCP Core
     private var server: MCP.Server?
@@ -128,6 +138,20 @@ final class MCPServerManager {
                     )
                 }
 
+                let isEnabled = await ToolRegistry.shared.isGlobalEnabled(params.name)
+                if !isEnabled {
+                    return .init(
+                        content: [
+                            .text(
+                                text: "Tool '\(params.name)' is disabled in Osaurus settings.",
+                                annotations: nil,
+                                _meta: nil
+                            )
+                        ],
+                        isError: true
+                    )
+                }
+
                 // Validate against tool schema when available
                 if let schema = await ToolRegistry.shared.parametersForTool(name: params.name) {
                     let result = SchemaValidator.validate(arguments: argumentsAny, against: schema)
@@ -162,8 +186,30 @@ final class MCPServerManager {
     }
 
     static func executeToolAsExternalMCP(name: String, argumentsJSON: String) async throws -> String {
-        try await ChatExecutionContext.$isExternalSurface.withValue(true) {
-            try await ToolRegistry.shared.execute(name: name, argumentsJSON: argumentsJSON)
+        guard ToolRegistry.shared.isGlobalEnabled(name) else {
+            throw NSError(
+                domain: "ToolRegistry",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Tool '\(name)' is disabled in Osaurus settings."
+                ]
+            )
+        }
+        return try await ChatExecutionContext.$isExternalSurface.withValue(true) {
+            try await ChatExecutionContext.$denyUnapprovedToolPrompts.withValue(true) {
+                try await ToolRegistry.shared.execute(name: name, argumentsJSON: argumentsJSON)
+            }
+        }
+    }
+
+    private func notifyInboundToolListChangedIfRunning() async {
+        guard let server else { return }
+        do {
+            try await server.notify(ToolListChangedNotification.message())
+        } catch {
+            mcpLog.error(
+                "Failed to emit tools/list_changed to MCP clients: \(error.localizedDescription, privacy: .public)"
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRefreshGate.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRefreshGate.swift
@@ -1,0 +1,32 @@
+//
+//  MCPOAuthRefreshGate.swift
+//  OsaurusCore
+//
+//  Per-provider single-flight around OAuth refresh. Prevents concurrent
+//  refresh_token rotations (Notion-style) from invalidating each other.
+//
+
+import Foundation
+
+actor MCPOAuthRefreshGate {
+    static let shared = MCPOAuthRefreshGate()
+
+    private var inflight: [UUID: Task<MCPOAuthTokens, Error>] = [:]
+
+    func refresh(
+        provider: MCPProvider,
+        tokens: MCPOAuthTokens,
+        persist: Bool
+    ) async throws -> MCPOAuthTokens {
+        if let existing = inflight[provider.id] {
+            return try await existing.value
+        }
+
+        let task = Task {
+            try await MCPOAuthService.performRefresh(provider: provider, tokens: tokens, persist: persist)
+        }
+        inflight[provider.id] = task
+        defer { inflight.removeValue(forKey: provider.id) }
+        return try await task.value
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
@@ -87,6 +87,9 @@ public enum MCPOAuthService {
     /// gives a hint. `offline_access` is requested so the AS issues a refresh token.
     public static let defaultScopes: [String] = ["offline_access"]
 
+    /// Maximum time to wait for the browser OAuth callback on the loopback listener.
+    public static let signInCallbackTimeout: TimeInterval = 300
+
     /// Run the full OAuth sign-in flow for `provider`.
     ///
     /// - Parameters:
@@ -220,10 +223,23 @@ public enum MCPOAuthService {
             throw MCPOAuthError.browserOpenFailed
         }
 
-        // 6. Wait for callback.
+        // 6. Wait for callback (bounded so a closed browser tab can't hang forever).
         let callback: OAuthCallbackResult
         do {
-            callback = try await server.waitForCallback()
+            callback = try await withThrowingTaskGroup(of: OAuthCallbackResult.self) { group in
+                group.addTask { try await server.waitForCallback() }
+                group.addTask {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(Self.signInCallbackTimeout * 1_000_000_000)
+                    )
+                    throw OAuthLoopbackError.callbackTimeout
+                }
+                guard let result = try await group.next() else {
+                    throw OAuthLoopbackError.callbackTimeout
+                }
+                group.cancelAll()
+                return result
+            }
         } catch let error as OAuthLoopbackError {
             throw MCPOAuthError.loopback(error)
         }
@@ -265,10 +281,27 @@ public enum MCPOAuthService {
 
     /// Refresh OAuth tokens using the cached configuration. Saves the result to Keychain
     /// when `persist` is true. Throws if the provider has no refresh_token.
+    ///
+    /// Concurrent refresh calls for the same provider are coalesced via
+    /// `MCPOAuthRefreshGate` so rotating refresh tokens aren't invalidated
+    /// by parallel tool calls.
     public static func refresh(
         provider: MCPProvider,
         tokens: MCPOAuthTokens,
         persist: Bool = true
+    ) async throws -> MCPOAuthTokens {
+        try await MCPOAuthRefreshGate.shared.refresh(
+            provider: provider,
+            tokens: tokens,
+            persist: persist
+        )
+    }
+
+    /// Single-flight refresh implementation. Call through `refresh(...)` or the gate.
+    static func performRefresh(
+        provider: MCPProvider,
+        tokens: MCPOAuthTokens,
+        persist: Bool
     ) async throws -> MCPOAuthTokens {
         guard let oauth = provider.oauth else {
             throw MCPOAuthError.missingClientId
@@ -315,6 +348,15 @@ public enum MCPOAuthService {
             MCPProviderKeychain.saveOAuthTokens(refreshed, for: provider.id)
         }
         return refreshed
+    }
+
+    /// True when a token-endpoint failure means cached credentials are permanently
+    /// invalid and the user must sign in again (`invalid_grant`, `invalid_token`).
+    public static func isPermanentAuthFailure(_ error: Error) -> Bool {
+        guard case MCPOAuthError.tokenRequestFailed(let code, let body) = error else { return false }
+        guard code == 400 || code == 401 else { return false }
+        let lowered = body?.lowercased() ?? ""
+        return lowered.contains("invalid_grant") || lowered.contains("invalid_token")
     }
 
     // MARK: - Internal helpers (also used by tests)

--- a/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
@@ -21,6 +21,7 @@
     import Foundation
     import MCP
     import System
+    import Darwin
 
     /// Spawn-and-pipe wrapper that ends up holding (a) the running `Process`
     /// and (b) the `MCP.StdioTransport` connected to its stdio. Callers
@@ -33,6 +34,15 @@
         private let process: Process
         private let stdinPipe: Pipe
         private let stdoutPipe: Pipe
+        private let stderrPipe: Pipe
+        private let stderrCapture = MCPStdioStderrCapture()
+
+        private var onProcessExitHandler: (@Sendable (Int32) -> Void)?
+
+        /// Called once when the subprocess exits unexpectedly while the runner is alive.
+        public func setProcessExitHandler(_ handler: @escaping @Sendable (Int32) -> Void) {
+            onProcessExitHandler = handler
+        }
 
         /// The transport object the `MCP.Client` connects to. Owned by the
         /// runner so its file descriptors stay alive for the subprocess's
@@ -55,15 +65,14 @@
 
             let stdinPipe = Pipe()
             let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
             let process = Process()
             process.executableURL = URL(fileURLWithPath: executablePath)
             process.arguments = provider.args
             process.environment = mergedEnv
             process.standardInput = stdinPipe
             process.standardOutput = stdoutPipe
-            // Inherit stderr — MCP servers tend to log diagnostic JSON there
-            // and we surface it in the host logs (which the user can tail).
-            process.standardError = FileHandle.standardError
+            process.standardError = stderrPipe
             if let cwd = provider.workingDirectory, !cwd.isEmpty {
                 process.currentDirectoryURL = URL(
                     fileURLWithPath: Self.expandUserPath(cwd),
@@ -74,6 +83,7 @@
             self.process = process
             self.stdinPipe = stdinPipe
             self.stdoutPipe = stdoutPipe
+            self.stderrPipe = stderrPipe
 
             // Wrap the pipe FDs in `MCP.StdioTransport`. The transport reads
             // from the subprocess's stdout (our `stdoutPipe.fileHandleForReading`)
@@ -181,21 +191,67 @@
             try await MCPChildSpawnLimiter.shared.acquire()
             spawnSlotHeld = true
             do {
+                process.terminationHandler = { [weak self] proc in
+                    let code = proc.terminationStatus
+                    Task { await self?.handleProcessExit(exitCode: code) }
+                }
+                startStderrPump()
                 try process.run()
             } catch {
                 // Release the slot we just reserved — the child never launched.
                 await MCPChildSpawnLimiter.shared.release()
                 spawnSlotHeld = false
+                stopStderrPump()
                 throw MCPStdioTransportError.processSpawnFailed(error.localizedDescription)
             }
         }
 
+        /// Drain stderr into the ring buffer via `readabilityHandler` — the
+        /// callback runs on a dispatch queue, so no thread blocks on the read.
+        private nonisolated func startStderrPump() {
+            let capture = stderrCapture
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    // EOF: subprocess closed its stderr (usually exit).
+                    handle.readabilityHandler = nil
+                    return
+                }
+                capture.append(data)
+            }
+        }
+
+        private nonisolated func stopStderrPump() {
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+        }
+
+        private func handleProcessExit(exitCode: Int32) {
+            stopStderrPump()
+            onProcessExitHandler?(exitCode)
+        }
+
+        public func lastStderrTail() -> String {
+            stderrCapture.tail()
+        }
+
         /// Tear down the subprocess. Idempotent — safe to call from
         /// `disconnect()` paths even if `start()` failed.
-        public func stop() async {
+        public func stop(forceKillGraceSeconds: TimeInterval = 2.0) async {
+            // Intentional teardown: never route through the "unexpected exit"
+            // handler, which would mark the provider as crashed.
+            onProcessExitHandler = nil
+            process.terminationHandler = nil
             await transport.disconnect()
+            stopStderrPump()
             if process.isRunning {
                 process.terminate()
+                let deadline = Date().addingTimeInterval(forceKillGraceSeconds)
+                while process.isRunning && Date() < deadline {
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                }
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                }
             }
             if spawnSlotHeld {
                 spawnSlotHeld = false

--- a/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioStderrCapture.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioStderrCapture.swift
@@ -1,0 +1,46 @@
+//
+//  MCPStdioStderrCapture.swift
+//  OsaurusCore
+//
+//  Ring buffer for stdio MCP subprocess stderr. Used by host and sandbox
+//  runners so unexpected exits surface the last diagnostic lines in UI.
+//
+
+import Foundation
+
+/// Thread-safe stderr line ring buffer for MCP stdio subprocesses.
+public final class MCPStdioStderrCapture: @unchecked Sendable {
+    public static let defaultLineLimit = 32
+    public static let defaultTailLength = 2_048
+
+    private let lock = NSLock()
+    private var lines: [String] = []
+    private let lineLimit: Int
+
+    public init(lineLimit: Int = defaultLineLimit) {
+        self.lineLimit = lineLimit
+    }
+
+    public func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        let text = String(decoding: data, as: UTF8.self)
+        lock.lock()
+        defer { lock.unlock() }
+        for line in text.split(whereSeparator: \.isNewline) {
+            let trimmed = String(line).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            lines.append(trimmed)
+            if lines.count > lineLimit {
+                lines.removeFirst(lines.count - lineLimit)
+            }
+        }
+    }
+
+    public func tail(maxLength: Int = defaultTailLength) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        let joined = lines.joined(separator: "\n")
+        guard joined.count > maxLength else { return joined }
+        return "…" + String(joined.suffix(maxLength))
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/Stdio/SandboxStdioRunner.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/SandboxStdioRunner.swift
@@ -33,6 +33,7 @@
         private let stdinBridge: SandboxStdioInputStream
         private let stdoutWriter: SandboxStdioWriter
         private let stderrWriter: SandboxStdioWriter
+        private let stderrCapture = MCPStdioStderrCapture()
 
         /// Public transport the `MCP.Client` connects to. Created upfront so
         /// callers can hold onto it before `start()` resolves.
@@ -41,6 +42,13 @@
         /// Linux process handle once `start()` has run. Used to terminate the
         /// subprocess on `stop()`.
         private var process: LinuxProcess?
+        private var exitWatchTask: Task<Void, Never>?
+        private var onProcessExitHandler: (@Sendable (Int32) -> Void)?
+
+        /// Called once when the sandbox subprocess exits while the runner is alive.
+        public func setProcessExitHandler(_ handler: @escaping @Sendable (Int32) -> Void) {
+            onProcessExitHandler = handler
+        }
 
         public init(provider: MCPProvider) throws {
             guard provider.transport == .stdio else {
@@ -65,7 +73,7 @@
 
             let stdinBridge = SandboxStdioInputStream()
             let stdoutWriter = SandboxStdioWriter()
-            let stderrWriter = SandboxStdioWriter(discard: true)
+            let stderrWriter = SandboxStdioWriter(capture: stderrCapture)
             self.stdinBridge = stdinBridge
             self.stdoutWriter = stdoutWriter
             self.stderrWriter = stderrWriter
@@ -90,7 +98,7 @@
             try? await SandboxManager.shared.ensureAgentUser("default")
 
             do {
-                self.process = try await SandboxManager.shared.execInteractive(
+                let proc = try await SandboxManager.shared.execInteractive(
                     user: agentUser,
                     command: command,
                     env: env,
@@ -99,6 +107,8 @@
                     stdout: stdoutWriter,
                     stderr: stderrWriter
                 )
+                self.process = proc
+                startExitWatch(for: proc)
             } catch {
                 await MCPChildSpawnLimiter.shared.release()
                 spawnSlotHeld = false
@@ -108,13 +118,45 @@
             }
         }
 
-        public func stop() async {
+        private func startExitWatch(for process: LinuxProcess) {
+            exitWatchTask = Task { [weak self] in
+                do {
+                    let status = try await process.wait()
+                    await self?.handleProcessExit(exitCode: status.exitCode)
+                } catch {
+                    await self?.handleProcessExit(exitCode: -1)
+                }
+            }
+        }
+
+        private func handleProcessExit(exitCode: Int32) {
+            exitWatchTask?.cancel()
+            onProcessExitHandler?(exitCode)
+        }
+
+        public func lastStderrTail() -> String {
+            stderrCapture.tail()
+        }
+
+        public func stop(forceKillGraceSeconds: Int64 = 2) async {
+            // Intentional teardown: never route through the "unexpected exit"
+            // handler, which would mark the provider as crashed.
+            onProcessExitHandler = nil
+            exitWatchTask?.cancel()
             await transport.disconnect()
             stdinBridge.finish()
             try? stdoutWriter.close()
             try? stderrWriter.close()
             if let proc = process {
                 try? await proc.kill(SIGTERM)
+                // Bounded wait; escalate to SIGKILL only if the child ignores
+                // SIGTERM past the grace period. `wait` returns immediately
+                // when the process exits, so the fast path stays fast.
+                do {
+                    _ = try await proc.wait(timeoutInSeconds: forceKillGraceSeconds)
+                } catch {
+                    try? await proc.kill(SIGKILL)
+                }
                 try? await proc.delete()
                 self.process = nil
             }
@@ -205,18 +247,20 @@
     }
 
     /// `Writer` adapter that fans every chunk out to an `AsyncStream<Data>`
-    /// the MCP transport consumes. `discard == true` is the stderr branch:
-    /// MCP clients don't read stderr so we drop bytes on the floor.
+    /// the MCP transport consumes. When `capture` is set, stderr bytes are
+    /// retained for diagnostics even if not forwarded to a consumer.
     final class SandboxStdioWriter: Writer, @unchecked Sendable {
         private let channel = SandboxStdioByteChannel()
-        private let discard: Bool
+        private let capture: MCPStdioStderrCapture?
 
-        init(discard: Bool = false) { self.discard = discard }
+        init(capture: MCPStdioStderrCapture? = nil) {
+            self.capture = capture
+        }
 
         func makeOutputStream() -> AsyncStream<Data> { channel.subscribe() }
 
         func write(_ data: Data) throws {
-            guard !discard else { return }
+            capture?.append(data)
             channel.push(data)
         }
 

--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -463,6 +463,8 @@ public enum OpenAICodexOAuthService {
             return .authorizationCallbackRejected(detail.isEmpty ? "OAuth provider returned an error" : detail)
         case .invalidCallback:
             return .authorizationCallbackFailed("invalid callback path or request")
+        case .callbackTimeout:
+            return .authorizationCallbackFailed("timed out waiting for browser callback")
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -450,12 +450,14 @@ public enum ProviderNetworkDiagnostics {
         if state?.isConnected == true {
             var detail = L("\(state?.discoveredToolCount ?? 0) tool(s) discovered.")
             if let connectedAt = state?.lastConnectedAt {
-                detail += " " + L("Last connected \(connectedAt.formatted(date: .abbreviated, time: .shortened)).")
+                let formatted = connectedAt.formatted(date: .abbreviated, time: .shortened)
+                detail += " " + L("Last connected \(formatted).")
             }
             if state?.isAutoReconnecting == true {
-                detail += " " + L("Auto-reconnecting after a stale session…")
-            } else if state?.lastAutoReconnectAt != nil {
-                detail += " " + L("Last auto-reconnect \(state!.lastAutoReconnectAt!.formatted(date: .omitted, time: .shortened)).")
+                detail += " " + L("Auto-reconnecting after a stale session.")
+            } else if let reconnectAt = state?.lastAutoReconnectAt {
+                let formatted = reconnectAt.formatted(date: .omitted, time: .shortened)
+                detail += " " + L("Last auto-reconnect \(formatted).")
             }
             return ProviderDiagnosticRow(
                 id: "connection",

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -448,12 +448,21 @@ public enum ProviderNetworkDiagnostics {
             )
         }
         if state?.isConnected == true {
+            var detail = L("\(state?.discoveredToolCount ?? 0) tool(s) discovered.")
+            if let connectedAt = state?.lastConnectedAt {
+                detail += " " + L("Last connected \(connectedAt.formatted(date: .abbreviated, time: .shortened)).")
+            }
+            if state?.isAutoReconnecting == true {
+                detail += " " + L("Auto-reconnecting after a stale session…")
+            } else if state?.lastAutoReconnectAt != nil {
+                detail += " " + L("Last auto-reconnect \(state!.lastAutoReconnectAt!.formatted(date: .omitted, time: .shortened)).")
+            }
             return ProviderDiagnosticRow(
                 id: "connection",
                 title: L("Connection"),
                 value: L("Connected"),
                 severity: .ok,
-                detail: L("\(state?.discoveredToolCount ?? 0) tool(s) discovered.")
+                detail: detail
             )
         }
         if state?.requiresAuth == true {

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -438,6 +438,8 @@ public enum XAIOAuthService {
             return .authorizationCallbackRejected(detail.isEmpty ? "OAuth provider returned an error" : detail)
         case .invalidCallback:
             return .authorizationCallbackFailed("invalid callback path or request")
+        case .callbackTimeout:
+            return .authorizationCallbackFailed("timed out waiting for browser callback")
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPFeatureGapRemediationTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPFeatureGapRemediationTests.swift
@@ -1,0 +1,128 @@
+//
+//  MCPFeatureGapRemediationTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for MCP feature-gap audit remediations.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("MCP feature gap remediation", .serialized)
+struct MCPFeatureGapRemediationTests {
+    @Test func permanentAuthFailureDetectsInvalidGrant() {
+        let error = MCPOAuthError.tokenRequestFailed(400, #"{"error":"invalid_grant"}"#)
+        #expect(MCPOAuthService.isPermanentAuthFailure(error))
+    }
+
+    @Test func permanentAuthFailureIgnoresTransientErrors() {
+        let error = MCPOAuthError.tokenRequestFailed(503, "service unavailable")
+        #expect(!MCPOAuthService.isPermanentAuthFailure(error))
+    }
+
+    @Test func oauthRefreshSingleFlightCoalescesConcurrentCalls() async throws {
+        let providerId = UUID()
+        var refreshCount = 0
+        MCPOAuthService.tokenRequestOverride = { _, _ in
+            refreshCount += 1
+            try await Task.sleep(nanoseconds: 100_000_000)
+            return MCPOAuthService.ParsedTokenResponse(
+                accessToken: "AT-\(refreshCount)",
+                refreshToken: "RT",
+                expiresAt: Date().addingTimeInterval(3600),
+                scope: nil
+            )
+        }
+        defer { MCPOAuthService.tokenRequestOverride = nil }
+
+        let provider = MCPProvider(
+            id: providerId,
+            name: "p",
+            url: "https://mcp.example.com/mcp",
+            authType: .oauth,
+            oauth: MCPOAuthConfig(
+                clientId: "client",
+                tokenEndpoint: "https://auth.example.com/token"
+            )
+        )
+        let tokens = MCPOAuthTokens(
+            accessToken: "old",
+            refreshToken: "RT",
+            expiresAt: Date().addingTimeInterval(-10),
+            scope: nil
+        )
+
+        async let first = MCPOAuthService.refresh(provider: provider, tokens: tokens, persist: false)
+        async let second = MCPOAuthService.refresh(provider: provider, tokens: tokens, persist: false)
+        let (a, b) = try await (first, second)
+
+        #expect(refreshCount == 1)
+        #expect(a.accessToken == b.accessToken)
+    }
+
+    @Test @MainActor func externalMCPDeniesAskPolicyTool() async {
+        let tool = AskGapTool()
+        ToolRegistry.shared.register(tool)
+        ToolRegistry.shared.setEnabled(true, for: tool.name)
+        defer { ToolRegistry.shared.unregister(names: [tool.name]) }
+
+        await #expect(throws: (any Error).self) {
+            _ = try await MCPServerManager.executeToolAsExternalMCP(
+                name: tool.name,
+                argumentsJSON: "{}"
+            )
+        }
+    }
+
+    @Test @MainActor func externalMCPRejectsDisabledToolBeforeExecution() async {
+        let tool = EchoGapTool()
+        ToolRegistry.shared.register(tool)
+        ToolRegistry.shared.setEnabled(false, for: tool.name)
+        defer { ToolRegistry.shared.unregister(names: [tool.name]) }
+
+        await #expect(throws: (any Error).self) {
+            _ = try await MCPServerManager.executeToolAsExternalMCP(
+                name: tool.name,
+                argumentsJSON: #"{"text":"hi"}"#
+            )
+        }
+    }
+
+    @Test func stderrCaptureKeepsTail() {
+        let capture = MCPStdioStderrCapture(lineLimit: 4)
+        capture.append(Data("line one\nline two\n".utf8))
+        capture.append(Data("line three\n".utf8))
+        let tail = capture.tail(maxLength: 100)
+        #expect(tail.contains("line one"))
+        #expect(tail.contains("line three"))
+    }
+}
+
+private struct EchoGapTool: OsaurusTool {
+    static let nameStatic = "echo_gap_tool"
+    let name = EchoGapTool.nameStatic
+    let description = "Echo for gap tests"
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object(["text": .object(["type": .string("string")])]),
+        "required": .array([.string("text")]),
+    ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        argumentsJSON
+    }
+}
+
+private final class AskGapTool: OsaurusTool, PermissionedTool, @unchecked Sendable {
+    let name = "ask_gap_tool"
+    let description = "Ask-policy probe"
+    let parameters: JSONValue? = nil
+    let requirements: [String] = []
+    let defaultPermissionPolicy: ToolPermissionPolicy = .ask
+
+    func execute(argumentsJSON: String) async throws -> String {
+        "ran"
+    }
+}

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthServiceTests.swift
@@ -346,6 +346,11 @@ struct MCPOAuthServiceTests {
         #expect(capturedForm?["client_secret"] == nil)
     }
 
+    @Test func refreshPermanentFailureDetectsInvalidToken() {
+        let error = MCPOAuthError.tokenRequestFailed(401, #"{"error":"invalid_token"}"#)
+        #expect(MCPOAuthService.isPermanentAuthFailure(error))
+    }
+
     // MARK: - Helpers
 
     private func makePRM(scopes: [String]?) -> MCPProtectedResourceMetadata {

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderReliabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderReliabilityTests.swift
@@ -1,0 +1,155 @@
+//
+//  MCPProviderReliabilityTests.swift
+//  osaurusTests
+//
+//  Regression coverage for remote MCP HTTP transport construction and
+//  stale-session recovery classification. Guards the fixes for:
+//  - session-wide URLSession timeouts killing long tool calls and the
+//    long-lived SSE GET stream,
+//  - Authorization being routed through `httpAdditionalHeaders` (Apple
+//    documents that as unsupported for auth headers),
+//  - "Connected" providers whose every tool call fails after the remote
+//    server expires the Mcp-Session-Id or the OAuth access token.
+//
+
+import Foundation
+import MCP
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Remote MCP provider reliability")
+struct MCPProviderReliabilityTests {
+
+    // MARK: - URLSession configuration
+
+    @Test func sessionRequestTimeoutCoversBothLogicalTimeouts() {
+        let configuration = MCPHTTPTransportBuilder.sessionConfiguration(
+            discoveryTimeout: 20,
+            toolCallTimeout: 45
+        )
+        // A tool call is allowed 45s at the MCP layer; the session-level
+        // idle timeout must not undercut it (it used to be 20s).
+        #expect(configuration.timeoutIntervalForRequest >= 45)
+    }
+
+    @Test func sessionRequestTimeoutHasFloorForTinyLogicalTimeouts() {
+        let configuration = MCPHTTPTransportBuilder.sessionConfiguration(
+            discoveryTimeout: 5,
+            toolCallTimeout: 5
+        )
+        #expect(
+            configuration.timeoutIntervalForRequest
+                >= MCPHTTPTransportBuilder.minimumRequestTimeout
+        )
+    }
+
+    @Test func sessionResourceTimeoutDoesNotKillLongLivedSSEStreams() {
+        let configuration = MCPHTTPTransportBuilder.sessionConfiguration(
+            discoveryTimeout: 20,
+            toolCallTimeout: 45
+        )
+        // The old code capped the total lifetime of EVERY request in the
+        // session at max(discovery, toolCall) = 45s, which force-closed the
+        // streaming GET SSE connection every 45 seconds. The resource
+        // timeout must stay at (or near) the URLSession default of 7 days.
+        #expect(configuration.timeoutIntervalForResource >= 86_400)
+    }
+
+    // MARK: - Per-request headers
+
+    @Test func requestModifierInjectsAuthorizationAndCustomHeaders() {
+        let modifier = MCPHTTPTransportBuilder.requestModifier(headers: [
+            "Authorization": "Bearer test-token",
+            "X-Account-Id": "acct-42",
+        ])
+        let request = URLRequest(url: URL(string: "https://mcp.example.com/mcp")!)
+
+        let modified = modifier(request)
+
+        #expect(modified.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+        #expect(modified.value(forHTTPHeaderField: "X-Account-Id") == "acct-42")
+    }
+
+    @Test func requestModifierNeverOverwritesHeadersSetByTheSDK() {
+        // The SDK sets Accept / Content-Type / Mcp-Session-Id on each
+        // request; a colliding custom header must not clobber them
+        // (matching httpAdditionalHeaders semantics).
+        let modifier = MCPHTTPTransportBuilder.requestModifier(headers: [
+            "Accept": "text/plain"
+        ])
+        var request = URLRequest(url: URL(string: "https://mcp.example.com/mcp")!)
+        request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+
+        let modified = modifier(request)
+
+        #expect(
+            modified.value(forHTTPHeaderField: "Accept") == "application/json, text/event-stream"
+        )
+    }
+
+    @Test func requestModifierWithNoHeadersIsIdentity() {
+        let modifier = MCPHTTPTransportBuilder.requestModifier(headers: [:])
+        var request = URLRequest(url: URL(string: "https://mcp.example.com/mcp")!)
+        request.setValue("value", forHTTPHeaderField: "X-Existing")
+
+        let modified = modifier(request)
+
+        #expect(modified == request)
+    }
+
+    // MARK: - Stale-session recovery classification
+
+    @Test func sessionExpiryAndAuthFailuresAreRecoverable() {
+        // Exact strings produced by HTTPClientTransport in the MCP SDK.
+        #expect(
+            MCPProviderManager.isRecoverableSessionError(
+                MCPError.internalError("Session expired")
+            )
+        )
+        #expect(
+            MCPProviderManager.isRecoverableSessionError(
+                MCPError.internalError("Authentication required")
+            )
+        )
+        #expect(
+            MCPProviderManager.isRecoverableSessionError(
+                MCPError.internalError("Access forbidden")
+            )
+        )
+        #expect(
+            MCPProviderManager.isRecoverableSessionError(
+                MCPError.internalError("Transport not connected")
+            )
+        )
+        #expect(
+            MCPProviderManager.isRecoverableSessionError(MCPError.connectionClosed)
+        )
+    }
+
+    @Test func timeoutsAndToolFailuresAreNotRetried() {
+        // A timed-out tool call may have executed server-side; retrying
+        // risks double execution.
+        #expect(!MCPProviderManager.isRecoverableSessionError(MCPProviderError.timeout))
+        #expect(
+            !MCPProviderManager.isRecoverableSessionError(
+                MCPProviderError.toolExecutionFailed("boom")
+            )
+        )
+        #expect(
+            !MCPProviderManager.isRecoverableSessionError(
+                MCPError.internalError("Server error: 500")
+            )
+        )
+        #expect(
+            !MCPProviderManager.isRecoverableSessionError(
+                MCPError.internalError(nil)
+            )
+        )
+        #expect(
+            !MCPProviderManager.isRecoverableSessionError(
+                NSError(domain: "test", code: 1)
+            )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -352,6 +352,44 @@ struct MCPHTTPHandlerTests {
         }
     }
 
+    @Test func mcp_call_rejects_disabled_tool() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            ToolRegistry.shared.register(EchoTool())
+            ToolRegistry.shared.setEnabled(false, for: EchoTool.nameStatic)
+            defer { ToolRegistry.shared.unregister(names: [EchoTool.nameStatic]) }
+
+            let server = try await startTestServer()
+            defer { Task { await server.shutdown() } }
+
+            var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)/mcp/call")!)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.authenticate()
+            let bodyObj: [String: Any] = [
+                "name": EchoTool.nameStatic,
+                "arguments": ["text": "hi"],
+            ]
+            request.httpBody = try JSONSerialization.data(withJSONObject: bodyObj)
+
+            let (data, resp) = try await URLSession.shared.data(for: request)
+            let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            #expect(status == 200)
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let isError = (json?["isError"] as? Bool) ?? false
+            #expect(isError == true)
+            let content = (json?["content"] as? [[String: Any]])?.first
+            let text = content?["text"] as? String ?? ""
+            #expect(text.contains("disabled"))
+        }
+    }
+
     @Test func mcp_call_with_missing_required_arg_returns_error() async throws {
         try await DynamicCatalogTestLock.shared.run {
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/Packages/OsaurusCore/Tests/Provider/MCPProviderToolNamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/MCPProviderToolNamingTests.swift
@@ -1,0 +1,50 @@
+//
+//  MCPProviderToolNamingTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for collision-safe MCP tool prefixes and description caps.
+//
+
+import Foundation
+import MCP
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("MCP provider tool naming")
+struct MCPProviderToolNamingTests {
+    @Test func sanitizedPrefixCollapsesSpacesAndHyphens() {
+        #expect(MCPProviderTool.sanitizedProviderPrefix(from: "My Server") == "my_server")
+        #expect(MCPProviderTool.sanitizedProviderPrefix(from: "my-server") == "my_server")
+    }
+
+    @Test func exposedNameDisambiguatesCollidingProviderPrefixes() {
+        let providerA = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+        let providerB = UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-FFFFFFFFFFFF")!
+
+        let reserved = Set([
+            MCPProviderTool.exposedName(
+                providerId: providerA,
+                providerName: "My Server",
+                mcpToolName: "search"
+            )
+        ])
+
+        let nameB = MCPProviderTool.exposedName(
+            providerId: providerB,
+            providerName: "my-server",
+            mcpToolName: "search",
+            reservedNames: reserved
+        )
+
+        #expect(nameB.contains("bbbbbbbb"))
+        #expect(nameB != reserved.first)
+    }
+
+    @Test func descriptionTruncationUsesRaisedCap() {
+        let long = String(repeating: "x", count: MCPProviderTool.maxDescriptionLength + 50)
+        let truncated = MCPProviderTool.truncatedDescription(long)
+        #expect(truncated.hasSuffix("..."))
+        #expect(truncated.count == MCPProviderTool.maxDescriptionLength + 3)
+    }
+}

--- a/Packages/OsaurusCore/Tools/MCPProviderTool.swift
+++ b/Packages/OsaurusCore/Tools/MCPProviderTool.swift
@@ -25,33 +25,35 @@ final class MCPProviderTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
     /// Original MCP tool name (may differ from exposed name if prefixed)
     let mcpToolName: String
 
+    /// Maximum length for remote MCP tool descriptions exposed to the model.
+    /// Vendors often put parameter semantics and examples beyond 200 chars; 4000
+    /// keeps the guardrail without stripping actionable detail.
+    static let maxDescriptionLength = 4_000
+
     init(
         mcpTool: MCP.Tool,
         providerId: UUID,
         providerName: String,
-        prefixWithProvider: Bool = true
+        prefixWithProvider: Bool = true,
+        reservedNames: Set<String> = []
     ) {
         self.providerId = providerId
         self.providerName = providerName
         self.mcpToolName = mcpTool.name
 
-        // Optionally prefix tool name with provider name to avoid conflicts
         if prefixWithProvider {
-            // Convert provider name to safe identifier (e.g., "My Server" -> "my_server")
-            let safeProviderName =
-                providerName
-                .lowercased()
-                .replacingOccurrences(of: " ", with: "_")
-                .replacingOccurrences(of: "-", with: "_")
-                .filter { $0.isLetter || $0.isNumber || $0 == "_" }
-            self.name = "\(safeProviderName)_\(mcpTool.name)"
+            self.name = Self.exposedName(
+                providerId: providerId,
+                providerName: providerName,
+                mcpToolName: mcpTool.name,
+                reservedNames: reservedNames
+            )
         } else {
             self.name = mcpTool.name
         }
 
-        // Truncate description to reasonable length
         let desc = mcpTool.description ?? "Tool from \(providerName)"
-        self.description = String(desc.prefix(200))
+        self.description = Self.truncatedDescription(desc)
 
         // Convert MCP input schema to JSONValue
         self.parameters = Self.convertInputSchema(mcpTool.inputSchema)
@@ -61,6 +63,59 @@ final class MCPProviderTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
 
         // Default to asking for permission since these are remote tools
         self.defaultPermissionPolicy = .ask
+    }
+
+    /// Sanitize a provider display name into a stable tool-name prefix segment.
+    static func sanitizedProviderPrefix(from providerName: String) -> String {
+        providerName
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "_")
+            .replacingOccurrences(of: "-", with: "_")
+            .filter { $0.isLetter || $0.isNumber || $0 == "_" }
+    }
+
+    /// Build the Osaurus-exposed tool name for an MCP tool, disambiguating when
+    /// two providers normalize to the same prefix (e.g. "My Server" / "my-server").
+    static func exposedName(
+        providerId: UUID,
+        providerName: String,
+        mcpToolName: String,
+        reservedNames: Set<String> = []
+    ) -> String {
+        let basePrefix = sanitizedProviderPrefix(from: providerName)
+        let prefix = basePrefix.isEmpty ? "mcp" : basePrefix
+        let candidate = sanitizeExposedToolName("\(prefix)_\(mcpToolName)")
+        guard reservedNames.contains(candidate) else { return candidate }
+
+        // Append a stable short id from the provider UUID so collisions can't
+        // silently overwrite another provider's tool in the registry.
+        let disambiguator = providerId.uuidString
+            .replacingOccurrences(of: "-", with: "")
+            .prefix(8)
+            .lowercased()
+        return sanitizeExposedToolName("\(prefix)_\(disambiguator)_\(mcpToolName)")
+    }
+
+    /// Local copy of `ToolRegistry.sanitizeToolName` so prefix logic stays
+    /// callable from this type's nonisolated initialiser path.
+    private static func sanitizeExposedToolName(_ raw: String) -> String {
+        var out = ""
+        out.reserveCapacity(raw.count)
+        for ch in raw {
+            if ch.isASCII, ch.isLetter || ch.isNumber || ch == "_" || ch == "-" {
+                out.append(ch)
+            } else {
+                out.append("_")
+            }
+        }
+        if out.isEmpty { out = "tool_unnamed" }
+        if out.count > 64 { out = String(out.prefix(64)) }
+        return out
+    }
+
+    static func truncatedDescription(_ raw: String) -> String {
+        guard raw.count > maxDescriptionLength else { return raw }
+        return String(raw.prefix(maxDescriptionLength)) + "..."
     }
 
     func execute(argumentsJSON: String) async throws -> String {

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -536,8 +536,11 @@ public final class ToolRegistry: ObservableObject {
                 if ChatExecutionContext.autoApproveToolPrompts {
                     approved = true
                 } else if ChatExecutionContext.denyUnapprovedToolPrompts {
-                    // Headless eval with no UI: deny instead of hanging on an
-                    // approval card nobody can click (see task-local doc).
+                    // Headless eval / external MCP with no UI: deny instead of
+                    // hanging on an approval card nobody can click.
+                    approved = false
+                } else if ChatExecutionContext.isExternalSurface {
+                    // External MCP/HTTP callers cannot interact with GUI prompts.
                     approved = false
                 } else {
                     approved = await ToolPermissionPromptService.requestApproval(
@@ -547,10 +550,15 @@ public final class ToolRegistry: ObservableObject {
                     )
                 }
                 if !approved {
+                    let message =
+                        ChatExecutionContext.isExternalSurface
+                        || ChatExecutionContext.denyUnapprovedToolPrompts
+                        ? "Tool '\(name)' requires interactive approval in the Osaurus app. Enable auto-approve or change the tool policy to auto before calling it from an external MCP client."
+                        : "User denied execution for tool: \(name)"
                     throw NSError(
                         domain: "ToolRegistry",
                         code: 4,
-                        userInfo: [NSLocalizedDescriptionKey: "User denied execution for tool: \(name)"]
+                        userInfo: [NSLocalizedDescriptionKey: message]
                     )
                 }
             case .auto:
@@ -1097,6 +1105,12 @@ public final class ToolRegistry: ObservableObject {
         return toolsByName.count
     }
 
+    /// Names of all currently registered tools. Used when minting MCP tool
+    /// names so two providers with the same sanitized prefix can't collide.
+    func registeredToolNames() -> [String] {
+        Array(toolsByName.keys)
+    }
+
     /// O(1) single-tool lookup as a `ToolEntry`. Prefer this over
     /// `listTools().first(where:)` on UI/render paths: `listTools()` sorts the
     /// entire registry and rebuilds every tool's JSON schema, while this only
@@ -1323,21 +1337,32 @@ public final class ToolRegistry: ObservableObject {
     /// Register a tool from a remote MCP provider.
     /// Auto-enables the tool on first registration so it is immediately usable;
     /// subsequent registrations preserve the user's choice.
-    func registerMCPTool(_ tool: OsaurusTool) {
+    func registerMCPTool(_ tool: MCPProviderTool) {
+        let name = tool.name
+        if let existing = toolsByName[name] as? MCPProviderTool,
+            existing.providerId != tool.providerId
+        {
+            NSLog(
+                "[ToolRegistry] MCP tool name collision on '\(name)': "
+                    + "existing provider '\(existing.providerName)' (\(existing.providerId)) "
+                    + "overwritten by '\(tool.providerName)' (\(tool.providerId)). "
+                    + "Consider renaming one of the providers."
+            )
+        }
         let firstTime =
-            toolsByName[tool.name] == nil
-            && !configuration.enabled.keys.contains(tool.name)
-        toolsByName[tool.name] = tool
-        sandboxToolNames.remove(tool.name)
-        builtInSandboxToolNames.remove(tool.name)
-        pluginToolNames.remove(tool.name)
-        mcpToolNames.insert(tool.name)
+            toolsByName[name] == nil
+            && !configuration.enabled.keys.contains(name)
+        toolsByName[name] = tool
+        sandboxToolNames.remove(name)
+        builtInSandboxToolNames.remove(name)
+        pluginToolNames.remove(name)
+        mcpToolNames.insert(name)
         if firstTime {
-            setEnabled(true, for: tool.name)
+            setEnabled(true, for: name)
         }
         Task {
             await ToolIndexService.shared.onToolRegistered(
-                name: tool.name,
+                name: name,
                 description: tool.description,
                 runtime: .mcp,
                 tokenCount: Self.estimateTokenCount(tool),

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -630,6 +630,14 @@ private struct ProviderCard: View {
                                     .foregroundColor(theme.secondaryText)
                                     .lineLimit(1)
                                     .truncationMode(.tail)
+                            } else if isConnected, let connectedAt = state?.lastConnectedAt {
+                                Text(
+                                    "Connected \(connectedAt.formatted(date: .abbreviated, time: .shortened))",
+                                    bundle: .module
+                                )
+                                .font(.system(size: 11))
+                                .foregroundColor(theme.secondaryText)
+                                .lineLimit(1)
                             }
                         }
 
@@ -925,6 +933,18 @@ private struct ProviderCard: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(Capsule().fill(theme.successColor.opacity(0.12)))
+        } else if state?.isAutoReconnecting == true {
+            HStack(spacing: 4) {
+                ProgressView()
+                    .scaleEffect(0.4)
+                    .frame(width: 6, height: 6)
+                Text("Reconnecting…", bundle: .module)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.accentColor)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(theme.accentColor.opacity(0.12)))
         } else if isConnecting {
             HStack(spacing: 4) {
                 ProgressView()

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -219,6 +219,11 @@ Add arbitrary HTTP headers. Mark a header as a **secret** to store its value in 
 | **Discovery Timeout** | Timeout for tool discovery (seconds)      | 20      |
 | **Tool Call Timeout** | Timeout for tool execution (seconds)      | 45      |
 
+Both timeouts are enforced at the MCP layer. The underlying HTTP session uses
+a looser idle timeout (at least the larger of the two, minimum 60s) so it
+never undercuts a long-running tool call, and it does not cap the total
+lifetime of the streaming SSE connection.
+
 ---
 
 ## How OAuth Auto Sign-In Works
@@ -255,6 +260,18 @@ The implementation lives in [`Packages/OsaurusCore/Services/MCP/OAuth/`](../Pack
 - Access tokens are refreshed proactively before they expire.
 - If a request returns `401 Unauthorized`, Osaurus probes the response's `WWW-Authenticate: Bearer` challenge, refreshes once, and retries. If that also fails, the provider's row surfaces a "Sign in again" prompt.
 - All tokens (access + refresh) live in Keychain; `mcp.json` only stores client IDs and metadata.
+
+### Session Expiry Recovery (tool calls)
+
+Remote streamable-HTTP servers expire their `Mcp-Session-Id` after idle
+periods or server restarts, and OAuth access tokens can expire while a
+provider stays connected. When a tool call fails with a session-expired,
+authentication, or closed-connection error, Osaurus automatically reconnects
+once — rebuilding the transport with fresh credentials and negotiating a new
+session — and retries the call. Timeouts are never retried, because the
+server may already have executed the tool. If the reconnect fails, the
+provider row shows the reconnect error (for example the "Sign in again"
+prompt) instead of silently staying green.
 
 ---
 


### PR DESCRIPTION
## Summary

Remediates the MCP feature gap audit across four surfaces: outbound HTTP/stdio providers, the OAuth 2.1 stack, the inbound MCP server (`/mcp/*` + `osaurus mcp` CLI bridge), and the tools/UI/config layer.

### Remote HTTP reliability
- `executeTool` now auto-recovers stale streamable-HTTP sessions (`Mcp-Session-Id` expiry) and expired OAuth tokens with one reconnect + retry; timeouts are deliberately excluded from retry (no double-execution risk).
- New `MCPHTTPTransportBuilder` centralizes timeout semantics and injects auth headers per-request (covers SSE reconnects; `httpAdditionalHeaders` is documented-unsupported for `Authorization`).
- HTTP transports are torn down explicitly on disconnect/failed connect so URLSessions and SSE retry loops no longer leak.

### Correctness & security
- Collision-safe MCP tool name prefixes ("My Server" / "my-server" no longer silently overwrite each other); registry logs conflicts. Description cap raised 200 → 4000 chars.
- Per-tool `isEnabled` enforced on every external execution path (`/mcp/call`, in-app MCP server, CLI bridge) — the Settings toggle is no longer discovery-only.
- Unapproved `.ask` tools are auto-denied for external MCP callers with a structured error instead of hanging headless clients (Claude Desktop, CI) on an NSPanel.
- Per-provider OAuth refresh single-flight (`MCPOAuthRefreshGate`) prevents rotating refresh tokens from being invalidated by concurrent tool calls; `invalid_grant`/`invalid_token` clears Keychain tokens and sets `requiresAuth`.
- OAuth loopback listener pinned to the loopback interface (RFC 8252 §7.3); sign-in callback bounded by a 5-minute timeout; `waitForCallback` is cancellation-safe.

### Stdio lifecycle
- Host and sandbox runners detect child exit, capture a stderr tail (ring buffer via new `MCPStdioStderrCapture`), mark the provider disconnected with the tail in `lastError`, and unregister its tools.
- `stop()` escalates SIGTERM → SIGKILL after a grace period; intentional teardown never routes through the crash handler.

### list_changed
- Outbound: subscribes to `notifications/tools/list_changed` and rediscovers tools automatically.
- Inbound: the app MCP server emits `listChanged` when the registry changes; the CLI proxy stops advertising a capability it cannot deliver.

### UI truthfulness & CLI
- Provider cards show `lastConnectedAt` and a live "Reconnecting…" badge; diagnostics reconcile probe snapshots against live connection state.
- `osaurus mcp` prints an accurate access-key hint when network exposure is enabled, and tool-list failures surface as MCP errors instead of a silent empty list.

## Test plan
- [x] `swift test --filter` across MCP suites: 55 tests in 9 suites pass (naming/prefix collisions, OAuth single-flight + invalid_grant, external ask-deny, disabled-tool rejection on `/mcp/call` and stdio server, stderr capture, transport reliability, hub/probe/discovery/registration)
- [x] `swift build` clean for OsaurusCore and OsaurusCLI
- [ ] Live smoke: connect a remote OAuth MCP provider, let the session idle-expire, confirm auto-reconnect on next tool call
- [ ] Live smoke: kill a stdio MCP child process, confirm the provider card flips to disconnected with the stderr tail