### PR TITLE
Run native-MTP cold warmup at model load, not on the first user request

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -542,6 +542,21 @@ public actor ModelRuntime {
         // Cache tier config is entirely osaurus-internal — not user-visible.
         await installCacheCoordinator(on: holder)
 
+        // Native-MTP bundles historically ran their FIRST request in plain
+        // autoregressive mode (the registry's cold-warmup rule), so the one
+        // request most users judge a model by silently lost the speculative
+        // speedup. Pay that warmup here instead, with a hidden two-token
+        // greedy generation, so the first user request decodes with MTP.
+        // Failure is non-fatal: the request path's cold-warmup rule remains
+        // as the fallback.
+        await MLXBatchAdapter.warmupNativeMTPAtLoad(
+            modelName: name,
+            container: holder.container,
+            draftStrategy: holder.draftStrategy,
+            runtime: getConfig(),
+            maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
+        )
+
         genLog.info(
             "loadContainer: loaded \(name, privacy: .public) isVLM=\(holder.isVLM, privacy: .public)"
         )

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -550,6 +550,76 @@ struct MLXBatchAdapter {
             return true
         }
 
+        func isNativeMTPWarm(modelName: String) -> Bool {
+            nativeMTPWarmModels.contains(modelName)
+        }
+
+        /// Un-warms a model whose load-time warmup generation failed after
+        /// it had already consumed the cold-warmup flag, so the next real
+        /// request runs the AR warmup exactly as it would have without the
+        /// load-time attempt.
+        func resetNativeMTPWarmup(modelName: String) {
+            nativeMTPWarmModels.remove(modelName)
+        }
+
+    }
+
+    // MARK: - Native MTP load-time warmup
+
+    /// Escape hatch in case a family surfaces a first-generation issue that
+    /// the two-token warmup does not absorb:
+    ///   defaults write ai.osaurus ai.osaurus.mtp.disableLoadWarmup -bool true
+    static let mtpLoadWarmupDisabledKey = "ai.osaurus.mtp.disableLoadWarmup"
+
+    /// Runs the native-MTP cold warmup at model-load time instead of on the
+    /// user's first request. The registry's cold-warmup rule forces the
+    /// first generation per model into plain AR mode; without this, that
+    /// "first generation" is the user's entire first response, which
+    /// silently loses the MTP decode speedup. A hidden two-token greedy
+    /// generation through the regular `generate` path (so gating, engine
+    /// creation, and solo-lease behavior are identical to a real request)
+    /// consumes the warmup for a fraction of a second instead.
+    ///
+    /// Failure is non-fatal and self-healing: the warm flag is reset so the
+    /// next real request performs the AR warmup exactly as before.
+    static func warmupNativeMTPAtLoad(
+        modelName: String,
+        container: ModelContainer,
+        draftStrategy: MLXLMCommon.DraftStrategy?,
+        runtime: RuntimeConfig,
+        maxBatchSize: Int
+    ) async {
+        guard draftStrategy?.usesNativeMTP == true else { return }
+        guard !UserDefaults.standard.bool(forKey: mtpLoadWarmupDisabledKey) else { return }
+        guard await !Registry.shared.isNativeMTPWarm(modelName: modelName) else { return }
+
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        do {
+            let prepared = try await generate(
+                modelName: modelName,
+                container: container,
+                buildChat: { [MLXLMCommon.Chat.Message(role: .user, content: "Hi")] },
+                buildToolsSpec: { nil },
+                generation: GenerationParameters(temperature: 0, maxTokens: 2),
+                toolChoice: nil,
+                stopSequences: [],
+                draftStrategy: draftStrategy,
+                runtime: runtime,
+                maxBatchSize: maxBatchSize
+            )
+            for await _ in prepared.stream {}
+            let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+            batchAdapterLog.info(
+                "native MTP load warmup: completed for \(modelName, privacy: .public) in \(elapsedMs, privacy: .public)ms; first user request decodes with MTP"
+            )
+        } catch {
+            // The failed generation may already have consumed the warm flag;
+            // reset it so the request path's AR warmup applies unchanged.
+            await Registry.shared.resetNativeMTPWarmup(modelName: modelName)
+            batchAdapterLog.notice(
+                "native MTP load warmup failed for \(modelName, privacy: .public): \(String(describing: error), privacy: .public) — falling back to first-request AR warmup"
+            )
+        }
     }
 
     // MARK: - Image preprocessing

--- a/Packages/OsaurusCore/Tests/Service/NativeMTPWarmupFlagTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/NativeMTPWarmupFlagTests.swift
@@ -1,0 +1,53 @@
+//
+//  NativeMTPWarmupFlagTests.swift
+//  osaurusTests
+//
+//  Covers the registry warm-flag lifecycle the load-time MTP warmup relies
+//  on: a successful warmup generation leaves the model warm (so the first
+//  real request keeps MTP), and a failed warmup resets the flag (so the
+//  request path's AR cold-warmup rule applies exactly as before).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct NativeMTPWarmupFlagTests {
+
+    @Test func consumeMarksModelWarmExactlyOnce() async {
+        let registry = MLXBatchAdapter.Registry.shared
+        let model = "warmup-flag-test-\(UUID().uuidString)"
+
+        #expect(await !registry.isNativeMTPWarm(modelName: model))
+        // First consumption wins the cold warmup (AR generation)…
+        #expect(await registry.consumeNativeMTPColdWarmup(modelName: model, requested: true))
+        // …every later request sees the model as warm.
+        #expect(await !registry.consumeNativeMTPColdWarmup(modelName: model, requested: true))
+        #expect(await registry.isNativeMTPWarm(modelName: model))
+
+        await registry.resetNativeMTPWarmup(modelName: model)
+    }
+
+    @Test func resetRestoresColdWarmupBehavior() async {
+        let registry = MLXBatchAdapter.Registry.shared
+        let model = "warmup-reset-test-\(UUID().uuidString)"
+
+        _ = await registry.consumeNativeMTPColdWarmup(modelName: model, requested: true)
+        await registry.resetNativeMTPWarmup(modelName: model)
+
+        #expect(await !registry.isNativeMTPWarm(modelName: model))
+        // After a reset the next request must win the cold warmup again.
+        #expect(await registry.consumeNativeMTPColdWarmup(modelName: model, requested: true))
+
+        await registry.resetNativeMTPWarmup(modelName: model)
+    }
+
+    @Test func nonMTPRequestsNeverTouchTheFlag() async {
+        let registry = MLXBatchAdapter.Registry.shared
+        let model = "warmup-nonmtp-test-\(UUID().uuidString)"
+
+        #expect(await !registry.consumeNativeMTPColdWarmup(modelName: model, requested: false))
+        #expect(await !registry.isNativeMTPWarm(modelName: model))
+    }
+}


### PR DESCRIPTION
## What

Runs the native-MTP cold warmup at **model-load time** instead of on the user's first request.

The registry's cold-warmup rule (`consumeNativeMTPColdWarmup`) forces the first generation per model into plain autoregressive mode before enabling native MTP. Today that "first generation" is the user's entire first response — the one request most users judge a model by — which silently loses the MTP decode speedup.

Model load now finishes with a hidden two-token greedy generation routed through the regular `MLXBatchAdapter.generate` path (identical MetalGate gating, engine creation, and solo-lease behavior as a real request), which consumes the AR warmup in a fraction of a second. The first user request then decodes with MTP.

Safety:
- **Non-fatal and self-healing**: on any warmup failure the warm flag is reset, so the next real request performs the AR warmup exactly as before this PR.
- **Escape hatch**: `defaults write ai.osaurus ai.osaurus.mtp.disableLoadWarmup -bool true` disables the warmup entirely if a family surfaces a first-generation issue the two-token warmup does not absorb.
- Non-MTP models are untouched (the warmup no-ops unless the bundle's draft strategy uses native MTP).

## Why

MTP bundles ship multi-token-prediction heads precisely to speed decode (~1.5–2× on typical acceptance rates), and the runtime already resolves and uses them — from the second request onward. Losing the speedup on the first request is a silent, per-model-load tax that disproportionately shapes first impressions ("this model is slow") and one-shot API usage, where every request is a first request.

## Measurement

Measured on an M5 Max / 128 GB with `OsaurusAI/Qwen3.6-35B-A3B-MXFP4-MTP` (loads as `native_mtp:d3`; its `vmlx_mtp_tuning.json` documents AR 83.9 → MTP 131.2 tok/s, 1.56×, measured with `cache_mode: off`):

- **Warmup cost is negligible**: first-request TTFT after a model swap (23 GB reload, hot page cache) measured **1,722 ms without** the warmup (pre-patch build) vs **1,863 ms with** it — an upper bound of ~140 ms including run-to-run noise.
- **Byte-exactness holds**: greedy outputs through the AR path (explicit `frequency_penalty` disables MTP) and the MTP path are **sha-identical** (reasoning + content, 292 chars, `537b730c64283d1c` both).
- **Honest finding — serving-path MTP currently shows parity, not 1.56×**: on `/v1/chat/completions`, first request / warm MTP / forced-AR all decode at **76–80 tok/s** on deterministic counting (491-token outputs), i.e. no measurable MTP gain despite the engine reporting `native_mtp:d3` and the tuning file promising 1.56×. Likely relevant: the tuning was measured `cache_mode: off`, while serving runs this hybrid MoE with SSM-companion caches (`/health` `batch_diagnostics` shows `ssm_companion_hits` accruing). That gap is an engine-side (vmlx) question worth its own investigation and is **independent of this PR**: whenever the engine does deliver tuned MTP gains, today's cold-warmup rule systematically forfeits them for the first request per load — including after every model swap and idle unload, since the warm flag is per-engine-lifetime. This PR removes that rule's user-visible cost for ~140 ms at load time.

Unit tests cover the registry warm-flag lifecycle: consume-marks-warm-exactly-once, reset-restores-cold-warmup, and non-MTP requests never touching the flag.

## Risk & rollback

The warmup adds a small one-time cost to model load (measured above; two tokens plus prompt prep). The known unknown is whether the two-token AR warmup absorbs whatever first-generation instability motivated the original per-request rule; the byte-exactness check in the measurement section addresses exactly that, and both the self-healing failure path and the defaults kill switch bound the blast radius. Revert = one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
