### PR TITLE
Add RAM tight-fit send gate and make model switches immediate

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -746,12 +746,12 @@ public final class ChatWindowManager: NSObject, ObservableObject {
             // Residency on window close (note: hotkey HIDE is not close — a
             // hidden window keeps its model warm for the quick-toggle flow):
             // - .immediately: unload anything no remaining window references.
-            // - .afterSeconds: accelerate the pending idle unload of
-            //   chat-sourced models to a short grace period instead of the
-            //   full policy, so a closed chat doesn't pin gigabytes of
-            //   unified memory for 15 minutes. Models last used by the HTTP
-            //   API keep their full residency; the fire-time guard re-checks
-            //   open windows so a reopen during the grace stays warm.
+            // - .afterSeconds: evict chat-sourced models immediately (zero
+            //   grace) instead of waiting out the policy, so a closed chat
+            //   doesn't pin gigabytes of unified memory. Models last used by
+            //   the HTTP API keep their full residency; the fire-time guard
+            //   re-checks lease count and open windows, so an in-flight
+            //   generation or an instant reopen keeps the model warm.
             // - .never: explicit user opt-in to permanent residency.
             let idlePolicy =
                 ServerConfigurationStore.load()?.modelIdleResidencyPolicy

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -130,34 +130,6 @@
         }
       }
     },
-    "%lld of %lld exposed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%lld von %lld freigegeben"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%2$lld개 중 %1$lld개 노출됨"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Открыто %lld из %lld"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "已公开 %lld/%lld"
-          }
-        }
-      }
-    },
     "-1001234567890 — one per line" : {
       "localizations" : {
         "de" : {
@@ -222,642 +194,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "-1001234567890 或 @channelname — 每行一個"
-          }
-        }
-      }
-    },
-    "Apple Foundation Model" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Apple Foundation-Modell"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Apple Foundation 모델"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Модель Apple Foundation"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Apple 基础模型"
-          }
-        }
-      }
-    },
-    "Auto-reconnecting after a stale session." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Automatische Wiederverbindung nach einer veralteten Sitzung."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "세션이 만료되어 자동으로 다시 연결하는 중입니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Автоматическое переподключение после устаревшей сессии."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "会话失效，正在自动重新连接。"
-          }
-        }
-      }
-    },
-    "Choose which models the API lists" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Wählen Sie, welche Modelle die API auflistet"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "API가 나열할 모델 선택"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Выберите, какие модели показывает API"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "选择 API 列出的模型"
-          }
-        }
-      }
-    },
-    "Close find bar" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suchleiste schließen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Close find bar"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "찾기 막대 닫기"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрыть панель поиска"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭查找栏"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關閉查找欄"
-          }
-        }
-      }
-    },
-    "Connected %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Verbunden %@"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "연결됨 %@"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Подключено %@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "已连接 %@"
-          }
-        }
-      }
-    },
-    "Currently connected, but the last probe failed." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Derzeit verbunden, aber die letzte Prüfung ist fehlgeschlagen."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "현재 연결되어 있지만 마지막 상태 확인이 실패했습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Сейчас подключено, но последняя проверка не удалась."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "当前已连接，但上次探测失败。"
-          }
-        }
-      }
-    },
-    "Expose all" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Alle freigeben"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "모두 노출"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Показать все"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "全部公开"
-          }
-        }
-      }
-    },
-    "Find in conversation" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In Konversation suchen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Find in conversation"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "대화에서 찾기"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Найти в беседе"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在对话中查找"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在對話中查找"
-          }
-        }
-      }
-    },
-    "Hidden by default. Enable the remote models you want the API to list." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Standardmäßig ausgeblendet. Aktivieren Sie die Remote-Modelle, die die API auflisten soll."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "기본적으로 숨겨져 있습니다. API에 나열할 원격 모델을 활성화하세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "По умолчанию скрыты. Включите удалённые модели, которые API должен показывать."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "默认隐藏。启用您希望 API 列出的远程模型。"
-          }
-        }
-      }
-    },
-    "Hide all" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Alle ausblenden"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "모두 숨기기"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Скрыть все"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "全部隐藏"
-          }
-        }
-      }
-    },
-    "Last auto-reconnect %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Letzte automatische Wiederverbindung: %@."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "마지막 자동 재연결: %@."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Последнее автоматическое переподключение: %@."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "上次自动重连：%@。"
-          }
-        }
-      }
-    },
-    "Last connected %@." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Zuletzt verbunden: %@."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "마지막 연결: %@."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Последнее подключение: %@."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "上次连接：%@。"
-          }
-        }
-      }
-    },
-    "Local Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Lokale Modelle"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "로컬 모델"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Локальные модели"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "本地模型"
-          }
-        }
-      }
-    },
-    "Next match" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nächster Treffer"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Next match"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다음 일치 항목"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Следующее совпадение"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一个匹配项"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一個匹配項"
-          }
-        }
-      }
-    },
-    "No local models match your search." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Keine lokalen Modelle entsprechen Ihrer Suche."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "검색과 일치하는 로컬 모델이 없습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Нет локальных моделей, соответствующих вашему запросу."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "没有符合搜索条件的本地模型。"
-          }
-        }
-      }
-    },
-    "No models match your search." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Keine Modelle entsprechen Ihrer Suche."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "검색과 일치하는 모델이 없습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Нет моделей, соответствующих вашему запросу."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "没有符合搜索条件的模型。"
-          }
-        }
-      }
-    },
-    "Previous match" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorheriger Treffer"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Previous match"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이전 일치 항목"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предыдущее совпадение"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上一个匹配项"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上一個匹配項"
-          }
-        }
-      }
-    },
-    "Reconnecting…" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Wird erneut verbunden …"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "다시 연결하는 중…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Повторное подключение…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "正在重新连接…"
-          }
-        }
-      }
-    },
-    "Remote Models" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Remote-Modelle"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "원격 모델"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Удалённые модели"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "远程模型"
-          }
-        }
-      }
-    },
-    "Scanning installed models…" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Installierte Modelle werden gescannt …"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "설치된 모델을 검색하는 중…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Сканирование установленных моделей…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "正在扫描已安装的模型…"
-          }
-        }
-      }
-    },
-    "The last probe succeeded, but the provider is not connected." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Die letzte Prüfung war erfolgreich, aber der Anbieter ist nicht verbunden."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "마지막 상태 확인은 성공했지만 공급자가 연결되어 있지 않습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Последняя проверка прошла успешно, но провайдер не подключён."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "上次探测成功，但提供方未连接。"
           }
         }
       }
@@ -2666,6 +2002,62 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 不是 MLX 模型，因此無法在 Osaurus 中使用。本地引擎僅支持運行 MLX 格式的模型。"
+          }
+        }
+      }
+    },
+    "%@ needs ~%@ GB to load and memory is at %@%% of %@ GB. Close other apps for best performance." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ benötigt zum Laden ~%2$@ GB und der Speicher ist zu %3$@%% von %4$@ GB belegt. Schließe andere Apps für die beste Leistung."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@을(를) 로드하려면 약 %2$@GB가 필요하며 메모리가 %4$@GB 중 %3$@%% 사용 중입니다. 최상의 성능을 위해 다른 앱을 닫으세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Для загрузки %1$@ нужно ~%2$@ ГБ, память заполнена на %3$@%% из %4$@ ГБ. Закройте другие приложения для лучшей производительности."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "加载 %1$@ 需要约 %2$@ GB，内存已使用 %4$@ GB 中的 %3$@%%。关闭其他应用可获得最佳性能。"
+          }
+        }
+      }
+    },
+    "%@ needs ~%@ GB to load, but memory is at %@%% of %@ GB. Sending is paused until memory frees — close other apps or pick a smaller model." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ benötigt zum Laden ~%2$@ GB, aber der Speicher ist zu %3$@%% von %4$@ GB belegt. Das Senden ist pausiert, bis Speicher frei wird — schließe andere Apps oder wähle ein kleineres Modell."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@을(를) 로드하려면 약 %2$@GB가 필요하지만 메모리가 %4$@GB 중 %3$@%% 사용 중입니다. 메모리가 확보될 때까지 전송이 일시 중지됩니다 — 다른 앱을 닫거나 더 작은 모델을 선택하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Для загрузки %1$@ нужно ~%2$@ ГБ, но память заполнена на %3$@%% из %4$@ ГБ. Отправка приостановлена, пока память не освободится — закройте другие приложения или выберите меньшую модель."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "加载 %1$@ 需要约 %2$@ GB，但内存已使用 %4$@ GB 中的 %3$@%%。发送已暂停，等待内存释放 — 请关闭其他应用或选择更小的模型。"
           }
         }
       }
@@ -4537,6 +3929,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$lld / %2$lld"
+          }
+        }
+      }
+    },
+    "%lld of %lld exposed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld von %lld freigegeben"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%2$lld개 중 %1$lld개 노출됨"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Открыто %lld из %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已公开 %lld/%lld"
           }
         }
       }
@@ -16169,6 +15589,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外觀"
+          }
+        }
+      }
+    },
+    "Apple Foundation Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Foundation-Modell"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Foundation 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Модель Apple Foundation"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple 基础模型"
           }
         }
       }
@@ -29301,6 +28749,34 @@
         }
       }
     },
+    "Choose which models the API lists" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wählen Sie, welche Modelle die API auflistet"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "API가 나열할 모델 선택"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Выберите, какие модели показывает API"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "选择 API 列出的模型"
+          }
+        }
+      }
+    },
     "Choose your model" : {
       "localizations" : {
         "de" : {
@@ -36121,6 +35597,10 @@
           }
         }
       }
+    },
+    "Controls the models returned by /models and /tags. Hidden models can still be used by requesting them directly. Changes apply immediately." : {
+      "comment" : "Description of the feature that allows the user to choose which models are visible to the API.",
+      "isCommentAutoGenerated" : true
     },
     "Conversation" : {
       "localizations" : {
@@ -55812,6 +55292,34 @@
         }
       }
     },
+    "Expose all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle freigeben"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모두 노출"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Показать все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部公开"
+          }
+        }
+      }
+    },
     "Expose this agent to the public internet via a relay tunnel so external services can reach it." : {
       "localizations" : {
         "de" : {
@@ -63150,6 +62658,34 @@
         }
       }
     },
+    "Hidden by default. Enable the remote models you want the API to list." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Standardmäßig ausgeblendet. Aktivieren Sie die Remote-Modelle, die die API auflisten soll."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "기본적으로 숨겨져 있습니다. API에 나열할 원격 모델을 활성화하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "По умолчанию скрыты. Включите удалённые модели, которые API должен показывать."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "默认隐藏。启用您希望 API 列出的远程模型。"
+          }
+        }
+      }
+    },
     "hidden in %@ mode" : {
       "localizations" : {
         "de" : {
@@ -63214,6 +62750,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱藏高級設置"
+          }
+        }
+      }
+    },
+    "Hide all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alle ausblenden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모두 숨기기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Скрыть все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全部隐藏"
           }
         }
       }
@@ -76176,6 +75740,34 @@
         }
       }
     },
+    "Local Models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lokale Modelle"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "로컬 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Локальные модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "本地模型"
+          }
+        }
+      }
+    },
     "Local models are compute-intensive and our curated picks need more unified memory than this machine has. We recommend a different path." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -80223,6 +79815,34 @@
         }
       }
     },
+    "Memory is tight for %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Der Speicher ist knapp für %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@에 대한 메모리가 부족합니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Мало памяти для %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ 的内存吃紧"
+          }
+        }
+      }
+    },
     "Memory Recall" : {
       "comment" : "A feature toggle that lets the agent search its memory mid-conversation.",
       "isCommentAutoGenerated" : true,
@@ -82633,6 +82253,9 @@
           }
         }
       }
+    },
+    "Model warm — ready for a fast first response" : {
+
     },
     "models" : {
       "localizations" : {
@@ -87480,6 +87103,38 @@
         }
       }
     },
+    "No local models installed yet. Download models from the Models manager and they will be exposed here automatically." : {
+      "comment" : "Message shown in the \"No local models installed yet\" empty state row of the server models tab.",
+      "isCommentAutoGenerated" : true
+    },
+    "No local models match your search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine lokalen Modelle entsprechen Ihrer Suche."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색과 일치하는 로컬 모델이 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет локальных моделей, соответствующих вашему запросу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "没有符合搜索条件的本地模型。"
+          }
+        }
+      }
+    },
     "No local proof" : {
       "localizations" : {
         "de" : {
@@ -88306,6 +87961,34 @@
         }
       }
     },
+    "No models match your search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Keine Modelle entsprechen Ihrer Suche."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색과 일치하는 모델이 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Нет моделей, соответствующих вашему запросу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "没有符合搜索条件的模型。"
+          }
+        }
+      }
+    },
     "No models on device yet" : {
       "localizations" : {
         "de" : {
@@ -88886,6 +88569,10 @@
           }
         }
       }
+    },
+    "No remote providers connected. Models from Osaurus Router and your own providers appear here once connected." : {
+      "comment" : "Text displayed in the \"Remote Models\" section when there are no remote providers connected.",
+      "isCommentAutoGenerated" : true
     },
     "No reply" : {
       "comment" : "Activity outcome: the request produced no visible reply.",
@@ -115334,6 +115021,34 @@
         }
       }
     },
+    "Remote Models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remote-Modelle"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "원격 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Удалённые модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "远程模型"
+          }
+        }
+      }
+    },
     "Remote Osaurus" : {
       "localizations" : {
         "de" : {
@@ -125633,6 +125348,34 @@
         }
       }
     },
+    "Scanning installed models…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Installierte Modelle werden gescannt …"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "설치된 모델을 검색하는 중…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сканирование установленных моделей…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "正在扫描已安装的模型…"
+          }
+        }
+      }
+    },
     "Scanning…" : {
       "localizations" : {
         "de" : {
@@ -130100,6 +129843,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "傳送已全域暫停。代理仍可讀取已允許清單的頻道。"
+          }
+        }
+      }
+    },
+    "Sending paused: not enough memory to load %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Senden pausiert: Nicht genug Speicher, um %@ zu laden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전송 일시 중지됨: %@을(를) 로드할 메모리가 부족합니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Отправка приостановлена: недостаточно памяти для загрузки %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "发送已暂停：内存不足，无法加载 %@"
           }
         }
       }
@@ -158476,6 +158247,28 @@
           }
         }
       }
+    },
+    "Warming up — loading model…" : {
+
+    },
+    "Warming up — prefilling context %lld%% (%lld/%lld tokens)" : {
+      "comment" : "A label indicating that a model is warming up, showing the percentage of the prefilling process that has completed and the number of tokens that have been processed. The first argument is the percentage of the prefilling process that has completed. The second argument is the number of tokens that have been successfully processed. The third argument is the total number of tokens that were expected to be processed.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Warming up — prefilling context %1$lld%% (%2$lld/%3$lld tokens)"
+          }
+        }
+      }
+    },
+    "Warming up — prefilling context…" : {
+
+    },
+    "Warming up…" : {
+      "comment" : "A message indicating that the model is warming up.",
+      "isCommentAutoGenerated" : true
     },
     "Warning" : {
       "localizations" : {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -7,9 +7,11 @@
 //  (system + tools + history, excluding the pending user turn) so the first
 //  real send can prefix-hit and pay less time-to-first-token cost.
 //
-//  Also owns the debounced model-switch policy: under strict single-model
-//  residency, eviction of the previous model is delayed ~2.5s so a quick
-//  switch-back keeps the prior model resident with its KV/coordinator state.
+//  Also owns the model-switch policy: a selection change acts immediately —
+//  any in-flight warm-up of the previous model is cancelled (waiting it out
+//  made switches feel stuck), the previous model is evicted per the
+//  residency policy, and the new model starts warming right away so the
+//  user gets instant visual feedback.
 //
 
 import Foundation
@@ -51,9 +53,6 @@ final class ChatWarmupController: ObservableObject {
         case warm
     }
 
-    /// Debounce before acting on a model switch under strict single-model
-    /// residency so a quick switch-back keeps the prior model's cache.
-    static let modelSwitchDebounce: Duration = .milliseconds(2_500)
     /// Debounce coalescing fingerprint-invalidating warm-up retriggers.
     static let scheduleDebounce: Duration = .milliseconds(500)
 
@@ -64,17 +63,16 @@ final class ChatWarmupController: ObservableObject {
 
     private var warmedFingerprint: String?
     private var scheduleTask: Task<Void, Never>?
-    private var modelSwitchTask: Task<Void, Never>?
     private var inFlightWarmup: Task<Void, Never>?
     private var inFlightWarmupID: UUID?
-    /// Model selected before the pending debounced switch — the "switch back
-    /// to this and nothing is lost" target.
-    private var modelBeforePendingSwitch: String?
-    /// Warm fingerprint held when the pending switch started, restored on a
-    /// quick switch-back so the dot snaps straight back to green.
-    private var fingerprintBeforePendingSwitch: String?
+    /// The immediate switch operation in flight (cancel stale warm-up →
+    /// evict per policy → schedule the new model's warm-up). Tracked so the
+    /// pre-send handshake can wait for the eviction to settle and so rapid
+    /// consecutive switches serialize instead of interleaving unloads.
+    private var activeModelSwitch: Task<Void, Never>?
+    private var activeModelSwitchID: UUID?
     /// Monotonic counter bumped by every switch-affecting entry point
-    /// (selection change, flush, reset). Handlers that suspend re-check it
+    /// (selection change, reset). Handlers that suspend re-check it
     /// afterwards so a stale resume can't cancel or restore state installed
     /// by a newer event.
     private var switchEpoch: UInt64 = 0
@@ -87,7 +85,7 @@ final class ChatWarmupController: ObservableObject {
 
     deinit {
         scheduleTask?.cancel()
-        modelSwitchTask?.cancel()
+        activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
     }
 
@@ -102,15 +100,14 @@ final class ChatWarmupController: ObservableObject {
     func reset() {
         switchEpoch &+= 1
         scheduleTask?.cancel()
-        modelSwitchTask?.cancel()
+        activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
         scheduleTask = nil
-        modelSwitchTask = nil
+        activeModelSwitch = nil
+        activeModelSwitchID = nil
         inFlightWarmup = nil
         inFlightWarmupID = nil
         warmedFingerprint = nil
-        modelBeforePendingSwitch = nil
-        fingerprintBeforePendingSwitch = nil
         state = .cold
     }
 
@@ -123,119 +120,92 @@ final class ChatWarmupController: ObservableObject {
 
     // MARK: - Model switch
 
-    /// Handle a model selection change: debounce eviction under strict
-    /// single-model residency (quick switch-back keeps the old model's
-    /// cache), evict-then-warm when the debounce fires, and skip eviction
-    /// entirely under multi-model residency.
+    /// Handle a model selection change immediately: cancel any warm-up still
+    /// running for the previous model (letting it finish deferred the
+    /// eviction and made switches feel stuck), evict per the residency
+    /// policy, and start warming the new model right away so the dot /
+    /// progress feedback reacts the moment the user picks a model.
+    ///
+    /// The `$selectedModel` sink fires at `willSet` time; the Task hop
+    /// defers the switch until after the property (and the rest of the view
+    /// update) has settled, so session reads see the new selection and
+    /// `@Published` state isn't mutated mid-publish.
     func handleModelSelectionChange(
         session: ChatWarmupSessionContext,
-        from previous: String?,
         to newModel: String?,
         performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
     ) {
         Task { @MainActor in
-            await self.handleModelSelectionChangeAsync(
+            self.performModelSelectionChange(
                 session: session,
-                from: previous,
                 to: newModel,
                 performSwitch: performSwitch
             )
         }
     }
 
-    private func handleModelSelectionChangeAsync(
+    private func performModelSelectionChange(
         session: ChatWarmupSessionContext,
-        from previous: String?,
         to newModel: String?,
         performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
-    ) async {
+    ) {
         guard !isShutDown else { return }
         switchEpoch &+= 1
         let epoch = switchEpoch
-        // Quick switch-back inside the debounce window: the old model is
-        // still resident (nothing was evicted yet), so cancel the pending
-        // switch and restore the warm claim it had.
-        if let newModel,
-            modelSwitchTask != nil,
-            newModel == modelBeforePendingSwitch,
-            await ModelRuntime.shared.isResident(name: newModel)
-        {
-            // The residency check suspended; a newer selection change, send
-            // flush, or reset may have replaced the pending-switch state this
-            // branch is about to cancel/restore.
-            guard epoch == switchEpoch else { return }
-            modelSwitchTask?.cancel()
-            modelSwitchTask = nil
-            modelBeforePendingSwitch = nil
-            let restored = fingerprintBeforePendingSwitch
-            fingerprintBeforePendingSwitch = nil
-            if let restored, restored.hasPrefix("\(newModel)|") {
-                warmedFingerprint = restored
-                state = .warm
-            } else {
-                invalidateWarmState()
-                scheduleWarmup(session: session, debounce: .zero)
-            }
-            return
-        }
-        // Same staleness rule for the fall-through: if the residency check
-        // above suspended and a newer event ran meanwhile, defer to it.
-        guard epoch == switchEpoch else { return }
 
-        let priorFingerprint = warmedFingerprint
         invalidateWarmState()
-        modelSwitchTask?.cancel()
-        modelSwitchTask = nil
-        modelBeforePendingSwitch = nil
-        fingerprintBeforePendingSwitch = nil
+
+        // A scheduled warm-up targets the old selection — drop it. A warm-up
+        // generation already in flight is cancelled AND detached: clearing
+        // the ID makes its stale-writer guards drop its state writes, so the
+        // cancelled unwind can't flip the fresh `.warming` below back to
+        // `.cold` (or claim a stale warm fingerprint).
+        cancelScheduledWarmup()
+        let staleWarmup = inFlightWarmup
+        if staleWarmup != nil {
+            inFlightWarmup = nil
+            inFlightWarmupID = nil
+            staleWarmup?.cancel()
+        }
 
         guard let newModel, !newModel.isEmpty else { return }
 
         let policy =
             ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
 
-        // Multi-model residency: nothing is ever evicted on switch, so
-        // there is no cache to protect — load + warm the new model now.
-        if policy == .manualMultiModel {
-            await performSwitch(false)
-            scheduleWarmup(session: session, debounce: .zero)
-            return
-        }
-
-        // Strict single-model: debounce before evicting so a quick
-        // switch-back keeps the prior model resident. Loading early is not
-        // an option — `loadContainer` performs strict eviction itself, so
-        // starting the new load would destroy the old cache immediately.
-        modelBeforePendingSwitch = previous
-        fingerprintBeforePendingSwitch = priorFingerprint
+        // Immediate visual feedback: the chip dot goes yellow the moment the
+        // selection changes (remote/non-warmable selections ignore state).
         state = .warming
 
-        modelSwitchTask = Task { @MainActor in
-            try? await Task.sleep(for: Self.modelSwitchDebounce)
+        let switchID = UUID()
+        let previousSwitch = activeModelSwitch
+        activeModelSwitchID = switchID
+        activeModelSwitch = Task { @MainActor in
+            // Serialize with a still-running earlier switch so evictions
+            // never interleave, then wait for the cancelled warm-up to
+            // actually unwind — its generation lease would otherwise make
+            // the runtime skip (not defer) the old model's unload.
+            await previousSwitch?.value
+            await staleWarmup?.value
             guard !Task.isCancelled else { return }
-            modelSwitchTask = nil
-            modelBeforePendingSwitch = nil
-            fingerprintBeforePendingSwitch = nil
-            await performSwitch(true)
-            scheduleWarmup(session: session, debounce: .zero)
+
+            // Evict models no window points at anymore (strict single-model
+            // only). Multi-model residency never evicts on switch.
+            await performSwitch(policy == .strictSingleModel)
+
+            guard self.activeModelSwitchID == switchID else { return }
+            self.activeModelSwitch = nil
+            self.activeModelSwitchID = nil
+            guard epoch == self.switchEpoch, !Task.isCancelled else { return }
+            self.scheduleWarmup(session: session, debounce: .zero)
         }
     }
 
-    /// Flush a pending model-switch debounce immediately (evict per policy).
-    /// Called on send so the user never waits out the debounce timer.
-    func flushPendingModelSwitch(
-        performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
-    ) async {
-        guard modelSwitchTask != nil else { return }
-        switchEpoch &+= 1
-        modelSwitchTask?.cancel()
-        modelSwitchTask = nil
-        modelBeforePendingSwitch = nil
-        fingerprintBeforePendingSwitch = nil
-
-        let policy =
-            ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
-        await performSwitch(policy == .strictSingleModel)
+    /// Wait for an in-flight immediate model switch (stale warm-up unwind +
+    /// eviction) to settle. Called by the pre-send handshake so a send right
+    /// after a switch generates against a clean residency state.
+    func awaitActiveModelSwitch() async {
+        await activeModelSwitch?.value
     }
 
     // MARK: - Warm-up
@@ -264,11 +234,11 @@ final class ChatWarmupController: ObservableObject {
     }
 
     /// True when a send must run the async pre-send handshake first
-    /// (pending debounced model switch or a warm-up generation in flight).
+    /// (model switch settling or a warm-up generation in flight).
     /// When false, sends can dispatch synchronously — preserving the
     /// "user turn is appended synchronously inside send()" contract.
     var needsPreSendHandshake: Bool {
-        modelSwitchTask != nil || inFlightWarmup != nil
+        activeModelSwitch != nil || inFlightWarmup != nil
     }
 
     /// Drop a scheduled-but-not-started warm-up so it can't fire mid-run.
@@ -290,10 +260,10 @@ final class ChatWarmupController: ObservableObject {
     private func shouldAttemptWarmup(session: ChatWarmupSessionContext) -> Bool {
         guard !isShutDown else { return false }
         guard ChatConfigurationStore.load().warmModelsOnLoad else { return false }
-        // Never load the new model while a debounced switch is pending —
-        // strict eviction inside `loadContainer` would tear down the old
-        // model and defeat the switch-back grace period.
-        guard modelSwitchTask == nil else { return false }
+        // Never load the new model while a switch is still settling — the
+        // switch task itself schedules the warm-up once eviction completes,
+        // and loading early would race the old model's teardown.
+        guard activeModelSwitch == nil else { return false }
         guard let model = session.selectedModel, !model.isEmpty else { return false }
         guard session.selectedModelIsLocal, !session.isRemoteAgentTarget else { return false }
         guard !session.isStreaming else { return false }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -187,10 +187,13 @@ public actor ModelRuntime {
     private var lastUseSource: [String: RequestSource] = [:]
 
     /// Grace period applied when the last chat window referencing a model
-    /// closes: long enough for an accidental-close reopen to stay warm, short
-    /// enough that the model doesn't hog unified memory for the full idle
-    /// policy (default 15 minutes) after the user walked away.
-    static let chatCloseUnloadGraceSeconds: TimeInterval = 15
+    /// closes. Zero: closing the chat evicts the model immediately — the
+    /// user closed the surface that was using it, and holding gigabytes of
+    /// unified memory "in case they reopen" costs more than a reload. The
+    /// unload still runs through the residency manager's fire-time guards
+    /// (lease count, reopen re-check), so an in-flight generation or an
+    /// instant reopen keeps the model resident.
+    static let chatCloseUnloadGraceSeconds: TimeInterval = 0
 
     private init() {}
 
@@ -280,8 +283,8 @@ public actor ModelRuntime {
     }
 
     /// Chat-window-close residency acceleration: shorten the pending idle
-    /// unload of chat-sourced resident models to `grace` seconds instead of
-    /// waiting out the full idle policy.
+    /// unload of chat-sourced resident models to `grace` seconds (default 0
+    /// — evict immediately) instead of waiting out the full idle policy.
     ///
     /// Only applies under an `.afterSeconds` idle policy — `.immediately` is
     /// handled by the caller's existing `unloadModelsNotIn` path, and `.never`
@@ -293,8 +296,8 @@ public actor ModelRuntime {
     /// Races with API traffic are resolved inside `ModelResidencyManager`:
     /// a new generation's `markActive` cancels the accelerated timer, the
     /// fire path re-checks the lease count, and `isModelStillWanted` is
-    /// re-evaluated at fire time so a window reopened during the grace
-    /// period keeps the model warm.
+    /// re-evaluated at fire time so a window reopened before the unload
+    /// fires keeps the model warm.
     func accelerateIdleUnloadAfterChatClose(
         keeping activeNames: Set<String>,
         grace: TimeInterval = ModelRuntime.chatCloseUnloadGraceSeconds,

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -947,6 +947,32 @@ public actor ModelRuntime {
         public let softLimitBytes: Int64
         public let hardLimitBytes: Int64
         public let timestamp: Date
+
+        /// UI severity for the chat input's tight-fit disclaimer.
+        public enum LoadPressureSeverity: String, Sendable, Equatable {
+            /// Comfortably within budget — no banner.
+            case none
+            /// Above the soft threshold (or free pages look short): show the
+            /// disclaimer but allow sending.
+            case warn
+            /// Above the hard ceiling, or the load can never fit in physical
+            /// memory: block sending until memory frees.
+            case block
+        }
+
+        /// Maps the assessment to the chat input's disclaimer/send-gate
+        /// severity. Pure so it can be unit-tested without UI. This is a
+        /// UI-layer gate only — the runtime load path stays advisory (see
+        /// `checkRAMFeasibility`).
+        public var loadPressureSeverity: LoadPressureSeverity {
+            if projectedBytes > hardLimitBytes || requiredAvailableBytes > physicalMemoryBytes {
+                return .block
+            }
+            if verdict != .ok || projectedBytes > softLimitBytes {
+                return .warn
+            }
+            return .none
+        }
     }
 
     /// Estimated KV-cache + activation headroom an incoming load needs beyond
@@ -1130,6 +1156,60 @@ public actor ModelRuntime {
         lastRAMFeasibility
     }
 
+    /// Shared verdict math for the pre-load advisory gate
+    /// (`checkRAMFeasibility`) and the chat input's candidate-load projection
+    /// (`projectedLoadFeasibility`), so the two assessments can't drift.
+    ///
+    /// On unified-memory Macs the OS satisfies a load by compressing,
+    /// evicting, or paging, so the immediately-free page count
+    /// (`available`) routinely sits below a model's full weight size even
+    /// when the load would succeed. A hard threshold refusal here is a fake
+    /// stability fix: it avoids crashes by blocking valid mmap-backed
+    /// loads. Keep the signal, evict idle resident models before this
+    /// point, and let real load errors propagate.
+    /// Internal (not private) so unit tests can drive the boundary math with
+    /// synthetic byte counts; production callers are the two methods above.
+    static func buildRAMFeasibility(
+        modelName: String,
+        incomingWeightsBytes: Int64,
+        incomingLoadFootprintBytes: Int64,
+        resident: Int64,
+        inflightOther: Int64,
+        kvHeadroom: Int64,
+        physical: Int64,
+        available: Int64
+    ) -> RAMFeasibility {
+        let requiredAvailable = incomingLoadFootprintBytes + kvHeadroom
+        let projected = resident + inflightOther + incomingLoadFootprintBytes + kvHeadroom
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        let softLimit = Int64(Double(physical) * thresholds.soft)
+        let hardLimit = Int64(Double(physical) * thresholds.hard)
+
+        let lowAvailable = available > 0 && requiredAvailable > available
+        let verdict: RAMFeasibility.Verdict
+        if projected > hardLimit || projected > softLimit || lowAvailable {
+            verdict = .tight
+        } else {
+            verdict = .ok
+        }
+
+        return RAMFeasibility(
+            modelName: modelName,
+            verdict: verdict,
+            incomingWeightsBytes: incomingWeightsBytes,
+            incomingLoadFootprintBytes: incomingLoadFootprintBytes,
+            residentWeightsBytes: resident,
+            kvHeadroomBytes: kvHeadroom,
+            projectedBytes: projected,
+            physicalMemoryBytes: physical,
+            availableMemoryBytes: available,
+            requiredAvailableBytes: requiredAvailable,
+            softLimitBytes: softLimit,
+            hardLimitBytes: hardLimit,
+            timestamp: Date()
+        )
+    }
+
     /// Pre-load RAM feasibility assessment. Records `lastRAMFeasibility` for
     /// observability but does not reject a user-requested load solely because
     /// RAM is currently full or projected pressure crosses a configured
@@ -1157,50 +1237,25 @@ public actor ModelRuntime {
             modelDirectory: modelDirectory,
             modelName: modelName
         )
-        let available = Self.availableMemoryBytes()
-        let requiredAvailable = incomingLoadFootprintBytes + kvHeadroom
-        let projected = resident + inflightOther + incomingLoadFootprintBytes + kvHeadroom
-        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
-        let softLimit = Int64(Double(physical) * thresholds.soft)
-        let hardLimit = Int64(Double(physical) * thresholds.hard)
-
-        // On unified-memory Macs the OS satisfies a load by compressing,
-        // evicting, or paging, so the immediately-free page count
-        // (`available`) routinely sits below a model's full weight size even
-        // when the load would succeed. A hard threshold refusal here is a fake
-        // stability fix: it avoids crashes by blocking valid mmap-backed
-        // loads. Keep the signal, evict idle resident models before this
-        // point, and let real load errors propagate.
-        let lowAvailable = available > 0 && requiredAvailable > available
-        let verdict: RAMFeasibility.Verdict
-        if projected > hardLimit || projected > softLimit || lowAvailable {
-            verdict = .tight
-        } else {
-            verdict = .ok
-        }
-
-        lastRAMFeasibility = RAMFeasibility(
+        let assessment = Self.buildRAMFeasibility(
             modelName: modelName,
-            verdict: verdict,
             incomingWeightsBytes: incomingWeightsBytes,
             incomingLoadFootprintBytes: incomingLoadFootprintBytes,
-            residentWeightsBytes: resident,
-            kvHeadroomBytes: kvHeadroom,
-            projectedBytes: projected,
-            physicalMemoryBytes: physical,
-            availableMemoryBytes: available,
-            requiredAvailableBytes: requiredAvailable,
-            softLimitBytes: softLimit,
-            hardLimitBytes: hardLimit,
-            timestamp: Date()
+            resident: resident,
+            inflightOther: inflightOther,
+            kvHeadroom: kvHeadroom,
+            physical: physical,
+            available: Self.availableMemoryBytes()
         )
 
-        switch verdict {
+        lastRAMFeasibility = assessment
+
+        switch assessment.verdict {
         case .ok:
             break
         case .tight:
             genLog.warning(
-                "loadContainer: RAM tight for \(modelName, privacy: .public) projected=\(projected, privacy: .public) soft=\(softLimit, privacy: .public) hard=\(hardLimit, privacy: .public) physical=\(physical, privacy: .public) available=\(available, privacy: .public) requiredAvailable=\(requiredAvailable, privacy: .public)"
+                "loadContainer: RAM tight for \(modelName, privacy: .public) projected=\(assessment.projectedBytes, privacy: .public) soft=\(assessment.softLimitBytes, privacy: .public) hard=\(assessment.hardLimitBytes, privacy: .public) physical=\(physical, privacy: .public) available=\(assessment.availableMemoryBytes, privacy: .public) requiredAvailable=\(assessment.requiredAvailableBytes, privacy: .public)"
             )
         case .refused:
             genLog.warning(
@@ -1211,6 +1266,75 @@ public actor ModelRuntime {
                 message: "ram-advisory model=\(modelName) verdict=refused"
             )
         }
+    }
+
+    /// Projected RAM feasibility for loading `name`, computed WITHOUT loading
+    /// anything. Backs the chat input's tight-fit disclaimer and send gate.
+    ///
+    /// Returns `nil` when no new load would happen or nothing can be
+    /// projected: the model is already resident, isn't installed locally, or
+    /// its bundle size can't be determined. Never mutates
+    /// `lastRAMFeasibility` and never gates the runtime load path — the
+    /// returned snapshot is a UI-layer signal keyed to the documented
+    /// soft/hard RAM threshold settings.
+    public func projectedLoadFeasibility(for name: String) async -> RAMFeasibility? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard modelCache[trimmed] == nil else { return nil }
+        guard let found = ModelManager.findInstalledModel(named: trimmed) else { return nil }
+        guard let localURL = Self.findLocalDirectory(forModelId: found.id) else { return nil }
+
+        let physical = Int64(ProcessInfo.processInfo.physicalMemory)
+        guard physical > 0 else { return nil }
+        let weightsBytes = candidateWeightsSizeBytes(modelName: trimmed, directory: localURL)
+        guard weightsBytes > 0 else { return nil }
+
+        let loadFootprintBytes = Self.effectiveLoadFootprintBytes(
+            rawWeightsBytes: weightsBytes,
+            modelDirectory: localURL,
+            modelName: trimmed
+        )
+        let kvHeadroom = Self.estimatedKVHeadroomBytes(
+            forWeights: loadFootprintBytes,
+            modelDirectory: localURL,
+            modelName: trimmed
+        )
+
+        // Strict single-model evicts the current resident before the load
+        // starts, so the projection must not double-count it. Flexible
+        // (multi-model) residency keeps other models around.
+        let policy =
+            await ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
+        let resident = policy == .strictSingleModel ? 0 : residentWeightBytes(excluding: trimmed)
+        let inflightOther = inflightLoadWeightBytes(excluding: trimmed)
+
+        return Self.buildRAMFeasibility(
+            modelName: trimmed,
+            incomingWeightsBytes: weightsBytes,
+            incomingLoadFootprintBytes: loadFootprintBytes,
+            resident: resident,
+            inflightOther: inflightOther,
+            kvHeadroom: kvHeadroom,
+            physical: physical,
+            available: Self.availableMemoryBytes()
+        )
+    }
+
+    /// Memoized bundle-size lookup for `projectedLoadFeasibility`: the UI
+    /// re-polls every ~2s while a banner is up, and `computeWeightsSizeBytes`
+    /// re-reads directory metadata / index JSON on every call. Keyed by model
+    /// name and invalidated when the resolved directory changes.
+    private var candidateWeightsBytesCache: [String: (path: String, bytes: Int64)] = [:]
+
+    private func candidateWeightsSizeBytes(modelName: String, directory: URL) -> Int64 {
+        if let cached = candidateWeightsBytesCache[modelName], cached.path == directory.path {
+            return cached.bytes
+        }
+        let bytes = Self.computeWeightsSizeBytes(at: directory, modelName: modelName)
+        if bytes > 0 {
+            candidateWeightsBytesCache[modelName] = (directory.path, bytes)
+        }
+        return bytes
     }
 
     private static func availableMemoryBytes() -> Int64 {

--- a/Packages/OsaurusCore/Services/ModelRuntime/ModelResidencyManager.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ModelResidencyManager.swift
@@ -115,11 +115,13 @@ public actor ModelResidencyManager {
         )
     }
 
-    /// Shorten an already-scheduled idle unload to fire after `grace` seconds.
+    /// Shorten an already-scheduled idle unload to fire after `grace` seconds
+    /// (zero fires on the next actor hop, i.e. immediately).
     ///
     /// Used when the last chat window referencing a model closes: instead of
     /// waiting out the full idle policy (default 15 minutes), the model is
-    /// released after a short grace period that still covers a quick reopen.
+    /// released right away — with the fire-time guards below still deciding
+    /// whether the unload is safe.
     ///
     /// Semantics — all deliberate, to stay race-free against API traffic:
     /// - Only ever SHORTENS a pending deadline; if the existing deadline is

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -33,32 +33,106 @@ struct ChatConfigurationWarmModelsOnLoadTests {
     }
 }
 
-@Suite("ChatWarmupController debounce")
+@Suite("ChatWarmupController immediate model switch")
 @MainActor
-struct ChatWarmupControllerDebounceTests {
+struct ChatWarmupControllerModelSwitchTests {
 
-    @Test("quick model switch-back does not evict before debounce fires")
-    func switchBackSkipsEviction() async {
+    @Test("selection change performs the residency switch immediately")
+    func selectionChangeSwitchesImmediately() async {
+        var evictionCount = 0
+        var lastEvictOthers: Bool?
+        let session = WarmupTestSession()
+        let controller = ChatWarmupController()
+
+        controller.handleModelSelectionChange(
+            session: session,
+            to: "other-model",
+            performSwitch: { evictOthers in
+                evictionCount += 1
+                lastEvictOthers = evictOthers
+            }
+        )
+
+        // No debounce: the switch (and its eviction) must run promptly, not
+        // after a multi-second grace timer.
+        for _ in 0 ..< 100 {
+            if evictionCount == 1 { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(evictionCount == 1)
+        // Default policy in the test environment is strict single-model, so
+        // the switch must ask for eviction of the previous model.
+        #expect(lastEvictOthers == true)
+        #expect(controller.state != .warm)
+    }
+
+    @Test("rapid consecutive switches all settle without losing an eviction")
+    func rapidSwitchesSerialize() async {
         var evictionCount = 0
         let session = WarmupTestSession()
         let controller = ChatWarmupController()
 
         controller.handleModelSelectionChange(
             session: session,
-            from: "test-model",
             to: "other-model",
             performSwitch: { _ in evictionCount += 1 }
         )
-
         controller.handleModelSelectionChange(
             session: session,
-            from: "other-model",
             to: "test-model",
             performSwitch: { _ in evictionCount += 1 }
         )
 
-        try? await Task.sleep(for: .milliseconds(100))
-        #expect(evictionCount == 0)
+        for _ in 0 ..< 100 {
+            if evictionCount == 2 { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(evictionCount == 2)
+    }
+
+    @Test("selection change cancels an in-flight warm-up generation")
+    func selectionChangeCancelsInFlightWarmup() async {
+        let engine = HangingWarmupEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|hint|"
+        )
+
+        let controller = ChatWarmupController()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        // Wait until the warm-up generation is actually streaming.
+        for _ in 0 ..< 100 {
+            if engine.started { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(engine.started)
+
+        // Keep the post-switch re-warm from starting another hanging stream:
+        // shouldAttemptWarmup bails while the session reports streaming.
+        session.isStreaming = true
+
+        var evictionCount = 0
+        controller.handleModelSelectionChange(
+            session: session,
+            to: "other-model",
+            performSwitch: { _ in evictionCount += 1 }
+        )
+
+        // The stale warm-up must be cancelled (stream terminated) and the
+        // eviction must not wait for the warm-up to finish on its own.
+        for _ in 0 ..< 100 {
+            if engine.terminated && evictionCount == 1 { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(engine.terminated)
+        #expect(evictionCount == 1)
+        #expect(controller.state == .warming)
     }
 }
 
@@ -182,6 +256,57 @@ private final class WarmupRecordingEngine: ChatEngineProtocol, @unchecked Sendab
     func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
         lastRequest = request
         return ChatCompletionResponse(
+            id: "test",
+            object: "chat.completion",
+            created: 0,
+            model: request.model,
+            choices: [],
+            usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
+        )
+    }
+}
+
+/// Engine whose stream never finishes on its own — only cancellation
+/// terminates it. Lets tests prove a model switch cancels the in-flight
+/// warm-up instead of waiting it out.
+private final class HangingWarmupEngine: ChatEngineProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _started = false
+    private var _terminated = false
+
+    var started: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _started
+    }
+
+    var terminated: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _terminated
+    }
+
+    private func markStarted() {
+        lock.lock()
+        _started = true
+        lock.unlock()
+    }
+
+    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        markStarted()
+        return AsyncThrowingStream { continuation in
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.lock.lock()
+                self._terminated = true
+                self.lock.unlock()
+            }
+            // Never finish: the warm-up only ends via task cancellation.
+        }
+    }
+
+    func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        ChatCompletionResponse(
             id: "test",
             object: "chat.completion",
             created: 0,

--- a/Packages/OsaurusCore/Tests/Service/ModelResidencyManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelResidencyManagerTests.swift
@@ -206,6 +206,78 @@ struct ModelResidencyManagerTests {
         #expect(await manager.snapshots().isEmpty)
     }
 
+    @Test("accelerateIdleUnload with zero grace unloads immediately")
+    func accelerateZeroGraceUnloadsImmediately() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+
+        await manager.scheduleIdleUnload(
+            modelName: "llama",
+            policy: .afterSeconds(900),
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        // Chat-window close with the immediate-eviction grace (0): the fire
+        // must not go through the injected sleep at all — only the original
+        // 900s policy timer ever slept, and it was cancelled.
+        await manager.accelerateIdleUnload(
+            modelName: "llama",
+            grace: 0,
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        #expect(await sleeper.recordedRequests() == [900_000_000_000])
+        #expect(await unloads.names() == ["llama"])
+        #expect(await manager.snapshots().isEmpty)
+    }
+
+    @Test("accelerateIdleUnload with zero grace still respects the fire-time reopen guard")
+    func accelerateZeroGraceRespectsReopenGuard() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+
+        await manager.scheduleIdleUnload(
+            modelName: "llama",
+            policy: .afterSeconds(900),
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        // A window reopened for this model between close and fire: the
+        // shouldStillUnload guard vetoes the immediate eviction.
+        await manager.accelerateIdleUnload(
+            modelName: "llama",
+            grace: 0,
+            now: now,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true },
+            shouldStillUnload: { _ in false }
+        )
+        await Self.allowTasksToRun()
+
+        #expect(await unloads.names().isEmpty)
+    }
+
     @Test("accelerateIdleUnload never extends a sooner deadline")
     func accelerateNeverExtendsSoonerDeadline() async {
         let sleeper = ResidencySleepRecorder()

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -1,0 +1,205 @@
+//
+//  ModelRuntimeRAMFeasibilityTests.swift
+//  Tests for the candidate-load RAM projection backing the chat input's
+//  tight-fit disclaimer and send gate.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ModelRuntime RAM feasibility — projection + severity mapping")
+struct ModelRuntimeRAMFeasibilityTests {
+
+    private let gb: Int64 = 1024 * 1024 * 1024
+
+    /// Builds an assessment through the shared verdict math with synthetic
+    /// byte counts. Thresholds come from the same store production uses, so
+    /// expectations are computed from the resolved values rather than
+    /// hardcoded 0.70/0.90.
+    private func assess(
+        footprint: Int64,
+        kvHeadroom: Int64 = 0,
+        resident: Int64 = 0,
+        inflightOther: Int64 = 0,
+        physical: Int64,
+        available: Int64
+    ) -> ModelRuntime.RAMFeasibility {
+        ModelRuntime.buildRAMFeasibility(
+            modelName: "test-model",
+            incomingWeightsBytes: footprint,
+            incomingLoadFootprintBytes: footprint,
+            resident: resident,
+            inflightOther: inflightOther,
+            kvHeadroom: kvHeadroom,
+            physical: physical,
+            available: available
+        )
+    }
+
+    // MARK: - Shared builder: verdict boundaries
+
+    @Test("Comfortable fit is ok with severity none")
+    func comfortableFitIsOK() {
+        let physical = 100 * gb
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        let softLimit = Int64(Double(physical) * thresholds.soft)
+
+        // Half the soft limit projected, plenty of free pages.
+        let f = assess(
+            footprint: softLimit / 2,
+            physical: physical,
+            available: physical
+        )
+
+        #expect(f.verdict == .ok)
+        #expect(f.loadPressureSeverity == .none)
+        #expect(f.softLimitBytes == softLimit)
+        #expect(f.hardLimitBytes == Int64(Double(physical) * thresholds.hard))
+        #expect(f.projectedBytes == softLimit / 2)
+        #expect(f.requiredAvailableBytes == softLimit / 2)
+    }
+
+    @Test("Crossing the soft threshold is tight / warn")
+    func softThresholdCrossingWarns() {
+        let physical = 100 * gb
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        let softLimit = Int64(Double(physical) * thresholds.soft)
+        let hardLimit = Int64(Double(physical) * thresholds.hard)
+
+        let atLimit = assess(footprint: softLimit, physical: physical, available: physical)
+        #expect(atLimit.verdict == .ok)
+        #expect(atLimit.loadPressureSeverity == .none)
+
+        let justOver = assess(footprint: softLimit + 1, physical: physical, available: physical)
+        #expect(justOver.verdict == .tight)
+        #expect(justOver.loadPressureSeverity == .warn)
+        #expect(justOver.projectedBytes <= hardLimit)
+    }
+
+    @Test("Crossing the hard ceiling blocks send")
+    func hardCeilingCrossingBlocks() {
+        let physical = 100 * gb
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        let hardLimit = Int64(Double(physical) * thresholds.hard)
+
+        let atLimit = assess(footprint: hardLimit, physical: physical, available: physical)
+        #expect(atLimit.loadPressureSeverity == .warn)
+
+        let justOver = assess(footprint: hardLimit + 1, physical: physical, available: physical)
+        #expect(justOver.verdict == .tight)
+        #expect(justOver.loadPressureSeverity == .block)
+    }
+
+    @Test("Low free pages alone warns but never blocks")
+    func lowAvailableWarnsWithoutBlocking() {
+        let physical = 100 * gb
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        let softLimit = Int64(Double(physical) * thresholds.soft)
+
+        // Projection is comfortably inside the soft limit, but immediately
+        // free pages are short — advisory tight, send still allowed (unified
+        // memory can compress/purge to make room).
+        let f = assess(
+            footprint: softLimit / 2,
+            physical: physical,
+            available: softLimit / 4
+        )
+
+        #expect(f.verdict == .tight)
+        #expect(f.loadPressureSeverity == .warn)
+    }
+
+    @Test("Model larger than physical memory blocks regardless of thresholds")
+    func modelLargerThanPhysicalBlocks() {
+        let physical = 16 * gb
+        let f = assess(
+            footprint: 32 * gb,
+            kvHeadroom: 2 * gb,
+            physical: physical,
+            available: physical
+        )
+
+        #expect(f.requiredAvailableBytes > f.physicalMemoryBytes)
+        #expect(f.loadPressureSeverity == .block)
+    }
+
+    @Test("Resident and in-flight bytes count toward the projection")
+    func residentAndInflightBytesCountTowardProjection() {
+        let physical = 100 * gb
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        let softLimit = Int64(Double(physical) * thresholds.soft)
+
+        // Footprint alone fits; resident + in-flight pushes past soft.
+        let footprint = softLimit / 2
+        let f = assess(
+            footprint: footprint,
+            resident: softLimit / 2,
+            inflightOther: 2,
+            physical: physical,
+            available: physical
+        )
+
+        #expect(f.projectedBytes == footprint + softLimit / 2 + 2)
+        #expect(f.verdict == .tight)
+        #expect(f.loadPressureSeverity == .warn)
+    }
+
+    // MARK: - Severity mapping is pure on the snapshot
+
+    @Test("Severity mapping derives from bytes, not the stored verdict")
+    func severityMappingUsesBytes() {
+        // A snapshot hand-built with verdict .ok but bytes past the hard
+        // limit must still block: the UI gate keys off the byte math so a
+        // stale/incoherent verdict can't unblock sending.
+        let f = ModelRuntime.RAMFeasibility(
+            modelName: "m",
+            verdict: .ok,
+            incomingWeightsBytes: 95 * gb,
+            incomingLoadFootprintBytes: 95 * gb,
+            residentWeightsBytes: 0,
+            kvHeadroomBytes: 0,
+            projectedBytes: 95 * gb,
+            physicalMemoryBytes: 100 * gb,
+            availableMemoryBytes: 100 * gb,
+            requiredAvailableBytes: 95 * gb,
+            softLimitBytes: 70 * gb,
+            hardLimitBytes: 90 * gb,
+            timestamp: Date()
+        )
+        #expect(f.loadPressureSeverity == .block)
+
+        // And a .tight verdict with bytes inside the soft limit still warns
+        // (low-available advisory case).
+        let warnOnly = ModelRuntime.RAMFeasibility(
+            modelName: "m",
+            verdict: .tight,
+            incomingWeightsBytes: 10 * gb,
+            incomingLoadFootprintBytes: 10 * gb,
+            residentWeightsBytes: 0,
+            kvHeadroomBytes: 0,
+            projectedBytes: 10 * gb,
+            physicalMemoryBytes: 100 * gb,
+            availableMemoryBytes: 1 * gb,
+            requiredAvailableBytes: 10 * gb,
+            softLimitBytes: 70 * gb,
+            hardLimitBytes: 90 * gb,
+            timestamp: Date()
+        )
+        #expect(warnOnly.loadPressureSeverity == .warn)
+    }
+
+    // MARK: - projectedLoadFeasibility guards
+
+    @Test("Unknown and empty model names project to nil")
+    func unknownModelProjectsToNil() async {
+        let missing = await ModelRuntime.shared.projectedLoadFeasibility(
+            for: "osaurus-test-nonexistent-\(UUID().uuidString)"
+        )
+        #expect(missing == nil)
+
+        let empty = await ModelRuntime.shared.projectedLoadFeasibility(for: "   ")
+        #expect(empty == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1972,8 +1972,11 @@ struct RuntimePolicySourceTests {
                 && runtime.contains("availableMemoryBytes: available"),
             "The load assessment must track available memory and expose it through health/logs without using it as a hard RAM block."
         )
+        // The verdict math lives in the shared builder so the advisory
+        // pre-load gate and the chat input's candidate projection can't
+        // drift apart.
         let assessmentBody = try Self.functionBody(
-            "private func checkRAMFeasibility",
+            "static func buildRAMFeasibility",
             in: runtime
         )
         // RAM pressure must not refuse a user-requested load: unified memory
@@ -1985,6 +1988,15 @@ struct RuntimePolicySourceTests {
                 && !assessmentBody.contains("throw LoadRefusedError(")
                 && !assessmentBody.contains("verdict = .refused"),
             "RAM pressure must warn as .tight, not throw or mark a hard refusal before vMLX attempts the load."
+        )
+        let advisoryGateBody = try Self.functionBody(
+            "private func checkRAMFeasibility",
+            in: runtime
+        )
+        #expect(
+            advisoryGateBody.contains("buildRAMFeasibility(")
+                && !advisoryGateBody.contains("throw LoadRefusedError("),
+            "The pre-load gate must route through the shared assessment builder and stay advisory."
         )
 
         let health = try Self.source("Networking/HTTPHandler.swift")

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -219,6 +219,15 @@ final class ChatSession: ObservableObject {
     /// Whether this run appended a new user turn. Regeneration sends reuse
     /// historical user turns and must not pop one during privacy-cancel rollback.
     private var appendedUserTurnForCurrentRun = false
+    /// True while a send is parked on the pre-send warm-up handshake (the
+    /// in-flight warm-up generation may still be loading the model). Drives a
+    /// placeholder typing-indicator row so the wait shows "Loading Model..."
+    /// instead of a silent gap under the user's message.
+    private var awaitingPreSendHandshake = false
+    /// Stable placeholder assistant turn rendered (never persisted, never in
+    /// `turns`) while `awaitingPreSendHandshake` is true. Stable identity so
+    /// the typing-indicator block id doesn't churn across rebuilds.
+    private let preSendHandshakePlaceholderTurn = ChatTurn(role: .assistant, content: "")
     /// Full transcript snapshot to restore when privacy review cancels a
     /// regeneration/edit-regeneration before the request leaves the device.
     private var turnsRollbackOnCancel: [ChatTurn]?
@@ -376,7 +385,6 @@ final class ChatSession: ObservableObject {
     nonisolated(unsafe) private var modelCacheCancellable: AnyCancellable?
     /// Flag to prevent auto-persist during initial load or programmatic resets
     private var isLoadingModel: Bool = false
-    private var previousSelectedModel: String?
 
     nonisolated(unsafe) private var localModelsObserver: NSObjectProtocol?
     /// Observer for `.privacyFilterRedactionsApproved`. Folds every
@@ -568,8 +576,6 @@ final class ChatSession: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] newModel in
                 guard let self = self, !self.isLoadingModel else { return }
-                let previous = self.previousSelectedModel
-                self.previousSelectedModel = newModel
                 guard let model = newModel else { return }
                 let pid = self.agentId ?? Agent.defaultId
                 // Mode 2 (remote agent run): the model is pinned to the remote
@@ -593,7 +599,6 @@ final class ChatSession: ObservableObject {
 
                 self.warmupController.handleModelSelectionChange(
                     session: self,
-                    from: previous,
                     to: model,
                     performSwitch: { [weak self] evictOthers in
                         await self?.performModelResidencySwitch(evictOthers: evictOthers)
@@ -780,7 +785,6 @@ final class ChatSession: ObservableObject {
         }
         loadActiveModelOptions(for: selectedModel)
         applyImageModelDefaults(for: selectedModel)
-        previousSelectedModel = selectedModel
         isLoadingModel = false
         notifySessionBecameActive()
     }
@@ -994,7 +998,17 @@ final class ChatSession: ObservableObject {
         // In Mode 2 the remote agent owns the conversation, so its name heads
         // the thread; otherwise fall back to the local agent's name.
         let displayName = threadAgentDisplayName ?? localName
-        let streamingTurnId = isStreaming ? turns.last?.id : nil
+        var streamingTurnId = isStreaming ? turns.last?.id : nil
+
+        // While a send waits on the pre-send warm-up handshake there is no
+        // assistant turn yet; render a placeholder typing-indicator group so
+        // the model-load/prefill wait is visible. The placeholder never
+        // enters `turns` — it exists only in this rebuild's block input.
+        var effectiveTurns = turns
+        if awaitingPreSendHandshake, !isStreaming, !turns.isEmpty {
+            effectiveTurns.append(preSendHandshakePlaceholderTurn)
+            streamingTurnId = preSendHandshakePlaceholderTurn.id
+        }
 
         if MockChatData.isEnabled {
             let mockTurns = MockChatData.mockTurnsForPerformanceTest()
@@ -1015,7 +1029,7 @@ final class ChatSession: ObservableObject {
         updateStreamingThinkingExpansion(streamingTurnId: streamingTurnId)
 
         let newBlocks = blockMemoizer.blocks(
-            from: turns,
+            from: effectiveTurns,
             streamingTurnId: streamingTurnId,
             agentName: displayName
         )
@@ -1369,17 +1383,18 @@ final class ChatSession: ObservableObject {
         send(text, attachments: attachments)
     }
 
-    /// Pre-send warm-up handshake: flush a pending debounced model switch
-    /// (the user must never wait out the switch timer), then wait for any
+    /// Pre-send warm-up handshake: wait for an in-flight model switch
+    /// (stale warm-up unwind + eviction) to settle, then wait for any
     /// in-flight warm-up generation to finish so its prefilled KV prefix is
     /// stored and the real request can prefix-hit. Does NOT start new
     /// warm-up work.
     private func prepareForSendWarmup() async {
-        await warmupController.flushPendingModelSwitch(
-            performSwitch: { [weak self] evictOthers in
-                await self?.performModelResidencySwitch(evictOthers: evictOthers)
-            }
-        )
+        await warmupController.awaitActiveModelSwitch()
+        // The switch task's last step schedules a fresh warm-up; this send
+        // owns the next generation, so drop that scheduled warm-up before it
+        // starts (a warm-up that already reached generation is covered by
+        // the await below and only pre-warms this send's own prefix).
+        warmupController.cancelScheduledWarmup()
         await warmupController.awaitInFlightWarmup()
     }
 
@@ -1631,6 +1646,7 @@ final class ChatSession: ObservableObject {
         showVoiceOverlay = false
         transientSessionIdForCurrentRun = nil
         appendedUserTurnForCurrentRun = false
+        awaitingPreSendHandshake = false
         turnsRollbackOnCancel = nil
         suppressQueuedSendFlushForCurrentRun = false
         // Clear session identity for new chat
@@ -1971,6 +1987,7 @@ final class ChatSession: ObservableObject {
         pendingAttachments = []
         transientSessionIdForCurrentRun = nil
         appendedUserTurnForCurrentRun = false
+        awaitingPreSendHandshake = false
         turnsRollbackOnCancel = nil
         suppressQueuedSendFlushForCurrentRun = false
         isDirty = false  // Fresh load, not dirty
@@ -1985,7 +2002,6 @@ final class ChatSession: ObservableObject {
         suppressVisibleBlockRebuild = false
         rebuildVisibleBlocks()
         warmupController.reset()
-        previousSelectedModel = selectedModel
 
         Task { [weak self] in
             await self?.refreshContextEstimates()
@@ -3486,16 +3502,42 @@ final class ChatSession: ObservableObject {
 
         // Common case: nothing pending — dispatch synchronously so the user
         // turn is appended inside send() (callers and tests rely on this).
-        // Only a pending debounced model switch or an in-flight warm-up
+        // Only a model switch still settling or an in-flight warm-up
         // generation requires the async handshake first.
         guard warmupController.needsPreSendHandshake else {
             dispatchSend(trimmed: trimmed, attachments: attachments, hasContent: hasContent)
             return
         }
 
+        // The handshake can wait out an entire model load (the in-flight
+        // warm-up generation loads the container first), so the user's
+        // message must appear NOW — not when the model finishes loading.
+        // Append the turn eagerly; dispatchSend skips the append, and the
+        // post-handshake guards roll it back if the dispatch aborts.
+        var preAppendedUserTurn: ChatTurn?
+        var preAppendIntroducedFirstTurn = false
+        if hasContent {
+            preAppendIntroducedFirstTurn = turns.isEmpty
+            let turn = ChatTurn(role: .user, content: trimmed, attachments: attachments)
+            turns.append(turn)
+            preAppendedUserTurn = turn
+        }
+        // Show the typing-indicator row (which surfaces "Loading Model..." /
+        // prefill progress) while the send waits on the warm-up, so the wait
+        // isn't a silent gap between the user's message and the run starting.
+        awaitingPreSendHandshake = true
+        rebuildVisibleBlocks()
+
         Task { @MainActor in
             await self.prepareForSendWarmup()
-            self.dispatchSend(trimmed: trimmed, attachments: attachments, hasContent: hasContent)
+            self.awaitingPreSendHandshake = false
+            self.dispatchSend(
+                trimmed: trimmed,
+                attachments: attachments,
+                hasContent: hasContent,
+                preAppendedUserTurn: preAppendedUserTurn,
+                preAppendIntroducedFirstTurn: preAppendIntroducedFirstTurn
+            )
         }
     }
 
@@ -3505,9 +3547,13 @@ final class ChatSession: ObservableObject {
     private func dispatchSend(
         trimmed: String,
         attachments: [Attachment],
-        hasContent: Bool
+        hasContent: Bool,
+        preAppendedUserTurn: ChatTurn? = nil,
+        preAppendIntroducedFirstTurn: Bool = false
     ) {
         guard activeRunId == nil, !isStreaming else {
+            rollbackPreAppendedUserTurn(
+                preAppendedUserTurn, restoringDraft: (trimmed, attachments))
             restoreTurnsRollbackAfterAbortedRegeneration()
             return
         }
@@ -3516,6 +3562,7 @@ final class ChatSession: ObservableObject {
             // `sendCurrent` already cleared the composer, and the warm-up
             // await above widened the window in which another window can
             // grab the runtime. Put the draft back instead of dropping it.
+            rollbackPreAppendedUserTurn(preAppendedUserTurn, restoringDraft: nil)
             if hasContent, input.isEmpty, pendingAttachments.isEmpty {
                 input = trimmed
                 pendingAttachments = attachments
@@ -3555,13 +3602,25 @@ final class ChatSession: ObservableObject {
         awaitingClarify = nil
 
         if hasContent {
-            let sendIntroducesFirstTurn = turns.isEmpty
+            // The pre-appended turn normally still sits in `turns`; it only
+            // disappears if the transcript was reset during the handshake
+            // (new chat / session load), in which case re-appending here
+            // restores the old dispatch-time-append behavior.
+            let preAppendedTurnPresent = preAppendedUserTurn.map { pre in
+                turns.contains { $0.id == pre.id }
+            }
+            let sendIntroducesFirstTurn =
+                preAppendedTurnPresent == true ? preAppendIntroducedFirstTurn : turns.isEmpty
             // One-shot activation signal — the install's first ever chat-UI
             // message. Inside the `hasContent` branch so a contentless
             // regeneration doesn't count as "used".
             FeatureTelemetry.firstTimeChatUsed()
 
-            turns.append(ChatTurn(role: .user, content: trimmed, attachments: attachments))
+            if let pre = preAppendedUserTurn {
+                if preAppendedTurnPresent == false { turns.append(pre) }
+            } else {
+                turns.append(ChatTurn(role: .user, content: trimmed, attachments: attachments))
+            }
             appendedUserTurnForCurrentRun = true
             // Stash the draft so we can put it back if the user cancels
             // out of the privacy review sheet. The text and attachments
@@ -5010,6 +5069,25 @@ final class ChatSession: ObservableObject {
 
     private func snapshotTurnsForCancelRollback() -> [ChatTurn] {
         turns.map { ChatTurn(from: ChatTurnData(from: $0)) }
+    }
+
+    /// Undo the eager user-turn append from `send()`'s pre-send-handshake
+    /// path when the post-handshake dispatch aborts (a run started or
+    /// another window grabbed the local runtime while we waited). Restores
+    /// the draft when asked so the user's text isn't silently dropped.
+    private func rollbackPreAppendedUserTurn(
+        _ turn: ChatTurn?,
+        restoringDraft draft: (text: String, attachments: [Attachment])?
+    ) {
+        guard let turn else { return }
+        if let index = turns.lastIndex(where: { $0.id == turn.id }) {
+            turns.remove(at: index)
+            rebuildVisibleBlocks()
+        }
+        if let draft, input.isEmpty, pendingAttachments.isEmpty {
+            input = draft.text
+            pendingAttachments = draft.attachments
+        }
     }
 
     private func restoreTurnsRollbackAfterAbortedRegeneration() {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -283,6 +283,19 @@ struct FloatingInputCard: View {
     @State private var clipboardPulseOpacity: Double = 0.0
     // Cache picker items to prevent popover refresh during streaming
     @State private var cachedPickerItems: [ModelPickerItem] = []
+
+    // MARK: - RAM Tight-Fit State
+
+    /// Latest candidate-load RAM projection for the selected local model.
+    /// Non-nil only when the projection crosses the soft threshold (warn) or
+    /// hard ceiling (block). `nil` = resident model, remote model, or a
+    /// comfortable fit — no banner, no gate.
+    @State private var pendingLoadFeasibility: ModelRuntime.RAMFeasibility?
+    /// Host memory usage captured alongside the feasibility refresh so the
+    /// banner shows a live percentage without this (large) view observing
+    /// `SystemMonitorService` and re-rendering on every 2s tick.
+    @State private var ramBannerUsagePercent: Int = 0
+    @State private var ramBannerTotalGB: Int = 0
     // MARK: - Voice Input State
     @ObservedObject private var speechService = SpeechService.shared
     @ObservedObject private var speechModelManager = SpeechModelManager.shared
@@ -382,6 +395,13 @@ struct FloatingInputCard: View {
         // let the inline notice explain, instead of silently degrading to a
         // tool-less chat that can't configure anything.
         guard !configContextTooSmall else { return false }
+
+        // RAM gate: loading the selected model would cross the hard RAM
+        // ceiling (documented `modelLoadRAMHardThreshold` setting). Block the
+        // send and let the floating banner explain; the periodic feasibility
+        // re-check lifts the block as memory frees. UI-only — the HTTP API
+        // and the runtime load path stay advisory.
+        guard !ramBlocked else { return false }
 
         let hasText = !localText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasContent = hasText || !pendingAttachments.isEmpty
@@ -600,7 +620,16 @@ struct FloatingInputCard: View {
                 configContextErrorOverlay
             }
             .animation(.easeOut(duration: 0.2), value: configContextTooSmall)
+            .modifier(
+                RAMTightFitModifier(
+                    severity: ramPressureSeverity,
+                    selectedModel: selectedModel,
+                    banner: ramPressureOverlay,
+                    refresh: refreshLoadFeasibility
+                )
+            )
             .onAppear {
+                refreshLoadFeasibility()
                 let isReappear = !localText.isEmpty || voiceInputState != .idle
                 localText = text
                 print("[VoiceDebug] FloatingInputCard onAppear (reappear=\(isReappear))")
@@ -892,6 +921,34 @@ fileprivate func voiceDebugLog(
 }
 
 // MARK: - Voice Debug Observers
+
+/// Groups the RAM tight-fit banner overlay and its refresh triggers into one
+/// modifier so the already-enormous `FloatingInputCard.body` chain doesn't
+/// gain four more inference nodes (the type-checker times out otherwise).
+private struct RAMTightFitModifier<Banner: View>: ViewModifier {
+    let severity: ModelRuntime.RAMFeasibility.LoadPressureSeverity
+    let selectedModel: String?
+    let banner: Banner
+    let refresh: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            // Float the tight-fit disclaimer above the card, same overlay
+            // mechanics as the configuration-context error banner.
+            .overlay(alignment: .top) {
+                banner
+            }
+            .animation(.easeOut(duration: 0.2), value: severity)
+            .onChange(of: selectedModel) { _, _ in
+                refresh()
+            }
+            // 2s host-memory tick: re-projects the tight-fit assessment so
+            // the warn/block banner clears on its own as RAM frees.
+            .onReceive(SystemMonitorService.shared.$memoryUsage) { _ in
+                refresh()
+            }
+    }
+}
 
 /// Watches the four properties that feed into isVoiceConfigured / isVoiceAvailable
 /// and emits a debug log line whenever any of them change.
@@ -2550,6 +2607,58 @@ extension FloatingInputCard {
         return ContextSizeResolver.resolve(modelId: model).sizeClass.disablesTools
     }
 
+    // MARK: - RAM Tight-Fit Gate
+
+    private var ramPressureSeverity: ModelRuntime.RAMFeasibility.LoadPressureSeverity {
+        pendingLoadFeasibility?.loadPressureSeverity ?? .none
+    }
+
+    /// Send is blocked while loading the selected model would cross the hard
+    /// RAM ceiling. Cleared automatically by the periodic feasibility
+    /// re-check as memory frees (or when the user picks a smaller model).
+    private var ramBlocked: Bool {
+        ramPressureSeverity == .block
+    }
+
+    /// Re-project the selected model's load feasibility. Called on appear,
+    /// on model change, and on `SystemMonitorService`'s 2s memory tick — the
+    /// tick is what auto-clears the warn/block state when RAM frees. The
+    /// runtime memoizes the bundle-size scan, so steady-state re-checks cost
+    /// one actor hop and a `vm_statistics64` read.
+    private func refreshLoadFeasibility() {
+        guard !isRemoteAgentRun, let model = selectedModel, isSelectedModelLocal else {
+            if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
+            return
+        }
+        Task { @MainActor in
+            let assessment = await ModelRuntime.shared.projectedLoadFeasibility(for: model)
+            // The selection may have moved while we were on the runtime actor.
+            guard selectedModel == model else { return }
+
+            guard let assessment, assessment.loadPressureSeverity != .none else {
+                if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
+                return
+            }
+            let monitor = SystemMonitorService.shared
+            let usagePercent = Int(monitor.memoryUsage.rounded())
+            let totalGB = Int(monitor.totalMemoryGB.rounded())
+            // Only touch @State when something the banner displays actually
+            // changed, so idle ticks don't re-render the card.
+            let changed =
+                pendingLoadFeasibility?.loadPressureSeverity != assessment.loadPressureSeverity
+                || pendingLoadFeasibility?.modelName != assessment.modelName
+                || pendingLoadFeasibility?.requiredAvailableBytes
+                    != assessment.requiredAvailableBytes
+                || ramBannerUsagePercent != usagePercent
+                || ramBannerTotalGB != totalGB
+            if changed {
+                pendingLoadFeasibility = assessment
+                ramBannerUsagePercent = usagePercent
+                ramBannerTotalGB = totalGB
+            }
+        }
+    }
+
     private var isSandboxAvailable: Bool {
         sandboxState.availability.isAvailable
     }
@@ -3265,6 +3374,90 @@ extension FloatingInputCard {
                 .alignmentGuide(.top) { dimensions in dimensions.height + 10 }
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
         }
+    }
+
+    /// Floating wrapper for `ramPressureBanner`, same overlay mechanics as
+    /// `configContextErrorOverlay`. The config-context error wins when both
+    /// apply — the two toasts share the space above the card.
+    @ViewBuilder
+    private var ramPressureOverlay: some View {
+        if !configContextTooSmall, let feasibility = pendingLoadFeasibility {
+            ramPressureBanner(feasibility)
+                .alignmentGuide(.top) { dimensions in dimensions.height + 10 }
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+
+    /// Foundation-style disclaimer shown above the card when loading the
+    /// selected model would be a tight RAM fit. Orange = warn (send allowed),
+    /// red = blocked (send paused until memory frees; the 2s feasibility
+    /// re-check clears it automatically).
+    private func ramPressureBanner(_ feasibility: ModelRuntime.RAMFeasibility) -> some View {
+        let blocked = feasibility.loadPressureSeverity == .block
+        let tint: Color = blocked ? .red : .orange
+        let modelName = selectedPickerItem?.displayName ?? feasibility.modelName
+        let neededGB = Self.formatGigabytes(feasibility.requiredAvailableBytes)
+        let usage = "\(ramBannerUsagePercent)"
+        let total = "\(ramBannerTotalGB)"
+
+        return HStack(spacing: 8) {
+            Image(systemName: blocked ? "memorychip.fill" : "memorychip")
+                .font(.system(size: CGFloat(theme.captionSize)))
+                .foregroundColor(tint)
+
+            Group {
+                if blocked {
+                    Text(
+                        "\(modelName) needs ~\(neededGB) GB to load, but memory is at \(usage)% of \(total) GB. Sending is paused until memory frees — close other apps or pick a smaller model.",
+                        bundle: .module
+                    )
+                } else {
+                    Text(
+                        "\(modelName) needs ~\(neededGB) GB to load and memory is at \(usage)% of \(total) GB. Close other apps for best performance.",
+                        bundle: .module
+                    )
+                }
+            }
+            .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+            .foregroundColor(theme.primaryText)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                showModelPicker = true
+            } label: {
+                Text("Choose model", bundle: .module)
+                    .font(theme.font(size: CGFloat(theme.captionSize), weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+            }
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(.regularMaterial)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(tint.opacity(0.12))
+            }
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(tint.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
+        .frame(maxWidth: 560)
+        .accessibilityLabel(
+            blocked
+                ? Text("Sending paused: not enough memory to load \(modelName)", bundle: .module)
+                : Text("Memory is tight for \(modelName)", bundle: .module)
+        )
+    }
+
+    /// One-decimal GB formatting for the RAM banner (e.g. "12.4").
+    private static func formatGigabytes(_ bytes: Int64) -> String {
+        String(format: "%.1f", Double(bytes) / 1_073_741_824.0)
     }
 
     /// Compact, floating toast shown above the card when the Default agent's

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -200,6 +200,11 @@ final class NativeTypingIndicatorView: NSView {
             sandbox.$isProvisioning.map { _ in () }.eraseToAnyPublisher(),
             agents.$activeAgentId.map { _ in () }.eraseToAnyPublisher(),
             agents.$agents.map { _ in () }.eraseToAnyPublisher(),
+            // Warm-up generations run with `suppressProgressUI` and publish
+            // load/prefill progress to this side channel instead of the
+            // global HUD. A send waiting on the pre-send handshake shows this
+            // indicator, so the warm-up's model load must surface here too.
+            WarmupProgressHub.shared.$phases.map { _ in () }.eraseToAnyPublisher(),
         ]
 
         cancellables.append(
@@ -227,6 +232,18 @@ final class NativeTypingIndicatorView: NSView {
         if agentUsesSandbox && sandboxBooting { return .sandbox }
         if let prefillProgress = cachedPrefill { return .prefill(prefillProgress) }
         if progress.loadInFlightCount > 0 { return .modelLoad }
+
+        // Fall back to warm-up progress: while a send waits on the pre-send
+        // handshake, the model load/prefill in flight belongs to a suppressed
+        // warm-up request whose progress only reaches WarmupProgressHub.
+        let warmupPhases = WarmupProgressHub.shared.phases.values
+        if warmupPhases.contains(.loadingModel) { return .modelLoad }
+        if case .prefilling(let state)? = warmupPhases.first(where: {
+            if case .prefilling = $0 { return true }
+            return false
+        }) {
+            return .prefill(state)
+        }
         return nil
     }
 


### PR DESCRIPTION
## Summary

**RAM tight-fit disclaimer + send gate** — a user-friendly guard for loading models that don't comfortably fit in memory:

- New `ModelRuntime.projectedLoadFeasibility(for:)` projects a candidate model's load (no load, no `lastRAMFeasibility` mutation), policy-aware: strict single-model counts resident bytes as 0 (the resident gets evicted first), multi-model counts current residents. The verdict math is refactored into a shared `buildRAMFeasibility` helper so the advisory pre-load gate and the projection can't drift, with a pure `loadPressureSeverity` mapping (`none` / `warn` / `block`) derived from the byte math.
- `FloatingInputCard` shows a foundation-style banner above the composer: orange warn past the soft threshold (default 70%), red block past the hard ceiling (default 90%) or when the model outright exceeds physical RAM — with live usage %, needed GB, and a "Choose model" action. Refreshes on appear, model change, and `SystemMonitorService`'s 2s tick, so the block clears on its own as memory frees. Bundle-size scans are memoized in the runtime; idle ticks don't re-render the card.
- `canSend` gains a `guard !ramBlocked` alongside the existing config-context gate. UI-only per the AGENTS.md rule: the HTTP API and the runtime load path stay advisory.
- New strings localized (en source + de/ko/ru/zh-Hans, `needs_review`).

**Immediate model switch** — switching models no longer feels stuck:

- The 2.5s switch debounce is gone; a selection change acts immediately.
- An in-flight warm-up of the previous model is cancelled and detached instead of waited out (its generation lease was deferring the eviction). The switch task awaits the cancelled warm-up's unwind so the lease drains before eviction, serializes rapid consecutive switches, and epoch-guards every suspension so a stale switch can't overwrite a newer one.
- The chip dot flips to warming synchronously and the new model's warm-up (with `WarmupProgressHub` load/prefill progress) starts as soon as eviction settles.

**Send during warm-up** — while a send waits on the pre-send handshake (which can span a whole model load), the user's message now appears immediately with a typing indicator that surfaces the suppressed warm-up's load/prefill progress; the eager append rolls back cleanly if the dispatch aborts.

**Immediate eviction on chat close** — closing the last chat window referencing a model now unloads it right away (`chatCloseUnloadGraceSeconds` 15 → 0) instead of after a grace period, so a closed chat never pins unified memory. The unload still runs through `ModelResidencyManager`'s fire-time guards: a held generation lease, an API/plugin/P2P-sourced model, or a window reopened before the fire keeps the model resident. Zero grace skips the sleep entirely and fires on the next actor hop.

## Test plan

- [x] `ModelRuntimeRAMFeasibilityTests` (new, 8 tests): soft/hard boundary verdicts, low-free-pages warn-never-block, resident/in-flight accounting, severity mapping independent of stored verdict, projection nil guards
- [x] `ChatWarmupControllerTests`: immediate eviction with strict-policy flag, rapid switches serialize, in-flight warm-up cancelled on selection change (hanging-stream engine), existing shutdown/fidelity tests
- [x] `RuntimePolicySourceTests` (87 tests) — assertions repointed at the shared feasibility builder
- [x] `ModelResidencyManagerTests` (+2 new): zero-grace fires immediately without touching the injected sleep; zero-grace still respects the fire-time reopen guard
- [x] `swift build` clean; `scripts/i18n/check.sh` passes
- [x] Full `make test` suite: 5120 tests, all PR-touched suites pass. Remaining issues are the known set: keychain-gated secrets suites that fail by design under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` (`ToolSecretsKeychainAgentSweepTests`, `ResolvedSecretsMergingTests`, agent-delete keychain sweeps) plus load-induced flakes (`ChatSessionStoreDeferredSaveTests`, `DatabaseToolsTests`, `ToolExposureControlCenterTests`, `pathResolverReadsFromHostWorkingFolder`) that pass when run in isolation
- [x] Manual: select an oversized model → red banner + paused send; free RAM → auto-unblock; switch models mid-warm-up → instant yellow dot + progress; close the chat window → model unloads immediately unless an API stream holds it