### PR TITLE
Add `osaurus bench --gauntlet`: measured model-capability probes writing the ledger

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
@@ -130,6 +130,10 @@ struct OsaurusCLI {
               osaurus bench [--model <id>] [--prompt-tokens 1024,8192] [--runs 3] [--json <path>]
                                       Benchmark TTFT / prefill / decode against the
                                       running server; emits JSON tagged with hardware info
+              osaurus bench --gauntlet [--model <id>] [--json <path>]
+                                      Run the onboarding verification suite (measured
+                                      probes against the running server) and record
+                                      per-model results in the capability ledger
               osaurus ui              Show the Osaurus menu popover in the menu bar
               osaurus tools list      List installed tools
               osaurus tools install <plugin_id|url-or-path>

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -41,6 +41,7 @@ public struct BenchCommand: Command {
         var port: Int
         var tunePrefill: Bool = false
         var tuneCandidates: [Int] = BenchCommand.defaultTuneCandidates
+        var gauntlet: Bool = false
     }
 
     public static func execute(args: [String]) async {
@@ -67,6 +68,11 @@ public struct BenchCommand: Command {
         if options.tunePrefill {
             await tunePrefill(options: options, model: model, base: base, health: health)
             // tunePrefill exits the process itself.
+        }
+
+        if options.gauntlet {
+            await runGauntlet(options: options, model: model, base: base, health: health)
+            // runGauntlet exits the process itself.
         }
 
         fputs("Benchmarking \(model) (\(options.runs) runs × prompt sizes \(options.promptTokens))…\n", stderr)
@@ -486,7 +492,7 @@ public struct BenchCommand: Command {
         Double(to.uptimeNanoseconds - from.uptimeNanoseconds) / 1_000_000
     }
 
-    private static func fetchJSON(_ url: URL) async -> [String: Any]? {
+    static func fetchJSON(_ url: URL) async -> [String: Any]? {
         var request = URLRequest(url: url)
         request.timeoutInterval = 2
         guard let (data, response) = try? await URLSession.shared.data(for: request),
@@ -536,6 +542,8 @@ public struct BenchCommand: Command {
                 options.port = n
             case "--tune-prefill":
                 options.tunePrefill = true
+            case "--gauntlet":
+                options.gauntlet = true
             case "--candidates":
                 guard let v = value() else { return nil }
                 let parsed = v.split(separator: ",").compactMap { Int($0) }.filter { $0 > 0 }
@@ -547,6 +555,10 @@ public struct BenchCommand: Command {
             }
             index += 1
         }
+        if options.tunePrefill && options.gauntlet {
+            fputs("--tune-prefill and --gauntlet are mutually exclusive.\n", stderr)
+            return nil
+        }
         return options
     }
 
@@ -557,6 +569,7 @@ public struct BenchCommand: Command {
                                  [--max-tokens 128] [--runs 3] [--json <path>] [--port N]
                    osaurus bench --tune-prefill [--model <id>] [--candidates 512,1024,2048,4096]
                                  [--prompt-tokens 8192] [--runs 3]
+                   osaurus bench --gauntlet [--model <id>] [--json <path>] [--port N]
 
             Requires a running server (`osaurus serve`). Reports uncached/cached
             TTFT, prefill tok/s, and decode tok/s per prompt size as JSON.
@@ -564,6 +577,14 @@ public struct BenchCommand: Command {
             --tune-prefill measures the model's TTFT at each candidate prefill
             step size and persists the per-model winner (the optimum is
             model-architecture-dependent); the server applies it immediately.
+
+            --gauntlet runs the onboarding verification suite (load,
+            template-leak, tool-call, stop-sequence, degeneration-canary,
+            mtp-equivalence, perf snapshot) and merge-writes the per-model
+            verdicts and evidence into the capability ledger
+            (~/.osaurus/config/model-ledger.json). V1 records candidate
+            evidence without changing productionServing. Exits non-zero
+            unless every critical probe passes.
 
             """, stderr)
     }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/BenchGauntlet.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/BenchGauntlet.swift
@@ -1,0 +1,643 @@
+//
+//  BenchGauntlet.swift
+//  osaurus
+//
+//  `osaurus bench --gauntlet` — onboarding verification suite. Where plain
+//  `bench` answers "how fast", the gauntlet answers "is this model fit to
+//  serve": it runs measured probes against the live server (load,
+//  template-token leakage, tool calling, stop sequences, long-generation
+//  degeneration, native-MTP output equivalence, and a perf snapshot) and
+//  merge-writes one record per model into the capability ledger
+//  (~/.osaurus/config/model-ledger.json) that `ModelCapabilityLedger` in
+//  OsaurusCore consults. Like the prefill-tuning writer, the CLI mirrors the
+//  ledger's JSON contract instead of linking OsaurusCore.
+//
+//  Verdict policy (v1): probes and evidence are recorded, but the CLI does
+//  not mutate `productionServing`. A promotion must eventually be bound to a
+//  weights digest that the runtime can verify; otherwise a re-quant under the
+//  same name could inherit stale evidence. Existing safety verdicts and
+//  unknown ledger fields are preserved by a field-level merge.
+//
+
+import CryptoKit
+import Foundation
+
+extension BenchCommand {
+
+    // MARK: - Probe outcome
+
+    struct ProbeOutcome {
+        let verdict: String  // "pass" | "fail" | "untested" (ModelCapabilityLedger.Verdict raw values)
+        let evidence: String
+
+        static func pass(_ evidence: String) -> ProbeOutcome {
+            ProbeOutcome(verdict: "pass", evidence: evidence)
+        }
+        static func fail(_ evidence: String) -> ProbeOutcome {
+            ProbeOutcome(verdict: "fail", evidence: evidence)
+        }
+        static func untested(_ evidence: String) -> ProbeOutcome {
+            ProbeOutcome(verdict: "untested", evidence: evidence)
+        }
+    }
+
+    /// Probes whose collective pass makes the report a production-serving
+    /// candidate. V1 records evidence but does not mutate the runtime ledger
+    /// verdict. tool-call and mtp-equivalence are deliberately excluded:
+    /// text-only models legitimately reject tools, and non-MTP bundles are
+    /// legitimately untestable for equivalence.
+    static let gauntletCriticalProbes = [
+        "load", "template-leak", "stop-sequence", "degeneration-canary",
+    ]
+
+    // MARK: - Suite runner
+
+    static func runGauntlet(
+        options: Options, model: String, base: URL, health: [String: Any]
+    ) async -> Never {
+        fputs("Gauntlet: verifying \(model) against \(base.absoluteString)…\n", stderr)
+
+        var probes: [String: String] = [:]
+        var evidence: [String: String] = [:]
+        func record(_ index: Int, _ name: String, _ outcome: ProbeOutcome) {
+            probes[name] = outcome.verdict
+            evidence[name] = outcome.evidence
+            fputs("  [\(index)/7] \(name): \(outcome.verdict) — \(outcome.evidence)\n", stderr)
+        }
+
+        record(1, "load", await probeLoad(base: base, model: model))
+        record(2, "template-leak", await probeTemplateLeak(base: base, model: model))
+        record(3, "tool-call", await probeToolCall(base: base, model: model))
+        record(4, "stop-sequence", await probeStopSequence(base: base, model: model))
+        record(5, "degeneration-canary", await probeDegenerationCanary(base: base, model: model))
+        // After probe 1 the model is resident, so /health now reflects its
+        // actual draft strategy — the equivalence probe re-reads it.
+        record(6, "mtp-equivalence", await probeMTPEquivalence(base: base, model: model))
+
+        // Perf snapshot carries no verdict: numbers are evidence for humans
+        // and future calibrated gates, not a pass/fail policy in v1.
+        let perf = await perfSnapshotEvidence(base: base, model: model, options: options)
+        evidence["perf"] = perf
+        fputs("  [7/7] perf: \(perf)\n", stderr)
+
+        let allCriticalPass = gauntletCriticalProbes.allSatisfy { probes[$0] == "pass" }
+        let ledgerRecord = GauntletLedgerRecord(
+            productionServing: nil,
+            source: "gauntlet",
+            chip: (health["hardware"] as? [String: Any])?["chip"] as? String,
+            measuredAt: ISO8601DateFormatter().string(from: Date()),
+            probes: probes,
+            evidence: evidence
+        )
+        let ledgerURL = ledgerFileURL()
+        let ledgerKey = ledgerNormalize(model)
+        do {
+            try writeLedgerRecord(at: ledgerURL, modelKey: ledgerKey, record: ledgerRecord)
+        } catch {
+            fputs("Failed to write \(ledgerURL.path): \(error.localizedDescription)\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+        if allCriticalPass {
+            fputs(
+                "All critical probes passed — recorded candidate evidence for \(ledgerKey) in \(ledgerURL.path). Production promotion remains unchanged until the evidence can be bound to a weights digest.\n",
+                stderr)
+        } else {
+            let notPassing = gauntletCriticalProbes
+                .filter { probes[$0] != "pass" }
+                .map { "\($0)=\(probes[$0] ?? "missing")" }
+                .joined(separator: ", ")
+            fputs(
+                "Critical probe(s) not passing (\(notPassing)) — recorded probe results for \(ledgerKey) in \(ledgerURL.path) without a productionServing verdict (v1 never auto-writes fail).\n",
+                stderr)
+        }
+
+        let report: [String: Any] = [
+            "schema": "osaurus-gauntlet/1",
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "model": model,
+            "hardware": (health["hardware"] as? [String: Any]) ?? NSNull(),
+            "probes": probes,
+            "evidence": evidence,
+            "production_serving_candidate": allCriticalPass ? "pass" : NSNull(),
+            "production_serving_recorded": NSNull(),
+            "ledger_path": ledgerURL.path,
+        ]
+        let data: Data
+        do {
+            data = try JSONSerialization.data(
+                withJSONObject: report, options: [.prettyPrinted, .sortedKeys])
+        } catch {
+            fputs("Failed to encode report: \(error.localizedDescription)\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+        if let path = options.jsonPath {
+            let url = URL(fileURLWithPath: path)
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            do {
+                try data.write(to: url)
+                fputs("Wrote \(path)\n", stderr)
+            } catch {
+                fputs("Failed to write \(path): \(error.localizedDescription)\n", stderr)
+                exit(EXIT_FAILURE)
+            }
+        } else {
+            print(String(bytes: data, encoding: .utf8) ?? "{}")
+        }
+        exit(allCriticalPass ? EXIT_SUCCESS : EXIT_FAILURE)
+    }
+
+    // MARK: - Probe 1: load
+
+    static func probeLoad(base: URL, model: String) async -> ProbeOutcome {
+        do {
+            let chat = try await gauntletChat(
+                base: base, model: model,
+                prompt: "Reply with the single word: ready.",
+                maxTokens: 32)
+            guard !(chat.content + chat.reasoning).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .fail("model returned an empty transcript for a trivial request")
+            }
+            return .pass("model returned a non-empty streamed response")
+        } catch {
+            return .fail("model did not answer a trivial request: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Probe 2: template-leak
+
+    /// Special tokens that must never surface in user-visible channels: chat
+    /// template markers (`<|im_start|>`/`<|im_end|>`, `〈|EOS|〉`), thinking
+    /// tags the server should have routed to `reasoning_content`, tool-call
+    /// markers (`<tool_call>`, the `]~!b[`/`[e~[` JANG framing), and the
+    /// U+FFFE in-band sentinel the SSE writer must always peel off.
+    static let templateLeakTokens: [String] = [
+        "<|im_start|>", "<|im_end|>", "〈|EOS|〉", "<think>", "</think>",
+        "<tool_call>", "]~!b[", "[e~[", "<start_of_turn>", "<end_of_turn>",
+        "<|eot_id|>", "<|start_header_id|>", "<|end_header_id|>", "<|end|>",
+        "<|endoftext|>", "\u{FFFE}",
+    ]
+
+    static let gauntletMinLeakTranscriptChars = 1
+
+    static func templateLeakVerdict(content: String, reasoning: String) -> ProbeOutcome {
+        let transcript = reasoning + content
+        guard transcript.count >= gauntletMinLeakTranscriptChars else {
+            return .untested("empty transcript cannot prove template-token isolation")
+        }
+        for (channel, text) in [("content", content), ("reasoning", reasoning)] {
+            if let leaked = templateLeakTokens.first(where: { text.contains($0) }) {
+                return .fail(
+                    "special token \(printableLeakToken(leaked)) leaked into streamed \(channel)")
+            }
+        }
+        return .pass("non-empty transcript contains no known special-token markers")
+    }
+
+    static func probeTemplateLeak(base: URL, model: String) async -> ProbeOutcome {
+        let prompts = [
+            "Say hello in one short sentence.",
+            "What is 2 + 2? Reply with just the number.",
+            "Name the capital of France in one word.",
+        ]
+        for prompt in prompts {
+            let chat: GauntletChat
+            do {
+                chat = try await gauntletChat(
+                    base: base, model: model, prompt: prompt, maxTokens: 200)
+            } catch {
+                // A chat that fails outright proves nothing about leakage.
+                return .untested("chat failed before leak scan: \(error.localizedDescription)")
+            }
+            let verdict = templateLeakVerdict(content: chat.content, reasoning: chat.reasoning)
+            if verdict.verdict != "pass" {
+                return verdict
+            }
+        }
+        return .pass(
+            "no special-token leakage across \(prompts.count) greedy chats (\(templateLeakTokens.count) markers scanned)")
+    }
+
+    private static func printableLeakToken(_ token: String) -> String {
+        token == "\u{FFFE}" ? "U+FFFE sentinel" : "\"\(token)\""
+    }
+
+    // MARK: - Probe 3: tool-call
+
+    static func probeToolCall(base: URL, model: String) async -> ProbeOutcome {
+        let tool: [String: Any] = [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "description": "Get the current weather for a location.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "location": [
+                            "type": "string",
+                            "description": "City name, e.g. Paris",
+                        ]
+                    ],
+                    "required": ["location"],
+                ],
+            ],
+        ]
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [["role": "user", "content": "What is the weather in Paris right now?"]],
+            "temperature": 0,
+            "max_tokens": 512,
+            "stream": false,
+            "tools": [tool],
+            "tool_choice": ["type": "function", "function": ["name": "get_weather"]],
+        ]
+        var request = URLRequest(url: base.appendingPathComponent("v1/chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 600
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            guard status == 200 else {
+                let message = serverErrorMessage(obj) ?? "HTTP \(status)"
+                if status == 400 {
+                    // Runtime policy (e.g. "tool calling as unsupported")
+                    // rejects the request before the model runs, so it says
+                    // nothing about the model's actual tool behavior.
+                    return .untested("server rejected tools for this model: \(message)")
+                }
+                return .fail("tools request failed: HTTP \(status): \(message)")
+            }
+            let choice = (obj?["choices"] as? [[String: Any]])?.first
+            guard
+                let message = choice?["message"] as? [String: Any],
+                let toolCalls = message["tool_calls"] as? [[String: Any]],
+                let function = toolCalls.first?["function"] as? [String: Any],
+                let name = function["name"] as? String,
+                let arguments = function["arguments"] as? String
+            else {
+                let finish = choice?["finish_reason"] as? String ?? "?"
+                return .fail("no tool_calls entry in response (finish_reason=\(finish))")
+            }
+            guard name == "get_weather" else {
+                return .fail("tool_calls returned unexpected function \(name)")
+            }
+            guard
+                let decoded = try? JSONSerialization.jsonObject(with: Data(arguments.utf8))
+                    as? [String: Any],
+                let location = decoded["location"] as? String,
+                !location.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                return .fail(
+                    "tool_calls arguments do not contain a non-empty string location: \(String(arguments.prefix(120)))")
+            }
+            return .pass(
+                "forced tool call returned \(name)(\(String(arguments.prefix(120)))) with parseable JSON arguments")
+        } catch {
+            return .fail("tools request failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Probe 4: stop-sequence
+
+    static func probeStopSequence(base: URL, model: String) async -> ProbeOutcome {
+        do {
+            let prompt = "Output exactly ALPHA<<GAUNTLET_STOP>>OMEGA with no other text."
+            let control = try await gauntletChat(
+                base: base, model: model, prompt: prompt, maxTokens: 64)
+            guard control.content.contains("ALPHA<<GAUNTLET_STOP>>OMEGA") else {
+                return .untested("control run did not emit the requested stop boundary")
+            }
+            let chat = try await gauntletChat(
+                base: base, model: model,
+                prompt: prompt, maxTokens: 64, stop: ["<<GAUNTLET_STOP>>"])
+            return stopSequenceVerdict(content: chat.content, finishReason: chat.finishReason)
+        } catch {
+            return .fail("stop-sequence request failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Pure verdict for the stopped half of the probe. The caller first proves
+    /// the model can emit `ALPHA<<GAUNTLET_STOP>>OMEGA` without a stop. A pass
+    /// then requires exact pre-boundary text, no marker/OMEGA leakage, and a
+    /// stop finish reason. Other model output is `untested`, not false proof.
+    static func stopSequenceVerdict(content: String, finishReason: String?) -> ProbeOutcome {
+        let finish = finishReason ?? "none"
+        if content.contains("<<GAUNTLET_STOP>>") {
+            return .fail(
+                "stop sequence leaked into content (finish_reason=\(finish))")
+        }
+        if content.contains("OMEGA") {
+            return .fail("content continued past the stop boundary (finish_reason=\(finish))")
+        }
+        guard content.trimmingCharacters(in: .whitespacesAndNewlines) == "ALPHA" else {
+            return .untested("stopped run did not produce the exact pre-boundary text")
+        }
+        guard finish == "stop" else {
+            return .fail("finish_reason=\(finish) is not stop-related")
+        }
+        return .pass(
+            "control emitted the full boundary and stopped run emitted only ALPHA (finish_reason=stop)")
+    }
+
+    // MARK: - Probe 5: degeneration-canary
+
+    static func probeDegenerationCanary(base: URL, model: String) async -> ProbeOutcome {
+        do {
+            let chat = try await gauntletChat(
+                base: base, model: model,
+                prompt:
+                    "Think carefully step by step: explain why the sky is blue, then critique your own explanation.",
+                maxTokens: 1_024)
+            // Loops routinely start inside the thinking channel, so the
+            // detector sees the full transcript, not just `content`.
+            let full = chat.reasoning.isEmpty ? chat.content : chat.reasoning + "\n" + chat.content
+            return degenerationCanaryVerdict(transcript: full)
+        } catch {
+            return .fail("canary generation failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Below this many transcript characters the canary has not observed
+    /// enough generation to certify "no runaway repetition" — a 0-char run
+    /// must not pass on vacuous evidence.
+    static let gauntletMinCanaryTranscriptChars = 256
+
+    /// Pure verdict for the degeneration canary. A detector hit is a fail on
+    /// any transcript length (repetition observed is repetition observed);
+    /// a clean short/empty transcript is `untested`, not pass.
+    static func degenerationCanaryVerdict(transcript: String) -> ProbeOutcome {
+        if let hit = DegenerationDetector.detect(in: transcript) {
+            return .fail(hit)
+        }
+        guard transcript.count >= gauntletMinCanaryTranscriptChars else {
+            return .untested(
+                "transcript too short to judge degeneration (\(transcript.count) chars, need ≥\(gauntletMinCanaryTranscriptChars))")
+        }
+        return .pass("no runaway repetition in \(transcript.count) generated characters")
+    }
+
+    // MARK: - Probe 6: mtp-equivalence
+
+    /// Native MTP (self-speculative decode) must be output-lossless: greedy
+    /// text through the MTP path must be byte-identical to the plain
+    /// autoregressive path, otherwise the speedup is silently changing
+    /// answers. Only testable when the model actually loaded with a
+    /// `native_mtp*` draft strategy (visible in /health after probe 1).
+    static func probeMTPEquivalence(base: URL, model: String) async -> ProbeOutcome {
+        guard let health = await fetchJSON(base.appendingPathComponent("health")),
+            let resident = health["resident_models"] as? [[String: Any]]
+        else {
+            return .untested("could not read resident_models from /health")
+        }
+        let key = ledgerNormalize(model)
+        let row = resident.first { ledgerNormalize(($0["name"] as? String) ?? "") == key }
+        guard let strategy = row?["draft_strategy"] as? String, strategy.hasPrefix("native_mtp")
+        else {
+            let observed = row?["draft_strategy"] as? String ?? "none"
+            return .untested(
+                "model is not serving with a native MTP draft strategy (draft_strategy=\(observed))")
+        }
+
+        // Identical prompt for both runs (greedy decode output does not
+        // depend on prefix-cache hits), long enough to clear the runtime's
+        // tiny-prompt AR fallback (24 tokens).
+        let prompt = makePrompt(targetTokens: 256, nonce: "gauntlet-mtp-equivalence")
+        do {
+            // Pure explicit greedy: the only sampling shape the runtime lets
+            // native MTP serve.
+            let mtp = try await gauntletChat(
+                base: base, model: model, prompt: prompt, maxTokens: 256)
+            // Forced AR with identical decoding: `top_k: 1` fails
+            // MLXBatchAdapter.requestSamplingIsExplicitGreedy, so the runtime
+            // drops the draft strategy (fallback reason "explicit_sampling"),
+            // and at temperature 0 vmlx's sampler() is ArgMaxSampler, which
+            // ignores topK — the knob forces the AR path and is then dropped,
+            // so decoding is identical greedy. (A nonzero frequency_penalty
+            // would also force AR — vmlx's canUseNativeMTP rejects it — but
+            // it is NOT dropped: vmlx builds a FrequencyPenaltyContext that
+            // perturbs logits, so a hash mismatch could be the penalty
+            // instead of MTP.)
+            let ar = try await gauntletChat(
+                base: base, model: model, prompt: prompt, maxTokens: 256,
+                extraParameters: ["top_k": 1])
+            // Empty (or near-empty) transcripts hash identically without
+            // proving anything: ""=="" is not equivalence evidence.
+            if let short = mtpEquivalenceTranscriptGuard(
+                mtpCompletionTokens: mtp.completionTokens,
+                arCompletionTokens: ar.completionTokens) {
+                return short
+            }
+            let mtpHash = transcriptHash(mtp)
+            let arHash = transcriptHash(ar)
+            guard mtpHash == arHash else {
+                return .fail(
+                    "\(strategy) greedy output diverges from forced-AR (mtp sha256 \(mtpHash.prefix(12)) vs ar \(arHash.prefix(12)))")
+            }
+            return .untested(
+                "\(strategy) output matched forced-AR (sha256 \(mtpHash.prefix(12))), but per-request MTP telemetry is unavailable so active MTP use is unproven")
+        } catch {
+            return .untested("equivalence runs failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Equivalence needs at least this many completion tokens from BOTH runs
+    /// before matching hashes count as evidence.
+    static let gauntletMinEquivalenceCompletionTokens = 16
+
+    /// Pure guard for the mtp-equivalence probe: returns the `untested`
+    /// outcome when either transcript is too short to compare, nil when the
+    /// hash comparison may proceed.
+    static func mtpEquivalenceTranscriptGuard(
+        mtpCompletionTokens: Int?, arCompletionTokens: Int?
+    ) -> ProbeOutcome? {
+        let mtpTokens = mtpCompletionTokens ?? 0
+        let arTokens = arCompletionTokens ?? 0
+        guard mtpTokens >= gauntletMinEquivalenceCompletionTokens,
+            arTokens >= gauntletMinEquivalenceCompletionTokens
+        else {
+            return .untested(
+                "empty transcript: equivalence needs ≥\(gauntletMinEquivalenceCompletionTokens) completion tokens from both runs (mtp \(mtpTokens), ar \(arTokens))")
+        }
+        return nil
+    }
+
+    /// sha256 over (reasoning + NUL + content): the separator keeps
+    /// "reasoning boundary moved" distinguishable from "same bytes".
+    static func transcriptHash(_ chat: GauntletChat) -> String {
+        let digest = SHA256.hash(data: Data((chat.reasoning + "\u{0000}" + chat.content).utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Probe 7: perf snapshot (evidence only)
+
+    static func perfSnapshotEvidence(
+        base: URL, model: String, options: Options
+    ) async -> String {
+        var parts: [String] = []
+        for target in [1_024, 8_192] {
+            // Unique prefix → uncached prefill; identical re-send → cached.
+            let prompt = makePrompt(
+                targetTokens: target, nonce: "gauntlet-perf-\(target)-\(UUID().uuidString)")
+            do {
+                let uncached = try await measureOnce(
+                    base: base, model: model, prompt: prompt, maxTokens: options.maxTokens)
+                let cached = try await measureOnce(
+                    base: base, model: model, prompt: prompt, maxTokens: options.maxTokens)
+                parts.append(
+                    String(
+                        format: "%dK: uncached TTFT %.0f ms, cached TTFT %.0f ms, decode %.1f tok/s",
+                        target / 1_024, uncached.ttftMs, cached.ttftMs, uncached.decodeTps))
+            } catch {
+                parts.append("\(target / 1_024)K: failed (\(error.localizedDescription))")
+            }
+        }
+        return parts.joined(separator: "; ")
+    }
+
+    // MARK: - Streaming chat helper
+
+    struct GauntletChat {
+        var content = ""
+        var reasoning = ""
+        var finishReason: String?
+        /// Server-reported completion tokens (`stream_options.include_usage`);
+        /// nil on older servers whose final chunk carries no usage.
+        var completionTokens: Int?
+    }
+
+    enum GauntletError: LocalizedError {
+        case http(Int, String)
+
+        var errorDescription: String? {
+            switch self {
+            case .http(let code, let message): return "HTTP \(code): \(message)"
+            }
+        }
+    }
+
+    /// One greedy streamed chat, returning the full text of both channels
+    /// and the final finish_reason. Unlike `measureOnce` this keeps the
+    /// bytes (the gauntlet inspects text, not timing).
+    static func gauntletChat(
+        base: URL, model: String, prompt: String, maxTokens: Int,
+        stop: [String]? = nil, extraParameters: [String: Any] = [:]
+    ) async throws -> GauntletChat {
+        var body: [String: Any] = [
+            "model": model,
+            "messages": [["role": "user", "content": prompt]],
+            "temperature": 0,
+            "max_tokens": maxTokens,
+            "stream": true,
+            "stream_options": ["include_usage": true],
+        ]
+        if let stop { body["stop"] = stop }
+        for (key, value) in extraParameters { body[key] = value }
+
+        var request = URLRequest(url: base.appendingPathComponent("v1/chat/completions"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 600
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            var bodyText = ""
+            for try await line in bytes.lines where bodyText.count < 4_096 {
+                bodyText += line
+            }
+            let obj = try? JSONSerialization.jsonObject(with: Data(bodyText.utf8)) as? [String: Any]
+            throw GauntletError.http(http.statusCode, serverErrorMessage(obj) ?? bodyText)
+        }
+
+        var result = GauntletChat()
+        for try await line in bytes.lines {
+            guard line.hasPrefix("data: ") else { continue }  // skips ": ping" keepalives
+            let payload = line.dropFirst(6)
+            if payload == "[DONE]" { break }
+            guard
+                let obj = try? JSONSerialization.jsonObject(
+                    with: Data(payload.utf8)) as? [String: Any]
+            else { continue }
+            // The usage chunk arrives with an empty `choices` array, so it
+            // must be read before the choice guard below.
+            if let usage = obj["usage"] as? [String: Any],
+                let completionTokens = usage["completion_tokens"] as? Int {
+                result.completionTokens = completionTokens
+            }
+            guard let choice = (obj["choices"] as? [[String: Any]])?.first else { continue }
+            if let delta = choice["delta"] as? [String: Any] {
+                if let piece = delta["content"] as? String { result.content += piece }
+                if let piece = delta["reasoning_content"] as? String { result.reasoning += piece }
+            }
+            if let finish = choice["finish_reason"] as? String { result.finishReason = finish }
+        }
+        return result
+    }
+
+    /// Extracts `error.message` from an OpenAI-style error body.
+    static func serverErrorMessage(_ obj: [String: Any]?) -> String? {
+        ((obj?["error"] as? [String: Any])?["message"] as? String)
+    }
+
+    // MARK: - Ledger write (CLI-side mirror of ModelCapabilityLedger)
+
+    /// CLI-side mirror of `ModelCapabilityLedger.Record` (OsaurusCore),
+    /// written without linking OsaurusCore — exactly like the prefill-tuning
+    /// helpers mirror `ModelPrefillTuningStore`. `probes` (verdict map) and
+    /// `evidence` are gauntlet-added fields; the server-side decoder ignores
+    /// keys it does not know, so the contract stays one-directional.
+    struct GauntletLedgerRecord: Codable {
+        /// Reserved for a future digest-bound promotion path. Gauntlet v1
+        /// leaves this absent and preserves any existing ledger verdict.
+        var productionServing: String?
+        var source: String
+        var chip: String?
+        var measuredAt: String
+        var probes: [String: String]
+        var evidence: [String: String]
+    }
+
+    /// The server-side reader is `ModelCapabilityLedger` (OsaurusCore).
+    static func ledgerFileURL() -> URL {
+        Configuration.root()
+            .appendingPathComponent("config", isDirectory: true)
+            .appendingPathComponent("model-ledger.json")
+    }
+
+    /// Same normalization as `ModelCapabilityLedger.normalize` so the
+    /// server's exact-key lookup finds gauntlet-written records.
+    static func ledgerNormalize(_ name: String) -> String {
+        name.lowercased().replacingOccurrences(of: "-", with: "_")
+    }
+
+    /// Field-merges one record under the normalized key. Unknown fields and
+    /// an existing production verdict/block reason survive a gauntlet run;
+    /// evidence collection must never silently remove a safety decision.
+    static func writeLedgerRecord(
+        at url: URL, modelKey: String, record: GauntletLedgerRecord
+    ) throws {
+        var records: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+            let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            records = existing
+        }
+        let encoded = try JSONEncoder().encode(record)
+        let update = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] ?? [:]
+        var modelRecord = records[modelKey] as? [String: Any] ?? [:]
+        for (key, value) in update where key != "productionServing" {
+            modelRecord[key] = value
+        }
+        if let verdict = record.productionServing {
+            modelRecord["productionServing"] = verdict
+        }
+        records[modelKey] = modelRecord
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: records, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/DegenerationDetector.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/DegenerationDetector.swift
@@ -1,0 +1,105 @@
+//
+//  DegenerationDetector.swift
+//  osaurus
+//
+//  Pure repetition detector for the gauntlet's degeneration canary
+//  (`osaurus bench --gauntlet`). Long greedy generations are where broken
+//  bundles betray themselves — the two failure modes seen in the wild are a
+//  single character repeated forever (`!!!!!…`) and a short phrase looping
+//  (`idea idea idea…`) — so the detector targets exactly those shapes:
+//
+//    - any single character repeated `minCharacterRun` (64) or more times
+//      consecutively, and
+//    - any n-gram of `minNGram`...`maxNGram` (2–12) whitespace-separated
+//      tokens occurring `minConsecutiveRepeats` (8) or more times
+//      back-to-back.
+//
+//  "Token" here means a whitespace-separated word, not a model token: the
+//  detector runs client-side over streamed text and must not depend on any
+//  tokenizer. A pure single-word loop (`idea idea …`) is caught by the
+//  3-gram rule once it spans 24 words; a pure character loop is caught by
+//  the run rule regardless of whitespace. Pure function, no I/O — kept that
+//  way so it stays unit-testable.
+//
+
+import Foundation
+
+public enum DegenerationDetector {
+    /// Smallest and largest repeating unit considered, in whitespace tokens.
+    public static let minNGram = 2
+    public static let maxNGram = 12
+    /// An n-gram must occur this many times back-to-back to count as a loop.
+    public static let minConsecutiveRepeats = 8
+    /// A single character repeated this many times consecutively is a loop.
+    public static let minCharacterRun = 64
+
+    /// Returns human-readable evidence (containing the repeating fragment)
+    /// when `text` degenerates per the thresholds above, or nil when clean.
+    /// Scan the FULL generation — reasoning and content — because loops
+    /// routinely start inside the thinking channel.
+    public static func detect(in text: String) -> String? {
+        if let (character, length) = firstCharacterRun(atLeast: minCharacterRun, in: text) {
+            return "character \"\(character)\" repeated \(length)x consecutively"
+        }
+
+        let tokens = text.split(whereSeparator: \.isWhitespace)
+        for n in minNGram...maxNGram {
+            // A loop of period n needs at least n × repeats tokens; larger
+            // n needs strictly more, so once one n is impossible all are.
+            guard tokens.count >= n * minConsecutiveRepeats else { break }
+            var start = 0
+            while start + n * minConsecutiveRepeats <= tokens.count {
+                var occurrences = 1
+                var next = start + n
+                while next + n <= tokens.count,
+                    blocksEqual(tokens, start, next, length: n) {
+                    occurrences += 1
+                    next += n
+                }
+                if occurrences >= minConsecutiveRepeats {
+                    let fragment = tokens[start..<(start + n)].joined(separator: " ")
+                    return "\(n)-token n-gram \"\(truncated(fragment))\" repeated \(occurrences)x consecutively"
+                }
+                start += 1
+            }
+        }
+        return nil
+    }
+
+    /// First run of a single repeated character reaching `threshold`,
+    /// returned with its full length for evidence.
+    private static func firstCharacterRun(
+        atLeast threshold: Int, in text: String
+    ) -> (Character, Int)? {
+        var runCharacter: Character?
+        var runLength = 0
+        for character in text {
+            if character == runCharacter {
+                runLength += 1
+            } else {
+                if runLength >= threshold, let runCharacter {
+                    return (runCharacter, runLength)
+                }
+                runCharacter = character
+                runLength = 1
+            }
+        }
+        if runLength >= threshold, let runCharacter {
+            return (runCharacter, runLength)
+        }
+        return nil
+    }
+
+    private static func blocksEqual(
+        _ tokens: [Substring], _ a: Int, _ b: Int, length: Int
+    ) -> Bool {
+        for offset in 0..<length where tokens[a + offset] != tokens[b + offset] {
+            return false
+        }
+        return true
+    }
+
+    private static func truncated(_ fragment: String, limit: Int = 80) -> String {
+        fragment.count <= limit ? fragment : String(fragment.prefix(limit)) + "…"
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchGauntletTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/BenchGauntletTests.swift
@@ -1,0 +1,222 @@
+//
+//  BenchGauntletTests.swift
+//  osaurus
+//
+//  Tests for the gauntlet's pure verdict functions: the stop-sequence
+//  probe's positive-evidence rule and the empty-transcript guards for
+//  mtp-equivalence and the degeneration canary. These verdicts feed the
+//  capability ledger, so a vacuous pass corrupts serving policy evidence.
+//
+
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class BenchGauntletTests: XCTestCase {
+    // MARK: - Stop-sequence verdict
+
+    func testStopSequenceCountedToBoundaryThenStoppedPasses() {
+        let outcome = BenchCommand.stopSequenceVerdict(
+            content: "ALPHA", finishReason: "stop")
+        XCTAssertEqual(outcome.verdict, "pass")
+    }
+
+    func testStopSequenceWordedAnswerIsUntestedNotPass() {
+        // Natural EOS also yields finish_reason "stop": without the digit
+        // "6" there is no evidence the stop sequence did anything.
+        let outcome = BenchCommand.stopSequenceVerdict(
+            content: "I cannot follow that format.", finishReason: "stop")
+        XCTAssertEqual(outcome.verdict, "untested")
+        XCTAssertTrue(outcome.evidence.contains("exact pre-boundary"))
+    }
+
+    func testStopSequenceEmptyContentIsUntested() {
+        let outcome = BenchCommand.stopSequenceVerdict(content: "", finishReason: "stop")
+        XCTAssertEqual(outcome.verdict, "untested")
+    }
+
+    func testStopSequenceContentContainingEightFails() {
+        let outcome = BenchCommand.stopSequenceVerdict(
+            content: "ALPHAOMEGA", finishReason: "stop")
+        XCTAssertEqual(outcome.verdict, "fail")
+        XCTAssertTrue(outcome.evidence.contains("continued past"))
+    }
+
+    func testStopSequenceLeakedStopTokenFails() {
+        // Counted to the boundary but the stop sequence itself surfaced in
+        // content: the sequence must be excluded from output.
+        let outcome = BenchCommand.stopSequenceVerdict(
+            content: "ALPHA<<GAUNTLET_STOP>>", finishReason: "stop")
+        XCTAssertEqual(outcome.verdict, "fail")
+        XCTAssertTrue(outcome.evidence.contains("leaked into content"))
+    }
+
+    func testStopSequenceNonStopFinishReasonFails() {
+        let outcome = BenchCommand.stopSequenceVerdict(
+            content: "ALPHA", finishReason: "length")
+        XCTAssertEqual(outcome.verdict, "fail")
+        XCTAssertTrue(outcome.evidence.contains("finish_reason=length"))
+    }
+
+    // MARK: - Template leakage positive evidence
+
+    func testTemplateLeakEmptyTranscriptIsUntested() {
+        XCTAssertEqual(
+            BenchCommand.templateLeakVerdict(content: "", reasoning: "").verdict,
+            "untested")
+    }
+
+    func testTemplateLeakRecognizesSupportedFamilyMarkers() {
+        for marker in ["<end_of_turn>", "<|eot_id|>", "<|end|>", "<|endoftext|>"] {
+            let outcome = BenchCommand.templateLeakVerdict(
+                content: "answer \(marker)", reasoning: "")
+            XCTAssertEqual(outcome.verdict, "fail", "marker \(marker) was not detected")
+        }
+    }
+
+    func testTemplateLeakCleanNonEmptyTranscriptPasses() {
+        XCTAssertEqual(
+            BenchCommand.templateLeakVerdict(content: "hello", reasoning: "").verdict,
+            "pass")
+    }
+
+    // MARK: - Ledger merge safety
+
+    func testLedgerWritePreservesExistingFailureAndUnknownFields() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("model-ledger.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let existing: [String: Any] = [
+            "org/model": [
+                "productionServing": "fail",
+                "blockReason": "measured regression",
+                "digest": "sha256:old",
+                "futureField": ["kept": true],
+            ]
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: url)
+
+        let record = BenchCommand.GauntletLedgerRecord(
+            productionServing: nil,
+            source: "gauntlet",
+            chip: "M4",
+            measuredAt: "2026-07-10T00:00:00Z",
+            probes: ["load": "pass"],
+            evidence: ["load": "ok"]
+        )
+        try BenchCommand.writeLedgerRecord(at: url, modelKey: "org/model", record: record)
+
+        let root = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+        let result = try XCTUnwrap(root["org/model"] as? [String: Any])
+        XCTAssertEqual(result["productionServing"] as? String, "fail")
+        XCTAssertEqual(result["blockReason"] as? String, "measured regression")
+        XCTAssertEqual(result["digest"] as? String, "sha256:old")
+        XCTAssertNotNil(result["futureField"])
+        XCTAssertEqual(result["source"] as? String, "gauntlet")
+    }
+
+    func testLedgerWritePreservesExistingPass() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("model-ledger.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: [
+            "org/model": ["productionServing": "pass", "digest": "sha256:weights"]
+        ]).write(to: url)
+
+        let record = BenchCommand.GauntletLedgerRecord(
+            productionServing: nil,
+            source: "gauntlet",
+            chip: nil,
+            measuredAt: "2026-07-10T00:00:00Z",
+            probes: ["load": "fail"],
+            evidence: ["load": "failed"]
+        )
+        try BenchCommand.writeLedgerRecord(at: url, modelKey: "org/model", record: record)
+
+        let root = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+        let result = try XCTUnwrap(root["org/model"] as? [String: Any])
+        XCTAssertEqual(result["productionServing"] as? String, "pass")
+        XCTAssertEqual(result["digest"] as? String, "sha256:weights")
+    }
+
+    // MARK: - mtp-equivalence empty-transcript guard
+
+    func testMTPGuardBothRunsSufficientProceeds() {
+        XCTAssertNil(
+            BenchCommand.mtpEquivalenceTranscriptGuard(
+                mtpCompletionTokens: 16, arCompletionTokens: 200))
+    }
+
+    func testMTPGuardEmptyTranscriptsAreUntested() {
+        let outcome = BenchCommand.mtpEquivalenceTranscriptGuard(
+            mtpCompletionTokens: 0, arCompletionTokens: 0)
+        XCTAssertEqual(outcome?.verdict, "untested")
+        XCTAssertTrue(outcome?.evidence.contains("empty transcript") == true)
+    }
+
+    func testMTPGuardRequiresBothRunsAboveThreshold() {
+        XCTAssertEqual(
+            BenchCommand.mtpEquivalenceTranscriptGuard(
+                mtpCompletionTokens: 200, arCompletionTokens: 15)?.verdict,
+            "untested")
+        XCTAssertEqual(
+            BenchCommand.mtpEquivalenceTranscriptGuard(
+                mtpCompletionTokens: 15, arCompletionTokens: 200)?.verdict,
+            "untested")
+    }
+
+    func testMTPGuardMissingUsageCountsAsEmpty() {
+        XCTAssertEqual(
+            BenchCommand.mtpEquivalenceTranscriptGuard(
+                mtpCompletionTokens: nil, arCompletionTokens: 200)?.verdict,
+            "untested")
+    }
+
+    // MARK: - Degeneration canary transcript guard
+
+    func testCanaryEmptyTranscriptIsUntestedNotPass() {
+        let outcome = BenchCommand.degenerationCanaryVerdict(transcript: "")
+        XCTAssertEqual(outcome.verdict, "untested")
+        XCTAssertTrue(outcome.evidence.contains("too short"))
+    }
+
+    func testCanaryShortCleanTranscriptIsUntested() {
+        let short = String(repeating: "varied words here ", count: 5)  // < 256 chars
+        XCTAssertLessThan(short.count, BenchCommand.gauntletMinCanaryTranscriptChars)
+        XCTAssertEqual(BenchCommand.degenerationCanaryVerdict(transcript: short).verdict, "untested")
+    }
+
+    func testCanaryLongCleanTranscriptPasses() {
+        // Sentence-length variety so the repetition detector stays quiet.
+        var long = ""
+        var index = 0
+        while long.count < 600 {
+            long += "Sentence number \(index) discusses a different topic entirely. "
+            index += 1
+        }
+        let outcome = BenchCommand.degenerationCanaryVerdict(transcript: long)
+        XCTAssertEqual(outcome.verdict, "pass", "evidence was: \(outcome.evidence)")
+    }
+
+    func testCanaryDetectorHitFailsEvenOnShortTranscript() throws {
+        let looping = String(repeating: "the same phrase over and over ", count: 40)
+        guard DegenerationDetector.detect(in: looping) != nil else {
+            // Detector thresholds are its own tests' concern; this test only
+            // asserts the verdict wiring when the detector does fire.
+            throw XCTSkip("detector did not fire on the synthetic loop")
+        }
+        XCTAssertEqual(BenchCommand.degenerationCanaryVerdict(transcript: looping).verdict, "fail")
+    }
+
+    // MARK: - Option exclusivity
+
+    func testTunePrefillAndGauntletAreMutuallyExclusive() {
+        XCTAssertNil(BenchCommand.parseOptions(["--tune-prefill", "--gauntlet"]))
+        XCTAssertNotNil(BenchCommand.parseOptions(["--gauntlet"]))
+        XCTAssertNotNil(BenchCommand.parseOptions(["--tune-prefill"]))
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/DegenerationDetectorTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/DegenerationDetectorTests.swift
@@ -1,0 +1,111 @@
+//
+//  DegenerationDetectorTests.swift
+//  osaurus
+//
+//  Threshold tests for the gauntlet's degeneration canary detector: the two
+//  known failure modes (`!!!!!…` character runs and `idea idea idea…` phrase
+//  loops) must trip it, and normal prose — including legitimate repetition
+//  just under the thresholds — must not.
+//
+
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class DegenerationDetectorTests: XCTestCase {
+
+    // MARK: - Character runs
+
+    func testCharacterRunAtThresholdIsDetected() {
+        let text = "The explanation ends here " + String(repeating: "!", count: 64)
+        let evidence = DegenerationDetector.detect(in: text)
+        XCTAssertNotNil(evidence)
+        XCTAssertTrue(evidence?.contains("\"!\"") == true, "evidence should name the character")
+        XCTAssertTrue(evidence?.contains("64") == true, "evidence should carry the run length")
+    }
+
+    func testCharacterRunBelowThresholdIsClean() {
+        let text = "Wow " + String(repeating: "!", count: 63) + " that is bright."
+        XCTAssertNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testCharacterRunAtEndOfTextIsDetected() {
+        // The run must be caught even when the text ends mid-run.
+        let text = "aaaa" + String(repeating: "e", count: 100)
+        XCTAssertNotNil(DegenerationDetector.detect(in: text))
+    }
+
+    // MARK: - N-gram loops
+
+    func testTwoTokenLoopIsDetected() {
+        let text = String(repeating: "I think ", count: 20)
+        XCTAssertNotNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testSingleWordLoopIsDetectedViaRepeatedPair() {
+        // Consecutive identical words form a repeated 2-token unit.
+        let text = "The core concept is "
+            + Array(repeating: "idea", count: 24).joined(separator: " ")
+        let evidence = DegenerationDetector.detect(in: text)
+        XCTAssertNotNil(evidence)
+        XCTAssertTrue(evidence?.contains("idea idea") == true)
+    }
+
+    func testPhraseLoopAtThresholdIsDetected() {
+        let text = Array(repeating: "the sky is blue because", count: 8).joined(separator: " ")
+        let evidence = DegenerationDetector.detect(in: text)
+        XCTAssertNotNil(evidence)
+        XCTAssertTrue(evidence?.contains("the sky is blue because") == true)
+    }
+
+    func testPhraseRepeatedSevenTimesIsClean() {
+        // One repeat under the threshold must not trip the detector.
+        let text = Array(repeating: "alpha beta gamma", count: 7).joined(separator: " ")
+        XCTAssertNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testLoopEmbeddedInProseIsDetected() {
+        let text =
+            "Rayleigh scattering explains the color. "
+            + Array(repeating: "shorter wavelengths scatter more", count: 9)
+                .joined(separator: " ")
+            + " and that is why the sky is blue."
+        XCTAssertNotNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testSevenWordPhraseLoopIsDetectedAsSevenGram() {
+        // Repeating units longer than 3 words are caught by their own
+        // n-gram size (here n=7), not just trigrams.
+        let text = Array(repeating: "blue sky today and calm sea tonight", count: 8)
+            .joined(separator: " ")
+        XCTAssertNotNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testNonConsecutiveRepetitionIsClean() {
+        // The same fragment appearing often but always separated by a
+        // varying token is emphasis, not a loop: no 3–12-gram ever repeats
+        // immediately back-to-back.
+        let text = (0..<12).map { "blue sky number \($0) is lovely" }.joined(separator: " ")
+        XCTAssertNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testNormalProseIsClean() {
+        let text = """
+            The sky appears blue because sunlight entering the atmosphere is \
+            scattered by air molecules. Shorter wavelengths, such as blue and \
+            violet, scatter far more strongly than longer red wavelengths — \
+            this is Rayleigh scattering. Our eyes are more sensitive to blue \
+            than violet, and some violet is absorbed high in the atmosphere, \
+            so the dome overhead looks blue. A fair critique: this account \
+            ignores Mie scattering from aerosols, which whitens the horizon, \
+            and it does not explain why sunsets are red.
+            """
+        XCTAssertNil(DegenerationDetector.detect(in: text))
+    }
+
+    func testEmptyAndTinyInputsAreClean() {
+        XCTAssertNil(DegenerationDetector.detect(in: ""))
+        XCTAssertNil(DegenerationDetector.detect(in: "ok"))
+        XCTAssertNil(DegenerationDetector.detect(in: "one two three four"))
+    }
+}


### PR DESCRIPTION
## What

Adds `osaurus bench --gauntlet`, a seven-probe model verification workflow:

1. Non-empty load/stream response
2. Template-marker leakage across content and reasoning channels
3. Forced tool call with exact function name and schema-valid arguments
4. Multi-character stop handling with an unstopped control run
5. Long-generation degeneration detection, including two-token loops and character runs
6. MTP-versus-AR comparison evidence
7. Prefill/decode performance snapshot

Results are field-merged into the capability ledger without deleting existing verdicts, block reasons, digests, or unknown fields.

## Safety contract

The gauntlet records per-probe evidence and a production-serving candidate result. It does not change `productionServing` in v1 because the runtime cannot yet bind that promotion to a verified weights digest. Failed or unproven critical probes exit nonzero. MTP equivalence remains `untested` unless the runtime can prove per-request MTP activation.

## Validation

- `BenchGauntletTests`: 20 passed
- `DegenerationDetectorTests`: 12 passed
- Scoped SwiftLint: passed
- `git diff --check`: passed
- Independent runtime review findings addressed: no vacuous stop/template passes, no stale ledger promotion, no destructive record replacement, and no two-token degeneration blind spot

## Risk and rollback

CLI and evidence-writing scope only. Runtime model behavior, prompts, templates, samplers, and generation defaults are unchanged. Reverting the single feature commit removes the workflow.