### PR TITLE
Show live tool-call progress card during buffered tool generation

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
+        "revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bdf6a1555ee0a71c299e2868bd776a37046bed4b32bd2a923dda5a9558799da7",
+  "originHash" : "5cf19a8dd43fb459ec28796d00e256a9e088916ada0d1265e9c5c4603097e749",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
+        "revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -43,10 +43,14 @@ let package = Package(
         // eval/asyncEval/item + synchronize/clearCache to kill the Metal
         // concurrent-encoder crash class) and #117 (NormConventionResolver:
         // an unrecognized norm_convention defers to the vote instead of
-        // silently disabling the (1+weight) shift).
+        // silently disabling the (1+weight) shift). Now also carries the
+        // incremental tool-call envelope progress event (`Generation
+        // .toolCallProgress`) so the app can show a live "preparing tool call"
+        // card during a long buffered tool write (e.g. a large file) instead of
+        // a frozen typing indicator. Additive — existing consumers unaffected.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
+            revision: "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -103623,6 +103623,40 @@
     "Preparing inspection..." : {
       "shouldTranslate" : false
     },
+    "Preparing tool call" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkzeugaufruf wird vorbereitet"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도구 호출 준비 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка вызова инструмента"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备工具调用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在準備工具調用"
+          }
+        }
+      }
+    },
     "Preparing…" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -315,6 +315,25 @@ enum StreamingPrefillProgressHint: Sendable {
     }
 }
 
+/// In-band signaling for a tool call that is still being generated. Carries the
+/// raw, format-specific envelope delta (not parsed arguments) so the native
+/// chat can show a live "building tool call" preview instead of a frozen
+/// indicator while a long call — e.g. a large `write_file` — is streamed inside
+/// the buffered tool-call envelope. Mirrors `StreamingToolHint`'s `\u{FFFE}`
+/// sentinel so HTTP handlers and ChatView drop it from visible model text; the
+/// committed call still arrives afterwards as a `\u{FFFE}tool:` / `\u{FFFE}args:`
+/// pair, so this hint never replaces the actionable tool event.
+enum StreamingToolCallProgressHint: Sendable {
+    private static let progressPrefix = "\u{FFFE}toolprogress:"
+
+    static func encode(_ envelopeDelta: String) -> String { progressPrefix + envelopeDelta }
+
+    static func decode(_ delta: String) -> String? {
+        guard delta.hasPrefix(progressPrefix) else { return nil }
+        return String(delta.dropFirst(progressPrefix.count))
+    }
+}
+
 /// In-band signaling for generation benchmarks (tok/s, token count).
 /// Uses the same `\u{FFFE}` sentinel pattern as `StreamingToolHint`.
 ///

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2293,6 +2293,11 @@ public actor ModelRuntime {
                 pendingTools.append(
                     ServiceToolInvocation(toolName: name, jsonArguments: argsJSON)
                 )
+            case .toolCallProgress:
+                // Non-streaming caller — the incremental envelope preview is a
+                // UI-only affordance; only the committed `.toolInvocation`
+                // matters here. Dropped, like `.reasoning`/`.prefillProgress`.
+                break
             case .completionInfo:
                 break
             }
@@ -2440,6 +2445,20 @@ public actor ModelRuntime {
                     case .prefillProgress(let progress):
                         if pendingTool == nil {
                             continuation.yield(StreamingPrefillProgressHint.encode(progress))
+                        }
+                    case .toolCallProgress(let envelopeDelta):
+                        // Live preview of the tool-call envelope as it is
+                        // written. Emitted before the committed
+                        // `.toolInvocation`, so `pendingTool` is still nil here.
+                        // Encoded behind the `\u{FFFE}` sentinel so it never
+                        // reaches the visible token stream or the OpenAI wire —
+                        // only the native ChatView decodes it, to keep the
+                        // tool-call card alive instead of showing a frozen
+                        // spinner during a long file-write call.
+                        if pendingTool == nil, !envelopeDelta.isEmpty {
+                            continuation.yield(
+                                StreamingToolCallProgressHint.encode(envelopeDelta)
+                            )
                         }
                     case .toolInvocation(let name, let argsJSON):
                         // Surface the first tool call's hints immediately, then

--- a/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
@@ -26,6 +26,15 @@ enum ModelRuntimeEvent: Sendable {
     /// cache lookup/restore work.
     case prefillProgress(PrefillProgressState)
     case toolInvocation(name: String, argsJSON: String)
+    /// Incremental raw-envelope delta of a tool call still being generated.
+    ///
+    /// Translated from vmlx-swift's `Generation.toolCallProgress(String)` (local
+    /// MLX). The payload is the format-specific envelope text as it streams (not
+    /// parsed arguments), so a UI can preview a long call — e.g. a file write —
+    /// as it is written instead of showing a silent gap for the whole call. The
+    /// fully parsed call still arrives once as `.toolInvocation` when the
+    /// envelope closes, so `.toolInvocation` remains the actionable tool event.
+    case toolCallProgress(String)
     /// Completion stats for the just-finished generation.
     ///
     /// `unclosedReasoning` mirrors vmlx's `GenerateCompletionInfo.unclosedReasoning`:

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -152,6 +152,22 @@ enum GenerationEventMapper {
                         .toolInvocation(name: call.function.name, argsJSON: argsJSON)
                     )
 
+                case .toolCallProgress(let envelopeDelta):
+                    // Raw envelope preview while the call is still being
+                    // written. Keeps the stream alive during a long file-write
+                    // call (which otherwise buffers silently until it closes)
+                    // so the chat can render progress instead of a frozen
+                    // indicator. Marks first output so the prefill spinner
+                    // clears — the model IS producing, just inside a tool
+                    // envelope. The parsed call still lands as `.toolInvocation`.
+                    guard !envelopeDelta.isEmpty else { continue }
+                    markFirstModelOutput()
+                    if firstChunk {
+                        firstChunk = false
+                        InferenceProgressManager.shared.prefillDidFinishAsync()
+                    }
+                    continuation.yield(.toolCallProgress(envelopeDelta))
+
                 case .info:
                     continue
 

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -77,6 +77,45 @@ struct GenerationEventMapperTests {
         #expect((parsed?["n"] as? Int) == 3 || (parsed?["n"] as? Double) == 3.0)
     }
 
+    @Test func toolCallProgress_passes_through_with_committed_call() async throws {
+        // While the engine buffers a tool-call envelope it now streams
+        // `.toolCallProgress` deltas (raw envelope text), then the committed
+        // `.toolCall` once it closes. The bridge must forward each progress
+        // delta as `.toolCallProgress` AND still surface the final call as
+        // `.toolInvocation` — the progress event never replaces the call.
+        let args: [String: any Sendable] = ["path": "/tmp/a.txt"]
+        let call = MLXLMCommon.ToolCall(
+            function: MLXLMCommon.ToolCall.Function(
+                name: "write_file",
+                arguments: args
+            )
+        )
+        let events: [Generation] = [
+            .toolCallProgress("<tool_call>{\"name\": \"write_"),
+            .toolCallProgress("file\", \"arguments\": {\"path\":"),
+            .toolCallProgress(" \"/tmp/a.txt\"}}"),
+            .toolCall(call),
+        ]
+        let out = try await collect(events: events)
+
+        let progressDeltas = out.compactMap { ev -> String? in
+            if case .toolCallProgress(let s) = ev { return s } else { return nil }
+        }
+        #expect(progressDeltas.count == 3)
+        #expect(progressDeltas.joined().contains("write_file"))
+
+        #expect(
+            out.contains { if case .toolInvocation(let n, _) = $0 { n == "write_file" } else { false } }
+        )
+    }
+
+    @Test func toolCallProgress_drops_empty_deltas() async throws {
+        // Empty envelope deltas carry no preview and must not produce events.
+        let events: [Generation] = [.toolCallProgress("")]
+        let out = try await collect(events: events)
+        #expect(!out.contains { if case .toolCallProgress = $0 { true } else { false } })
+    }
+
     @Test func info_emits_completionInfo() async throws {
         let info = GenerateCompletionInfo(
             promptTokenCount: 12,

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
-        #expect(packageResolved.contains(#""revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
-        #expect(workspaceResolved.contains(#""revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
-        #expect(appResolved.contains(#""revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f""#))
+        #expect(packageSwift.contains(#"revision: "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
+        #expect(packageResolved.contains(#""revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
+        #expect(workspaceResolved.contains(#""revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
+        #expect(appResolved.contains(#""revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -666,8 +666,12 @@ struct RuntimePolicySourceTests {
         // set_input_array double-free), and the NormConventionResolver
         // fallback (vmlx-swift#117) so an unrecognized norm_convention
         // declaration defers to the order-independent vote instead of
-        // silently disabling the (1+weight) RMSNorm shift.
-        let expectedRuntimeHardenedRevision = "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
+        // silently disabling the (1+weight) RMSNorm shift, plus the
+        // incremental tool-call envelope progress event
+        // (vmlx-swift#119, `Generation.toolCallProgress`) that lets the
+        // native chat show a live "Preparing tool call" card during a long
+        // buffered tool write instead of a frozen typing indicator.
+        let expectedRuntimeHardenedRevision = "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2881,6 +2881,26 @@ final class ChatSession: ObservableObject {
                     rebuildVisibleBlocks()
                     continue
                 }
+                // A tool call is still being generated: the model is emitting the
+                // raw envelope (e.g. a large `write_file` argument) but it hasn't
+                // closed yet, so the parsed name/args aren't available. Local MLX
+                // buffers the whole envelope, so without this the assistant turn
+                // has no visible content and no `pendingToolName`, leaving only the
+                // frozen typing indicator for the entire (multi-second) write.
+                // Seed a neutral in-progress tool card so the view flips from the
+                // static dots to the shimmering pending-tool row; the committed
+                // `StreamingToolHint.decode` above overwrites the placeholder with
+                // the real tool name once the envelope closes. The raw envelope
+                // text itself is intentionally NOT rendered (it isn't parsed args
+                // and could be any format), so it never leaks as message text.
+                if StreamingToolCallProgressHint.decode(delta) != nil {
+                    uiToolSentinelCount += 1
+                    if currentTurn.pendingToolName == nil {
+                        currentTurn.pendingToolName = ToolDisplayName.pendingToolSentinel
+                        rebuildVisibleBlocks()
+                    }
+                    continue
+                }
                 // Captured OpenAI Responses reasoning item (id + encrypted blob).
                 // Not visible text — stash it on the turn so the next request
                 // re-emits it before this turn's function_call(s).

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2743,6 +2743,18 @@ final class ChatSession: ObservableObject {
     /// Processes the streaming delta loop from the chat engine, updating the given
     /// assistant turn and UI state. Returns any parsed tool invocations and the
     /// final updated assistant turn.
+    /// Clears the transient `pendingToolName` placeholder seeded by the
+    /// tool-call-progress branch when — and only when — it is still the
+    /// sentinel at stream end (i.e. no committed tool name ever overwrote it).
+    /// A real tool name replaces the sentinel at `\u{FFFE}tool:`, so this is a
+    /// no-op for genuine pending tool calls; it only prevents a "Preparing tool
+    /// call" card from surviving on a cancelled or reclassified turn.
+    private static func clearPendingToolCallProgressPlaceholder(on turn: ChatTurn) {
+        if turn.pendingToolName == ToolDisplayName.pendingToolSentinel {
+            turn.pendingToolName = nil
+        }
+    }
+
     private func processStreamDeltas(
         stream: AsyncThrowingStream<String, Error>,
         assistantTurn: ChatTurn,
@@ -2752,6 +2764,12 @@ final class ChatSession: ObservableObject {
         selectedModel: String?
     ) async throws -> (invocations: [ServiceToolInvocation], finalTurn: ChatTurn) {
         var currentTurn = assistantTurn
+        // On every exit — clean end, cancel, tool-invocation throw, or a
+        // mid-stream error — drop a tool-call-progress placeholder if it never
+        // resolved to a committed tool name, so the "Preparing tool call" card
+        // can't persist on the finalized turn. No-op for real pending calls
+        // (the committed `\u{FFFE}tool:` name overwrites the sentinel first).
+        defer { Self.clearPendingToolCallProgressPlaceholder(on: currentTurn) }
         var uiDeltaCount = 0
         var uiReasoningDeltaCount = 0
         var uiToolSentinelCount = 0

--- a/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
+++ b/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
@@ -17,6 +17,14 @@ import Foundation
 
 enum ToolDisplayName {
 
+    /// Placeholder `pendingToolName` used while a local-MLX tool call is still
+    /// being generated and its parsed name isn't known yet (the engine buffers
+    /// the whole envelope, then emits the name once it closes). Prefixed with an
+    /// invisible separator so it can never collide with a real tool name, and it
+    /// is display-only — the committed name overwrites it before the call is
+    /// ever executed. See `ChatView`'s tool-call-progress branch.
+    static let pendingToolSentinel = "\u{2063}osaurus.pendingToolCall"
+
     /// Present-continuous + past phrasings for one tool.
     private struct ToolLabel {
         let running: String  // e.g. "Inserting into the database"
@@ -40,6 +48,11 @@ enum ToolDisplayName {
     /// query into the title — "Searching “foo”" / "Searched for “foo”" — so a
     /// column of otherwise identical "Search" rows stays distinguishable.
     static func friendly(for rawName: String, running: Bool, arguments: String? = nil) -> String {
+        if rawName == pendingToolSentinel {
+            // A call is being written but hasn't closed, so the tool isn't known
+            // yet. Present-continuous only — it always resolves to the real name.
+            return L("Preparing tool call")
+        }
         if isSearchTool(rawName) {
             return searchLabel(rawName, running: running, arguments: arguments)
         }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "53840914f693e9e1305fbbacb1ecc8e5c1e9625f"
+        "revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
       }
     },
     {


### PR DESCRIPTION
## What

Shows a live "Preparing tool call" card in the native chat while a local model is still generating a tool call, replacing the frozen typing indicator during a long buffered tool write (e.g. a large file).

Pairs with the vmlx-swift engine event in osaurus-ai/vmlx-swift#118 (`Generation.toolCallProgress`) — this PR is the consumer side that turns those deltas into UI.

## The issue (reproduced)

On the native chat with a local MLX model and a file-writing tool, while the model generates the tool call the chat shows the **typing indicator (bouncing dots) with no progress** for the whole duration of the write; the tool card only appears once the call is fully parsed.

Reproduced at the wire level against a local dev build (`gemma-4-e2b`, sandbox `write_file`, ~1.3 KB file):

```
events           : 8
SENTINEL LEAKS   : 0
tool_name        : write_file
args parse OK    : True  path='/tmp/osaurus_probe.py'  content_len=1318
biggest inter-event gap: 4.57s  (immediately before the tool_call delta)
```

That single **4.57s window with zero stream events** is the frozen UI. It scales to tens of seconds for a real file.

## Root cause

The engine (vmlx-swift) buffers the entire tool-call envelope and emits nothing until the call closes — correct, so a half-written envelope never leaks into visible content. During that window the assistant turn has no visible content and no `pendingToolName`, so `ContentBlock` falls back to the plain typing indicator (the `pendingToolName == nil` branch at `ContentBlock.swift:499`).

The live tool-call rendering added in #1683 assumed tool arguments stream incrementally; on the local path they don't, because the engine had no channel to surface in-flight progress. This is the consumer-side half of that gap — the engine event (vmlx-swift#118) is the other half.

## The change

Consumes the new engine event end to end:

- **`GenerationEventMapper`**: maps `Generation.toolCallProgress` → `ModelRuntimeEvent.toolCallProgress` and clears the prefill spinner (the model IS producing, just inside an envelope).
- **`ModelRuntime.streamWithTools`**: encodes it behind the shared `￾` sentinel via a new `StreamingToolCallProgressHint`, only before a tool is committed.
- **`ChatView`** native loop: decodes the hint and seeds a neutral `pendingToolName` placeholder, flipping the frozen dots to the existing shimmering pending-tool card. The committed `StreamingToolHint` name overwrites the placeholder when the envelope closes.
- **`ToolDisplayName`**: `pendingToolSentinel` + localized "Preparing tool call" label.

## Scoping (deliberately narrow — not a blanket change)

- **No wire change**: the sentinel is already dropped from every OpenAI-compatible / Ollama / Anthropic / Responses SSE writer (`StreamingToolHint.isSentinel`), verified live (`SENTINEL LEAKS: 0`). The HTTP API is byte-for-byte unchanged.
- The raw envelope text is **never rendered as message text** and **never committed as a tool call** — the progress branch only toggles the pending-tool display state. `pendingToolName` is display-only (memoizer key + typing-indicator-vs-card decision + card title); it is never executed or persisted, and the committed name overwrites the placeholder.
- Non-streaming (`respondWithTools`) drops the event, matching `.reasoning`/`.prefillProgress`.
- The pending-tool card view is unchanged (its existing shimmer signals liveness); no new block types.

## Pin

Bumps the vmlx-swift pin to the commit carrying `Generation.toolCallProgress`. To be finalized to the merged vmlx-swift commit before this merges.

## Testing

- **Wire (live, dev build)**: `write_file` tool call parses correctly (no regression), `SENTINEL LEAKS: 0` (wire unchanged), and the 4.57s buffered dead-window reproduced — the window this fills in the UI.
- **Unit**: `GenerationEventMapper` forwards each progress delta as `.toolCallProgress` while still surfacing the committed call as `.toolInvocation`; empty deltas produce no event.
- Native multi-turn UI verification (card appears during a large-file write; content + reasoning streaming unaffected) is the remaining live check.
