### PR TITLE
fixed notch overlay covering the menu bar and improved its hover/ dismiss behavior

### DIFF
--- a/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
+++ b/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
@@ -76,6 +76,38 @@ struct NotchPanelPlacementTests {
         #expect(placement.frame.midX == screenFrame.midX)
     }
 
+    @Test func panelReservesRevealStripWhenMenuBarAutoHides() {
+        // Auto-hidden menu bar: visibleFrame extends to the top of the screen.
+        let screenFrame = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let visibleFrame = screenFrame
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame,
+            preferredSize: CGSize(width: 600, height: 500),
+            hiddenMenuBarInset: 32
+        )
+
+        #expect(placement.frame.maxY == screenFrame.maxY - 32)
+        #expect(placement.frame.midX == screenFrame.midX)
+    }
+
+    @Test func panelIgnoresInsetWhenMenuBarIsVisible() {
+        // Visible menu bar already reserves the strip; the inset must not
+        // push the panel down a second time.
+        let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1440, height: 868)
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame,
+            preferredSize: CGSize(width: 600, height: 500),
+            hiddenMenuBarInset: 32
+        )
+
+        #expect(placement.frame.maxY == visibleFrame.maxY)
+    }
+
     @Test func alertContentTopPaddingMatchesMenuBarGap() {
         let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let visibleFrame = CGRect(x: 0, y: 0, width: 1440, height: 868)

--- a/Packages/OsaurusCore/Views/Common/AnimatedProgressComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedProgressComponents.swift
@@ -377,14 +377,19 @@ private struct CheckmarkShape: Shape {
         let width = rect.width
         let height = rect.height
 
+        // Points are chosen so the glyph's bounding box is symmetric around
+        // the rect center (x: 0.05–0.95, y: 0.2–0.8) — an off-center box
+        // reads as a visibly misaligned checkmark inside the status circle
+        // at small sizes.
+
         // Start at left point
-        path.move(to: CGPoint(x: width * 0.1, y: height * 0.5))
+        path.move(to: CGPoint(x: width * 0.05, y: height * 0.5))
 
         // Line to bottom point
-        path.addLine(to: CGPoint(x: width * 0.4, y: height * 0.85))
+        path.addLine(to: CGPoint(x: width * 0.35, y: height * 0.8))
 
         // Line to top-right point
-        path.addLine(to: CGPoint(x: width * 0.95, y: height * 0.15))
+        path.addLine(to: CGPoint(x: width * 0.95, y: height * 0.2))
 
         return path
     }

--- a/Packages/OsaurusCore/Views/Common/AnimatedProgressComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedProgressComponents.swift
@@ -340,58 +340,34 @@ private struct SmallSpinnerShape: Shape {
 
 // MARK: - Completed Checkmark Icon
 
+/// SF Symbol checkmark with a spring pop-in. The symbol centers itself via
+/// font metrics — the previous hand-drawn trim-animated path sat visibly
+/// off-center inside the circle at small sizes — and matches the `xmark`
+/// symbol the failed state uses.
 private struct CompletedCheckmarkIcon: View {
     let theme: ThemeProtocol
     let size: CGFloat
 
-    @State private var checkmarkProgress: CGFloat = 0
+    @State private var revealed = false
 
     var body: some View {
         ZStack {
             Circle()
                 .fill(theme.successColor)
                 .frame(width: size, height: size)
-                .scaleEffect(checkmarkProgress > 0 ? 1 : 0.5)
+                .scaleEffect(revealed ? 1 : 0.5)
 
-            // Checkmark path
-            CheckmarkShape()
-                .trim(from: 0, to: checkmarkProgress)
-                .stroke(Color.white, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
-                .frame(width: size * 0.5, height: size * 0.5)
+            Image(systemName: "checkmark")
+                .font(.system(size: size * 0.5, weight: .bold))
+                .foregroundColor(.white)
+                .scaleEffect(revealed ? 1 : 0.4)
+                .opacity(revealed ? 1 : 0)
         }
         .onAppear {
             withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
-                checkmarkProgress = 1
+                revealed = true
             }
         }
-    }
-}
-
-// MARK: - Checkmark Shape
-
-/// Custom shape for animated checkmark drawing
-private struct CheckmarkShape: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-
-        let width = rect.width
-        let height = rect.height
-
-        // Points are chosen so the glyph's bounding box is symmetric around
-        // the rect center (x: 0.05–0.95, y: 0.2–0.8) — an off-center box
-        // reads as a visibly misaligned checkmark inside the status circle
-        // at small sizes.
-
-        // Start at left point
-        path.move(to: CGPoint(x: width * 0.05, y: height * 0.5))
-
-        // Line to bottom point
-        path.addLine(to: CGPoint(x: width * 0.35, y: height * 0.8))
-
-        // Line to top-right point
-        path.addLine(to: CGPoint(x: width * 0.95, y: height * 0.2))
-
-        return path
     }
 }
 

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -651,7 +651,12 @@ struct NotchView: View {
                 withAnimation(.easeOut(duration: 0.25)) { contentRevealed = true }
             }
         } else {
-            withAnimation(.easeOut(duration: 0.15)) { contentRevealed = false }
+            // Fade the content over the same window as the frame's settle
+            // spring. A fast fade makes the card read as "already collapsed"
+            // the instant the content blinks out, so the frame's shrink looks
+            // abrupt even though it animates — the eye tracks the content,
+            // not the border.
+            withAnimation(.easeInOut(duration: 0.3)) { contentRevealed = false }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -238,6 +238,19 @@ struct NotchView: View {
         .spring(response: 0.45, dampingFraction: 0.68, blendDuration: 0.1)
     }
 
+    /// Collapse animation. The bouncy `swingSpring` reads as playful on the
+    /// way open but as judder on the way closed — the card overshoots past
+    /// pill size and rebounds after its content has already faded. Nearly
+    /// critically damped so the collapse settles in one motion.
+    private var settleSpring: Animation {
+        .spring(response: 0.38, dampingFraction: 0.9, blendDuration: 0.1)
+    }
+
+    /// Direction-aware animation for expansion-state changes.
+    private var expansionAnimation: Animation {
+        expansion == .expanded ? swingSpring : settleSpring
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -253,7 +266,7 @@ struct NotchView: View {
             }
         }
         .padding(.top, windowController.alertContentTopPadding)
-        .animation(swingSpring, value: expansion)
+        .animation(expansionAnimation, value: expansion)
         .animation(swingSpring, value: sortedTasks.map(\.id))
         .animation(swingSpring, value: activeTaskIndex)
         .onChange(of: sortedTasks.count) { _, newCount in
@@ -311,7 +324,7 @@ struct NotchView: View {
         guard hovering != isHovering else { return }
         let delay = hovering ? 0.15 : 0.2
         let work = DispatchWorkItem {
-            withAnimation(swingSpring) { isHovering = hovering }
+            withAnimation(hovering ? swingSpring : settleSpring) { isHovering = hovering }
         }
         hoverTransitionWorkItem = work
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -98,8 +98,10 @@ struct NotchView: View {
     @State private var showCancelConfirmation = false
     @State private var contentRevealed = false
     @State private var absorbingTaskIds: Set<UUID> = []
-    /// Pending hover-intent dwell before the trigger zone expands the notch.
-    @State private var hoverExpandWorkItem: DispatchWorkItem?
+    /// Pending debounced hover transition (dwell before expanding, grace
+    /// period before collapsing). Cancelled whenever the hover state flips
+    /// again before the deadline.
+    @State private var hoverTransitionWorkItem: DispatchWorkItem?
 
     // MARK: - Metrics & Colors
 
@@ -297,25 +299,22 @@ struct NotchView: View {
 
     /// Hover on the notch body — the only entry point for expansion, sized
     /// by whatever is actually rendered (compact pill or expanded card).
-    /// Expansion requires a short dwell: the pill floats over whatever
-    /// window sits below (e.g. a browser's tab strip), so a cursor merely
-    /// passing through on its way to that window must not balloon the card
-    /// open and steal the click. Leaving cancels a pending dwell and
-    /// collapses immediately; once expanded, staying inside the card keeps
-    /// it open with no further dwell.
+    /// Both directions are debounced. Expanding requires a short dwell: the
+    /// pill floats over whatever window sits below (e.g. a browser's tab
+    /// strip), so a cursor merely passing through on its way to that window
+    /// must not balloon the card open and steal the click. Collapsing gets a
+    /// grace period so skimming the card's edge (or the jitter of a hand
+    /// coming to rest) doesn't slam it shut and replay the animation.
     private func handleBodyHover(_ hovering: Bool) {
-        hoverExpandWorkItem?.cancel()
-        hoverExpandWorkItem = nil
-        if hovering {
-            guard !isHovering else { return }
-            let work = DispatchWorkItem {
-                withAnimation(swingSpring) { isHovering = true }
-            }
-            hoverExpandWorkItem = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
-        } else {
-            withAnimation(swingSpring) { isHovering = false }
+        hoverTransitionWorkItem?.cancel()
+        hoverTransitionWorkItem = nil
+        guard hovering != isHovering else { return }
+        let delay = hovering ? 0.15 : 0.2
+        let work = DispatchWorkItem {
+            withAnimation(swingSpring) { isHovering = hovering }
         }
+        hoverTransitionWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
     }
 
     // MARK: - Content Switching

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -350,7 +350,16 @@ struct NotchView: View {
                             .combined(with: .scale(scale: 0.6, anchor: .top))
                             .combined(with: .opacity)
                     )
-                    : .opacity
+                    // Plain .opacity removal leaves a full-size ghost of the
+                    // card cross-fading over the already-final-size pill, so
+                    // the collapse reads as an abrupt size snap. Scaling the
+                    // outgoing card toward its top anchor makes it visibly
+                    // retract into the pill instead.
+                    : .asymmetric(
+                        insertion: .opacity,
+                        removal: .scale(scale: 0.12, anchor: .top)
+                            .combined(with: .opacity)
+                    )
             )
         }
     }

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -547,6 +547,19 @@ struct NotchView: View {
             Spacer()
         }
         .padding(.top, 2)
+        // Dismiss every finished task at once instead of forcing the user to
+        // surface and close each dot individually. Running tasks are left
+        // untouched — mass-cancelling them silently would be destructive.
+        .overlay(alignment: .trailing) {
+            if finishedTasks.count > 1 {
+                Button(action: handleDismissAllFinished) {
+                    Text("Clear All", bundle: .module)
+                        .font(.system(size: 9.5, weight: .medium))
+                        .foregroundColor(notchTertiaryText)
+                }
+                .buttonStyle(.plain)
+            }
+        }
     }
 
     // MARK: - Background & Border
@@ -615,6 +628,26 @@ struct NotchView: View {
             }
         } else {
             withAnimation(.easeOut(duration: 0.15)) { contentRevealed = false }
+        }
+    }
+
+    private var finishedTasks: [BackgroundTaskState] {
+        sortedTasks.filter { !$0.status.isActive }
+    }
+
+    /// Absorb-and-finalize every finished task in one action ("Clear All").
+    /// Mirrors the single-task dismiss path in `handleDismiss`.
+    private func handleDismissAllFinished() {
+        let finished = finishedTasks
+        guard !finished.isEmpty else { return }
+        withAnimation(swingSpring) {
+            absorbingTaskIds.formUnion(finished.map(\.id))
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+            for task in finished {
+                BackgroundTaskManager.shared.finalizeTask(task.id)
+                absorbingTaskIds.remove(task.id)
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -88,17 +88,18 @@ struct NotchView: View {
 
     // MARK: - State
 
-    /// Split hover tracking: trigger zone (top strip) + body (expanded content).
-    @State private var isHoveringTrigger = false
-    @State private var isHoveringBody = false
+    /// Single hover flag driven by the notch body's own bounds. The hover
+    /// region therefore always matches what's on screen: the compact pill,
+    /// or the expanded card once open. (A previous split trigger-strip +
+    /// body-content scheme let the collapsing card re-report hover from the
+    /// area below the pill and ping-pong the expansion.)
+    @State private var isHovering = false
     @State private var activeTaskIndex: Int = 0
     @State private var showCancelConfirmation = false
     @State private var contentRevealed = false
     @State private var absorbingTaskIds: Set<UUID> = []
     /// Pending hover-intent dwell before the trigger zone expands the notch.
     @State private var hoverExpandWorkItem: DispatchWorkItem?
-
-    private var isHovering: Bool { isHoveringTrigger || isHoveringBody }
 
     // MARK: - Metrics & Colors
 
@@ -258,8 +259,7 @@ struct NotchView: View {
                 activeTaskIndex = max(0, newCount - 1)
             }
         }
-        .onChange(of: isHoveringTrigger) { _, _ in handleHoverChange() }
-        .onChange(of: isHoveringBody) { _, _ in handleHoverChange() }
+        .onChange(of: isHovering) { _, _ in handleHoverChange() }
     }
 
     // MARK: - Notch Body
@@ -273,7 +273,7 @@ struct NotchView: View {
             .clipShape(currentShape)
             .contentShape(currentShape)
             .overlay(notchBorderOverlay)
-            .overlay(alignment: .top) { hoverTriggerZone }
+            .onHover(perform: handleBodyHover)
             .shadow(
                 color: Color.black.opacity(expansion == .compact ? 0 : (isHovering ? 0.6 : 0.4)),
                 radius: expansion == .compact ? 0 : (isHovering ? 20 : 12),
@@ -295,29 +295,27 @@ struct NotchView: View {
             )
     }
 
-    /// Thin strip at the top that triggers hover — the only entry point for
-    /// expansion. Expansion requires a short dwell: the pill floats over
-    /// whatever window sits below (e.g. a browser's tab strip), so a cursor
-    /// merely passing through on its way to that window must not balloon the
-    /// card open and steal the click. Leaving cancels a pending dwell and
-    /// collapses immediately.
-    private var hoverTriggerZone: some View {
-        Color.clear
-            .frame(width: metrics.notchWidth + 60, height: metrics.notchHeight)
-            .contentShape(Rectangle())
-            .onHover { hovering in
-                hoverExpandWorkItem?.cancel()
-                hoverExpandWorkItem = nil
-                if hovering {
-                    let work = DispatchWorkItem {
-                        withAnimation(swingSpring) { isHoveringTrigger = true }
-                    }
-                    hoverExpandWorkItem = work
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
-                } else {
-                    withAnimation(swingSpring) { isHoveringTrigger = false }
-                }
+    /// Hover on the notch body — the only entry point for expansion, sized
+    /// by whatever is actually rendered (compact pill or expanded card).
+    /// Expansion requires a short dwell: the pill floats over whatever
+    /// window sits below (e.g. a browser's tab strip), so a cursor merely
+    /// passing through on its way to that window must not balloon the card
+    /// open and steal the click. Leaving cancels a pending dwell and
+    /// collapses immediately; once expanded, staying inside the card keeps
+    /// it open with no further dwell.
+    private func handleBodyHover(_ hovering: Bool) {
+        hoverExpandWorkItem?.cancel()
+        hoverExpandWorkItem = nil
+        if hovering {
+            guard !isHovering else { return }
+            let work = DispatchWorkItem {
+                withAnimation(swingSpring) { isHovering = true }
             }
+            hoverExpandWorkItem = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+        } else {
+            withAnimation(swingSpring) { isHovering = false }
+        }
     }
 
     // MARK: - Content Switching
@@ -422,9 +420,6 @@ struct NotchView: View {
             .offset(y: contentRevealed ? 0 : 8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .onHover { hovering in
-            withAnimation(swingSpring) { isHoveringBody = hovering }
-        }
     }
 
     private var expandedHeader: some View {

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -95,6 +95,8 @@ struct NotchView: View {
     @State private var showCancelConfirmation = false
     @State private var contentRevealed = false
     @State private var absorbingTaskIds: Set<UUID> = []
+    /// Pending hover-intent dwell before the trigger zone expands the notch.
+    @State private var hoverExpandWorkItem: DispatchWorkItem?
 
     private var isHovering: Bool { isHoveringTrigger || isHoveringBody }
 
@@ -293,13 +295,28 @@ struct NotchView: View {
             )
     }
 
-    /// Thin strip at the top that triggers hover — the only entry point for expansion.
+    /// Thin strip at the top that triggers hover — the only entry point for
+    /// expansion. Expansion requires a short dwell: the pill floats over
+    /// whatever window sits below (e.g. a browser's tab strip), so a cursor
+    /// merely passing through on its way to that window must not balloon the
+    /// card open and steal the click. Leaving cancels a pending dwell and
+    /// collapses immediately.
     private var hoverTriggerZone: some View {
         Color.clear
             .frame(width: metrics.notchWidth + 60, height: metrics.notchHeight)
             .contentShape(Rectangle())
             .onHover { hovering in
-                withAnimation(swingSpring) { isHoveringTrigger = hovering }
+                hoverExpandWorkItem?.cancel()
+                hoverExpandWorkItem = nil
+                if hovering {
+                    let work = DispatchWorkItem {
+                        withAnimation(swingSpring) { isHoveringTrigger = true }
+                    }
+                    hoverExpandWorkItem = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+                } else {
+                    withAnimation(swingSpring) { isHoveringTrigger = false }
+                }
             }
     }
 

--- a/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
@@ -55,7 +55,8 @@ struct NotchPanelPlacement: Equatable {
     static func panelRect(
         screenFrame: CGRect,
         visibleFrame: CGRect,
-        preferredSize: CGSize
+        preferredSize: CGSize,
+        hiddenMenuBarInset: CGFloat = 0
     ) -> NotchPanelPlacement {
         let safeFrame = visibleFrame.isEmpty ? screenFrame : visibleFrame
         let width = min(preferredSize.width, max(1, safeFrame.width))
@@ -64,7 +65,15 @@ struct NotchPanelPlacement: Equatable {
         let minX = safeFrame.minX
         let maxX = safeFrame.maxX - width
         let x = min(max(centeredX, minX), maxX)
-        let y = safeFrame.maxY - height
+        // When the menu bar auto-hides, `visibleFrame` extends to the very top
+        // of the screen, which would place the panel exactly in the strip
+        // where the menu bar reappears — overlapping the clock / status icons
+        // whenever it reveals. Reserve that strip explicitly in that case.
+        let topY =
+            safeFrame.maxY >= screenFrame.maxY
+            ? safeFrame.maxY - hiddenMenuBarInset
+            : safeFrame.maxY
+        let y = topY - height
 
         return NotchPanelPlacement(frame: CGRect(x: x, y: y, width: width, height: height))
     }
@@ -275,12 +284,15 @@ public final class NotchWindowController: NSObject, ObservableObject {
         isExpandedForAlert = alertActive
     }
 
-    /// Panel positioned at the top of the usable display area, below the menu bar.
+    /// Panel positioned at the top of the usable display area, below the menu
+    /// bar — including the reveal strip of an auto-hidden menu bar, which
+    /// `visibleFrame` does not reserve.
     private func panelRect(for screen: NSScreen) -> NSRect {
         NotchPanelPlacement.panelRect(
             screenFrame: screen.frame,
             visibleFrame: screen.visibleFrame,
-            preferredSize: CGSize(width: Self.panelWidth, height: Self.panelHeight)
+            preferredSize: CGSize(width: Self.panelWidth, height: Self.panelHeight),
+            hiddenMenuBarInset: NotchScreenMetrics.detect(for: screen).notchHeight
         ).frame
     }
 


### PR DESCRIPTION
## Summary

  Closes #1818

  - kept the task progress notch below the menu bar reveal strip when "Automatically hide and show the menu bar" is enabled. the panel previously sat flush with the top of the screen and overlapped the clock and status icons whenever the menu bar reappeared
  - added a "Clear All" action next to the task dots so multiple finished tasks can be dismissed at once instead of one by one (running tasks are left untouched)
  - required a short hover dwell before the notch expands so a cursor passing through on its way to a window underneath (like. browser tabs) no longer balloons the card open and steals the click
  - tracked hover on the rendered notch body itself to fix a glitch where the collapsing card kept re-expanding when the cursor was below the pill
  - debounced collapse with a short grace period so skimming the card's edge doesn't slam it shut
  - made the collapse animation retract the card into the pill with a settle spring instead of an abrupt size snap
  - replaced the hand-drawn completion checkmark with the SF Symbol to fix its off-center alignment inside the status circle and matching the failure icon
  - added regression tests for the new panel placement behavior

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
