### PR TITLE
added per-model API exposure controls with a Models tab in Server settings

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -1126,9 +1126,12 @@ public final class RemoteProviderManager: ObservableObject {
 // MARK: - OpenAI Models Integration
 
 extension RemoteProviderManager {
-    /// Get OpenAI-compatible model objects for all connected providers
+    /// Get OpenAI-compatible model objects for all connected providers.
+    /// Remote models are hidden from API listings by default; only models
+    /// the user exposed in Server > Models are returned.
     func getOpenAIModels() -> [OpenAIModel] {
         var models: [OpenAIModel] = []
+        let exposure = ModelExposureStore.shared
 
         for provider in configuration.providers {
             guard let state = providerStates[provider.id], state.isConnected else {
@@ -1142,6 +1145,7 @@ extension RemoteProviderManager {
 
             for modelId in state.discoveredModels {
                 let prefixedId = "\(prefix)/\(modelId)"
+                guard exposure.isExposed(id: prefixedId, kind: .remote) else { continue }
                 var model = OpenAIModel(modelName: prefixedId)
                 model.owned_by = provider.name
                 models.append(model)

--- a/Packages/OsaurusCore/Models/Configuration/ModelExposureStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelExposureStore.swift
@@ -1,0 +1,160 @@
+//
+//  ModelExposureStore.swift
+//  osaurus
+//
+//  Per-model API exposure settings: which models the server lists on
+//  /models, /tags, and the plugin list_models surface.
+//
+
+import Foundation
+
+/// The kind of model being resolved for exposure. Determines the default
+/// when the user has not explicitly toggled the model.
+public enum ModelExposureKind: Sendable {
+    /// Installed local MLX models and the Apple Foundation model.
+    /// Exposed by default.
+    case local
+    /// Remote provider models (Osaurus Router and BYOK providers),
+    /// identified by their prefixed id (e.g. "osaurus/openai/gpt-5.2").
+    /// Hidden by default.
+    case remote
+
+    public var defaultExposed: Bool {
+        switch self {
+        case .local: return true
+        case .remote: return false
+        }
+    }
+}
+
+/// Persisted exposure settings. Only explicit user toggles are stored;
+/// everything else resolves to the kind's default. This means existing
+/// users automatically get "local on, remote off" without migration,
+/// and newly installed/discovered models pick up the right default.
+public struct ModelExposureSettings: Codable, Equatable, Sendable {
+    /// Model id -> exposed. Keys match the ids the API returns: the repo
+    /// slug for local models (e.g. "qwen3-4b-4bit"), "foundation", and
+    /// the provider-prefixed id for remote models.
+    public var overrides: [String: Bool]
+
+    public init(overrides: [String: Bool] = [:]) {
+        self.overrides = overrides
+    }
+
+    public func isExposed(id: String, kind: ModelExposureKind) -> Bool {
+        overrides[id] ?? kind.defaultExposed
+    }
+}
+
+/// Thread-safe store for `ModelExposureSettings`. HTTP handlers run off the
+/// MainActor, so reads go through an in-memory snapshot behind a lock
+/// (loaded once from disk, updated on save) instead of per-request disk I/O.
+public final class ModelExposureStore: @unchecked Sendable {
+    public static let shared = ModelExposureStore()
+
+    /// When set, reads/writes use this directory instead of the default
+    /// config path. Tests set this before any access.
+    public var overrideDirectory: URL? {
+        didSet {
+            lock.lock()
+            cached = nil
+            lock.unlock()
+        }
+    }
+
+    private let lock = NSLock()
+    private var cached: ModelExposureSettings?
+
+    /// Internal so tests can create isolated instances pointed at a temp
+    /// directory. Production code uses `shared`.
+    init(overrideDirectory: URL? = nil) {
+        self.overrideDirectory = overrideDirectory
+    }
+
+    // MARK: - Reads
+
+    public func isExposed(id: String, kind: ModelExposureKind) -> Bool {
+        settings().isExposed(id: id, kind: kind)
+    }
+
+    public func settings() -> ModelExposureSettings {
+        lock.lock()
+        defer { lock.unlock() }
+        if let cached { return cached }
+        let loaded = loadFromDisk() ?? ModelExposureSettings()
+        cached = loaded
+        return loaded
+    }
+
+    // MARK: - Writes
+
+    public func setExposed(_ exposed: Bool, id: String, kind: ModelExposureKind) {
+        mutate { settings in
+            if exposed == kind.defaultExposed {
+                settings.overrides.removeValue(forKey: id)
+            } else {
+                settings.overrides[id] = exposed
+            }
+        }
+    }
+
+    /// Bulk toggle used by per-provider "Expose all / Hide all" actions.
+    public func setExposed(_ exposed: Bool, ids: [String], kind: ModelExposureKind) {
+        mutate { settings in
+            for id in ids {
+                if exposed == kind.defaultExposed {
+                    settings.overrides.removeValue(forKey: id)
+                } else {
+                    settings.overrides[id] = exposed
+                }
+            }
+        }
+    }
+
+    private func mutate(_ change: (inout ModelExposureSettings) -> Void) {
+        lock.lock()
+        var settings = cached ?? loadFromDisk() ?? ModelExposureSettings()
+        change(&settings)
+        cached = settings
+        lock.unlock()
+        persist(settings)
+    }
+
+    // MARK: - Persistence
+
+    private func fileURL() -> URL {
+        if let dir = overrideDirectory {
+            return dir.appendingPathComponent("model-exposure.json")
+        }
+        return OsaurusPaths.config().appendingPathComponent("model-exposure.json")
+    }
+
+    private func loadFromDisk() -> ModelExposureSettings? {
+        let url = fileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        do {
+            return try JSONDecoder().decode(ModelExposureSettings.self, from: Data(contentsOf: url))
+        } catch {
+            print("[Osaurus] Failed to load ModelExposureSettings: \(error)")
+            return nil
+        }
+    }
+
+    private func persist(_ settings: ModelExposureSettings) {
+        let url = fileURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(settings)
+            ConfigDiskWriter.write(
+                data,
+                to: url,
+                synchronous: overrideDirectory != nil || OsaurusPaths.overrideRoot != nil,
+                onError: { print("[Osaurus] Failed to save ModelExposureSettings: \($0)") }
+            )
+        } catch {
+            print("[Osaurus] Failed to save ModelExposureSettings: \(error)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -8919,9 +8919,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logSelf = self
 
         runRequestTask(priority: .userInitiated) {
-            // Get local models
-            var models = MLXService.getAvailableModels().map { OpenAIModel(modelName: $0) }
-            if FoundationModelService.isDefaultModelAvailable() {
+            // Get local models (filtered by the per-model exposure settings)
+            let exposure = ModelExposureStore.shared
+            var models = MLXService.getAvailableModels()
+                .filter { exposure.isExposed(id: $0, kind: .local) }
+                .map { OpenAIModel(modelName: $0) }
+            if FoundationModelService.isDefaultModelAvailable(),
+                exposure.isExposed(id: "foundation", kind: .local)
+            {
                 models.insert(OpenAIModel(modelName: "foundation"), at: 0)
             }
 
@@ -8976,19 +8981,24 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         runRequestTask(priority: .userInitiated) {
             let now = Date().ISO8601Format()
 
-            // Get local models
-            var models = MLXService.getAvailableModels().map { name -> OpenAIModel in
-                var m = OpenAIModel(from: name)
-                m.name = name
-                m.model = name
-                m.modified_at = now
-                m.size = 0
-                m.digest = ""
-                m.details = ModelDetails.localMLXModelDetails(for: name)
-                return m
-            }
+            // Get local models (filtered by the per-model exposure settings)
+            let exposure = ModelExposureStore.shared
+            var models = MLXService.getAvailableModels()
+                .filter { exposure.isExposed(id: $0, kind: .local) }
+                .map { name -> OpenAIModel in
+                    var m = OpenAIModel(from: name)
+                    m.name = name
+                    m.model = name
+                    m.modified_at = now
+                    m.size = 0
+                    m.digest = ""
+                    m.details = ModelDetails.localMLXModelDetails(for: name)
+                    return m
+                }
 
-            if FoundationModelService.isDefaultModelAvailable() {
+            if FoundationModelService.isDefaultModelAvailable(),
+                exposure.isExposed(id: "foundation", kind: .local)
+            {
                 var fm = OpenAIModel(modelName: "foundation")
                 fm.name = "foundation"
                 fm.model = "foundation"

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -130,6 +130,34 @@
         }
       }
     },
+    "%lld of %lld exposed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld von %lld freigegeben"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%2$lld개 중 %1$lld개 노출됨"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Открыто %lld из %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已公开 %lld/%lld"
+          }
+        }
+      }
+    },
     "-1001234567890 — one per line" : {
       "localizations" : {
         "de" : {
@@ -198,6 +226,34 @@
         }
       }
     },
+    "Apple Foundation Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Foundation-Modell"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Foundation 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Модель Apple Foundation"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple 基础模型"
+          }
+        }
+      }
+    },
     "Auto-reconnecting after a stale session." : {
       "localizations" : {
         "de" : {
@@ -222,6 +278,34 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "会话失效，正在自动重新连接。"
+          }
+        }
+      }
+    },
+    "Choose which models the API lists" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wählen Sie, welche Modelle die API auflistet"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "API가 나열할 모델 선택"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выберите, какие модели показывает API"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "选择 API 列出的模型"
           }
         }
       }
@@ -322,6 +406,34 @@
         }
       }
     },
+    "Expose all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle freigeben"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모두 노출"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показать все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部公开"
+          }
+        }
+      }
+    },
     "Find in conversation" : {
       "localizations" : {
         "de" : {
@@ -358,6 +470,62 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在對話中查找"
+          }
+        }
+      }
+    },
+    "Hidden by default. Enable the remote models you want the API to list." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Standardmäßig ausgeblendet. Aktivieren Sie die Remote-Modelle, die die API auflisten soll."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "기본적으로 숨겨져 있습니다. API에 나열할 원격 모델을 활성화하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "По умолчанию скрыты. Включите удалённые модели, которые API должен показывать."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "默认隐藏。启用您希望 API 列出的远程模型。"
+          }
+        }
+      }
+    },
+    "Hide all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle ausblenden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모두 숨기기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Скрыть все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部隐藏"
           }
         }
       }
@@ -418,6 +586,34 @@
         }
       }
     },
+    "Local Models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lokale Modelle"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "로컬 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Локальные модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "本地模型"
+          }
+        }
+      }
+    },
     "Next match" : {
       "localizations" : {
         "de" : {
@@ -454,6 +650,62 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下一個匹配項"
+          }
+        }
+      }
+    },
+    "No local models match your search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine lokalen Modelle entsprechen Ihrer Suche."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색과 일치하는 로컬 모델이 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет локальных моделей, соответствующих вашему запросу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "没有符合搜索条件的本地模型。"
+          }
+        }
+      }
+    },
+    "No models match your search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine Modelle entsprechen Ihrer Suche."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색과 일치하는 모델이 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет моделей, соответствующих вашему запросу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "没有符合搜索条件的模型。"
           }
         }
       }
@@ -522,6 +774,62 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "正在重新连接…"
+          }
+        }
+      }
+    },
+    "Remote Models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remote-Modelle"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "원격 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Удалённые модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "远程模型"
+          }
+        }
+      }
+    },
+    "Scanning installed models…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Installierte Modelle werden gescannt …"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "설치된 모델을 검색하는 중…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сканирование установленных моделей…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在扫描已安装的模型…"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -2458,9 +2458,12 @@ final class PluginHostContext: @unchecked Sendable {
     func listModels() -> String {
         Self.blockingAsync(fallback: Self.pluginHostTimeoutJSON(kind: "list_models")) {
             var models: [[String: Any]] = []
+            let exposure = ModelExposureStore.shared
 
             // Apple Foundation Model
-            if FoundationModelService.isDefaultModelAvailable() {
+            if FoundationModelService.isDefaultModelAvailable(),
+                exposure.isExposed(id: "foundation", kind: .local)
+            {
                 models.append([
                     "id": "foundation",
                     "name": "Apple Foundation Model",
@@ -2470,8 +2473,9 @@ final class PluginHostContext: @unchecked Sendable {
                 ])
             }
 
-            // Local MLX models
-            for name in MLXService.getAvailableModels() {
+            // Local MLX models (filtered by the per-model exposure settings)
+            for name in MLXService.getAvailableModels()
+            where exposure.isExposed(id: name, kind: .local) {
                 models.append([
                     "id": name,
                     "name": name,

--- a/Packages/OsaurusCore/Tests/Networking/ModelExposureStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ModelExposureStoreTests.swift
@@ -1,0 +1,168 @@
+//
+//  ModelExposureStoreTests.swift
+//  OsaurusCoreTests
+//
+//  Per-model API exposure: local models list by default, remote models are
+//  hidden until opted in, and only explicit user toggles persist. Also pins
+//  the remote-listing filter in `RemoteProviderManager.getOpenAIModels()`.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ModelExposureStoreTests {
+
+    // MARK: - Defaults
+
+    @Test func defaults_localExposed_remoteHidden() throws {
+        let settings = ModelExposureSettings()
+        #expect(settings.isExposed(id: "qwen3-4b-4bit", kind: .local))
+        #expect(settings.isExposed(id: "foundation", kind: .local))
+        #expect(!settings.isExposed(id: "osaurus/openai/gpt-5.2", kind: .remote))
+    }
+
+    @Test func overrides_winOverDefaults() throws {
+        let settings = ModelExposureSettings(overrides: [
+            "qwen3-4b-4bit": false,
+            "osaurus/openai/gpt-5.2": true,
+        ])
+        #expect(!settings.isExposed(id: "qwen3-4b-4bit", kind: .local))
+        #expect(settings.isExposed(id: "osaurus/openai/gpt-5.2", kind: .remote))
+        // Untouched ids still resolve to their kind default.
+        #expect(settings.isExposed(id: "other-local", kind: .local))
+        #expect(!settings.isExposed(id: "osaurus/other", kind: .remote))
+    }
+
+    // MARK: - Store round-trip
+
+    @Test func store_roundTrip_persistsOnlyExplicitOverrides() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = ModelExposureStore(overrideDirectory: dir)
+        store.setExposed(false, id: "hidden-local", kind: .local)
+        store.setExposed(true, id: "osaurus/openai/gpt-5.2", kind: .remote)
+        // Setting the default value must not create an override entry.
+        store.setExposed(true, id: "default-local", kind: .local)
+        store.setExposed(false, id: "osaurus/default-remote", kind: .remote)
+
+        // A fresh store instance reads the same file back from disk.
+        let reloaded = ModelExposureStore(overrideDirectory: dir)
+        let settings = reloaded.settings()
+        #expect(
+            settings.overrides == [
+                "hidden-local": false,
+                "osaurus/openai/gpt-5.2": true,
+            ]
+        )
+        #expect(!reloaded.isExposed(id: "hidden-local", kind: .local))
+        #expect(reloaded.isExposed(id: "osaurus/openai/gpt-5.2", kind: .remote))
+        #expect(reloaded.isExposed(id: "default-local", kind: .local))
+        #expect(!reloaded.isExposed(id: "osaurus/default-remote", kind: .remote))
+    }
+
+    @Test func store_togglingBackToDefault_removesOverride() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = ModelExposureStore(overrideDirectory: dir)
+        store.setExposed(false, id: "model-a", kind: .local)
+        #expect(store.settings().overrides["model-a"] == false)
+
+        store.setExposed(true, id: "model-a", kind: .local)
+        #expect(store.settings().overrides.isEmpty)
+    }
+
+    @Test func store_bulkToggle_appliesToAllIds() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = ModelExposureStore(overrideDirectory: dir)
+        let ids = ["osaurus/a", "osaurus/b", "osaurus/c"]
+        store.setExposed(true, ids: ids, kind: .remote)
+        for id in ids {
+            #expect(store.isExposed(id: id, kind: .remote))
+        }
+
+        // Bulk-hiding remotes restores the default, clearing every override.
+        store.setExposed(false, ids: ids, kind: .remote)
+        #expect(store.settings().overrides.isEmpty)
+        for id in ids {
+            #expect(!store.isExposed(id: id, kind: .remote))
+        }
+    }
+
+    @Test func store_absentFile_yieldsDefaults() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = ModelExposureStore(overrideDirectory: dir)
+        #expect(store.settings().overrides.isEmpty)
+        #expect(store.isExposed(id: "any-local", kind: .local))
+        #expect(!store.isExposed(id: "any/remote", kind: .remote))
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("osaurus-model-exposure-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}
+
+// MARK: - Remote listing filter
+
+/// `getOpenAIModels()` feeds `/models`, `/tags`, and the plugin `list_models`
+/// surface; these tests pin its default-hidden behavior for remote models.
+/// Serialized because they mutate the shared exposure store and the shared
+/// `RemoteProviderManager`.
+@Suite(.serialized)
+struct RemoteModelExposureFilterTests {
+
+    @Test @MainActor func getOpenAIModels_hidesRemoteModelsByDefault() async throws {
+        let dir = try makeTempDirectory()
+        ModelExposureStore.shared.overrideDirectory = dir
+        defer {
+            ModelExposureStore.shared.overrideDirectory = nil
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        let manager = RemoteProviderManager.shared
+        let provider = RemoteProvider(name: "Test Remote", host: "api.example.com")
+        manager._testInstallConnectedProvider(provider, discoveredModels: ["model-a", "model-b"])
+        defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+        let ids = manager.getOpenAIModels().map(\.id)
+        #expect(!ids.contains("test-remote/model-a"))
+        #expect(!ids.contains("test-remote/model-b"))
+    }
+
+    @Test @MainActor func getOpenAIModels_listsOnlyExposedRemoteModels() async throws {
+        let dir = try makeTempDirectory()
+        ModelExposureStore.shared.overrideDirectory = dir
+        defer {
+            ModelExposureStore.shared.overrideDirectory = nil
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        let manager = RemoteProviderManager.shared
+        let provider = RemoteProvider(name: "Test Remote", host: "api.example.com")
+        manager._testInstallConnectedProvider(provider, discoveredModels: ["model-a", "model-b"])
+        defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+        ModelExposureStore.shared.setExposed(true, id: "test-remote/model-b", kind: .remote)
+
+        let ids = manager.getOpenAIModels().map(\.id)
+        #expect(!ids.contains("test-remote/model-a"))
+        #expect(ids.contains("test-remote/model-b"))
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("osaurus-model-exposure-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ServerModelsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerModelsTabContent.swift
@@ -1,0 +1,456 @@
+//
+//  ServerModelsTabContent.swift
+//  osaurus
+//
+//  Server > Models: choose which models the API lists on /models and /tags.
+//  Local models are exposed by default; remote provider models are hidden
+//  until the user opts them in.
+//
+
+import SwiftUI
+
+// MARK: - Row model
+
+private struct ExposureModelRow: Identifiable, Equatable {
+    /// The id exactly as the API lists it (repo slug, "foundation", or the
+    /// provider-prefixed remote id). Also the exposure-override key.
+    let id: String
+    let title: String
+    let subtitle: String
+    let kind: ModelExposureKind
+
+    func matches(_ query: String) -> Bool {
+        guard !query.isEmpty else { return true }
+        return id.localizedCaseInsensitiveContains(query)
+            || title.localizedCaseInsensitiveContains(query)
+            || subtitle.localizedCaseInsensitiveContains(query)
+    }
+}
+
+private struct RemoteProviderGroup: Identifiable, Equatable {
+    let id: UUID
+    let name: String
+    let rows: [ExposureModelRow]
+}
+
+// MARK: - Tab content
+
+struct ServerModelsTabContent: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let searchText: String
+
+    @State private var localRows: [ExposureModelRow] = []
+    @State private var hasLoadedLocalRows = false
+    /// Snapshot of connected remote providers and their models. Never computed
+    /// inside `body`: `cachedAvailableModels()` mutates the manager's
+    /// `@Published` state (managed-router injection), so calling it during a
+    /// view update would publish mid-render and loop.
+    @State private var remoteGroups: [RemoteProviderGroup] = []
+    /// Resolved exposure values for every toggled row, seeded lazily from the
+    /// store so bindings stay cheap.
+    @State private var exposedState: [String: Bool] = [:]
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filteredLocal = localRows.filter { $0.matches(query) }
+        let groups = remoteGroups
+        let filteredGroups: [(group: RemoteProviderGroup, rows: [ExposureModelRow])] =
+            groups.compactMap { group in
+                let rows = group.rows.filter { $0.matches(query) }
+                return rows.isEmpty && !query.isEmpty ? nil : (group, rows)
+            }
+
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 20) {
+                introBanner
+
+                // Local models
+                ModelExposureSection(
+                    title: L("Local Models"),
+                    icon: "internaldrive",
+                    exposedCount: exposedCount(in: localRows),
+                    totalCount: localRows.count,
+                    bulkAction: localRows.isEmpty
+                        ? nil
+                        : { exposed in setAll(localRows, exposed: exposed) }
+                ) {
+                    if !hasLoadedLocalRows {
+                        loadingRow
+                    } else if localRows.isEmpty {
+                        emptyStateRow(
+                            icon: "arrow.down.circle",
+                            message: L(
+                                "No local models installed yet. Download models from the Models manager and they will be exposed here automatically."
+                            )
+                        )
+                    } else if filteredLocal.isEmpty {
+                        emptyStateRow(icon: "magnifyingglass", message: L("No local models match your search."))
+                    } else {
+                        ForEach(filteredLocal) { row in
+                            exposureToggleRow(row)
+                        }
+                    }
+                }
+
+                // Remote models
+                remoteModelsHeader
+
+                if groups.isEmpty {
+                    ModelExposureSection(
+                        title: L("Remote Models"),
+                        icon: "cloud",
+                        exposedCount: nil,
+                        totalCount: nil,
+                        bulkAction: nil
+                    ) {
+                        emptyStateRow(
+                            icon: "antenna.radiowaves.left.and.right",
+                            message: L(
+                                "No remote providers connected. Models from Osaurus Router and your own providers appear here once connected."
+                            )
+                        )
+                    }
+                } else {
+                    ForEach(filteredGroups, id: \.group.id) { entry in
+                        ModelExposureSection(
+                            title: entry.group.name,
+                            icon: "cloud",
+                            exposedCount: exposedCount(in: entry.group.rows),
+                            totalCount: entry.group.rows.count,
+                            bulkAction: { exposed in setAll(entry.group.rows, exposed: exposed) }
+                        ) {
+                            if entry.rows.isEmpty {
+                                emptyStateRow(
+                                    icon: "magnifyingglass",
+                                    message: L("No models match your search.")
+                                )
+                            } else {
+                                ForEach(entry.rows) { row in
+                                    exposureToggleRow(row)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 24)
+            .frame(maxWidth: .infinity)
+        }
+        .task {
+            reloadRemoteGroups()
+            await loadLocalRows()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .remoteProviderModelsChanged)
+                .receive(on: DispatchQueue.main)
+        ) { _ in
+            reloadRemoteGroups()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .remoteProviderStatusChanged)
+                .receive(on: DispatchQueue.main)
+        ) { _ in
+            reloadRemoteGroups()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var introBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "list.bullet.rectangle")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(theme.accentColor)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(L("Choose which models the API lists"))
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text(
+                    L(
+                        "Controls the models returned by /models and /tags. Hidden models can still be used by requesting them directly. Changes apply immediately."
+                    )
+                )
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.accentColor.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.accentColor.opacity(0.18), lineWidth: 1)
+                )
+        )
+    }
+
+    private var remoteModelsHeader: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(L("Remote Models"))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+            Text(L("Hidden by default. Enable the remote models you want the API to list."))
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+        }
+        .padding(.top, 4)
+    }
+
+    private var loadingRow: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text(L("Scanning installed models…"))
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.vertical, 12)
+    }
+
+    private func emptyStateRow(icon: String, message: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 13))
+                .foregroundColor(theme.tertiaryText)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 4)
+    }
+
+    private func exposureToggleRow(_ row: ExposureModelRow) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if row.subtitle != row.title {
+                    Text(row.subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer()
+
+            Toggle("", isOn: exposureBinding(for: row))
+                .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+                .labelsHidden()
+                .controlSize(.small)
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.inputBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.inputBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    // MARK: - State
+
+    private func isExposed(_ row: ExposureModelRow) -> Bool {
+        exposedState[row.id] ?? ModelExposureStore.shared.isExposed(id: row.id, kind: row.kind)
+    }
+
+    private func exposureBinding(for row: ExposureModelRow) -> Binding<Bool> {
+        Binding(
+            get: { isExposed(row) },
+            set: { newValue in
+                ModelExposureStore.shared.setExposed(newValue, id: row.id, kind: row.kind)
+                exposedState[row.id] = newValue
+            }
+        )
+    }
+
+    private func exposedCount(in rows: [ExposureModelRow]) -> Int {
+        rows.count(where: { isExposed($0) })
+    }
+
+    private func setAll(_ rows: [ExposureModelRow], exposed: Bool) {
+        guard let kind = rows.first?.kind else { return }
+        ModelExposureStore.shared.setExposed(exposed, ids: rows.map(\.id), kind: kind)
+        for row in rows {
+            exposedState[row.id] = exposed
+        }
+    }
+
+    // MARK: - Loading
+
+    private func reloadRemoteGroups() {
+        let groups = RemoteProviderManager.shared.cachedAvailableModels().map { entry in
+            RemoteProviderGroup(
+                id: entry.providerId,
+                name: entry.providerName,
+                rows: entry.models.map { prefixedId in
+                    ExposureModelRow(
+                        id: prefixedId,
+                        title: Self.unprefixedRemoteId(prefixedId, providerName: entry.providerName),
+                        subtitle: prefixedId,
+                        kind: .remote
+                    )
+                }
+            )
+        }
+        if groups != remoteGroups {
+            remoteGroups = groups
+        }
+    }
+
+    private func loadLocalRows() async {
+        let discovered = await ModelManager.discoverLocalModelsOffMain()
+
+        // Mirror `ModelManager.installedModelNames()`: the API id is the repo
+        // slug, deduped case-insensitively, sorted by slug.
+        var seen: Set<String> = []
+        var rows: [ExposureModelRow] = []
+        for model in discovered {
+            let slug =
+                model.id.split(separator: "/").last.map(String.init)?.lowercased()
+                ?? model.id.lowercased()
+            guard !seen.contains(slug) else { continue }
+            seen.insert(slug)
+            rows.append(
+                ExposureModelRow(
+                    id: slug,
+                    title: slug,
+                    subtitle: model.id,
+                    kind: .local
+                )
+            )
+        }
+        rows.sort { $0.id < $1.id }
+
+        if FoundationModelService.isDefaultModelAvailable() {
+            rows.insert(
+                ExposureModelRow(
+                    id: "foundation",
+                    title: "foundation",
+                    subtitle: L("Apple Foundation Model"),
+                    kind: .local
+                ),
+                at: 0
+            )
+        }
+
+        localRows = rows
+        hasLoadedLocalRows = true
+    }
+
+    // MARK: - Helpers
+
+    /// Strips the provider prefix from a prefixed remote id, using the same
+    /// slug rule as `RemoteProviderManager` ("Osaurus" -> "osaurus/").
+    private static func unprefixedRemoteId(_ prefixedId: String, providerName: String) -> String {
+        let prefix =
+            providerName
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "-")
+            .replacingOccurrences(of: "/", with: "-") + "/"
+        guard prefixedId.hasPrefix(prefix) else { return prefixedId }
+        return String(prefixedId.dropFirst(prefix.count))
+    }
+}
+
+// MARK: - Section card
+
+private struct ModelExposureSection<Content: View>: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let title: String
+    let icon: String
+    let exposedCount: Int?
+    let totalCount: Int?
+    /// When non-nil, renders "Expose all" / "Hide all" header actions.
+    let bulkAction: ((Bool) -> Void)?
+    @ViewBuilder let content: () -> Content
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+
+                Text(title)
+                    .textCase(.uppercase)
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(theme.secondaryText)
+                    .tracking(0.5)
+
+                if let exposedCount, let totalCount, totalCount > 0 {
+                    Text(L("\(exposedCount) of \(totalCount) exposed"))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.tertiaryText)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule().fill(theme.inputBackground)
+                        )
+                }
+
+                Spacer()
+
+                if let bulkAction {
+                    HStack(spacing: 6) {
+                        bulkButton(L("Expose all")) { bulkAction(true) }
+                        bulkButton(L("Hide all")) { bulkAction(false) }
+                    }
+                }
+            }
+
+            LazyVStack(alignment: .leading, spacing: 8) {
+                content()
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func bulkButton(_ label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule()
+                        .fill(theme.inputBackground)
+                        .overlay(Capsule().stroke(theme.inputBorder, lineWidth: 1))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ServerView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerView.swift
@@ -13,12 +13,14 @@ import UniformTypeIdentifiers
 
 enum ServerTab: String, CaseIterable, AnimatedTabItem {
     case overview = "Overview"
+    case models = "Models"
     case settings = "Settings"
     case apiReference = "API Reference"
 
     var title: String {
         switch self {
         case .overview: return L("Overview")
+        case .models: return L("Models")
         case .settings: return L("Settings")
         case .apiReference: return L("API Reference")
         }
@@ -69,6 +71,8 @@ struct ServerView: View {
                 switch selectedTab {
                 case .overview:
                     OverviewTabContent()
+                case .models:
+                    ServerModelsTabContent(searchText: searchText)
                 case .settings:
                     ServerSettingsTabContent()
                 case .apiReference:
@@ -101,8 +105,8 @@ struct ServerView: View {
             HeaderTabsRow(
                 selection: $selectedTab,
                 searchText: $searchText,
-                searchPlaceholder: "Search endpoints",
-                showSearch: selectedTab == .apiReference
+                searchPlaceholder: selectedTab == .models ? "Search models" : "Search endpoints",
+                showSearch: selectedTab == .apiReference || selectedTab == .models
             )
         }
     }


### PR DESCRIPTION
## Summary

- Osaurus Router catalogs were flooding `/models`, forcing users to turn the router off. This adds per-model exposure controls for what the API lists on `/models`, `/tags`, and the plugin `list_models` surface.
- New **Models** tab in Server settings: local models (and Apple Foundation) are exposed by default; remote models (Osaurus Router + BYOK providers) are hidden by default with per-model toggles, per-provider "Expose all / Hide all" bulk actions, search, and counts.
- Settings persist to `~/.osaurus/config/model-exposure.json` via a lock-protected `ModelExposureStore` (HTTP handlers read an in-memory snapshot off the MainActor). Only explicit toggles are stored, so existing users get local-on / remote-off with no migration and new models pick up the right default automatically.
- Exposure controls listing only — hidden models can still be used by requesting them directly, so existing client workflows keep working.

## Test plan

- [x] `ModelExposureStoreTests`: defaults (local on, remote off), override round-trip, toggling back to default removes the override, bulk toggles, absent file yields defaults
- [x] `RemoteModelExposureFilterTests`: `getOpenAIModels()` hides remote models by default and lists only user-exposed ones
- [x] Manual: Models tab renders local + remote sections, toggles apply immediately, search filters both sections