### PR TITLE
added terminal style input history navigation with arrow keys in chat input text field

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatInputHistory.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatInputHistory.swift
@@ -1,0 +1,88 @@
+//
+//  ChatInputHistory.swift
+//  osaurus
+//
+//  Pure logic for terminal-style input history in the chat composer:
+//  Up recalls previously sent messages of the current conversation
+//  (newest first), Down walks back toward the in-progress draft.
+//  Extracted from the composer so the invariants are unit-testable.
+//
+
+import Foundation
+
+/// Snapshot of the composer's history-navigation state.
+struct ChatInputHistoryState: Equatable {
+    /// Position in the history entries (0 = most recent sent message);
+    /// nil when the user is editing their draft, not navigating.
+    var index: Int? = nil
+    /// The in-progress draft stashed when navigation began, restored when
+    /// the user walks Down past the most recent entry.
+    var savedDraft: String = ""
+}
+
+@MainActor
+enum ChatInputHistory {
+
+    /// History entries for a conversation: the user's sent messages, newest
+    /// first, blank entries dropped and consecutive duplicates collapsed
+    /// (recalling "retry" three times shouldn't take three Up presses to
+    /// get past).
+    static func entries(from turns: [ChatTurn]) -> [String] {
+        var out: [String] = []
+        for turn in turns.reversed() where turn.role == .user {
+            let content = turn.content
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+            if out.last == content { continue }
+            out.append(content)
+        }
+        return out
+    }
+
+    /// Up arrow: step one entry further into the past. Entering navigation
+    /// (index nil → 0) stashes `currentDraft` for later restoration. Returns
+    /// nil when there is nothing to recall (no entries, or already at the
+    /// oldest entry) — the caller should then let the caret move normally.
+    static func recall(
+        state: ChatInputHistoryState,
+        entries: [String],
+        currentDraft: String
+    ) -> (state: ChatInputHistoryState, text: String)? {
+        guard !entries.isEmpty else { return nil }
+        guard let index = state.index else {
+            return (
+                ChatInputHistoryState(index: 0, savedDraft: currentDraft),
+                entries[0]
+            )
+        }
+        let next = index + 1
+        guard next < entries.count else { return nil }
+        return (
+            ChatInputHistoryState(index: next, savedDraft: state.savedDraft),
+            entries[next]
+        )
+    }
+
+    /// Down arrow: step one entry back toward the present. Walking past the
+    /// most recent entry leaves navigation and restores the stashed draft.
+    /// Returns nil when not navigating — the caller should then let the
+    /// caret move normally.
+    static func advance(
+        state: ChatInputHistoryState,
+        entries: [String]
+    ) -> (state: ChatInputHistoryState, text: String)? {
+        guard let index = state.index else { return nil }
+        guard index > 0 else {
+            return (ChatInputHistoryState(), state.savedDraft)
+        }
+        let previous = index - 1
+        guard previous < entries.count else {
+            // Entries shrank underneath us (e.g. conversation cleared);
+            // bail back to the draft rather than indexing out of bounds.
+            return (ChatInputHistoryState(), state.savedDraft)
+        }
+        return (
+            ChatInputHistoryState(index: previous, savedDraft: state.savedDraft),
+            entries[previous]
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatInputHistoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatInputHistoryTests.swift
@@ -1,0 +1,129 @@
+//
+//  ChatInputHistoryTests.swift
+//  osaurusTests
+//
+//  Pins the composer's terminal-style input history: entry derivation,
+//  draft stashing/restoration, and both navigation directions.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ChatInputHistoryTests {
+
+    // MARK: - Entries
+
+    @Test func entriesAreUserTurnsNewestFirst() {
+        let turns = [
+            ChatTurn(role: .user, content: "first"),
+            ChatTurn(role: .assistant, content: "reply"),
+            ChatTurn(role: .user, content: "second"),
+            ChatTurn(role: .user, content: "third"),
+        ]
+        #expect(ChatInputHistory.entries(from: turns) == ["third", "second", "first"])
+    }
+
+    @Test func entriesSkipBlankAndCollapseConsecutiveDuplicates() {
+        let turns = [
+            ChatTurn(role: .user, content: "retry"),
+            ChatTurn(role: .user, content: "retry"),
+            ChatTurn(role: .user, content: "   "),
+            ChatTurn(role: .user, content: "done"),
+        ]
+        #expect(ChatInputHistory.entries(from: turns) == ["done", "retry"])
+    }
+
+    @Test func entriesIgnoreNonUserRoles() {
+        let turns = [
+            ChatTurn(role: .system, content: "prompt"),
+            ChatTurn(role: .assistant, content: "hello"),
+            ChatTurn(role: .tool, content: "output"),
+        ]
+        #expect(ChatInputHistory.entries(from: turns).isEmpty)
+    }
+
+    // MARK: - Recall (Up)
+
+    @Test func firstRecallStashesDraftAndShowsNewestEntry() {
+        let result = ChatInputHistory.recall(
+            state: ChatInputHistoryState(),
+            entries: ["newest", "older"],
+            currentDraft: "work in progress"
+        )
+        #expect(result?.text == "newest")
+        #expect(result?.state == ChatInputHistoryState(index: 0, savedDraft: "work in progress"))
+    }
+
+    @Test func repeatedRecallWalksTowardOldest() {
+        var state = ChatInputHistoryState()
+        let entries = ["a", "b", "c"]
+
+        for expected in ["a", "b", "c"] {
+            let result = ChatInputHistory.recall(state: state, entries: entries, currentDraft: "")
+            #expect(result?.text == expected)
+            state = result!.state
+        }
+        // At the oldest entry Up recalls nothing further.
+        #expect(ChatInputHistory.recall(state: state, entries: entries, currentDraft: "") == nil)
+    }
+
+    @Test func recallWithNoHistoryDoesNothing() {
+        let result = ChatInputHistory.recall(
+            state: ChatInputHistoryState(),
+            entries: [],
+            currentDraft: "draft"
+        )
+        #expect(result == nil)
+    }
+
+    @Test func recallPreservesOriginalDraftAcrossSteps() {
+        let entries = ["a", "b"]
+        var state = ChatInputHistoryState()
+        state = ChatInputHistory.recall(state: state, entries: entries, currentDraft: "my draft")!.state
+        state = ChatInputHistory.recall(state: state, entries: entries, currentDraft: "a")!.state
+        // The stash keeps the ORIGINAL draft, not the recalled text passed
+        // on subsequent steps.
+        #expect(state.savedDraft == "my draft")
+    }
+
+    // MARK: - Advance (Down)
+
+    @Test func advanceWalksBackAndRestoresDraft() {
+        let entries = ["a", "b", "c"]
+        var state = ChatInputHistoryState(index: 2, savedDraft: "draft")
+
+        var result = ChatInputHistory.advance(state: state, entries: entries)
+        #expect(result?.text == "b")
+        state = result!.state
+
+        result = ChatInputHistory.advance(state: state, entries: entries)
+        #expect(result?.text == "a")
+        state = result!.state
+
+        // Walking past the newest entry restores the draft and leaves navigation.
+        result = ChatInputHistory.advance(state: state, entries: entries)
+        #expect(result?.text == "draft")
+        #expect(result?.state == ChatInputHistoryState())
+    }
+
+    @Test func advanceWhileNotNavigatingDoesNothing() {
+        let result = ChatInputHistory.advance(
+            state: ChatInputHistoryState(),
+            entries: ["a"]
+        )
+        #expect(result == nil)
+    }
+
+    @Test func advanceRecoversWhenEntriesShrink() {
+        // Conversation was cleared mid-navigation; state points past the end.
+        let result = ChatInputHistory.advance(
+            state: ChatInputHistoryState(index: 5, savedDraft: "draft"),
+            entries: ["only"]
+        )
+        #expect(result?.text == "draft")
+        #expect(result?.state == ChatInputHistoryState())
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5443,7 +5443,12 @@ struct ChatView: View {
                                 remoteConnectionPending: windowState.remoteAgentConnectionPhase
                                     == .connecting,
                                 isRemoteAgentRun: windowState.selectedDiscoveredAgentProviderId
-                                    != nil
+                                    != nil,
+                                inputHistoryProvider: { [weak observedSession] in
+                                    guard let observedSession else { return [] }
+                                    return ChatInputHistory.entries(from: observedSession.turns)
+                                },
+                                inputHistoryKey: observedSession.sessionId
                             )
                             .frame(maxWidth: 1100)
                             .frame(maxWidth: .infinity)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -101,6 +101,13 @@ struct FloatingInputCard: View {
     /// sandbox, working folder, screen-context, and the thinking / model-option
     /// chips — because none of them are sent to (or honored by) the remote peer.
     var isRemoteAgentRun: Bool = false
+    /// Terminal-style input history (Up/Down arrows recall previously sent
+    /// messages). Returns the current conversation's sent inputs, newest
+    /// first; nil disables the feature.
+    var inputHistoryProvider: (() -> [String])?
+    /// Identity of the conversation backing the history. Navigation state
+    /// resets when it changes so a recalled index can't leak across chats.
+    var inputHistoryKey: UUID?
 
     init(
         text: Binding<String>,
@@ -138,7 +145,9 @@ struct FloatingInputCard: View {
         isModelPinned: Bool = false,
         pinnedModelLabel: String? = nil,
         remoteConnectionPending: Bool = false,
-        isRemoteAgentRun: Bool = false
+        isRemoteAgentRun: Bool = false,
+        inputHistoryProvider: (() -> [String])? = nil,
+        inputHistoryKey: UUID? = nil
     ) {
         self._text = text
         self._selectedModel = selectedModel
@@ -176,6 +185,8 @@ struct FloatingInputCard: View {
         self.pinnedModelLabel = pinnedModelLabel
         self.remoteConnectionPending = remoteConnectionPending
         self.isRemoteAgentRun = isRemoteAgentRun
+        self.inputHistoryProvider = inputHistoryProvider
+        self.inputHistoryKey = inputHistoryKey
     }
 
     // Observe managers for reactive updates
@@ -197,6 +208,11 @@ struct FloatingInputCard: View {
 
     private var slashRegistry = SlashCommandRegistry.shared
     @State private var slashSelectedIndex: Int = 0
+
+    // MARK: - Input History State
+
+    /// Terminal-style history navigation position + stashed draft.
+    @State private var inputHistoryState = ChatInputHistoryState()
 
     /// Non-nil when the cursor is inside a slash command token (e.g. "/tr" or "hello /tr").
     /// The slash must be at the start of text or immediately after whitespace.
@@ -1410,7 +1426,73 @@ extension FloatingInputCard {
         textViewFocusController.lockFocus(for: 0.3)
         localText = ""
         text = ""
+        // Sending resets history navigation; the sent text becomes the
+        // newest history entry once its turn lands.
+        inputHistoryState = ChatInputHistoryState()
         onSend(message)
+    }
+
+    // MARK: - Input History (terminal-style Up/Down recall)
+
+    private func handleHistoryArrowUp() -> Bool {
+        guard let provider = inputHistoryProvider, caretIsOnFirstLine else { return false }
+        guard
+            let result = ChatInputHistory.recall(
+                state: inputHistoryState,
+                entries: provider(),
+                currentDraft: localText
+            )
+        else { return false }
+        inputHistoryState = result.state
+        applyHistoryText(result.text)
+        return true
+    }
+
+    private func handleHistoryArrowDown() -> Bool {
+        guard inputHistoryState.index != nil, caretIsOnLastLine else { return false }
+        guard
+            let result = ChatInputHistory.advance(
+                state: inputHistoryState,
+                entries: inputHistoryProvider?() ?? []
+            )
+        else { return false }
+        inputHistoryState = result.state
+        applyHistoryText(result.text)
+        return true
+    }
+
+    /// Replace the composer text with a recalled entry and put the caret at
+    /// the end, matching terminal behavior.
+    private func applyHistoryText(_ newText: String) {
+        localText = newText
+        text = newText
+        DispatchQueue.main.async {
+            guard let tv = textViewFocusController.textView else { return }
+            let end = (tv.string as NSString).length
+            tv.setSelectedRange(NSRange(location: end, length: 0))
+            tv.scrollRangeToVisible(NSRange(location: end, length: 0))
+        }
+    }
+
+    /// True when the caret is a plain insertion point on the first line of
+    /// the composer. History recall only triggers there, so Up still moves
+    /// the caret inside a multi-line draft.
+    private var caretIsOnFirstLine: Bool {
+        guard let tv = textViewFocusController.textView else { return false }
+        let range = tv.selectedRange()
+        guard range.length == 0 else { return false }
+        let ns = tv.string as NSString
+        return !ns.substring(to: min(range.location, ns.length)).contains("\n")
+    }
+
+    /// True when the caret is a plain insertion point on the last line of
+    /// the composer. Walking history forward only triggers there.
+    private var caretIsOnLastLine: Bool {
+        guard let tv = textViewFocusController.textView else { return false }
+        let range = tv.selectedRange()
+        guard range.length == 0 else { return false }
+        let ns = tv.string as NSString
+        return !ns.substring(from: min(range.location, ns.length)).contains("\n")
     }
 
     // MARK: - Slash Commands
@@ -4070,13 +4152,13 @@ extension FloatingInputCard {
                 ? {
                     slashSelectedIndex = max(0, slashSelectedIndex - 1)
                     return true
-                } : nil,
+                } : { handleHistoryArrowUp() },
             onArrowDown: showSlashPopup
                 ? {
                     let maxIndex = slashFilteredCommands.count - 1
                     slashSelectedIndex = min(maxIndex, slashSelectedIndex + 1)
                     return true
-                } : nil,
+                } : { handleHistoryArrowDown() },
             onEscape: showSlashPopup
                 ? {
                     // Dismiss popup by clearing the slash prefix
@@ -4093,6 +4175,12 @@ extension FloatingInputCard {
             }
         )
         .frame(maxHeight: maxHeight)
+        // A different conversation now backs the composer — drop any
+        // in-flight history navigation so its index can't recall entries
+        // from the previous chat.
+        .onChange(of: inputHistoryKey) { _, _ in
+            inputHistoryState = ChatInputHistoryState()
+        }
         .overlay(alignment: .topLeading) {
             // Placeholder - uses theme body size
             if showPlaceholder {


### PR DESCRIPTION
## Summary

closes #1877

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
