### PR TITLE
added option to expand thinking while streaming

### DIFF
--- a/Packages/OsaurusCore/Managers/BlockMemoizer.swift
+++ b/Packages/OsaurusCore/Managers/BlockMemoizer.swift
@@ -45,8 +45,7 @@ final class BlockMemoizer {
         from turns: [ChatTurn],
         streamingTurnId: UUID?,
         agentName: String,
-        version: Int = 0,
-        thinkingEnabled: Bool = false
+        version: Int = 0
     ) -> [ContentBlock] {
         let count = turns.count
         let lastId = turns.last?.id
@@ -95,8 +94,7 @@ final class BlockMemoizer {
                 at: count - 1,
                 in: turns,
                 streamingTurnId: streamingTurnId,
-                agentName: agentName,
-                thinkingEnabled: thinkingEnabled
+                agentName: agentName
             )
             wasIncremental = true
         } else if canAppend {
@@ -106,8 +104,7 @@ final class BlockMemoizer {
                 at: lastCount - 1,
                 in: turns,
                 streamingTurnId: streamingTurnId,
-                agentName: agentName,
-                thinkingEnabled: thinkingEnabled
+                agentName: agentName
             )
             wasIncremental = false
         } else {
@@ -115,8 +112,7 @@ final class BlockMemoizer {
             blocks = ContentBlock.generateBlocks(
                 from: turns,
                 streamingTurnId: streamingTurnId,
-                agentName: agentName,
-                thinkingEnabled: thinkingEnabled
+                agentName: agentName
             )
             wasIncremental = false
         }
@@ -156,8 +152,7 @@ final class BlockMemoizer {
         at turnIndex: Int,
         in turns: [ChatTurn],
         streamingTurnId: UUID?,
-        agentName: String,
-        thinkingEnabled: Bool = false
+        agentName: String
     ) -> [ContentBlock] {
         let turnId = turns[turnIndex].id
 
@@ -167,8 +162,7 @@ final class BlockMemoizer {
             return ContentBlock.generateBlocks(
                 from: turns,
                 streamingTurnId: streamingTurnId,
-                agentName: agentName,
-                thinkingEnabled: thinkingEnabled
+                agentName: agentName
             )
         }
 
@@ -184,8 +178,7 @@ final class BlockMemoizer {
             from: turnsToGenerate,
             streamingTurnId: streamingTurnId,
             agentName: agentName,
-            previousTurn: previousTurn,
-            thinkingEnabled: thinkingEnabled
+            previousTurn: previousTurn
         )
 
         return stablePrefix + freshBlocks

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -382,8 +382,7 @@ extension ContentBlock {
         from turns: [ChatTurn],
         streamingTurnId: UUID?,
         agentName: String,
-        previousTurn: ChatTurn? = nil,
-        thinkingEnabled: Bool = false
+        previousTurn: ChatTurn? = nil
     ) -> [ContentBlock] {
         var blocks: [ContentBlock] = []
         var previousRole: MessageRole? = previousTurn?.role
@@ -501,24 +500,14 @@ extension ContentBlock {
                 && !hasSharedArtifacts && (turn.toolCalls ?? []).isEmpty && turn.pendingToolName == nil
                 && !turn.hasRemoteToolActivity
             {
-                // During prefill (no content/thinking/tools yet), always show the typing
+                // During prefill (no content/thinking/tools yet), show the typing
                 // indicator so the interface doesn't appear frozen. Skipped once a
                 // Mode 2 remote tool is running — the running tool chip already
                 // signals progress, so a typing indicator on top would be noise.
-                // Only add the thinking placeholder when thinking is actually enabled for
-                // this model — non-thinking models don't need it.
-                if thinkingEnabled {
-                    turnBlocks.append(
-                        .thinking(
-                            turnId: turn.id,
-                            index: 0,
-                            text: "",
-                            isStreaming: true,
-                            duration: nil,
-                            position: .middle
-                        )
-                    )
-                }
+                // Deliberately no "Thinking" placeholder here: the model hasn't
+                // produced reasoning yet, so labeling load/prefill as thinking
+                // misstates the phase. The real thinking block above appears on
+                // the first reasoning delta via `hasRenderableThinking`.
                 turnBlocks.append(.typingIndicator(turnId: turn.id, position: .middle))
             }
 

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -53434,6 +53434,46 @@
         }
       }
     },
+    "Expand Thinking While Streaming" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denkprozess beim Streaming ausklappen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expand Thinking While Streaming"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스트리밍 중 사고 과정 펼치기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разворачивать размышления во время стриминга"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流式输出时展开思考过程"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流式輸出時展開思考過程"
+          }
+        }
+      }
+    },
     "Expected a directory but found a file or other non-directory item." : {
       "localizations" : {
         "de" : {
@@ -70153,6 +70193,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "繼續運行"
+          }
+        }
+      }
+    },
+    "Keep the model's reasoning expanded while it is actively thinking, then collapse it automatically once the response begins. Useful for monitoring long-running agent tasks in real time." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hält die Denkschritte des Modells ausgeklappt, während es aktiv nachdenkt, und klappt sie automatisch wieder ein, sobald die Antwort beginnt. Nützlich, um langlaufende Agent-Aufgaben in Echtzeit zu verfolgen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Keep the model's reasoning expanded while it is actively thinking, then collapse it automatically once the response begins. Useful for monitoring long-running agent tasks in real time."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델이 사고하는 동안 사고 과정을 펼쳐서 보여주고, 응답이 시작되면 자동으로 접습니다. 장시간 실행되는 에이전트 작업을 실시간으로 모니터링할 때 유용합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размышления модели остаются развёрнутыми, пока она активно думает, и автоматически сворачиваются, как только начинается ответ. Полезно для наблюдения за длительными задачами агента в реальном времени."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在模型思考期间保持思考过程展开，回答开始后自动折叠。便于实时监控长时间运行的智能体任务。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在模型思考期間保持思考過程展開，回答開始後自動摺疊。便於即時監控長時間執行的智能體任務。"
           }
         }
       }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -259,15 +259,6 @@ final class ChatSession: ObservableObject {
     /// `cachedContext` is reset so a new agent/session recomposes fresh.
     private var cachedPreviewContext: ComposedContext?
 
-    private var thinkingEnabledForCurrentModel: Bool {
-        guard let selectedModel else {
-            return activeModelOptions["disableThinking"]?.boolValue == false
-        }
-        return ModelProfileRegistry.thinkingEnabled(
-            for: selectedModel,
-            values: activeModelOptions
-        ) ?? false
-    }
     /// Estimated memory-section token cost for the next send. Populated by
     /// `refreshMemoryTokens` and surfaced through `estimatedContextBreakdown`
     /// so the Context Budget popover shows a "Memory" line even before the
@@ -976,8 +967,7 @@ final class ChatSession: ObservableObject {
             let newBlocks = blockMemoizer.blocks(
                 from: mockTurns,
                 streamingTurnId: nil,
-                agentName: displayName,
-                thinkingEnabled: thinkingEnabledForCurrentModel
+                agentName: displayName
             )
             let newHeaderMap = blockMemoizer.groupHeaderMap
             withAnimation(.none) {
@@ -993,8 +983,7 @@ final class ChatSession: ObservableObject {
         let newBlocks = blockMemoizer.blocks(
             from: turns,
             streamingTurnId: streamingTurnId,
-            agentName: displayName,
-            thinkingEnabled: thinkingEnabledForCurrentModel
+            agentName: displayName
         )
         let newHeaderMap = blockMemoizer.groupHeaderMap
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -155,6 +155,13 @@ final class ChatSession: ObservableObject {
     /// than force-expanding in the cell) lets the user collapse the block
     /// afterward; this set stops us re-expanding it on the next rebuild.
     private var autoExpandedReasoningBlockIds: Set<String> = []
+
+    /// Thinking-block ids auto-expanded while their turn was actively
+    /// streaming reasoning (opt-in "Expand Thinking While Streaming"
+    /// setting). Each id is expanded at most once so a manual collapse
+    /// mid-stream sticks, and collapsed exactly once when the thinking
+    /// phase ends.
+    private var streamingAutoExpandedThinkingBlockIds: Set<String> = []
     @Published var input: String = ""
     @Published var pendingAttachments: [Attachment] = []
     @Published var selectedModel: String? = nil
@@ -981,6 +988,7 @@ final class ChatSession: ObservableObject {
         }
 
         seedAutoExpandedReasoningBlocks(streamingTurnId: streamingTurnId)
+        updateStreamingThinkingExpansion(streamingTurnId: streamingTurnId)
 
         let newBlocks = blockMemoizer.blocks(
             from: turns,
@@ -1014,6 +1022,47 @@ final class ChatSession: ObservableObject {
             guard !autoExpandedReasoningBlockIds.contains(blockId) else { continue }
             autoExpandedReasoningBlockIds.insert(blockId)
             expandedBlocksStore.expand(blockId)
+        }
+    }
+
+    /// While the streaming turn is in its reasoning-only phase (no answer
+    /// content or tool calls yet), keep its thinking block expanded so the
+    /// user can watch the reasoning live; once the phase ends, collapse it
+    /// again to keep the thread clean. Opt-in via the Chat settings toggle
+    /// (`chatExpandThinkingWhileStreamingEnabled`, default off). Runs on
+    /// every visible-blocks rebuild, which fires per streaming delta and
+    /// once more from `completeRunCleanup`, so the collapse also lands when
+    /// a run ends or is cancelled mid-thought.
+    private func updateStreamingThinkingExpansion(streamingTurnId: UUID?) {
+        let activeThinkingBlockId: String? = {
+            guard
+                UserDefaults.standard.bool(forKey: "chatExpandThinkingWhileStreamingEnabled"),
+                let streamingTurnId,
+                let turn = turns.last, turn.id == streamingTurnId,
+                turn.role == .assistant,
+                turn.hasRenderableThinking,
+                turn.contentIsBlank,
+                (turn.toolCalls ?? []).isEmpty
+            else { return nil }
+            return ContentBlock.thinkingBlockId(turnId: streamingTurnId)
+        }()
+
+        // Collapse blocks whose thinking phase has ended — unless the
+        // completed-reasoning-only seeding above wants them expanded.
+        for blockId in streamingAutoExpandedThinkingBlockIds where blockId != activeThinkingBlockId {
+            streamingAutoExpandedThinkingBlockIds.remove(blockId)
+            if !autoExpandedReasoningBlockIds.contains(blockId) {
+                expandedBlocksStore.collapse(blockId)
+            }
+        }
+
+        // Expand at most once per block so a manual collapse mid-stream
+        // isn't fought on the next delta.
+        if let activeThinkingBlockId,
+            !streamingAutoExpandedThinkingBlockIds.contains(activeThinkingBlockId)
+        {
+            streamingAutoExpandedThinkingBlockIds.insert(activeThinkingBlockId)
+            expandedBlocksStore.expand(activeThinkingBlockId)
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
@@ -42,6 +42,11 @@ final class NativeThinkingView: NSView {
 
     private var isExpanded = false
     private var currentWidth: CGFloat = 0
+    /// Block this view was last configured for. The chevron only animates on
+    /// an expand-state change within the same block — a fresh or recycled
+    /// cell arriving mid-stream must snap to its state, not replay the
+    /// collapsed→expanded rotation on every reconfigure.
+    private var configuredBlockId: String?
 
     // MARK: Callbacks
 
@@ -135,8 +140,13 @@ final class NativeThinkingView: NSView {
         charCountLabel.font = NSFont.systemFont(ofSize: CGFloat(theme.captionSize) - 2, weight: .medium)
         charCountLabel.textColor = NSColor(theme.tertiaryText)
 
-        updateChevron(expanded: isExpanded, animated: isExpanded != self.isExpanded)
+        let isSameBlock = configuredBlockId == blockId
+        updateChevron(
+            expanded: isExpanded,
+            animated: isSameBlock && isExpanded != self.isExpanded
+        )
         self.isExpanded = isExpanded
+        configuredBlockId = blockId
 
         contentContainer.isHidden = !isExpanded
         separatorView.isHidden = !isExpanded

--- a/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
@@ -64,6 +64,11 @@ final class NativeThinkingView: NSView {
 
     override func layout() {
         super.layout()
+        // AppKit resets view-managed layer geometry during layout, wiping the
+        // chevron's rotation. Streaming deltas re-layout on every height
+        // change, so reapply the current rotation or the arrow visibly snaps
+        // back to the collapsed direction between reconfigures.
+        updateChevron(expanded: isExpanded, animated: false)
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -42,6 +42,13 @@ struct ChatSettingsView: View {
     /// `StreamingDeltaProcessor` reads per delta. Applied immediately, so
     /// it's excluded from the debounced save baseline.
     @AppStorage("chatSmoothStreamingEnabled") private var smoothStreamingEnabled: Bool = true
+    /// Auto-expand the thinking block while the model is actively reasoning
+    /// and collapse it again once the answer starts. Default off. Bound to
+    /// `UserDefaults` key `chatExpandThinkingWhileStreamingEnabled` which
+    /// `ChatSession` reads on every visible-blocks rebuild. Applied
+    /// immediately, so it's excluded from the debounced save baseline.
+    @AppStorage("chatExpandThinkingWhileStreamingEnabled")
+    private var expandThinkingWhileStreamingEnabled: Bool = false
     /// Free-text "voice" instruction for AI-generated empty-state
     /// greetings — the global default voice. The on/off is per-agent
     /// (`AgentSettings.generativeGreetingsEnabled`). Empty = use the
@@ -172,6 +179,13 @@ struct ChatSettingsView: View {
                     description:
                         "Pace incoming tokens at a steady rate so streaming looks like a typewriter across all providers. Disable to render tokens as soon as they arrive — useful with very fast remote providers that you'd rather see complete instantly.",
                     isOn: $smoothStreamingEnabled
+                )
+
+                SettingsToggle(
+                    title: L("Expand Thinking While Streaming"),
+                    description:
+                        "Keep the model's reasoning expanded while it is actively thinking, then collapse it automatically once the response begins. Useful for monitoring long-running agent tasks in real time.",
+                    isOn: $expandThinkingWhileStreamingEnabled
                 )
 
                 SettingsToggle(


### PR DESCRIPTION
## Summary

  Closes #1859

<img width="650" height="488" alt="image" src="https://github.com/user-attachments/assets/5c23218c-80d8-48f0-a498-5d47872f52fe" />

  - added an "Expand Thinking While Streaming" toggle to Chat settings, disabled by default
  - when enabled, the thinking block stays expanded while the model is actively reasoning and collapses automatically
  once the response begins, so long-running agent tasks can be monitored in real time
  - a manual collapse during streaming is respected and never overridden
  - removed the empty thinking placeholder shown during model load and prefill, which mislabeled the loading phase as
  thinking before any reasoning tokens existed; the typing indicator alone now signals progress there
  - fixed the thinking block chevron flickering between expanded and collapsed during streaming, caused by layout
  passes resetting its rotation and by recycled cells replaying the expand animation

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
