### PR TITLE
added full text conversation search and in-chat find with Cmd+F

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -73,6 +73,11 @@ final class ChatWindowState: ObservableObject {
     /// no view re-renders.
     var cancelInlineEdit: (() -> Void)?
 
+    /// Drives the in-conversation find bar (Cmd+F). Set by the window-level
+    /// key monitor (which cannot touch `ChatView`'s `@State`) and cleared by
+    /// the bar's close button or the Esc dismissal chain.
+    @Published var isFindBarVisible: Bool = false
+
     // MARK: - Agent State
 
     @Published var agentId: UUID

--- a/Packages/OsaurusCore/Models/Chat/ChatFindMatcher.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatFindMatcher.swift
@@ -1,0 +1,78 @@
+//
+//  ChatFindMatcher.swift
+//  osaurus
+//
+//  Pure match logic for the in-conversation find bar (Cmd+F). Extracted from
+//  ChatView so the invariants — role filtering, case-insensitive matching,
+//  current-match preservation across streaming recomputes, and wraparound
+//  navigation — are unit-testable without the view layer.
+//
+
+import Foundation
+
+/// Snapshot of the find bar's match state.
+struct ChatFindState: Equatable {
+    /// Ordered turn ids whose content matches the query.
+    var matchTurnIds: [UUID] = []
+    /// Zero-based index of the current match; 0 when there are no matches.
+    var matchIndex: Int = 0
+}
+
+@MainActor
+enum ChatFindMatcher {
+
+    /// Recompute the match list for `query` over `turns`.
+    ///
+    /// Only user and assistant turns participate, matched by case-insensitive
+    /// substring over their content. When `preserveCurrentMatch` is true (used
+    /// when streaming appends turns mid-search) and the previous current match
+    /// still matches, the index follows it instead of resetting; otherwise the
+    /// index resets to the first match. `jumpTo` is non-nil only when the
+    /// caller asked to jump (`preserveCurrentMatch == false`) and a match
+    /// exists.
+    static func recompute(
+        query: String,
+        turns: [ChatTurn],
+        previous: ChatFindState,
+        preserveCurrentMatch: Bool
+    ) -> (state: ChatFindState, jumpTo: UUID?) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return (ChatFindState(), nil)
+        }
+        let matches = turns
+            .filter { turn in
+                (turn.role == .user || turn.role == .assistant)
+                    && turn.content.range(of: trimmed, options: [.caseInsensitive]) != nil
+            }
+            .map(\.id)
+
+        let previousCurrent =
+            previous.matchTurnIds.indices.contains(previous.matchIndex)
+            ? previous.matchTurnIds[previous.matchIndex] : nil
+        if preserveCurrentMatch, let previousCurrent,
+            let index = matches.firstIndex(of: previousCurrent)
+        {
+            return (ChatFindState(matchTurnIds: matches, matchIndex: index), nil)
+        }
+        return (
+            ChatFindState(matchTurnIds: matches, matchIndex: 0),
+            preserveCurrentMatch ? nil : matches.first
+        )
+    }
+
+    /// Step the current match by `delta`, wrapping at both ends. Returns the
+    /// unchanged state (and no jump target) when there are no matches.
+    static func advance(
+        _ state: ChatFindState,
+        by delta: Int
+    ) -> (state: ChatFindState, jumpTo: UUID?) {
+        let count = state.matchTurnIds.count
+        guard count > 0 else { return (state, nil) }
+        let index = ((state.matchIndex + delta) % count + count) % count
+        return (
+            ChatFindState(matchTurnIds: state.matchTurnIds, matchIndex: index),
+            state.matchTurnIds[index]
+        )
+    }
+}

--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -41,11 +41,16 @@ enum ChatSessionStore {
 
     /// Session ids whose message bodies contain `text` (case-insensitive
     /// substring). Backs the sidebar's full-text search; returns an empty set
-    /// for a blank query or while the database is deferred/closed.
-    static func sessionIds(withContentContaining text: String) -> Set<UUID> {
+    /// for a blank query or while the database is deferred/closed. The scan
+    /// itself runs off the main actor so typing in the search field never
+    /// blocks on the database's serial queue.
+    static func sessionIds(withContentContaining text: String) async -> Set<UUID> {
         ensureOpen()
         guard didOpen else { return [] }
-        return ChatHistoryDatabase.shared.sessionIds(withContentContaining: text)
+        let db = ChatHistoryDatabase.shared
+        return await Task.detached(priority: .userInitiated) {
+            db.sessionIds(withContentContaining: text)
+        }.value
     }
 
     /// Save a session (creates or updates)

--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -39,6 +39,15 @@ enum ChatSessionStore {
         return recovered
     }
 
+    /// Session ids whose message bodies contain `text` (case-insensitive
+    /// substring). Backs the sidebar's full-text search; returns an empty set
+    /// for a blank query or while the database is deferred/closed.
+    static func sessionIds(withContentContaining text: String) -> Set<UUID> {
+        ensureOpen()
+        guard didOpen else { return [] }
+        return ChatHistoryDatabase.shared.sessionIds(withContentContaining: text)
+    }
+
     /// Save a session (creates or updates)
     static func save(_ session: ChatSessionData) {
         guard !pendingDeletes.contains(session.id) else { return }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -226,6 +226,46 @@
         }
       }
     },
+    "Close find bar" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suchleiste schließen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close find bar"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "찾기 막대 닫기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть панель поиска"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭查找栏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉查找欄"
+          }
+        }
+      }
+    },
     "Connected %@" : {
       "localizations" : {
         "de" : {
@@ -282,6 +322,46 @@
         }
       }
     },
+    "Find in conversation" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Konversation suchen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Find in conversation"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대화에서 찾기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найти в беседе"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在对话中查找"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在對話中查找"
+          }
+        }
+      }
+    },
     "Last auto-reconnect %@." : {
       "localizations" : {
         "de" : {
@@ -334,6 +414,86 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "上次连接：%@。"
+          }
+        }
+      }
+    },
+    "Next match" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nächster Treffer"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Next match"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 일치 항목"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующее совпадение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一个匹配项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一個匹配項"
+          }
+        }
+      }
+    },
+    "Previous match" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorheriger Treffer"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Previous match"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이전 일치 항목"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предыдущее совпадение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一个匹配项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一個匹配項"
           }
         }
       }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -127300,6 +127300,46 @@
         }
       }
     },
+    "Searching conversations…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konversationen werden durchsucht …"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Searching conversations…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대화 검색 중…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск в беседах…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在搜索对话…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在搜尋對話…"
+          }
+        }
+      }
+    },
     "Searching files" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
@@ -494,6 +494,45 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         return counts
     }
 
+    /// Session ids whose message bodies contain `text` as a substring
+    /// (case-insensitive for ASCII, SQLite `LIKE` semantics). Backs the
+    /// sidebar's full-text conversation search; title/metadata matching
+    /// happens separately in memory. A plain scan over `turns.content` —
+    /// there is no FTS index, but local history is small and the scan works
+    /// unchanged under SQLCipher.
+    public func sessionIds(withContentContaining text: String) -> Set<UUID> {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        // Escape LIKE wildcards so a literal % or _ in the query matches
+        // literally instead of exploding the scan.
+        let escaped =
+            trimmed
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+        var ids: Set<UUID> = []
+        let sql = "SELECT DISTINCT session_id FROM turns WHERE content LIKE ?1 ESCAPE '\\'"
+        do {
+            try prepareAndExecute(
+                sql,
+                bind: { stmt in
+                    Self.bindText(stmt, index: 1, value: "%\(escaped)%")
+                },
+                process: { stmt in
+                    while sqlite3_step(stmt) == SQLITE_ROW {
+                        guard let cString = sqlite3_column_text(stmt, 0) else { continue }
+                        if let uuid = UUID(uuidString: String(cString: cString)) {
+                            ids.insert(uuid)
+                        }
+                    }
+                }
+            )
+        } catch {
+            print("[ChatHistoryDatabase] sessionIds(withContentContaining:) failed: \(error)")
+        }
+        return ids
+    }
+
     /// Find an existing session by `(source, external_session_key)`,
     /// optionally constrained to `agentId`. Used by HTTP / scheduler / watcher
     /// dispatch paths where there's no plugin id to scope by. Returns the

--- a/Packages/OsaurusCore/Tests/Chat/ChatFindMatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatFindMatcherTests.swift
@@ -1,0 +1,148 @@
+//
+//  ChatFindMatcherTests.swift
+//  osaurusTests
+//
+//  Pins the in-conversation find bar's match logic: role filtering,
+//  case-insensitive matching, current-match preservation across streaming
+//  recomputes, and wraparound navigation.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ChatFindMatcherTests {
+
+    private func makeTurns() -> [ChatTurn] {
+        [
+            ChatTurn(role: .user, content: "how do I configure the notch?"),
+            ChatTurn(role: .assistant, content: "The notch overlay lives in settings."),
+            ChatTurn(role: .user, content: "thanks!"),
+            ChatTurn(role: .assistant, content: "You can also move the NOTCH per display."),
+        ]
+    }
+
+    @Test func matchesUserAndAssistantTurnsCaseInsensitively() {
+        let turns = makeTurns()
+        let (state, jumpTo) = ChatFindMatcher.recompute(
+            query: "notch",
+            turns: turns,
+            previous: ChatFindState(),
+            preserveCurrentMatch: false
+        )
+        #expect(state.matchTurnIds == [turns[0].id, turns[1].id, turns[3].id])
+        #expect(state.matchIndex == 0)
+        #expect(jumpTo == turns[0].id)
+    }
+
+    @Test func ignoresNonConversationRoles() {
+        let turns = [
+            ChatTurn(role: .system, content: "notch instructions"),
+            ChatTurn(role: .tool, content: "notch tool output"),
+            ChatTurn(role: .user, content: "notch question"),
+        ]
+        let (state, _) = ChatFindMatcher.recompute(
+            query: "notch",
+            turns: turns,
+            previous: ChatFindState(),
+            preserveCurrentMatch: false
+        )
+        #expect(state.matchTurnIds == [turns[2].id])
+    }
+
+    @Test func blankQueryClearsState() {
+        let turns = makeTurns()
+        let previous = ChatFindState(matchTurnIds: [turns[0].id], matchIndex: 0)
+        for query in ["", "   ", "\n"] {
+            let (state, jumpTo) = ChatFindMatcher.recompute(
+                query: query,
+                turns: turns,
+                previous: previous,
+                preserveCurrentMatch: false
+            )
+            #expect(state == ChatFindState())
+            #expect(jumpTo == nil)
+        }
+    }
+
+    @Test func noMatchesProducesEmptyStateWithoutJump() {
+        let (state, jumpTo) = ChatFindMatcher.recompute(
+            query: "zzz-not-present",
+            turns: makeTurns(),
+            previous: ChatFindState(),
+            preserveCurrentMatch: false
+        )
+        #expect(state.matchTurnIds.isEmpty)
+        #expect(state.matchIndex == 0)
+        #expect(jumpTo == nil)
+    }
+
+    @Test func preservesCurrentMatchWhenTurnsAppend() {
+        var turns = makeTurns()
+        var (state, _) = ChatFindMatcher.recompute(
+            query: "notch",
+            turns: turns,
+            previous: ChatFindState(),
+            preserveCurrentMatch: false
+        )
+        // Navigate to the second match, then a streaming turn appends.
+        (state, _) = ChatFindMatcher.advance(state, by: 1)
+        #expect(state.matchIndex == 1)
+
+        turns.append(ChatTurn(role: .assistant, content: "more about the notch"))
+        let (recomputed, jumpTo) = ChatFindMatcher.recompute(
+            query: "notch",
+            turns: turns,
+            previous: state,
+            preserveCurrentMatch: true
+        )
+        // Current match (turns[1]) survives at the same position; no jump.
+        #expect(recomputed.matchTurnIds.count == 4)
+        #expect(recomputed.matchTurnIds[recomputed.matchIndex] == turns[1].id)
+        #expect(jumpTo == nil)
+    }
+
+    @Test func resetsToFirstWhenCurrentMatchDisappears() {
+        let turns = makeTurns()
+        let gone = ChatFindState(matchTurnIds: [UUID()], matchIndex: 0)
+        let (state, jumpTo) = ChatFindMatcher.recompute(
+            query: "notch",
+            turns: turns,
+            previous: gone,
+            preserveCurrentMatch: true
+        )
+        #expect(state.matchIndex == 0)
+        #expect(state.matchTurnIds.first == turns[0].id)
+        // Preserving recomputes never jump, even after a reset.
+        #expect(jumpTo == nil)
+    }
+
+    @Test func advanceWrapsBothDirections() {
+        let ids = [UUID(), UUID(), UUID()]
+        var state = ChatFindState(matchTurnIds: ids, matchIndex: 0)
+
+        var jumpTo: UUID?
+        (state, jumpTo) = ChatFindMatcher.advance(state, by: 1)
+        #expect(state.matchIndex == 1)
+        #expect(jumpTo == ids[1])
+
+        (state, jumpTo) = ChatFindMatcher.advance(state, by: 1)
+        (state, jumpTo) = ChatFindMatcher.advance(state, by: 1)
+        // Wrapped past the end back to the first match.
+        #expect(state.matchIndex == 0)
+        #expect(jumpTo == ids[0])
+
+        (state, jumpTo) = ChatFindMatcher.advance(state, by: -1)
+        // Wrapped backwards from the first match to the last.
+        #expect(state.matchIndex == 2)
+        #expect(jumpTo == ids[2])
+    }
+
+    @Test func advanceOnEmptyStateIsANoOp() {
+        let (state, jumpTo) = ChatFindMatcher.advance(ChatFindState(), by: 1)
+        #expect(state == ChatFindState())
+        #expect(jumpTo == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Storage/ChatContentSearchTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatContentSearchTests.swift
@@ -1,0 +1,114 @@
+//
+//  ChatContentSearchTests.swift
+//  osaurusTests
+//
+//  Verifies the sidebar full-text search primitive: session-id lookup by
+//  message-body substring over `turns.content`.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ChatContentSearchTests {
+
+    private func openInMemory() throws -> ChatHistoryDatabase {
+        let db = ChatHistoryDatabase()
+        try db.openInMemory()
+        return db
+    }
+
+    private func makeSession(title: String, contents: [String]) -> ChatSessionData {
+        ChatSessionData(
+            id: UUID(),
+            title: title,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            selectedModel: "m",
+            turns: contents.enumerated().map { index, content in
+                ChatTurnData(role: index.isMultiple(of: 2) ? .user : .assistant, content: content)
+            },
+            agentId: nil,
+            source: .chat,
+            sourcePluginId: nil,
+            externalSessionKey: nil,
+            dispatchTaskId: nil
+        )
+    }
+
+    @Test
+    func findsSessionsByMessageBodySubstring() throws {
+        let db = try openInMemory()
+        defer { db.close() }
+
+        let matching = makeSession(
+            title: "Untitled",
+            contents: ["how do I configure the notch overlay?", "You can adjust it in Settings."]
+        )
+        let other = makeSession(
+            title: "Untitled",
+            contents: ["what's the weather like?", "Sunny."]
+        )
+        try db.saveSession(matching)
+        try db.saveSession(other)
+
+        let ids = db.sessionIds(withContentContaining: "notch overlay")
+        #expect(ids == [matching.id])
+    }
+
+    @Test
+    func matchIsCaseInsensitive() throws {
+        let db = try openInMemory()
+        defer { db.close() }
+
+        let session = makeSession(title: "T", contents: ["Deploy the Firecrawl plugin"])
+        try db.saveSession(session)
+
+        #expect(db.sessionIds(withContentContaining: "firecrawl") == [session.id])
+        #expect(db.sessionIds(withContentContaining: "FIRECRAWL") == [session.id])
+    }
+
+    @Test
+    func likeWildcardsInQueryAreLiteral() throws {
+        let db = try openInMemory()
+        defer { db.close() }
+
+        let literal = makeSession(title: "T", contents: ["progress is at 100% done"])
+        let decoy = makeSession(title: "T", contents: ["progress is at 100 percent done"])
+        try db.saveSession(literal)
+        try db.saveSession(decoy)
+
+        // "%" must match only the literal percent sign, not act as a wildcard.
+        #expect(db.sessionIds(withContentContaining: "100% done") == [literal.id])
+        // "_" must not act as a single-character wildcard.
+        #expect(db.sessionIds(withContentContaining: "100_done").isEmpty)
+    }
+
+    @Test
+    func blankQueryReturnsNothing() throws {
+        let db = try openInMemory()
+        defer { db.close() }
+
+        let session = makeSession(title: "T", contents: ["anything"])
+        try db.saveSession(session)
+
+        #expect(db.sessionIds(withContentContaining: "").isEmpty)
+        #expect(db.sessionIds(withContentContaining: "   ").isEmpty)
+    }
+
+    @Test
+    func sessionIsReportedOncePerMultipleMatchingTurns() throws {
+        let db = try openInMemory()
+        defer { db.close() }
+
+        let session = makeSession(
+            title: "T",
+            contents: ["tell me about dinosaurs", "dinosaurs were reptiles", "more dinosaurs please"]
+        )
+        try db.saveSession(session)
+
+        #expect(db.sessionIds(withContentContaining: "dinosaurs") == [session.id])
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatFindBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatFindBar.swift
@@ -1,0 +1,95 @@
+//
+//  ChatFindBar.swift
+//  osaurus
+//
+//  In-conversation find bar (Cmd+F). Floats at the top-trailing edge of the
+//  message thread; matches are computed per turn in ChatView and navigated
+//  via the same scroll-to-turn machinery the minimap uses.
+//
+
+import SwiftUI
+
+struct ChatFindBar: View {
+    @Environment(\.theme) private var theme
+
+    @Binding var query: String
+    /// Zero-based index of the current match; meaningless when `matchCount == 0`.
+    let matchIndex: Int
+    let matchCount: Int
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+    let onClose: () -> Void
+
+    @FocusState private var isFieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.tertiaryText)
+
+            TextField(L("Find in conversation"), text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(theme.primaryText)
+                .frame(width: 170)
+                .focused($isFieldFocused)
+                .onSubmit {
+                    // Enter advances; Shift+Enter is handled by the ⌃/⌄
+                    // buttons since TextField can't distinguish it here.
+                    onNext()
+                }
+
+            Text(matchCountLabel)
+                .font(.system(size: 11, weight: .medium).monospacedDigit())
+                .foregroundColor(theme.tertiaryText)
+                .frame(minWidth: 34)
+
+            Divider().frame(height: 14)
+
+            navButton(systemName: "chevron.up", action: onPrevious)
+                .help(Text("Previous match", bundle: .module))
+            navButton(systemName: "chevron.down", action: onNext)
+                .help(Text("Next match", bundle: .module))
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(Text("Close find bar", bundle: .module))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.secondaryBackground)
+                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(theme.primaryBorder, lineWidth: 1)
+        )
+        .onAppear { isFieldFocused = true }
+    }
+
+    private var matchCountLabel: String {
+        guard matchCount > 0 else { return query.isEmpty ? "" : "0" }
+        return "\(matchIndex + 1)/\(matchCount)"
+    }
+
+    private func navButton(systemName: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(matchCount > 0 ? theme.primaryText : theme.tertiaryText)
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(matchCount == 0)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -49,6 +49,13 @@ struct ChatSessionSidebar: View {
     @State private var searchQuery: String = ""
     @State private var sourceFilter: SourceFilter = .all
     @State private var hoveredFilter: SourceFilter?
+    /// Sessions whose message bodies match the current search query,
+    /// resolved asynchronously against the chat-history database (debounced
+    /// per keystroke). Merged with the synchronous title/metadata matching in
+    /// `filteredSessions` so search covers conversation content, not just
+    /// titles.
+    @State private var contentMatchedSessionIds: Set<UUID> = []
+    @State private var contentSearchTask: Task<Void, Never>?
     @FocusState private var isSearchFocused: Bool
 
     // MARK: - Source Filter
@@ -104,10 +111,33 @@ struct ChatSessionSidebar: View {
             {
                 return true
             }
+            // Full-text match over message bodies, resolved asynchronously
+            // into `contentMatchedSessionIds`.
+            if contentMatchedSessionIds.contains(session.id) { return true }
             // Match capability labels so "vision" / "code" finds tagged chats.
             return session.capabilities.contains { cap in
                 SearchService.matches(query: searchQuery, in: cap.label)
             }
+        }
+    }
+
+    /// Debounced full-text lookup for the search query. The in-memory
+    /// sessions carry metadata only (turns are never loaded for the list), so
+    /// content matching goes to the chat-history database.
+    private func scheduleContentSearch(_ query: String) {
+        contentSearchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            contentMatchedSessionIds = []
+            return
+        }
+        contentSearchTask = Task { @MainActor in
+            // Debounce so fast typing doesn't scan the database per keystroke.
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+            let ids = await ChatSessionStore.sessionIds(withContentContaining: trimmed)
+            guard !Task.isCancelled else { return }
+            contentMatchedSessionIds = ids
         }
     }
 
@@ -173,6 +203,9 @@ struct ChatSessionSidebar: View {
         // sidebar's loadSession) is a context change — wipe per-window
         // filter state so the new agent starts on "All" with an empty
         // search instead of inheriting the previous agent's lens.
+        .onChange(of: searchQuery) { _, query in
+            scheduleContentSearch(query)
+        }
         .onChange(of: agentId) { _, _ in
             sourceFilter = .all
             searchQuery = ""

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -56,6 +56,9 @@ struct ChatSessionSidebar: View {
     /// titles.
     @State private var contentMatchedSessionIds: Set<UUID> = []
     @State private var contentSearchTask: Task<Void, Never>?
+    /// True from query change until its (debounced) database lookup returns.
+    /// Drives the search field's trailing spinner.
+    @State private var isContentSearchInFlight: Bool = false
     @FocusState private var isSearchFocused: Bool
 
     // MARK: - Source Filter
@@ -129,15 +132,19 @@ struct ChatSessionSidebar: View {
         let trimmed = query.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else {
             contentMatchedSessionIds = []
+            isContentSearchInFlight = false
             return
         }
+        isContentSearchInFlight = true
         contentSearchTask = Task { @MainActor in
             // Debounce so fast typing doesn't scan the database per keystroke.
             try? await Task.sleep(nanoseconds: 250_000_000)
             guard !Task.isCancelled else { return }
             let ids = await ChatSessionStore.sessionIds(withContentContaining: trimmed)
+            // A cancelled task must not clear the flag owned by its successor.
             guard !Task.isCancelled else { return }
             contentMatchedSessionIds = ids
+            isContentSearchInFlight = false
         }
     }
 
@@ -166,7 +173,8 @@ struct ChatSessionSidebar: View {
             SidebarSearchField(
                 text: $searchQuery,
                 placeholder: "Search conversations...",
-                isFocused: $isSearchFocused
+                isFocused: $isSearchFocused,
+                isSearching: isContentSearchInFlight
             )
             .padding(.horizontal, 12)
             .padding(.bottom, 6)

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -196,6 +196,10 @@ struct ChatSessionSidebar: View {
             // Session list
             if sessions.isEmpty {
                 emptyState
+            } else if filteredSessions.isEmpty, isContentSearchInFlight {
+                // The async content lookup hasn't finished — don't claim
+                // "no results" until the whole search process is complete.
+                searchingPlaceholder
             } else if filteredSessions.isEmpty {
                 SidebarNoResultsView(searchQuery: searchQuery) {
                     withAnimation(theme.animationQuick()) {
@@ -379,6 +383,22 @@ struct ChatSessionSidebar: View {
     }
 
     // MARK: - Empty State
+
+    /// Interim state while the async content lookup is still running and no
+    /// title/metadata match is visible yet. Prevents a premature "No matches
+    /// found" flash before the search process has actually finished.
+    private var searchingPlaceholder: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            ProgressView()
+                .controlSize(.small)
+            Text("Searching conversations…", bundle: .module)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.secondaryText.opacity(0.8))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
 
     private var emptyState: some View {
         VStack(spacing: 8) {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4891,6 +4891,12 @@ struct ChatView: View {
     @State private var activeMinimapTurnId: UUID?
     @State private var scrollToTurnId: UUID?
     @State private var scrollToTurnTrigger: Int = 0
+    // In-conversation find (Cmd+F). Visibility lives on `windowState` so the
+    // window-level key monitor can toggle it; query/matches are view state.
+    @State private var findQuery: String = ""
+    /// Ordered turn ids whose content matches `findQuery`.
+    @State private var findMatchTurnIds: [UUID] = []
+    @State private var findMatchIndex: Int = 0
     // What's New modal
     @State private var pendingWhatsNew: WhatsNewRelease? = nil
     @State private var showAutoSpeakPrompt: Bool = false
@@ -6073,6 +6079,36 @@ struct ChatView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .allowsHitTesting(session.lastCompletionSummary != nil || session.currentTodo != nil)
 
+            // Find bar overlay (Cmd+F) — top-trailing, above the thread.
+            if windowState.isFindBarVisible {
+                VStack {
+                    HStack {
+                        Spacer()
+                        ChatFindBar(
+                            query: $findQuery,
+                            matchIndex: findMatchIndex,
+                            matchCount: findMatchTurnIds.count,
+                            onPrevious: { advanceFindMatch(by: -1) },
+                            onNext: { advanceFindMatch(by: 1) },
+                            onClose: { windowState.isFindBarVisible = false }
+                        )
+                        .padding(.trailing, 16)
+                        .padding(.top, inlineInsetHeight + 8)
+                    }
+                    Spacer()
+                }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .onChange(of: findQuery) { _, query in
+                    recomputeFindMatches(query: query, jumpToFirst: true)
+                }
+                .onChange(of: session.turns.count) { _, _ in
+                    recomputeFindMatches(query: findQuery, jumpToFirst: false)
+                }
+                .onAppear {
+                    recomputeFindMatches(query: findQuery, jumpToFirst: false)
+                }
+            }
+
             // Minimap overlay — sits at vertical center, right edge
             if minimapMarkers.count >= 2 {
                 HStack {
@@ -6439,6 +6475,49 @@ extension ChatView {
         windowState.cancelInlineEdit = nil
     }
 
+    // MARK: - In-Conversation Find (Cmd+F)
+
+    /// Recompute the ordered turn-id match list for `query` over the visible
+    /// conversation. `jumpToFirst` scrolls to the first match (used while
+    /// typing); otherwise the current match is preserved when it survives the
+    /// recompute (used when streaming appends turns).
+    private func recomputeFindMatches(query: String, jumpToFirst: Bool) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            findMatchTurnIds = []
+            findMatchIndex = 0
+            return
+        }
+        let previousCurrent =
+            findMatchTurnIds.indices.contains(findMatchIndex)
+            ? findMatchTurnIds[findMatchIndex] : nil
+        let matches = session.turns
+            .filter { turn in
+                (turn.role == .user || turn.role == .assistant)
+                    && turn.content.range(of: trimmed, options: [.caseInsensitive]) != nil
+            }
+            .map(\.id)
+        findMatchTurnIds = matches
+        if !jumpToFirst, let previousCurrent, let idx = matches.firstIndex(of: previousCurrent) {
+            findMatchIndex = idx
+            return
+        }
+        findMatchIndex = 0
+        if jumpToFirst, let first = matches.first {
+            scrollToTurnId = first
+            scrollToTurnTrigger &+= 1
+        }
+    }
+
+    /// Step to the next/previous match, wrapping at both ends.
+    private func advanceFindMatch(by delta: Int) {
+        guard !findMatchTurnIds.isEmpty else { return }
+        let count = findMatchTurnIds.count
+        findMatchIndex = ((findMatchIndex + delta) % count + count) % count
+        scrollToTurnId = findMatchTurnIds[findMatchIndex]
+        scrollToTurnTrigger &+= 1
+    }
+
     // Key monitor for Esc. Dismisses transient UI in priority order
     // before falling through to closing the window. The monitor owns the
     // key event before SwiftUI's `.keyboardShortcut(.cancelAction)` /
@@ -6453,6 +6532,18 @@ extension ChatView {
         let windowState = self.windowState
 
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak session, weak windowState] event in
+            // Cmd+F opens the in-conversation find bar.
+            if event.modifierFlags.intersection([.command, .shift, .option, .control]) == .command,
+                event.charactersIgnoringModifiers?.lowercased() == "f"
+            {
+                guard let ourWindow = ChatWindowManager.shared.getNSWindow(id: capturedWindowId),
+                    event.window === ourWindow,
+                    let windowState
+                else { return event }
+                windowState.isFindBarVisible = true
+                return nil
+            }
+
             // Esc key code is 53
             if event.keyCode == 53 {
                 // Only handle Esc if this event is for our specific window
@@ -6469,6 +6560,14 @@ extension ChatView {
                 // Stage 0: Slash command popup is open — let the text view delegate handle it
                 if SlashCommandRegistry.shared.isPopupVisible {
                     return event
+                }
+
+                // Stage 0.5: Find bar is open — close it before any other
+                // transient UI so Esc can't fall through to window close
+                // while the user is mid-search.
+                if let windowState, windowState.isFindBarVisible {
+                    windowState.isFindBarVisible = false
+                    return nil
                 }
 
                 // Stage 1: A transient popover (model picker, model

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6485,42 +6485,35 @@ extension ChatView {
     /// Recompute the ordered turn-id match list for `query` over the visible
     /// conversation. `jumpToFirst` scrolls to the first match (used while
     /// typing); otherwise the current match is preserved when it survives the
-    /// recompute (used when streaming appends turns).
+    /// recompute (used when streaming appends turns). Logic lives in
+    /// `ChatFindMatcher` so the invariants are unit-tested.
     private func recomputeFindMatches(query: String, jumpToFirst: Bool) {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            findMatchTurnIds = []
-            findMatchIndex = 0
-            return
-        }
-        let previousCurrent =
-            findMatchTurnIds.indices.contains(findMatchIndex)
-            ? findMatchTurnIds[findMatchIndex] : nil
-        let matches = session.turns
-            .filter { turn in
-                (turn.role == .user || turn.role == .assistant)
-                    && turn.content.range(of: trimmed, options: [.caseInsensitive]) != nil
-            }
-            .map(\.id)
-        findMatchTurnIds = matches
-        if !jumpToFirst, let previousCurrent, let idx = matches.firstIndex(of: previousCurrent) {
-            findMatchIndex = idx
-            return
-        }
-        findMatchIndex = 0
-        if jumpToFirst, let first = matches.first {
-            scrollToTurnId = first
+        let (state, jumpTo) = ChatFindMatcher.recompute(
+            query: query,
+            turns: session.turns,
+            previous: ChatFindState(matchTurnIds: findMatchTurnIds, matchIndex: findMatchIndex),
+            preserveCurrentMatch: !jumpToFirst
+        )
+        findMatchTurnIds = state.matchTurnIds
+        findMatchIndex = state.matchIndex
+        if let jumpTo {
+            scrollToTurnId = jumpTo
             scrollToTurnTrigger &+= 1
         }
     }
 
     /// Step to the next/previous match, wrapping at both ends.
     private func advanceFindMatch(by delta: Int) {
-        guard !findMatchTurnIds.isEmpty else { return }
-        let count = findMatchTurnIds.count
-        findMatchIndex = ((findMatchIndex + delta) % count + count) % count
-        scrollToTurnId = findMatchTurnIds[findMatchIndex]
-        scrollToTurnTrigger &+= 1
+        let (state, jumpTo) = ChatFindMatcher.advance(
+            ChatFindState(matchTurnIds: findMatchTurnIds, matchIndex: findMatchIndex),
+            by: delta
+        )
+        findMatchTurnIds = state.matchTurnIds
+        findMatchIndex = state.matchIndex
+        if let jumpTo {
+            scrollToTurnId = jumpTo
+            scrollToTurnTrigger &+= 1
+        }
     }
 
     // Key monitor for Esc. Dismisses transient UI in priority order

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6266,6 +6266,8 @@ private struct IsolatedThreadView: View {
     /// scroll controls so existing call sites stay backward-
     /// compatible (it's a defaulted property with an empty map).
     var sessionRedactions: [String: String] = [:]
+    /// Active in-conversation find query (Cmd+F); empty when the bar is closed.
+    var searchHighlightQuery: String = ""
 
     var body: some View {
         let _ = ChatPerfTrace.shared.count("body.IsolatedThreadView")
@@ -6296,7 +6298,8 @@ private struct IsolatedThreadView: View {
             onVisibleTopUserTurnChanged: onVisibleTopUserTurnChanged,
             scrollToTurnId: scrollToTurnId,
             scrollToTurnTrigger: scrollToTurnTrigger,
-            sessionRedactions: sessionRedactions
+            sessionRedactions: sessionRedactions,
+            searchHighlightQuery: searchHighlightQuery
         )
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6060,7 +6060,9 @@ struct ChatView: View {
                 },
                 scrollToTurnId: scrollToTurnId,
                 scrollToTurnTrigger: scrollToTurnTrigger,
-                sessionRedactions: session.sessionRedactions
+                sessionRedactions: session.sessionRedactions,
+                searchHighlightQuery: windowState.isFindBarVisible
+                    ? findQuery.trimmingCharacters(in: .whitespacesAndNewlines) : ""
             )
             .safeAreaInset(edge: .top, spacing: 0) {
                 Color.clear

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -106,6 +106,10 @@ struct MessageTableRepresentable: NSViewRepresentable {
     /// scrubbed anything in this window yet.
     var sessionRedactions: [String: String] = [:]
 
+    /// Active in-conversation find query (Cmd+F); empty when the find bar is
+    /// closed. Threaded into every cell so match occurrences are highlighted.
+    var searchHighlightQuery: String = ""
+
     // MARK: - NSViewRepresentable Lifecycle
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -233,6 +237,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
             sessionRedactions: sessionRedactions,
+            searchHighlightQuery: searchHighlightQuery,
             hasChartBeenDrawn: { [weak coordinator] id in
                 coordinator?.drawnChartBlockIds.contains(id) ?? false
             },
@@ -277,7 +282,8 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onSpeak: onSpeak,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
-            sessionRedactions: sessionRedactions
+            sessionRedactions: sessionRedactions,
+            searchHighlightQuery: searchHighlightQuery
         )
     }
 
@@ -667,6 +673,7 @@ extension MessageTableRepresentable {
             let widthChanged = abs(ctx.width - context.width) > 1.0
             let expandedIdsChanged = context.expandedIds != ctx.expandedIds
             let previousEditingTurnId = ctx.editingTurnId
+            let previousSearchHighlightQuery = ctx.searchHighlightQuery
             let previousStreaming = ctx.isStreaming
             let previousLastAssistantTurnId = ctx.lastAssistantTurnId
             // NSView backed cells snapshot the theme
@@ -692,6 +699,13 @@ extension MessageTableRepresentable {
             if context.editingTurnId != previousEditingTurnId {
                 reconfigureCellsForTurn(previousEditingTurnId)
                 reconfigureCellsForTurn(context.editingTurnId)
+            }
+
+            // Find-highlight query also lives in the context, not the blocks.
+            // Repaint every materialized cell when it changes so matches
+            // highlight (and un-highlight on close) immediately.
+            if context.searchHighlightQuery != previousSearchHighlightQuery {
+                reconfigureAllCellsFromLookup(blockLookup)
             }
 
             let newIds = blocks.map(\.id)

--- a/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
@@ -53,6 +53,8 @@ struct MessageThreadView: View {
     /// empty so callers without a chat session (preview / mock)
     /// don't have to thread it.
     var sessionRedactions: [String: String] = [:]
+    /// Active in-conversation find query (Cmd+F); empty when the bar is closed.
+    var searchHighlightQuery: String = ""
 
     @Environment(\.theme) private var theme
 
@@ -111,7 +113,8 @@ struct MessageThreadView: View {
             onVisibleTopUserTurnChanged: onVisibleTopUserTurnChanged,
             scrollToTurnId: scrollToTurnId,
             scrollToTurnTrigger: scrollToTurnTrigger,
-            sessionRedactions: sessionRedactions
+            sessionRedactions: sessionRedactions,
+            searchHighlightQuery: searchHighlightQuery
         )
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -122,6 +122,14 @@ final class NativeMarkdownView: NSView {
     /// first time `redactionHighlights` becomes non-empty; reused
     /// across updates so the NSTrackingArea stays installed.
     private var hoverController: RedactionHoverController?
+    /// Active in-conversation find query (Cmd+F). Every case-insensitive
+    /// occurrence in the body text gets a translucent background. Empty =
+    /// feature inactive, zero cost.
+    private var searchHighlightQuery: String = ""
+    /// Ranges the search highlighter painted, so a query change (or clear)
+    /// removes exactly what it added — never a background the markdown
+    /// renderer itself owns (e.g. inline-code chips).
+    private var appliedSearchRanges: [NSRange] = []
     /// cancels stale loads when segment id is reused with a new URL or view is removed
     private var imageLoadTasks: [String: (UUID, Task<Void, Never>)] = [:]
     /// Per-image height constraint, updated to match the loaded image's
@@ -206,6 +214,70 @@ final class NativeMarkdownView: NSView {
                 child.setRedactionHighlights(highlights, theme: theme)
             }
         }
+    }
+
+    /// Set the active find query (Cmd+F). Repaints when the query changed
+    /// and propagates into mixed-segment children like the redaction path.
+    func setSearchHighlight(query: String, theme: any ThemeProtocol) {
+        let changed = query != searchHighlightQuery
+        searchHighlightQuery = query
+        if changed {
+            applySearchHighlightsIfNeeded(theme: theme)
+        }
+        for entry in segmentViews {
+            if let child = entry.view as? NativeMarkdownView {
+                child.setSearchHighlight(query: query, theme: theme)
+            }
+        }
+    }
+
+    /// Repaint search-match backgrounds on the current textStorage. Always
+    /// removes the previously painted ranges first so a query change or
+    /// storage rebuild can't leave stale backgrounds behind. Occurrences
+    /// that already carry a background attribute (inline-code chips) are
+    /// skipped rather than clobbered.
+    private func applySearchHighlightsIfNeeded(theme: any ThemeProtocol) {
+        guard let tv = textView, let storage = tv.textStorage else {
+            appliedSearchRanges = []
+            return
+        }
+        if !appliedSearchRanges.isEmpty {
+            storage.beginEditing()
+            for range in appliedSearchRanges where range.upperBound <= storage.length {
+                storage.removeAttribute(.backgroundColor, range: range)
+            }
+            storage.endEditing()
+            appliedSearchRanges = []
+        }
+        let query = searchHighlightQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty, storage.length > 0 else {
+            tv.needsDisplay = true
+            return
+        }
+        let color = NSColor(theme.accentColor).withAlphaComponent(0.3)
+        let string = storage.string as NSString
+        var searchRange = NSRange(location: 0, length: string.length)
+        storage.beginEditing()
+        while searchRange.length > 0 {
+            let found = string.range(of: query, options: [.caseInsensitive], range: searchRange)
+            if found.location == NSNotFound { break }
+            var hasExistingBackground = false
+            storage.enumerateAttribute(.backgroundColor, in: found, options: []) { value, _, stop in
+                if value != nil {
+                    hasExistingBackground = true
+                    stop.pointee = true
+                }
+            }
+            if !hasExistingBackground {
+                storage.addAttribute(.backgroundColor, value: color, range: found)
+                appliedSearchRanges.append(found)
+            }
+            let next = found.location + max(found.length, 1)
+            if next >= string.length { break }
+            searchRange = NSRange(location: next, length: string.length - next)
+        }
+        storage.endEditing()
+        tv.needsDisplay = true
     }
 
     /// Re-paint highlights on the current textStorage. Called from
@@ -298,6 +370,11 @@ final class NativeMarkdownView: NSView {
     private func resetIncrementalHighlightCursor() {
         redactionHighlightAppliedThrough = 0
         appliedHighlightRanges = []
+        // The storage was swapped wholesale — previously painted search
+        // ranges point into the old string, so removing them from the new
+        // one could strip a background the renderer owns. The fresh string
+        // carries no search backgrounds; just forget the stale ranges.
+        appliedSearchRanges = []
     }
 
     /// Localized a11y label for VoiceOver. Outbound: "Redacted before
@@ -431,6 +508,7 @@ final class NativeMarkdownView: NSView {
                 tv.needsDisplay = true
             }
             applyRedactionHighlightsIfNeeded(theme: theme)
+            applySearchHighlightsIfNeeded(theme: theme)
             if isStreaming && textChanged {
                 notifyTextReveal()
             }
@@ -631,6 +709,7 @@ final class NativeMarkdownView: NSView {
                 tv.needsDisplay = true
             }
             applyRedactionHighlightsIfNeeded(theme: theme)
+            applySearchHighlightsIfNeeded(theme: theme)
             if isStreaming && textChanged {
                 notifyTextReveal()
             }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -50,6 +50,10 @@ struct CellRenderingContext {
     /// bubbles. Empty dict means no privacy redactions in this
     /// session yet (the highlight pass short-circuits).
     var sessionRedactions: [String: String] = [:]
+    /// Active in-conversation find query (Cmd+F). Empty when the find bar is
+    /// closed. Message cells paint every case-insensitive occurrence in
+    /// their body text via `NativeMarkdownView.setSearchHighlight`.
+    var searchHighlightQuery: String = ""
     /// Coordinator-scoped predicate: has the chart with this block id ever
     /// been drawn (and thus already played its entry animation) in the
     /// current chat? Used by `configureAsChart` to suppress the animation
@@ -1807,6 +1811,7 @@ final class NativeMessageCellView: NSTableCellView {
             Self.buildHighlights(from: context.sessionRedactions, direction: .inbound),
             theme: context.theme
         )
+        mv.setSearchHighlight(query: context.searchHighlightQuery, theme: context.theme)
 
         // Apply assistant bubble background only when the target value actually changes —
         // configure() runs on every streaming token, so unconditional CGColor assignment
@@ -2211,6 +2216,7 @@ final class NativeMessageCellView: NSTableCellView {
                 Self.buildHighlights(from: context.sessionRedactions, direction: .outbound),
                 theme: theme
             )
+            mv.setSearchHighlight(query: context.searchHighlightQuery, theme: theme)
         }
 
         if let stack = userImageStack {

--- a/Packages/OsaurusCore/Views/Management/SharedSidebarComponents.swift
+++ b/Packages/OsaurusCore/Views/Management/SharedSidebarComponents.swift
@@ -228,6 +228,9 @@ struct SidebarSearchField: View {
     @Binding var text: String
     let placeholder: LocalizedStringKey
     var isFocused: FocusState<Bool>.Binding
+    /// Shows a small trailing spinner while an asynchronous search pass
+    /// (e.g. the chat sidebar's full-text conversation lookup) is in flight.
+    var isSearching: Bool = false
 
     @Environment(\.theme) private var theme
 
@@ -235,6 +238,12 @@ struct SidebarSearchField: View {
         HStack(spacing: 8) {
             searchIcon
             searchTextField
+            if isSearching {
+                ProgressView()
+                    .controlSize(.mini)
+                    .frame(width: 12, height: 12)
+                    .transition(.opacity)
+            }
             clearButton
         }
         .padding(.horizontal, 10)
@@ -243,6 +252,7 @@ struct SidebarSearchField: View {
         .overlay(focusBorder)
         .animation(theme.animationQuick(), value: isFocused.wrappedValue)
         .animation(theme.animationQuick(), value: text.isEmpty)
+        .animation(theme.animationQuick(), value: isSearching)
     }
 
     private var searchIcon: some View {


### PR DESCRIPTION
## Summary

  closes #1876

  - extended the sidebar conversation search to match message bodies instead of just titles
  - Added a substring search primitive to the chat history database with SQL wildcard escaping (supports old conversations as well)
  - added an in-conversation find bar opened with Cmd+F

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
