### PR TITLE
Add browsing eval evidence scaffold

### DIFF
--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -23,6 +23,7 @@ Packages/OsaurusEvals/
     AgentLoopFrontier/  — harder agent-loop tasks for the local-vs-frontier proof lane (LLM)
     AppleScript/        — AppleScript tool discipline: scripted CI lane + live lane (LLM or scripted)
     ArgumentCoercion/   — ArgumentCoercion.{stringArray,int,bool} pinning
+    Browsing/           — current-behavior browser plugin E2E tasks with pinned fixture/provenance evidence (LLM)
     CapabilityClaims/   — agent-loop "do you have X" behaviour + LLM judge (LLM)
     CapabilitySearch/   — index-only recall measurements (no LLM)
     ComputerUse/        — single-action gate / effect classification (no LLM)
@@ -90,6 +91,19 @@ step does it only when you opt in with `OSAURUS_EVALS_INSTALL_BROWSER=1`
 a selected case declares `fixtures.requirePlugins`, the runner now
 auto-bootstraps installed plugins (no `--bootstrap-plugins` needed); pass
 `--no-plugin-bootstrap` to force-skip them.
+
+The `Browsing` suite is the current-behavior evidence lane for live
+`osaurus.browser` execution. It requires a local fixture base URL in
+`OSAURUS_EVALS_BROWSER_FIXTURE_URL` and skips when that variable or the browser
+plugin is absent. Use `scripts/review/evals-browsing-evidence.sh` for PR
+evidence; it starts a deterministic loopback HTTP fixture server, forces native
+plugin bootstrap, runs the browsing suite with report output, and records the
+app checkout plus the optional `OSAURUS_TOOLS_SOURCE` SHA / plugin artifact
+hashes. These cases do not assert unsafe URL blocking, redirect/private-target
+blocking, redaction, or prompt-injection resistance; add those only with the
+matching browser/fetch/search security plugin build pinned. When browser URL
+policy starts blocking loopback by default, that adoption PR must provide an
+explicit eval/test fixture allowance instead of weakening the production policy.
 
 Or call the CLI directly if you need flags the Makefile doesn't expose:
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -66,6 +66,11 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// missing requirements are SKIPPED in the report (not failed)
         /// so an incomplete local setup doesn't mask real regressions.
         public let requirePlugins: [String]?
+        /// Environment variables the case needs at runtime. Cases with
+        /// missing or empty variables are SKIPPED in the report, matching
+        /// `requirePlugins`. This keeps local-only fixture URLs explicit
+        /// without baking machine-specific paths into committed JSON.
+        public let requireEnvironment: [String]?
         /// Methods to insert into `MethodDatabase` before the case
         /// runs (and remove afterwards). Used by `capability_search`
         /// cases that probe the methods lane — methods have no
@@ -186,6 +191,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
 
         public init(
             requirePlugins: [String]? = nil,
+            requireEnvironment: [String]? = nil,
             seedMethods: [SeedMethod]? = nil,
             enableSkills: [String]? = nil,
             enableTools: [String]? = nil,
@@ -198,6 +204,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             seedSql: [String]? = nil
         ) {
             self.requirePlugins = requirePlugins
+            self.requireEnvironment = requireEnvironment
             self.seedMethods = seedMethods
             self.enableSkills = enableSkills
             self.enableTools = enableTools

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -555,6 +555,9 @@ public enum EvalRunner {
         suiteDirectory: URL
     ) async -> EvalCaseReport {
         let label = testCase.label ?? testCase.id
+        if let skip = requiredFixtureSkipReport(testCase, label: label, modelId: modelId) {
+            return skip
+        }
 
         switch testCase.domain {
         case "schema":
@@ -629,6 +632,40 @@ public enum EvalRunner {
                 modelId: modelId
             )
         }
+    }
+
+    static func requiredFixtureSkipReport(
+        _ testCase: EvalCase,
+        label: String,
+        modelId: String
+    ) -> EvalCaseReport? {
+        var notes: [String] = []
+
+        if let required = testCase.fixtures.requirePlugins, !required.isEmpty {
+            let installed = EvalHostBootstrap.installedPluginIds()
+            let missing = required.filter { !installed.contains($0) }
+            if !missing.isEmpty {
+                notes.append("missing plugins: \(missing.joined(separator: ", "))")
+            }
+        }
+
+        if let required = testCase.fixtures.requireEnvironment, !required.isEmpty {
+            let env = ProcessInfo.processInfo.environment
+            let missing = required.filter { (env[$0] ?? "").isEmpty }
+            if !missing.isEmpty {
+                notes.append("missing environment: \(missing.joined(separator: ", "))")
+            }
+        }
+
+        guard !notes.isEmpty else { return nil }
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: .skipped,
+            notes: notes,
+            modelId: modelId
+        )
     }
 
     // MARK: - Schema domain

--- a/Packages/OsaurusEvals/Suites/Browsing/README.md
+++ b/Packages/OsaurusEvals/Suites/Browsing/README.md
@@ -1,0 +1,30 @@
+# Browsing
+
+Current-behavior browsing evidence for the native `osaurus.browser` plugin.
+
+These cases exercise live `agent_loop` tool execution against deterministic
+HTTP fixture pages supplied by `OSAURUS_EVALS_BROWSER_FIXTURE_URL`. They are
+not security-result assertions: they do not claim unsafe URL blocking,
+redirect/private-target blocking, redaction, or prompt-injection resistance.
+Run evidence through `scripts/review/evals-browsing-evidence.sh` so the report
+records the app checkout, the optional `osaurus-tools` source SHA, plugin
+artifact hashes, fixture URL, model, commands, and per-case outcomes.
+
+Direct run:
+
+```bash
+OSAURUS_EVALS_BROWSER_FIXTURE_URL=http://127.0.0.1:PORT \
+swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+  --suite Packages/OsaurusEvals/Suites/Browsing \
+  --model auto \
+  --bootstrap-plugins \
+  --transcripts \
+  --out build/evals/pr-evidence/browsing-report.json
+```
+
+Cases skip when `osaurus.browser` is not loaded or the fixture URL environment
+variable is absent.
+
+The helper starts a loopback fixture server for deterministic current-behavior
+proof. Future browser URL-policy adoption must keep that allowance eval-only
+and continue blocking loopback in production by default.

--- a/Packages/OsaurusEvals/Suites/Browsing/dialog-handle.json
+++ b/Packages/OsaurusEvals/Suites/Browsing/dialog-handle.json
@@ -1,0 +1,53 @@
+{
+  "id": "browsing.dialog-handle",
+  "domain": "agent_loop",
+  "label": "browsing • handle a deterministic dialog",
+  "query": "Use shell_run to read OSAURUS_EVALS_BROWSER_FIXTURE_URL, for example: printf %s \"$OSAURUS_EVALS_BROWSER_FIXTURE_URL\". Then use browser_navigate to open <base>/dialog.html. Before clicking the Trigger dialog button, call browser_handle_dialog with action accept. Click the button using browser controls. Write the resulting page confirmation text exactly as shown to browsing-dialog-result.txt, and include the same confirmation in your final answer. Do not use browser_execute_script, web search, or fetch.",
+  "notes": "Current-behavior scaffold only. This proves dialog handling against a caller-provided local HTTP fixture and intentionally does not assert unsafe URL blocking, redirect/private-target blocking, redaction, or prompt-injection resistance. Evidence must be tied to the browser plugin build or osaurus-tools source SHA used for the run.",
+  "fixtures": {
+    "requirePlugins": ["osaurus.browser"],
+    "requireEnvironment": ["OSAURUS_EVALS_BROWSER_FIXTURE_URL"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 9,
+      "mustCallTools": ["shell_run", "browser_navigate", "browser_handle_dialog", "file_write"],
+      "mustCallAnyTools": ["browser_do", "browser_click"],
+      "mustNotCallTools": [
+        "browser_execute_script",
+        "browser_open_login",
+        "fetch",
+        "fetch_json",
+        "fetch_html",
+        "download",
+        "search",
+        "search_news",
+        "search_images",
+        "search_and_extract"
+      ],
+      "maxToolCalls": 9,
+      "noToolErrors": true,
+      "files": [
+        {
+          "path": "browsing-dialog-result.txt",
+          "contains": "Dialog accepted larch-19"
+        }
+      ],
+      "finalTextContains": ["Dialog accepted larch-19"],
+      "toolUsageAudit": [
+        {
+          "tool": "browser_navigate",
+          "minCalls": 1,
+          "maxErrors": 0,
+          "argsMustContain": "dialog.html"
+        },
+        {
+          "tool": "browser_handle_dialog",
+          "minCalls": 1,
+          "maxErrors": 0,
+          "argsMustContain": "accept"
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Browsing/form-complete.json
+++ b/Packages/OsaurusEvals/Suites/Browsing/form-complete.json
@@ -1,0 +1,47 @@
+{
+  "id": "browsing.form-complete",
+  "domain": "agent_loop",
+  "label": "browsing • complete a deterministic form",
+  "query": "Use shell_run to read OSAURUS_EVALS_BROWSER_FIXTURE_URL, for example: printf %s \"$OSAURUS_EVALS_BROWSER_FIXTURE_URL\". Then use browser_navigate to open <base>/form.html. Use browser form controls to enter orchid-72 into the Codename field and submit the form. Write the resulting confirmation text exactly as shown to browsing-form-result.txt, and include the same confirmation in your final answer. Do not use browser_execute_script, web search, or fetch.",
+  "notes": "Current-behavior scaffold only. This proves form interaction against a caller-provided local HTTP fixture and intentionally does not assert unsafe URL blocking, redirect/private-target blocking, redaction, or prompt-injection resistance. Evidence must be tied to the browser plugin build or osaurus-tools source SHA used for the run.",
+  "fixtures": {
+    "requirePlugins": ["osaurus.browser"],
+    "requireEnvironment": ["OSAURUS_EVALS_BROWSER_FIXTURE_URL"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "mustCallTools": ["shell_run", "browser_navigate", "file_write"],
+      "mustCallAnyTools": ["browser_do", "browser_type", "browser_click"],
+      "mustNotCallTools": [
+        "browser_execute_script",
+        "browser_open_login",
+        "fetch",
+        "fetch_json",
+        "fetch_html",
+        "download",
+        "search",
+        "search_news",
+        "search_images",
+        "search_and_extract"
+      ],
+      "maxToolCalls": 8,
+      "noToolErrors": true,
+      "files": [
+        {
+          "path": "browsing-form-result.txt",
+          "contains": "Submitted: orchid-72"
+        }
+      ],
+      "finalTextContains": ["Submitted: orchid-72"],
+      "toolUsageAudit": [
+        {
+          "tool": "browser_navigate",
+          "minCalls": 1,
+          "maxErrors": 0,
+          "argsMustContain": "form.html"
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Browsing/inspect-page.json
+++ b/Packages/OsaurusEvals/Suites/Browsing/inspect-page.json
@@ -1,0 +1,46 @@
+{
+  "id": "browsing.inspect-page",
+  "domain": "agent_loop",
+  "label": "browsing • inspect a deterministic page",
+  "query": "Use shell_run to read OSAURUS_EVALS_BROWSER_FIXTURE_URL, for example: printf %s \"$OSAURUS_EVALS_BROWSER_FIXTURE_URL\". Then use browser_navigate to open <base>/inspect.html with detail full. From the page, write exactly this line to browsing-inspect-result.txt: Cobalt delta 47 | Owner Mira | Status ready. Include the same exact line in your final answer. Do not use browser_execute_script, web search, or fetch.",
+  "notes": "Current-behavior scaffold only. This proves page navigation and inspection against a caller-provided local HTTP fixture and intentionally does not assert unsafe URL blocking, redirect/private-target blocking, redaction, or prompt-injection resistance. Evidence must be tied to the browser plugin build or osaurus-tools source SHA used for the run.",
+  "fixtures": {
+    "requirePlugins": ["osaurus.browser"],
+    "requireEnvironment": ["OSAURUS_EVALS_BROWSER_FIXTURE_URL"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 7,
+      "mustCallTools": ["shell_run", "browser_navigate", "file_write"],
+      "mustNotCallTools": [
+        "browser_execute_script",
+        "browser_open_login",
+        "fetch",
+        "fetch_json",
+        "fetch_html",
+        "download",
+        "search",
+        "search_news",
+        "search_images",
+        "search_and_extract"
+      ],
+      "maxToolCalls": 7,
+      "noToolErrors": true,
+      "files": [
+        {
+          "path": "browsing-inspect-result.txt",
+          "contains": "Cobalt delta 47 | Owner Mira | Status ready"
+        }
+      ],
+      "finalTextContains": ["Cobalt delta 47", "Owner Mira", "Status ready"],
+      "toolUsageAudit": [
+        {
+          "tool": "browser_navigate",
+          "minCalls": 1,
+          "maxErrors": 0,
+          "argsMustContain": "inspect.html"
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/BrowsingEvalSuiteTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/BrowsingEvalSuiteTests.swift
@@ -1,0 +1,106 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+@Suite(.serialized)
+struct BrowsingEvalSuiteTests {
+    private func loadSuite() throws -> EvalSuite {
+        let suiteDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // OsaurusEvalsKitTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // OsaurusEvals
+            .appendingPathComponent("Suites/Browsing", isDirectory: true)
+        return try EvalSuite.load(from: suiteDir)
+    }
+
+    @Test func suiteDecodesAsCurrentBehaviorAgentLoopCases() throws {
+        let suite = try loadSuite()
+        #expect(suite.decodeFailures.isEmpty, "decode failures: \(suite.decodeFailures)")
+        #expect(suite.cases.count >= 3, "Browsing suite shrank; got \(suite.cases.count)")
+
+        for testCase in suite.cases {
+            #expect(testCase.domain == "agent_loop", "\(testCase.id) must be an agent_loop case")
+            #expect(testCase.id.hasPrefix("browsing."), "\(testCase.id) id prefix")
+            #expect(testCase.fixtures.requirePlugins == ["osaurus.browser"])
+            #expect(testCase.fixtures.requireEnvironment == ["OSAURUS_EVALS_BROWSER_FIXTURE_URL"])
+            #expect(testCase.notes?.contains("Current-behavior scaffold only") == true)
+            #expect(testCase.notes?.contains("intentionally does not assert unsafe URL blocking") == true)
+
+            let exp = try #require(testCase.expect.agentLoop, "\(testCase.id) missing expect.agentLoop")
+            let requiredTools = (exp.mustCallTools ?? []) + (exp.mustCallAnyTools ?? [])
+            #expect(
+                requiredTools.contains { $0.hasPrefix("browser_") },
+                "\(testCase.id) must require at least one browser tool"
+            )
+            #expect(
+                (exp.files ?? []).contains { $0.path.hasPrefix("browsing-") },
+                "\(testCase.id) must ground the browser result in a workspace file"
+            )
+        }
+    }
+
+    @Test func suiteDoesNotPinFutureSecurityResults() throws {
+        let suiteDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Suites/Browsing", isDirectory: true)
+        let files = try FileManager.default.contentsOfDirectory(
+            at: suiteDir,
+            includingPropertiesForKeys: nil
+        )
+        let jsonFiles = files.filter { $0.pathExtension == "json" }
+        #expect(!jsonFiles.isEmpty)
+
+        let forbidden = [
+            "SSRF_BLOCKED",
+            "SECRET_IN_URL",
+            "UNSAFE_SCHEME",
+            "redirect/private target blocked",
+            "cookie/password/token value does not appear",
+        ]
+        for url in jsonFiles {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            for needle in forbidden {
+                #expect(!text.contains(needle), "\(url.lastPathComponent) contains future security assertion \(needle)")
+            }
+        }
+    }
+
+    @MainActor
+    @Test func requiredFixtureSkipReportsMissingPluginAndEnvironment() {
+        let envName = "OSAURUS_EVALS_BROWSER_FIXTURE_URL_TEST_MISSING"
+        let previous = getenv(envName).map { String(cString: $0) }
+        unsetenv(envName)
+        defer {
+            if let previous {
+                setenv(envName, previous, 1)
+            } else {
+                unsetenv(envName)
+            }
+        }
+
+        let testCase = EvalCase(
+            id: "browsing.skip-fixture",
+            domain: "agent_loop",
+            query: "query",
+            fixtures: .init(
+                requirePlugins: ["osaurus.browser.missing-for-test"],
+                requireEnvironment: [envName]
+            ),
+            expect: .init(agentLoop: .init(mustCallTools: ["browser_navigate"]))
+        )
+
+        let row = EvalRunner.requiredFixtureSkipReport(
+            testCase,
+            label: "label",
+            modelId: "model"
+        )
+
+        #expect(row?.outcome == .skipped)
+        #expect(row?.notes.contains("missing plugins: osaurus.browser.missing-for-test") == true)
+        #expect(row?.notes.contains("missing environment: \(envName)") == true)
+    }
+}

--- a/scripts/review/evals-browsing-evidence.sh
+++ b/scripts/review/evals-browsing-evidence.sh
@@ -65,6 +65,7 @@ printf "name\tcommand\tlog\texit_code\tduration_ms\n" > "$RESULTS_TSV"
 fail=0
 fixture_server_pid=""
 
+# shellcheck disable=SC2329 # invoked by the EXIT trap below.
 cleanup() {
   if [[ -n "$fixture_server_pid" ]] && kill -0 "$fixture_server_pid" >/dev/null 2>&1; then
     kill "$fixture_server_pid" >/dev/null 2>&1 || true
@@ -199,7 +200,8 @@ PY
     exit 1
   fi
 
-  export OSAURUS_EVALS_BROWSER_FIXTURE_URL="http://127.0.0.1:$(cat "$port_file")"
+  OSAURUS_EVALS_BROWSER_FIXTURE_URL="http://127.0.0.1:$(cat "$port_file")"
+  export OSAURUS_EVALS_BROWSER_FIXTURE_URL
   echo "Started fixture server: ${OSAURUS_EVALS_BROWSER_FIXTURE_URL}"
 }
 

--- a/scripts/review/evals-browsing-evidence.sh
+++ b/scripts/review/evals-browsing-evidence.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Run focused browsing eval evidence with explicit native plugin bootstrap.
+
+Usage:
+  scripts/review/evals-browsing-evidence.sh
+
+Environment:
+  OUT_DIR=path                       Evidence output directory.
+                                     Default: build/evals/pr-evidence/<UTC timestamp>
+  MODEL=id                           Model id passed to osaurus-evals. Default: auto.
+  OSAURUS_TOOLS_SOURCE=path          Optional osaurus-tools checkout to record as plugin source provenance.
+  OSAURUS_BROWSER_PLUGIN_DYLIB=path  Optional browser plugin dylib path to hash in the manifest.
+  OSAURUS_BROWSER_PLUGIN_ROOT=path   Optional installed plugin root. Default: ~/.osaurus/Tools/osaurus.browser
+  OSAURUS_EVALS_BROWSER_FIXTURE_URL  Optional fixture base URL. If unset, this script starts a local fixture server.
+  REQUIRE_BROWSING_PASS=0            Do not fail when all browsing cases skip/fail. Default: 1.
+  STRICT=0                           Always exit 0 after writing artifacts. Default exits nonzero on required failures.
+  PYTHON_BIN=python3                 Python interpreter used for fixture server and manifest generation.
+
+The script does not install plugins. It only loads already-installed native
+plugins through osaurus-evals --bootstrap-plugins and records the source/artifact
+identity used for the run.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+cd "$REPO_ROOT"
+
+timestamp="$(date -u +"%Y%m%d-%H%M%S")"
+OUT_DIR="${OUT_DIR:-build/evals/pr-evidence/${timestamp}}"
+LOG_DIR="${OUT_DIR}/logs"
+RESULTS_TSV="${OUT_DIR}/command-results.tsv"
+REPORT_PATH="${OUT_DIR}/browsing-report.json"
+MODEL="${MODEL:-auto}"
+STRICT="${STRICT:-1}"
+REQUIRE_BROWSING_PASS="${REQUIRE_BROWSING_PASS:-1}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+BROWSER_PLUGIN_ROOT="${OSAURUS_BROWSER_PLUGIN_ROOT:-${HOME}/.osaurus/Tools/osaurus.browser}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "error: ${PYTHON_BIN} is required to run browsing evidence." >&2
+  exit 1
+fi
+
+if [[ -z "${OSAURUS_TOOLS_SOURCE:-}" ]]; then
+  candidate_tools_source="$(cd "${REPO_ROOT}/../.." && pwd)/osaurus-tools"
+  if [[ -d "${candidate_tools_source}/.git" ]]; then
+    OSAURUS_TOOLS_SOURCE="${candidate_tools_source}"
+  fi
+fi
+
+mkdir -p "$LOG_DIR"
+printf "name\tcommand\tlog\texit_code\tduration_ms\n" > "$RESULTS_TSV"
+
+fail=0
+fixture_server_pid=""
+
+cleanup() {
+  if [[ -n "$fixture_server_pid" ]] && kill -0 "$fixture_server_pid" >/dev/null 2>&1; then
+    kill "$fixture_server_pid" >/dev/null 2>&1 || true
+    wait "$fixture_server_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+quote_cmd() {
+  local out=""
+  local arg
+  for arg in "$@"; do
+    printf -v out '%s%q ' "$out" "$arg"
+  done
+  printf '%s' "${out% }"
+}
+
+now_ms() {
+  "$PYTHON_BIN" -c 'import time; print(int(time.time() * 1000))'
+}
+
+run_step() {
+  local name="$1"
+  shift
+  local log="${LOG_DIR}/${name}.log"
+  local rel_log="logs/${name}.log"
+  local cmd_display
+  cmd_display="$(quote_cmd "$@")"
+  local start end duration rc
+  start="$(now_ms)"
+  echo "==> ${name}: ${cmd_display}"
+  set +e
+  "$@" >"$log" 2>&1
+  rc=$?
+  set -e
+  end="$(now_ms)"
+  duration=$((end - start))
+  printf "%s\t%s\t%s\t%d\t%d\n" "$name" "$cmd_display" "$rel_log" "$rc" "$duration" >> "$RESULTS_TSV"
+  if [[ "$rc" -eq 0 ]]; then
+    echo "PASS ${name} (${duration}ms)"
+  else
+    echo "FAIL ${name} (${duration}ms); see ${log}" >&2
+    fail=1
+  fi
+}
+
+start_fixture_server_if_needed() {
+  if [[ -n "${OSAURUS_EVALS_BROWSER_FIXTURE_URL:-}" ]]; then
+    echo "Using caller-provided fixture URL: ${OSAURUS_EVALS_BROWSER_FIXTURE_URL}"
+    return
+  fi
+
+  local fixture_dir="${OUT_DIR}/fixtures/browser-site"
+  local port_file="${OUT_DIR}/fixture-port.txt"
+  mkdir -p "$fixture_dir"
+  cat > "${fixture_dir}/inspect.html" <<'HTML'
+<!doctype html>
+<meta charset="utf-8">
+<title>Browsing Eval Inspect</title>
+<main>
+  <h1>Osaurus Browse Eval</h1>
+  <p id="fact">Cobalt delta 47</p>
+  <p id="owner">Owner Mira</p>
+  <p id="status">Status ready</p>
+</main>
+HTML
+  cat > "${fixture_dir}/form.html" <<'HTML'
+<!doctype html>
+<meta charset="utf-8">
+<title>Browsing Eval Form</title>
+<form id="form">
+  <label>Codename <input id="code" name="code" autocomplete="off"></label>
+  <button id="submit" type="submit">Submit</button>
+</form>
+<output id="result"></output>
+<script>
+document.getElementById("form").addEventListener("submit", function(event) {
+  event.preventDefault();
+  document.getElementById("result").textContent =
+    "Submitted: " + document.getElementById("code").value;
+});
+</script>
+HTML
+  cat > "${fixture_dir}/dialog.html" <<'HTML'
+<!doctype html>
+<meta charset="utf-8">
+<title>Browsing Eval Dialog</title>
+<button id="go">Trigger dialog</button>
+<p id="result">Pending</p>
+<script>
+document.getElementById("go").addEventListener("click", function() {
+  alert("Dialog code larch-19");
+  document.getElementById("result").textContent = "Dialog accepted larch-19";
+});
+</script>
+HTML
+
+  "$PYTHON_BIN" - "$fixture_dir" "$port_file" <<'PY' &
+import functools
+import http.server
+import pathlib
+import socketserver
+import sys
+
+directory = pathlib.Path(sys.argv[1]).resolve()
+port_file = pathlib.Path(sys.argv[2])
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
+
+handler = functools.partial(QuietHandler, directory=str(directory))
+with socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler) as httpd:
+    port = httpd.server_address[1]
+    port_file.write_text(str(port), encoding="utf-8")
+    httpd.serve_forever()
+PY
+  fixture_server_pid=$!
+
+  for _ in {1..100}; do
+    if [[ -s "$port_file" ]]; then
+      break
+    fi
+    if ! kill -0 "$fixture_server_pid" >/dev/null 2>&1; then
+      echo "error: fixture server exited before writing ${port_file}" >&2
+      exit 1
+    fi
+    sleep 0.1
+  done
+  if [[ ! -s "$port_file" ]]; then
+    echo "error: fixture server did not start within timeout" >&2
+    exit 1
+  fi
+
+  export OSAURUS_EVALS_BROWSER_FIXTURE_URL="http://127.0.0.1:$(cat "$port_file")"
+  echo "Started fixture server: ${OSAURUS_EVALS_BROWSER_FIXTURE_URL}"
+}
+
+start_fixture_server_if_needed
+
+run_step evals-browsing \
+  env OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
+    OSAURUS_EVALS_BROWSER_FIXTURE_URL="${OSAURUS_EVALS_BROWSER_FIXTURE_URL}" \
+    swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+      --suite Packages/OsaurusEvals/Suites/Browsing \
+      --model "$MODEL" \
+      --bootstrap-plugins \
+      --transcripts \
+      --out "$REPORT_PATH"
+
+set +e
+"$PYTHON_BIN" - "$OUT_DIR" "$RESULTS_TSV" "$fail" "$MODEL" \
+  "${OSAURUS_EVALS_BROWSER_FIXTURE_URL}" "${OSAURUS_TOOLS_SOURCE:-}" \
+  "${OSAURUS_BROWSER_PLUGIN_DYLIB:-}" "$BROWSER_PLUGIN_ROOT" "$REPORT_PATH" \
+  "$REQUIRE_BROWSING_PASS" <<'PY'
+import csv
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+out_dir = pathlib.Path(sys.argv[1])
+tsv = pathlib.Path(sys.argv[2])
+failed = sys.argv[3] != "0"
+model = sys.argv[4]
+fixture_url = sys.argv[5]
+tools_source = sys.argv[6]
+explicit_dylib = sys.argv[7]
+plugin_root = pathlib.Path(sys.argv[8]).expanduser()
+report_path = pathlib.Path(sys.argv[9])
+require_passed = sys.argv[10] != "0"
+
+steps = []
+with tsv.open(newline="", encoding="utf-8") as f:
+    for row in csv.DictReader(f, delimiter="\t"):
+        steps.append(
+            {
+                "name": row["name"],
+                "command": row["command"],
+                "log": row["log"],
+                "exit_code": int(row["exit_code"]),
+                "duration_ms": int(row["duration_ms"]),
+            }
+        )
+
+def git_info(path):
+    root = pathlib.Path(path)
+    if not root.exists():
+        return {"path": str(root), "exists": False}
+
+    def git(args):
+        try:
+            return subprocess.check_output(
+                ["git", "-C", str(root), *args],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except Exception:
+            return ""
+
+    return {
+        "path": str(root),
+        "exists": True,
+        "branch": git(["rev-parse", "--abbrev-ref", "HEAD"]),
+        "head": git(["rev-parse", "HEAD"]),
+        "dirty_status_lines": git(["status", "--short"]).splitlines(),
+    }
+
+def sha256(path):
+    h = hashlib.sha256()
+    with pathlib.Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+def dylib_record(path):
+    p = pathlib.Path(path).expanduser()
+    record = {"path": str(p), "exists": p.exists()}
+    if p.exists() and p.is_file():
+        record["sha256"] = sha256(p)
+        record["size_bytes"] = p.stat().st_size
+    return record
+
+dylibs = []
+if explicit_dylib:
+    dylibs.append(dylib_record(explicit_dylib))
+if plugin_root.exists():
+    for p in sorted(plugin_root.rglob("*.dylib")):
+        text = str(p)
+        if explicit_dylib and pathlib.Path(explicit_dylib).expanduser() == p:
+            continue
+        dylibs.append(dylib_record(text))
+
+report = None
+cases = []
+if report_path.exists():
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        cases = report.get("cases", [])
+    except Exception as exc:
+        cases = [{"id": "(report decode)", "outcome": "errored", "notes": [str(exc)]}]
+
+case_outcomes = {}
+for case in cases:
+    outcome = case.get("outcome", "unknown")
+    case_outcomes[outcome] = case_outcomes.get(outcome, 0) + 1
+passed = case_outcomes.get("passed", 0)
+if require_passed and passed == 0:
+    failed = True
+
+proof_status = "passed" if passed > 0 else "no_passed_cases"
+if case_outcomes.get("failed", 0) or case_outcomes.get("errored", 0):
+    proof_status = "failed_or_errored"
+elif case_outcomes.get("skipped", 0) and passed == 0:
+    proof_status = "skipped"
+
+app_info = git_info(pathlib.Path.cwd())
+tools_info = git_info(tools_source) if tools_source else {"path": "", "exists": False}
+
+try:
+    report_ref = str(report_path.relative_to(out_dir))
+except ValueError:
+    report_ref = str(report_path)
+
+manifest = {
+    "schema": 1,
+    "kind": "browsing_eval_pr_evidence",
+    "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "result": "failed" if failed else "passed",
+    "proof_status": proof_status,
+    "model": model,
+    "fixture_url": fixture_url,
+    "app": app_info,
+    "osaurus_tools_source": tools_info,
+    "browser_plugin": {
+        "plugin_id": "osaurus.browser",
+        "installed_root": str(plugin_root),
+        "explicit_dylib": explicit_dylib,
+        "dylibs": dylibs,
+    },
+    "commands": steps,
+    "report": report_ref if report_path.exists() else str(report_path),
+    "case_outcomes": case_outcomes,
+    "cases": [
+        {
+            "id": case.get("id"),
+            "outcome": case.get("outcome"),
+            "notes": case.get("notes", []),
+            "tool_usage": case.get("toolUsage"),
+        }
+        for case in cases
+    ],
+    "required": {
+        "native_plugin_bootstrap": "--bootstrap-plugins",
+        "source_or_artifact_provenance": bool(
+            tools_info.get("head") or any(d.get("sha256") for d in dylibs)
+        ),
+        "require_passed_case": require_passed,
+    },
+    "artifacts": {
+        "summary": "summary.md",
+        "command_results": "command-results.tsv",
+        "logs": "logs/",
+    },
+}
+
+(out_dir / "manifest.json").write_text(
+    json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+
+lines = [
+    "# Browsing Eval Evidence",
+    "",
+    f"- Result: **{manifest['result']}**",
+    f"- Proof status: `{proof_status}`",
+    f"- Model: `{model}`",
+    f"- App head: `{app_info.get('head', '')}`",
+    f"- Tools source head: `{tools_info.get('head', '')}`",
+    f"- Fixture URL: `{fixture_url}`",
+    f"- Browser dylibs hashed: `{sum(1 for d in dylibs if d.get('sha256'))}`",
+    "",
+    "| Step | Exit | Duration | Log |",
+    "| --- | ---: | ---: | --- |",
+]
+for step in steps:
+    seconds = step["duration_ms"] / 1000.0
+    lines.append(
+        f"| `{step['name']}` | {step['exit_code']} | {seconds:.2f}s | `{step['log']}` |"
+    )
+lines.extend(["", "## Cases", ""])
+if cases:
+    lines.extend(["| Case | Outcome | Notes |", "| --- | --- | --- |"])
+    for case in cases:
+        notes = "; ".join(str(n).replace("\n", " ") for n in case.get("notes", []))
+        lines.append(f"| `{case.get('id')}` | `{case.get('outcome')}` | {notes} |")
+else:
+    lines.append("No case report was written.")
+lines.extend(
+    [
+        "",
+        "Current-behavior scope: this evidence does not assert unsafe URL blocking, redirect/private-target blocking, redaction, or prompt-injection resistance.",
+        "Generated artifacts live under `build/` and are intentionally ignored by git.",
+        "",
+    ]
+)
+(out_dir / "summary.md").write_text("\n".join(lines), encoding="utf-8")
+
+sys.exit(1 if failed else 0)
+PY
+post_rc=$?
+set -e
+if [[ "$post_rc" -ne 0 ]]; then
+  fail=1
+fi
+
+echo "Evidence artifacts: ${OUT_DIR}"
+
+if [[ "$fail" -ne 0 && "$STRICT" != "0" ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
Adds a focused Browsing eval evidence lane for live `osaurus.browser` behavior:

- new `Packages/OsaurusEvals/Suites/Browsing` current-behavior cases for page inspection, form completion, and dialog handling
- fixture/environment skip support so missing browser plugin or fixture URL reports as skipped instead of a misleading tool failure
- `scripts/review/evals-browsing-evidence.sh` to start a deterministic fixture server, force native plugin bootstrap, run the Browsing suite, and write manifest/summary artifacts with app/plugin provenance
- README guidance that this suite is current-behavior evidence only and does not claim URL safety, redaction, or prompt-injection security until matching plugin builds are pinned

## Validation
- `swift test --package-path Packages/OsaurusEvals --filter BrowsingEvalSuiteTests`
- `swift test --package-path Packages/OsaurusEvals`
- `bash -n scripts/review/evals-browsing-evidence.sh`
- `git diff --check`

## Notes
- The evidence helper does not install plugins. It records the installed browser plugin root and optional `OSAURUS_TOOLS_SOURCE` / plugin dylib hashes for provenance.
- The helper uses a deterministic loopback fixture server. Future browser URL-policy adoption should keep that allowance eval-only while preserving production loopback blocking by default.
