### PR TITLE
Shorten chat-close unload grace from 60s to 15s

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -190,7 +190,7 @@ public actor ModelRuntime {
     /// closes: long enough for an accidental-close reopen to stay warm, short
     /// enough that the model doesn't hog unified memory for the full idle
     /// policy (default 15 minutes) after the user walked away.
-    static let chatCloseUnloadGraceSeconds: TimeInterval = 60
+    static let chatCloseUnloadGraceSeconds: TimeInterval = 15
 
     private init() {}
 


### PR DESCRIPTION
## Summary
- Follow-up to #1901: shorten `ModelRuntime.chatCloseUnloadGraceSeconds` from 60s to 15s. Fifteen seconds still covers an accidental close-and-reopen (the fire-time `shouldStillUnload` guard re-checks open windows regardless), while returning unified memory to the user much sooner after they walk away.
- All the race protections are grace-duration-independent: `markActive` from any new generation (API or chat) still cancels the timer, and lease/residency checks still run at fire time.

## Test plan
- `ModelResidencyManagerTests` and `RuntimePolicySourceTests` pass (101 tests); the acceleration tests parameterize the grace value, so no test depends on the constant.