### PR TITLE
Add provider connectivity issue triage

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
@@ -55,14 +55,77 @@ public enum ProviderConnectivityFilter: String, Sendable, Equatable, CaseIterabl
         case .all:
             return true
         case .attention:
-            return report.status == .needsAttention
-                || report.highestSeverity == .blocked
-                || report.highestSeverity == .warning
+            return report.isAttentionWorthy
         case .connected:
             return report.status == .connected
         case .disabled:
             return report.status == .disabled
         }
+    }
+}
+
+public struct ProviderConnectivityIssueKind: Sendable, Equatable, Hashable, Identifiable {
+    public let id: String
+
+    public var displayName: String {
+        if self == .authentication { return L("Authentication") }
+        if self == .connection { return L("Connection") }
+        if self == .oauthContext { return L("OAuth") }
+        if self == .requestEvidence { return L("Request evidence") }
+        if self == .models { return L("Models") }
+        if self == .format { return L("Request format") }
+        if self == .proxy { return L("Global proxy") }
+        if self == .transport { return L("Transport") }
+        if self == .repro { return L("Repro path") }
+        if self == .uncategorized || isUnknown { return L("Unknown") }
+        return id
+    }
+    public var isUnknown: Bool { id.hasPrefix(Self.unknownPrefix) }
+
+    public static let authentication = ProviderConnectivityIssueKind(id: "auth")
+    public static let connection = ProviderConnectivityIssueKind(id: "connection")
+    public static let oauthContext = ProviderConnectivityIssueKind(id: "oauth-context")
+    public static let requestEvidence = ProviderConnectivityIssueKind(id: "request-evidence")
+    public static let models = ProviderConnectivityIssueKind(id: "models")
+    public static let format = ProviderConnectivityIssueKind(id: "format")
+    public static let proxy = ProviderConnectivityIssueKind(id: "proxy")
+    public static let transport = ProviderConnectivityIssueKind(id: "transport")
+    public static let repro = ProviderConnectivityIssueKind(id: "repro")
+    public static let uncategorized = ProviderConnectivityIssueKind(id: "unknown:unclassified")
+
+    public init(id: String) {
+        self.id = id
+    }
+
+    public static func kind(forDiagnosticRowID rowID: String) -> ProviderConnectivityIssueKind {
+        knownByRowID[rowID] ?? ProviderConnectivityIssueKind(id: "\(unknownPrefix)\(rowID)")
+    }
+
+    private static let unknownPrefix = "unknown:"
+
+    private static let knownByRowID: [String: ProviderConnectivityIssueKind] = [
+        authentication.id: .authentication,
+        connection.id: .connection,
+        oauthContext.id: .oauthContext,
+        requestEvidence.id: .requestEvidence,
+        models.id: .models,
+        format.id: .format,
+        proxy.id: .proxy,
+        transport.id: .transport,
+        repro.id: .repro,
+    ]
+
+    fileprivate var sortKey: (Int, String) {
+        if self == .authentication { return (0, id) }
+        if self == .connection { return (1, id) }
+        if self == .oauthContext { return (2, id) }
+        if self == .requestEvidence { return (3, id) }
+        if self == .models { return (4, id) }
+        if self == .format { return (5, id) }
+        if self == .proxy { return (6, id) }
+        if self == .transport { return (7, id) }
+        if self == .repro { return (8, id) }
+        return (1_000, id)
     }
 }
 
@@ -77,9 +140,15 @@ public struct ProviderConnectivityProviderReport: Identifiable, Sendable {
     public let recommendedAction: String?
     public let modelCount: Int
     public let manualModelCount: Int
+    public let issueKinds: [ProviderConnectivityIssueKind]
+    public let primaryIssueKind: ProviderConnectivityIssueKind?
 
     public var hasAttention: Bool {
         status == .needsAttention || highestSeverity == .blocked || highestSeverity == .warning
+    }
+
+    public var isAttentionWorthy: Bool {
+        provider.enabled && hasAttention
     }
 }
 
@@ -91,10 +160,27 @@ public struct ProviderConnectivitySnapshot: Sendable {
     public var enabledCount: Int { reports.filter { $0.provider.enabled }.count }
     public var connectedCount: Int { reports.filter { $0.status == .connected }.count }
     public var connectingCount: Int { reports.filter { $0.status == .connecting }.count }
-    public var attentionCount: Int { reports.filter(\.hasAttention).count }
+    public var attentionCount: Int { attentionReports.count }
     public var disabledCount: Int { reports.filter { $0.status == .disabled }.count }
     public var manualModelProviderCount: Int { reports.filter { $0.manualModelCount > 0 }.count }
     public var modelCount: Int { reports.reduce(0) { $0 + $1.modelCount } }
+    public var attentionReports: [ProviderConnectivityProviderReport] {
+        reports.filter(\.isAttentionWorthy)
+    }
+
+    public var issueKindCounts: [ProviderConnectivityIssueKind: Int] {
+        countsByIssueKind(for: attentionReports)
+    }
+
+    public var sortedIssueKinds: [ProviderConnectivityIssueKind] {
+        issueKindCounts.keys.sorted(by: issueKindLessThan)
+    }
+
+    public var groupedReportsByPrimaryIssueKind: [ProviderConnectivityIssueKind: [ProviderConnectivityProviderReport]] {
+        Dictionary(grouping: attentionReports) { report in
+            bucketedIssueKind(for: report)
+        }
+    }
 
     public var highestSeverity: ProviderDiagnosticSeverity {
         reports.map(\.highestSeverity).max(by: severityLessThan) ?? .info
@@ -102,6 +188,33 @@ public struct ProviderConnectivitySnapshot: Sendable {
 
     public func filtered(by filter: ProviderConnectivityFilter) -> [ProviderConnectivityProviderReport] {
         reports.filter { filter.includes($0) }
+    }
+
+    public func filtered(
+        by filter: ProviderConnectivityFilter,
+        issueKind: ProviderConnectivityIssueKind?
+    ) -> [ProviderConnectivityProviderReport] {
+        let statusFiltered = filtered(by: filter)
+        guard filter.allowsIssueFiltering else {
+            return statusFiltered
+        }
+        guard let issueKind else { return statusFiltered }
+        guard issueKindCounts(for: filter)[issueKind, default: 0] > 0 else { return [] }
+        return statusFiltered.filter {
+            $0.isAttentionWorthy && bucketedIssueKinds(for: $0).contains(issueKind)
+        }
+    }
+
+    public func issueReportCount(for filter: ProviderConnectivityFilter) -> Int {
+        issueReports(for: filter).count
+    }
+
+    public func issueKindCounts(for filter: ProviderConnectivityFilter) -> [ProviderConnectivityIssueKind: Int] {
+        countsByIssueKind(for: issueReports(for: filter))
+    }
+
+    public func sortedIssueKinds(for filter: ProviderConnectivityFilter) -> [ProviderConnectivityIssueKind] {
+        issueKindCounts(for: filter).keys.sorted(by: issueKindLessThan)
     }
 
     public var pasteboardText: String {
@@ -117,6 +230,69 @@ public struct ProviderConnectivitySnapshot: Sendable {
             lines.append(report.diagnostics.pasteboardText)
         }
         return lines.joined(separator: "\n")
+    }
+
+    public func groupedPasteboardText(issueKind: ProviderConnectivityIssueKind?) -> String {
+        let normalizedIssueKind = issueKind.flatMap {
+            issueKindCounts[$0, default: 0] > 0 ? $0 : nil
+        }
+        let groupedReports: [(ProviderConnectivityIssueKind, [ProviderConnectivityProviderReport])]
+        if let normalizedIssueKind {
+            groupedReports = [
+                (
+                    normalizedIssueKind,
+                    attentionReports.filter { bucketedIssueKinds(for: $0).contains(normalizedIssueKind) }
+                ),
+            ]
+        } else {
+            groupedReports = sortedIssueKinds.map { kind in
+                (kind, attentionReports.filter { bucketedIssueKinds(for: $0).contains(kind) })
+            }
+        }
+
+        var lines = [
+            "provider-connectivity-issue-diagnostics",
+            "attention-providers=\(attentionCount) issue-buckets=\(groupedReports.count)",
+            "global-proxy: \(proxy.summaryText)",
+        ]
+        for (kind, reports) in groupedReports where !reports.isEmpty {
+            lines.append("")
+            lines.append("\(kind.displayName) (\(reports.count))")
+            for report in reports {
+                lines.append("")
+                lines.append(report.diagnostics.pasteboardText)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func issueReports(for filter: ProviderConnectivityFilter) -> [ProviderConnectivityProviderReport] {
+        filtered(by: filter).filter(\.isAttentionWorthy)
+    }
+
+    private func bucketedIssueKind(
+        for report: ProviderConnectivityProviderReport
+    ) -> ProviderConnectivityIssueKind {
+        report.primaryIssueKind ?? .uncategorized
+    }
+
+    private func bucketedIssueKinds(
+        for report: ProviderConnectivityProviderReport
+    ) -> [ProviderConnectivityIssueKind] {
+        if !report.issueKinds.isEmpty {
+            return report.issueKinds
+        }
+        return [bucketedIssueKind(for: report)]
+    }
+
+    private func countsByIssueKind(
+        for reports: [ProviderConnectivityProviderReport]
+    ) -> [ProviderConnectivityIssueKind: Int] {
+        reports.reduce(into: [:]) { counts, report in
+            for kind in bucketedIssueKinds(for: report) {
+                counts[kind, default: 0] += 1
+            }
+        }
     }
 }
 
@@ -157,6 +333,10 @@ public enum ProviderConnectivityCenter {
             diagnostics.rows.first { $0.severity == .blocked }
             ?? diagnostics.rows.first { $0.severity == .warning }
         let summaryRow = firstActionableRow ?? diagnostics.rows.first { $0.id == "connection" }
+        let issueKinds = actionableIssueKinds(from: diagnostics.rows)
+        let primaryIssueKind = firstActionableRow.map {
+            ProviderConnectivityIssueKind.kind(forDiagnosticRowID: $0.id)
+        }
 
         return ProviderConnectivityProviderReport(
             id: provider.id,
@@ -168,7 +348,9 @@ public enum ProviderConnectivityCenter {
             summary: summary(for: summaryRow, fallback: status.displayName),
             recommendedAction: firstActionableRow?.action,
             modelCount: state?.modelCount ?? 0,
-            manualModelCount: provider.manualModelIds.count
+            manualModelCount: provider.manualModelIds.count,
+            issueKinds: issueKinds,
+            primaryIssueKind: primaryIssueKind
         )
     }
 
@@ -192,6 +374,41 @@ public enum ProviderConnectivityCenter {
             return "\(row.title): \(row.value) - \(detail)"
         }
         return "\(row.title): \(row.value)"
+    }
+
+    private static func actionableIssueKinds(from rows: [ProviderDiagnosticRow]) -> [ProviderConnectivityIssueKind] {
+        var seen: Set<ProviderConnectivityIssueKind> = []
+        var kinds: [ProviderConnectivityIssueKind] = []
+        for row in rows where row.severity == .blocked || row.severity == .warning {
+            let kind = ProviderConnectivityIssueKind.kind(forDiagnosticRowID: row.id)
+            guard !seen.contains(kind) else {
+                continue
+            }
+            seen.insert(kind)
+            kinds.append(kind)
+        }
+        return kinds.sorted(by: issueKindLessThan)
+    }
+}
+
+private func issueKindLessThan(
+    _ lhs: ProviderConnectivityIssueKind,
+    _ rhs: ProviderConnectivityIssueKind
+) -> Bool {
+    if lhs.sortKey.0 != rhs.sortKey.0 {
+        return lhs.sortKey.0 < rhs.sortKey.0
+    }
+    return lhs.sortKey.1 < rhs.sortKey.1
+}
+
+private extension ProviderConnectivityFilter {
+    var allowsIssueFiltering: Bool {
+        switch self {
+        case .all, .attention:
+            return true
+        case .connected, .disabled:
+            return false
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
@@ -67,7 +67,9 @@ struct ProviderConnectivityCenterTests {
         #expect(snapshot.filtered(by: .connected).map(\.provider.name) == ["OpenAI"])
         #expect(snapshot.filtered(by: .disabled).map(\.provider.name) == ["Azure"])
         #expect(snapshot.filtered(by: .attention).contains { $0.provider.name == "Lemonade" })
-        #expect(snapshot.filtered(by: .attention).contains { $0.provider.name == "Azure" })
+        #expect(!snapshot.filtered(by: .attention).contains { $0.provider.name == "Azure" })
+        #expect(snapshot.issueKindCounts[.connection] == 1)
+        #expect(snapshot.groupedReportsByPrimaryIssueKind[.connection]?.map(\.provider.name) == ["Lemonade"])
         #expect(snapshot.pasteboardText.contains("Provider connectivity diagnostics"))
         #expect(snapshot.pasteboardText.contains("https://proxy.example.com:8443"))
         #expect(!snapshot.pasteboardText.contains("secret-token"))
@@ -93,6 +95,248 @@ struct ProviderConnectivityCenterTests {
         #expect(report.highestSeverity == .warning)
         #expect(report.summary.contains("Model discovery"))
         #expect(report.recommendedAction?.contains("deployment") == true)
+    }
+
+    @Test func issueKindMappingUsesStableDiagnosticRowIDs() {
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "connection") == .connection)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "auth") == .authentication)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "oauth-context") == .oauthContext)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "request-evidence") == .requestEvidence)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "models") == .models)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "format") == .format)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "proxy") == .proxy)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "transport") == .transport)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "repro") == .repro)
+
+        let unknown = ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "future-row")
+        #expect(unknown.id == "unknown:future-row")
+        #expect(unknown.isUnknown)
+    }
+
+    @Test func everyProviderNetworkDiagnosticRowIDHasAnIssueBucket() {
+        let emittedIDs = [
+            "auth",
+            "connection",
+            "format",
+            "models",
+            "oauth-context",
+            "proxy",
+            "repro",
+            "request-evidence",
+            "transport",
+        ]
+
+        for rowID in emittedIDs {
+            #expect(!ProviderConnectivityIssueKind.kind(forDiagnosticRowID: rowID).isUnknown)
+        }
+    }
+
+    @Test func unknownIssueBucketsKeepCountsReconciled() {
+        let provider = RemoteProvider(
+            id: UUID(),
+            name: "Future provider",
+            host: "api.future.test",
+            authType: .none
+        )
+        let unknown = ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "future-row")
+        let report = ProviderConnectivityProviderReport(
+            id: provider.id,
+            provider: provider,
+            state: nil,
+            diagnostics: ProviderDiagnosticReport(
+                title: "Remote provider diagnostics",
+                subtitle: "Future provider | https://api.future.test",
+                rows: [
+                    ProviderDiagnosticRow(
+                        id: "future-row",
+                        title: "Future row",
+                        value: "Warning",
+                        severity: .warning
+                    ),
+                ]
+            ),
+            status: .needsAttention,
+            highestSeverity: .warning,
+            summary: "Future row: Warning",
+            recommendedAction: nil,
+            modelCount: 0,
+            manualModelCount: 0,
+            issueKinds: [unknown],
+            primaryIssueKind: unknown
+        )
+        let snapshot = ProviderConnectivitySnapshot(reports: [report], proxy: .disabled)
+
+        #expect(snapshot.issueKindCounts == [unknown: 1])
+        #expect(snapshot.groupedReportsByPrimaryIssueKind[unknown]?.map(\.provider.name) == ["Future provider"])
+        #expect(snapshot.issueKindCounts.values.reduce(0, +) == snapshot.attentionCount)
+    }
+
+    @Test func attentionReportWithoutPrimaryIssueUsesUnclassifiedBucket() {
+        let provider = RemoteProvider(
+            id: UUID(),
+            name: "Unclassified provider",
+            host: "api.unclassified.test",
+            authType: .none
+        )
+        let report = ProviderConnectivityProviderReport(
+            id: provider.id,
+            provider: provider,
+            state: nil,
+            diagnostics: ProviderDiagnosticReport(
+                title: "Remote provider diagnostics",
+                subtitle: "Unclassified provider | https://api.unclassified.test",
+                rows: []
+            ),
+            status: .needsAttention,
+            highestSeverity: .info,
+            summary: "Needs attention",
+            recommendedAction: nil,
+            modelCount: 0,
+            manualModelCount: 0,
+            issueKinds: [],
+            primaryIssueKind: nil
+        )
+        let snapshot = ProviderConnectivitySnapshot(reports: [report], proxy: .disabled)
+
+        #expect(snapshot.issueKindCounts == [.uncategorized: 1])
+        #expect(snapshot.issueKindCounts.values.reduce(0, +) == snapshot.attentionCount)
+    }
+
+    @Test func primaryIssueKindMatchesTheActionableSummaryRow() {
+        let provider = RemoteProvider(
+            name: "Broken API",
+            host: "api.example.test",
+            authType: .apiKey
+        )
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = "HTTP 401 unauthorized"
+
+        let report = ProviderConnectivityCenter.providerReport(
+            provider: provider,
+            state: state,
+            proxy: .invalid("Proxy host 'localhost' is reserved for local networking."),
+            credentialPresence: RemoteProviderCredentialPresence(apiKeyPresent: false)
+        )
+
+        #expect(report.issueKinds == [.authentication, .connection, .proxy])
+        #expect(report.primaryIssueKind == .connection)
+        #expect(report.summary.contains("Connection"))
+        #expect(report.recommendedAction?.contains("Test") == true)
+
+        let snapshot = ProviderConnectivitySnapshot(reports: [report], proxy: .disabled)
+        #expect(snapshot.issueKindCounts == [.authentication: 1, .connection: 1, .proxy: 1])
+        #expect(snapshot.filtered(by: .attention, issueKind: .authentication).map(\.provider.name) == ["Broken API"])
+        #expect(snapshot.filtered(by: .attention, issueKind: .connection).map(\.provider.name) == ["Broken API"])
+        #expect(snapshot.filtered(by: .attention, issueKind: .proxy).map(\.provider.name) == ["Broken API"])
+    }
+
+    @Test func infoRowsDoNotBecomeReportIssues() {
+        let provider = OpenAICodexOAuthService.makeProvider(id: UUID())
+
+        let report = ProviderConnectivityCenter.providerReport(
+            provider: provider,
+            state: nil,
+            proxy: .disabled,
+            credentialPresence: RemoteProviderCredentialPresence(oauthTokensPresent: true)
+        )
+
+        #expect(report.issueKinds.isEmpty)
+        #expect(report.primaryIssueKind == nil)
+    }
+
+    @Test func issueCountsGroupingFilteringAndDisabledExclusionUsePrimaryIssueBuckets() {
+        let auth = RemoteProvider(
+            id: UUID(),
+            name: "Missing key",
+            host: "api.example.test",
+            authType: .apiKey
+        )
+        let proxy = RemoteProvider(
+            id: UUID(),
+            name: "Proxy warning",
+            host: "api.proxy.test",
+            authType: .none
+        )
+        let disabled = RemoteProvider(
+            id: UUID(),
+            name: "Disabled key",
+            host: "api.disabled.test",
+            authType: .apiKey,
+            enabled: false
+        )
+
+        var proxyState = RemoteProviderState(providerId: proxy.id)
+        proxyState.isConnected = true
+        proxyState.discoveredModels = ["model-a"]
+
+        let snapshot = ProviderConnectivityCenter.snapshot(
+            providers: [auth, proxy, disabled],
+            states: [proxy.id: proxyState],
+            proxy: .invalid("Proxy host 'localhost' is reserved for local networking."),
+            credentialsByProvider: [:]
+        )
+
+        #expect(snapshot.attentionCount == 2)
+        #expect(snapshot.issueKindCounts == [.authentication: 1, .proxy: 2])
+        #expect(snapshot.groupedReportsByPrimaryIssueKind[.authentication]?.map(\.provider.name) == ["Missing key"])
+        #expect(snapshot.groupedReportsByPrimaryIssueKind[.proxy]?.map(\.provider.name) == ["Proxy warning"])
+        #expect(!snapshot.groupedReportsByPrimaryIssueKind.values.flatMap { $0 }.contains { $0.provider.name == "Disabled key" })
+        #expect(snapshot.filtered(by: .all, issueKind: .authentication).map(\.provider.name) == ["Missing key"])
+        #expect(snapshot.filtered(by: .attention, issueKind: .authentication).map(\.provider.name) == ["Missing key"])
+        #expect(snapshot.filtered(by: .attention, issueKind: .proxy).map(\.provider.name) == ["Missing key", "Proxy warning"])
+        #expect(snapshot.filtered(by: .attention, issueKind: .requestEvidence).isEmpty)
+        #expect(snapshot.filtered(by: .connected, issueKind: .proxy).map(\.provider.name) == ["Proxy warning"])
+        #expect(snapshot.issueKindCounts(for: .attention) == [.authentication: 1, .proxy: 2])
+    }
+
+    @Test func groupedIssueExportReusesRedactedProviderDiagnostics() throws {
+        let provider = RemoteProvider(
+            name: "Local API",
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 8000,
+            basePath: "/api/v1",
+            authType: .apiKey,
+            providerType: .openaiLegacy
+        )
+        let url = try #require(URL(string: "http://127.0.0.1:8000/api/v1/models?access_token=url-secret"))
+        var request = URLRequest(url: url)
+        request.setValue("Bearer sk-report-secret-12345", forHTTPHeaderField: "Authorization")
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )
+        )
+        let diagnostics = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: request,
+            response: response,
+            responseData: Data(#"{"error":{"message":"invalid api_key=sk-report-body-12345"}}"#.utf8)
+        )
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = #"HTTP 401: {"access_token":"state-secret"}"#
+        state.lastReplayDiagnostics = diagnostics
+
+        let snapshot = ProviderConnectivityCenter.snapshot(
+            providers: [provider],
+            states: [provider.id: state],
+            proxy: .disabled,
+            credentialsByProvider: [
+                provider.id: RemoteProviderCredentialPresence(apiKeyPresent: true),
+            ]
+        )
+
+        let copied = snapshot.groupedPasteboardText(issueKind: .connection)
+        #expect(copied.contains("provider-connectivity-issue-diagnostics"))
+        #expect(copied.contains("Local API"))
+        #expect(copied.contains("Provider request evidence:"))
+        #expect(!copied.contains("url-secret"))
+        #expect(!copied.contains("sk-report-secret-12345"))
+        #expect(!copied.contains("sk-report-body-12345"))
+        #expect(!copied.contains("state-secret"))
     }
 }
 

--- a/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
@@ -27,6 +27,7 @@ struct RemoteProvidersView: View {
     @State private var showReorderSheet = false
     @State private var hasAppeared = false
     @State private var providerFilter: ProviderConnectivityFilter = .all
+    @State private var selectedIssueKind: ProviderConnectivityIssueKind?
     @State private var credentialPresence: [UUID: RemoteProviderCredentialPresence] = [:]
     @State private var reconnectingAll = false
     @State private var reconnectingProviderIds: Set<UUID> = []
@@ -167,7 +168,24 @@ struct RemoteProvidersView: View {
     }
 
     private var visibleProviderReports: [ProviderConnectivityProviderReport] {
-        connectivitySnapshot.filtered(by: providerFilter)
+        connectivitySnapshot.filtered(
+            by: providerFilter,
+            issueKind: activeIssueKind
+        )
+    }
+
+    private var activeIssueKind: ProviderConnectivityIssueKind? {
+        switch providerFilter {
+        case .all, .attention:
+            guard let selectedIssueKind,
+                connectivitySnapshot.issueKindCounts(for: providerFilter)[selectedIssueKind, default: 0] > 0
+            else {
+                return nil
+            }
+            return selectedIssueKind
+        case .connected, .disabled:
+            return nil
+        }
     }
 
     private func presentAPIKeyPicker() {
@@ -236,9 +254,12 @@ struct RemoteProvidersView: View {
     private var connectivityCenterView: some View {
         ProviderConnectivityCenterPanel(
             snapshot: connectivitySnapshot,
+            statusFilter: providerFilter,
+            selectedIssueKind: activeIssueKind,
             isReconnecting: reconnectingAll,
             onReconnectAll: reconnectAllProviders,
-            onCopyReport: copyConnectivityReport
+            onCopyReport: copyConnectivityReport,
+            onSelectIssueKind: { selectedIssueKind = $0 }
         )
     }
 
@@ -339,7 +360,11 @@ struct RemoteProvidersView: View {
     }
 
     private func copyConnectivityReport() {
-        copyText(connectivitySnapshot.pasteboardText)
+        if activeIssueKind != nil {
+            copyText(connectivitySnapshot.groupedPasteboardText(issueKind: activeIssueKind))
+        } else {
+            copyText(connectivitySnapshot.pasteboardText)
+        }
     }
 
     private func copyDiagnostics(_ report: ProviderDiagnosticReport) {
@@ -359,9 +384,12 @@ private struct ProviderConnectivityCenterPanel: View {
     @Environment(\.theme) private var theme
 
     let snapshot: ProviderConnectivitySnapshot
+    let statusFilter: ProviderConnectivityFilter
+    let selectedIssueKind: ProviderConnectivityIssueKind?
     let isReconnecting: Bool
     let onReconnectAll: () -> Void
     let onCopyReport: () -> Void
+    let onSelectIssueKind: (ProviderConnectivityIssueKind?) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -435,6 +463,36 @@ private struct ProviderConnectivityCenterPanel: View {
                     color: theme.infoColor
                 )
             }
+
+            if showsIssueFilters {
+                Divider()
+                    .background(theme.primaryBorder)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ProviderConnectivityIssueChip(
+                            title: L("All"),
+                            count: snapshot.issueReportCount(for: statusFilter),
+                            color: theme.warningColor,
+                            isSelected: selectedIssueKind == nil
+                        ) {
+                            onSelectIssueKind(nil)
+                        }
+
+                        ForEach(snapshot.sortedIssueKinds(for: statusFilter)) { kind in
+                            ProviderConnectivityIssueChip(
+                                title: kind.displayName,
+                                count: snapshot.issueKindCounts(for: statusFilter)[kind, default: 0],
+                                color: issueColor(kind),
+                                isSelected: selectedIssueKind == kind
+                            ) {
+                                onSelectIssueKind(kind)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 1)
+                }
+            }
         }
         .padding(16)
         .background(
@@ -478,6 +536,31 @@ private struct ProviderConnectivityCenterPanel: View {
             "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(snapshot.modelCount) models"
         )
     }
+
+    private var showsIssueFilters: Bool {
+        switch statusFilter {
+        case .all, .attention:
+            return !snapshot.issueKindCounts(for: statusFilter).isEmpty
+        case .connected, .disabled:
+            return false
+        }
+    }
+
+    private func issueColor(_ kind: ProviderConnectivityIssueKind) -> Color {
+        if kind == .authentication || kind == .oauthContext {
+            return theme.errorColor
+        }
+        if kind == .connection || kind == .requestEvidence || kind == .proxy || kind == .repro {
+            return theme.warningColor
+        }
+        if kind == .models {
+            return theme.accentColor
+        }
+        if kind == .format || kind == .transport {
+            return theme.infoColor
+        }
+        return Color.orange
+    }
 }
 
 private struct ProviderConnectivityMetricPill: View {
@@ -499,6 +582,45 @@ private struct ProviderConnectivityMetricPill: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Capsule().fill(color.opacity(0.1)))
+    }
+}
+
+private struct ProviderConnectivityIssueChip: View {
+    @Environment(\.theme) private var theme
+
+    let title: String
+    let count: Int
+    let color: Color
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(isSelected ? color : theme.secondaryText)
+                    .lineLimit(1)
+
+                Text("\(count)")
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundColor(color)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(color.opacity(0.12)))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(isSelected ? color.opacity(0.12) : theme.tertiaryBackground)
+                    .overlay(
+                        Capsule()
+                            .stroke(isSelected ? color.opacity(0.45) : theme.primaryBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
     }
 }
 
@@ -567,6 +689,12 @@ private struct ProviderCardView: View {
                             .foregroundColor(theme.primaryText)
 
                         statusBadge
+
+                        if let primaryIssueKind = report.primaryIssueKind,
+                            provider.enabled,
+                            report.hasAttention {
+                            issueBadge(primaryIssueKind)
+                        }
 
                         if provider.providerType == .osaurus {
                             // Osaurus peers talk through the Secure Channel —
@@ -786,6 +914,31 @@ private struct ProviderCardView: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
             .background(Capsule().fill(color.opacity(0.12)))
+    }
+
+    private func issueBadge(_ kind: ProviderConnectivityIssueKind) -> some View {
+        Text(kind.displayName)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(issueColor(kind))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(issueColor(kind).opacity(0.12)))
+    }
+
+    private func issueColor(_ kind: ProviderConnectivityIssueKind) -> Color {
+        if kind == .authentication || kind == .oauthContext {
+            return theme.errorColor
+        }
+        if kind == .connection || kind == .requestEvidence || kind == .proxy || kind == .repro {
+            return theme.warningColor
+        }
+        if kind == .models {
+            return theme.accentColor
+        }
+        if kind == .format || kind == .transport {
+            return theme.infoColor
+        }
+        return Color.orange
     }
 }
 


### PR DESCRIPTION
Summary
- Adds issue-kind triage to the provider connectivity center using existing provider diagnostic row ids.
- Shows issue chips/counts for attention-worthy providers and lets users filter providers by actionable issue bucket.
- Keeps grouped diagnostic copy redacted by reusing existing provider diagnostic pasteboard output.

Scope
- Provider connectivity aggregation, provider settings panel issue chips, and provider connectivity tests.
- Does not add provider presets or change provider network behavior.

Security / Safety
- Grouped export reuses existing redacted diagnostics.
- Tests cover request URL/header/body/state secret redaction through the grouped copy path.

Validation
- git diff --check
- swiftlint --quiet Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-provider-connectivity swift test --package-path Packages/OsaurusCore --filter 'ProviderConnectivityCenterTests|ProviderNetworkDiagnosticsTests|ProviderReplayDiagnosticsTests|RemoteProviderHeaderRedactorTests'\n\nReview Notes\n- Opened as draft while GitHub checks run.\n- Full local make test was attempted during parallel validation but the broad suite hit unrelated existing ToolExposureControlCenter failures / SwiftPM signal behavior; focused provider/security diagnostics passed on the final diff.