### PR TITLE
Derive idle-residency default from RAM tier (2 min / 15 min / resident)

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
@@ -328,8 +328,12 @@ public enum ModelIdleResidencyPolicy: Codable, Equatable, Hashable, Sendable {
         return .defaultWarm
     }
 
-    /// Settings picker presets.
+    /// Settings picker presets. Every value `tierDefault(physicalMemoryBytes:)`
+    /// can return must appear here, otherwise the Settings picker has no
+    /// matching tag on exactly the machines that tier targets (120 s is the
+    /// ≤ 16 GiB default).
     public static let presets: [ModelIdleResidencyPolicy] = [
+        .afterSeconds(120),
         .afterSeconds(300),
         .defaultWarm,
         .afterSeconds(1_800),
@@ -342,6 +346,8 @@ public enum ModelIdleResidencyPolicy: Codable, Equatable, Hashable, Sendable {
         switch self {
         case .immediately:
             return L("Immediately")
+        case .afterSeconds(120):
+            return L("2 minutes")
         case .afterSeconds(300):
             return L("5 minutes")
         case .afterSeconds(900):

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
@@ -224,7 +224,8 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
             allowedOrigins: [],
             globalProxyURL: nil,
             modelEvictionPolicy: .strictSingleModel,
-            modelIdleResidencyPolicy: .defaultWarm,
+            modelIdleResidencyPolicy: .tierDefault(
+                physicalMemoryBytes: ChipProfile.current.physicalMemoryBytes),
             modelLoadRAMSoftThreshold: Self.defaultModelLoadRAMSoftThreshold,
             modelLoadRAMHardThreshold: Self.defaultModelLoadRAMHardThreshold,
             maxRequestBodyBytes: 32 * 1024 * 1024,
@@ -299,6 +300,30 @@ public enum ModelIdleResidencyPolicy: Codable, Equatable, Hashable, Sendable {
     /// every response. Immediate unload remains available as an explicit
     /// low-memory setting.
     public static let defaultWarm: ModelIdleResidencyPolicy = .afterSeconds(900)
+
+    /// RAM-tier-aware default, used when the user has not chosen a policy.
+    /// The flat 15-minute default is the wrong trade at both ends of the
+    /// hardware range:
+    ///
+    ///   - ≤ 16 GiB: idle weights are the main driver of memory pressure on
+    ///     these machines (see `InferenceLoadCoordinator`'s jetsam notes);
+    ///     2 minutes still covers rapid follow-up turns while releasing RAM
+    ///     well before the system starts compressing/swapping.
+    ///   - ≥ 128 GiB: reload cost dominates (tens of seconds for the model
+    ///     sizes these machines are bought for) and idle RAM is abundant, so
+    ///     weights stay resident until an explicit unload. Strict single-model
+    ///     eviction, manual unload, `clearAll`, and memory cleanup still win
+    ///     over residency, exactly as for every other policy value.
+    ///
+    /// An explicit user selection always takes precedence — this only decides
+    /// the starting value (`ServerConfiguration.default` and the decode
+    /// fallback for configs saved before the key existed).
+    public static func tierDefault(physicalMemoryBytes: UInt64) -> ModelIdleResidencyPolicy {
+        let gib = UInt64(1) << 30
+        if physicalMemoryBytes <= 16 * gib { return .afterSeconds(120) }
+        if physicalMemoryBytes >= 128 * gib { return .never }
+        return .defaultWarm
+    }
 
     /// Settings picker presets.
     public static let presets: [ModelIdleResidencyPolicy] = [

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
@@ -311,9 +311,12 @@ public enum ModelIdleResidencyPolicy: Codable, Equatable, Hashable, Sendable {
     ///     well before the system starts compressing/swapping.
     ///   - ≥ 128 GiB: reload cost dominates (tens of seconds for the model
     ///     sizes these machines are bought for) and idle RAM is abundant, so
-    ///     weights stay resident until an explicit unload. Strict single-model
-    ///     eviction, manual unload, `clearAll`, and memory cleanup still win
-    ///     over residency, exactly as for every other policy value.
+    ///     the window stretches to an hour. Deliberately NOT `.never` as a
+    ///     default: an implicit hold-forever would sidestep the
+    ///     memory-pressure relief that eventual idle unload provides (review
+    ///     feedback on #1902) — a default must guarantee weights leave on
+    ///     their own without user action. `.never` remains available as an
+    ///     explicit Settings choice.
     ///
     /// An explicit user selection always takes precedence — this only decides
     /// the starting value (`ServerConfiguration.default` and the decode
@@ -321,7 +324,7 @@ public enum ModelIdleResidencyPolicy: Codable, Equatable, Hashable, Sendable {
     public static func tierDefault(physicalMemoryBytes: UInt64) -> ModelIdleResidencyPolicy {
         let gib = UInt64(1) << 30
         if physicalMemoryBytes <= 16 * gib { return .afterSeconds(120) }
-        if physicalMemoryBytes >= 128 * gib { return .never }
+        if physicalMemoryBytes >= 128 * gib { return .afterSeconds(3_600) }
         return .defaultWarm
     }
 

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift
@@ -64,7 +64,13 @@ enum ServerConfigurationStore {
             return false
         }
 
-        configuration.modelIdleResidencyPolicy = .defaultWarm
+        // Legacy `.immediately` users predate the warm-residency default;
+        // migrate them to the same RAM-tier default a fresh install would
+        // get (2 min on ≤ 16 GiB, 15 min mid-range, 60 min on ≥ 128 GiB)
+        // rather than a flat `.defaultWarm`, so low-memory machines aren't
+        // moved onto a 15-minute warm window they can't afford.
+        configuration.modelIdleResidencyPolicy = ModelIdleResidencyPolicy.tierDefault(
+            physicalMemoryBytes: ChipProfile.current.physicalMemoryBytes)
         OsaurusPaths.ensureExistsSilent(markerURL.deletingLastPathComponent())
         try? Data().write(to: markerURL, options: [.atomic])
         return true

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -8854,6 +8854,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let obj: [String: Any] = [
                 "status": "healthy",
                 "timestamp": Date().ISO8601Format(),
+                "hardware": ChipProfile.current.healthJSONObject(),
                 "loaded": loaded,
                 "current_model": current,
                 "inflight": inflightObj,

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -6945,6 +6945,46 @@
         }
       }
     },
+    "2 minutes" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 Minuten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "2 minutes"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2분"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 минуты"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 分鐘"
+          }
+        }
+      }
+    },
     "15 minutes" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/ChipProfile.swift
+++ b/Packages/OsaurusCore/Services/ChipProfile.swift
@@ -1,0 +1,175 @@
+//
+//  ChipProfile.swift
+//  osaurus
+//
+//  Detects the Apple Silicon chip this process is running on (generation,
+//  tier, RAM, GPU core count, Metal working-set budget) so runtime policy can
+//  be derived from hardware capability instead of one-size-fits-all
+//  constants. Detection is read-only and resolved once per process; nothing
+//  in this file changes runtime behavior by itself.
+//
+//  Why not persist the result: every field is re-derivable in microseconds
+//  from sysctl/IOKit/Metal at launch, and a cached file would go stale when a
+//  Time Machine / Migration Assistant restore moves the install to different
+//  hardware. Persistence becomes worthwhile only for *measured* values
+//  (micro-benchmarked bandwidth/FLOPS), which are out of scope here.
+//
+
+import Foundation
+import IOKit
+import Metal
+import os.log
+
+private let chipLog = Logger(subsystem: "com.dinoki.osaurus", category: "ChipProfile")
+
+/// Immutable snapshot of the host's compute capability.
+struct ChipProfile: Sendable, Equatable {
+    /// Performance tier encoded in Apple's chip branding. `unknown` covers
+    /// Intel Macs, virtual machines, and future naming schemes; policy code
+    /// must treat it as the most conservative tier.
+    enum Tier: String, Sendable {
+        case base
+        case pro
+        case max
+        case ultra
+        case unknown
+    }
+
+    /// Marketing name as reported by the kernel, e.g. "Apple M4 Pro".
+    let brandString: String
+    /// Apple Silicon generation (1 for M1, 5 for M5, …); `nil` when the
+    /// brand string is not an "Apple M<n>" chip.
+    let generation: Int?
+    let tier: Tier
+    /// Physical unified memory in bytes (`hw.memsize`).
+    let physicalMemoryBytes: UInt64
+    /// GPU core count from the IOKit accelerator node; `nil` when the node
+    /// or property is missing (VMs, future driver changes).
+    let gpuCoreCount: Int?
+    /// Metal's per-process working-set recommendation. This is the OS's own
+    /// answer to "how much GPU-visible memory may I comfortably use" and is
+    /// the anchor for any future wired-memory policy.
+    let recommendedMaxWorkingSetBytes: UInt64?
+    /// The M5 family embeds matrix units ("Neural Accelerators") in each GPU
+    /// core, which shifts the prefill/decode balance materially. Derived
+    /// from `generation`, not probed — Metal exposes no direct capability
+    /// bit for them at the API level osaurus targets.
+    var hasGPUNeuralAccelerators: Bool { (generation ?? 0) >= 5 }
+
+    /// Tier for policy decisions: never `unknown`. Unknown hardware gets
+    /// base-tier (most conservative) treatment.
+    var policyTier: Tier { tier == .unknown ? .base : tier }
+
+    // MARK: - Resolution
+
+    /// The host's profile, resolved once on first access.
+    static let current: ChipProfile = {
+        let profile = ChipProfile.detect()
+        chipLog.info(
+            "resolved: brand=\(profile.brandString, privacy: .public) generation=\(profile.generation.map(String.init) ?? "unknown", privacy: .public) tier=\(profile.tier.rawValue, privacy: .public) ramBytes=\(profile.physicalMemoryBytes, privacy: .public) gpuCores=\(profile.gpuCoreCount.map(String.init) ?? "unknown", privacy: .public) workingSetBytes=\(profile.recommendedMaxWorkingSetBytes.map(String.init) ?? "unknown", privacy: .public) neuralAccelerators=\(profile.hasGPUNeuralAccelerators, privacy: .public)"
+        )
+        return profile
+    }()
+
+    static func detect() -> ChipProfile {
+        let brand = sysctlString("machdep.cpu.brand_string") ?? "unknown"
+        let identity = parse(brandString: brand)
+        return ChipProfile(
+            brandString: brand,
+            generation: identity.generation,
+            tier: identity.tier,
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
+            gpuCoreCount: detectGPUCoreCount(),
+            recommendedMaxWorkingSetBytes: MTLCreateSystemDefaultDevice()
+                .map { UInt64($0.recommendedMaxWorkingSetSize) }
+        )
+    }
+
+    // MARK: - Brand-string parsing (pure, unit-tested)
+
+    /// Parses "Apple M<generation>[ Pro|Max|Ultra]" into its components.
+    /// Anything else — Intel brand strings, VMs, a renamed future family —
+    /// yields `(nil, .unknown)` so callers fall back to conservative policy
+    /// rather than guessing.
+    static func parse(brandString: String) -> (generation: Int?, tier: Tier) {
+        let trimmed = brandString.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Anchored so adulterated strings ("VirtualApple M2 …") don't match.
+        guard
+            let match = trimmed.wholeMatch(
+                of: /Apple M(\d+)(?:\s+(Pro|Max|Ultra))?/
+            )
+        else {
+            return (nil, .unknown)
+        }
+        let generation = Int(match.1)
+        let tier: Tier
+        switch match.2 ?? "" {
+        case "Pro": tier = .pro
+        case "Max": tier = .max
+        case "Ultra": tier = .ultra
+        default: tier = .base
+        }
+        return (generation, tier)
+    }
+
+    // MARK: - /health surface
+
+    /// JSON-object form for the `/health` endpoint's `hardware` block.
+    /// Unknown values are surfaced as JSON null (not omitted) so clients can
+    /// distinguish "not detectable here" from "old server without the field".
+    func healthJSONObject() -> [String: Any] {
+        [
+            "chip": brandString,
+            "generation": generation as Any? ?? NSNull(),
+            "tier": tier.rawValue,
+            "physical_memory_bytes": physicalMemoryBytes,
+            "gpu_core_count": gpuCoreCount as Any? ?? NSNull(),
+            "recommended_max_working_set_bytes":
+                recommendedMaxWorkingSetBytes as Any? ?? NSNull(),
+            "gpu_neural_accelerators": hasGPUNeuralAccelerators,
+        ]
+    }
+
+    // MARK: - Probes
+
+    private static func sysctlString(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
+        return String(cString: buffer)
+    }
+
+    /// Reads `gpu-core-count` from the AGXAccelerator IORegistry node. There
+    /// is exactly one such node on Apple Silicon; iterating covers the
+    /// (never observed) multi-node case and returns the first match.
+    private static func detectGPUCoreCount() -> Int? {
+        var iterator: io_iterator_t = 0
+        guard
+            IOServiceGetMatchingServices(
+                kIOMainPortDefault,
+                IOServiceMatching("AGXAccelerator"),
+                &iterator
+            ) == KERN_SUCCESS
+        else { return nil }
+        defer { IOObjectRelease(iterator) }
+
+        var coreCount: Int? = nil
+        var entry = IOIteratorNext(iterator)
+        while entry != 0 {
+            if coreCount == nil,
+                let value = IORegistryEntryCreateCFProperty(
+                    entry,
+                    "gpu-core-count" as CFString,
+                    kCFAllocatorDefault,
+                    0
+                )?.takeRetainedValue() as? Int
+            {
+                coreCount = value
+            }
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(iterator)
+        }
+        return coreCount
+    }
+}

--- a/Packages/OsaurusCore/Tests/Configuration/ResidencyTierDefaultTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ResidencyTierDefaultTests.swift
@@ -35,11 +35,16 @@ struct ResidencyTierDefaultTests {
         }
     }
 
-    @Test func bigMemoryMachinesKeepWeightsResident() {
+    @Test func bigMemoryMachinesGetTheHourWindow() {
+        // Not `.never`: a default must guarantee weights eventually leave on
+        // their own so memory-pressure relief doesn't depend on user action
+        // (review feedback on #1902). `.never` stays an explicit choice.
         #expect(
-            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(128)) == .never)
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(128))
+                == .afterSeconds(3_600))
         #expect(
-            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(512)) == .never)
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(512))
+                == .afterSeconds(3_600))
     }
 
     @Test func boundariesAreInclusiveLowExclusiveMiddle() {

--- a/Packages/OsaurusCore/Tests/Configuration/ResidencyTierDefaultTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ResidencyTierDefaultTests.swift
@@ -1,0 +1,66 @@
+//
+//  ResidencyTierDefaultTests.swift
+//  osaurusTests
+//
+//  Covers the RAM-tier mapping for the idle-residency default and the two
+//  contracts around it: explicit user selections are never overridden (the
+//  tier default only feeds `ServerConfiguration.default`), and the decode
+//  path keeps honoring a persisted policy.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ResidencyTierDefaultTests {
+
+    private func gib(_ n: UInt64) -> UInt64 { n << 30 }
+
+    @Test func smallMachinesReleaseWeightsQuickly() {
+        #expect(
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(8))
+                == .afterSeconds(120))
+        #expect(
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(16))
+                == .afterSeconds(120))
+    }
+
+    @Test func midRangeKeepsTheEstablishedWarmDefault() {
+        for ram in [24, 32, 48, 64, 96] {
+            #expect(
+                ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(UInt64(ram)))
+                    == .defaultWarm,
+                "expected defaultWarm at \(ram) GiB")
+        }
+    }
+
+    @Test func bigMemoryMachinesKeepWeightsResident() {
+        #expect(
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(128)) == .never)
+        #expect(
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(512)) == .never)
+    }
+
+    @Test func boundariesAreInclusiveLowExclusiveMiddle() {
+        // 16 GiB is still "small"; the first byte past it is mid-range.
+        #expect(
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(16) + 1)
+                == .defaultWarm)
+        // One byte short of 128 GiB is still mid-range.
+        #expect(
+            ModelIdleResidencyPolicy.tierDefault(physicalMemoryBytes: gib(128) - 1)
+                == .defaultWarm)
+    }
+
+    /// A persisted explicit policy must survive decode untouched — the tier
+    /// default only applies through `ServerConfiguration.default` when the
+    /// key is absent.
+    @Test func persistedPolicySurvivesRoundTrip() throws {
+        var config = ServerConfiguration.default
+        config.modelIdleResidencyPolicy = .afterSeconds(300)
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ServerConfiguration.self, from: data)
+        #expect(decoded.modelIdleResidencyPolicy == .afterSeconds(300))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Configuration/ResidencyTierDefaultTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ResidencyTierDefaultTests.swift
@@ -58,6 +58,23 @@ struct ResidencyTierDefaultTests {
                 == .defaultWarm)
     }
 
+    /// Every value the tier function can return must be a Settings preset,
+    /// otherwise the picker has no matching tag on exactly the machines that
+    /// tier targets (the ≤ 16 GiB default of 120 s was missing at first).
+    @Test func everyTierDefaultIsASettingsPreset() {
+        for ram: UInt64 in [4, 8, 16, 24, 64, 127, 128, 512] {
+            let tierDefault = ModelIdleResidencyPolicy.tierDefault(
+                physicalMemoryBytes: gib(ram))
+            #expect(
+                ModelIdleResidencyPolicy.presets.contains(tierDefault),
+                "tier default for \(ram) GiB (\(tierDefault)) is not a Settings preset")
+        }
+    }
+
+    @Test func smallTierDefaultRendersTwoMinutes() {
+        #expect(ModelIdleResidencyPolicy.afterSeconds(120).displayName == "2 minutes")
+    }
+
     /// A persisted explicit policy must survive decode untouched — the tier
     /// default only applies through `ServerConfiguration.default` when the
     /// key is absent.

--- a/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
@@ -102,7 +102,16 @@ struct ServerConfigurationStoreTests {
     }
 
     @Test func modelIdleResidencyPolicy_defaultsWarmForMultiTurnChat() async throws {
-        #expect(ServerConfiguration.default.modelIdleResidencyPolicy == .afterSeconds(900))
+        // The default is derived from the host's RAM tier, so this test must
+        // not pin a single value — it would pass or fail depending on which
+        // machine runs CI. Assert the two intents instead: the default
+        // matches the tier function for this host, and it is never the old
+        // unload-immediately behavior (every tier keeps weights warm for at
+        // least a couple of minutes).
+        let expected = ModelIdleResidencyPolicy.tierDefault(
+            physicalMemoryBytes: ChipProfile.current.physicalMemoryBytes)
+        #expect(ServerConfiguration.default.modelIdleResidencyPolicy == expected)
+        #expect(ServerConfiguration.default.modelIdleResidencyPolicy != .immediately)
         #expect(ModelIdleResidencyPolicy.presets.first == .afterSeconds(300))
         #expect(ModelIdleResidencyPolicy.presets.contains(.immediately))
     }

--- a/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
@@ -112,8 +112,11 @@ struct ServerConfigurationStoreTests {
             physicalMemoryBytes: ChipProfile.current.physicalMemoryBytes)
         #expect(ServerConfiguration.default.modelIdleResidencyPolicy == expected)
         #expect(ServerConfiguration.default.modelIdleResidencyPolicy != .immediately)
-        #expect(ModelIdleResidencyPolicy.presets.first == .afterSeconds(300))
+        #expect(ModelIdleResidencyPolicy.presets.first == .afterSeconds(120))
         #expect(ModelIdleResidencyPolicy.presets.contains(.immediately))
+        // The Settings picker can only render the host's default if it is
+        // one of the preset tags — this must hold for every tier default.
+        #expect(ModelIdleResidencyPolicy.presets.contains(expected))
     }
 
     @Test @MainActor func modelIdleResidencyPolicy_migratesLegacyImmediateOnce() async throws {
@@ -139,8 +142,14 @@ struct ServerConfigurationStoreTests {
             """
         try Data(legacyJSON.utf8).write(to: dir.appendingPathComponent("server.json"))
 
+        // Legacy `.immediately` migrates to the host's RAM-tier default —
+        // the same value a fresh install would get — not a flat
+        // `.defaultWarm`, so low-memory machines land on the short window.
         let migrated = try #require(ServerConfigurationStore.load())
-        #expect(migrated.modelIdleResidencyPolicy == .defaultWarm)
+        let tierDefault = ModelIdleResidencyPolicy.tierDefault(
+            physicalMemoryBytes: ChipProfile.current.physicalMemoryBytes)
+        #expect(migrated.modelIdleResidencyPolicy == tierDefault)
+        #expect(migrated.modelIdleResidencyPolicy != .immediately)
 
         var explicitImmediate = migrated
         explicitImmediate.modelIdleResidencyPolicy = .immediately

--- a/Packages/OsaurusCore/Tests/Service/ChipProfileTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ChipProfileTests.swift
@@ -1,0 +1,107 @@
+//
+//  ChipProfileTests.swift
+//  osaurusTests
+//
+//  Covers the pure brand-string parser (every shipped Apple Silicon tier,
+//  future generations, and non-Apple fallbacks) plus the invariants the
+//  policy layer will rely on: `policyTier` never returns `.unknown`, and
+//  the neural-accelerator flag flips exactly at the M5 generation.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ChipProfileTests {
+
+    // MARK: - Brand-string parsing
+
+    @Test func parsesEveryShippedTier() {
+        #expect(ChipProfile.parse(brandString: "Apple M1") == (1, .base))
+        #expect(ChipProfile.parse(brandString: "Apple M1 Pro") == (1, .pro))
+        #expect(ChipProfile.parse(brandString: "Apple M1 Max") == (1, .max))
+        #expect(ChipProfile.parse(brandString: "Apple M1 Ultra") == (1, .ultra))
+        #expect(ChipProfile.parse(brandString: "Apple M3 Pro") == (3, .pro))
+        #expect(ChipProfile.parse(brandString: "Apple M4") == (4, .base))
+        #expect(ChipProfile.parse(brandString: "Apple M5 Max") == (5, .max))
+        #expect(ChipProfile.parse(brandString: "Apple M5 Ultra") == (5, .ultra))
+    }
+
+    @Test func parsesFutureGenerationsWithoutACodeChange() {
+        #expect(ChipProfile.parse(brandString: "Apple M6 Pro") == (6, .pro))
+        #expect(ChipProfile.parse(brandString: "Apple M12") == (12, .base))
+    }
+
+    @Test func toleratesSurroundingWhitespace() {
+        #expect(ChipProfile.parse(brandString: "  Apple M2 Ultra\n") == (2, .ultra))
+    }
+
+    @Test func rejectsNonAppleSiliconBrandStrings() {
+        let intel = ChipProfile.parse(
+            brandString: "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz")
+        #expect(intel.generation == nil)
+        #expect(intel.tier == .unknown)
+
+        // Unknown suffixes and adulterated strings must not half-match:
+        // policy code prefers "unknown, be conservative" over a wrong tier.
+        #expect(ChipProfile.parse(brandString: "Apple M4 Extreme").tier == .unknown)
+        #expect(ChipProfile.parse(brandString: "VirtualApple M2 Pro").tier == .unknown)
+        #expect(ChipProfile.parse(brandString: "").tier == .unknown)
+    }
+
+    // MARK: - Policy invariants
+
+    @Test func policyTierNeverExposesUnknown() {
+        let unknown = ChipProfile(
+            brandString: "Intel(R) Xeon(R)",
+            generation: nil,
+            tier: .unknown,
+            physicalMemoryBytes: 8 << 30,
+            gpuCoreCount: nil,
+            recommendedMaxWorkingSetBytes: nil
+        )
+        #expect(unknown.policyTier == .base)
+
+        let known = ChipProfile(
+            brandString: "Apple M5 Max",
+            generation: 5,
+            tier: .max,
+            physicalMemoryBytes: 128 << 30,
+            gpuCoreCount: 40,
+            recommendedMaxWorkingSetBytes: 100 << 30
+        )
+        #expect(known.policyTier == .max)
+    }
+
+    @Test func neuralAcceleratorFlagFlipsAtM5() {
+        func profile(generation: Int?) -> ChipProfile {
+            ChipProfile(
+                brandString: "test",
+                generation: generation,
+                tier: .base,
+                physicalMemoryBytes: 16 << 30,
+                gpuCoreCount: nil,
+                recommendedMaxWorkingSetBytes: nil
+            )
+        }
+        #expect(!profile(generation: 4).hasGPUNeuralAccelerators)
+        #expect(profile(generation: 5).hasGPUNeuralAccelerators)
+        #expect(profile(generation: 6).hasGPUNeuralAccelerators)
+        #expect(!profile(generation: nil).hasGPUNeuralAccelerators)
+    }
+
+    // MARK: - Live detection smoke test (runs on whatever hardware CI has)
+
+    @Test func detectReturnsInternallyConsistentProfile() {
+        let profile = ChipProfile.detect()
+        #expect(!profile.brandString.isEmpty)
+        #expect(profile.physicalMemoryBytes > 0)
+        if let cores = profile.gpuCoreCount {
+            #expect(cores > 0)
+        }
+        // JSON surface must serialize (guards against a non-plist value
+        // sneaking into the /health object).
+        #expect(JSONSerialization.isValidJSONObject(profile.healthJSONObject()))
+    }
+}


### PR DESCRIPTION
## What

Derives the **default** idle-residency policy from the host's RAM tier (via `ChipProfile`, #1861) instead of using a flat 15 minutes everywhere:

| Host RAM | Default policy |
|---|---|
| ≤ 16 GiB | unload after **2 minutes** |
| 16–128 GiB | **15 minutes** (unchanged — the existing `defaultWarm`) |
| ≥ 128 GiB | unload after **60 minutes** (`.never` stays an explicit Settings-only choice) |

Only the *default* moves. An explicit user selection always wins; strict single-model eviction, manual unload, `clearAll`, and memory cleanup all still override residency exactly as before; and a persisted policy survives decode untouched.

**Stacked on #1861** (first commit is the ChipProfile detection layer).

## Why

The flat 15-minute default is the wrong trade at both ends of the hardware range:

- On ≤ 16 GiB machines, idle model weights are the main driver of memory pressure — the jetsam class that `InferenceLoadCoordinator` exists to mitigate. Two minutes still covers rapid follow-up turns while releasing RAM well before the system starts compressing and swapping.
- On ≥ 128 GiB machines the trade inverts: idle RAM is abundant and the avoided reload is what the user feels. Today the 15-minute timer silently unloads, and the next request pays a full cold load. Per review feedback, the big-RAM default is a 60-minute window rather than `.never`, so weights always leave on their own eventually and memory-pressure relief never depends on user action.

## Measurement

On the dev machine (M5 Max, 128 GB):

- **What a reload costs** (the thing this default avoids on big machines): from the committed bench baseline (#1863), a cold load adds **4,485 ms vs 183 ms warm TTFT (~4.3 s)** for a small 4.1 GB model *with a hot page cache*; a 23 GB Qwen3.6 bundle measured ~1.9 s page-cache-hot and takes tens of seconds from cold storage. The 15-minute timer guarantees this cost after every idle gap.
- **Explicit-setting contract, live**: this machine has a persisted explicit policy (`{"mode": "after_seconds", "seconds": 900}` in `server.json`), and on the patched build `/health` correctly keeps showing `idle_unload_at` with the 900 s countdown — the tier default did **not** override it. Fresh installs (no persisted key) resolve through `ServerConfiguration.default`, which is where the tier default applies.
- **Tier mapping**: unit tests cover 8/16/24–96/128/512 GiB, the inclusive/exclusive boundaries, the decode round-trip of an explicit policy, and the hardware-independent rewrite of the previous `defaultsWarmForMultiTurnChat` test (which pinned 900 s and would otherwise fail on ≥128 GiB CI hosts).

## Risk & rollback

Higher idle RAM usage on big machines is the intended trade, bounded by the same eviction paths as before. The tier function keys on RAM only (always detectable); unknown chips are irrelevant to it. Users who prefer aggressive unloading pick any explicit policy in Settings, which wins unconditionally. Revert = two commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)