### PR TITLE
qwen3.5 agent-loop nudge + JANGTQ_K unblock + ZAYA tool-arg parser repin

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
+        "revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5cf19a8dd43fb459ec28796d00e256a9e088916ada0d1265e9c5c4603097e749",
+  "originHash" : "65e3237144419ba6e862058b4a18440e70ba90bc4e73db274e72fab957c62145",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
+        "revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         // a frozen typing indicator. Additive — existing consumers unaffected.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
+            revision: "ff714f1d0033768e85d48435fad2d244d80c91d6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -109,6 +109,16 @@ public final class AgentTaskState {
     /// before failing.
     private static let execLikeTools: Set<String> = ["shell_run", "sandbox_exec"]
 
+    /// Planning/meta tools whose whole purpose is (re)stating intent rather
+    /// than acting on the world. Re-issuing one of these repeatedly — even
+    /// with a reworded body each turn — is re-planning without progress, and
+    /// is what the reworded-`todo` stall does. Deliberately an ALLOWLIST, not
+    /// "everything that isn't read/write/exec/search": tools like `image`,
+    /// `db_*`, `capabilities_load`, `spawn`, and `web_*` are legitimately
+    /// called several times in a row (three images, three row inserts, three
+    /// capability loads) and must NOT be treated as a stalled plan.
+    private static let planningLikeTools: Set<String> = ["todo"]
+
     /// Tools whose `invalid_args` / `not_found` failures are DETERMINISTIC
     /// given an unchanged filesystem / capability catalog: re-issuing the
     /// identical call must return the identical error. Their held errors are
@@ -347,24 +357,23 @@ public final class AgentTaskState {
             repeatedCallName = count >= Self.repeatedCallThreshold ? name : nil
         }
 
-        // Same-NAME run for planning/meta tools (NOT read/write/exec/search):
-        // re-issuing one of these repeatedly — even with different arguments
+        // Same-NAME run for a planning/meta tool (an explicit allowlist —
+        // `todo` today): re-issuing one repeatedly — even with a reworded body
         // each turn — is re-planning without progress. This catches the
         // reworded-`todo` loop the identical-args `nonReadCallCounts` counter
         // above cannot: every new checklist is a fresh signature, so that
-        // counter never fires while the model burns turns re-planning. The
-        // productive tools (read/write/exec/search) are excluded because
-        // repeating them with varied arguments is legitimate work (writing
-        // several files, searching several terms). Advisory only.
-        let isProductiveTool =
-            Self.readLikeTools.contains(name) || Self.writeLikeTools.contains(name)
-            || Self.execLikeTools.contains(name) || Self.searchLikeTools.contains(name)
-        if isProductiveTool {
-            planningRunName = nil
-            planningRunCount = 0
-        } else {
+        // counter never fires while the model burns turns re-planning. Every
+        // non-planning tool DISARMS the run — that keeps legitimate consecutive
+        // work (three `image` generations, three `db_insert`s, three
+        // `capabilities_load`s) from being mislabeled a stalled plan, and
+        // ensures the planning nudge never masks another result-class nudge
+        // (e.g. the `image` gen→edit continuation). Advisory only.
+        if Self.planningLikeTools.contains(name) {
             planningRunCount = (previousToolName == name) ? planningRunCount + 1 : 1
             planningRunName = planningRunCount >= Self.repeatedCallThreshold ? name : nil
+        } else {
+            planningRunName = nil
+            planningRunCount = 0
         }
 
         // Wandering counter: a listing is a step that hasn't reached a file

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -194,6 +194,12 @@ public final class AgentTaskState {
     /// Set when the most recent recorded call was a non-read tool repeated
     /// to (or past) `repeatedCallThreshold`; cleared by any other call.
     private var repeatedCallName: String?
+    /// Set when a planning/meta tool (not read/write/exec/search) has been
+    /// called `repeatedCallThreshold`+ times in a row REGARDLESS of arguments;
+    /// cleared by any productive call or a different tool. Drives the
+    /// reworded-planning-loop nudge (e.g. `todo` re-issued every turn).
+    private var planningRunName: String?
+    private var planningRunCount = 0
 
     public init(biasEnabled: Bool = true) {
         self.biasEnabled = biasEnabled
@@ -215,6 +221,8 @@ public final class AgentTaskState {
         consecutiveListingsWithoutRead = 0
         nonReadCallCounts.removeAll(keepingCapacity: true)
         repeatedCallName = nil
+        planningRunName = nil
+        planningRunCount = 0
     }
 
     // MARK: Dedupe
@@ -268,6 +276,7 @@ public final class AgentTaskState {
         let sig = signature(name: name, argsJSON: argsJSON)
         let resultClass = Self.classify(result)
 
+        let previousToolName = lastToolName
         lastResultEnvelope = result
         lastResultClass = resultClass
         lastToolName = name
@@ -338,6 +347,26 @@ public final class AgentTaskState {
             repeatedCallName = count >= Self.repeatedCallThreshold ? name : nil
         }
 
+        // Same-NAME run for planning/meta tools (NOT read/write/exec/search):
+        // re-issuing one of these repeatedly — even with different arguments
+        // each turn — is re-planning without progress. This catches the
+        // reworded-`todo` loop the identical-args `nonReadCallCounts` counter
+        // above cannot: every new checklist is a fresh signature, so that
+        // counter never fires while the model burns turns re-planning. The
+        // productive tools (read/write/exec/search) are excluded because
+        // repeating them with varied arguments is legitimate work (writing
+        // several files, searching several terms). Advisory only.
+        let isProductiveTool =
+            Self.readLikeTools.contains(name) || Self.writeLikeTools.contains(name)
+            || Self.execLikeTools.contains(name) || Self.searchLikeTools.contains(name)
+        if isProductiveTool {
+            planningRunName = nil
+            planningRunCount = 0
+        } else {
+            planningRunCount = (previousToolName == name) ? planningRunCount + 1 : 1
+            planningRunName = planningRunCount >= Self.repeatedCallThreshold ? name : nil
+        }
+
         // Wandering counter: a listing is a step that hasn't reached a file
         // yet, so it increments. ONLY a successful file read counts as
         // progress and resets it. A `not_found` / `error` is a FAILED read —
@@ -391,6 +420,15 @@ public final class AgentTaskState {
         if let name = repeatedCallName {
             return
                 "You have now made the exact same `\(name)` call with identical arguments \(Self.repeatedCallThreshold)+ times. Repeating it will not change the outcome — change your approach, or report what is blocking you."
+        }
+
+        // Reworded planning loop: a meta/planning tool (e.g. `todo`) re-issued
+        // repeatedly with DIFFERENT arguments each turn — the identical-args
+        // check above never catches it, yet no external progress is made.
+        // Reactive (3rd consecutive call) and advisory: the call still ran.
+        if let name = planningRunName {
+            return
+                "You have called `\(name)` \(Self.repeatedCallThreshold)+ times in a row without taking any other action. Re-planning is not progress — if you already have what you need, execute the next concrete step or finish the task; otherwise call a different tool. Do not issue another `\(name)` now."
         }
 
         // Listing nudges are reactive: suppressed until the model is observed

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -284,25 +284,9 @@ actor MLXService: ToolCapableService {
         {
             issues.append("Model capability detection reports tool calling as unsupported.")
         }
-        if isBlockedProductionModel(modelName: modelName, modelId: modelId) {
-            issues.append(
-                "ZAYA1-VL JANGTQ_K is a diagnostic artifact with a proven first-token fidelity failure; use zaya1-vl-8b-mxfp4 or zaya1-vl-8b-jangtq4 for production serving."
-            )
-        }
-
         if !issues.isEmpty {
             throw RuntimePolicyError(modelName: modelName, issues: issues)
         }
-    }
-
-    private nonisolated static func isBlockedProductionModel(
-        modelName: String,
-        modelId: String
-    ) -> Bool {
-        let combined = "\(modelName) \(modelId)"
-            .lowercased()
-            .replacingOccurrences(of: "-", with: "_")
-        return combined.contains("zaya1_vl_8b_jangtq_k")
     }
 
     nonisolated static func supportsLocalToolCalling(

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -632,6 +632,27 @@ struct AgentTaskStateTests {
         #expect(state.nextStepBias() == nil, "interleaved action resets the planning run")
     }
 
+    /// False-positive guard for the allowlist scope: a NON-planning tool
+    /// (e.g. `db_insert`, `image`, `web_search`, `capabilities_load`) issued
+    /// 3× in a row with varied args is legitimate consecutive work, NOT a
+    /// stalled plan — the planning detector is an allowlist (`todo` only), so
+    /// it must never arm for these. This also guarantees the planning nudge
+    /// cannot mask/contradict the `image` gen→edit continuation nudge.
+    @Test func planningLoop_consecutiveNonPlanningToolNotNudged() {
+        for tool in ["db_insert", "image", "web_search", "capabilities_load"] {
+            let state = AgentTaskState()
+            state.record(name: tool, argsJSON: #"{"q":"1"}"#,
+                result: ToolEnvelope.success(tool: tool, text: "ok"))
+            state.record(name: tool, argsJSON: #"{"q":"2"}"#,
+                result: ToolEnvelope.success(tool: tool, text: "ok"))
+            state.record(name: tool, argsJSON: #"{"q":"3"}"#,
+                result: ToolEnvelope.success(tool: tool, text: "ok"))
+            #expect(
+                state.nextStepBias() == nil,
+                "3 consecutive \(tool) calls are work, not a planning loop")
+        }
+    }
+
     /// A different call between repeats disarms the pending nudge — the
     /// notice describes the MOST RECENT call only.
     @Test func repeatedCall_differentCallDisarms() {

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -585,6 +585,53 @@ struct AgentTaskStateTests {
         #expect(bias.contains("file_write"))
     }
 
+    /// Reworded planning loop: `todo` re-issued with a DIFFERENT checklist each
+    /// turn (as the qwen3.5 AgentWorld/Ornith models do) evades the
+    /// identical-args counter — every list is a fresh signature — yet makes no
+    /// progress. The same-NAME run detector must still arm at the 3rd call.
+    @Test func planningLoop_rewordedTodoArmsNudgeAtThird() {
+        let state = AgentTaskState()
+        func todo(_ n: Int) -> String {
+            ToolEnvelope.success(tool: "todo", text: "Todo updated: 0/\(n) complete.")
+        }
+        state.record(name: "todo", argsJSON: #"{"markdown":"- [ ] a"}"#, result: todo(5))
+        #expect(state.nextStepBias() == nil, "first todo: no nudge")
+        state.record(name: "todo", argsJSON: #"{"markdown":"- [ ] a\n- [ ] b"}"#, result: todo(4))
+        #expect(state.nextStepBias() == nil, "second (reworded) todo: no nudge")
+        state.record(name: "todo", argsJSON: #"{"markdown":"- [ ] x\n- [ ] y\n- [ ] z"}"#, result: todo(3))
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("todo"), "third reworded todo: nudge names the tool")
+        #expect(bias.contains("Re-planning is not progress"), "nudge steers toward action")
+    }
+
+    /// False-positive guard: a productive tool (`file_write`) issued 3× to
+    /// DIFFERENT paths is legitimate work, not a planning loop — the same-name
+    /// run detector must NOT fire for it (only the identical-args detector may,
+    /// and only on identical args, which these are not).
+    @Test func planningLoop_productiveMultiTargetNotNudged() {
+        let state = AgentTaskState()
+        state.record(name: "file_write", argsJSON: #"{"path":"a.txt","content":"1"}"#,
+            result: ToolEnvelope.success(tool: "file_write", text: "ok"))
+        state.record(name: "file_write", argsJSON: #"{"path":"b.txt","content":"2"}"#,
+            result: ToolEnvelope.success(tool: "file_write", text: "ok"))
+        state.record(name: "file_write", argsJSON: #"{"path":"c.txt","content":"3"}"#,
+            result: ToolEnvelope.success(tool: "file_write", text: "ok"))
+        #expect(state.nextStepBias() == nil, "multi-file writes are progress, not a loop")
+    }
+
+    /// A productive action between planning calls disarms the run — the model
+    /// that plans, acts, then plans again is progressing, not stuck.
+    @Test func planningLoop_intervalActionDisarms() {
+        let state = AgentTaskState()
+        let todoEnv = ToolEnvelope.success(tool: "todo", text: "Todo updated.")
+        state.record(name: "todo", argsJSON: #"{"markdown":"- [ ] a"}"#, result: todoEnv)
+        state.record(name: "todo", argsJSON: #"{"markdown":"- [ ] b"}"#, result: todoEnv)
+        state.record(name: "file_write", argsJSON: #"{"path":"a.txt","content":"x"}"#,
+            result: ToolEnvelope.success(tool: "file_write", text: "ok"))
+        state.record(name: "todo", argsJSON: #"{"markdown":"- [ ] c"}"#, result: todoEnv)
+        #expect(state.nextStepBias() == nil, "interleaved action resets the planning run")
+    }
+
     /// A different call between repeats disarms the pending nudge — the
     /// notice describes the MOST RECENT call only.
     @Test func repeatedCall_differentCallDisarms() {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
-        #expect(packageResolved.contains(#""revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
-        #expect(workspaceResolved.contains(#""revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
-        #expect(appResolved.contains(#""revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65""#))
+        #expect(packageSwift.contains(#"revision: "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
+        #expect(packageResolved.contains(#""revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
+        #expect(workspaceResolved.contains(#""revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
+        #expect(appResolved.contains(#""revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -142,17 +142,21 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
-    @Test func policyRejectsKnownBadZayaVLJANGTQKDiagnosticArtifact() {
-        #expect(throws: MLXService.RuntimePolicyError.self) {
-            try MLXService.validateRuntimePolicy(
-                modelName: "zaya1-vl-8b-jangtq_k",
-                modelId: "JANGQ/ZAYA1-VL-8B-JANGTQ_K",
-                messages: [ChatMessage(role: "user", content: "Compute 7 + 8 - 11.")],
-                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
-                tools: [],
-                runtime: VMLXServerRuntimeSettings()
-            )
-        }
+    /// The `zaya1-vl-8b-jangtq_k` hard block was removed: its stated reason
+    /// ("proven first-token fidelity failure") was disproven live — the model
+    /// streams coherent text with correct first tokens (the original failure was
+    /// a since-fixed runtime issue, not the quant). It must now pass runtime
+    /// policy like any other text-coherent bundle; this guards against silently
+    /// re-introducing the stale block.
+    @Test func policyNoLongerBlocksZayaVLJANGTQK() throws {
+        try MLXService.validateRuntimePolicy(
+            modelName: "zaya1-vl-8b-jangtq_k",
+            modelId: "JANGQ/ZAYA1-VL-8B-JANGTQ_K",
+            messages: [ChatMessage(role: "user", content: "Compute 7 + 8 - 11.")],
+            parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+            tools: [],
+            runtime: VMLXServerRuntimeSettings()
+        )
     }
 
     @Test func policyRejectsGemma3nToolsInsteadOfLeakingTemplateMarkers() {

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -671,7 +671,7 @@ struct RuntimePolicySourceTests {
         // (vmlx-swift#119, `Generation.toolCallProgress`) that lets the
         // native chat show a live "Preparing tool call" card during a long
         // buffered tool write instead of a frozen typing indicator.
-        let expectedRuntimeHardenedRevision = "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
+        let expectedRuntimeHardenedRevision = "ff714f1d0033768e85d48435fad2d244d80c91d6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8d0ef7e115f40bf428d05eee6f6a21ab0ddffb65"
+        "revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6"
       }
     },
     {


### PR DESCRIPTION
Three related local-model fixes, each root-caused live and proven.

## 1. qwen3.5 agent-loop stall — reworded planning-tool loop
Ornith-1.0 / Qwen AgentWorld (qwen3.5 family) stall by re-issuing a planning tool — `todo` — every turn with a slightly **reworded** checklist, never taking a concrete action (reproduced: the model burns its whole turn budget re-planning; a user reported it as "timing out"). The existing repeated-call detector keys on tool name **+ canonical args**, so each new checklist is a fresh signature and the counter never fires.

**Fix** (`AgentTaskState`): a same-**name** run detector for planning/meta tools (everything that is not read/write/exec/search — the productive tools where varied repetition is legitimate work). When such a tool is issued `repeatedCallThreshold`+ times in a row regardless of arguments, arm an advisory next-step nudge steering the model to act or finish. Non-load-bearing (the call still executes), mirroring the existing listing / not-found / identical-args nudges; a productive action between plans disarms it.

Root cause proven by discrimination: a non-qwen control (gemma-4) does not loop; both qwen3.5 models advance correctly when history is threaded with a clean 2-tool prompt (so it is **not** a history-rendering bug — `mapOpenAIChatToMLX` preserves tool history correctly); the stall is prompt+toolset-sensitive re-planning. Tests: reworded-`todo` arms the nudge; multi-target `file_write` does **not** (false-positive guard); an interleaved action disarms.

## 2. Remove stale JANGTQ_K production block
`MLXService.isBlockedProductionModel` refused to serve `zaya1-vl-8b-jangtq_k` citing a "proven first-token fidelity failure." Live retest disproves that reason — the model streams coherent text with correct first tokens (the original failure was a since-fixed runtime issue, not the quant). Proven live: the model now loads and chats. (It remains weak at tool-arg completeness — a separate model-quality limit, not grounds for a hard load block.)

## 3. Repin vmlx-swift → main `ff714f1d` (ZAYA nested tool-arg parser)
Picks up osaurus-ai/vmlx-swift#121: `XMLFunctionParser` now extracts ZAYA's nested tool-call bodies (`<parameter><name>k</name><value>v</value></parameter>`), so JANGTQ4-style calls no longer surface with required args missing. Proven live post-repin: a JANGTQ4 nested call parses to `{"path":…,"content":…}`.

## Proof
- Unit: AgentTaskState 41/41 (incl. 3 new planning-loop tests); AgentToolLoop + AgentTaskState suites 83/83, no regression.
- Live (Debug build, this repin): JANGTQ_K loads + chats; JANGTQ4 nested tool-call parses correctly.---
## Live proof — dev app (Release), multi-turn, RAM-isolated
Verified against the Release-built app (vmlx pinned at ff714f1d) on an idle GPU (co-resident MLX servers stopped first):

- **JANGTQ_K unblock:** `zaya1-vl-8b-jangtq_k` loads with no `RuntimePolicyError` and holds context across turns (recalled "three cats, second is Pixel" ✓). The removed block's "first-token fidelity failure" claim is empirically false — the model is coherent (it is tool-weak in auto-mode, a separate model-quality property the block was never about).
- **Nested tool-arg parser (repin #121):** `zaya1-vl-8b-jangtq4`, auto-mode primed → emits a tool call and the parser extracts `{"path":"/var/log/system.log"}` exactly (`finish_reason=tool_calls`). The prior "Missing required property: path" arg-drop is gone. Required-mode 400 on short prompts is pre-existing model-emission behavior, unrelated to the parser.
- **qwen3.5-type matrix (no repin regression):** `osaurusagent-35b-a3b-mxfp8` — reasoning ON produces reasoning_content + correct answer (40 mph); reasoning OFF + tools produces a clean `get_weather {"city":"Tokyo"}`.

## Regression review (real issues found)
- Fixed a real pin inconsistency the contract test caught: `Packages/OsaurusCore/Package.resolved` was still on the old vmlx revision (8d0ef7e1) while `Package.swift` + both workspace resolves were on ff714f1d. All four now agree.
- Parser change is non-invasive by construction: `parseNestedParameterForm` returns nil (falling through to the unchanged attribute scan) unless both `<name>` and `<value>` markers are present.
- Nudge is advisory-only and additive; it can only append a steer line when a non-productive tool repeats 3× consecutively, so it cannot break existing tool flows.## Diligence sweep (post-review refinement)
A parallel regression sweep across past-issue clusters (cache, compiled-decode, tool-parsing, templates/VL, agent-loop) found nothing blocking, and surfaced two real defects in the *original* nudge that are now fixed in `454ca26ac`:
- The detector was a **denylist** (any non-read/write/exec/search tool), so legit consecutive `image` / `db_insert` / `capabilities_load` / `web_search` runs were falsely nudged. It also **masked the image gen→edit continuation nudge with contradictory advice** after 3 consecutive generations. Now an explicit **allowlist** (`todo`); every non-planning tool disarms the run. New guard test added; existing reworded-todo + nativeImage gen→edit tests still green (42/42 local).

Confirmed clean by the sweep (no fold-in needed): parser change is gated/regression-safe across attribute-form/JSON/Hermes/Qwen-XML/bare-array; the two previously-open HIGH cache bugs (solo seed-boundary gate, DiskCache orphan-row) are already fixed on main; compiled-decode stays gated off (reachability unchanged); tool-call-progress collision resolved on main and untouched here.

Separately-tracked follow-ups (orthogonal, not folded in): Zaya-VL `enable_thinking` drop (MLXBatchAdapter early-return), thinking-toggle display default, ornith/qwen3.5 prefix-cache never-hits, gemma4 empty-`tools`-array history edge.