### PR TITLE
Free model memory on chat close, respond to memory pressure, and cap unbounded caches

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -269,6 +269,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // leaves a unified-log breadcrumb diagnosable without a debugger.
         MainThreadWatchdog.shared.start()
 
+        // Respond to macOS memory pressure: free reconstructible UI caches on
+        // warning, and additionally unload idle (lease-free) model weights on
+        // critical, so local models never push the system into swap while
+        // sitting unused.
+        MemoryPressureResponder.shared.start()
+
         // Initialize directory access early so security-scoped bookmark is active
         _ = DirectoryPickerService.shared
 

--- a/Packages/OsaurusCore/AppleScript/Knowledge/AppleScriptDictionaryService.swift
+++ b/Packages/OsaurusCore/AppleScript/Knowledge/AppleScriptDictionaryService.swift
@@ -41,11 +41,30 @@ enum AppleScriptDictionaryService {
 
     private static let cacheLock = NSLock()
     nonisolated(unsafe) private static var cache: [String: CacheEntry] = [:]
+    /// LRU order: least-recently-used bundle path first. Summaries are capped
+    /// at `maxSummaryChars` each, but the set of scripted apps is open-ended —
+    /// without a bound, one entry per app the agent ever touched accumulates
+    /// for the process lifetime.
+    nonisolated(unsafe) private static var cacheAccessOrder: [String] = []
+    private static let maxCachedBundles = 16
+
+    /// Must be called with `cacheLock` held.
+    private static func touchLocked(_ path: String) {
+        if let index = cacheAccessOrder.firstIndex(of: path) {
+            cacheAccessOrder.remove(at: index)
+        }
+        cacheAccessOrder.append(path)
+        while cacheAccessOrder.count > maxCachedBundles {
+            let evicted = cacheAccessOrder.removeFirst()
+            cache.removeValue(forKey: evicted)
+        }
+    }
 
     // MARK: - Public entry
 
     /// The distilled scripting-dictionary summary for the app at `bundleURL`,
-    /// or `nil` when the app has no usable dictionary. Cached per bundle.
+    /// or `nil` when the app has no usable dictionary. Cached per bundle
+    /// (LRU-bounded to `maxCachedBundles` apps).
     static func dictionarySummary(appName: String, bundleURL: URL) -> String? {
         let path = bundleURL.path
         let modified =
@@ -54,6 +73,7 @@ enum AppleScriptDictionaryService {
         cacheLock.lock()
         if let entry = cache[path], entry.modified == modified {
             let cached = entry.summary
+            touchLocked(path)
             cacheLock.unlock()
             return cached
         }
@@ -63,6 +83,7 @@ enum AppleScriptDictionaryService {
 
         cacheLock.lock()
         cache[path] = CacheEntry(modified: modified, summary: summary)
+        touchLocked(path)
         cacheLock.unlock()
         return summary
     }

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/BackgroundDriver.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/BackgroundDriver.swift
@@ -90,6 +90,11 @@ private enum BundleClass {
         "org.chromium.Chromium",
     ]
 
+    /// Prune threshold: pids recycle over time, so entries for dead
+    /// processes are both stale (a reused pid could classify wrongly) and a
+    /// slow leak. When the cache crosses this size, drop dead-pid entries.
+    private static let pruneThreshold = 64
+
     static func classify(pid: pid_t) -> AppClass {
         lock.lock()
         if let cached = cache[pid] {
@@ -101,6 +106,11 @@ private enum BundleClass {
         let result = computeClass(for: pid)
 
         lock.lock()
+        if cache.count >= pruneThreshold {
+            // `NSRunningApplication(processIdentifier:)` returns nil for dead
+            // pids; that also evicts any entry a recycled pid would have hit.
+            cache = cache.filter { NSRunningApplication(processIdentifier: $0.key) != nil }
+        }
         cache[pid] = result
         lock.unlock()
         return result

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -743,12 +743,35 @@ public final class ChatWindowManager: NSObject, ObservableObject {
                 // next compose pass.
                 await MemoryContextAssembler.shared.invalidateCache(agentId: aid.uuidString)
             }
+            // Residency on window close (note: hotkey HIDE is not close — a
+            // hidden window keeps its model warm for the quick-toggle flow):
+            // - .immediately: unload anything no remaining window references.
+            // - .afterSeconds: accelerate the pending idle unload of
+            //   chat-sourced models to a short grace period instead of the
+            //   full policy, so a closed chat doesn't pin gigabytes of
+            //   unified memory for 15 minutes. Models last used by the HTTP
+            //   API keep their full residency; the fire-time guard re-checks
+            //   open windows so a reopen during the grace stays warm.
+            // - .never: explicit user opt-in to permanent residency.
             let idlePolicy =
                 ServerConfigurationStore.load()?.modelIdleResidencyPolicy
                 ?? ServerConfiguration.default.modelIdleResidencyPolicy
-            if idlePolicy == .immediately {
+            switch idlePolicy {
+            case .immediately:
                 let active = self.activeLocalModelNames()
                 await ModelRuntime.shared.unloadModelsNotIn(active)
+            case .afterSeconds:
+                let active = self.activeLocalModelNames()
+                await ModelRuntime.shared.accelerateIdleUnloadAfterChatClose(
+                    keeping: active,
+                    isModelStillWanted: { name in
+                        await MainActor.run {
+                            ChatWindowManager.shared.activeLocalModelNames().contains(name)
+                        }
+                    }
+                )
+            case .never:
+                break
             }
         }
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -210,6 +210,10 @@ final class ChatWindowState: ObservableObject {
         selectedDiscoveredAgent = nil
         selectedDiscoveredAgentProviderId = nil
         selectedRelayAgent = nil
+        // Shut the warm-up controller BEFORE stop(): stop() on an idle session
+        // runs completeRunCleanup(), whose run-completed hook would otherwise
+        // schedule a fresh warm-up for a session that is being torn down.
+        session.warmupController.shutdown()
         session.stop()
         session.onSessionChanged = nil
     }

--- a/Packages/OsaurusCore/Models/Chat/Attachment.swift
+++ b/Packages/OsaurusCore/Models/Chat/Attachment.swift
@@ -268,8 +268,20 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
     private static let nilSentinel = NSNumber(value: -1)
     // NSCache is documented thread-safe for concurrent access from multiple
     // threads; the compiler just can't see that through `Sendable`.
-    nonisolated(unsafe) private static let lineCountCache = NSCache<NSString, NSNumber>()
-    nonisolated(unsafe) private static let tokenEstimateCache = NSCache<NSString, NSNumber>()
+    // Explicit countLimit: without one NSCache only evicts under system
+    // memory pressure, so a long session with many attachments accumulates
+    // entries indefinitely. Values are tiny (NSNumber) but keys embed
+    // content hashes; 2048 covers any realistic working set.
+    nonisolated(unsafe) private static let lineCountCache: NSCache<NSString, NSNumber> = {
+        let c = NSCache<NSString, NSNumber>()
+        c.countLimit = 2_048
+        return c
+    }()
+    nonisolated(unsafe) private static let tokenEstimateCache: NSCache<NSString, NSNumber> = {
+        let c = NSCache<NSString, NSNumber>()
+        c.countLimit = 2_048
+        return c
+    }()
 
     public var isVideo: Bool {
         switch kind {

--- a/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
+++ b/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
@@ -1268,6 +1268,9 @@ extension Color {
         )
 
         Color.themeHexCacheLock.lock()
+        // Safety-net cap (reset-on-overflow): the theme palette is small and
+        // fixed, but custom themes contribute arbitrary hex strings over time.
+        if Color.themeHexCache.count >= 512 { Color.themeHexCache.removeAll() }
         Color.themeHexCache[key] = self
         Color.themeHexCacheLock.unlock()
     }

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -170,7 +170,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             idempotencyKey: request.idempotencyKey,
             runAsRemoteAgent: request.runAsRemoteAgent,
             suppressProgressUI: request.suppressProgressUI,
-            warmupPrefill: request.warmupPrefill
+            warmupPrefill: request.warmupPrefill,
+            requestSource: inferenceSource
         )
 
         // Mode 2 (remote agent run): route to the *selected agent's provider*,

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -79,10 +79,24 @@ final class ChatWarmupController: ObservableObject {
     /// by a newer event.
     private var switchEpoch: UInt64 = 0
 
+    /// True once the owning window began teardown. `session.stop()` during
+    /// window close runs the normal run-completed cleanup, which schedules a
+    /// fresh warm-up — pointless model work for a session that is about to be
+    /// deallocated. Once shut down, all scheduling entry points are inert.
+    private var isShutDown = false
+
     deinit {
         scheduleTask?.cancel()
         modelSwitchTask?.cancel()
         inFlightWarmup?.cancel()
+    }
+
+    /// Permanently stop this controller: cancel pending and in-flight warm-up
+    /// work and refuse any future scheduling. Called from window teardown
+    /// (`ChatWindowState.cleanup()`) before `session.stop()`.
+    func shutdown() {
+        isShutDown = true
+        reset()
     }
 
     func reset() {
@@ -135,6 +149,7 @@ final class ChatWarmupController: ObservableObject {
         to newModel: String?,
         performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
     ) async {
+        guard !isShutDown else { return }
         switchEpoch &+= 1
         let epoch = switchEpoch
         // Quick switch-back inside the debounce window: the old model is
@@ -273,6 +288,7 @@ final class ChatWarmupController: ObservableObject {
     // MARK: - Private
 
     private func shouldAttemptWarmup(session: ChatWarmupSessionContext) -> Bool {
+        guard !isShutDown else { return false }
         guard ChatConfigurationStore.load().warmModelsOnLoad else { return false }
         // Never load the new model while a debounced switch is pending —
         // strict eviction inside `loadContainer` would tear down the old

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -74,6 +74,12 @@ struct GenerationParameters: Sendable {
     /// history cache boundary before prefill (see
     /// `ChatCompletionRequest.warmupPrefill`).
     let warmupPrefill: Bool
+    /// Where the request originated (chat UI, HTTP API, plugin, P2P).
+    /// `ModelRuntime` records this per model so chat-window close can
+    /// accelerate idle unload of chat-sourced models without touching models
+    /// kept warm by API clients. Defaults to `.httpAPI` — the conservative
+    /// choice (never accelerated) for paths that don't set it explicitly.
+    let requestSource: RequestSource
 
     init(
         temperature: Float?,
@@ -94,7 +100,8 @@ struct GenerationParameters: Sendable {
         idempotencyKey: String? = nil,
         runAsRemoteAgent: Bool = false,
         suppressProgressUI: Bool = false,
-        warmupPrefill: Bool = false
+        warmupPrefill: Bool = false,
+        requestSource: RequestSource = .httpAPI
     ) {
         self.temperature = temperature
         self.maxTokens = maxTokens
@@ -115,6 +122,7 @@ struct GenerationParameters: Sendable {
         self.runAsRemoteAgent = runAsRemoteAgent
         self.suppressProgressUI = suppressProgressUI
         self.warmupPrefill = warmupPrefill
+        self.requestSource = requestSource
     }
 }
 

--- a/Packages/OsaurusCore/Services/Memory/MemoryService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryService.swift
@@ -632,6 +632,14 @@ public actor MemoryService {
         // Quick global gate before queuing — signals stale-by-the-time-
         // we-run is not an issue because `performDistillSession`
         // re-reads from `pending_signals` inside the coordinator body.
+        //
+        // Whatever the outcome, this attempt consumed the debounce entry:
+        // drop the task reference so `debounceTasks` doesn't accumulate one
+        // entry per conversation for the process lifetime (several early
+        // outcomes — disabled, not-resident, no-signals — used to leak it).
+        // A newer turn re-arms its own entry via `bufferTurn`.
+        defer { debounceTasks[conversationId] = nil }
+
         let config = MemoryConfigurationStore.load()
         guard config.enabled else { return .skipped(reason: "memory_disabled") }
 

--- a/Packages/OsaurusCore/Services/MemoryPressureResponder.swift
+++ b/Packages/OsaurusCore/Services/MemoryPressureResponder.swift
@@ -1,0 +1,90 @@
+//
+//  MemoryPressureResponder.swift
+//  osaurus
+//
+//  Responds to macOS memory-pressure events by proactively freeing app-side
+//  caches (warning) and unloading idle model weights (critical), instead of
+//  relying solely on NSCache's passive eviction.
+//
+//  This never refuses loads or applies hidden RAM limits — it only frees
+//  reconstructible caches and lease-free models through the existing
+//  `ModelRuntime.unload` path, and logs every action so the behavior is
+//  observable.
+//
+
+import Foundation
+import os
+
+public final class MemoryPressureResponder: @unchecked Sendable {
+    public static let shared = MemoryPressureResponder()
+
+    private static let log = Logger(subsystem: "com.dinoki.osaurus", category: "MemoryPressure")
+
+    private let queue = DispatchQueue(label: "com.dinoki.osaurus.memory-pressure", qos: .utility)
+    private var source: DispatchSourceMemoryPressure?
+
+    private init() {}
+
+    /// Install the memory-pressure handler. Idempotent; called once at launch.
+    public func start() {
+        queue.sync {
+            guard source == nil else { return }
+            let src = DispatchSource.makeMemoryPressureSource(
+                eventMask: [.warning, .critical],
+                queue: queue
+            )
+            src.setEventHandler { [weak self] in
+                guard let self, let source = self.source else { return }
+                let event = source.data
+                if event.contains(.critical) {
+                    Self.log.warning("critical memory pressure — freeing caches and idle models")
+                    self.respondToWarning()
+                    self.respondToCritical()
+                } else if event.contains(.warning) {
+                    Self.log.info("memory pressure warning — freeing app caches")
+                    self.respondToWarning()
+                }
+            }
+            src.activate()
+            source = src
+        }
+    }
+
+    public func stop() {
+        queue.sync {
+            source?.cancel()
+            source = nil
+        }
+    }
+
+    /// Warning tier: drop reconstructible UI caches and return MLX's
+    /// freed-buffer pool to the allocator. Everything here is re-derived
+    /// lazily on next use; nothing user-visible is lost.
+    private func respondToWarning() {
+        ThreadCache.shared.clear()
+        ChatImageCache.shared.removeAll()
+        LaTeXRenderer.shared.clearCache()
+        SymbolImageCache.clear()
+        NativeHeaderView.clearMonogramCache()
+        Task {
+            await ThemePreviewImageCache.shared.removeAll()
+            await ModelRuntime.shared.trimFreedBufferCacheUnderMemoryPressure()
+        }
+    }
+
+    /// Critical tier: additionally release idle (lease-free) model weights
+    /// through the normal unload path and purge detection memo caches.
+    private func respondToCritical() {
+        LocalReasoningCapability.invalidate()
+        Task {
+            let unloaded = await ModelRuntime.shared.unloadIdleModelsUnderMemoryPressure()
+            if unloaded.isEmpty {
+                Self.log.info("critical memory pressure: no idle models to unload")
+            } else {
+                Self.log.warning(
+                    "critical memory pressure: unloaded \(unloaded.joined(separator: ", "), privacy: .public)"
+                )
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -178,6 +178,20 @@ public actor ModelRuntime {
     private var activeGenerationTasks: [UInt64: ActiveGenerationRecord] = [:]
     private var nextGenerationTaskID: UInt64 = 0
 
+    /// Last request source (chat UI / HTTP API / plugin / P2P) that generated
+    /// against each resident model. Read by the chat-window-close path so it
+    /// only accelerates idle unload of chat-sourced models — a model kept warm
+    /// by API clients must not have its residency shortened when an unrelated
+    /// chat window closes. `nil` (never generated — e.g. a warm preload) is
+    /// treated as chat-sourced, since preloads are chat-driven.
+    private var lastUseSource: [String: RequestSource] = [:]
+
+    /// Grace period applied when the last chat window referencing a model
+    /// closes: long enough for an accidental-close reopen to stay warm, short
+    /// enough that the model doesn't hog unified memory for the full idle
+    /// policy (default 15 minutes) after the user walked away.
+    static let chatCloseUnloadGraceSeconds: TimeInterval = 60
+
     private init() {}
 
     // MARK: - Public API
@@ -210,6 +224,102 @@ public actor ModelRuntime {
         }
         if modelCache[found.name] != nil { return }
         _ = try await loadContainer(id: found.id, name: found.name)
+        // A preload never acquires a generation lease, so without arming the
+        // idle timer here the model would stay resident FOREVER if no
+        // generation ever follows (the timer is otherwise only scheduled on
+        // lease release). Any subsequent generation's `markActive` cancels
+        // this timer and its release re-arms the policy normally.
+        if await ModelLease.shared.count(for: found.name) == 0 {
+            await scheduleIdleResidency(for: found.name)
+        }
+    }
+
+    /// Best-effort MLX freed-buffer pool trim under OS memory pressure.
+    ///
+    /// Skipped while any generation is in flight — the pool is being actively
+    /// reused, and the exclusive teardown gate would block behind the stream
+    /// anyway. This only returns already-freed buffers to the allocator; it
+    /// never touches resident weights or KV state.
+    func trimFreedBufferCacheUnderMemoryPressure() async {
+        guard activeGenerationTasks.isEmpty else { return }
+        await MetalGate.shared.enterModelTeardown(model: "memory-pressure-trim")
+        Stream.gpu.synchronize()
+        Memory.clearCache()
+        Stream.gpu.synchronize()
+        await MetalGate.shared.exitModelTeardown(model: "memory-pressure-trim")
+        genLog.info("memory pressure: trimmed MLX freed-buffer pool")
+    }
+
+    /// Unload every resident model with no active generation lease in
+    /// response to CRITICAL OS memory pressure. Returns the unloaded names.
+    ///
+    /// Respects the user's `.never` idle-residency policy: an explicit
+    /// opt-in to permanent residency is honored even under pressure (the
+    /// skip is logged so the behavior is observable). Models mid-generation
+    /// are left alone — their buffers cannot be freed anyway.
+    func unloadIdleModelsUnderMemoryPressure() async -> [String] {
+        let policy =
+            await ServerConfigurationStore.load()?.modelIdleResidencyPolicy
+            ?? ServerConfiguration.default.modelIdleResidencyPolicy
+        guard policy != .never else {
+            genLog.info(
+                "memory pressure: idle residency policy is 'never' — keeping resident models"
+            )
+            return []
+        }
+        var unloaded: [String] = []
+        for name in modelCache.keys {
+            guard await ModelLease.shared.count(for: name) == 0 else { continue }
+            genLog.info(
+                "memory pressure: unloading idle model \(name, privacy: .public)"
+            )
+            await unload(name: name)
+            unloaded.append(name)
+        }
+        return unloaded
+    }
+
+    /// Chat-window-close residency acceleration: shorten the pending idle
+    /// unload of chat-sourced resident models to `grace` seconds instead of
+    /// waiting out the full idle policy.
+    ///
+    /// Only applies under an `.afterSeconds` idle policy — `.immediately` is
+    /// handled by the caller's existing `unloadModelsNotIn` path, and `.never`
+    /// is an explicit user opt-in to permanent residency that must be
+    /// respected. Models whose last generation came from the HTTP API, a
+    /// plugin, or P2P are left untouched: an unrelated chat window closing
+    /// must never shorten residency an API client is relying on.
+    ///
+    /// Races with API traffic are resolved inside `ModelResidencyManager`:
+    /// a new generation's `markActive` cancels the accelerated timer, the
+    /// fire path re-checks the lease count, and `isModelStillWanted` is
+    /// re-evaluated at fire time so a window reopened during the grace
+    /// period keeps the model warm.
+    func accelerateIdleUnloadAfterChatClose(
+        keeping activeNames: Set<String>,
+        grace: TimeInterval = ModelRuntime.chatCloseUnloadGraceSeconds,
+        isModelStillWanted: @Sendable @escaping (String) async -> Bool
+    ) async {
+        let policy =
+            await ServerConfigurationStore.load()?.modelIdleResidencyPolicy
+            ?? ServerConfiguration.default.modelIdleResidencyPolicy
+        guard case .afterSeconds = policy else { return }
+
+        for name in modelCache.keys where !activeNames.contains(name) {
+            if let source = lastUseSource[name], source != .chatUI { continue }
+            guard await ModelLease.shared.count(for: name) == 0 else { continue }
+            await ModelResidencyManager.shared.accelerateIdleUnload(
+                modelName: name,
+                grace: grace,
+                unload: { name in await ModelRuntime.shared.unload(name: name) },
+                leaseCount: { name in await ModelLease.shared.count(for: name) },
+                isResident: { name in await ModelRuntime.shared.isResident(name: name) },
+                shouldStillUnload: { name in
+                    let stillWanted = await isModelStillWanted(name)
+                    return !stillWanted
+                }
+            )
+        }
     }
 
     func cachedModelSummaries(refreshTopology: Bool = false) async -> [ModelCacheSummary] {
@@ -279,6 +389,8 @@ public actor ModelRuntime {
         }
 
         await ModelResidencyManager.shared.markActive(modelName: holder.name)
+        // Live voice runs inside the chat UI, so its residency is chat-scoped.
+        lastUseSource[holder.name] = .chatUI
         await ModelLease.shared.acquire(holder.name)
         let soloLease = await MLXBatchAdapter.Registry.shared.acquireSoloLease(for: holder.name)
 
@@ -595,6 +707,7 @@ public actor ModelRuntime {
         autoreleasepool {
             _ = modelCache.removeValue(forKey: name)
         }
+        lastUseSource.removeValue(forKey: name)
         if currentModelName == name { currentModelName = nil }
 
         Memory.cacheLimit = mlxCacheLimit()
@@ -710,6 +823,7 @@ public actor ModelRuntime {
             }
             loadingTasks.removeAll()
             supersededLoadingTaskIDs.removeAll()
+            lastUseSource.removeAll()
             currentModelName = nil
             cachedConfig = nil
             return
@@ -728,6 +842,7 @@ public actor ModelRuntime {
         autoreleasepool {
             modelCache.removeAll()
         }
+        lastUseSource.removeAll()
         loadingTasks.removeAll()
         supersededLoadingTaskIDs.removeAll()
         currentModelName = nil
@@ -2125,6 +2240,7 @@ public actor ModelRuntime {
 
         genLog.info("generateEventStream: start model=\(modelName, privacy: .public)")
         await ModelResidencyManager.shared.markActive(modelName: modelName)
+        lastUseSource[modelName] = parameters.requestSource
 
         // Scoped start/finish around ONLY a cold container load. Hot
         // resident turns still call `loadContainer` to get the holder, but

--- a/Packages/OsaurusCore/Services/ModelRuntime/ModelResidencyManager.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ModelResidencyManager.swift
@@ -115,6 +115,71 @@ public actor ModelResidencyManager {
         )
     }
 
+    /// Shorten an already-scheduled idle unload to fire after `grace` seconds.
+    ///
+    /// Used when the last chat window referencing a model closes: instead of
+    /// waiting out the full idle policy (default 15 minutes), the model is
+    /// released after a short grace period that still covers a quick reopen.
+    ///
+    /// Semantics — all deliberate, to stay race-free against API traffic:
+    /// - Only ever SHORTENS a pending deadline; if the existing deadline is
+    ///   already sooner, this is a no-op.
+    /// - No-op when the model has no pending unload timer (model is actively
+    ///   generating, or policy is `.never`). An active generation's release
+    ///   re-arms the full policy afterwards, so API usage always wins.
+    /// - Participates in the generation counter: any `markActive` (a new
+    ///   chat/API generation starting) cancels the accelerated timer exactly
+    ///   like a policy timer.
+    /// - The fire path re-checks lease count, residency, and the optional
+    ///   `shouldStillUnload` guard (e.g. "no open chat window re-selected
+    ///   this model") before unloading.
+    public func accelerateIdleUnload(
+        modelName: String,
+        grace: TimeInterval,
+        now: Date = Date(),
+        unload: @Sendable @escaping (String) async -> Void,
+        leaseCount: @Sendable @escaping (String) async -> Int,
+        isResident: @Sendable @escaping (String) async -> Bool,
+        shouldStillUnload: @Sendable @escaping (String) async -> Bool = { _ in true }
+    ) {
+        guard let existing = entries[modelName],
+            existing.task != nil,
+            let existingUnloadAt = existing.unloadAt
+        else { return }
+
+        let clampedGrace = max(0, grace)
+        let target = now.addingTimeInterval(clampedGrace)
+        guard target < existingUnloadAt else { return }
+
+        nextGeneration &+= 1
+        let generation = nextGeneration
+        existing.task?.cancel()
+
+        let delayNanoseconds = UInt64(clampedGrace * 1_000_000_000)
+        let task = Task { [sleep] in
+            if delayNanoseconds > 0 {
+                await sleep(delayNanoseconds)
+            }
+            guard !Task.isCancelled else { return }
+            await self.fire(
+                modelName: modelName,
+                generation: generation,
+                unload: unload,
+                leaseCount: leaseCount,
+                isResident: isResident,
+                shouldStillUnload: shouldStillUnload
+            )
+        }
+
+        entries[modelName] = Entry(
+            generation: generation,
+            lastUsedAt: existing.lastUsedAt,
+            unloadAt: target,
+            policy: existing.policy,
+            task: task
+        )
+    }
+
     public func cancel(modelName: String) {
         entries[modelName]?.task?.cancel()
         entries.removeValue(forKey: modelName)
@@ -146,7 +211,8 @@ public actor ModelResidencyManager {
         generation: UInt64,
         unload: @Sendable @escaping (String) async -> Void,
         leaseCount: @Sendable @escaping (String) async -> Int,
-        isResident: @Sendable @escaping (String) async -> Bool
+        isResident: @Sendable @escaping (String) async -> Bool,
+        shouldStillUnload: @Sendable @escaping (String) async -> Bool = { _ in true }
     ) async {
         guard let entry = entries[modelName], entry.generation == generation else { return }
 
@@ -157,6 +223,15 @@ public actor ModelResidencyManager {
 
         guard await isResident(modelName) else {
             entries.removeValue(forKey: modelName)
+            return
+        }
+
+        // Caller-supplied late guard (e.g. chat-close acceleration re-checks
+        // that no reopened window wants the model). On refusal the entry is
+        // kept without a timer — the next generation's release re-arms the
+        // normal policy — mirroring the lease-held case above.
+        guard await shouldStillUnload(modelName) else {
+            clearCompletedTimer(modelName: modelName, generation: generation)
             return
         }
 

--- a/Packages/OsaurusCore/Subagent/SubagentFeed.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentFeed.swift
@@ -131,6 +131,13 @@ public final class SubagentFeed: @unchecked Sendable {
     private let lock = NSLock()
     private var _events: [SubagentActivityEvent] = []
 
+    /// Upper bound on retained events. Long computer-use / spawn runs emit
+    /// continuously (act/verify/tool rows), and every emission republishes the
+    /// full snapshot to the UI — an unbounded buffer grows both the feed and
+    /// each published copy. When the cap is hit the oldest rows are dropped;
+    /// the UI shows the most recent activity, which is what matters mid-run.
+    private static let maxRetainedEvents = 2_000
+
     private nonisolated(unsafe) let eventsSubject: CurrentValueSubject<[SubagentActivityEvent], Never>
     private nonisolated(unsafe) let statusSubject: CurrentValueSubject<SubagentRunStatus, Never>
 
@@ -165,6 +172,9 @@ public final class SubagentFeed: @unchecked Sendable {
     private func mutateEvents(_ body: (inout [SubagentActivityEvent]) -> Void) {
         lock.lock()
         body(&_events)
+        if _events.count > Self.maxRetainedEvents {
+            _events.removeFirst(_events.count - Self.maxRetainedEvents)
+        }
         let snapshot = _events
         lock.unlock()
         eventsSubject.send(snapshot)

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -99,6 +99,62 @@ struct ChatWarmupControllerRequestTests {
     }
 }
 
+@Suite("ChatWarmupController shutdown")
+@MainActor
+struct ChatWarmupControllerShutdownTests {
+
+    /// Window close calls `cleanup()` → `shutdown()` before `session.stop()`.
+    /// `stop()`'s run-completed path calls `scheduleWarmup` again; after
+    /// shutdown that must be inert so teardown can't start model work.
+    @Test("scheduleWarmup after shutdown does not run a warm-up")
+    func scheduleAfterShutdownIsInert() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|hint|"
+        )
+
+        let controller = ChatWarmupController()
+        controller.shutdown()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        try? await Task.sleep(for: .milliseconds(150))
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.lastRequest == nil)
+        #expect(controller.state == .cold)
+    }
+
+    @Test("shutdown cancels a scheduled-but-not-started warm-up")
+    func shutdownCancelsScheduledWarmup() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|hint|"
+        )
+
+        let controller = ChatWarmupController()
+        controller.scheduleWarmup(session: session, debounce: .milliseconds(80))
+        controller.shutdown()
+
+        try? await Task.sleep(for: .milliseconds(200))
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.lastRequest == nil)
+        #expect(controller.state == .cold)
+    }
+}
+
 @MainActor
 private final class WarmupTestSession: ChatWarmupSessionContext {
     var selectedModel: String? = "test-model"

--- a/Packages/OsaurusCore/Tests/Service/ModelResidencyManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelResidencyManagerTests.swift
@@ -166,6 +166,284 @@ struct ModelResidencyManagerTests {
         #expect(await manager.snapshots().isEmpty)
     }
 
+    @Test("accelerateIdleUnload shortens a pending idle unload")
+    func accelerateShortensPendingUnload() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+
+        await manager.scheduleIdleUnload(
+            modelName: "llama",
+            policy: .afterSeconds(900),
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        await manager.accelerateIdleUnload(
+            modelName: "llama",
+            grace: 60,
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        #expect(await sleeper.recordedRequests() == [900_000_000_000, 60_000_000_000])
+        let snapshots = await manager.snapshots()
+        #expect(snapshots.first?.unloadAt == now.addingTimeInterval(60))
+
+        await sleeper.finishAll()
+        await Self.allowTasksToRun()
+        // The superseded 900s timer was cancelled; only the grace timer fires.
+        #expect(await unloads.names() == ["llama"])
+        #expect(await manager.snapshots().isEmpty)
+    }
+
+    @Test("accelerateIdleUnload never extends a sooner deadline")
+    func accelerateNeverExtendsSoonerDeadline() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+
+        await manager.scheduleIdleUnload(
+            modelName: "llama",
+            policy: .afterSeconds(30),
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        await manager.accelerateIdleUnload(
+            modelName: "llama",
+            grace: 60,
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        // No second timer: the existing 30s deadline is sooner than now+60s.
+        #expect(await sleeper.recordedRequests() == [30_000_000_000])
+        let snapshots = await manager.snapshots()
+        #expect(snapshots.first?.unloadAt == now.addingTimeInterval(30))
+    }
+
+    @Test("accelerateIdleUnload is a no-op while the model is active")
+    func accelerateNoOpWhileModelActive() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        // markActive state: entry exists but has no pending timer — the
+        // API/chat stream in flight owns residency until it releases.
+        await manager.markActive(modelName: "busy")
+        await manager.accelerateIdleUnload(
+            modelName: "busy",
+            grace: 60,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 1 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        #expect(await sleeper.recordedRequests().isEmpty)
+        #expect(await unloads.names().isEmpty)
+    }
+
+    @Test("accelerateIdleUnload is a no-op under the never policy")
+    func accelerateNoOpUnderNeverPolicy() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        await manager.scheduleIdleUnload(
+            modelName: "pinned",
+            policy: .never,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await manager.accelerateIdleUnload(
+            modelName: "pinned",
+            grace: 60,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        #expect(await sleeper.recordedRequests().isEmpty)
+        #expect(await unloads.names().isEmpty)
+        #expect(await manager.snapshots().first?.policy == .never)
+    }
+
+    @Test("markActive during the grace window cancels the accelerated unload")
+    func markActiveDuringGraceCancelsAcceleratedUnload() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        await manager.scheduleIdleUnload(
+            modelName: "gemma",
+            policy: .afterSeconds(900),
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+        await manager.accelerateIdleUnload(
+            modelName: "gemma",
+            grace: 60,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        // An API request starts during the grace window.
+        await manager.markActive(modelName: "gemma")
+        await sleeper.finishAll()
+        await Self.allowTasksToRun()
+
+        #expect(await unloads.names().isEmpty)
+        #expect(await manager.snapshots().first?.unloadAt == nil)
+    }
+
+    @Test("accelerated fire with a held lease does not unload")
+    func acceleratedFireWithHeldLeaseDoesNotUnload() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        await manager.scheduleIdleUnload(
+            modelName: "gemma",
+            policy: .afterSeconds(900),
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+        // Lease is re-checked at FIRE time; report it held there.
+        await manager.accelerateIdleUnload(
+            modelName: "gemma",
+            grace: 60,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 1 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+        await sleeper.finishAll()
+        await Self.allowTasksToRun()
+
+        #expect(await unloads.names().isEmpty)
+        // Entry kept (timer consumed) — the stream's release re-arms policy.
+        #expect(await manager.snapshots().first?.modelName == "gemma")
+        #expect(await manager.snapshots().first?.unloadAt == nil)
+    }
+
+    @Test("shouldStillUnload guard aborts the accelerated unload")
+    func shouldStillUnloadGuardAbortsAcceleratedUnload() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        await manager.scheduleIdleUnload(
+            modelName: "gemma",
+            policy: .afterSeconds(900),
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+        // A window reopened during the grace and re-selected the model.
+        await manager.accelerateIdleUnload(
+            modelName: "gemma",
+            grace: 60,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true },
+            shouldStillUnload: { _ in false }
+        )
+        await Self.allowTasksToRun()
+        await sleeper.finishAll()
+        await Self.allowTasksToRun()
+
+        #expect(await unloads.names().isEmpty)
+        #expect(await manager.snapshots().first?.modelName == "gemma")
+        #expect(await manager.snapshots().first?.unloadAt == nil)
+    }
+
+    @Test("a new generation after acceleration re-arms the full policy")
+    func generationAfterAccelerationReArmsFullPolicy() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        await manager.scheduleIdleUnload(
+            modelName: "gemma",
+            policy: .afterSeconds(900),
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+        await manager.accelerateIdleUnload(
+            modelName: "gemma",
+            grace: 60,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        // API generation starts (cancels grace) and later releases,
+        // re-arming the full policy timer.
+        await manager.markActive(modelName: "gemma")
+        await manager.scheduleIdleUnload(
+            modelName: "gemma",
+            policy: .afterSeconds(900),
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        #expect(
+            await sleeper.recordedRequests()
+                == [900_000_000_000, 60_000_000_000, 900_000_000_000]
+        )
+        await sleeper.finishAll()
+        await Self.allowTasksToRun()
+        // Only the final full-policy timer fires; the superseded grace
+        // timer was cancelled by markActive.
+        #expect(await unloads.names() == ["gemma"])
+    }
+
     @Test("cancelAll cancels timers and clears snapshots")
     func cancelAllCancelsTimersAndClearsSnapshots() async {
         let sleeper = ResidencySleepRecorder()

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2306,7 +2306,13 @@ struct RuntimePolicySourceTests {
         #expect(health.contains("\"idle_unload_at\""))
         #expect(health.contains("\"idle_seconds_remaining\""))
         #expect(windows.contains("modelIdleResidencyPolicy"))
-        #expect(windows.contains("if idlePolicy == .immediately"))
+        // Window close must branch on the full policy: immediate GC for
+        // `.immediately`, short-grace acceleration for `.afterSeconds`
+        // (chat-sourced models only, with a fire-time reopen guard), and no
+        // action for `.never`.
+        #expect(windows.contains("case .immediately:"))
+        #expect(windows.contains("case .afterSeconds:"))
+        #expect(windows.contains("accelerateIdleUnloadAfterChatClose"))
         #expect(
             windows.contains("let found = ModelManager.findInstalledModel(named: model)")
                 && windows.contains("return found.name"),

--- a/Packages/OsaurusCore/Views/Chat/ChatImageCache.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatImageCache.swift
@@ -65,6 +65,12 @@ final class ChatImageCache: @unchecked Sendable {
             Task { await decode(a.data, id: a.id) }
         }
     }
+
+    /// Drop every decoded thumbnail (memory-pressure response). Thumbnails
+    /// are re-decoded lazily from attachment data on next display.
+    func removeAll() {
+        cache.removeAllObjects()
+    }
 }
 
 // MARK: - Actor-based in-flight task registry

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -726,6 +726,18 @@ extension MessageTableRepresentable {
                         toolGroupViewCache.removeValue(forKey: key)
                     }
                 }
+                // Drop measured heights for blocks that left the thread —
+                // without this, chat switches / session reloads accumulate
+                // stale entries until a width or theme change wipes the cache.
+                if !heightCache.isEmpty || !lastNotedHeight.isEmpty {
+                    let newIdSet = Set(newIds)
+                    for key in heightCache.keys where !newIdSet.contains(key) {
+                        heightCache.removeValue(forKey: key)
+                    }
+                    for key in lastNotedHeight.keys where !newIdSet.contains(key) {
+                        lastNotedHeight.removeValue(forKey: key)
+                    }
+                }
             }
             // Use uniquingKeysWith instead of uniqueKeysWithValues to avoid a
             // precondition crash if block IDs collide (e.g. stale memoizer cache

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -266,6 +266,15 @@ final class NativeHeaderView: NSView {
     /// share the same key once stringified.
     private static var monogramCache: [String: NSImage] = [:]
     private static let monogramCacheLock = NSLock()
+
+    /// Drop all memoized monograms (memory-pressure response); re-rendered
+    /// lazily on next display.
+    static func clearMonogramCache() {
+        monogramCacheLock.lock()
+        monogramCache.removeAll()
+        monogramCacheLock.unlock()
+    }
+
     private static func monogramImage(
         name: String,
         tint: NSColor,
@@ -306,6 +315,9 @@ final class NativeHeaderView: NSView {
             return true
         }
         monogramCacheLock.lock()
+        // Safety-net cap (reset-on-overflow): keys vary by initial/tint/size,
+        // and monograms are cheap to re-render.
+        if monogramCache.count >= 256 { monogramCache.removeAll() }
         monogramCache[key] = image
         monogramCacheLock.unlock()
         return image

--- a/Packages/OsaurusCore/Views/Chat/SymbolImageCache.swift
+++ b/Packages/OsaurusCore/Views/Chat/SymbolImageCache.swift
@@ -39,8 +39,19 @@ enum SymbolImageCache {
             return nil
         }
         lock.lock()
+        // The distinct-symbol working set is small; the cap is a safety net
+        // (reset-on-overflow, not LRU — entries are cheap to re-resolve).
+        if cache.count >= 512 { cache.removeAll() }
         cache[key] = image
         lock.unlock()
         return image
+    }
+
+    /// Drop all memoized symbols (memory-pressure response). Entries are
+    /// re-resolved lazily on next use.
+    static func clear() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to a memory audit: local models should stop hogging unified memory after the user walks away from chat, without ever racing against API traffic.

### Model residency on chat close
- Closing the last chat window now **accelerates idle unload of chat-sourced models to a 60s grace** (`ModelRuntime.chatCloseUnloadGraceSeconds`) instead of holding them for the full idle policy (default 15 min). Quick reopens stay warm.
- New `ModelResidencyManager.accelerateIdleUnload` only ever *shortens* a deadline, is a no-op for active models or `.never` policy, and rides the existing generation counter — so any new generation (`markActive`), API or chat, cancels the grace timer. The fire path re-checks lease count, residency, and a `shouldStillUnload` guard (reopened windows) before unloading. Models whose last generation came from the HTTP API / plugins / P2P are never accelerated (`ModelRuntime.lastUseSource` tracking via a new `GenerationParameters.requestSource`).
- Fixed `ModelRuntime.preload` never arming an idle timer: preloaded models used to stay resident forever until a generation happened.
- `ChatWarmupController` gains `shutdown()`, called from `ChatWindowState.cleanup()` before `session.stop()`, so window teardown can't reschedule a fresh warm-up for a dying session.

### Memory-pressure responder (new)
- `MemoryPressureResponder` (started in `AppDelegate`) listens to `DispatchSourceMemoryPressure`:
  - **warning**: clears reconstructible UI caches (thread/image/LaTeX/symbol/monogram/theme-preview) and trims MLX's freed GPU buffer pool (guarded against active generations).
  - **critical**: additionally unloads lease-free idle models (respects `.never` policy).

### Cap unbounded app-side caches
- `SubagentFeed` events (2,000), AppleScript dictionary summaries (LRU 16), attachment line/token NSCaches (2,048), `MemoryService` debounce entries (defer-cleared), message-table height caches (pruned to live block IDs), `BackgroundDriver` pid classifications (dead-PID pruning), and symbol/monogram/theme-hex memos (safety-net caps).

## Testing
- New `ModelResidencyManagerTests` covering acceleration: shorten-only, never-extend, active/`.never` no-ops, `markActive` during grace cancels unload, held lease blocks unload, `shouldStillUnload` abort, and full-policy re-arm after a new generation.
- New `ChatWarmupControllerTests` for `shutdown()` semantics.
- Full suite run (`make test`, 5,081 tests): the only failures are keychain-gated suites (by design under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`) and load-induced timeout flakes that all pass when rerun in isolation; every suite covering this PR's areas passed.