### PR TITLE
Reflect tool-call failure in the collapsed card title

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/ToolDisplayNameFailedTenseTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolDisplayNameFailedTenseTests.swift
@@ -1,0 +1,54 @@
+//
+//  ToolDisplayNameFailedTenseTests.swift
+//  osaurusTests
+//
+//  Pins the failure tense on the collapsed tool card title. A completed call
+//  whose result was an error keeps a red node but previously still read
+//  "Wrote a file" (success past tense) — contradicting the node. `friendly`
+//  now renders a "Failed: <tool>" title when `failed` is set on a finished
+//  call, while success and in-flight titles are untouched.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ToolDisplayNameFailedTenseTests {
+
+    @Test("failed completed call does not claim success")
+    func failedCompletedCallShowsFailure() {
+        let title = ToolDisplayName.friendly(for: "file_write", running: false, failed: true)
+        #expect(title == String(format: L("Failed: %@"), "File write"))
+        // Must NOT read as the success past tense.
+        #expect(title != L("Wrote a file"))
+    }
+
+    @Test("successful completed call is unchanged")
+    func successfulCompletedCallUnchanged() {
+        #expect(ToolDisplayName.friendly(for: "file_write", running: false, failed: false) == L("Wrote a file"))
+        // Default (no failed arg) preserves the historical behavior.
+        #expect(ToolDisplayName.friendly(for: "file_write", running: false) == L("Wrote a file"))
+    }
+
+    @Test("in-flight title ignores the failure verdict (present tense during the attempt)")
+    func runningTitleIgnoresFailed() {
+        #expect(ToolDisplayName.friendly(for: "file_write", running: true, failed: true) == L("Writing a file"))
+    }
+
+    @Test("failure tense applies uniformly to uncurated tools")
+    func failedGenericTool() {
+        let title = ToolDisplayName.friendly(for: "my_plugin_action", running: false, failed: true)
+        #expect(title == String(format: L("Failed: %@"), "My plugin action"))
+    }
+
+    @Test("pending sentinel is never treated as a failure")
+    func pendingSentinelUnaffectedByFailed() {
+        let title = ToolDisplayName.friendly(
+            for: ToolDisplayName.pendingToolSentinel,
+            running: false,
+            failed: true
+        )
+        #expect(title == L("Preparing tool call"))
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
@@ -1015,10 +1015,14 @@ final class NativeToolCallRowView: NSView {
         } else {
             let titleFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
             nameLabel.font = titleFont
+            // A completed call that returned an error keeps its red node but must
+            // not claim success in the title — reflect the failure verdict here.
+            let failed = item.result.map { isErrorResult($0, callId: item.call.id) } ?? false
             let past = ToolDisplayName.friendly(
                 for: item.call.function.name,
                 running: false,
-                arguments: item.call.function.arguments
+                arguments: item.call.function.arguments,
+                failed: failed
             )
             runningTitle = ToolDisplayName.friendly(
                 for: item.call.function.name,

--- a/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
+++ b/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
@@ -47,11 +47,23 @@ enum ToolDisplayName {
     /// `arguments` (the raw tool-call JSON) lets search-style tools hoist their
     /// query into the title — "Searching “foo”" / "Searched for “foo”" — so a
     /// column of otherwise identical "Search" rows stays distinguishable.
-    static func friendly(for rawName: String, running: Bool, arguments: String? = nil) -> String {
+    static func friendly(
+        for rawName: String,
+        running: Bool,
+        arguments: String? = nil,
+        failed: Bool = false
+    ) -> String {
         if rawName == pendingToolSentinel {
             // A call is being written but hasn't closed, so the tool isn't known
             // yet. Present-continuous only — it always resolves to the real name.
             return L("Preparing tool call")
+        }
+        // A completed call whose result was an error must not read as success:
+        // the past tense ("Wrote a file") would contradict the red error node
+        // when e.g. `file_write` returns `ok:false`. Name the tool and mark the
+        // failure instead. Only applies once the call has completed.
+        if failed, !running {
+            return String(format: L("Failed: %@"), humanize(rawName))
         }
         if isSearchTool(rawName) {
             return searchLabel(rawName, running: running, arguments: arguments)


### PR DESCRIPTION
## Problem
A completed tool call keeps a **red** status node when its result is an error (`nodeStatusColor` → `errorColor`), but the collapsed card **title** still read the success past tense. A `file_write` that returned `{"ok":false,...}` (e.g. a path rejected as outside the working folder) collapsed as **"Wrote a file"** — directly contradicting its own red node.

Verified live: gemma-4-e2b-it-4bit, folder tools, a rejected write showed a red node titled "Wrote a file · 403ms" with an `ok:false` result on expand.

## Fix
`ToolDisplayName.friendly` gains a `failed` flag. On a **finished** call whose result `ToolEnvelope.isError()` is true, it renders **"Failed: <tool>"** (e.g. "Failed: File write") instead of the success tense. Running and success titles are unchanged; the flag is only consulted for completed calls. `NativeToolCallGroupView` computes the verdict from the already-memoized `isErrorResult()`. Reuses the existing `"Failed: %@"` catalog key — no new localization work.

Note: a *successful* `file_write` renders as a rich file-diff card (`good.txt +1 −1`) via `NativeFileDiffView`, not the generic row — so this only changes the failure path that generic tool rows fall through to. No success-path regression.

## Tests
`ToolDisplayNameFailedTenseTests` — failure tense, untouched success/running paths, generic (uncurated) tools, and that the pending-tool sentinel is never treated as a failure. Localization catalog check passes (reused key).

## Live proof
Native Debug build, gemma-4-e2b: a rejected `file_write` now collapses as a red **"Failed: File write"** card; a successful write still shows the green diff card; multi-turn follow-ups coherent with no template/sentinel leaks.