### PR TITLE
Add `osaurus bench --kv-matrix`: automated fp16-vs-TurboQuant KV codec evidence

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -394,12 +394,18 @@ public struct BenchCommand: Command {
 
     enum KVMatrixError: LocalizedError {
         case malformedConfig(String)
+        case runtimeSettingsReadbackMismatch
+        case persistedSettingsReadbackMismatch
         case restoreFailed(String)
 
         var errorDescription: String? {
             switch self {
             case .malformedConfig(let detail):
                 return "server-runtime.json does not look like a runtime settings file (\(detail))"
+            case .runtimeSettingsReadbackMismatch:
+                return "runtime settings readback differs from the requested probe; Osaurus normalized or migrated additional fields, or another settings writer changed them"
+            case .persistedSettingsReadbackMismatch:
+                return "server-runtime.json differs from /admin/runtime-settings readback; preserving it as an unrecognized settings change"
             case .restoreFailed(let detail):
                 return "could not restore server-runtime.json (\(detail))"
             }
@@ -418,14 +424,39 @@ public struct BenchCommand: Command {
     ) async -> Never {
         let configURL = runtimeConfigFileURL()
         let originalData: Data
-        let codecConfigData: [String: Data]
         do {
             originalData = try Data(contentsOf: configURL)
-            // Validate up front so we never restart on a file we could not
-            // mutate (and therefore could not have restored) safely.
+        } catch {
+            fputs(
+                "Cannot use \(configURL.path): \(error.localizedDescription)\nLaunch Osaurus once so the runtime settings file exists.\n",
+                stderr)
+            exit(EXIT_FAILURE)
+        }
+        guard
+            let baselineResponse = await fetchJSON(
+                base.appendingPathComponent("admin/runtime-settings")),
+            let baselineSettingsData = runtimeSettingsData(
+                inRuntimeSettingsResponse: baselineResponse)
+        else {
+            fputs(
+                "Cannot read canonical settings from /admin/runtime-settings; no runtime settings were changed.\n",
+                stderr)
+            exit(EXIT_FAILURE)
+        }
+        guard (try? Data(contentsOf: configURL)) == originalData else {
+            fputs(
+                "server-runtime.json changed while reading the canonical runtime-settings baseline; no runtime settings were changed.\n",
+                stderr)
+            exit(EXIT_FAILURE)
+        }
+        let codecConfigData: [String: Data]
+        do {
+            // Build probes from the running app's canonical settings rather
+            // than potentially pre-normalized disk bytes. The exact disk bytes
+            // remain the restoration source.
             codecConfigData = try Dictionary(
                 uniqueKeysWithValues: kvMatrixCodecs.map { codec in
-                    (codec, try configData(settingLiveKVCodec: codec, in: originalData))
+                    (codec, try configData(settingLiveKVCodec: codec, in: baselineSettingsData))
                 })
         } catch {
             fputs(
@@ -450,17 +481,19 @@ public struct BenchCommand: Command {
                 stderr)
             exit(EXIT_FAILURE)
         }
+        var ownedConfigData =
+            [originalData, baselineSettingsData] + Array(codecConfigData.values)
         armKVMatrixRestore(
             configURL: configURL,
             originalData: originalData,
-            ownedData: [originalData] + Array(codecConfigData.values),
+            ownedData: ownedConfigData,
             backup: backup
         )
         installKVMatrixSignalHandlers()
 
         fputs(
             "KV matrix for \(model): codecs \(kvMatrixCodecs), prompt sizes \(options.promptTokens), \(options.runs) run(s) each.\n"
-                + "Each codec needs a full app restart; the original config is restored on clean completion. Concurrent edits are preserved and keep the pre-run backup at \(backup.path).\n",
+                + "Each codec needs a full app restart; the original config is restored on clean completion. Unrecognized settings changes are preserved and keep the pre-run backup at \(backup.path).\n",
             stderr)
 
         var codecBlocks: [[String: Any]] = []
@@ -470,17 +503,17 @@ public struct BenchCommand: Command {
         var lastWrittenData: Data?
 
         measurement: for codec in kvMatrixCodecs {
+            guard let mutated = codecConfigData[codec] else {
+                fatal = "missing prepared config for codec \(codec)"
+                break measurement
+            }
             do {
-                guard let mutated = codecConfigData[codec] else {
-                    fatal = "missing prepared config for codec \(codec)"
-                    break measurement
-                }
                 let expected = lastWrittenData ?? originalData
                 guard try writeKVMatrixConfig(
                     at: configURL, expectedData: expected, newData: mutated)
                 else {
                     fatal =
-                        "server-runtime.json changed during the run; refusing to overwrite concurrent changes"
+                        "server-runtime.json changed after the last verified runtime-settings readback; refusing to overwrite the unrecognized file"
                     break measurement
                 }
                 didMutateConfig = true
@@ -494,7 +527,12 @@ public struct BenchCommand: Command {
                 fatal = "server did not come back healthy after restart for codec \(codec)"
                 break measurement
             }
-            guard let active = await activeLiveKVCodec(base: base) else {
+            guard
+                let runtimeSettingsResponse = await fetchJSON(
+                    base.appendingPathComponent("admin/runtime-settings")),
+                let active = activeLiveKVCodec(
+                    inRuntimeSettingsResponse: runtimeSettingsResponse)
+            else {
                 fatal =
                     "cannot verify codec \"\(codec)\": /admin/runtime-settings did not return cache.liveKVCodec"
                 break measurement
@@ -502,6 +540,28 @@ public struct BenchCommand: Command {
             guard active == codec else {
                 fatal =
                     "server reports live KV codec \"\(active)\" after restart (expected \"\(codec)\") — aborting so cells are not mislabeled"
+                break measurement
+            }
+            do {
+                let persistedData = try Data(contentsOf: configURL)
+                try verifyKVMatrixReadback(
+                    requestedData: mutated,
+                    runtimeSettingsResponse: runtimeSettingsResponse,
+                    persistedData: persistedData)
+                // ServerRuntimeSettingsStore may re-encode the file while
+                // loading. Adopt those verified bytes for the next exact CAS;
+                // semantic changes beyond the canonical probe fail above.
+                lastWrittenData = persistedData
+                if !ownedConfigData.contains(persistedData) {
+                    ownedConfigData.append(persistedData)
+                }
+                armKVMatrixRestore(
+                    configURL: configURL,
+                    originalData: originalData,
+                    ownedData: ownedConfigData,
+                    backup: backup)
+            } catch {
+                fatal = "[\(codec)] \(error.localizedDescription)"
                 break measurement
             }
             // Absorb the cold model load after the restart so it doesn't
@@ -594,32 +654,62 @@ public struct BenchCommand: Command {
             )
         }
 
-        // Restore the user's config bytes unconditionally (defer-style: this
-        // runs on the fatal paths above too), then restart once more so the
-        // running server matches the restored on-disk settings again.
+        // Restore the user's exact bytes, reload them, verify the app's
+        // canonical interpretation, then re-pin the exact bytes because load
+        // normalization may have re-encoded or migrated the file.
         if didMutateConfig {
             var restored = false
+            var restoreFailure: String?
             if let lastWrittenData {
                 do {
-                    restored = try restoreKVMatrixConfig(
+                    let restoredForReload = try restoreKVMatrixConfig(
                         at: configURL,
                         expectedData: [lastWrittenData],
                         originalData: originalData)
+                    guard restoredForReload else {
+                        throw KVMatrixError.restoreFailed(
+                            "server-runtime.json no longer matches a verified KV-matrix state")
+                    }
+                    guard await restartServerForConfigReload(port: options.port) else {
+                        throw KVMatrixError.restoreFailed(
+                            "server did not come back healthy after loading the original config")
+                    }
+                    guard
+                        let restoredResponse = await fetchJSON(
+                            base.appendingPathComponent("admin/runtime-settings"))
+                    else {
+                        throw KVMatrixError.restoreFailed(
+                            "/admin/runtime-settings was unavailable after reload")
+                    }
+                    let normalizedRestoredData = try Data(contentsOf: configURL)
+                    try verifyKVMatrixReadback(
+                        requestedData: baselineSettingsData,
+                        runtimeSettingsResponse: restoredResponse,
+                        persistedData: normalizedRestoredData)
+                    guard try writeKVMatrixConfig(
+                        at: configURL,
+                        expectedData: normalizedRestoredData,
+                        newData: originalData)
+                    else {
+                        throw KVMatrixError.restoreFailed(
+                            "server-runtime.json changed after restoration readback")
+                    }
+                    restored = true
                 } catch {
-                    let restoreFailure = "restore failed: \(error.localizedDescription)"
-                    fatal = fatal.map { "\($0); \(restoreFailure)" } ?? restoreFailure
+                    restoreFailure = error.localizedDescription
                 }
             }
             if restored {
-                fputs("Restored original \(configURL.lastPathComponent).\n", stderr)
-            } else {
-                let restoreFailure =
-                    "server-runtime.json changed during the run; concurrent changes were preserved and the original bytes remain in \(backup.path)"
-                if !((fatal ?? "").contains("restore failed")) {
-                    fatal = fatal.map { "\($0); \(restoreFailure)" } ?? restoreFailure
-                }
                 fputs(
-                    "Concurrent modification detected. Refusing to overwrite \(configURL.path). The current file was preserved; the pre-run bytes remain in \(backup.path).\n",
+                    "Restored byte-identical original \(configURL.lastPathComponent) after canonical reload.\n",
+                    stderr)
+            } else {
+                let detail = restoreFailure ?? "exact restoration could not be verified"
+                let recoveryFailure =
+                    "\(detail); the current settings file was preserved and the original bytes remain in \(backup.path)"
+                fatal = fatal.map { "\($0); \(recoveryFailure)" } ?? recoveryFailure
+                fputs(
+                    "KV matrix could not verify exact settings restoration: \(recoveryFailure).\n",
                     stderr)
             }
             // Disarm the signal-handler safety net; keep the sidecar backup
@@ -627,12 +717,7 @@ public struct BenchCommand: Command {
             clearKVMatrixRestore()
             disarmKVMatrixSignalHandlers()
             if restored { try? FileManager.default.removeItem(at: backup) }
-            if restored {
-                if await restartServerForConfigReload(port: options.port) == false {
-                    fatal = fatal
-                        ?? "server did not come back healthy after restoring the original config"
-                }
-            } else {
+            if !restored {
                 _ = await AppControl.terminateAppAndWait()
             }
         } else {
@@ -688,7 +773,7 @@ public struct BenchCommand: Command {
                 "ttft": "request start → first non-empty content delta",
                 "decode_tps": "(completion_tokens - 1) / (last delta - first delta)",
                 "codec_application":
-                    "cache.liveKVCodec written to server-runtime.json (TurboQuant uses explicit 3/3 bits), full app restart per codec, active setting verified after every restart, effective mode verified from /admin/cache-stats after generation, and original config restored afterwards",
+                    "probe documents derived from canonical GET /admin/runtime-settings, cache.liveKVCodec written to server-runtime.json (TurboQuant uses explicit 3/3 bits), full app restart per codec, semantic API and disk readback verified after every restart, verified app re-encodings adopted for the next byte-exact write guard, effective mode verified from /admin/cache-stats after generation, and the byte-exact original restored, canonically reloaded, then re-pinned",
                 "codec_verified":
                     "always true in an emitted report; settings and effective runtime mode are both verified, and any unavailable endpoint, malformed response, or mismatch aborts the run",
                 "low_confidence":
@@ -824,7 +909,7 @@ public struct BenchCommand: Command {
                     stderr)
             } else {
                 fputs(
-                    "\nInterrupted after a concurrent config edit. The current file was preserved; pre-run bytes remain in \(state.backup.path). Restart Osaurus to apply the current file.\n",
+                    "\nInterrupted after an unrecognized config change. The current file was preserved; pre-run bytes remain in \(state.backup.path). Restart Osaurus to apply the current file.\n",
                     stderr)
             }
         } catch {
@@ -835,14 +920,16 @@ public struct BenchCommand: Command {
         return true
     }
 
-    /// Restores only when the on-disk bytes are still owned by this run.
-    /// Returning false preserves a concurrent writer's changes and keeps the
-    /// sidecar backup available for manual reconciliation.
+    /// Restores only when the on-disk document is still semantically owned by
+    /// this run. App load may re-encode a probe; semantic equality accepts that
+    /// rewrite while still rejecting changes to any setting value.
     static func restoreKVMatrixConfig(
         at configURL: URL, expectedData: [Data], originalData: Data
     ) throws -> Bool {
         let current = try Data(contentsOf: configURL)
-        guard expectedData.contains(current) else { return false }
+        guard expectedData.contains(where: { configDocumentsMatch(current, $0) }) else {
+            return false
+        }
         try originalData.write(to: configURL, options: .atomic)
         guard try Data(contentsOf: configURL) == originalData else {
             throw KVMatrixError.restoreFailed("post-write byte verification failed")
@@ -900,6 +987,54 @@ public struct BenchCommand: Command {
         return cache["liveKVCodec"] as? String
     }
 
+    /// Extracts the Codable settings document from the admin response. Probe
+    /// configs are based on this canonical runtime state so load-time repairs
+    /// such as legacy MTP `off` -> `auto` are not reintroduced from stale bytes.
+    static func runtimeSettingsData(
+        inRuntimeSettingsResponse response: [String: Any]
+    ) -> Data? {
+        guard let settings = response["settings"],
+              JSONSerialization.isValidJSONObject(settings)
+        else { return nil }
+        return try? JSONSerialization.data(
+            withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    static func configDocumentsMatch(_ lhs: Data, _ rhs: Data) -> Bool {
+        if lhs == rhs { return true }
+        guard
+            let lhsObject = try? JSONSerialization.jsonObject(with: lhs),
+            let rhsObject = try? JSONSerialization.jsonObject(with: rhs),
+            JSONSerialization.isValidJSONObject(lhsObject),
+            JSONSerialization.isValidJSONObject(rhsObject),
+            let normalizedLHS = try? JSONSerialization.data(
+                withJSONObject: lhsObject, options: [.sortedKeys]),
+            let normalizedRHS = try? JSONSerialization.data(
+                withJSONObject: rhsObject, options: [.sortedKeys])
+        else { return false }
+        return normalizedLHS == normalizedRHS
+    }
+
+    /// Confirms that both the running snapshot and the file persisted during
+    /// app load still describe exactly the requested probe. Formatting-only
+    /// rewrites are accepted; any value change remains fail-closed.
+    static func verifyKVMatrixReadback(
+        requestedData: Data,
+        runtimeSettingsResponse: [String: Any],
+        persistedData: Data
+    ) throws {
+        guard
+            let runtimeData = runtimeSettingsData(
+                inRuntimeSettingsResponse: runtimeSettingsResponse),
+            configDocumentsMatch(requestedData, runtimeData)
+        else {
+            throw KVMatrixError.runtimeSettingsReadbackMismatch
+        }
+        guard configDocumentsMatch(runtimeData, persistedData) else {
+            throw KVMatrixError.persistedSettingsReadbackMismatch
+        }
+    }
+
     static func kvMatrixIsLowConfidence(completionTokens: [Int]) -> Bool {
         completionTokens.contains { $0 < kvMatrixLowConfidenceCompletionTokens }
     }
@@ -938,16 +1073,6 @@ public struct BenchCommand: Command {
             try? await Task.sleep(nanoseconds: 500_000_000)
         }
         return false
-    }
-
-    /// Codec the running server actually applied (GET /admin/runtime-settings,
-    /// the automation companion of the Server Settings panel). Nil when the
-    /// endpoint is unavailable or malformed. The caller fails closed because
-    /// an unverified codec label cannot be used as runtime evidence.
-    static func activeLiveKVCodec(base: URL) async -> String? {
-        guard let response = await fetchJSON(base.appendingPathComponent("admin/runtime-settings"))
-        else { return nil }
-        return activeLiveKVCodec(inRuntimeSettingsResponse: response)
     }
 
     /// `/admin/runtime-settings` serializes the settings value through its
@@ -1256,8 +1381,9 @@ public struct BenchCommand: Command {
             per prompt size: uncached/cached TTFT and decode tok/s. It edits
             cache.liveKVCodec in server-runtime.json and restarts the app per
             codec (the file is only read at launch). The original is restored
-            on clean completion; concurrent edits are preserved with a pre-run
-            recovery backup. Measurement only — it changes no defaults.
+            on clean completion; unrecognized settings changes are preserved
+            with a pre-run recovery backup. Measurement only — it changes no
+            defaults.
 
             """, stderr)
     }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -380,6 +380,7 @@ public struct BenchCommand: Command {
     /// `VMLXKVCacheCodec` contract in `server-runtime.json`). Baseline first,
     /// so turboquant cells can be reported against engine-selected behavior.
     static let kvMatrixCodecs = ["engine_selected", "turboquant"]
+    static let kvMatrixTurboQuantBits = 3
 
     static let kvMatrixCodecDescriptions: [String: String] = [
         "engine_selected":
@@ -505,10 +506,26 @@ public struct BenchCommand: Command {
             // Absorb the cold model load after the restart so it doesn't
             // pollute the first uncached TTFT sample (same warm-up as
             // --tune-prefill).
-            _ = try? await measureOnce(
-                base: base, model: model,
-                prompt: makePrompt(targetTokens: 256, nonce: "kv-warm-\(UUID().uuidString)"),
-                maxTokens: 8)
+            do {
+                _ = try await measureOnce(
+                    base: base, model: model,
+                    prompt: makePrompt(targetTokens: 256, nonce: "kv-warm-\(UUID().uuidString)"),
+                    maxTokens: 8)
+            } catch {
+                fatal = "[\(codec)] warm-up generation failed: \(error.localizedDescription)"
+                break measurement
+            }
+            guard let effectiveKVMode = await effectiveKVMode(base: base, model: model) else {
+                fatal = "[\(codec)] /admin/cache-stats did not report an effective KV mode for \(model)"
+                break measurement
+            }
+            if codec == "turboquant",
+               effectiveKVMode != "turbo(\(kvMatrixTurboQuantBits),\(kvMatrixTurboQuantBits))" {
+                fatal =
+                    "[turboquant] runtime reports effective KV mode \"\(effectiveKVMode)\"; "
+                    + "expected turbo(\(kvMatrixTurboQuantBits),\(kvMatrixTurboQuantBits))"
+                break measurement
+            }
 
             var scenarios: [[String: Any]] = []
             for target in options.promptTokens {
@@ -567,7 +584,13 @@ public struct BenchCommand: Command {
                         medianDecodeTps: median(uncached.map { $0.decodeTps }),
                         lowConfidence: lowConfidence))
             }
-            codecBlocks.append(kvMatrixCodecBlock(codec: codec, scenarios: scenarios))
+            codecBlocks.append(
+                kvMatrixCodecBlock(
+                    codec: codec,
+                    effectiveKVMode: effectiveKVMode,
+                    scenarios: scenarios
+                )
+            )
         }
 
         // Restore the user's config bytes unconditionally (defer-style: this
@@ -646,9 +669,9 @@ public struct BenchCommand: Command {
                 "ttft": "request start → first non-empty content delta",
                 "decode_tps": "(completion_tokens - 1) / (last delta - first delta)",
                 "codec_application":
-                    "cache.liveKVCodec written to server-runtime.json, full app restart per codec (the file is only read at launch), active setting verified after every restart, and original config restored afterwards",
+                    "cache.liveKVCodec written to server-runtime.json (TurboQuant uses explicit 3/3 bits), full app restart per codec, active setting verified after every restart, effective mode verified from /admin/cache-stats after generation, and original config restored afterwards",
                 "codec_verified":
-                    "always true in an emitted report; an unavailable endpoint, malformed response, or mismatch aborts the run",
+                    "always true in an emitted report; settings and effective runtime mode are both verified, and any unavailable endpoint, malformed response, or mismatch aborts the run",
                 "low_confidence":
                     "cells with any sample below \(kvMatrixLowConfidenceCompletionTokens) completion_tokens are flagged low_confidence: the decode window is too short for a stable tok/s estimate",
                 "context":
@@ -660,11 +683,16 @@ public struct BenchCommand: Command {
 
     /// Per-codec block of the JSON report. Pure so the codec_verified
     /// plumbing is unit-testable.
-    static func kvMatrixCodecBlock(codec: String, scenarios: [[String: Any]]) -> [String: Any] {
+    static func kvMatrixCodecBlock(
+        codec: String,
+        effectiveKVMode: String,
+        scenarios: [[String: Any]]
+    ) -> [String: Any] {
         [
             "codec": codec,
             "description": kvMatrixCodecDescriptions[codec] ?? "",
             "codec_verified": true,
+            "effective_kv_mode": effectiveKVMode,
             "scenarios": scenarios,
         ]
     }
@@ -811,8 +839,10 @@ public struct BenchCommand: Command {
             .appendingPathComponent("server-runtime.json")
     }
 
-    /// Returns `data` re-serialized with `cache.liveKVCodec` set to `codec`,
-    /// leaving every other field untouched. Throws instead of inventing
+    /// Returns `data` re-serialized with the requested live codec. The
+    /// TurboQuant probe also sets explicit 3/3 bits because a codec selection
+    /// with nil bit widths resolves to fp16. Every unrelated field is kept.
+    /// Throws instead of inventing
     /// structure: a document without a `cache` object is not a runtime
     /// settings file, and writing a partial one could destroy user config.
     static func configData(settingLiveKVCodec codec: String, in data: Data) throws -> Data {
@@ -823,6 +853,10 @@ public struct BenchCommand: Command {
             throw KVMatrixError.malformedConfig("no \"cache\" object")
         }
         cache["liveKVCodec"] = codec
+        if codec == "turboquant" {
+            cache["turboQuantKeyBits"] = kvMatrixTurboQuantBits
+            cache["turboQuantValueBits"] = kvMatrixTurboQuantBits
+        }
         root["cache"] = cache
         return try JSONSerialization.data(
             withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
@@ -880,11 +914,38 @@ public struct BenchCommand: Command {
     /// endpoint is unavailable or malformed. The caller fails closed because
     /// an unverified codec label cannot be used as runtime evidence.
     static func activeLiveKVCodec(base: URL) async -> String? {
-        guard let obj = await fetchJSON(base.appendingPathComponent("admin/runtime-settings")),
-            let settings = obj["settings"] as? [String: Any],
-            let cache = settings["cache"] as? [String: Any]
+        guard let response = await fetchJSON(base.appendingPathComponent("admin/runtime-settings"))
         else { return nil }
-        return cache["liveKVCodec"] as? String
+        return activeLiveKVCodec(inRuntimeSettingsResponse: response)
+    }
+
+    /// The admin API uses snake_case even though server-runtime.json uses
+    /// Codable's camelCase keys. Keep the two contracts explicit so a config
+    /// key can never accidentally stand in for live runtime verification.
+    static func activeLiveKVCodec(
+        inRuntimeSettingsResponse response: [String: Any]
+    ) -> String? {
+        guard let settings = response["settings"] as? [String: Any],
+              let cache = settings["cache"] as? [String: Any]
+        else { return nil }
+        return cache["live_kv_codec"] as? String
+    }
+
+    static func effectiveKVMode(base: URL, model: String) async -> String? {
+        guard let response = await fetchJSON(base.appendingPathComponent("admin/cache-stats"))
+        else { return nil }
+        return effectiveKVMode(inCacheStatsResponse: response, model: model)
+    }
+
+    static func effectiveKVMode(
+        inCacheStatsResponse response: [String: Any],
+        model: String
+    ) -> String? {
+        guard let models = response["models"] as? [[String: Any]],
+              let row = models.first(where: { ($0["name"] as? String) == model }),
+              row["cache_enabled"] as? Bool == true
+        else { return nil }
+        return row["effective_kv_mode"] as? String
     }
 
     struct KVMatrixCell {

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -32,6 +32,11 @@ public struct BenchCommand: Command {
 
     private static let defaultTuneCandidates = [512, 1_024, 2_048, 4_096]
 
+    /// `--kv-matrix` defaults cover a common long prompt and a larger context
+    /// where codec overhead and memory pressure can become visible.
+    private static let defaultKVMatrixPromptTokens = [8_192, 32_768]
+    private static let defaultKVMatrixRuns = 2
+
     struct Options {
         var model: String?
         var promptTokens: [Int] = BenchCommand.defaultPromptTokens
@@ -41,6 +46,11 @@ public struct BenchCommand: Command {
         var port: Int
         var tunePrefill: Bool = false
         var tuneCandidates: [Int] = BenchCommand.defaultTuneCandidates
+        var kvMatrix: Bool = false
+        /// Set when the user passed the flag explicitly, so `--kv-matrix`
+        /// can apply its own defaults without overriding a user's choice.
+        var promptTokensExplicit: Bool = false
+        var runsExplicit: Bool = false
     }
 
     public static func execute(args: [String]) async {
@@ -67,6 +77,13 @@ public struct BenchCommand: Command {
         if options.tunePrefill {
             await tunePrefill(options: options, model: model, base: base, health: health)
             // tunePrefill exits the process itself.
+        }
+
+        if options.kvMatrix {
+            if !options.promptTokensExplicit { options.promptTokens = defaultKVMatrixPromptTokens }
+            if !options.runsExplicit { options.runs = defaultKVMatrixRuns }
+            await kvMatrix(options: options, model: model, base: base, health: health)
+            // kvMatrix exits the process itself.
         }
 
         fputs("Benchmarking \(model) (\(options.runs) runs × prompt sizes \(options.promptTokens))…\n", stderr)
@@ -128,6 +145,12 @@ public struct BenchCommand: Command {
             ],
         ]
 
+        emitReportAndExit(report, jsonPath: options.jsonPath)
+    }
+
+    /// Serializes a report and emits it (file with `--json`, stdout
+    /// otherwise). Shared by the main bench path and `--kv-matrix`.
+    static func emitReportAndExit(_ report: [String: Any], jsonPath: String?) -> Never {
         let data: Data
         do {
             data = try JSONSerialization.data(
@@ -136,7 +159,7 @@ public struct BenchCommand: Command {
             fputs("Failed to encode report: \(error.localizedDescription)\n", stderr)
             exit(EXIT_FAILURE)
         }
-        if let path = options.jsonPath {
+        if let path = jsonPath {
             let url = URL(fileURLWithPath: path)
             try? FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -351,6 +374,568 @@ public struct BenchCommand: Command {
         }
     }
 
+    // MARK: - KV codec matrix (`--kv-matrix`)
+
+    /// `cache.liveKVCodec` values under test (raw values of the vmlx
+    /// `VMLXKVCacheCodec` contract in `server-runtime.json`). Baseline first,
+    /// so turboquant cells can be reported against engine-selected behavior.
+    static let kvMatrixCodecs = ["engine_selected", "turboquant"]
+
+    static let kvMatrixCodecDescriptions: [String: String] = [
+        "engine_selected":
+            "engine-selected live KV baseline; effective codec resolution remains runtime-defined",
+        "turboquant": "TurboQuant live KV — explicit opt-in, never auto-enabled",
+    ]
+
+    /// Below this many completion tokens the decode window is too short for
+    /// a stable tok/s estimate, so the cell is flagged low-confidence.
+    static let kvMatrixLowConfidenceCompletionTokens = 32
+
+    enum KVMatrixError: LocalizedError {
+        case malformedConfig(String)
+        case restoreFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .malformedConfig(let detail):
+                return "server-runtime.json does not look like a runtime settings file (\(detail))"
+            case .restoreFailed(let detail):
+                return "could not restore server-runtime.json (\(detail))"
+            }
+        }
+    }
+
+    /// Fp16 vs TurboQuant live-KV measurement matrix. It produces per-model,
+    /// per-machine evidence without changing runtime defaults.
+    ///
+    /// Per codec: write `cache.liveKVCodec`, full app restart (the app only
+    /// reads `server-runtime.json` at launch — a bare server stop/serve keeps
+    /// the in-memory snapshot), verify the active codec over HTTP, then run
+    /// the same uncached/cached measurement pairs as the main bench path.
+    static func kvMatrix(
+        options: Options, model: String, base: URL, health: [String: Any]
+    ) async -> Never {
+        let configURL = runtimeConfigFileURL()
+        let originalData: Data
+        let codecConfigData: [String: Data]
+        do {
+            originalData = try Data(contentsOf: configURL)
+            // Validate up front so we never restart on a file we could not
+            // mutate (and therefore could not have restored) safely.
+            codecConfigData = try Dictionary(
+                uniqueKeysWithValues: kvMatrixCodecs.map { codec in
+                    (codec, try configData(settingLiveKVCodec: codec, in: originalData))
+                })
+        } catch {
+            fputs(
+                "Cannot use \(configURL.path): \(error.localizedDescription)\nLaunch Osaurus once so the runtime settings file exists.\n",
+                stderr)
+            exit(EXIT_FAILURE)
+        }
+
+        // Interruption safety: the run mutates the LIVE server-runtime.json,
+        // so Ctrl-C/SIGTERM mid-run would otherwise leave a probe codec
+        // installed permanently. Before the first mutation: (1) write a
+        // sidecar backup so even SIGKILL is hand-recoverable, and (2) install
+        // SIGINT/SIGTERM handlers that restore the original bytes (printing
+        // the recovery blob on failure) and exit non-zero.
+        let backup = kvMatrixBackupURL(for: configURL)
+        do {
+            try createKVMatrixBackup(originalData, at: backup)
+        } catch {
+            fputs(
+                "Cannot create backup \(backup.path): \(error.localizedDescription)\n"
+                    + "If this is left from an interrupted run, restore or remove it before retrying.\n",
+                stderr)
+            exit(EXIT_FAILURE)
+        }
+        armKVMatrixRestore(
+            configURL: configURL,
+            originalData: originalData,
+            ownedData: [originalData] + Array(codecConfigData.values),
+            backup: backup
+        )
+        installKVMatrixSignalHandlers()
+
+        fputs(
+            "KV matrix for \(model): codecs \(kvMatrixCodecs), prompt sizes \(options.promptTokens), \(options.runs) run(s) each.\nEach codec needs a full app restart; your original config is restored afterwards (backup: \(backup.path)).\n",
+            stderr)
+
+        var codecBlocks: [[String: Any]] = []
+        var cells: [KVMatrixCell] = []
+        var fatal: String?
+        var didMutateConfig = false
+        var lastWrittenData: Data?
+
+        measurement: for codec in kvMatrixCodecs {
+            do {
+                guard let mutated = codecConfigData[codec] else {
+                    fatal = "missing prepared config for codec \(codec)"
+                    break measurement
+                }
+                let expected = lastWrittenData ?? originalData
+                guard try writeKVMatrixConfig(
+                    at: configURL, expectedData: expected, newData: mutated)
+                else {
+                    fatal =
+                        "server-runtime.json changed during the run; refusing to overwrite concurrent changes"
+                    break measurement
+                }
+                didMutateConfig = true
+                lastWrittenData = mutated
+            } catch {
+                fatal = "failed to write \(configURL.path): \(error.localizedDescription)"
+                break measurement
+            }
+            fputs("[\(codec)] restarting server…\n", stderr)
+            guard await restartServerForConfigReload(port: options.port) else {
+                fatal = "server did not come back healthy after restart for codec \(codec)"
+                break measurement
+            }
+            guard let active = await activeLiveKVCodec(base: base) else {
+                fatal =
+                    "cannot verify codec \"\(codec)\": /admin/runtime-settings did not return cache.liveKVCodec"
+                break measurement
+            }
+            guard active == codec else {
+                fatal =
+                    "server reports live KV codec \"\(active)\" after restart (expected \"\(codec)\") — aborting so cells are not mislabeled"
+                break measurement
+            }
+            // Absorb the cold model load after the restart so it doesn't
+            // pollute the first uncached TTFT sample (same warm-up as
+            // --tune-prefill).
+            _ = try? await measureOnce(
+                base: base, model: model,
+                prompt: makePrompt(targetTokens: 256, nonce: "kv-warm-\(UUID().uuidString)"),
+                maxTokens: 8)
+
+            var scenarios: [[String: Any]] = []
+            for target in options.promptTokens {
+                var uncached: [Sample] = []
+                var cached: [Sample] = []
+                for run in 0..<options.runs {
+                    // Unique-nonce prompt then identical resend, exactly like
+                    // the main bench path: first request cannot hit the prefix
+                    // cache, the resend measures the cache-hit path.
+                    let prompt = makePrompt(
+                        targetTokens: target, nonce: "kv-\(codec)-run\(run)-\(UUID().uuidString)")
+                    do {
+                        let first = try await measureOnce(
+                            base: base, model: model, prompt: prompt, maxTokens: options.maxTokens)
+                        let second = try await measureOnce(
+                            base: base, model: model, prompt: prompt, maxTokens: options.maxTokens)
+                        uncached.append(first)
+                        cached.append(second)
+                        fputs(
+                            String(
+                                format:
+                                    "[%@] prompt≈%d run %d: uncached TTFT %.0f ms → cached %.0f ms, decode %.1f tok/s\n",
+                                codec, target, run + 1, first.ttftMs, second.ttftMs,
+                                first.decodeTps),
+                            stderr)
+                    } catch {
+                        fatal =
+                            "[\(codec)] prompt≈\(target) run \(run + 1) failed: \(error.localizedDescription)"
+                        break measurement
+                    }
+                }
+                guard uncached.count == options.runs, cached.count == options.runs else {
+                    fatal =
+                        "[\(codec)] prompt≈\(target) produced an incomplete sample set; no evidence report was emitted"
+                    break measurement
+                }
+                let lowConfidence = kvMatrixIsLowConfidence(
+                    completionTokens: (uncached + cached).map { $0.completionTokens })
+                scenarios.append([
+                    "target_prompt_tokens": target,
+                    "actual_prompt_tokens": uncached.map { $0.promptTokens },
+                    "completion_tokens": [
+                        "uncached": uncached.map { $0.completionTokens },
+                        "cached": cached.map { $0.completionTokens },
+                    ],
+                    "low_confidence": lowConfidence,
+                    "uncached": summarize(uncached),
+                    "cached": summarize(cached),
+                ])
+                cells.append(
+                    KVMatrixCell(
+                        codec: codec,
+                        targetPromptTokens: target,
+                        medianUncachedTTFTMs: median(uncached.map { $0.ttftMs }),
+                        medianCachedTTFTMs: median(cached.map { $0.ttftMs }),
+                        medianDecodeTps: median(uncached.map { $0.decodeTps }),
+                        lowConfidence: lowConfidence))
+            }
+            codecBlocks.append(kvMatrixCodecBlock(codec: codec, scenarios: scenarios))
+        }
+
+        // Restore the user's config bytes unconditionally (defer-style: this
+        // runs on the fatal paths above too), then restart once more so the
+        // running server matches the restored on-disk settings again.
+        if didMutateConfig {
+            var restored = false
+            if let lastWrittenData {
+                do {
+                    restored = try restoreKVMatrixConfig(
+                        at: configURL,
+                        expectedData: [lastWrittenData],
+                        originalData: originalData)
+                } catch {
+                    let restoreFailure = "restore failed: \(error.localizedDescription)"
+                    fatal = fatal.map { "\($0); \(restoreFailure)" } ?? restoreFailure
+                }
+            }
+            if restored {
+                fputs("Restored original \(configURL.lastPathComponent).\n", stderr)
+            } else {
+                let restoreFailure =
+                    "server-runtime.json changed during the run; concurrent changes were preserved and the original bytes remain in \(backup.path)"
+                if !((fatal ?? "").contains("restore failed")) {
+                    fatal = fatal.map { "\($0); \(restoreFailure)" } ?? restoreFailure
+                }
+                fputs(
+                    "Concurrent modification detected. Refusing to overwrite \(configURL.path). The current file was preserved; the pre-run bytes remain in \(backup.path).\n",
+                    stderr)
+            }
+            // Disarm the signal-handler safety net; keep the sidecar backup
+            // around when the restore failed (it is the recovery source).
+            clearKVMatrixRestore()
+            disarmKVMatrixSignalHandlers()
+            if restored { try? FileManager.default.removeItem(at: backup) }
+            if restored {
+                if await restartServerForConfigReload(port: options.port) == false {
+                    fatal = fatal
+                        ?? "server did not come back healthy after restoring the original config"
+                }
+            } else {
+                _ = await AppControl.terminateAppAndWait()
+            }
+        } else {
+            // Nothing was mutated: just disarm the safety net.
+            clearKVMatrixRestore()
+            disarmKVMatrixSignalHandlers()
+            try? FileManager.default.removeItem(at: backup)
+        }
+
+        if let fatal {
+            fputs("KV matrix failed: \(fatal)\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+        let measuredCodecs = Set(cells.map { $0.codec })
+        guard measuredCodecs.count == kvMatrixCodecs.count else {
+            fputs(
+                "KV matrix incomplete: measured \(measuredCodecs.sorted()) of \(kvMatrixCodecs); no comparison possible.\n",
+                stderr)
+            exit(EXIT_FAILURE)
+        }
+
+        fputs("\n" + kvMatrixTableLines(cells).joined(separator: "\n") + "\n\n", stderr)
+
+        let report: [String: Any] = [
+            "schema": "osaurus-kv-matrix/1",
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "model": model,
+            "max_tokens": options.maxTokens,
+            "runs": options.runs,
+            "hardware": (health["hardware"] as? [String: Any]) ?? NSNull(),
+            "codecs": codecBlocks,
+            "methodology": [
+                "sampling": "temperature 0 (greedy)",
+                "token_counts": "server usage via stream_options.include_usage",
+                "ttft": "request start → first non-empty content delta",
+                "decode_tps": "(completion_tokens - 1) / (last delta - first delta)",
+                "codec_application":
+                    "cache.liveKVCodec written to server-runtime.json, full app restart per codec (the file is only read at launch), active setting verified after every restart, and original config restored afterwards",
+                "codec_verified":
+                    "always true in an emitted report; an unavailable endpoint, malformed response, or mismatch aborts the run",
+                "low_confidence":
+                    "cells with any sample below \(kvMatrixLowConfidenceCompletionTokens) completion_tokens are flagged low_confidence: the decode window is too short for a stable tok/s estimate",
+                "context":
+                    "per-family evidence for the fail-closed TurboQuant policy (2026-06-12): TurboQuant live KV is never auto-enabled and must win per family on measured numbers like these",
+            ],
+        ]
+        emitReportAndExit(report, jsonPath: options.jsonPath)
+    }
+
+    /// Per-codec block of the JSON report. Pure so the codec_verified
+    /// plumbing is unit-testable.
+    static func kvMatrixCodecBlock(codec: String, scenarios: [[String: Any]]) -> [String: Any] {
+        [
+            "codec": codec,
+            "description": kvMatrixCodecDescriptions[codec] ?? "",
+            "codec_verified": true,
+            "scenarios": scenarios,
+        ]
+    }
+
+    /// Sidecar backup of the pre-run config, written before the first
+    /// mutation and removed on clean completion — recovery source for
+    /// SIGKILL (which no handler can catch) and for a failed restore.
+    static func kvMatrixBackupURL(for configURL: URL) -> URL {
+        URL(fileURLWithPath: configURL.path + ".kvmatrix-backup")
+    }
+
+    static func createKVMatrixBackup(_ data: Data, at backupURL: URL) throws {
+        let temporaryURL = backupURL.deletingLastPathComponent().appendingPathComponent(
+            ".\(backupURL.lastPathComponent).\(UUID().uuidString).tmp")
+        defer { try? FileManager.default.removeItem(at: temporaryURL) }
+        try data.write(to: temporaryURL, options: .atomic)
+        // Publishing with a hard link is atomic and fails when the recovery
+        // path already exists; unlike Data's writing options, it supports
+        // both guarantees together.
+        try FileManager.default.linkItem(at: temporaryURL, to: backupURL)
+    }
+
+    struct KVMatrixRestoreState {
+        let configURL: URL
+        let originalData: Data
+        let ownedData: [Data]
+        let backup: URL
+    }
+
+    nonisolated(unsafe) static var kvMatrixRestore: KVMatrixRestoreState?
+    private static let kvMatrixRestoreLock = NSLock()
+    nonisolated(unsafe) static var kvMatrixSignalSources: [DispatchSourceSignal] = []
+
+    static func armKVMatrixRestore(
+        configURL: URL, originalData: Data, ownedData: [Data], backup: URL
+    ) {
+        kvMatrixRestoreLock.lock()
+        kvMatrixRestore = KVMatrixRestoreState(
+            configURL: configURL,
+            originalData: originalData,
+            ownedData: ownedData,
+            backup: backup)
+        kvMatrixRestoreLock.unlock()
+    }
+
+    @discardableResult
+    static func clearKVMatrixRestore() -> KVMatrixRestoreState? {
+        kvMatrixRestoreLock.lock()
+        defer { kvMatrixRestoreLock.unlock() }
+        let state = kvMatrixRestore
+        kvMatrixRestore = nil
+        return state
+    }
+
+    static func hasKVMatrixRestoreState() -> Bool {
+        kvMatrixRestoreLock.lock()
+        defer { kvMatrixRestoreLock.unlock() }
+        return kvMatrixRestore != nil
+    }
+
+    static func installKVMatrixSignalHandlers() {
+        signal(SIGINT, SIG_IGN)
+        signal(SIGTERM, SIG_IGN)
+        kvMatrixSignalSources = [SIGINT, SIGTERM].map { signalNumber in
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .main)
+            source.setEventHandler {
+                if BenchCommand.kvMatrixAbortRestore() {
+                    _Exit(EXIT_FAILURE)
+                }
+            }
+            source.resume()
+            return source
+        }
+    }
+
+    static func disarmKVMatrixSignalHandlers() {
+        kvMatrixSignalSources.forEach { $0.cancel() }
+        kvMatrixSignalSources = []
+        signal(SIGINT, SIG_DFL)
+        signal(SIGTERM, SIG_DFL)
+    }
+
+    /// Restores the pre-run `server-runtime.json` bytes and removes the
+    /// sidecar backup; prints the recovery blob (and keeps the backup) when
+    /// the restore write fails. Called from the SIGINT/SIGTERM handlers;
+    /// a no-op once the run has disarmed it.
+    @discardableResult
+    static func kvMatrixAbortRestore() -> Bool {
+        guard let state = clearKVMatrixRestore() else { return false }
+        do {
+            if try restoreKVMatrixConfig(
+                at: state.configURL,
+                expectedData: state.ownedData,
+                originalData: state.originalData) {
+                try? FileManager.default.removeItem(at: state.backup)
+                fputs(
+                    "\nInterrupted — restored original \(state.configURL.lastPathComponent). The server may still be running a probe codec; restart it (`osaurus serve`) to reload the restored config.\n",
+                    stderr)
+            } else {
+                fputs(
+                    "\nInterrupted after a concurrent config edit. The current file was preserved; pre-run bytes remain in \(state.backup.path). Restart Osaurus to apply the current file.\n",
+                    stderr)
+            }
+        } catch {
+            fputs(
+                "\nInterrupted — FAILED to restore \(state.configURL.path): \(error.localizedDescription)\nRestore it manually from \(state.backup.path) — original contents follow:\n\(String(bytes: state.originalData, encoding: .utf8) ?? "<binary>")\n",
+                stderr)
+        }
+        return true
+    }
+
+    /// Restores only when the on-disk bytes are still owned by this run.
+    /// Returning false preserves a concurrent writer's changes and keeps the
+    /// sidecar backup available for manual reconciliation.
+    static func restoreKVMatrixConfig(
+        at configURL: URL, expectedData: [Data], originalData: Data
+    ) throws -> Bool {
+        let current = try Data(contentsOf: configURL)
+        guard expectedData.contains(current) else { return false }
+        try originalData.write(to: configURL, options: .atomic)
+        guard try Data(contentsOf: configURL) == originalData else {
+            throw KVMatrixError.restoreFailed("post-write byte verification failed")
+        }
+        return true
+    }
+
+    /// Replaces a probe config only if the file still contains the bytes this
+    /// run last wrote. This catches settings-panel or process edits between
+    /// codec cells instead of silently overwriting them.
+    static func writeKVMatrixConfig(
+        at configURL: URL, expectedData: Data, newData: Data
+    ) throws -> Bool {
+        guard try Data(contentsOf: configURL) == expectedData else { return false }
+        try newData.write(to: configURL, options: .atomic)
+        return try Data(contentsOf: configURL) == newData
+    }
+
+    /// The runtime settings file owned by the app's
+    /// `ServerRuntimeSettingsStore` (OsaurusCore); the CLI edits the same
+    /// JSON contract without linking OsaurusCore — mirrors `tuningFileURL()`.
+    static func runtimeConfigFileURL() -> URL {
+        Configuration.root()
+            .appendingPathComponent("config", isDirectory: true)
+            .appendingPathComponent("server-runtime.json")
+    }
+
+    /// Returns `data` re-serialized with `cache.liveKVCodec` set to `codec`,
+    /// leaving every other field untouched. Throws instead of inventing
+    /// structure: a document without a `cache` object is not a runtime
+    /// settings file, and writing a partial one could destroy user config.
+    static func configData(settingLiveKVCodec codec: String, in data: Data) throws -> Data {
+        guard var root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw KVMatrixError.malformedConfig("top level is not an object")
+        }
+        guard var cache = root["cache"] as? [String: Any] else {
+            throw KVMatrixError.malformedConfig("no \"cache\" object")
+        }
+        cache["liveKVCodec"] = codec
+        root["cache"] = cache
+        return try JSONSerialization.data(
+            withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    static func liveKVCodec(inConfigData data: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let cache = root["cache"] as? [String: Any]
+        else { return nil }
+        return cache["liveKVCodec"] as? String
+    }
+
+    static func kvMatrixIsLowConfidence(completionTokens: [Int]) -> Bool {
+        completionTokens.contains { $0 < kvMatrixLowConfidenceCompletionTokens }
+    }
+
+    /// Stop notification → app termination → relaunch → serve notification →
+    /// /health 200. A bare server stop/serve cycle is deliberately NOT used:
+    /// the app never re-reads `server-runtime.json` after launch, so only a
+    /// full app relaunch applies an on-disk codec edit (see
+    /// `AppControl.terminateAppAndWait`).
+    static func restartServerForConfigReload(port: Int) async -> Bool {
+        AppControl.postDistributedNotification(
+            name: "com.dinoki.osaurus.control.stop", userInfo: [:])
+        // Let in-flight requests wind down before the app exits (Stop.swift's
+        // stop-then-verify pattern, with a longer budget for model unload).
+        let stopDeadline = Date().addingTimeInterval(10)
+        while Date() < stopDeadline {
+            if !(await ServerControl.checkHealth(port: port)) { break }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        guard await AppControl.terminateAppAndWait() else { return false }
+        await AppControl.launchAppIfNeeded()
+        AppControl.postDistributedNotification(
+            name: "com.dinoki.osaurus.control.serve", userInfo: [:])
+        let start = Date()
+        let deadline = start.addingTimeInterval(60)
+        var reposted = false
+        while Date() < deadline {
+            if await ServerControl.checkHealth(port: port) { return true }
+            // The app may miss the first signal while still initializing;
+            // re-post once, like Serve.swift.
+            if !reposted, Date().timeIntervalSince(start) > 3 {
+                AppControl.postDistributedNotification(
+                    name: "com.dinoki.osaurus.control.serve", userInfo: [:])
+                reposted = true
+            }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
+        return false
+    }
+
+    /// Codec the running server actually applied (GET /admin/runtime-settings,
+    /// the automation companion of the Server Settings panel). Nil when the
+    /// endpoint is unavailable or malformed. The caller fails closed because
+    /// an unverified codec label cannot be used as runtime evidence.
+    static func activeLiveKVCodec(base: URL) async -> String? {
+        guard let obj = await fetchJSON(base.appendingPathComponent("admin/runtime-settings")),
+            let settings = obj["settings"] as? [String: Any],
+            let cache = settings["cache"] as? [String: Any]
+        else { return nil }
+        return cache["liveKVCodec"] as? String
+    }
+
+    struct KVMatrixCell {
+        let codec: String
+        let targetPromptTokens: Int
+        let medianUncachedTTFTMs: Double
+        let medianCachedTTFTMs: Double
+        let medianDecodeTps: Double
+        let lowConfidence: Bool
+    }
+
+    /// Final medians table (stderr). Deltas are against the `engine_selected`
+    /// baseline cell of the same prompt size — the comparison that decides
+    /// whether TurboQuant earns a per-family allow-list entry.
+    static func kvMatrixTableLines(_ cells: [KVMatrixCell]) -> [String] {
+        func pad(_ text: String, _ width: Int) -> String {
+            text.count >= width
+                ? text + " " : text + String(repeating: " ", count: width - text.count)
+        }
+        func delta(_ value: Double, _ baseline: Double?) -> String {
+            guard let baseline, baseline > 0 else { return "" }
+            return String(format: " (%+.0f%%)", (value - baseline) / baseline * 100)
+        }
+        var baselines: [Int: KVMatrixCell] = [:]
+        for cell in cells where cell.codec == kvMatrixCodecs[0] {
+            baselines[cell.targetPromptTokens] = cell
+        }
+        var lines = [
+            pad("codec", 17) + pad("prompt", 8) + pad("uncached TTFT", 21) + pad("cached TTFT", 19)
+                + "decode tok/s"
+        ]
+        for cell in cells {
+            let baseline = cell.codec == kvMatrixCodecs[0]
+                ? nil : baselines[cell.targetPromptTokens]
+            let uncached =
+                String(format: "%.0f ms", cell.medianUncachedTTFTMs)
+                + delta(cell.medianUncachedTTFTMs, baseline?.medianUncachedTTFTMs)
+            let cached =
+                String(format: "%.0f ms", cell.medianCachedTTFTMs)
+                + delta(cell.medianCachedTTFTMs, baseline?.medianCachedTTFTMs)
+            var decode =
+                String(format: "%.1f", cell.medianDecodeTps)
+                + delta(cell.medianDecodeTps, baseline?.medianDecodeTps)
+            if cell.lowConfidence { decode += " [low-confidence]" }
+            lines.append(
+                pad(cell.codec, 17) + pad(String(cell.targetPromptTokens), 8)
+                    + pad(uncached, 21) + pad(cached, 19) + decode)
+        }
+        return lines
+    }
+
     // MARK: - Single measurement
 
     struct Sample {
@@ -522,12 +1107,14 @@ public struct BenchCommand: Command {
                 let parsed = v.split(separator: ",").compactMap { Int($0) }.filter { $0 > 0 }
                 guard !parsed.isEmpty else { return nil }
                 options.promptTokens = parsed
+                options.promptTokensExplicit = true
             case "--max-tokens":
                 guard let v = value(), let n = Int(v), n > 0 else { return nil }
                 options.maxTokens = n
             case "--runs":
                 guard let v = value(), let n = Int(v), n > 0 else { return nil }
                 options.runs = n
+                options.runsExplicit = true
             case "--json":
                 guard let v = value() else { return nil }
                 options.jsonPath = v
@@ -536,6 +1123,8 @@ public struct BenchCommand: Command {
                 options.port = n
             case "--tune-prefill":
                 options.tunePrefill = true
+            case "--kv-matrix":
+                options.kvMatrix = true
             case "--candidates":
                 guard let v = value() else { return nil }
                 let parsed = v.split(separator: ",").compactMap { Int($0) }.filter { $0 > 0 }
@@ -547,6 +1136,10 @@ public struct BenchCommand: Command {
             }
             index += 1
         }
+        if options.tunePrefill && options.kvMatrix {
+            fputs("--tune-prefill and --kv-matrix are mutually exclusive.\n", stderr)
+            return nil
+        }
         return options
     }
 
@@ -557,6 +1150,8 @@ public struct BenchCommand: Command {
                                  [--max-tokens 128] [--runs 3] [--json <path>] [--port N]
                    osaurus bench --tune-prefill [--model <id>] [--candidates 512,1024,2048,4096]
                                  [--prompt-tokens 8192] [--runs 3]
+                   osaurus bench --kv-matrix [--model <id>] [--prompt-tokens 8192,32768]
+                                 [--runs 2] [--json <path>]
 
             Requires a running server (`osaurus serve`). Reports uncached/cached
             TTFT, prefill tok/s, and decode tok/s per prompt size as JSON.
@@ -564,6 +1159,12 @@ public struct BenchCommand: Command {
             --tune-prefill measures the model's TTFT at each candidate prefill
             step size and persists the per-model winner (the optimum is
             model-architecture-dependent); the server applies it immediately.
+
+            --kv-matrix measures engine-selected vs TurboQuant live-KV
+            per prompt size: uncached/cached TTFT and decode tok/s. It edits
+            cache.liveKVCodec in server-runtime.json and restarts the app per
+            codec (the file is only read at launch); the original config is
+            always restored. Measurement only — it changes no defaults.
 
             """, stderr)
     }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -919,16 +919,16 @@ public struct BenchCommand: Command {
         return activeLiveKVCodec(inRuntimeSettingsResponse: response)
     }
 
-    /// The admin API uses snake_case even though server-runtime.json uses
-    /// Codable's camelCase keys. Keep the two contracts explicit so a config
-    /// key can never accidentally stand in for live runtime verification.
+    /// `/admin/runtime-settings` serializes the settings value through its
+    /// Codable contract, so this key intentionally matches server-runtime.json.
+    /// `/admin/cache-stats` uses a separate hand-built snake_case contract.
     static func activeLiveKVCodec(
         inRuntimeSettingsResponse response: [String: Any]
     ) -> String? {
         guard let settings = response["settings"] as? [String: Any],
               let cache = settings["cache"] as? [String: Any]
         else { return nil }
-        return cache["live_kv_codec"] as? String
+        return cache["liveKVCodec"] as? String
     }
 
     static func effectiveKVMode(base: URL, model: String) async -> String? {

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -459,7 +459,8 @@ public struct BenchCommand: Command {
         installKVMatrixSignalHandlers()
 
         fputs(
-            "KV matrix for \(model): codecs \(kvMatrixCodecs), prompt sizes \(options.promptTokens), \(options.runs) run(s) each.\nEach codec needs a full app restart; your original config is restored afterwards (backup: \(backup.path)).\n",
+            "KV matrix for \(model): codecs \(kvMatrixCodecs), prompt sizes \(options.promptTokens), \(options.runs) run(s) each.\n"
+                + "Each codec needs a full app restart; the original config is restored on clean completion. Concurrent edits are preserved and keep the pre-run backup at \(backup.path).\n",
             stderr)
 
         var codecBlocks: [[String: Any]] = []
@@ -635,10 +636,28 @@ public struct BenchCommand: Command {
                 _ = await AppControl.terminateAppAndWait()
             }
         } else {
-            // Nothing was mutated: just disarm the safety net.
+            // A rejected or failed first write may still have raced after its
+            // pre-write check. Remove the recovery copy only when the config
+            // is provably still the byte-identical original.
             clearKVMatrixRestore()
             disarmKVMatrixSignalHandlers()
-            try? FileManager.default.removeItem(at: backup)
+            do {
+                if try removeKVMatrixBackupIfOriginalIsIntact(
+                    configURL: configURL,
+                    originalData: originalData,
+                    backupURL: backup
+                ) == false {
+                    let recoveryFailure =
+                        "server-runtime.json is not the pre-run original; the current file was preserved and the original bytes remain in \(backup.path)"
+                    if fatal == nil { fatal = recoveryFailure }
+                    fputs("KV matrix retained recovery backup: \(recoveryFailure).\n", stderr)
+                }
+            } catch {
+                let recoveryFailure =
+                    "could not verify cleanup of server-runtime.json (\(error.localizedDescription)); the pre-run backup remains in \(backup.path)"
+                fatal = fatal.map { "\($0); \(recoveryFailure)" } ?? recoveryFailure
+                fputs("KV matrix retained recovery backup: \(recoveryFailure).\n", stderr)
+            }
         }
 
         if let fatal {
@@ -713,6 +732,18 @@ public struct BenchCommand: Command {
         // path already exists; unlike Data's writing options, it supports
         // both guarantees together.
         try FileManager.default.linkItem(at: temporaryURL, to: backupURL)
+    }
+
+    /// Removes the recovery copy only when no write, including a raced or
+    /// partially observed first probe write, changed the original config.
+    static func removeKVMatrixBackupIfOriginalIsIntact(
+        configURL: URL,
+        originalData: Data,
+        backupURL: URL
+    ) throws -> Bool {
+        guard try Data(contentsOf: configURL) == originalData else { return false }
+        try FileManager.default.removeItem(at: backupURL)
+        return true
     }
 
     struct KVMatrixRestoreState {
@@ -1224,8 +1255,9 @@ public struct BenchCommand: Command {
             --kv-matrix measures engine-selected vs TurboQuant live-KV
             per prompt size: uncached/cached TTFT and decode tok/s. It edits
             cache.liveKVCodec in server-runtime.json and restarts the app per
-            codec (the file is only read at launch); the original config is
-            always restored. Measurement only — it changes no defaults.
+            codec (the file is only read at launch). The original is restored
+            on clean completion; concurrent edits are preserved with a pre-run
+            recovery backup. Measurement only — it changes no defaults.
 
             """, stderr)
     }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
@@ -20,6 +20,38 @@ public struct AppControl {
         )
     }
 
+    /// Bundle identifier of the Osaurus menu-bar app that hosts the server.
+    private static let appBundleID = "com.dinoki.osaurus"
+
+    /// Terminates the running app and waits until the process exits so a
+    /// subsequent launch observes settings written by a benchmark run.
+    @MainActor
+    public static func terminateAppAndWait(timeoutSeconds: TimeInterval = 20) async -> Bool {
+        guard requestAppTermination(force: false) else { return true }
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if !isAppRunning() { return true }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        _ = requestAppTermination(force: true)
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        return !isAppRunning()
+    }
+
+    @MainActor
+    private static func requestAppTermination(force: Bool) -> Bool {
+        let apps = NSRunningApplication.runningApplications(withBundleIdentifier: appBundleID)
+        for app in apps {
+            _ = force ? app.forceTerminate() : app.terminate()
+        }
+        return !apps.isEmpty
+    }
+
+    @MainActor
+    private static func isAppRunning() -> Bool {
+        !NSRunningApplication.runningApplications(withBundleIdentifier: appBundleID).isEmpty
+    }
+
     @MainActor
     public static func launchAppIfNeeded() async {
         // Try to detect if server responds; if yes, nothing to do

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
@@ -49,6 +49,115 @@ final class BenchKVMatrixTests: XCTestCase {
         XCTAssertEqual(cache["turboQuantValueBits"] as? Int, 3)
     }
 
+    func testCanonicalProbeAcceptsLoadNormalizationAndReencoding() throws {
+        let preNormalization = Data(
+            """
+            {
+              "cache" : {
+                "liveKVCodec" : "engine_selected"
+              },
+              "contractVersion" : 1,
+              "mtp" : {
+                "acceptedTokensOnlyEnterBaseCache" : true,
+                "draftTokenLimit" : null,
+                "keepDraftCacheSeparate" : true,
+                "mode" : "off"
+              }
+            }
+            """.utf8)
+        var canonical = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: preNormalization) as? [String: Any])
+        var mtp = try XCTUnwrap(canonical["mtp"] as? [String: Any])
+        mtp["mode"] = "auto"
+        canonical["mtp"] = mtp
+
+        let canonicalData = try XCTUnwrap(
+            BenchCommand.runtimeSettingsData(
+                inRuntimeSettingsResponse: ["settings": canonical]))
+        let probe = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant",
+            in: canonicalData)
+        let probeObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: probe) as? [String: Any])
+        let appReencoded = try JSONSerialization.data(
+            withJSONObject: probeObject, options: [.sortedKeys])
+
+        XCTAssertFalse(BenchCommand.configDocumentsMatch(preNormalization, canonicalData))
+        XCTAssertNotEqual(probe, appReencoded)
+        XCTAssertNoThrow(
+            try BenchCommand.verifyKVMatrixReadback(
+                requestedData: probe,
+                runtimeSettingsResponse: ["settings": probeObject],
+                persistedData: appReencoded))
+        XCTAssertFalse(
+            BenchCommand.configDocumentsMatch(
+                Data(#"{"enabled":true}"#.utf8),
+                Data(#"{"enabled":1}"#.utf8)))
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-normalized-restore-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        try appReencoded.write(to: configURL, options: .atomic)
+
+        XCTAssertTrue(
+            try BenchCommand.restoreKVMatrixConfig(
+                at: configURL,
+                expectedData: [probe],
+                originalData: preNormalization))
+        XCTAssertEqual(try Data(contentsOf: configURL), preNormalization)
+    }
+
+    func testSemanticReadbackMismatchDoesNotClaimConcurrentModification() throws {
+        let requested = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant",
+            in: sampleConfig)
+        var changed = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: requested) as? [String: Any])
+        changed["generation"] = ["temperature": 0.75]
+        let changedData = try JSONSerialization.data(withJSONObject: changed)
+
+        XCTAssertThrowsError(
+            try BenchCommand.verifyKVMatrixReadback(
+                requestedData: requested,
+                runtimeSettingsResponse: ["settings": changed],
+                persistedData: changedData)
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("normalized or migrated"))
+            XCTAssertTrue(error.localizedDescription.contains("another settings writer"))
+            XCTAssertFalse(
+                error.localizedDescription.localizedCaseInsensitiveContains(
+                    "concurrent modification"))
+        }
+    }
+
+    func testPersistedReadbackMismatchDoesNotClaimConcurrentModification() throws {
+        let requested = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant",
+            in: sampleConfig)
+        let requestedObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: requested) as? [String: Any])
+        var changedOnDisk = requestedObject
+        changedOnDisk["generation"] = ["temperature": 0.75]
+        let changedData = try JSONSerialization.data(withJSONObject: changedOnDisk)
+
+        XCTAssertThrowsError(
+            try BenchCommand.verifyKVMatrixReadback(
+                requestedData: requested,
+                runtimeSettingsResponse: ["settings": requestedObject],
+                persistedData: changedData)
+        ) { error in
+            XCTAssertTrue(
+                error.localizedDescription.contains(
+                    "differs from /admin/runtime-settings readback"))
+            XCTAssertTrue(error.localizedDescription.contains("unrecognized settings change"))
+            XCTAssertFalse(
+                error.localizedDescription.localizedCaseInsensitiveContains(
+                    "concurrent modification"))
+        }
+    }
+
     func testEffectiveKVModeRequiresMatchingCacheEnabledModel() {
         let response: [String: Any] = [
             "models": [

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
@@ -199,6 +199,36 @@ final class BenchKVMatrixTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: backup), existing)
     }
 
+    func testBackupCleanupRequiresByteIdenticalOriginalConfig() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-backup-cleanup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        let backup = BenchCommand.kvMatrixBackupURL(for: configURL)
+        try sampleConfig.write(to: configURL, options: .atomic)
+        try sampleConfig.write(to: backup, options: .atomic)
+
+        XCTAssertTrue(
+            try BenchCommand.removeKVMatrixBackupIfOriginalIsIntact(
+                configURL: configURL,
+                originalData: sampleConfig,
+                backupURL: backup))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+
+        let concurrent = Data(#"{"cache":{"liveKVCodec":"engine_selected"},"writer":"settings"}"#.utf8)
+        try concurrent.write(to: configURL, options: .atomic)
+        try sampleConfig.write(to: backup, options: .atomic)
+
+        XCTAssertFalse(
+            try BenchCommand.removeKVMatrixBackupIfOriginalIsIntact(
+                configURL: configURL,
+                originalData: sampleConfig,
+                backupURL: backup))
+        XCTAssertEqual(try Data(contentsOf: configURL), concurrent)
+        XCTAssertEqual(try Data(contentsOf: backup), sampleConfig)
+    }
+
     func testAbortRestoreRestoresOriginalBytesAndRemovesBackup() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("kv-matrix-abort-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
@@ -1,0 +1,298 @@
+//
+//  BenchKVMatrixTests.swift
+//  osaurus
+//
+//  `--kv-matrix` mutates the user's `server-runtime.json` and MUST hand it
+//  back byte-identical, so the config read/modify/restore round-trip is the
+//  safety-critical logic here. Table/median math is covered because the JSON
+//  report is consumed as policy evidence — a wrong median or a mislabeled
+//  low-confidence cell corrupts the TurboQuant decision matrix.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class BenchKVMatrixTests: XCTestCase {
+    /// Shaped like a real (abridged) server-runtime.json: nested `cache`
+    /// object plus sibling sections that must survive the codec edit.
+    private let sampleConfig = Data(
+        """
+        {
+          "cache" : {
+            "defaultMaxKVSize" : 65536,
+            "liveKVCodec" : "engine_selected",
+            "storedKVCodec" : "auto",
+            "turboQuantKeyBits" : null
+          },
+          "contractVersion" : 1,
+          "network" : {
+            "host" : "127.0.0.1",
+            "port" : 1337
+          }
+        }
+        """.utf8)
+
+    // MARK: - Config read/modify/restore
+
+    func testSettingCodecRewritesOnlyTheCodecField() throws {
+        let mutated = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant", in: sampleConfig)
+
+        XCTAssertEqual(BenchCommand.liveKVCodec(inConfigData: mutated), "turboquant")
+
+        // Every sibling field survives the round-trip.
+        let root = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: mutated) as? [String: Any])
+        XCTAssertEqual(root["contractVersion"] as? Int, 1)
+        let network = try XCTUnwrap(root["network"] as? [String: Any])
+        XCTAssertEqual(network["port"] as? Int, 1337)
+        let cache = try XCTUnwrap(root["cache"] as? [String: Any])
+        XCTAssertEqual(cache["defaultMaxKVSize"] as? Int, 65536)
+        XCTAssertEqual(cache["storedKVCodec"] as? String, "auto")
+        XCTAssertTrue(cache["turboQuantKeyBits"] is NSNull)
+    }
+
+    func testRoundTripOnTempFileRestoresOriginalBytes() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("server-runtime.json")
+        try sampleConfig.write(to: url, options: .atomic)
+
+        // Mutate on disk the way kvMatrix does…
+        let original = try Data(contentsOf: url)
+        let mutated = try BenchCommand.configData(settingLiveKVCodec: "turboquant", in: original)
+        try mutated.write(to: url, options: .atomic)
+        XCTAssertEqual(
+            BenchCommand.liveKVCodec(inConfigData: try Data(contentsOf: url)), "turboquant")
+
+        // …then restore: the file must be byte-identical to what the user had.
+        try original.write(to: url, options: .atomic)
+        XCTAssertEqual(try Data(contentsOf: url), sampleConfig)
+    }
+
+    func testSettingCodecThrowsOnDocumentWithoutCacheObject() {
+        let noCache = Data(#"{"network":{"port":1337}}"#.utf8)
+        XCTAssertThrowsError(
+            try BenchCommand.configData(settingLiveKVCodec: "turboquant", in: noCache))
+
+        let notAnObject = Data(#"[1,2,3]"#.utf8)
+        XCTAssertThrowsError(
+            try BenchCommand.configData(settingLiveKVCodec: "turboquant", in: notAnObject))
+    }
+
+    func testLiveKVCodecReaderToleratesGarbage() {
+        XCTAssertNil(BenchCommand.liveKVCodec(inConfigData: Data("not json".utf8)))
+        XCTAssertNil(BenchCommand.liveKVCodec(inConfigData: Data("{}".utf8)))
+        XCTAssertEqual(BenchCommand.liveKVCodec(inConfigData: sampleConfig), "engine_selected")
+    }
+
+    // MARK: - codec verification contract
+
+    func testCodecBlockCanOnlyRepresentVerifiedEvidence() {
+        let scenarios: [[String: Any]] = [["target_prompt_tokens": 8192]]
+        let block = BenchCommand.kvMatrixCodecBlock(
+            codec: "engine_selected", scenarios: scenarios)
+        XCTAssertEqual(block["codec"] as? String, "engine_selected")
+        XCTAssertEqual(block["codec_verified"] as? Bool, true)
+        XCTAssertEqual((block["scenarios"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(
+            block["description"] as? String,
+            BenchCommand.kvMatrixCodecDescriptions["engine_selected"])
+    }
+
+    // MARK: - Sidecar backup + abort restore
+
+    func testBackupURLIsSidecarNextToConfig() {
+        let config = URL(fileURLWithPath: "/tmp/config/server-runtime.json")
+        XCTAssertEqual(
+            BenchCommand.kvMatrixBackupURL(for: config).path,
+            "/tmp/config/server-runtime.json.kvmatrix-backup")
+    }
+
+    func testBackupCreationRefusesToOverwriteRecoveryFile() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-backup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let backup = dir.appendingPathComponent("server-runtime.json.kvmatrix-backup")
+        let existing = Data("existing recovery".utf8)
+        try existing.write(to: backup)
+
+        XCTAssertThrowsError(try BenchCommand.createKVMatrixBackup(sampleConfig, at: backup))
+        XCTAssertEqual(try Data(contentsOf: backup), existing)
+    }
+
+    func testAbortRestoreRestoresOriginalBytesAndRemovesBackup() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-abort-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        try sampleConfig.write(to: configURL, options: .atomic)
+
+        // Run mutates the config after writing the sidecar backup…
+        let backup = BenchCommand.kvMatrixBackupURL(for: configURL)
+        try sampleConfig.write(to: backup, options: .atomic)
+        let mutated = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant", in: sampleConfig)
+        try mutated.write(to: configURL, options: .atomic)
+
+        // …then the signal handler's body fires.
+        BenchCommand.armKVMatrixRestore(
+            configURL: configURL,
+            originalData: sampleConfig,
+            ownedData: [sampleConfig, mutated],
+            backup: backup
+        )
+        BenchCommand.kvMatrixAbortRestore()
+
+        XCTAssertEqual(try Data(contentsOf: configURL), sampleConfig)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+        XCTAssertFalse(
+            BenchCommand.hasKVMatrixRestoreState(),
+            "abort restore must disarm itself")
+
+        // A second call must be a harmless no-op.
+        BenchCommand.kvMatrixAbortRestore()
+        XCTAssertEqual(try Data(contentsOf: configURL), sampleConfig)
+    }
+
+    func testAbortRestoreRecognizesPreviousProbeDuringCodecTransition() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-transition-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        let backup = BenchCommand.kvMatrixBackupURL(for: configURL)
+        let previousProbe = try BenchCommand.configData(
+            settingLiveKVCodec: "engine_selected", in: sampleConfig)
+        let nextProbe = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant", in: sampleConfig)
+        try previousProbe.write(to: configURL, options: .atomic)
+        try sampleConfig.write(to: backup, options: .atomic)
+        BenchCommand.armKVMatrixRestore(
+            configURL: configURL,
+            originalData: sampleConfig,
+            ownedData: [sampleConfig, previousProbe, nextProbe],
+            backup: backup)
+
+        XCTAssertTrue(BenchCommand.kvMatrixAbortRestore())
+        XCTAssertEqual(try Data(contentsOf: configURL), sampleConfig)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: backup.path))
+    }
+
+    func testRestoreRefusesToOverwriteConcurrentWriter() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-conflict-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        let expected = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant", in: sampleConfig)
+        let concurrent = Data(#"{"cache":{"liveKVCodec":"engine_selected"},"writer":"settings"}"#.utf8)
+        try concurrent.write(to: configURL, options: .atomic)
+
+        let restored = try BenchCommand.restoreKVMatrixConfig(
+            at: configURL,
+            expectedData: [expected],
+            originalData: sampleConfig)
+
+        XCTAssertFalse(restored)
+        XCTAssertEqual(try Data(contentsOf: configURL), concurrent)
+    }
+
+    func testRestoreVerifiesByteIdenticalOriginal() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-restore-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        let expected = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant", in: sampleConfig)
+        try expected.write(to: configURL, options: .atomic)
+
+        XCTAssertTrue(
+            try BenchCommand.restoreKVMatrixConfig(
+                at: configURL,
+                expectedData: [expected],
+                originalData: sampleConfig))
+        XCTAssertEqual(try Data(contentsOf: configURL), sampleConfig)
+    }
+
+    func testNextCodecWriteRefusesConcurrentChanges() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kv-matrix-write-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let configURL = dir.appendingPathComponent("server-runtime.json")
+        let firstProbe = try BenchCommand.configData(
+            settingLiveKVCodec: "engine_selected", in: sampleConfig)
+        let secondProbe = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant", in: sampleConfig)
+        let concurrent = Data(#"{"cache":{"liveKVCodec":"engine_selected"},"writer":"settings"}"#.utf8)
+        try concurrent.write(to: configURL, options: .atomic)
+
+        XCTAssertFalse(
+            try BenchCommand.writeKVMatrixConfig(
+                at: configURL,
+                expectedData: firstProbe,
+                newData: secondProbe))
+        XCTAssertEqual(try Data(contentsOf: configURL), concurrent)
+    }
+
+    // MARK: - Median / low-confidence math
+
+    func testMedian() {
+        XCTAssertEqual(BenchCommand.median([]), 0)
+        XCTAssertEqual(BenchCommand.median([42]), 42)
+        XCTAssertEqual(BenchCommand.median([3, 1, 2]), 2)
+        XCTAssertEqual(BenchCommand.median([4, 1, 3, 2]), 2.5)
+    }
+
+    func testLowConfidenceFlag() {
+        XCTAssertFalse(BenchCommand.kvMatrixIsLowConfidence(completionTokens: [32, 128]))
+        XCTAssertTrue(BenchCommand.kvMatrixIsLowConfidence(completionTokens: [128, 31]))
+        XCTAssertFalse(BenchCommand.kvMatrixIsLowConfidence(completionTokens: []))
+    }
+
+    // MARK: - Table rendering
+
+    func testTableDeltasAreAgainstEngineSelectedBaselineOfSamePromptSize() {
+        let cells = [
+            BenchCommand.KVMatrixCell(
+                codec: "engine_selected", targetPromptTokens: 8192,
+                medianUncachedTTFTMs: 1000, medianCachedTTFTMs: 50,
+                medianDecodeTps: 40, lowConfidence: false),
+            BenchCommand.KVMatrixCell(
+                codec: "turboquant", targetPromptTokens: 8192,
+                medianUncachedTTFTMs: 1500, medianCachedTTFTMs: 60,
+                medianDecodeTps: 28, lowConfidence: true),
+        ]
+        let lines = BenchCommand.kvMatrixTableLines(cells)
+
+        XCTAssertEqual(lines.count, 3)  // header + one row per cell
+        // Baseline row carries no delta annotations.
+        XCTAssertFalse(lines[1].contains("%"))
+        // Candidate row: +50% uncached TTFT, +20% cached, -30% decode.
+        XCTAssertTrue(lines[2].contains("(+50%)"))
+        XCTAssertTrue(lines[2].contains("(+20%)"))
+        XCTAssertTrue(lines[2].contains("(-30%)"))
+        XCTAssertTrue(lines[2].contains("[low-confidence]"))
+    }
+
+    func testTableRowsWithoutBaselineOmitDeltas() {
+        let cells = [
+            BenchCommand.KVMatrixCell(
+                codec: "turboquant", targetPromptTokens: 32768,
+                medianUncachedTTFTMs: 2000, medianCachedTTFTMs: 80,
+                medianDecodeTps: 25, lowConfidence: false)
+        ]
+        let lines = BenchCommand.kvMatrixTableLines(cells)
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertFalse(lines[1].contains("%"))
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
@@ -15,6 +15,77 @@ import XCTest
 @testable import OsaurusCLICore
 
 final class BenchKVMatrixTests: XCTestCase {
+    func testRuntimeSettingsResponseUsesAdminAPISnakeCaseCodecKey() {
+        let response: [String: Any] = [
+            "status": "ok",
+            "settings": [
+                "cache": ["live_kv_codec": "turboquant"],
+            ],
+        ]
+
+        XCTAssertEqual(
+            BenchCommand.activeLiveKVCodec(inRuntimeSettingsResponse: response),
+            "turboquant"
+        )
+        XCTAssertNil(
+            BenchCommand.activeLiveKVCodec(inRuntimeSettingsResponse: [
+                "settings": ["cache": ["liveKVCodec": "turboquant"]],
+            ])
+        )
+    }
+
+    func testTurboQuantProbeSetsExplicitBitsAndPreservesOtherFields() throws {
+        let mutated = try BenchCommand.configData(
+            settingLiveKVCodec: "turboquant",
+            in: sampleConfig
+        )
+        let root = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: mutated) as? [String: Any]
+        )
+        let cache = try XCTUnwrap(root["cache"] as? [String: Any])
+
+        XCTAssertEqual(cache["liveKVCodec"] as? String, "turboquant")
+        XCTAssertEqual(cache["turboQuantKeyBits"] as? Int, 3)
+        XCTAssertEqual(cache["turboQuantValueBits"] as? Int, 3)
+    }
+
+    func testEffectiveKVModeRequiresMatchingCacheEnabledModel() {
+        let response: [String: Any] = [
+            "models": [
+                [
+                    "name": "mlx/model-a",
+                    "cache_enabled": true,
+                    "effective_kv_mode": "turbo(3,3)",
+                ],
+                [
+                    "name": "mlx/model-b",
+                    "cache_enabled": false,
+                    "effective_kv_mode": "fp16",
+                ],
+            ],
+        ]
+
+        XCTAssertEqual(
+            BenchCommand.effectiveKVMode(
+                inCacheStatsResponse: response,
+                model: "mlx/model-a"
+            ),
+            "turbo(3,3)"
+        )
+        XCTAssertNil(
+            BenchCommand.effectiveKVMode(
+                inCacheStatsResponse: response,
+                model: "mlx/model-b"
+            )
+        )
+        XCTAssertNil(
+            BenchCommand.effectiveKVMode(
+                inCacheStatsResponse: response,
+                model: "mlx/missing"
+            )
+        )
+    }
+
     /// Shaped like a real (abridged) server-runtime.json: nested `cache`
     /// object plus sibling sections that must survive the codec edit.
     private let sampleConfig = Data(
@@ -36,7 +107,7 @@ final class BenchKVMatrixTests: XCTestCase {
 
     // MARK: - Config read/modify/restore
 
-    func testSettingCodecRewritesOnlyTheCodecField() throws {
+    func testSettingTurboQuantPreservesSiblingsAndSetsRequiredBits() throws {
         let mutated = try BenchCommand.configData(
             settingLiveKVCodec: "turboquant", in: sampleConfig)
 
@@ -51,7 +122,8 @@ final class BenchKVMatrixTests: XCTestCase {
         let cache = try XCTUnwrap(root["cache"] as? [String: Any])
         XCTAssertEqual(cache["defaultMaxKVSize"] as? Int, 65536)
         XCTAssertEqual(cache["storedKVCodec"] as? String, "auto")
-        XCTAssertTrue(cache["turboQuantKeyBits"] is NSNull)
+        XCTAssertEqual(cache["turboQuantKeyBits"] as? Int, 3)
+        XCTAssertEqual(cache["turboQuantValueBits"] as? Int, 3)
     }
 
     func testRoundTripOnTempFileRestoresOriginalBytes() throws {
@@ -95,9 +167,10 @@ final class BenchKVMatrixTests: XCTestCase {
     func testCodecBlockCanOnlyRepresentVerifiedEvidence() {
         let scenarios: [[String: Any]] = [["target_prompt_tokens": 8192]]
         let block = BenchCommand.kvMatrixCodecBlock(
-            codec: "engine_selected", scenarios: scenarios)
+            codec: "engine_selected", effectiveKVMode: "fp16", scenarios: scenarios)
         XCTAssertEqual(block["codec"] as? String, "engine_selected")
         XCTAssertEqual(block["codec_verified"] as? Bool, true)
+        XCTAssertEqual(block["effective_kv_mode"] as? String, "fp16")
         XCTAssertEqual((block["scenarios"] as? [[String: Any]])?.count, 1)
         XCTAssertEqual(
             block["description"] as? String,

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchKVMatrixTests.swift
@@ -15,11 +15,11 @@ import XCTest
 @testable import OsaurusCLICore
 
 final class BenchKVMatrixTests: XCTestCase {
-    func testRuntimeSettingsResponseUsesAdminAPISnakeCaseCodecKey() {
+    func testRuntimeSettingsResponseUsesCodableCodecKey() {
         let response: [String: Any] = [
             "status": "ok",
             "settings": [
-                "cache": ["live_kv_codec": "turboquant"],
+                "cache": ["liveKVCodec": "turboquant"],
             ],
         ]
 
@@ -29,7 +29,7 @@ final class BenchKVMatrixTests: XCTestCase {
         )
         XCTAssertNil(
             BenchCommand.activeLiveKVCodec(inRuntimeSettingsResponse: [
-                "settings": ["cache": ["liveKVCodec": "turboquant"]],
+                "settings": ["cache": ["live_kv_codec": "turboquant"]],
             ])
         )
     }

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -243,10 +243,10 @@ final class ServerController: ObservableObject {
         if let saved = ServerConfigurationStore.load() {
             self.configuration = saved
         }
-        // Read-only load. The legacy → vmlx migration (which writes to
-        // `~/.osaurus/config/`) is intentionally deferred to
-        // `bootstrapRuntimeSettings()` so a fresh install stays pristine
-        // until the AppDelegate explicitly runs it during launch.
+        // Load an existing runtime file without creating one from legacy
+        // settings. `load()` may normalize and rewrite an existing file;
+        // first-time legacy → vmlx creation is intentionally deferred to
+        // `bootstrapRuntimeSettings()` until AppDelegate launch.
         if let existing = ServerRuntimeSettingsStore.load() {
             self.runtimeSettings = existing
         }


### PR DESCRIPTION
## Summary

Adds `osaurus bench --kv-matrix` to generate reproducible per-model evidence comparing the engine-selected KV baseline with explicit TurboQuant 3/3 behavior across configured prompt sizes.

The workflow derives each probe from the canonical `/admin/runtime-settings` document, restarts Osaurus, verifies the effective persisted settings and loaded-model KV mode, runs matched uncached and cached samples, and restores the original settings byte for byte.

## Safety and evidence contract

- Changes no runtime defaults.
- Uses exact-byte compare-and-swap before every file mutation.
- Accepts formatting-only runtime rewrites but rejects semantic changes.
- Adopts verified persisted bytes as the next compare-and-swap baseline.
- Restores the original document, reloads and verifies it semantically, then re-pins the exact original bytes.
- Preserves a collision-safe backup for manual recovery after an uncatchable termination or failed restore.
- Requires runtime settings and cache telemetry to prove the requested codec before emitting a result.

## Validation

- 23 focused KV matrix tests passed.
- Full OsaurusCLI suite passed: 153 XCTest tests and 18 Swift Testing tests.
- Release CLI build passed.
- `git diff --check` passed.
- Scoped SwiftLint passed for the benchmark implementation. One unrelated pre-existing violation remains in an untouched section of `ServerController.swift`.

## Draft gate

This PR is intentionally draft. The implementation and safety contract are tested, but promotion still requires live evidence from a real local model matrix:

- real engine and TurboQuant cycles;
- `/admin/cache-stats` evidence;
- token/s and physical-footprint measurements;
- 8K and 32K prompt rows;
- normal, SIGINT, SIGTERM, and concurrent-settings restoration proof.

No performance claim should be inferred until those artifacts are attached.
