### PR TITLE
Add thermal/chassis awareness: ChipProfile v2 + ThermalStateMonitor + first consumer

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -255,6 +255,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // NSWorkspace activation observer.
         FrontmostAppTracker.shared.start()
 
+        // Track thermal pressure so background inference (greeting pre-warm)
+        // sheds itself while the chassis is throttled — sustained-throughput
+        // insurance for fanless laptops where discretionary GPU work extends
+        // the throttle window macOS imposes on the user's real turns.
+        ThermalStateMonitor.shared.start()
+
         // Set up distributed control listeners (local-only management)
         setupControlNotifications()
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9119,6 +9119,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 "status": "healthy",
                 "timestamp": Date().ISO8601Format(),
                 "hardware": ChipProfile.current.healthJSONObject(),
+                // Read fresh from ProcessInfo (thread-safe) rather than the
+                // @MainActor monitor so /health never queues behind the UI.
+                "thermal_state": ThermalStateMonitor.healthLabel(
+                    for: ProcessInfo.processInfo.thermalState
+                ),
                 "loaded": loaded,
                 "current_model": current,
                 "inflight": inflightObj,

--- a/Packages/OsaurusCore/Services/Chat/GenerativeGreetingPool.swift
+++ b/Packages/OsaurusCore/Services/Chat/GenerativeGreetingPool.swift
@@ -117,6 +117,14 @@ public actor GenerativeGreetingPool {
     /// `resume()` from `ChatWindowManager`'s NSWorkspace observers.
     private var paused = false
 
+    /// True while the host reports a serious/critical thermal state.
+    /// Kept separate from `paused` on purpose: sleep/wake and thermal
+    /// pressure are independent signals, and folding them into one flag
+    /// would let a wake-time `resume()` silently clear a still-active
+    /// throttle (or vice versa). Toggled by `ThermalStateMonitor`.
+    private var thermallyThrottled = false
+    private var lastThermalTransitionSequence: UInt64 = 0
+
     /// Public diagnostics snapshot. Returned by `stats()` and emitted
     /// once per ticker pass at `info` so the Console signal exists
     /// without a new in-app surface. Useful for spot-checking that
@@ -129,7 +137,7 @@ public actor GenerativeGreetingPool {
         public var refillsStarted: Int = 0
         public var refillsSucceeded: Int = 0
         public var refillsFailed: Int = 0
-        public var lastFailure: String? = nil
+        public var lastFailure: String?
     }
 
     private var stats = Stats()
@@ -259,7 +267,7 @@ public actor GenerativeGreetingPool {
     /// while paused — the wake handler will warm up the active agent.
     public func warmUp(for agent: Agent, model: String) {
         startTickerIfNeeded()
-        if paused { return }
+        if paused || thermallyThrottled { return }
         if refillTasks[agent.id] != nil { return }
 
         let agentId = agent.id
@@ -296,6 +304,34 @@ public actor GenerativeGreetingPool {
     public func resume() {
         paused = false
         if let agent = activeAgent, let model = activeModel {
+            warmUp(for: agent, model: model)
+        }
+    }
+
+    /// Thermal gate, driven by `ThermalStateMonitor` on serious/critical
+    /// boundary crossings. Entering the throttled state cancels in-flight
+    /// refills — a background greeting mid-generation is exactly the
+    /// discretionary GPU work macOS is asking us to shed, and on a fanless
+    /// chassis letting it finish extends the throttle window for the
+    /// user's actual turns. Leaving it warms the active agent back up
+    /// (`warmUp` still honors the independent sleep `paused` flag).
+    public func setThermallyThrottled(
+        _ throttled: Bool,
+        transitionSequence: UInt64? = nil
+    ) {
+        if let transitionSequence {
+            guard transitionSequence > lastThermalTransitionSequence else { return }
+            lastThermalTransitionSequence = transitionSequence
+        }
+        guard thermallyThrottled != throttled else { return }
+        thermallyThrottled = throttled
+        if throttled {
+            // Drain BEFORE cancelling — same Dictionary-mutation hazard
+            // documented in `pause()`.
+            let tasks = Array(refillTasks.values)
+            refillTasks.removeAll()
+            for task in tasks { task.cancel() }
+        } else if let agent = activeAgent, let model = activeModel {
             warmUp(for: agent, model: model)
         }
     }
@@ -600,7 +636,7 @@ public actor GenerativeGreetingPool {
             if Task.isCancelled { break }
             purgeAllExpired()
             logTickSummary()
-            if paused { continue }
+            if paused || thermallyThrottled { continue }
             guard let agent = activeAgent, let model = activeModel else { continue }
             // Drop the stale active context when the feature was toggled
             // off so the loop goes fully idle next tick instead of
@@ -678,6 +714,19 @@ public actor GenerativeGreetingPool {
         /// In-memory entry count for `agentId`.
         internal func _testingEntryCount(for agentId: UUID) -> Int {
             pools[agentId]?.count ?? 0
+        }
+
+        /// Whether a refill task is currently registered for `agentId`.
+        /// Lets the thermal-gate test assert that `warmUp` was a no-op
+        /// while throttled without racing the refill's own completion.
+        internal func _testingHasRefillTask(for agentId: UUID) -> Bool {
+            refillTasks[agentId] != nil
+        }
+
+        /// Current thermal-gate flag, for asserting `setThermallyThrottled`
+        /// round-trips.
+        internal func _testingIsThermallyThrottled() -> Bool {
+            thermallyThrottled
         }
     }
 #endif

--- a/Packages/OsaurusCore/Services/ChipProfile.swift
+++ b/Packages/OsaurusCore/Services/ChipProfile.swift
@@ -35,6 +35,16 @@ struct ChipProfile: Sendable, Equatable {
         case unknown
     }
 
+    /// Enclosure class. Laptops (especially fanless Airs) throttle under
+    /// sustained GPU load where desktops don't, so thermal-aware policy
+    /// needs to know which one it's on. `unknown` covers VMs and future
+    /// identifiers; policy code must treat it like a laptop (conservative).
+    enum Chassis: String, Sendable {
+        case laptop
+        case desktop
+        case unknown
+    }
+
     /// Marketing name as reported by the kernel, e.g. "Apple M4 Pro".
     let brandString: String
     /// Apple Silicon generation (1 for M1, 5 for M5, …); `nil` when the
@@ -50,6 +60,9 @@ struct ChipProfile: Sendable, Equatable {
     /// answer to "how much GPU-visible memory may I comfortably use" and is
     /// the anchor for any future wired-memory policy.
     let recommendedMaxWorkingSetBytes: UInt64?
+    /// Enclosure class derived from `hw.model` (with an IOKit product-name
+    /// fallback for opaque "Mac14,12"-style identifiers).
+    let chassis: Chassis
     /// The M5 family embeds matrix units ("Neural Accelerators") in each GPU
     /// core, which shifts the prefill/decode balance materially. Derived
     /// from `generation`, not probed — Metal exposes no direct capability
@@ -66,7 +79,7 @@ struct ChipProfile: Sendable, Equatable {
     static let current: ChipProfile = {
         let profile = ChipProfile.detect()
         chipLog.info(
-            "resolved: brand=\(profile.brandString, privacy: .public) generation=\(profile.generation.map(String.init) ?? "unknown", privacy: .public) tier=\(profile.tier.rawValue, privacy: .public) ramBytes=\(profile.physicalMemoryBytes, privacy: .public) gpuCores=\(profile.gpuCoreCount.map(String.init) ?? "unknown", privacy: .public) workingSetBytes=\(profile.recommendedMaxWorkingSetBytes.map(String.init) ?? "unknown", privacy: .public) neuralAccelerators=\(profile.hasGPUNeuralAccelerators, privacy: .public)"
+            "resolved: brand=\(profile.brandString, privacy: .public) generation=\(profile.generation.map(String.init) ?? "unknown", privacy: .public) tier=\(profile.tier.rawValue, privacy: .public) ramBytes=\(profile.physicalMemoryBytes, privacy: .public) gpuCores=\(profile.gpuCoreCount.map(String.init) ?? "unknown", privacy: .public) workingSetBytes=\(profile.recommendedMaxWorkingSetBytes.map(String.init) ?? "unknown", privacy: .public) neuralAccelerators=\(profile.hasGPUNeuralAccelerators, privacy: .public) chassis=\(profile.chassis.rawValue, privacy: .public)"
         )
         return profile
     }()
@@ -81,7 +94,22 @@ struct ChipProfile: Sendable, Equatable {
             physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
             gpuCoreCount: detectGPUCoreCount(),
             recommendedMaxWorkingSetBytes: MTLCreateSystemDefaultDevice()
-                .map { UInt64($0.recommendedMaxWorkingSetSize) }
+                .map { UInt64($0.recommendedMaxWorkingSetSize) },
+            chassis: detectChassis()
+        )
+    }
+
+    /// Two-stage chassis detection: the model identifier alone classifies
+    /// every pre-2022 machine; the IOKit product-name probe only runs for
+    /// the opaque "Mac14,12"-style identifiers, keeping the common path a
+    /// single sysctl.
+    private static func detectChassis() -> Chassis {
+        let model = sysctlString("hw.model") ?? ""
+        let fromModel = parseChassis(modelIdentifier: model)
+        if fromModel != .unknown { return fromModel }
+        return parseChassis(
+            modelIdentifier: model,
+            productName: platformProductName()
         )
     }
 
@@ -112,6 +140,36 @@ struct ChipProfile: Sendable, Equatable {
         return (generation, tier)
     }
 
+    // MARK: - Chassis parsing (pure, unit-tested)
+
+    /// Classifies a `hw.model` identifier (e.g. "MacBookPro18,3") into a
+    /// chassis class, optionally falling back to the IOKit marketing
+    /// product name (e.g. "MacBook Pro") for the opaque "Mac14,12"-style
+    /// identifiers Apple ships since 2022, which encode nothing about the
+    /// enclosure. Anything unclassifiable — VMs, Xserve, future naming —
+    /// yields `.unknown` so policy falls back to the conservative
+    /// (laptop-like) treatment rather than guessing.
+    static func parseChassis(modelIdentifier: String, productName: String? = nil) -> Chassis {
+        if let chassis = classifyChassis(modelIdentifier) { return chassis }
+        if let productName, let chassis = classifyChassis(productName) { return chassis }
+        return .unknown
+    }
+
+    /// Shared matcher for both identifier styles. Lowercased and
+    /// de-spaced so "Mac mini" (product name) and "Macmini9,1" (hw.model)
+    /// hit the same token. Laptop is checked first so "macbookpro" can
+    /// never substring-match the desktop "macpro" token.
+    private static func classifyChassis(_ raw: String) -> Chassis? {
+        let normalized = raw.lowercased().replacingOccurrences(of: " ", with: "")
+        guard !normalized.isEmpty else { return nil }
+        // "book" covers MacBook / MacBookPro / MacBookAir — the only
+        // battery-powered, thermally constrained enclosures Apple ships.
+        if normalized.contains("book") { return .laptop }
+        let desktopTokens = ["macmini", "macstudio", "macpro", "imac"]
+        if desktopTokens.contains(where: { normalized.contains($0) }) { return .desktop }
+        return nil
+    }
+
     // MARK: - /health surface
 
     /// JSON-object form for the `/health` endpoint's `hardware` block.
@@ -127,6 +185,7 @@ struct ChipProfile: Sendable, Equatable {
             "recommended_max_working_set_bytes":
                 recommendedMaxWorkingSetBytes as Any? ?? NSNull(),
             "gpu_neural_accelerators": hasGPUNeuralAccelerators,
+            "chassis": chassis.rawValue,
         ]
     }
 
@@ -138,6 +197,44 @@ struct ChipProfile: Sendable, Equatable {
         var buffer = [CChar](repeating: 0, count: size)
         guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
         return String(cString: buffer)
+    }
+
+    /// Reads the marketing `product-name` ("MacBook Pro (14-inch, M5 Max)",
+    /// "Mac mini", …). Only consulted when `hw.model` is an opaque
+    /// "Mac14,12"-style identifier. On current Apple Silicon the property
+    /// lives on the device tree's `product` node (verified on Mac17,7);
+    /// IOPlatformExpertDevice is probed second for older firmware layouts.
+    /// Missing on Intel and most VMs, in which case chassis stays `.unknown`.
+    private static func platformProductName() -> String? {
+        if let name = productNameProperty(
+            of: IORegistryEntryFromPath(kIOMainPortDefault, "IODeviceTree:/product")
+        ) {
+            return name
+        }
+        return productNameProperty(
+            of: IOServiceGetMatchingService(
+                kIOMainPortDefault,
+                IOServiceMatching("IOPlatformExpertDevice")
+            )
+        )
+    }
+
+    /// Extracts the `product-name` string from `entry`, releasing the entry
+    /// (callers hand over ownership; MACH_PORT_NULL is tolerated so lookup
+    /// failures need no separate guard).
+    private static func productNameProperty(of entry: io_registry_entry_t) -> String? {
+        guard entry != 0 else { return nil }
+        defer { IOObjectRelease(entry) }
+        guard let value = IORegistryEntryCreateCFProperty(
+            entry,
+            "product-name" as CFString,
+            kCFAllocatorDefault,
+            0
+        )?.takeRetainedValue() else { return nil }
+        if let name = value as? String { return name }
+        guard let data = value as? Data else { return nil }
+        // The registry value is commonly a NUL-terminated C string in CFData.
+        return String(bytes: data.prefix { $0 != 0 }, encoding: .utf8)
     }
 
     /// Reads `gpu-core-count` from the AGXAccelerator IORegistry node. There
@@ -154,7 +251,7 @@ struct ChipProfile: Sendable, Equatable {
         else { return nil }
         defer { IOObjectRelease(iterator) }
 
-        var coreCount: Int? = nil
+        var coreCount: Int?
         var entry = IOIteratorNext(iterator)
         while entry != 0 {
             if coreCount == nil,
@@ -163,8 +260,7 @@ struct ChipProfile: Sendable, Equatable {
                     "gpu-core-count" as CFString,
                     kCFAllocatorDefault,
                     0
-                )?.takeRetainedValue() as? Int
-            {
+                )?.takeRetainedValue() as? Int {
                 coreCount = value
             }
             IOObjectRelease(entry)

--- a/Packages/OsaurusCore/Services/ModelRuntime/ThermalStateMonitor.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ThermalStateMonitor.swift
@@ -1,0 +1,127 @@
+//
+//  ThermalStateMonitor.swift
+//  osaurus
+//
+//  Tracks `ProcessInfo.thermalState` so background inference work can shed
+//  itself while the chassis is throttled. This matters most on fanless
+//  laptops (MacBook Air): once macOS reaches `.serious` it is already
+//  down-clocking the GPU, and every discretionary inference we run both
+//  slows the user's foreground turn and keeps the enclosure hot longer.
+//
+//  Scope: this PR wires exactly one consumer (`GenerativeGreetingPool`).
+//  Batch sizing and generation policy stay untouched until there is
+//  measured evidence they should react to thermals.
+//
+
+import Foundation
+
+@MainActor
+public final class ThermalStateMonitor: ObservableObject {
+    public static let shared = ThermalStateMonitor()
+
+    /// Last observed thermal state. `@Published` so future UI or policy
+    /// surfaces can observe transitions the same way they observe
+    /// `SystemMonitorService`.
+    @Published public private(set) var thermalState: ProcessInfo.ThermalState
+
+    /// True while macOS reports `.serious` or `.critical`.
+    public var isThrottled: Bool { Self.isThrottled(thermalState) }
+
+    private var observer: NSObjectProtocol?
+    private var transitionSequence: UInt64 = 0
+
+    private init() {
+        thermalState = ProcessInfo.processInfo.thermalState
+    }
+
+    /// Begin observing thermal-state changes. Idempotent. Called once at
+    /// launch (AppDelegate) so throttle transitions are caught even before
+    /// any chat window exists.
+    public func start() {
+        guard observer == nil else { return }
+        // A process launched while the machine is already hot never sees a
+        // transition, so sync the initial state (and gate the pool) here
+        // instead of waiting for the first notification.
+        let initial = ProcessInfo.processInfo.thermalState
+        if thermalState != initial { thermalState = initial }
+        if Self.isThrottled(initial) {
+            announceAndPush(throttled: true, state: initial)
+        }
+        observer = NotificationCenter.default.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            // System notifications can arrive outside a Swift task context;
+            // use a real actor hop instead of assumeIsolated.
+            Task { @MainActor in
+                ThermalStateMonitor.shared.apply(ProcessInfo.processInfo.thermalState)
+            }
+        }
+    }
+
+    /// Records the new state and, on a throttle-boundary crossing, logs
+    /// once and pushes the flag into the greeting pool. Intermediate
+    /// nominal↔fair changes are state-only: they carry no policy meaning
+    /// yet and logging them would just be noise.
+    private func apply(_ newState: ProcessInfo.ThermalState) {
+        let wasThrottled = Self.isThrottled(thermalState)
+        if thermalState != newState { thermalState = newState }
+        let nowThrottled = Self.isThrottled(newState)
+        guard nowThrottled != wasThrottled else { return }
+        announceAndPush(throttled: nowThrottled, state: newState)
+    }
+
+    /// One log line per boundary crossing + the actual consumer fan-out.
+    /// Today the only consumer is the greeting pool; when a second one
+    /// arrives this becomes the subscription seam.
+    private func announceAndPush(throttled: Bool, state: ProcessInfo.ThermalState) {
+        if throttled {
+            NSLog(
+                "[Osaurus] thermal: %@ — shedding background inference work",
+                Self.healthLabel(for: state)
+            )
+        } else {
+            NSLog(
+                "[Osaurus] thermal: recovered to %@ — resuming background inference work",
+                Self.healthLabel(for: state)
+            )
+        }
+        transitionSequence &+= 1
+        let sequence = transitionSequence
+        Task {
+            await GenerativeGreetingPool.shared.setThermallyThrottled(
+                throttled, transitionSequence: sequence)
+        }
+    }
+
+    // MARK: - Pure mappings (unit-tested)
+
+    /// Throttle threshold is `.serious`: that is the level at which macOS
+    /// documents that it is reducing performance and asks apps to cut
+    /// resource usage. `.fair` only signals elevated temperature — shedding
+    /// pre-warm work there would cost cache hits for no measured benefit.
+    nonisolated static func isThrottled(_ state: ProcessInfo.ThermalState) -> Bool {
+        switch state {
+        case .serious, .critical: return true
+        case .nominal, .fair: return false
+        @unknown default:
+            // A future hotter-than-critical level should shed work, not
+            // silently run at full tilt.
+            return true
+        }
+    }
+
+    /// Stable string form for the `/health` endpoint. Kept as an explicit
+    /// mapping (not `String(describing:)`) so the wire contract can't drift
+    /// with an SDK rename.
+    nonisolated static func healthLabel(for state: ProcessInfo.ThermalState) -> String {
+        switch state {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "critical"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ChipProfileTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ChipProfileTests.swift
@@ -50,6 +50,57 @@ struct ChipProfileTests {
         #expect(ChipProfile.parse(brandString: "").tier == .unknown)
     }
 
+    // MARK: - Chassis parsing
+
+    @Test func classifiesLaptopIdentifiers() {
+        #expect(ChipProfile.parseChassis(modelIdentifier: "MacBookPro18,3") == .laptop)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "MacBookAir10,1") == .laptop)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "MacBook10,1") == .laptop)
+    }
+
+    @Test func classifiesDesktopIdentifiers() {
+        #expect(ChipProfile.parseChassis(modelIdentifier: "Macmini9,1") == .desktop)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "Mac13,2") == .unknown)  // pre-fallback Studio
+        #expect(ChipProfile.parseChassis(modelIdentifier: "MacPro7,1") == .desktop)
+        // Intel-era identifiers still classify without the IOKit fallback.
+        #expect(ChipProfile.parseChassis(modelIdentifier: "iMac19,1") == .desktop)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "iMacPro1,1") == .desktop)
+    }
+
+    @Test func opaqueIdentifiersResolveViaProductNameFallback() {
+        // 2022+ identifiers encode nothing about the enclosure; only the
+        // IOKit marketing name can disambiguate. Note the marketing form
+        // has spaces ("Mac mini") that the hw.model form lacks.
+        #expect(
+            ChipProfile.parseChassis(modelIdentifier: "Mac14,12", productName: "Mac mini")
+                == .desktop)
+        #expect(
+            ChipProfile.parseChassis(modelIdentifier: "Mac14,12", productName: "MacBook Pro")
+                == .laptop)
+        #expect(
+            ChipProfile.parseChassis(modelIdentifier: "Mac13,2", productName: "Mac Studio")
+                == .desktop)
+        #expect(
+            ChipProfile.parseChassis(
+                modelIdentifier: "Mac16,6", productName: "MacBook Pro (14-inch, Nov 2024)")
+                == .laptop)
+    }
+
+    @Test func unresolvableIdentifiersStayUnknown() {
+        // No product name available (Intel VMs, stripped registry).
+        #expect(ChipProfile.parseChassis(modelIdentifier: "Mac14,12") == .unknown)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "Mac14,12", productName: nil) == .unknown)
+        // Product name present but equally opaque.
+        #expect(
+            ChipProfile.parseChassis(
+                modelIdentifier: "VirtualMac2,1",
+                productName: "Apple Virtualization Generic Platform"
+            ) == .unknown)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "Xserve3,1") == .unknown)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "") == .unknown)
+        #expect(ChipProfile.parseChassis(modelIdentifier: "", productName: "") == .unknown)
+    }
+
     // MARK: - Policy invariants
 
     @Test func policyTierNeverExposesUnknown() {
@@ -59,7 +110,8 @@ struct ChipProfileTests {
             tier: .unknown,
             physicalMemoryBytes: 8 << 30,
             gpuCoreCount: nil,
-            recommendedMaxWorkingSetBytes: nil
+            recommendedMaxWorkingSetBytes: nil,
+            chassis: .unknown
         )
         #expect(unknown.policyTier == .base)
 
@@ -69,7 +121,8 @@ struct ChipProfileTests {
             tier: .max,
             physicalMemoryBytes: 128 << 30,
             gpuCoreCount: 40,
-            recommendedMaxWorkingSetBytes: 100 << 30
+            recommendedMaxWorkingSetBytes: 100 << 30,
+            chassis: .desktop
         )
         #expect(known.policyTier == .max)
     }
@@ -82,7 +135,8 @@ struct ChipProfileTests {
                 tier: .base,
                 physicalMemoryBytes: 16 << 30,
                 gpuCoreCount: nil,
-                recommendedMaxWorkingSetBytes: nil
+                recommendedMaxWorkingSetBytes: nil,
+                chassis: .unknown
             )
         }
         #expect(!profile(generation: 4).hasGPUNeuralAccelerators)
@@ -102,6 +156,8 @@ struct ChipProfileTests {
         }
         // JSON surface must serialize (guards against a non-plist value
         // sneaking into the /health object).
-        #expect(JSONSerialization.isValidJSONObject(profile.healthJSONObject()))
+        let json = profile.healthJSONObject()
+        #expect(JSONSerialization.isValidJSONObject(json))
+        #expect(json["chassis"] as? String == profile.chassis.rawValue)
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/ThermalStateMonitorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ThermalStateMonitorTests.swift
@@ -1,0 +1,98 @@
+//
+//  ThermalStateMonitorTests.swift
+//  osaurusTests
+//
+//  Covers the pure thermal mappings (throttle threshold at `.serious`,
+//  /health label contract) plus a live smoke test that the monitor's
+//  initial state is readable, and the greeting pool's thermal gate
+//  (throttled → `warmUp` is a no-op; recovery clears the flag).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ThermalStateMonitorTests {
+
+    // MARK: - Throttle threshold
+
+    @Test func throttleFlipsExactlyAtSerious() {
+        // `.serious` is where macOS starts cutting performance and asks
+        // apps to shed work; `.fair` must NOT shed or we'd lose greeting
+        // cache hits on every warm afternoon.
+        #expect(!ThermalStateMonitor.isThrottled(.nominal))
+        #expect(!ThermalStateMonitor.isThrottled(.fair))
+        #expect(ThermalStateMonitor.isThrottled(.serious))
+        #expect(ThermalStateMonitor.isThrottled(.critical))
+    }
+
+    // MARK: - /health label contract
+
+    @Test func healthLabelsMatchWireContract() {
+        #expect(ThermalStateMonitor.healthLabel(for: .nominal) == "nominal")
+        #expect(ThermalStateMonitor.healthLabel(for: .fair) == "fair")
+        #expect(ThermalStateMonitor.healthLabel(for: .serious) == "serious")
+        #expect(ThermalStateMonitor.healthLabel(for: .critical) == "critical")
+    }
+
+    @Test func everyLabelIsThrottleConsistent() {
+        // The /health string and the shedding decision must never disagree
+        // about the same state.
+        let states: [ProcessInfo.ThermalState] = [.nominal, .fair, .serious, .critical]
+        for state in states {
+            let throttledLabel = ["serious", "critical"]
+                .contains(ThermalStateMonitor.healthLabel(for: state))
+            #expect(ThermalStateMonitor.isThrottled(state) == throttledLabel)
+        }
+    }
+
+    // MARK: - Live smoke test (notification plumbing)
+
+    @Test @MainActor func initialStateIsReadableAndConsistent() {
+        let monitor = ThermalStateMonitor.shared
+        monitor.start()
+        // Whatever hardware runs this, the published state must be one of
+        // the four documented levels and agree with `isThrottled`.
+        let states: [ProcessInfo.ThermalState] = [.nominal, .fair, .serious, .critical]
+        #expect(states.contains(monitor.thermalState))
+        #expect(monitor.isThrottled == ThermalStateMonitor.isThrottled(monitor.thermalState))
+    }
+
+    // MARK: - Greeting pool gate
+
+    @Test func throttledPoolIgnoresWarmUpAndRecovers() async {
+        let pool = GenerativeGreetingPool.shared
+        // Synthetic agent: the gate rejects before any lookup, so only the
+        // id matters (same rationale as the pool persistence tests).
+        let agent = Agent(
+            id: UUID(),
+            name: "Thermal Probe",
+            description: "Synthetic agent for thermal-gate tests.",
+            systemPrompt: "Test prompt.",
+            isBuiltIn: false
+        )
+
+        await pool.setThermallyThrottled(true)
+        #expect(await pool._testingIsThermallyThrottled())
+
+        // Gated before any refill task is registered, so this is
+        // deterministic — no race against a refill completing.
+        await pool.warmUp(for: agent, model: "test-model")
+        #expect(await !pool._testingHasRefillTask(for: agent.id))
+
+        // Always clear the shared singleton's flag so other suites see
+        // the default state.
+        await pool.setThermallyThrottled(false)
+        #expect(await !pool._testingIsThermallyThrottled())
+    }
+
+    @Test func staleThermalTransitionsCannotOverwriteNewerState() async {
+        let pool = GenerativeGreetingPool.shared
+        await pool.setThermallyThrottled(true, transitionSequence: 10_002)
+        await pool.setThermallyThrottled(false, transitionSequence: 10_001)
+        #expect(await pool._testingIsThermallyThrottled())
+        await pool.setThermallyThrottled(false, transitionSequence: 10_003)
+        #expect(await !pool._testingIsThermallyThrottled())
+    }
+}


### PR DESCRIPTION
## What

Adds thermal and chassis awareness with one conservative runtime consumer:

- Extends `ChipProfile` with `laptop`, `desktop`, and `unknown` chassis classification, including modern opaque Mac identifiers and IORegistry product names represented as either strings or data.
- Adds `ThermalStateMonitor` for nominal, fair, serious, and critical states.
- Pauses and cancels discretionary greeting pre-generation at serious or critical thermal pressure, independently from sleep/wake pause state.
- Exposes `thermal_state` and `chassis` through `/health`.
- Uses sequenced cross-actor updates so rapid thermal transitions cannot leave stale throttle state applied.

Batch sizing, foreground generation, prompts, sampling, and model policy are unchanged.

## Validation

- Thermal monitor tests: 6 passed, including stale-transition rejection
- Chip profile tests: 11 passed
- Earlier focused thermal run: 5 passed
- Scoped SwiftLint completed; only existing full-file warnings were reported
- `git diff --check`: passed
- Independent concurrency/runtime reviews: no blocking findings after replacing unsafe actor assumptions and adding transition ordering

## Risk and rollback

The policy only removes discretionary background work under documented OS thermal pressure. Unknown chassis values remain conservative telemetry and do not alter generation behavior. Reverting the single feature commit removes the policy.