### PR TITLE
Skip proactive model warm-up when the projected load exceeds the hard RAM ceiling

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -167,6 +167,16 @@ extension ChatSession: ChatWarmupSessionContext {
 
         guard !ChatConfigurationStore.load().warmModelsOnLoad else { return }
         guard let model = selectedModel, !model.isEmpty, selectedModelIsLocal else { return }
+        // Same RAM gate as the warm-up path: a switch-triggered preload is
+        // Osaurus-initiated background work and must not force a load whose
+        // projection exceeds the hard RAM ceiling — that's a fatal Metal OOM
+        // on machines where the selected model can't fit. The send path
+        // surfaces the block to the user via the input card's banner.
+        if let feasibility = await ModelRuntime.shared.projectedLoadFeasibility(for: model),
+            feasibility.loadPressureSeverity == .block
+        {
+            return
+        }
         try? await ModelRuntime.shared.preload(name: model)
     }
 

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -56,6 +56,17 @@ final class ChatWarmupController: ObservableObject {
     /// Debounce coalescing fingerprint-invalidating warm-up retriggers.
     static let scheduleDebounce: Duration = .milliseconds(500)
 
+    /// Projected RAM feasibility for a candidate warm-up load (test seam;
+    /// production queries the shared runtime). Warm-up is Osaurus-initiated
+    /// background work, so a projection past the hard RAM ceiling skips it
+    /// entirely — proactively loading a model that can't fit is how a
+    /// window-open warm-up turns into a fatal Metal OOM
+    /// (kIOGPUCommandBufferCallbackErrorOutOfMemory) on small machines.
+    var projectedLoadFeasibility: @MainActor (String) async -> ModelRuntime.RAMFeasibility? =
+        { model in
+            await ModelRuntime.shared.projectedLoadFeasibility(for: model)
+        }
+
     @Published private(set) var state: WarmState = .cold
 
     /// True when the UI should render the green "warm" dot.
@@ -290,6 +301,24 @@ final class ChatWarmupController: ObservableObject {
             state = .warm
             return
         }
+
+        // RAM gate: never proactively load a model whose projection exceeds
+        // the hard ceiling (documented `modelLoadRAMHardThreshold`) or that
+        // outright exceeds physical memory. The send path stays gated by the
+        // input card's red banner, which tells the user why; a nil projection
+        // (model already resident, or size unknown) proceeds normally.
+        if let feasibility = await projectedLoadFeasibility(payload.model),
+            feasibility.loadPressureSeverity == .block
+        {
+            state = .cold
+            debugLog(
+                "[ChatWarmup] skipped model=\(payload.model): projected load "
+                    + "\(feasibility.projectedBytes)B exceeds hard limit \(feasibility.hardLimitBytes)B"
+            )
+            return
+        }
+        guard !Task.isCancelled else { return }
+        guard shouldAttemptWarmup(session: session) else { return }
 
         state = .warming
         let id = UUID()

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -136,6 +136,108 @@ struct ChatWarmupControllerModelSwitchTests {
     }
 }
 
+@Suite("ChatWarmupController RAM gate")
+@MainActor
+struct ChatWarmupControllerRAMGateTests {
+
+    private static func feasibility(
+        projected: Int64,
+        soft: Int64,
+        hard: Int64,
+        physical: Int64,
+        requiredAvailable: Int64
+    ) -> ModelRuntime.RAMFeasibility {
+        ModelRuntime.RAMFeasibility(
+            modelName: "test-model",
+            verdict: projected > soft ? .tight : .ok,
+            incomingWeightsBytes: projected,
+            incomingLoadFootprintBytes: projected,
+            residentWeightsBytes: 0,
+            kvHeadroomBytes: 0,
+            projectedBytes: projected,
+            physicalMemoryBytes: physical,
+            availableMemoryBytes: physical,
+            requiredAvailableBytes: requiredAvailable,
+            softLimitBytes: soft,
+            hardLimitBytes: hard,
+            timestamp: Date()
+        )
+    }
+
+    /// Sentry APPLE-MACOS-3T: a window-open warm-up of a 31B model on a
+    /// 24GB machine died in a fatal Metal OOM. Proactive warm-up must skip
+    /// entirely when the projection is block-severity.
+    @Test("warm-up is skipped when the projected load exceeds the hard RAM ceiling")
+    func warmupSkippedWhenProjectionBlocks() async {
+        let gib: Int64 = 1_073_741_824
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|hint|"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in
+            Self.feasibility(
+                projected: 23 * gib,
+                soft: Int64(16.8 * Double(gib)),
+                hard: Int64(21.6 * Double(gib)),
+                physical: 24 * gib,
+                requiredAvailable: 23 * gib
+            )
+        }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        try? await Task.sleep(for: .milliseconds(150))
+        await controller.awaitInFlightWarmup()
+
+        // No generation was started, and the dot must not claim warming.
+        #expect(engine.lastRequest == nil)
+        #expect(controller.state == .cold)
+    }
+
+    @Test("warn-severity projection still warms up")
+    func warnSeverityStillWarms() async {
+        let gib: Int64 = 1_073_741_824
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|hint|"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in
+            Self.feasibility(
+                projected: 18 * gib,
+                soft: Int64(16.8 * Double(gib)),
+                hard: Int64(21.6 * Double(gib)),
+                physical: 24 * gib,
+                requiredAvailable: 18 * gib
+            )
+        }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.lastRequest != nil)
+        #expect(controller.state == .warm)
+    }
+}
+
 @Suite("ChatWarmupController request fidelity")
 @MainActor
 struct ChatWarmupControllerRequestTests {


### PR DESCRIPTION
## Summary

Fixes APPLE-MACOS-3T

**The crash** (83 events in 0.21.8, ongoing): a fatal, unhandled `[METAL] Command buffer execution failed: Insufficient Memory (kIOGPUCommandBufferCallbackErrorOutOfMemory)`. Breadcrumbs on the latest event show app start → chat window focused → `model.load begin model=gemma-4-31b-jang_4m-uncensored` ~670ms after focus (matching the warm-up's 500ms schedule debounce) → crash ~1s later, on a 24GB Mac with ~168MB free. The user never sent a message — the proactive warm-up on window open triggered the load.

**The gap**: the RAM tight-fit gate only blocks *sends*. The proactive warm-up (`ChatWarmupController.performWarmup`) and the switch-triggered plain preload (`performModelResidencySwitch`, warm-up feature off) loaded unconditionally.

**The fix**: both paths now check `ModelRuntime.projectedLoadFeasibility` before loading and skip at block severity — projection past the documented `modelLoadRAMHardThreshold` (default 90%), or a model that outright exceeds physical memory:

- `ChatWarmupController` gets the projection through an injectable seam (unit-testable without GPU). A blocked warm-up leaves the dot cold and logs the projected vs. limit bytes; the input card's red RAM banner (already shipped) tells the user why and blocks send.
- A `nil` projection (model already resident, or size unprovable) proceeds normally, so warm resident turns are unaffected.
- Scope is Osaurus-initiated background work only: the runtime/API load path stays advisory per the model-runtime rules — no new hidden RAM blocks, only the documented threshold already used by the send gate.

Once memory frees or the user selects a smaller model, warm-up resumes automatically on the next trigger (model change, session activation, run completion).

## Test plan

- [x] `ChatWarmupControllerTests` — new "RAM gate" suite: block-severity projection skips the warm-up entirely (no generation started, dot stays cold); warn-severity projection still warms
- [x] All existing warm-up suites pass (immediate model switch, request fidelity, shutdown) — 19 tests green
- [x] `swift build` clean
- [ ] Manual: select an oversized model on a small machine → no load on window open, red banner explains; select a fitting model → warm-up proceeds