### PR TITLE
Add chat input history navigation

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatInputHistoryNavigator.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatInputHistoryNavigator.swift
@@ -1,0 +1,65 @@
+//
+//  ChatInputHistoryNavigator.swift
+//  osaurus
+//
+
+import Foundation
+
+struct ChatInputHistoryNavigator: Equatable, Sendable {
+    private(set) var entries: [String] = []
+    private var cursor: Int?
+    private var draft: String = ""
+    private let limit: Int
+
+    init(limit: Int = 100) {
+        self.limit = max(1, limit)
+    }
+
+    var isNavigating: Bool {
+        cursor != nil
+    }
+
+    mutating func record(_ text: String) {
+        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        defer { resetNavigation() }
+        guard !normalized.isEmpty else { return }
+        if entries.last == normalized { return }
+        entries.append(normalized)
+        if entries.count > limit {
+            entries.removeFirst(entries.count - limit)
+        }
+    }
+
+    mutating func previous(currentText: String) -> String? {
+        guard !entries.isEmpty else { return nil }
+        if cursor == nil {
+            draft = currentText
+            cursor = entries.count - 1
+        } else if let current = cursor, current > 0 {
+            cursor = current - 1
+        }
+        guard let cursor else { return nil }
+        return entries[cursor]
+    }
+
+    mutating func next() -> String? {
+        guard let current = cursor else { return nil }
+        if current < entries.count - 1 {
+            cursor = current + 1
+            return entries[current + 1]
+        }
+        let restored = draft
+        resetNavigation()
+        return restored
+    }
+
+    mutating func resetNavigation() {
+        cursor = nil
+        draft = ""
+    }
+
+    mutating func reset() {
+        entries.removeAll()
+        resetNavigation()
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatInputHistoryNavigatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatInputHistoryNavigatorTests.swift
@@ -1,0 +1,68 @@
+//
+//  ChatInputHistoryNavigatorTests.swift
+//  osaurusTests
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+struct ChatInputHistoryNavigatorTests {
+    @Test
+    func previousReturnsMostRecentEntryAndThenOlderEntries() {
+        var history = ChatInputHistoryNavigator()
+        history.record("first")
+        history.record("second")
+
+        #expect(history.previous(currentText: "") == "second")
+        #expect(history.previous(currentText: "") == "first")
+        #expect(history.previous(currentText: "") == "first")
+    }
+
+    @Test
+    func nextRestoresDraftAfterNewestEntry() {
+        var history = ChatInputHistoryNavigator()
+        history.record("first")
+        history.record("second")
+
+        #expect(history.previous(currentText: "draft") == "second")
+        #expect(history.next() == "draft")
+        #expect(history.next() == nil)
+    }
+
+    @Test
+    func recordTrimsSkipsBlankAndDeduplicatesAdjacentEntries() {
+        var history = ChatInputHistoryNavigator()
+        history.record("  ")
+        history.record("  first  ")
+        history.record("first")
+        history.record("second")
+
+        #expect(history.entries == ["first", "second"])
+    }
+
+    @Test
+    func recordCapsEntriesToConfiguredLimit() {
+        var history = ChatInputHistoryNavigator(limit: 2)
+        history.record("one")
+        history.record("two")
+        history.record("three")
+
+        #expect(history.entries == ["two", "three"])
+        #expect(history.previous(currentText: "") == "three")
+        #expect(history.previous(currentText: "") == "two")
+    }
+
+    @Test
+    func resetClearsEntriesAndDraftNavigation() {
+        var history = ChatInputHistoryNavigator()
+        history.record("first")
+
+        #expect(history.previous(currentText: "draft") == "first")
+        history.reset()
+
+        #expect(history.entries.isEmpty)
+        #expect(history.next() == nil)
+        #expect(history.previous(currentText: "") == nil)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5430,6 +5430,7 @@ struct ChatView: View {
                                 onStop: { observedSession.stop() },
                                 focusTrigger: focusTrigger,
                                 agentId: windowState.agentId,
+                                sessionId: observedSession.sessionId,
                                 windowId: windowState.windowId,
                                 isCompact: windowState.showSidebar,
                                 isEmptyChat: !observedSession.hasVisibleThreadMessages,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -47,6 +47,8 @@ struct FloatingInputCard: View {
     var focusTrigger: Int = 0
     /// Current agent ID (used for agent-specific settings)
     var agentId: UUID? = nil
+    /// Current chat session. Used only to scope transient composer history.
+    var sessionId: UUID?
     /// Window ID for targeted VAD notifications
     var windowId: UUID? = nil
     /// Compact mode (sidebar open) - hides secondary chip content
@@ -123,6 +125,7 @@ struct FloatingInputCard: View {
         onStop: @escaping () -> Void,
         focusTrigger: Int = 0,
         agentId: UUID? = nil,
+        sessionId: UUID? = nil,
         windowId: UUID? = nil,
         isCompact: Bool = false,
         isEmptyChat: Bool = false,
@@ -160,6 +163,7 @@ struct FloatingInputCard: View {
         self.onStop = onStop
         self.focusTrigger = focusTrigger
         self.agentId = agentId
+        self.sessionId = sessionId
         self.windowId = windowId
         self.isCompact = isCompact
         self.isEmptyChat = isEmptyChat
@@ -229,6 +233,7 @@ struct FloatingInputCard: View {
 
     // Local state for text input to prevent parent re-renders on every keystroke
     @State private var localText: String = ""
+    @State private var inputHistory = ChatInputHistoryNavigator()
     @State private var isFocused: Bool = false
     @State private var isComposing: Bool = false
     /// Keeps focus in the input through the send/queue state cascade.
@@ -367,6 +372,10 @@ struct FloatingInputCard: View {
 
     private var showPlaceholder: Bool {
         localText.isEmpty && pendingAttachments.isEmpty && !isComposing
+    }
+
+    private var canNavigateInputHistory: Bool {
+        !showSlashPopup && !isComposing && localText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     /// Context tokens including what's currently being typed (localText may differ from text binding)
@@ -1403,6 +1412,7 @@ extension FloatingInputCard {
     private func syncAndSend() {
         guard canSend else { return }
         let message = localText
+        inputHistory.record(message)
         // Hold first responder through the binding-flush cascade
         // (clearing local + bound text, parent reconcile, optional
         // new run kickoff). 300 ms covers the longest observed
@@ -1411,6 +1421,30 @@ extension FloatingInputCard {
         localText = ""
         text = ""
         onSend(message)
+    }
+
+    private func showPreviousInputHistoryEntry() -> Bool {
+        guard canNavigateInputHistory,
+            let previous = inputHistory.previous(currentText: localText)
+        else {
+            return false
+        }
+        localText = previous
+        text = previous
+        isFocused = true
+        return true
+    }
+
+    private func showNextInputHistoryEntry() -> Bool {
+        guard canNavigateInputHistory,
+            let next = inputHistory.next()
+        else {
+            return false
+        }
+        localText = next
+        text = next
+        isFocused = true
+        return true
     }
 
     // MARK: - Slash Commands
@@ -4066,17 +4100,21 @@ extension FloatingInputCard {
                 }
             },
             onShiftCommit: nil,
-            onArrowUp: showSlashPopup
-                ? {
+            onArrowUp: {
+                if showSlashPopup {
                     slashSelectedIndex = max(0, slashSelectedIndex - 1)
                     return true
-                } : nil,
-            onArrowDown: showSlashPopup
-                ? {
+                }
+                return showPreviousInputHistoryEntry()
+            },
+            onArrowDown: {
+                if showSlashPopup {
                     let maxIndex = slashFilteredCommands.count - 1
                     slashSelectedIndex = min(maxIndex, slashSelectedIndex + 1)
                     return true
-                } : nil,
+                }
+                return showNextInputHistoryEntry()
+            },
             onEscape: showSlashPopup
                 ? {
                     // Dismiss popup by clearing the slash prefix
@@ -4092,6 +4130,9 @@ extension FloatingInputCard {
                 return true
             }
         )
+        .onChange(of: sessionId) { _, _ in
+            inputHistory.reset()
+        }
         .frame(maxHeight: maxHeight)
         .overlay(alignment: .topLeading) {
             // Placeholder - uses theme body size


### PR DESCRIPTION
## Summary
- Adds in-memory chat input history for the chat composer.
- Up/Down recalls previous sent text prompts only when the composer is empty, so normal cursor movement in drafts is preserved.
- Scopes history to the current chat session and clears it on session changes.

## Scope
- Chat composer productivity only.
- No model runtime, MLX, provider, channel, tool schema, prompt, or agent-loop behavior changes.
- Refs #1877.

## Privacy and Safety
- Input history is in-memory only and not persisted.
- History resets when the chat session changes to avoid cross-conversation leakage.
- Blank messages are ignored; adjacent duplicates are deduplicated; history is capped at 100 entries.

## Validation
- `git diff --check`
- `swiftlint --quiet --config .swiftlint.yml Packages/OsaurusCore/Models/Chat/ChatInputHistoryNavigator.swift Packages/OsaurusCore/Tests/Chat/ChatInputHistoryNavigatorTests.swift Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift Packages/OsaurusCore/Views/Chat/ChatView.swift`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-chat-input-history swift test --package-path Packages/OsaurusCore --filter 'ChatInputHistoryNavigatorTests|PromptQueueTests|ChatSessionQueuedSendTests'`