### PR TITLE
Micro-batch local embeddings into one batched MLX forward

### DIFF
--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -234,6 +234,10 @@ let package = Package(
                 "OsaurusCore",
                 "OsaurusSQLCipher",
                 .product(name: "VMLXJinja", package: "vmlx-swift"),
+                // Reference implementation for the embedding batch-parity
+                // test: the batched forward in VMLXModel2VecEmbedder must
+                // match vmlx's original sequential Model2Vec pipeline.
+                .product(name: "MLXEmbedders", package: "vmlx-swift"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "VecturaKit", package: "VecturaKit"),
             ],

--- a/Packages/OsaurusCore/Services/Memory/EmbeddingBatcher.swift
+++ b/Packages/OsaurusCore/Services/Memory/EmbeddingBatcher.swift
@@ -1,0 +1,216 @@
+//
+//  EmbeddingBatcher.swift
+//  osaurus
+//
+//  Micro-batches concurrent single-text embedding requests into one batched
+//  forward pass. Memory search and distillation fan out many single-text
+//  embeds (VecturaKit embeds each search query with `embed(text:)`), and
+//  without coalescing those callers serialize one-by-one through MetalGate.
+//
+//  Constraint: this layer sits ABOVE MetalGate. The backend it is given must
+//  be the gate-acquiring path (`MetalSafeEmbedder.embed(texts:)`), so one
+//  coalesced batch acquires the gate exactly once. The batcher itself never
+//  touches the gate and must not change its semantics.
+//
+//  Constraint: a lone request's added latency is bounded by the coalescing
+//  window (default 25 ms) — the window timer starts with the first request
+//  and is never extended by later arrivals.
+//
+
+import Foundation
+import VecturaKit
+
+public enum EmbeddingBatcherError: Error, Equatable {
+    /// The backend returned a different number of vectors than texts sent.
+    case mismatchedResultCount(expected: Int, received: Int)
+}
+
+/// Coalesces single-text embedding requests that arrive within a short
+/// window into one backend call, and distributes the resulting vectors back
+/// to the awaiting callers by index.
+public actor EmbeddingBatcher {
+    /// One batched forward over the given texts. Must return exactly one
+    /// vector per input text, in input order. This is the gate-acquiring
+    /// boundary: it must acquire MetalGate once for the whole batch.
+    public typealias Backend = @Sendable ([String]) async throws -> [[Float]]
+
+    /// Coalescing window. 25 ms is long enough for a memory-search or
+    /// distillation fan-out (tasks spawned in the same event-loop tick land
+    /// within a millisecond) yet short enough that a lone caller's
+    /// worst-case added latency stays negligible next to the embed forward
+    /// itself. Batched-forward measurements in the MLX ecosystem show
+    /// batch 4-8 giving ~1.5x throughput at this latency cost.
+    public static let defaultWindow: Duration = .milliseconds(25)
+
+    /// Upper bound on one coalesced batch. 16 keeps the padded [N, L, D]
+    /// gather small (16 x 512 tokens x 128 dims of Float is ~4 MB) and keeps
+    /// per-batch gate hold times short so generation is not starved.
+    public static let defaultMaxBatchSize = 16
+
+    private let window: Duration
+    private let maxBatchSize: Int
+    private let clock: any Clock<Duration>
+    private let backend: Backend
+
+    /// Texts of the batch currently accumulating in the open window.
+    private var pendingBatch: [(id: UInt64, text: String)] = []
+    /// Continuations for every request not yet resumed, including requests
+    /// already handed to an in-flight backend call. Keyed by request id so a
+    /// cancelled waiter can be resumed early without disturbing the batch.
+    private var waiters: [UInt64: CheckedContinuation<[Float], any Error>] = [:]
+    /// Requests whose cancellation raced ahead of their enqueue.
+    private var cancelledBeforeEnqueue: Set<UInt64> = []
+    /// Requests currently inside `embed`, so a late cancellation Task can
+    /// tell "not yet enqueued" apart from "already completed" and never
+    /// leaves a stale entry in `cancelledBeforeEnqueue`.
+    private var activeIDs: Set<UInt64> = []
+    private var windowTask: Task<Void, Never>?
+    private var nextID: UInt64 = 0
+
+    public init(
+        window: Duration = EmbeddingBatcher.defaultWindow,
+        maxBatchSize: Int = EmbeddingBatcher.defaultMaxBatchSize,
+        clock: any Clock<Duration> = ContinuousClock(),
+        backend: @escaping Backend
+    ) {
+        precondition(maxBatchSize >= 1, "maxBatchSize must be at least 1")
+        self.window = window
+        self.maxBatchSize = maxBatchSize
+        self.clock = clock
+        self.backend = backend
+    }
+
+    /// Embed one text, coalescing with other requests that arrive within the
+    /// window. Worst-case added latency for a lone caller is one window.
+    /// Cancelling the calling task resumes only this waiter with
+    /// `CancellationError`; the rest of the batch proceeds.
+    public func embed(_ text: String) async throws -> [Float] {
+        let id = nextID
+        nextID &+= 1
+        activeIDs.insert(id)
+        defer {
+            activeIDs.remove(id)
+            cancelledBeforeEnqueue.remove(id)
+        }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                enqueue(id: id, text: text, continuation: continuation)
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+    }
+
+    // MARK: - Batch lifecycle
+
+    private func enqueue(
+        id: UInt64,
+        text: String,
+        continuation: CheckedContinuation<[Float], any Error>
+    ) {
+        if cancelledBeforeEnqueue.contains(id) {
+            cancelledBeforeEnqueue.remove(id)
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        waiters[id] = continuation
+        pendingBatch.append((id: id, text: text))
+
+        if pendingBatch.count >= maxBatchSize {
+            // Full batch: flush immediately instead of waiting out the window.
+            windowTask?.cancel()
+            windowTask = nil
+            Task { await self.flush() }
+        } else if windowTask == nil {
+            // First request of an idle period opens the window. Later
+            // arrivals join the batch but never extend the deadline, so the
+            // first caller's added latency is bounded by one window.
+            windowTask = Task { [clock, window] in
+                do {
+                    try await clock.sleep(for: window, tolerance: nil)
+                } catch {
+                    return  // Cancelled by a max-batch-size flush.
+                }
+                await self.windowExpired()
+            }
+        }
+    }
+
+    private func windowExpired() async {
+        windowTask = nil
+        await flush()
+    }
+
+    /// Drain the pending batch through the backend in chunks of at most
+    /// `maxBatchSize`, resuming each waiter with its vector (or the batch
+    /// error). Runs on the actor; the backend await is a reentrancy point,
+    /// so new requests can keep enqueueing while a batch is in flight.
+    private func flush() async {
+        while !pendingBatch.isEmpty {
+            let batch = Array(pendingBatch.prefix(maxBatchSize))
+            pendingBatch.removeFirst(batch.count)
+            do {
+                let vectors = try await backend(batch.map(\.text))
+                guard vectors.count == batch.count else {
+                    throw EmbeddingBatcherError.mismatchedResultCount(
+                        expected: batch.count, received: vectors.count
+                    )
+                }
+                for (index, entry) in batch.enumerated() {
+                    // nil when the waiter was cancelled mid-flight; its
+                    // result is simply discarded.
+                    waiters.removeValue(forKey: entry.id)?.resume(returning: vectors[index])
+                }
+            } catch {
+                for entry in batch {
+                    waiters.removeValue(forKey: entry.id)?.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func cancelWaiter(_ id: UInt64) {
+        if let continuation = waiters.removeValue(forKey: id) {
+            // Still pending (not yet flushed): drop the text from the batch.
+            // Already in flight: the batch keeps running for the others and
+            // this waiter's slot is discarded on completion.
+            pendingBatch.removeAll { $0.id == id }
+            continuation.resume(throwing: CancellationError())
+        } else if activeIDs.contains(id) {
+            // Cancellation ran before enqueue registered the continuation.
+            cancelledBeforeEnqueue.insert(id)
+        }
+    }
+}
+
+/// `VecturaEmbedder` front for the shared embedding path: single-text embeds
+/// (VecturaKit search queries, incremental index updates) coalesce through
+/// the `EmbeddingBatcher`; caller-assembled multi-text batches pass straight
+/// to the direct embedder — they are already one batched forward, and
+/// holding them for a window would only add latency.
+///
+/// The `direct` embedder must be the MetalGate-acquiring path
+/// (`MetalSafeEmbedder`), and the batcher's backend must call that same
+/// path, so every underlying forward — coalesced or pass-through — holds the
+/// gate exactly once.
+public struct CoalescingEmbedder: VecturaEmbedder {
+    private let direct: any VecturaEmbedder
+    private let batcher: EmbeddingBatcher
+
+    public init(direct: any VecturaEmbedder, batcher: EmbeddingBatcher) {
+        self.direct = direct
+        self.batcher = batcher
+    }
+
+    public var dimension: Int {
+        get async throws { try await direct.dimension }
+    }
+
+    public func embed(texts: [String]) async throws -> [[Float]] {
+        try await direct.embed(texts: texts)
+    }
+
+    public func embed(text: String) async throws -> [Float] {
+        try await batcher.embed(text)
+    }
+}

--- a/Packages/OsaurusCore/Services/Memory/EmbeddingService.swift
+++ b/Packages/OsaurusCore/Services/Memory/EmbeddingService.swift
@@ -17,14 +17,28 @@ public actor EmbeddingService {
     /// Known dimension for potion-base-4M so VecturaKit can init without loading the model.
     public static let embeddingDimension = 128
 
-    /// Single shared embedder used by all VecturaKit indexes and the embedding API.
-    /// Wrapped in MetalSafeEmbedder to coordinate embedding and generation work.
-    public static let sharedEmbedder: MetalSafeEmbedder = MetalSafeEmbedder(
+    /// Direct (non-coalescing) embedder: MetalSafeEmbedder serializes every
+    /// call against MLX generation via MetalGate. Kept exposed so tests and
+    /// already-batched callers can bypass the micro-batching window.
+    public static let directEmbedder: MetalSafeEmbedder = MetalSafeEmbedder(
         inner: VMLXModel2VecEmbedder(
             modelName: modelName,
             dimension: embeddingDimension,
             tokenizerLoader: SwiftTransformersTokenizerLoader()
         )
+    )
+
+    /// Single shared embedder used by all VecturaKit indexes and the embedding API.
+    /// Single-text embeds coalesce through `EmbeddingBatcher` into one batched
+    /// forward (one MetalGate acquisition per batch); multi-text embeds pass
+    /// straight through to `directEmbedder`. Worst-case added latency for a
+    /// lone single-text embed is one batching window
+    /// (`EmbeddingBatcher.defaultWindow`, 25 ms).
+    public static let sharedEmbedder: CoalescingEmbedder = CoalescingEmbedder(
+        direct: directEmbedder,
+        batcher: EmbeddingBatcher { texts in
+            try await directEmbedder.embed(texts: texts)
+        }
     )
 
     private static let logger = Logger(subsystem: "ai.osaurus", category: "EmbeddingService")

--- a/Packages/OsaurusCore/Services/Memory/MetalSafeEmbedder.swift
+++ b/Packages/OsaurusCore/Services/Memory/MetalSafeEmbedder.swift
@@ -8,7 +8,7 @@
 //
 
 import Foundation
-import MLXEmbedders
+import MLX
 import MLXLMCommon
 import VecturaKit
 
@@ -48,11 +48,42 @@ public actor MetalSafeEmbedder: VecturaEmbedder {
     }
 }
 
+/// Model2Vec static-embedding embedder with a genuinely batched forward:
+/// `embed(texts:)` runs ONE padded `[N, L]` gather + masked mean + eval for
+/// the whole batch (vmlx-swift's `Model2VecStaticEmbeddingPipeline` only
+/// loops `embed(text:)` per element, so it cannot back the micro-batcher).
+/// Loads the same bundle layout the vmlx pipeline loads (`model.safetensors`
+/// "embeddings" tensor, `config.json` `normalize` flag, tokenizer).
+///
+/// Must only run behind `MetalSafeEmbedder` (or another MetalGate holder):
+/// both the lazy weight load and the forward submit MLX GPU work.
 public actor VMLXModel2VecEmbedder: VecturaEmbedder {
+    private struct LoadedModel {
+        let embeddings: MLXArray
+        let tokenizer: any Tokenizer
+        let unknownTokenId: Int?
+        let normalize: Bool
+    }
+
+    private struct BundleConfiguration: Decodable {
+        /// Missing key defaults to false, matching the vmlx pipeline's
+        /// `config?.normalize ?? false`.
+        let normalize: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case normalize
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            normalize = try container.decodeIfPresent(Bool.self, forKey: .normalize) ?? false
+        }
+    }
+
     private let modelName: String
     private let dimensionValue: Int
     private let tokenizerLoader: any TokenizerLoader
-    private var pipeline: Model2VecStaticEmbeddingPipeline?
+    private var model: LoadedModel?
 
     public init(
         modelName: String,
@@ -69,25 +100,108 @@ public actor VMLXModel2VecEmbedder: VecturaEmbedder {
     }
 
     public func embed(texts: [String]) async throws -> [[Float]] {
-        let pipeline = try await pipeline()
-        return try await pipeline.embed(texts: texts)
+        guard !texts.isEmpty else { return [] }
+        let model = try await loadedModel()
+        let dimension = model.embeddings.shape[1]
+
+        // Tokenize on CPU, dropping unknown tokens exactly like the vmlx
+        // pipeline does.
+        let tokenIDs: [[Int32]] = texts.map { text in
+            model.tokenizer.encode(text: text, addSpecialTokens: false)
+                .filter { token in
+                    guard let unknownTokenId = model.unknownTokenId else { return true }
+                    return token != unknownTokenId
+                }
+                .map(Int32.init)
+        }
+
+        let maxLength = tokenIDs.map(\.count).max() ?? 0
+        guard maxLength > 0 else {
+            // Every text tokenized to nothing: zero vectors, no GPU work.
+            return texts.map { _ in [Float](repeating: 0, count: dimension) }
+        }
+
+        // Pad token ids to [N, L] with row 0 (any valid row); the mask zeroes
+        // the padding's contribution to the mean.
+        var flatIDs = [Int32]()
+        flatIDs.reserveCapacity(texts.count * maxLength)
+        var flatMask = [Float]()
+        flatMask.reserveCapacity(texts.count * maxLength)
+        for ids in tokenIDs {
+            flatIDs.append(contentsOf: ids)
+            flatIDs.append(contentsOf: repeatElement(0, count: maxLength - ids.count))
+            flatMask.append(contentsOf: repeatElement(1, count: ids.count))
+            flatMask.append(contentsOf: repeatElement(0, count: maxLength - ids.count))
+        }
+
+        let ids = MLXArray(flatIDs, [texts.count, maxLength])
+        let mask = MLXArray(flatMask, [texts.count, maxLength, 1])
+        let gathered = model.embeddings.take(ids, axis: 0)  // [N, L, D]
+        // Masked mean; the max(count, 1) keeps an all-unknown text a clean
+        // zero vector instead of 0/0 (matching the pipeline's empty-token
+        // early return).
+        let counts = maximum(mask.sum(axis: 1), MLXArray(Float(1)))  // [N, 1]
+        let means = (gathered * mask).sum(axis: 1) / counts  // [N, D]
+        let vectors: MLXArray
+        if model.normalize {
+            // Row-wise L2 normalize with the norm clamped away from zero,
+            // matching `MLXArray.l2Normalized(axis:eps:)` (which is declared
+            // identically in both MLX and MLXEmbedders and is therefore
+            // ambiguous to call here).
+            let norms = sqrt((means * means).sum(axis: -1, keepDims: true))
+            vectors = means / maximum(norms, MLXArray(Float(1e-12)))
+        } else {
+            vectors = means
+        }
+        eval(vectors)
+
+        let flat = vectors.asArray(Float.self)
+        return (0..<texts.count).map { row in
+            Array(flat[(row * dimension)..<((row + 1) * dimension)])
+        }
     }
 
     public func embed(text: String) async throws -> [Float] {
-        let pipeline = try await pipeline()
-        return try await pipeline.embed(text: text)
+        guard let vector = try await embed(texts: [text]).first else {
+            throw VMLXModel2VecEmbedderError.invalidModelBundle(
+                "Embedding forward returned no vector for a single-text batch"
+            )
+        }
+        return vector
     }
 
-    private func pipeline() async throws -> Model2VecStaticEmbeddingPipeline {
-        if let pipeline {
-            return pipeline
+    private func loadedModel() async throws -> LoadedModel {
+        if let model {
+            return model
         }
         let directory = try resolveModelDirectory()
-        let loaded = try await Model2VecStaticEmbeddingPipeline.load(
-            from: directory,
-            using: tokenizerLoader
+        let weightsURL = directory.appending(component: "model.safetensors")
+        let weights = try loadArrays(url: weightsURL)
+        guard let embeddings = weights["embeddings"] else {
+            throw VMLXModel2VecEmbedderError.invalidModelBundle(
+                "Missing 'embeddings' tensor in \(weightsURL.path)"
+            )
+        }
+        guard embeddings.shape.count == 2 else {
+            throw VMLXModel2VecEmbedderError.invalidModelBundle(
+                "Model2Vec embeddings tensor must be rank 2, got shape \(embeddings.shape)"
+            )
+        }
+        eval(embeddings)
+
+        let configURL = directory.appending(component: "config.json")
+        let config = try? JSONDecoder.json5().decode(
+            BundleConfiguration.self,
+            from: Data(contentsOf: configURL)
         )
-        pipeline = loaded
+        let tokenizer = try await tokenizerLoader.load(from: directory)
+        let loaded = LoadedModel(
+            embeddings: embeddings,
+            tokenizer: tokenizer,
+            unknownTokenId: tokenizer.unknownTokenId,
+            normalize: config?.normalize ?? false
+        )
+        model = loaded
         return loaded
     }
 
@@ -166,12 +280,15 @@ public actor VMLXModel2VecEmbedder: VecturaEmbedder {
 
 public enum VMLXModel2VecEmbedderError: LocalizedError {
     case modelNotFound(String)
+    case invalidModelBundle(String)
 
     public var errorDescription: String? {
         switch self {
         case .modelNotFound(let modelName):
             return
                 "Could not find local Model2Vec embedding model '\(modelName)'. Set OSAURUS_EMBEDDING_MODEL_DIR or install minishlab/\(modelName) in the Hugging Face cache."
+        case .invalidModelBundle(let reason):
+            return "Invalid Model2Vec embedding model bundle: \(reason)"
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Memory/MetalSafeEmbedder.swift
+++ b/Packages/OsaurusCore/Services/Memory/MetalSafeEmbedder.swift
@@ -102,6 +102,42 @@ public actor VMLXModel2VecEmbedder: VecturaEmbedder {
     public func embed(texts: [String]) async throws -> [[Float]] {
         guard !texts.isEmpty else { return [] }
         let model = try await loadedModel()
+
+        // Bound the batched forward's working set: the padded gather
+        // materializes [N, L_max, D] floats, and N is CLIENT-CONTROLLED on
+        // the /v1/embeddings pass-through (CoalescingEmbedder hands
+        // caller-assembled arrays straight here) — an unbounded request
+        // would materialize an unbounded GPU allocation. Process in chunks
+        // of at most `EmbeddingBatcher.defaultMaxBatchSize` (the same bound
+        // the micro-batcher keeps for its coalesced batches: 16 × 512
+        // tokens × 128 dims of Float is ~4 MB per chunk) and concatenate.
+        // Sequential chunks all run inside the CALLER's single MetalGate
+        // acquisition — `MetalSafeEmbedder.embed(texts:)` wraps this whole
+        // method, so chunking never releases/re-acquires the gate mid-batch.
+        var results: [[Float]] = []
+        results.reserveCapacity(texts.count)
+        for range in Self.forwardChunkRanges(
+            count: texts.count,
+            maxChunkSize: EmbeddingBatcher.defaultMaxBatchSize
+        ) {
+            results.append(contentsOf: embedChunk(Array(texts[range]), model: model))
+        }
+        return results
+    }
+
+    /// Contiguous ranges of at most `maxChunkSize` covering `0..<count`, in
+    /// order. Pure helper backing the bounded chunked forward above; kept
+    /// static so the boundary math is unit-testable without loading MLX.
+    static func forwardChunkRanges(count: Int, maxChunkSize: Int) -> [Range<Int>] {
+        guard count > 0, maxChunkSize > 0 else { return [] }
+        return stride(from: 0, to: count, by: maxChunkSize).map { start in
+            start..<min(start + maxChunkSize, count)
+        }
+    }
+
+    /// One bounded batched forward: padded `[N, L]` gather + masked mean +
+    /// eval for `texts.count <= EmbeddingBatcher.defaultMaxBatchSize` texts.
+    private func embedChunk(_ texts: [String], model: LoadedModel) -> [[Float]] {
         let dimension = model.embeddings.shape[1]
 
         // Tokenize on CPU, dropping unknown tokens exactly like the vmlx

--- a/Packages/OsaurusCore/Tests/Memory/EmbeddingBatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/EmbeddingBatcherTests.swift
@@ -1,0 +1,338 @@
+//
+//  EmbeddingBatcherTests.swift
+//  osaurusTests
+//
+//  Batcher-logic tests run against a mock backend (never the real model):
+//  coalescing, result distribution, error propagation, cancellation
+//  isolation, and the window latency bound. Timing-sensitive tests inject
+//  the window duration and only assert bounds that cannot flake (lower
+//  bounds from `clock.sleep`, and upper bounds far below an injected huge
+//  window).
+//
+
+import Foundation
+import MLX
+import Testing
+import VecturaKit
+
+@testable import OsaurusCore
+
+// MARK: - Mocks
+
+/// Backend that records every batch it receives and returns a deterministic
+/// vector per text (no time, no randomness).
+private actor CountingBackend {
+    private(set) var calls: [[String]] = []
+    private let failure: (any Error)?
+
+    init(failure: (any Error)? = nil) {
+        self.failure = failure
+    }
+
+    func embed(_ texts: [String]) throws -> [[Float]] {
+        calls.append(texts)
+        if let failure {
+            throw failure
+        }
+        return texts.map(Self.vector(for:))
+    }
+
+    nonisolated static func vector(for text: String) -> [Float] {
+        [
+            Float(text.utf8.count),
+            Float(text.unicodeScalars.first?.value ?? 0),
+            Float(text.unicodeScalars.last?.value ?? 0),
+        ]
+    }
+}
+
+private struct BackendFailure: Error, Equatable {}
+
+private actor RecordingVecturaEmbedder: VecturaEmbedder {
+    private(set) var singleCalls: [String] = []
+    private(set) var batchCalls: [[String]] = []
+
+    var dimension: Int {
+        get async throws { 3 }
+    }
+
+    func embed(texts: [String]) async throws -> [[Float]] {
+        batchCalls.append(texts)
+        return texts.map(CountingBackend.vector(for:))
+    }
+
+    func embed(text: String) async throws -> [Float] {
+        singleCalls.append(text)
+        return CountingBackend.vector(for: text)
+    }
+}
+
+// MARK: - Batcher tests
+
+struct EmbeddingBatcherTests {
+    private func makeBatcher(
+        window: Duration,
+        maxBatchSize: Int = EmbeddingBatcher.defaultMaxBatchSize,
+        backend: CountingBackend
+    ) -> EmbeddingBatcher {
+        EmbeddingBatcher(window: window, maxBatchSize: maxBatchSize) { texts in
+            try await backend.embed(texts)
+        }
+    }
+
+    @Test func batchedOutputMatchesSequentialOutput() async throws {
+        let backend = CountingBackend()
+        let batcher = makeBatcher(window: .milliseconds(100), backend: backend)
+        let texts = ["alpha", "bravo", "charlie", "delta", "echo"]
+
+        let batched = try await withThrowingTaskGroup(of: (String, [Float]).self) { group in
+            for text in texts {
+                group.addTask { (text, try await batcher.embed(text)) }
+            }
+            var results: [String: [Float]] = [:]
+            for try await (text, vector) in group {
+                results[text] = vector
+            }
+            return results
+        }
+
+        // Sequential reference: what one direct call per text would return.
+        for text in texts {
+            #expect(batched[text] == CountingBackend.vector(for: text))
+        }
+    }
+
+    @Test func concurrentCallersCoalesceIntoOneBackendCall() async throws {
+        let backend = CountingBackend()
+        // Generous window so all concurrently spawned callers land inside it
+        // even on a heavily loaded machine.
+        let batcher = makeBatcher(window: .milliseconds(500), backend: backend)
+        let texts = ["one", "two", "three", "four"]
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for text in texts {
+                group.addTask { _ = try await batcher.embed(text) }
+            }
+            try await group.waitForAll()
+        }
+
+        let calls = await backend.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.sorted() == texts.sorted())
+    }
+
+    @Test func loneCallerLatencyIsBoundedByWindow() async throws {
+        let backend = CountingBackend()
+        let window: Duration = .milliseconds(50)
+        let batcher = makeBatcher(window: window, backend: backend)
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let vector = try await batcher.embed("solo")
+        let elapsed = clock.now - start
+
+        #expect(vector == CountingBackend.vector(for: "solo"))
+        // A lone request waits out exactly one window before its (instant,
+        // mocked) forward: at least `window`, and nowhere near 100x it. The
+        // generous upper bound only catches "window never closed" bugs
+        // without flaking on scheduler noise.
+        #expect(elapsed >= window)
+        #expect(elapsed < .seconds(5))
+        let calls = await backend.calls
+        #expect(calls == [["solo"]])
+    }
+
+    @Test func errorPropagatesToEveryWaiter() async throws {
+        let backend = CountingBackend(failure: BackendFailure())
+        let batcher = makeBatcher(window: .milliseconds(100), backend: backend)
+
+        let outcomes = await withTaskGroup(of: Bool.self) { group in
+            for text in ["a", "b", "c"] {
+                group.addTask {
+                    do {
+                        _ = try await batcher.embed(text)
+                        return false
+                    } catch is BackendFailure {
+                        return true
+                    } catch {
+                        return false
+                    }
+                }
+            }
+            var failures: [Bool] = []
+            for await sawExpectedError in group {
+                failures.append(sawExpectedError)
+            }
+            return failures
+        }
+
+        #expect(outcomes == [true, true, true])
+        let calls = await backend.calls
+        #expect(calls.count == 1)
+    }
+
+    @Test func cancellingOneWaiterDoesNotKillTheBatch() async throws {
+        let backend = CountingBackend()
+        let batcher = makeBatcher(window: .milliseconds(500), backend: backend)
+
+        let survivorA = Task { try await batcher.embed("alpha") }
+        let cancelled = Task { try await batcher.embed("bravo") }
+        let survivorB = Task { try await batcher.embed("charlie") }
+
+        // Give all three time to enqueue inside the 500 ms window, then
+        // cancel the middle waiter while the window is still open.
+        try await Task.sleep(for: .milliseconds(100))
+        cancelled.cancel()
+
+        #expect(try await survivorA.value == CountingBackend.vector(for: "alpha"))
+        #expect(try await survivorB.value == CountingBackend.vector(for: "charlie"))
+        await #expect(throws: CancellationError.self) {
+            _ = try await cancelled.value
+        }
+
+        let calls = await backend.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.contains("alpha") == true)
+        #expect(calls.first?.contains("charlie") == true)
+    }
+
+    @Test func fullBatchFlushesWithoutWaitingForTheWindow() async throws {
+        let backend = CountingBackend()
+        // Window intentionally enormous: completion well before it proves the
+        // max-batch-size flush fired, with no dependence on tight timing.
+        let batcher = makeBatcher(
+            window: .seconds(30), maxBatchSize: 3, backend: backend
+        )
+        let texts = ["x", "y", "z"]
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for text in texts {
+                group.addTask { _ = try await batcher.embed(text) }
+            }
+            try await group.waitForAll()
+        }
+        let elapsed = clock.now - start
+
+        #expect(elapsed < .seconds(10))
+        let calls = await backend.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.count == 3)
+    }
+
+    @Test func sequentialLoneCallersGetOneBatchEach() async throws {
+        let backend = CountingBackend()
+        let batcher = makeBatcher(window: .milliseconds(20), backend: backend)
+
+        let first = try await batcher.embed("first")
+        let second = try await batcher.embed("second")
+
+        #expect(first == CountingBackend.vector(for: "first"))
+        #expect(second == CountingBackend.vector(for: "second"))
+        let calls = await backend.calls
+        #expect(calls == [["first"], ["second"]])
+    }
+}
+
+// MARK: - CoalescingEmbedder routing
+
+struct CoalescingEmbedderTests {
+    @Test func singleTextRoutesThroughBatcherAndBatchesPassThrough() async throws {
+        let direct = RecordingVecturaEmbedder()
+        let backend = CountingBackend()
+        let embedder = CoalescingEmbedder(
+            direct: direct,
+            batcher: EmbeddingBatcher(window: .milliseconds(20)) { texts in
+                try await backend.embed(texts)
+            }
+        )
+
+        // Caller-assembled batches bypass the window entirely.
+        let batchResult = try await embedder.embed(texts: ["p", "q"])
+        #expect(batchResult == [["p", "q"].map(CountingBackend.vector(for:))].flatMap { $0 })
+        #expect(await direct.batchCalls == [["p", "q"]])
+        #expect(await backend.calls.isEmpty)
+
+        // Single-text embeds coalesce through the batcher's backend.
+        let single = try await embedder.embed(text: "r")
+        #expect(single == CountingBackend.vector(for: "r"))
+        #expect(await backend.calls == [["r"]])
+        #expect(await direct.singleCalls.isEmpty)
+    }
+}
+
+// MARK: - Real-model batch parity (skipped when the model is not local)
+
+/// Verifies the batched `[N, L]` padded forward in `VMLXModel2VecEmbedder`
+/// produces the same vectors as one-at-a-time forwards — i.e. padding and
+/// masking do not change any text's embedding.
+///
+/// Opt-in: MLX hard-aborts the whole test process when its metallib is not
+/// locatable, and plain `swift test` has no Cmlx resource bundle. Run with
+/// the model directory override set and a `default.metallib` (from an app
+/// build's Cmlx bundle) copied next to the package manifest:
+///
+///     OSAURUS_EMBEDDING_MODEL_DIR=/path/to/potion-base-4M \
+///       swift test --package-path Packages/OsaurusCore \
+///       --filter VMLXModel2VecEmbedderBatchParityTests
+struct VMLXModel2VecEmbedderBatchParityTests {
+    private static var explicitModelDirectoryUsable: Bool {
+        // Require the deliberate env override — merely having the model in
+        // the Hugging Face cache must not opt a plain `swift test` run into
+        // MLX initialization (see the metallib abort note above).
+        guard
+            let override = ProcessInfo.processInfo.environment["OSAURUS_EMBEDDING_MODEL_DIR"],
+            !override.isEmpty
+        else { return false }
+        return VMLXModel2VecEmbedder.locateModelDirectory(modelName: EmbeddingService.modelName)
+            != nil
+    }
+
+    @Test(.enabled(if: explicitModelDirectoryUsable))
+    func batchedForwardMatchesPerTextForward() async throws {
+        // The parity property (padding/masking must not change any text's
+        // vector) is device-independent; pin to the CPU device so results
+        // do not depend on the host GPU.
+        Device.setDefault(device: .cpu)
+
+        let embedder = VMLXModel2VecEmbedder(
+            modelName: EmbeddingService.modelName,
+            dimension: EmbeddingService.embeddingDimension,
+            tokenizerLoader: SwiftTransformersTokenizerLoader()
+        )
+        // Mixed lengths force real padding; the empty string exercises the
+        // zero-token row inside a batch.
+        let texts = [
+            "dog",
+            "a much longer sentence about memory search and distillation workloads",
+            "",
+            "batching",
+        ]
+
+        let batched = try await embedder.embed(texts: texts)
+        #expect(batched.count == texts.count)
+
+        for (index, text) in texts.enumerated() {
+            let single = try await embedder.embed(text: text)
+            #expect(single.count == batched[index].count)
+            let maxDelta = zip(single, batched[index])
+                .map { abs($0 - $1) }
+                .max() ?? 0
+            // Reduction order differs between the padded batched mean and the
+            // single-text mean, so allow float32 noise but nothing more.
+            #expect(maxDelta < 1e-4, "vector mismatch for texts[\(index)] = \(text)")
+        }
+
+        // potion-base-4M normalizes: every non-empty text embeds to a unit
+        // vector, and the empty text stays exactly zero.
+        for (index, text) in texts.enumerated() {
+            let norm = batched[index].map { $0 * $0 }.reduce(0, +).squareRoot()
+            if text.isEmpty {
+                #expect(norm == 0)
+            } else {
+                #expect(abs(norm - 1) < 1e-3)
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Memory/EmbeddingBatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/EmbeddingBatcherTests.swift
@@ -234,6 +234,97 @@ struct EmbeddingBatcherTests {
         let calls = await backend.calls
         #expect(calls == [["first"], ["second"]])
     }
+
+    /// Chunked == unchunked: 40 concurrent requests against the default
+    /// 16-text bound must return exactly the vectors a direct unchunked
+    /// call would, with every backend batch capped at the bound.
+    @Test func fortyTextsChunkedResultsMatchUnchunkedReference() async throws {
+        let backend = CountingBackend()
+        let batcher = makeBatcher(window: .milliseconds(200), backend: backend)
+        let texts = (0..<40).map { "text-\($0)" }
+
+        let chunked = try await withThrowingTaskGroup(of: (String, [Float]).self) { group in
+            for text in texts {
+                group.addTask { (text, try await batcher.embed(text)) }
+            }
+            var results: [String: [Float]] = [:]
+            for try await (text, vector) in group {
+                results[text] = vector
+            }
+            return results
+        }
+
+        // Unchunked reference: the deterministic per-text vector the mock
+        // returns regardless of batching.
+        for text in texts {
+            #expect(chunked[text] == CountingBackend.vector(for: text))
+        }
+        let calls = await backend.calls
+        #expect(calls.flatMap { $0 }.count == texts.count)
+        #expect(
+            calls.allSatisfy { $0.count <= EmbeddingBatcher.defaultMaxBatchSize },
+            "every backend batch must respect the 16-text bound"
+        )
+    }
+
+    /// A backend returning the wrong number of vectors must surface the
+    /// typed `mismatchedResultCount` to every waiter of that batch —
+    /// silently misaligning vectors to texts would corrupt the index.
+    @Test func mismatchedResultCountPropagatesTypedError() async throws {
+        let batcher = EmbeddingBatcher(window: .milliseconds(100)) { texts in
+            // Wrong count: drops the last vector.
+            texts.dropLast().map(CountingBackend.vector(for:))
+        }
+
+        let outcomes = await withTaskGroup(of: Bool.self) { group in
+            for text in ["a", "b", "c"] {
+                group.addTask {
+                    do {
+                        _ = try await batcher.embed(text)
+                        return false
+                    } catch let error as EmbeddingBatcherError {
+                        return error
+                            == .mismatchedResultCount(expected: 3, received: 2)
+                    } catch {
+                        return false
+                    }
+                }
+            }
+            var sawTypedError: [Bool] = []
+            for await outcome in group {
+                sawTypedError.append(outcome)
+            }
+            return sawTypedError
+        }
+        #expect(outcomes == [true, true, true])
+    }
+}
+
+// MARK: - Direct-forward chunk bounds (pure math, no MLX)
+
+struct VMLXModel2VecEmbedderChunkingTests {
+    /// The /v1/embeddings pass-through bound: client-controlled arrays are
+    /// processed in chunks of at most `EmbeddingBatcher.defaultMaxBatchSize`
+    /// so the padded [N, L_max, D] gather can never be sized by the client.
+    @Test func fortyTextsSplitIntoBoundedOrderedRanges() {
+        let ranges = VMLXModel2VecEmbedder.forwardChunkRanges(
+            count: 40, maxChunkSize: EmbeddingBatcher.defaultMaxBatchSize
+        )
+        #expect(ranges == [0..<16, 16..<32, 32..<40])
+    }
+
+    @Test func chunkRangeEdgeCases() {
+        #expect(VMLXModel2VecEmbedder.forwardChunkRanges(count: 0, maxChunkSize: 16).isEmpty)
+        #expect(VMLXModel2VecEmbedder.forwardChunkRanges(count: 1, maxChunkSize: 16) == [0..<1])
+        #expect(VMLXModel2VecEmbedder.forwardChunkRanges(count: 16, maxChunkSize: 16) == [0..<16])
+        #expect(
+            VMLXModel2VecEmbedder.forwardChunkRanges(count: 17, maxChunkSize: 16)
+                == [0..<16, 16..<17]
+        )
+        // Defensive: a non-positive bound yields no ranges instead of
+        // looping forever.
+        #expect(VMLXModel2VecEmbedder.forwardChunkRanges(count: 5, maxChunkSize: 0).isEmpty)
+    }
 }
 
 // MARK: - CoalescingEmbedder routing
@@ -376,6 +467,32 @@ struct VMLXModel2VecEmbedderBatchParityTests {
         #expect(try await embedder.embed(texts: []).isEmpty)
         await #expect(throws: (any Error).self) {
             _ = try await reference.embed(texts: [])
+        }
+    }
+
+    /// The bounded direct pass-through: a 40-text call crosses the 16-text
+    /// chunk bound (three sequential chunks) and must return exactly the
+    /// per-text vectors, in input order — chunk boundaries must be
+    /// invisible in the output.
+    @Test(.enabled(if: explicitModelDirectoryUsable))
+    func chunkedDirectBatchMatchesPerTextForward() async throws {
+        Device.setDefault(device: .cpu)
+
+        let embedder = VMLXModel2VecEmbedder(
+            modelName: EmbeddingService.modelName,
+            dimension: EmbeddingService.embeddingDimension,
+            tokenizerLoader: SwiftTransformersTokenizerLoader()
+        )
+        let texts = (0..<40).map { "chunk parity sample number \($0) with some shared words" }
+
+        let chunked = try await embedder.embed(texts: texts)
+        #expect(chunked.count == texts.count)
+        for (index, text) in texts.enumerated() {
+            let single = try await embedder.embed(text: text)
+            let maxDelta = zip(single, chunked[index])
+                .map { abs($0 - $1) }
+                .max() ?? 0
+            #expect(maxDelta < 1e-4, "vector mismatch for texts[\(index)] = \(text)")
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Memory/EmbeddingBatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/EmbeddingBatcherTests.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import MLX
+import MLXEmbedders
 import Testing
 import VecturaKit
 
@@ -265,8 +266,12 @@ struct CoalescingEmbedderTests {
 // MARK: - Real-model batch parity (skipped when the model is not local)
 
 /// Verifies the batched `[N, L]` padded forward in `VMLXModel2VecEmbedder`
-/// produces the same vectors as one-at-a-time forwards — i.e. padding and
-/// masking do not change any text's embedding.
+/// against two references: its own one-at-a-time forwards (padding and
+/// masking must not change any text's embedding) and vmlx-swift's ORIGINAL
+/// sequential `Model2VecStaticEmbeddingPipeline` — the implementation the
+/// batched forward replaced — so a systematic semantic deviation (tokenizer
+/// handling, unknown-token filtering, normalize behavior) cannot hide
+/// behind a self-comparison where both sides run the new code.
 ///
 /// Opt-in: MLX hard-aborts the whole test process when its metallib is not
 /// locatable, and plain `swift test` has no Cmlx resource bundle. Run with
@@ -333,6 +338,44 @@ struct VMLXModel2VecEmbedderBatchParityTests {
             } else {
                 #expect(abs(norm - 1) < 1e-3)
             }
+        }
+
+        // Reference parity against vmlx-swift's original sequential pipeline,
+        // loaded from the same bundle with the same tokenizer loader. This is
+        // the semantic ground truth the batched forward must reproduce.
+        let directory = try #require(
+            VMLXModel2VecEmbedder.locateModelDirectory(modelName: EmbeddingService.modelName)
+        )
+        let reference = try await Model2VecStaticEmbeddingPipeline.load(
+            from: directory,
+            using: SwiftTransformersTokenizerLoader()
+        )
+        for (index, text) in texts.enumerated() {
+            // Per-text calls, so the reference runs its own (sequential)
+            // convention for every input — including the empty string, for
+            // which it returns an all-zero vector like the batched forward.
+            let expected = try await reference.embed(texts: [text])[0]
+            #expect(expected.count == batched[index].count)
+            let maxDelta = zip(expected, batched[index])
+                .map { abs($0 - $1) }
+                .max() ?? 0
+            // Observed on potion-base-4M: max delta 1.5e-08 (float32
+            // reduction-order noise on the longest text; exact zeros
+            // elsewhere).
+            #expect(
+                maxDelta < 1e-4,
+                "vmlx reference pipeline mismatch for texts[\(index)] = \(text)"
+            )
+        }
+
+        // Intentional convention difference, asserted on both sides so a
+        // silent change in either implementation fails here: for an EMPTY
+        // INPUT ARRAY the batched embedder returns [] (VecturaKit callers
+        // may forward empty document lists), while the vmlx pipeline throws
+        // `Model2VecStaticEmbeddingError.emptyBatch`.
+        #expect(try await embedder.embed(texts: []).isEmpty)
+        await #expect(throws: (any Error).self) {
+            _ = try await reference.embed(texts: [])
         }
     }
 }


### PR DESCRIPTION
## What

Micro-batches the local embedding path into genuinely batched MLX forwards:

- **`EmbeddingBatcher`** (actor): the first request in an idle period opens a 25 ms window (later arrivals never extend it, so a lone caller's added latency is bounded by one window); up to 16 requests coalesce, with immediate flush when full; per-batch errors propagate to every waiter; cancelling one waiter removes only that caller. Clock and window are injectable for tests.
- **A true `[N, L]` batched forward** in `VMLXModel2VecEmbedder`: padded gather → masked mean → row L2-normalize → **one** `eval` per batch. This was necessary because vmlx-swift's `embed(texts:)` is secretly a sequential loop (`texts.map(embedOne)` — one gather+eval per text), so a coalescing front alone would have been a fake batch.
- All four VecturaKit call sites (memory/skill/tool/method search) pick up batching through the shared embedder with zero call-site changes; `/v1/embeddings` and the plugin `embed(texts:)` paths are pass-through.
- **MetalGate discipline preserved and improved**: one coalesced batch acquires the embedding gate once, instead of N sequential acquisitions each potentially queueing behind active generation.

## Why

Embeddings are the highest-frequency small inference in osaurus (memory search + distillation), and they serialize today — both at the gate and in vmlx's per-text loop. Batched execution amortizes the gate acquisition, kernel launches, and eval/`asArray` round-trips; the biggest practical win is under generation load, where each embedding previously re-queued behind the generation gate individually.

## Measurement

- **Reference parity against vmlx's original pipeline** (the implementation this replaces), on the real potion-base-4M bundle: max delta **1.49e-08** on the longest padded text, exactly **0.0** on the others including the empty string; unit norms verified. The reference dependency (`MLXEmbedders`) is test-target-only.
- One intentional convention difference, asserted explicitly on both sides so silent drift fails the test: empty *input array* returns `[]` here vs vmlx throwing `emptyBatch`.
- 9/9 batcher tests (batched==sequential via counting mock; N concurrent callers → exactly 1 backend call; lone-caller latency bound; error propagation; cancellation isolation; full-batch early flush) + 106 memory-suite regression tests green; build + swiftlint clean.
- The real-model parity test is opt-in (`OSAURUS_EMBEDDING_MODEL_DIR`) because MLX hard-aborts the test process when its metallib isn't locatable under plain `swift test` — the same reason no existing test runs MLX compute.

## Risk & rollback

Worst case for a lone embedding call is +25 ms (documented; negligible against gate-contention waits it replaces). The batched math is validated to 1e-8 against the prior implementation. A follow-up worth doing upstream: vectorize `Model2VecStaticEmbeddingPipeline.embed(texts:)` in vmlx-swift so the ~40 mirrored loader lines here can shrink back to a coalescing front. Revert = two commits.