### PR TITLE
Fix 0.21.7 Sentry issues: notch display-reconfig hangs and TextKit downgrade crash

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Views/RedactionPreviewTextView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/RedactionPreviewTextView.swift
@@ -73,7 +73,9 @@ struct RedactionPreviewTextView: NSViewRepresentable {
         scrollView.borderType = .noBorder
         scrollView.scrollerStyle = .overlay
 
-        let textView = SelectableNSTextView()
+        // TextKit 1 from birth — avoids the lazy TextKit 2 → 1 downgrade on
+        // first `.layoutManager` access (see EditableTextView.makeNSView).
+        let textView = SelectableNSTextView(usingTextLayoutManager: false)
         textView.isEditable = false
         textView.isSelectable = true
         textView.isRichText = true

--- a/Packages/OsaurusCore/Tests/Chat/TextViewTextKitModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TextViewTextKitModeTests.swift
@@ -1,0 +1,76 @@
+//
+//  TextViewTextKitModeTests.swift
+//  osaurusTests
+//
+//  Regression coverage for Sentry APPLE-MACOS-YG (NSInvalidArgumentException in
+//  -[NSLayoutManager glyphRangeForTextContainer:]): text views that later read
+//  `.layoutManager` must be built as TextKit 1 from birth. A default-init view
+//  starts as TextKit 2 and lazily downgrades on first `.layoutManager` access,
+//  which can leave AppKit key-binding code holding a stale layout-manager /
+//  text-container pairing.
+//
+
+import AppKit
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct TextViewTextKitModeTests {
+
+    /// The view must have no TextKit 2 stack and a correctly paired
+    /// TextKit 1 stack: the text container appears in its layout
+    /// manager's container list (the exact invariant whose violation
+    /// throws in `glyphRangeForTextContainer:`).
+    private func expectTextKit1Paired(_ textView: NSTextView) {
+        #expect(textView.textLayoutManager == nil, "expected no TextKit 2 layout manager")
+
+        let layoutManager = textView.layoutManager
+        let textContainer = textView.textContainer
+        #expect(layoutManager != nil)
+        #expect(textContainer != nil)
+        if let layoutManager, let textContainer {
+            #expect(layoutManager.textContainers.contains(textContainer))
+            #expect(textContainer.layoutManager === layoutManager)
+        }
+    }
+
+    @Test
+    func customNSTextView_isTextKit1FromBirth() {
+        let textView = CustomNSTextView(usingTextLayoutManager: false)
+        expectTextKit1Paired(textView)
+
+        // `contentHeight` reads `.layoutManager` — the access that used to
+        // trigger the lazy downgrade. It must not disturb the pairing.
+        _ = textView.contentHeight
+        expectTextKit1Paired(textView)
+    }
+
+    @Test
+    func selectableNSTextView_isTextKit1FromBirth() {
+        let textView = SelectableNSTextView(usingTextLayoutManager: false)
+        expectTextKit1Paired(textView)
+    }
+
+    /// Exercises the exact code path that crashed in production:
+    /// `moveDown:` runs `_rangeForMoveDownFromRange:` which calls
+    /// `glyphRangeForTextContainer:` on the view's text container. With a
+    /// mispaired stack this throws NSInvalidArgumentException.
+    @Test
+    func customNSTextView_arrowNavigationAfterLayoutManagerAccess() {
+        let textView = CustomNSTextView(usingTextLayoutManager: false)
+        textView.frame = NSRect(x: 0, y: 0, width: 200, height: 80)
+        textView.isEditable = true
+        textView.string = "line one\nline two\nline three"
+
+        // Read `.layoutManager` first, as the composer does for sizing.
+        _ = textView.contentHeight
+
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        textView.moveDown(nil)
+        textView.moveDown(nil)
+        textView.moveUp(nil)
+
+        expectTextKit1Paired(textView)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
@@ -77,7 +77,12 @@ struct EditableTextView: NSViewRepresentable {
         scrollView.focusRingType = .none
         scrollView.borderType = .noBorder
 
-        let textView = CustomNSTextView()
+        // TextKit 1 from birth. The default init builds a TextKit 2 view whose
+        // first `.layoutManager` access (see `contentHeight`) triggers a lazy
+        // compatibility downgrade mid-lifecycle; AppKit key-binding code can
+        // then hit a stale layout-manager/text-container pairing and throw
+        // (Sentry APPLE-MACOS-YG: NSLayoutManager glyphRangeForTextContainer).
+        let textView = CustomNSTextView(usingTextLayoutManager: false)
         textView.focusRingType = .none
         textView.delegate = context.coordinator
         textView.maxHeight = maxHeight

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -949,7 +949,9 @@ final class NativeMarkdownView: NSView {
     private func ensureTextView(width: CGFloat, theme: any ThemeProtocol) -> SelectableNSTextView {
         if let tv = textView { return tv }
 
-        let tv = SelectableNSTextView()
+        // TextKit 1 from birth — avoids the lazy TextKit 2 → 1 downgrade on
+        // first `.layoutManager` access (see EditableTextView.makeNSView).
+        let tv = SelectableNSTextView(usingTextLayoutManager: false)
         tv.isEditable = false
         tv.isSelectable = true
         tv.isRichText = true

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -928,7 +928,9 @@ private final class UserMessageInlineEditView: NSView, NSTextViewDelegate {
     private var lastLayoutWidth: CGFloat = 0
 
     override init(frame frameRect: NSRect) {
-        let tv = CustomNSTextView()
+        // TextKit 1 from birth — avoids the lazy TextKit 2 → 1 downgrade on
+        // first `.layoutManager` access (see EditableTextView.makeNSView).
+        let tv = CustomNSTextView(usingTextLayoutManager: false)
         tv.maxHeight = 240
         tv.focusRingType = .none
         tv.isRichText = false

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -82,7 +82,10 @@ struct SelectableTextView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> SelectableNSTextView {
-        let textView = SelectableNSTextView()
+        // TextKit 1 from birth — this view reads `.layoutManager` for hit
+        // testing and drawing, which would otherwise force a lazy TextKit 2 → 1
+        // downgrade mid-lifecycle (see EditableTextView.makeNSView).
+        let textView = SelectableNSTextView(usingTextLayoutManager: false)
         textView.isEditable = false
         textView.isSelectable = true
         textView.isRichText = true

--- a/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
@@ -99,6 +99,7 @@ public final class NotchWindowController: NSObject, ObservableObject {
     private var hostingView: NSHostingView<NotchContentView>?
     private var cancellables = Set<AnyCancellable>()
     private var isExpandedForAlert = false
+    private var screenChangeDebounce: DispatchWorkItem?
 
     /// Current screen's notch metrics (published for SwiftUI observation).
     @Published public private(set) var metrics = NotchScreenMetrics(
@@ -129,7 +130,7 @@ public final class NotchWindowController: NSObject, ObservableObject {
         guard let screen = NSScreen.main else { return }
 
         metrics = NotchScreenMetrics.detect(for: screen)
-        let panelFrame = panelRect(for: screen)
+        let panelFrame = panelRect(for: screen, metrics: metrics)
 
         let panel = NSPanel(
             contentRect: panelFrame,
@@ -204,6 +205,8 @@ public final class NotchWindowController: NSObject, ObservableObject {
     public func teardown() {
         NotificationCenter.default.removeObserver(self)
         cancellables.removeAll()
+        screenChangeDebounce?.cancel()
+        screenChangeDebounce = nil
         notchPanel?.close()
         notchPanel = nil
         hostingView = nil
@@ -211,7 +214,23 @@ public final class NotchWindowController: NSObject, ObservableObject {
 
     // MARK: - Private
 
+    /// `didChangeScreenParametersNotification` is delivered synchronously inside
+    /// the window server's display-reconfigure callout, and macOS posts it
+    /// several times per reconfigure. Repositioning immediately performs
+    /// window-server round-trips (`NotchScreenMetrics.detect`, `setFrame`) that
+    /// can block in `mach_msg` for seconds while the server is mid-reconfigure
+    /// (Sentry APPLE-MACOS-YC / -YH / -YK). Debounce so the work runs once,
+    /// after the reconfiguration burst settles.
     @objc private func screenDidChange() {
+        screenChangeDebounce?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.handleScreenChange()
+        }
+        screenChangeDebounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+
+    private func handleScreenChange() {
         updatePanelScreen(forWindowId: ChatWindowManager.shared.lastFocusedWindowId)
         // Re-apply alert expansion now that the screen set changed. If a prior
         // `syncAlertExpansion` bailed because no display was attached, the panel
@@ -245,7 +264,7 @@ public final class NotchWindowController: NSObject, ObservableObject {
         // Don't shrink back to notch size while an alert is covering the screen.
         guard !isExpandedForAlert else { return }
 
-        let newFrame = panelRect(for: targetScreen)
+        let newFrame = panelRect(for: targetScreen, metrics: newMetrics)
         if panel.frame != newFrame {
             panel.setFrame(newFrame, display: true)
         }
@@ -263,7 +282,10 @@ public final class NotchWindowController: NSObject, ObservableObject {
             // stuck at the wrong size. We'll retry on the next sync.
             return
         }
-        let targetFrame = alertActive ? screen.frame : panelRect(for: screen)
+        let targetFrame =
+            alertActive
+            ? screen.frame
+            : panelRect(for: screen, metrics: NotchScreenMetrics.detect(for: screen))
         let targetLevel = alertActive ? Self.alertPanelLevel : NSWindow.Level.floating
         let targetPadding = alertActive
             ? NotchPanelPlacement.alertContentTopPadding(
@@ -287,12 +309,15 @@ public final class NotchWindowController: NSObject, ObservableObject {
     /// Panel positioned at the top of the usable display area, below the menu
     /// bar — including the reveal strip of an auto-hidden menu bar, which
     /// `visibleFrame` does not reserve.
-    private func panelRect(for screen: NSScreen) -> NSRect {
+    ///
+    /// Takes already-detected metrics so callers don't pay a second
+    /// `NotchScreenMetrics.detect` window-server round-trip per pass.
+    private func panelRect(for screen: NSScreen, metrics: NotchScreenMetrics) -> NSRect {
         NotchPanelPlacement.panelRect(
             screenFrame: screen.frame,
             visibleFrame: screen.visibleFrame,
             preferredSize: CGSize(width: Self.panelWidth, height: Self.panelHeight),
-            hiddenMenuBarInset: NotchScreenMetrics.detect(for: screen).notchHeight
+            hiddenMenuBarInset: metrics.notchHeight
         ).frame
     }
 


### PR DESCRIPTION
## Summary

Fixes 4 of the 5 unresolved production issues from release `com.dinoki.osaurus@0.21.7`.

### Display-reconfiguration app hangs (APPLE-MACOS-YC, APPLE-MACOS-YH, APPLE-MACOS-YK)

`NSApplication.didChangeScreenParametersNotification` is delivered synchronously inside the window server's display-reconfigure callout, and `NotchWindowController.screenDidChange` immediately performed window-server round-trips (`NotchScreenMetrics.detect`, `setFrame`) that blocked in `mach_msg` for 3+ seconds.

- Debounce `screenDidChange` with a cancel-and-reschedule `DispatchWorkItem` (300 ms) so repositioning runs after the reconfiguration burst settles; also coalesces the multiple notifications macOS posts per reconfigure.
- `panelRect(for:)` now takes already-detected metrics instead of running a second `NotchScreenMetrics.detect` round-trip per pass.

### NSLayoutManager crash on arrow-down (APPLE-MACOS-YG)

`CustomNSTextView`/`SelectableNSTextView` were built with the default init, which creates a TextKit 2 view that lazily downgrades to TextKit 1 on first `.layoutManager` access. AppKit key bindings (`moveDown:`) could then hit a stale layout-manager/text-container pairing and throw `NSInvalidArgumentException` in `glyphRangeForTextContainer:`. All construction sites now use `init(usingTextLayoutManager: false)` so the views are TextKit 1 from birth.

The fifth issue (APPLE-MACOS-YM, EXC_BAD_ACCESS in `SelectorChip.body` on a macOS 27 developer beta) is a single unsymbolicated event in SwiftUI internals — left open to monitor.

## Test plan

- [x] New `TextViewTextKitModeTests`: asserts TextKit 1 pairing invariant (`glyphRangeForTextContainer:`'s exact precondition) and replays the crashing path (`.layoutManager` access then `moveDown`/`moveUp`)
- [x] `NotchPanelPlacementTests` and `EditableTextViewFocusLockTests` pass unchanged
- [x] Full `make test` (keychain-disabled env): only pre-existing, unrelated failures (keychain-gated suites, adapter timeouts)
- [x] Live smoke on Release build: notch panel comes up at expected geometry (600x500, floating level, centered under the menu bar), app healthy, clean shutdown
- [ ] Manual pass: composer typing/IME and a physical display hot-plug