### PR TITLE
Add Agent Channels live proof readiness

### DIFF
--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelLiveProofReadiness.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelLiveProofReadiness.swift
@@ -1,0 +1,203 @@
+//
+//  AgentChannelLiveProofReadiness.swift
+//  osaurus
+//
+//  Release-proof readiness classification for native Agent Channels.
+//
+
+import Foundation
+
+enum AgentChannelLiveProofStatus: String, Equatable, Sendable {
+    case ready
+    case blocked
+}
+
+struct AgentChannelLiveProofReadinessReport: Equatable, Sendable {
+    let kind: AgentChannelKind
+    let status: AgentChannelLiveProofStatus
+    let blockers: [String]
+    let manualProof: [String]
+    let notes: [String]
+
+    var isReadyForLiveProof: Bool {
+        status == .ready
+    }
+}
+
+enum AgentChannelFeedbackSource: Equatable, Sendable {
+    case nativeAgentChannel(AgentChannelKind)
+    case legacyTelegramPlugin
+    case unknown
+}
+
+struct AgentChannelFeedbackRouting: Equatable, Sendable {
+    let source: AgentChannelFeedbackSource
+    let appliesToNativeChannels: Bool
+    let guidance: String
+}
+
+enum AgentChannelLiveProofReadiness {
+    static func telegram(_ diagnostics: TelegramConnectionDiagnostics) -> AgentChannelLiveProofReadinessReport {
+        var blockers: [String] = []
+        var manualProof: [String] = []
+        var notes: [String] = diagnostics.notes
+        let readableChatIds = nonEmptyEntries(diagnostics.readableChatIds)
+        let writableChatIds = nonEmptyEntries(diagnostics.writableChatIds)
+        let senderAllowlist = nonEmptyEntries(diagnostics.senderAllowlist)
+
+        if !diagnostics.tokenSaved {
+            blockers.append("Save a Telegram bot token.")
+        }
+        if diagnostics.bot == nil {
+            blockers.append("Run Test Connection until Telegram accepts the bot token.")
+        }
+        if !diagnostics.receiveStorageEnabled {
+            blockers.append("Enable Store Incoming Messages for receive proof.")
+        }
+        if !diagnostics.longPollingEnabled {
+            blockers.append("Enable Long Polling for local desktop receive proof.")
+        }
+        if diagnostics.webhook?.registered == true {
+            blockers.append("Remove the registered Telegram webhook before long polling.")
+        }
+        if diagnostics.bot != nil && diagnostics.longPollingEnabled && diagnostics.webhook == nil {
+            blockers.append("Verify no Telegram webhook is registered before long polling proof.")
+        }
+        if let probeError = diagnostics.webhook?.probeError {
+            blockers.append("Verify Telegram webhook state before long polling proof: \(probeError)")
+        }
+        if readableChatIds.isEmpty {
+            blockers.append("Add at least one readable Telegram chat id.")
+        }
+        if senderAllowlist.isEmpty {
+            blockers.append("Add at least one authorized Telegram sender id.")
+        }
+        if diagnostics.writeEnabled && writableChatIds.isEmpty {
+            blockers.append("Add at least one writable Telegram chat id or turn writes off.")
+        }
+        appendDiagnosticFailures(diagnostics.failures, to: &blockers)
+
+        if diagnostics.writeEnabled {
+            manualProof.append("Send one confirmed message to a write-allowlisted Telegram chat.")
+        } else {
+            notes.append("Telegram writes are off; live proof can cover receive/read-only behavior.")
+        }
+        manualProof.append("Send one inbound Telegram message from an authorized sender.")
+        manualProof.append("Confirm an unauthorized sender in the same group is ignored.")
+        manualProof.append("Restart Osaurus and confirm the Telegram inbox and configuration persist.")
+
+        return AgentChannelLiveProofReadinessReport(
+            kind: .telegram,
+            status: blockers.isEmpty ? .ready : .blocked,
+            blockers: blockers,
+            manualProof: manualProof,
+            notes: notes
+        )
+    }
+
+    static func slack(_ diagnostics: SlackConnectionDiagnostics) -> AgentChannelLiveProofReadinessReport {
+        var blockers: [String] = []
+        var manualProof: [String] = []
+        var notes: [String] = []
+        let readableChannelIds = nonEmptyEntries(diagnostics.readableChannelIds)
+        let writableChannelIds = nonEmptyEntries(diagnostics.writableChannelIds)
+        let senderAllowlist = nonEmptyEntries(diagnostics.senderAllowlist)
+
+        if !diagnostics.botTokenSaved {
+            blockers.append("Save a Slack bot token.")
+        }
+        if !diagnostics.signingSecretSaved {
+            notes.append("Signed Slack HTTP event proof is unavailable until a signing secret is saved.")
+        }
+        if !diagnostics.appTokenSaved {
+            blockers.append("Save a Slack Socket Mode app token for local desktop receive proof.")
+        }
+        if diagnostics.identity == nil {
+            blockers.append("Run Test Connection until Slack accepts the bot token.")
+        }
+        if diagnostics.configuredTeams.isEmpty {
+            blockers.append("Add the Slack workspace/team id to the configured team allowlist.")
+        } else {
+            let rejectedTeams = diagnostics.configuredTeams.filter { $0.status != "accessible" }
+            for team in rejectedTeams {
+                blockers.append("Allowlisted Slack team \(team.id) is not usable: \(team.reason ?? team.status).")
+            }
+        }
+        if readableChannelIds.isEmpty {
+            blockers.append("Add at least one readable Slack channel id.")
+        }
+        if senderAllowlist.isEmpty {
+            blockers.append("Add at least one authorized Slack sender id.")
+        }
+        if diagnostics.writeEnabled && writableChannelIds.isEmpty {
+            blockers.append("Add at least one writable Slack channel id or turn writes off.")
+        }
+        if diagnostics.allowBroadcastMentions {
+            notes.append("Broadcast mentions are enabled; release proof should confirm this is intentional.")
+        }
+        appendDiagnosticFailures(diagnostics.failures, to: &blockers)
+
+        if diagnostics.writeEnabled {
+            manualProof.append("Send one confirmed message to a write-allowlisted Slack channel.")
+        } else {
+            notes.append("Slack writes are off; live proof can cover receive/read-only behavior.")
+        }
+        manualProof.append("Receive one Slack message through Socket Mode from an authorized sender.")
+        manualProof.append("Confirm an unauthorized sender in the same channel is ignored.")
+        manualProof.append("Restart Osaurus and confirm Slack transport health and configuration persist.")
+
+        return AgentChannelLiveProofReadinessReport(
+            kind: .slack,
+            status: blockers.isEmpty ? .ready : .blocked,
+            blockers: blockers,
+            manualProof: manualProof,
+            notes: notes
+        )
+    }
+
+    static func routeFeedback(source: AgentChannelFeedbackSource) -> AgentChannelFeedbackRouting {
+        switch source {
+        case .nativeAgentChannel(let kind):
+            return AgentChannelFeedbackRouting(
+                source: source,
+                appliesToNativeChannels: true,
+                guidance: "Investigate the native \(providerName(kind)) Agent Channel path."
+            )
+        case .legacyTelegramPlugin:
+            return AgentChannelFeedbackRouting(
+                source: source,
+                appliesToNativeChannels: false,
+                guidance: "Investigate the legacy Telegram plugin separately. Do not claim the native Telegram Agent Channel fixed this path until the plugin is tested or a migration is complete."
+            )
+        case .unknown:
+            return AgentChannelFeedbackRouting(
+                source: source,
+                appliesToNativeChannels: false,
+                guidance: "Clarify whether the report came from native Agent Channels or a legacy plugin before assigning it to the channel implementation."
+            )
+        }
+    }
+
+    private static func providerName(_ kind: AgentChannelKind) -> String {
+        switch kind {
+        case .discord:
+            return "Discord"
+        case .slack:
+            return "Slack"
+        case .telegram:
+            return "Telegram"
+        case .customHTTP:
+            return "Custom HTTP"
+        }
+    }
+
+    private static func nonEmptyEntries(_ values: [String]) -> [String] {
+        values.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    }
+
+    private static func appendDiagnosticFailures(_ failures: [String], to blockers: inout [String]) {
+        for failure in failures where !failure.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            blockers.append(failure)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelLiveProofReadinessTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelLiveProofReadinessTests.swift
@@ -1,0 +1,269 @@
+//
+//  AgentChannelLiveProofReadinessTests.swift
+//  osaurusTests
+//
+//  Tests for release-proof readiness and plugin-vs-channel feedback routing.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct AgentChannelLiveProofReadinessTests {
+
+    @Test func telegramTokenOnlyIsBlockedForReceiveProof() {
+        let report = AgentChannelLiveProofReadiness.telegram(
+            TelegramConnectionDiagnostics(
+                tokenSaved: true,
+                bot: nil,
+                readableChatIds: [],
+                writableChatIds: [],
+                senderAllowlist: [],
+                writeEnabled: false,
+                receiveStorageEnabled: true,
+                longPollingEnabled: false,
+                status: "connected_receive_long_poll_disabled",
+                failures: []
+            )
+        )
+
+        #expect(report.kind == .telegram)
+        #expect(report.status == .blocked)
+        #expect(!report.isReadyForLiveProof)
+        #expect(report.blockers.contains("Run Test Connection until Telegram accepts the bot token."))
+        #expect(report.blockers.contains("Enable Long Polling for local desktop receive proof."))
+        #expect(report.blockers.contains("Add at least one readable Telegram chat id."))
+        #expect(report.blockers.contains("Add at least one authorized Telegram sender id."))
+    }
+
+    @Test func telegramWebhookConflictBlocksLongPollProof() {
+        let report = AgentChannelLiveProofReadiness.telegram(
+            TelegramConnectionDiagnostics(
+                tokenSaved: true,
+                bot: .fixtureBot,
+                readableChatIds: ["-100111222333"],
+                writableChatIds: ["-100111222333"],
+                senderAllowlist: ["123456789"],
+                writeEnabled: true,
+                receiveStorageEnabled: true,
+                longPollingEnabled: true,
+                webhook: TelegramWebhookDiagnostic(
+                    registered: true,
+                    redactedURL: "https://example.test/***",
+                    pendingUpdateCount: 1,
+                    probeError: nil
+                ),
+                status: "connected_long_poll_webhook_conflict",
+                failures: []
+            )
+        )
+
+        #expect(report.status == .blocked)
+        #expect(report.blockers == ["Remove the registered Telegram webhook before long polling."])
+    }
+
+    @Test func telegramCompleteReadWriteSetupIsReadyButRequiresManualProof() {
+        let report = AgentChannelLiveProofReadiness.telegram(
+            TelegramConnectionDiagnostics(
+                tokenSaved: true,
+                bot: .fixtureBot,
+                readableChatIds: ["-100111222333"],
+                writableChatIds: ["-100111222333"],
+                senderAllowlist: ["123456789"],
+                writeEnabled: true,
+                receiveStorageEnabled: true,
+                longPollingEnabled: true,
+                webhook: TelegramWebhookDiagnostic(
+                    registered: false,
+                    redactedURL: "",
+                    pendingUpdateCount: 0,
+                    probeError: nil
+                ),
+                status: "connected_read_write",
+                failures: []
+            )
+        )
+
+        #expect(report.status == .ready)
+        #expect(report.isReadyForLiveProof)
+        #expect(report.blockers.isEmpty)
+        #expect(report.manualProof.contains("Send one inbound Telegram message from an authorized sender."))
+        #expect(report.manualProof.contains("Confirm an unauthorized sender in the same group is ignored."))
+        #expect(report.manualProof.contains("Send one confirmed message to a write-allowlisted Telegram chat."))
+    }
+
+    @Test func telegramWebhookProbeFailureBlocksReadiness() {
+        let report = AgentChannelLiveProofReadiness.telegram(
+            TelegramConnectionDiagnostics(
+                tokenSaved: true,
+                bot: .fixtureBot,
+                readableChatIds: ["-100111222333"],
+                writableChatIds: [],
+                senderAllowlist: ["123456789"],
+                writeEnabled: false,
+                receiveStorageEnabled: true,
+                longPollingEnabled: true,
+                webhook: TelegramWebhookDiagnostic(
+                    registered: false,
+                    redactedURL: "",
+                    pendingUpdateCount: nil,
+                    probeError: "network unavailable"
+                ),
+                status: "connected_read_only",
+                failures: []
+            )
+        )
+
+        #expect(report.status == .blocked)
+        #expect(report.blockers == [
+            "Verify Telegram webhook state before long polling proof: network unavailable",
+        ])
+    }
+
+    @Test func telegramBlankAllowlistEntriesDoNotCountAsSecurityProof() {
+        let report = AgentChannelLiveProofReadiness.telegram(
+            TelegramConnectionDiagnostics(
+                tokenSaved: true,
+                bot: .fixtureBot,
+                readableChatIds: [" "],
+                writableChatIds: ["\n"],
+                senderAllowlist: ["\t"],
+                writeEnabled: true,
+                receiveStorageEnabled: true,
+                longPollingEnabled: true,
+                webhook: TelegramWebhookDiagnostic(
+                    registered: false,
+                    redactedURL: "",
+                    pendingUpdateCount: 0,
+                    probeError: nil
+                ),
+                status: "connected_read_write",
+                failures: []
+            )
+        )
+
+        #expect(report.status == .blocked)
+        #expect(report.blockers.contains("Add at least one readable Telegram chat id."))
+        #expect(report.blockers.contains("Add at least one authorized Telegram sender id."))
+        #expect(report.blockers.contains("Add at least one writable Telegram chat id or turn writes off."))
+    }
+
+    @Test func slackMissingSocketModeCredentialIsBlocked() {
+        let report = AgentChannelLiveProofReadiness.slack(
+            SlackConnectionDiagnostics(
+                botTokenSaved: true,
+                signingSecretSaved: true,
+                appTokenSaved: false,
+                identity: .fixture,
+                configuredTeams: [
+                    SlackConfiguredTeamDiagnostic(id: "T12345", name: "Example", status: "accessible", reason: nil),
+                ],
+                readableChannelIds: ["C12345"],
+                writableChannelIds: [],
+                senderAllowlist: ["U12345"],
+                writeEnabled: false,
+                allowBroadcastMentions: false,
+                status: "connected_read_only",
+                failures: []
+            )
+        )
+
+        #expect(report.kind == .slack)
+        #expect(report.status == .blocked)
+        #expect(report.blockers == ["Save a Slack Socket Mode app token for local desktop receive proof."])
+    }
+
+    @Test func slackCompleteSocketModeSetupIsReady() {
+        let report = AgentChannelLiveProofReadiness.slack(
+            SlackConnectionDiagnostics(
+                botTokenSaved: true,
+                signingSecretSaved: false,
+                appTokenSaved: true,
+                identity: .fixture,
+                configuredTeams: [
+                    SlackConfiguredTeamDiagnostic(id: "T12345", name: "Example", status: "accessible", reason: nil),
+                ],
+                readableChannelIds: ["C12345"],
+                writableChannelIds: ["C12345"],
+                senderAllowlist: ["U12345"],
+                writeEnabled: true,
+                allowBroadcastMentions: false,
+                status: "connected_read_write",
+                failures: []
+            )
+        )
+
+        #expect(report.status == .ready)
+        #expect(report.isReadyForLiveProof)
+        #expect(report.blockers.isEmpty)
+        #expect(report.notes == ["Signed Slack HTTP event proof is unavailable until a signing secret is saved."])
+        #expect(report.manualProof.contains("Receive one Slack message through Socket Mode from an authorized sender."))
+        #expect(report.manualProof.contains("Send one confirmed message to a write-allowlisted Slack channel."))
+    }
+
+    @Test func slackDiagnosticFailuresBlockReadiness() {
+        let report = AgentChannelLiveProofReadiness.slack(
+            SlackConnectionDiagnostics(
+                botTokenSaved: true,
+                signingSecretSaved: true,
+                appTokenSaved: true,
+                identity: .fixture,
+                configuredTeams: [
+                    SlackConfiguredTeamDiagnostic(id: "T12345", name: "Example", status: "accessible", reason: nil),
+                ],
+                readableChannelIds: ["C12345"],
+                writableChannelIds: [],
+                senderAllowlist: ["U12345"],
+                writeEnabled: false,
+                allowBroadcastMentions: false,
+                status: "token_invalid_or_unavailable",
+                failures: ["Slack API token check failed."]
+            )
+        )
+
+        #expect(report.status == .blocked)
+        #expect(report.blockers == ["Slack API token check failed."])
+    }
+
+    @Test func legacyTelegramPluginFeedbackDoesNotApplyToNativeChannels() {
+        let routing = AgentChannelLiveProofReadiness.routeFeedback(source: .legacyTelegramPlugin)
+
+        #expect(routing.source == .legacyTelegramPlugin)
+        #expect(!routing.appliesToNativeChannels)
+        #expect(routing.guidance.contains("legacy Telegram plugin"))
+        #expect(routing.guidance.contains("Do not claim the native Telegram Agent Channel fixed this path"))
+    }
+
+    @Test func nativeChannelFeedbackRoutesToNativeChannelPath() {
+        let routing = AgentChannelLiveProofReadiness.routeFeedback(source: .nativeAgentChannel(.telegram))
+
+        #expect(routing.appliesToNativeChannels)
+        #expect(routing.guidance == "Investigate the native Telegram Agent Channel path.")
+    }
+}
+
+private extension TelegramUser {
+    static var fixtureBot: TelegramUser {
+        TelegramUser(
+            id: 42,
+            isBot: true,
+            firstName: "Osaurus",
+            lastName: nil,
+            username: "osaurus_test_bot"
+        )
+    }
+}
+
+private extension SlackAuthIdentity {
+    static var fixture: SlackAuthIdentity {
+        SlackAuthIdentity(
+            url: "https://example.slack.com/",
+            team: "Example",
+            user: "osaurus",
+            teamId: "T12345",
+            userId: "U12345",
+            botId: "B12345"
+        )
+    }
+}

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -97,6 +97,33 @@ and
 Primary desktop transports are Slack Socket Mode and Telegram long-poll; public
 webhooks are advanced/future proof paths.
 
+## Release Readiness and Plugin Migration
+
+Native Agent Channels should be treated as ready for testing only after the
+connection is configured and the live proof checklist passes. A saved credential
+is not enough. Telegram receive, for example, also needs local message storage,
+long polling, readable chat ids, authorized sender ids, and no active webhook
+for the same bot token.
+
+Use the native readiness classifier in code for support tooling or future UI:
+
+- Slack local desktop receive proof is blocked until the bot and Socket Mode
+  credentials are saved, the workspace/team is allowlisted, readable channels
+  exist, and authorized senders are configured. Signed HTTP event proof also
+  requires the signing secret.
+- Telegram is blocked until the bot token validates, receive storage and long
+  polling are enabled, readable chats and authorized senders are configured, and
+  no webhook conflicts with long polling.
+- Writes remain a separate gate: enabled writes require write-allowlisted
+  destinations and confirmed send calls.
+
+The legacy Telegram plugin remains a separate integration path. User feedback
+from that plugin should be routed to plugin support unless the user confirms
+they configured Settings -> Channels -> Telegram. The plugin can be deprecated
+after native Telegram Channels have real receive/read/write/restart/group-auth
+proof and a clear migration note, but it should not be removed or described as
+fixed by native-channel work before that proof exists.
+
 ## Configuration
 
 Non-secret channel definitions live in `agent-channels.json`. Secrets should be

--- a/docs/AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md
+++ b/docs/AGENT_CHANNELS_SLACK_TELEGRAM_SETUP.md
@@ -23,6 +23,30 @@ Advanced or future transports:
   require a public HTTPS endpoint and `X-Telegram-Bot-Api-Secret-Token`
   verification.
 
+## Native Channels vs. the Legacy Telegram Plugin
+
+The native Telegram Agent Channel and the legacy Telegram plugin are separate
+paths:
+
+| Path | Where it is configured | Receive path | Message store | Review status |
+| --- | --- | --- | --- | --- |
+| Native Telegram Agent Channel | Settings -> Channels -> Telegram | Bot API long polling, with public webhooks reserved for future proof | Agent Channel message store | New replacement path; use this guide for live proof |
+| Legacy Telegram plugin | Plugin installation/configuration flow | Plugin-owned route/webhook behavior | Plugin-owned SQLite database | Keep separate until native Channels are proven |
+
+If feedback says "I put in the Telegram token and nothing happened," first
+confirm which path the user configured. A report from the legacy Telegram plugin
+does not prove a native Agent Channel bug, and a native Agent Channel fix should
+not be claimed as a plugin fix unless the plugin path was tested too.
+
+Deprecation should be staged, not abrupt:
+
+1. Prove native Telegram Agent Channels with the live checklist below.
+2. Document the migration path from plugin configuration to native channel
+   settings.
+3. Keep the plugin available for at least one overlap window.
+4. Mark the plugin deprecated only after native receive, read, write, restart,
+   and group authorization proof is complete.
+
 ## Slack App Manifest
 
 Create a disposable Slack app for a disposable workspace. Use a dedicated bot
@@ -142,6 +166,42 @@ The diagnostics field `receive_ready` is the authoritative signal that the local
 inbox should fill from Telegram. A long-poll transport can still start and then
 report conflict health if Telegram rejects `getUpdates` because a webhook or
 another consumer owns the same bot token.
+
+## Live Proof Checklist
+
+Run this checklist in a disposable workspace/chat before telling a maintainer
+the channel is ready for user testing:
+
+### Telegram
+
+- Bot token saved and **Test Connection** returns bot identity.
+- `Store Incoming Messages` is enabled.
+- `Enable Long Polling` is enabled.
+- At least one readable chat id is allowlisted.
+- At least one authorized sender id is allowlisted.
+- No webhook is registered for the bot token.
+- Send one inbound message from an authorized sender and confirm it appears in
+  the local Agent Channel inbox.
+- Send one inbound message from an unauthorized sender in the same group and
+  confirm it is ignored.
+- If writes are enabled, send one confirmed message to a write-allowlisted chat.
+- Restart Osaurus and confirm configuration and stored messages persist.
+
+### Slack
+
+- Bot token and Socket Mode app token are saved for local desktop receive proof.
+  Signing secret is also saved when signed HTTP event proof is in scope.
+- **Test Connection** returns bot identity and the configured workspace/team is
+  allowlisted.
+- At least one readable channel id is allowlisted.
+- At least one authorized sender id is allowlisted.
+- Send one inbound Socket Mode message from an authorized sender and confirm it
+  appears in the local Agent Channel inbox.
+- Send one inbound message from an unauthorized sender in the same channel and
+  confirm it is ignored.
+- If writes are enabled, send one confirmed message to a write-allowlisted
+  channel.
+- Restart Osaurus and confirm transport health and configuration persist.
 
 Webhook setup is advanced/future. When it is used, set a random webhook secret
 token and verify the `X-Telegram-Bot-Api-Secret-Token` header before decoding


### PR DESCRIPTION
Summary
- Adds a native Agent Channels live-proof readiness classifier for Slack and Telegram.
- Separates native Telegram Channels from the legacy Telegram plugin in support guidance.
- Adds release-readiness docs and live proof checklists for authorized and unauthorized sender behavior.

Scope
- Slack and Telegram channel diagnostics readiness only.
- No MLX, model runtime, prompt, or tool parser changes.
- No UI exposure in this PR; this gives support tooling and future UI a tested readiness model.

Security / Safety
- Treats missing sender, chat, channel, and write allowlists as blockers.
- Blocks readiness when diagnostic failures are present.
- Blocks Telegram long-poll proof when webhook state is conflicting or unverified.
- Clarifies that legacy Telegram plugin reports should not be claimed fixed by native channel work until that path is tested or migrated.

Validation
- `git diff --check`
- `swiftlint --quiet Packages/OsaurusCore/Models/AgentChannel/AgentChannelLiveProofReadiness.swift Packages/OsaurusCore/Tests/AgentChannel/AgentChannelLiveProofReadinessTests.swift`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-channel-live-proof swift test --package-path Packages/OsaurusCore --filter 'AgentChannelLiveProofReadinessTests|AgentChannelStatusPresentationTests|TelegramConnectionTests|SlackConnectionTests'`

Review Notes
- Manual/live validation still recommended with a disposable Slack workspace and Telegram bot/group before calling external user testing complete.
- External review: Fable found Slack readiness and failure-handling blockers; fixed. Grok final pass reported no remaining blocking issues.
