### PR TITLE
Fix folder file-write bugs: firmlinked-root rejection + new-file diff count

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -115,18 +115,32 @@ enum FolderToolHelpers {
         // Symlink-safe containment: the lexical check above only resolves
         // `..` / `.`, so a symlink *inside* the root (e.g. `notes.txt ->
         // ~/.ssh/id_rsa`) would pass it and then be followed out of scope
-        // on read. Resolve symlinks on both the target and the root and
-        // re-check. `resolvingSymlinksInPath()` resolves existing
-        // components (and macOS firmlinks like `/tmp` -> `/private/tmp`),
-        // leaving not-yet-created trailing components intact — so a new
-        // file under a real directory still passes, while a symlink whose
-        // real target escapes the root is rejected. Both sides are
-        // resolved so the firmlink rewrite can't cause a false mismatch.
+        // on read. Resolve symlinks and re-check.
+        //
+        // `resolvingSymlinksInPath()` only rewrites components that exist on
+        // disk. Applying it to the *whole* target is asymmetric with the root
+        // when the target's trailing component doesn't exist yet: for a
+        // firmlinked root like `/tmp` (`/private/tmp`) or `/var`
+        // (`/private/var`), the fully-existing root resolves to the `/tmp`
+        // side while the new file — its trailing name unresolved — keeps the
+        // `/private/tmp` side, so the prefix check falsely fails and every
+        // write under such a root is rejected as "outside the working
+        // directory". Resolve the *deepest existing ancestor* of the target
+        // instead: it flips firmlinks exactly as the root does (symmetry), and
+        // an in-root symlink escaping the root still resolves out and is
+        // rejected. Components below the existing ancestor don't exist yet, so
+        // they can't be symlinks and are safe to treat lexically.
         let realRoot = rootPath.resolvingSymlinksInPath().standardized.path
-        let realResolved = resolvedURL.resolvingSymlinksInPath().standardized.path
+        var existingAncestor = resolvedURL
+        while !FileManager.default.fileExists(atPath: existingAncestor.path) {
+            let parent = existingAncestor.deletingLastPathComponent()
+            if parent.path == existingAncestor.path { break }
+            existingAncestor = parent
+        }
+        let realExisting = existingAncestor.resolvingSymlinksInPath().standardized.path
         let isWithinRealRoot =
-            realResolved == realRoot
-            || realResolved.hasPrefix(realRoot + "/")
+            realExisting == realRoot
+            || realExisting.hasPrefix(realRoot + "/")
         guard isWithinRealRoot else {
             throw FolderToolError.pathOutsideRoot(relativePath)
         }

--- a/Packages/OsaurusCore/Folder/WorkspaceWriteSafety.swift
+++ b/Packages/OsaurusCore/Folder/WorkspaceWriteSafety.swift
@@ -265,8 +265,12 @@ enum WorkspaceWriteSafety {
         oldLabel: String,
         newLabel: String
     ) -> (text: String, truncated: Bool) {
-        let oldLines = old.components(separatedBy: .newlines)
-        let newLines = new.components(separatedBy: .newlines)
+        // An empty side has zero lines, not one empty line. `"".components(
+        // separatedBy:)` returns `[""]`, which would make creating a new file
+        // (empty `old`) diff as a phantom removal of one empty line — the card
+        // then shows `+1 −1` for a brand-new one-line file instead of `+1 −0`.
+        let oldLines = old.isEmpty ? [] : old.components(separatedBy: .newlines)
+        let newLines = new.isEmpty ? [] : new.components(separatedBy: .newlines)
         var lines: [String] = [
             "--- \(path) (\(oldLabel))",
             "+++ \(path) (\(newLabel))",

--- a/Packages/OsaurusCore/Tests/Folder/ResolvePathScopeTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/ResolvePathScopeTests.swift
@@ -95,4 +95,46 @@ struct ResolvePathScopeTests {
         let resolved = try FolderToolHelpers.resolvePath("out/new.txt", rootPath: root)
         #expect(resolved.lastPathComponent == "new.txt")
     }
+
+    /// Create a root addressed via the literal `/private/tmp` path — the form
+    /// the macOS folder picker hands back for a folder under `/tmp`. This is
+    /// the firmlink form that `resolvingSymlinksInPath()` rewrites (to `/tmp`)
+    /// only when the whole path exists, so `FileManager.temporaryDirectory`
+    /// (which yields the `/var/folders` form) never exercises it.
+    private func makePrivateTmpRoot() -> URL {
+        let dir = URL(fileURLWithPath: "/private/tmp")
+            .appendingPathComponent("osaurus-resolvepath-firmlink-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func allowsNewFileDirectlyUnderFirmlinkedPrivateTmpRoot() throws {
+        // Regression: a bare new filename under a `/private/tmp` root was
+        // falsely rejected as "outside the working directory" because the
+        // fully-existing root resolved to the `/tmp` firmlink side while the
+        // not-yet-created target kept the `/private/tmp` side, so the two
+        // landed on opposite sides of the firmlink. The deepest-existing-
+        // ancestor resolution keeps both sides symmetric.
+        let root = makePrivateTmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolved = try FolderToolHelpers.resolvePath("out.txt", rootPath: root)
+        #expect(resolved.lastPathComponent == "out.txt")
+    }
+
+    @Test func stillRejectsSymlinkEscapeUnderFirmlinkedPrivateTmpRoot() throws {
+        // The firmlink fix must not weaken the escaping-symlink guard.
+        let root = makePrivateTmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let outside = makeRoot()
+        defer { try? FileManager.default.removeItem(at: outside) }
+        let secret = outside.appendingPathComponent("id_rsa")
+        try "PRIVATE KEY".write(to: secret, atomically: true, encoding: .utf8)
+        let link = root.appendingPathComponent("notes.txt")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: secret)
+
+        #expect(throws: FolderToolError.self) {
+            _ = try FolderToolHelpers.resolvePath("notes.txt", rootPath: root)
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Folder/WorkspaceDiffNewFileCountTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/WorkspaceDiffNewFileCountTests.swift
@@ -1,0 +1,57 @@
+//
+//  WorkspaceDiffNewFileCountTests.swift
+//  osaurusTests
+//
+//  Pins the new-file diff counts surfaced on the file-write card header.
+//  Creating a file must read as pure additions (`+N −0`): an empty `old`
+//  side has zero lines, not one empty line, so it must not diff as a phantom
+//  removal. Genuine edits still report removals.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct WorkspaceDiffNewFileCountTests {
+
+    /// Count added / removed body lines the way the card header does, skipping
+    /// the `---` / `+++` file headers.
+    private func counts(_ text: String) -> (added: Int, removed: Int) {
+        var added = 0
+        var removed = 0
+        for line in text.components(separatedBy: "\n") {
+            if line.hasPrefix("--- ") || line.hasPrefix("+++ ") { continue }
+            if line.hasPrefix("+") { added += 1 }
+            if line.hasPrefix("-") { removed += 1 }
+        }
+        return (added, removed)
+    }
+
+    @Test func newSingleLineFileIsPureAddition() {
+        let diff = WorkspaceWriteSafety.unifiedDiffText(
+            old: "", new: "firmlink-fixed", path: "out.txt", existed: false
+        )
+        let c = counts(diff.text)
+        #expect(c.added == 1)
+        #expect(c.removed == 0)
+    }
+
+    @Test func newMultiLineFileCountsEveryAddedLineAndNoRemovals() {
+        let diff = WorkspaceWriteSafety.unifiedDiffText(
+            old: "", new: "alpha\nbeta\ngamma", path: "out.txt", existed: false
+        )
+        let c = counts(diff.text)
+        #expect(c.added == 3)
+        #expect(c.removed == 0)
+    }
+
+    @Test func genuineEditStillReportsRemovals() {
+        let diff = WorkspaceWriteSafety.unifiedDiffText(
+            old: "before", new: "after", path: "out.txt", existed: true
+        )
+        let c = counts(diff.text)
+        #expect(c.added == 1)
+        #expect(c.removed == 1)
+    }
+}


### PR DESCRIPTION
## Problem
`FolderToolHelpers.resolvePath` rejected **every** `file_write` / `file_edit` under a firmlinked folder root — a folder picked under `/tmp` (`/private/tmp`) or `/var` (`/private/var`, where macOS app temp dirs live) — with `Path is outside the working directory`, even for a bare filename.

Reproduced live (gemma-4-e2b, folder tools): writing `out.txt` to a `/private/tmp/...` root returned
`{"ok":false,"kind":"invalid_args","message":"Path 'out.txt' is outside the working directory..."}`.

## Root cause
The symlink-safe containment check resolved symlinks on the **whole** target path. `resolvingSymlinksInPath()` only rewrites components that exist on disk, so a not-yet-created write target keeps its trailing name unresolved. For a firmlinked root the two sides diverge:

```
root  /private/tmp/.../proof            .resolvingSymlinksInPath() → /tmp/.../proof            (rewritten)
target /private/tmp/.../proof/out.txt   .resolvingSymlinksInPath() → /private/tmp/.../out.txt  (out.txt missing → not rewritten)
```

`realRoot` lands on the `/tmp` side, `realResolved` on the `/private/tmp` side → the prefix check fails → false rejection.

## Fix
Resolve the **deepest existing ancestor** of the target instead of the whole path. It flips firmlinks identically to the root (restoring symmetry), while an in-root symlink that escapes the root still resolves out and is rejected — components below the existing ancestor don't exist yet, so they can't be symlinks and are safe to treat lexically.

## Tests
`ResolvePathScopeTests` gains a `/private/tmp`-rooted case (red without the fix: `.pathOutsideRoot("out.txt")`; green with it) plus an escape-symlink case under the same firmlinked root proving the guard is preserved. The existing suite missed this because `FileManager.temporaryDirectory` yields the `/var/folders` form, which resolves symmetrically and never exercises the `/private/*` input the folder picker returns. Red-green verified (revert the source hunk → the new test fails with the exact live error).
---

## Also in this PR: new-file diff count (`+1 −1` → `+1 −0`)
Found in the same folder-tool testing pass. `WorkspaceWriteSafety.unifiedDiff` split both sides with `.components(separatedBy: .newlines)`; for a brand-new file the `old` side is empty and `"".components(...)` returns `[""]` (one empty line, not zero), so creating a one-line file diffed as a phantom removal of that empty line plus the real addition — the file-write card header read **`+1 −1`** instead of `+1 −0`. Fix: treat an empty side as zero lines. `WorkspaceDiffNewFileCountTests` covers single/multi-line new files (red without the fix: `removed == 1`) and an edit that still reports a removal.

## Live proof (firmlink fix)
Native Debug build, gemma-4-e2b, folder root under `/private/tmp`: `file_write out.txt` now returns a green diff card and the file lands on disk at the real path with the exact content — the same write returned a red "Failed: File write / ok:false" before the fix. Read-back via `file_read` returns the content; no template/sentinel leaks.