### PR TITLE
Add opt-in auto batch sizing driven by observed demand, tier-capped

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -8854,6 +8854,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let obj: [String: Any] = [
                 "status": "healthy",
                 "timestamp": Date().ISO8601Format(),
+                "hardware": ChipProfile.current.healthJSONObject(),
                 "loaded": loaded,
                 "current_model": current,
                 "inflight": inflightObj,

--- a/Packages/OsaurusCore/Services/ChipProfile.swift
+++ b/Packages/OsaurusCore/Services/ChipProfile.swift
@@ -1,0 +1,175 @@
+//
+//  ChipProfile.swift
+//  osaurus
+//
+//  Detects the Apple Silicon chip this process is running on (generation,
+//  tier, RAM, GPU core count, Metal working-set budget) so runtime policy can
+//  be derived from hardware capability instead of one-size-fits-all
+//  constants. Detection is read-only and resolved once per process; nothing
+//  in this file changes runtime behavior by itself.
+//
+//  Why not persist the result: every field is re-derivable in microseconds
+//  from sysctl/IOKit/Metal at launch, and a cached file would go stale when a
+//  Time Machine / Migration Assistant restore moves the install to different
+//  hardware. Persistence becomes worthwhile only for *measured* values
+//  (micro-benchmarked bandwidth/FLOPS), which are out of scope here.
+//
+
+import Foundation
+import IOKit
+import Metal
+import os.log
+
+private let chipLog = Logger(subsystem: "com.dinoki.osaurus", category: "ChipProfile")
+
+/// Immutable snapshot of the host's compute capability.
+struct ChipProfile: Sendable, Equatable {
+    /// Performance tier encoded in Apple's chip branding. `unknown` covers
+    /// Intel Macs, virtual machines, and future naming schemes; policy code
+    /// must treat it as the most conservative tier.
+    enum Tier: String, Sendable {
+        case base
+        case pro
+        case max
+        case ultra
+        case unknown
+    }
+
+    /// Marketing name as reported by the kernel, e.g. "Apple M4 Pro".
+    let brandString: String
+    /// Apple Silicon generation (1 for M1, 5 for M5, …); `nil` when the
+    /// brand string is not an "Apple M<n>" chip.
+    let generation: Int?
+    let tier: Tier
+    /// Physical unified memory in bytes (`hw.memsize`).
+    let physicalMemoryBytes: UInt64
+    /// GPU core count from the IOKit accelerator node; `nil` when the node
+    /// or property is missing (VMs, future driver changes).
+    let gpuCoreCount: Int?
+    /// Metal's per-process working-set recommendation. This is the OS's own
+    /// answer to "how much GPU-visible memory may I comfortably use" and is
+    /// the anchor for any future wired-memory policy.
+    let recommendedMaxWorkingSetBytes: UInt64?
+    /// The M5 family embeds matrix units ("Neural Accelerators") in each GPU
+    /// core, which shifts the prefill/decode balance materially. Derived
+    /// from `generation`, not probed — Metal exposes no direct capability
+    /// bit for them at the API level osaurus targets.
+    var hasGPUNeuralAccelerators: Bool { (generation ?? 0) >= 5 }
+
+    /// Tier for policy decisions: never `unknown`. Unknown hardware gets
+    /// base-tier (most conservative) treatment.
+    var policyTier: Tier { tier == .unknown ? .base : tier }
+
+    // MARK: - Resolution
+
+    /// The host's profile, resolved once on first access.
+    static let current: ChipProfile = {
+        let profile = ChipProfile.detect()
+        chipLog.info(
+            "resolved: brand=\(profile.brandString, privacy: .public) generation=\(profile.generation.map(String.init) ?? "unknown", privacy: .public) tier=\(profile.tier.rawValue, privacy: .public) ramBytes=\(profile.physicalMemoryBytes, privacy: .public) gpuCores=\(profile.gpuCoreCount.map(String.init) ?? "unknown", privacy: .public) workingSetBytes=\(profile.recommendedMaxWorkingSetBytes.map(String.init) ?? "unknown", privacy: .public) neuralAccelerators=\(profile.hasGPUNeuralAccelerators, privacy: .public)"
+        )
+        return profile
+    }()
+
+    static func detect() -> ChipProfile {
+        let brand = sysctlString("machdep.cpu.brand_string") ?? "unknown"
+        let identity = parse(brandString: brand)
+        return ChipProfile(
+            brandString: brand,
+            generation: identity.generation,
+            tier: identity.tier,
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
+            gpuCoreCount: detectGPUCoreCount(),
+            recommendedMaxWorkingSetBytes: MTLCreateSystemDefaultDevice()
+                .map { UInt64($0.recommendedMaxWorkingSetSize) }
+        )
+    }
+
+    // MARK: - Brand-string parsing (pure, unit-tested)
+
+    /// Parses "Apple M<generation>[ Pro|Max|Ultra]" into its components.
+    /// Anything else — Intel brand strings, VMs, a renamed future family —
+    /// yields `(nil, .unknown)` so callers fall back to conservative policy
+    /// rather than guessing.
+    static func parse(brandString: String) -> (generation: Int?, tier: Tier) {
+        let trimmed = brandString.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Anchored so adulterated strings ("VirtualApple M2 …") don't match.
+        guard
+            let match = trimmed.wholeMatch(
+                of: /Apple M(\d+)(?:\s+(Pro|Max|Ultra))?/
+            )
+        else {
+            return (nil, .unknown)
+        }
+        let generation = Int(match.1)
+        let tier: Tier
+        switch match.2 ?? "" {
+        case "Pro": tier = .pro
+        case "Max": tier = .max
+        case "Ultra": tier = .ultra
+        default: tier = .base
+        }
+        return (generation, tier)
+    }
+
+    // MARK: - /health surface
+
+    /// JSON-object form for the `/health` endpoint's `hardware` block.
+    /// Unknown values are surfaced as JSON null (not omitted) so clients can
+    /// distinguish "not detectable here" from "old server without the field".
+    func healthJSONObject() -> [String: Any] {
+        [
+            "chip": brandString,
+            "generation": generation as Any? ?? NSNull(),
+            "tier": tier.rawValue,
+            "physical_memory_bytes": physicalMemoryBytes,
+            "gpu_core_count": gpuCoreCount as Any? ?? NSNull(),
+            "recommended_max_working_set_bytes":
+                recommendedMaxWorkingSetBytes as Any? ?? NSNull(),
+            "gpu_neural_accelerators": hasGPUNeuralAccelerators,
+        ]
+    }
+
+    // MARK: - Probes
+
+    private static func sysctlString(_ name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else { return nil }
+        return String(cString: buffer)
+    }
+
+    /// Reads `gpu-core-count` from the AGXAccelerator IORegistry node. There
+    /// is exactly one such node on Apple Silicon; iterating covers the
+    /// (never observed) multi-node case and returns the first match.
+    private static func detectGPUCoreCount() -> Int? {
+        var iterator: io_iterator_t = 0
+        guard
+            IOServiceGetMatchingServices(
+                kIOMainPortDefault,
+                IOServiceMatching("AGXAccelerator"),
+                &iterator
+            ) == KERN_SUCCESS
+        else { return nil }
+        defer { IOObjectRelease(iterator) }
+
+        var coreCount: Int? = nil
+        var entry = IOIteratorNext(iterator)
+        while entry != 0 {
+            if coreCount == nil,
+                let value = IORegistryEntryCreateCFProperty(
+                    entry,
+                    "gpu-core-count" as CFString,
+                    kCFAllocatorDefault,
+                    0
+                )?.takeRetainedValue() as? Int
+            {
+                coreCount = value
+            }
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(iterator)
+        }
+        return coreCount
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2122,11 +2122,20 @@ public actor ModelRuntime {
         // that is a cache hit and must not flash the UI back to
         // "Loading Model..." on every message.
         let cfg = await getConfig()
+        // Model-aware resolution: identical to the legacy static var unless
+        // the opt-in auto batch sizing flag is set, in which case the
+        // BatchAutoscaler recommendation (observed same-model demand, capped
+        // by hardware tier) decides. `MLXBatchAdapter.generate` re-resolves
+        // on the auto path after recording its own demand sample, so this
+        // value is a floor there, not the final word.
+        let maxBatchSize = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            model: modelName
+        )
         await MLXBatchAdapter.recordPendingEffectiveGenerationSettings(
             modelName: modelName,
             generation: parameters,
             runtimeDefaults: cfg.generation,
-            maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
+            maxBatchSize: maxBatchSize
         )
         trace?.mark("load_container_start")
         let shouldReportModelLoad = modelCache[modelName] == nil
@@ -2184,7 +2193,7 @@ public actor ModelRuntime {
                 stopSequences: stopSequences,
                 draftStrategy: holder.draftStrategy,
                 runtime: cfg,
-                maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
+                maxBatchSize: maxBatchSize
             )
         } catch {
             InferenceProgressManager.shared.prefillDidFinishAsync()

--- a/Packages/OsaurusCore/Services/ModelRuntime/BatchAutoscaler.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/BatchAutoscaler.swift
@@ -72,7 +72,11 @@ enum BatchAutoscalerPolicy {
     static func decision(windowMax: Int, tierCap: Int, previous: Int) -> Int {
         let cap = max(tierCap, 1)
         guard windowMax > 1 else { return 1 }
-        let target = min(nextPowerOfTwo(windowMax), cap)
+        // Cap BEFORE rounding up: `nextPowerOfTwo` of an unbounded
+        // windowMax can overflow-shift for absurd demand values, and any
+        // rounded value above the cap would be discarded anyway. The outer
+        // `min` keeps non-power-of-two caps authoritative.
+        let target = min(nextPowerOfTwo(min(windowMax, cap)), cap)
         return min(max(target, previous), cap)
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/BatchAutoscaler.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/BatchAutoscaler.swift
@@ -1,0 +1,294 @@
+//
+//  BatchAutoscaler.swift
+//  osaurus
+//
+//  "Auto" batch sizing for the MLX `BatchEngine`: keep `maxBatchSize == 1`
+//  (the compiled-decode fast path — the documented 9× TTFT win per the
+//  `InferenceFeatureFlags.mlxBatchEngineMaxBatchSize` doc comment) for
+//  single-user chat, and escalate a model's slot count ONLY when real
+//  overlapping demand for that model has been observed recently, capped by
+//  the hardware tier.
+//
+//  Escalation is one-way sticky within a busy window: downsizing an engine
+//  mid-burst thrashes engine rebuilds and (per the vmlx invariant) a
+//  hot-resize DOWN never recovers the compiled decode path anyway. The
+//  recommendation falls back to 1 only after a FULL quiet window (no
+//  overlapping demand for `windowSeconds`), and the return-to-1 path tears
+//  the engine down via `MLXBatchAdapter.Registry.shutdownEngineIfIdle` —
+//  off the request path, and only when the engine is idle — so the next
+//  request rebuilds fresh at 1 and regains compile eligibility.
+//
+
+import Foundation
+import os.log
+
+private let autoBatchLog = Logger(subsystem: "ai.osaurus", category: "BatchAutoscaler")
+
+/// Pure decision rules for auto batch sizing. Kept side-effect free (no
+/// clock, no actor state) so the escalation/stickiness contract is unit
+/// testable without `BatchAutoscaler` itself.
+enum BatchAutoscalerPolicy {
+    /// Hardware ceiling for auto escalation, keyed by chip tier.
+    ///
+    /// Rationale: decode on Apple Silicon is memory-bandwidth bound, and
+    /// every extra concurrent sequence multiplies per-step KV + activation
+    /// traffic. Base dies (~100–150 GB/s) cannot feed even two concurrent
+    /// decode streams meaningfully faster than serial execution, so on base
+    /// tier escalation would trade away the 9× compiled-decode TTFT win for
+    /// throughput the bandwidth can't deliver — base NEVER escalates.
+    /// Pro (~200–300 GB/s) sustains a small fan-out, Max (~400–550 GB/s)
+    /// roughly doubles that, Ultra (two fused Max dies, ~800+ GB/s) doubles
+    /// it again. `unknown` (Intel, VMs, future naming schemes) gets the most
+    /// conservative cap, matching `ChipProfile`'s "unknown means be
+    /// conservative" contract.
+    static func tierCap(for tier: ChipProfile.Tier) -> Int {
+        switch tier {
+        case .base, .unknown: return 1
+        case .pro: return 4
+        case .max: return 8
+        case .ultra: return 16
+        }
+    }
+
+    /// Smallest power of two >= `value`. Values <= 1 map to 1.
+    static func nextPowerOfTwo(_ value: Int) -> Int {
+        guard value > 1 else { return 1 }
+        var result = 1
+        while result < value {
+            result <<= 1
+        }
+        return result
+    }
+
+    /// One recommendation step.
+    ///
+    /// - No overlap in the window (`windowMax <= 1`): return to 1 — the
+    ///   compile-friendly single-slot configuration. This is the ONLY path
+    ///   that can lower the recommendation; a full quiet window must elapse
+    ///   before samples age out and `windowMax` drops.
+    /// - Overlap: `min(nextPowerOfTwo(windowMax), tierCap)`, but never below
+    ///   `previous` (one-way sticky within a busy window — mid-burst
+    ///   downsizing thrashes engine rebuilds without recovering compile).
+    static func decision(windowMax: Int, tierCap: Int, previous: Int) -> Int {
+        let cap = max(tierCap, 1)
+        guard windowMax > 1 else { return 1 }
+        let target = min(nextPowerOfTwo(windowMax), cap)
+        return min(max(target, previous), cap)
+    }
+}
+
+/// Tracks recent same-model overlapping demand and recommends a
+/// `BatchEngine` `maxBatchSize` from it. See the file header for the
+/// escalate/stick/decay contract.
+///
+/// The submission path (`MLXBatchAdapter.generate`) feeds
+/// `recordSubmission(model:pendingAndActive:)`; the resolution path
+/// (`InferenceFeatureFlags`) reads `recommendedBatchSize(for:tierCap:)`.
+actor BatchAutoscaler {
+    /// Production instance. The return-to-1 hook shuts the engine down (only
+    /// when idle) so the next request rebuilds fresh at 1 and regains
+    /// compile eligibility — a hot-resize down would NOT recover it.
+    static let shared = BatchAutoscaler(
+        onReturnToOne: { model in
+            await MLXBatchAdapter.Registry.shared.shutdownEngineIfIdle(for: model)
+        }
+    )
+
+    typealias NowProvider = @Sendable () -> TimeInterval
+    typealias Sleeper = @Sendable (TimeInterval) async -> Void
+
+    private struct ModelState {
+        /// Sliding window of (timestamp, pending+active) demand samples;
+        /// pruned to `windowSeconds` on every touch.
+        var samples: [(at: TimeInterval, demand: Int)] = []
+        var recommendation = 1
+        /// Last tier cap seen from the resolution path; used only for the
+        /// decay-side change log line.
+        var lastTierCap = 1
+        /// Set when the recommendation returned to 1 but the engine teardown
+        /// (which restores compile eligibility) has not succeeded yet — e.g.
+        /// the engine was still busy. The decay loop retries until it lands.
+        var pendingTeardown = false
+        var decayTask: Task<Void, Never>?
+    }
+
+    private let windowSeconds: TimeInterval
+    /// Retry cadence for a return-to-1 teardown that found the engine busy.
+    private let teardownRetrySeconds: TimeInterval
+    private let now: NowProvider
+    private let sleep: Sleeper
+    private let onReturnToOne: @Sendable (String) async -> Bool
+    private var states: [String: ModelState] = [:]
+
+    /// Recommendation-change log lines, oldest first, capped. Exists so
+    /// tests can assert the change-gated logging (one line per CHANGE, none
+    /// for repeats) without scraping os.log.
+    private(set) var recentChangeLogs: [String] = []
+
+    /// - Parameters:
+    ///   - windowSeconds: quiet interval that must elapse before decay.
+    ///   - now: injectable clock (monotonic seconds) for tests.
+    ///   - sleep: injectable suspension for the decay loop, so tests never
+    ///     wait wall-clock time.
+    ///   - onReturnToOne: teardown hook run off the request path when the
+    ///     recommendation decays to 1. Returns whether teardown completed
+    ///     (false = engine busy, retry later).
+    init(
+        windowSeconds: TimeInterval = 60,
+        teardownRetrySeconds: TimeInterval = 10,
+        now: @escaping NowProvider = { ProcessInfo.processInfo.systemUptime },
+        sleep: @escaping Sleeper = { seconds in
+            try? await Task.sleep(nanoseconds: UInt64(max(seconds, 0) * 1_000_000_000))
+        },
+        onReturnToOne: @escaping @Sendable (String) async -> Bool
+    ) {
+        self.windowSeconds = windowSeconds
+        self.teardownRetrySeconds = teardownRetrySeconds
+        self.now = now
+        self.sleep = sleep
+        self.onReturnToOne = onReturnToOne
+    }
+
+    // MARK: - Signal intake
+
+    /// Record one submission's observed concurrent demand
+    /// (`pendingAndActive` = the engine's pending+active counts including
+    /// this submission). Called from `MLXBatchAdapter.generate` BEFORE the
+    /// solo lease — after the lease, single-slot serialization makes the
+    /// counts read 1 forever and overlap would never be observed.
+    func recordSubmission(model: String, pendingAndActive: Int) {
+        var state = states[model] ?? ModelState()
+        let timestamp = now()
+        state.samples.append((at: timestamp, demand: max(pendingAndActive, 1)))
+        prune(&state, at: timestamp)
+        states[model] = state
+        if pendingAndActive > 1 {
+            scheduleDecayLoop(for: model)
+        }
+    }
+
+    // MARK: - Recommendation
+
+    /// Current recommendation for `model` under the hardware `tierCap`.
+    /// Logs one line on every recommendation CHANGE (never on repeats).
+    func recommendedBatchSize(for model: String, tierCap: Int) -> Int {
+        var state = states[model] ?? ModelState()
+        let timestamp = now()
+        prune(&state, at: timestamp)
+        state.lastTierCap = tierCap
+        let windowMax = state.samples.map(\.demand).max() ?? 0
+        let previous = state.recommendation
+        let next = BatchAutoscalerPolicy.decision(
+            windowMax: windowMax,
+            tierCap: tierCap,
+            previous: previous
+        )
+        if next != previous {
+            logChange(model: model, from: previous, to: next, windowMax: windowMax, tierCap: tierCap)
+            if next == 1 {
+                // Decayed on a read. The engine (resized up during the
+                // burst) is running uncompiled; flag it for the off-path
+                // teardown so the next quiet-moment rebuild restores the
+                // compiled single-slot path.
+                state.pendingTeardown = true
+            }
+        }
+        state.recommendation = next
+        states[model] = state
+        if next > 1 || state.pendingTeardown {
+            scheduleDecayLoop(for: model)
+        }
+        return next
+    }
+
+    // MARK: - Decay
+
+    /// One decay evaluation. Internal (not private) so tests can drive it
+    /// directly with an advanced injected clock instead of sleeping.
+    func sweep(model: String) async {
+        guard var state = states[model] else { return }
+        let timestamp = now()
+        prune(&state, at: timestamp)
+        let windowMax = state.samples.map(\.demand).max() ?? 0
+        if windowMax <= 1, state.recommendation > 1 {
+            logChange(
+                model: model,
+                from: state.recommendation,
+                to: 1,
+                windowMax: windowMax,
+                tierCap: state.lastTierCap
+            )
+            state.recommendation = 1
+            state.pendingTeardown = true
+        }
+        states[model] = state
+        guard windowMax <= 1, state.pendingTeardown else { return }
+        // Off-request-path teardown. `onReturnToOne` (Registry
+        // `shutdownEngineIfIdle`) declines while the engine has pending or
+        // active work; the loop retries on `teardownRetrySeconds`. The actor
+        // suspends across the await, so re-read state before mutating.
+        let done = await onReturnToOne(model)
+        if done {
+            states[model]?.pendingTeardown = false
+        }
+    }
+
+    /// Idempotent: at most one decay loop per model. The loop re-computes
+    /// its own wake-up point each iteration, so new samples never need to
+    /// cancel/reschedule it.
+    private func scheduleDecayLoop(for model: String) {
+        guard states[model] != nil, states[model]?.decayTask == nil else { return }
+        let task = Task<Void, Never> { [weak self] in
+            guard let self else { return }
+            await self.decayLoop(model: model)
+        }
+        states[model]?.decayTask = task
+    }
+
+    private func decayLoop(model: String) async {
+        while !Task.isCancelled {
+            guard let delay = nextDecayDelay(for: model) else { break }
+            await sleep(delay)
+            if Task.isCancelled { break }
+            await sweep(model: model)
+        }
+        states[model]?.decayTask = nil
+    }
+
+    /// Seconds until the next decay check, or `nil` when no decay work
+    /// remains (recommendation already 1 and no teardown owed).
+    private func nextDecayDelay(for model: String) -> TimeInterval? {
+        guard var state = states[model] else { return nil }
+        let timestamp = now()
+        prune(&state, at: timestamp)
+        states[model] = state
+        if let lastOverlapAt = state.samples.filter({ $0.demand > 1 }).map(\.at).max() {
+            // Wake just after the newest overlap sample ages out of the
+            // window — the earliest instant decay could apply.
+            return max(lastOverlapAt + windowSeconds - timestamp, 0.05)
+        }
+        if state.recommendation > 1 {
+            // Quiet window already elapsed; sweep imminently.
+            return 0.05
+        }
+        if state.pendingTeardown {
+            return teardownRetrySeconds
+        }
+        return nil
+    }
+
+    // MARK: - Helpers
+
+    private func prune(_ state: inout ModelState, at timestamp: TimeInterval) {
+        state.samples.removeAll { timestamp - $0.at >= windowSeconds }
+    }
+
+    private func logChange(model: String, from: Int, to: Int, windowMax: Int, tierCap: Int) {
+        let line = "[Osaurus] autobatch: model=\(model) \(from)→\(to) (windowMax=\(windowMax), tierCap=\(tierCap))"
+        autoBatchLog.notice("\(line, privacy: .public)")
+        recentChangeLogs.append(line)
+        if recentChangeLogs.count > 32 {
+            recentChangeLogs.removeFirst(recentChangeLogs.count - 32)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime/InferenceFeatureFlags.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/InferenceFeatureFlags.swift
@@ -4,11 +4,13 @@
 //
 //  Runtime-tunable knobs for the MLX inference path.
 //
-//  Today the only knob is `mlxBatchEngineMaxBatchSize` — `BatchEngine` is the
-//  single MLX entry point (no per-request `TokenIterator` fallback) and the
-//  prior osaurus-side scheduler / cooperative-yield / multi-stream gates have
-//  all been retired. Their behaviour is now provided by vmlx-swift's actor
-//  loop (see `vmlx-swift/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md`).
+//  The knobs are `mlxBatchEngineMaxBatchSize` and the opt-in
+//  `autoBatchSize` mode (resolve the batch size from observed demand via
+//  `BatchAutoscaler`) — `BatchEngine` is the single MLX entry point (no
+//  per-request `TokenIterator` fallback) and the prior osaurus-side
+//  scheduler / cooperative-yield / multi-stream gates have all been
+//  retired. Their behaviour is now provided by vmlx-swift's actor loop
+//  (see `vmlx-swift/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md`).
 //
 
 import Foundation
@@ -17,6 +19,7 @@ import Foundation
 public enum InferenceFeatureFlags {
     private enum Keys {
         static let mlxBatchEngineMaxSize = "ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize"
+        static let autoBatchSize = "ai.osaurus.scheduler.autoBatchSize"
     }
 
     /// Maximum number of sequences `BatchEngine` decodes simultaneously per
@@ -77,5 +80,77 @@ public enum InferenceFeatureFlags {
             return min(value, 32)
         }
         return mlxBatchEngineMaxBatchSize(in: userDefaults)
+    }
+
+    // MARK: - Auto batch sizing (opt-in)
+
+    /// Whether the "auto" batch-sizing pathway is active. Default FALSE —
+    /// nothing changes for anyone who hasn't opted in:
+    ///
+    ///   `defaults write ai.osaurus ai.osaurus.scheduler.autoBatchSize -bool true`
+    ///
+    /// Auto only applies when NO explicit size is configured: an explicit
+    /// `concurrency.maxConcurrentSequences` (Server → Settings) or a legacy
+    /// `mlxBatchEngineMaxBatchSize` UserDefaults value is a deliberate
+    /// choice of the compile-vs-throughput trade-off and always wins.
+    /// `continuousBatching == false` pins single-slot on the legacy path,
+    /// so auto (whose whole point is multi-slot escalation) defers to it.
+    static var autoBatchSizingEnabled: Bool {
+        autoBatchSizingEnabled(
+            in: .standard,
+            runtime: ServerRuntimeSettingsStore.snapshot()
+        )
+    }
+
+    static func autoBatchSizingEnabled(
+        in userDefaults: UserDefaults,
+        runtime: VMLXServerRuntimeSettings
+    ) -> Bool {
+        guard userDefaults.bool(forKey: Keys.autoBatchSize) else { return false }
+        guard runtime.concurrency.continuousBatching else { return false }
+        if let explicit = runtime.concurrency.maxConcurrentSequences, explicit > 0 {
+            return false
+        }
+        return userDefaults.integer(forKey: Keys.mlxBatchEngineMaxSize) <= 0
+    }
+
+    /// Model-aware resolution used by the generation path.
+    ///
+    /// With auto batch sizing OFF (the default) this returns exactly what
+    /// the legacy `mlxBatchEngineMaxBatchSize(in:runtime:)` resolution
+    /// returns — behavior identical to today. With auto ON (and no explicit
+    /// size configured) it returns the `BatchAutoscaler` recommendation:
+    /// 1 (compiled decode, 9× TTFT) until real overlapping demand for this
+    /// model is observed, then the next power of two of the observed
+    /// concurrency, capped by the `ChipProfile` hardware tier.
+    ///
+    /// `autoscaler` / `tierCapOverride` are test seams; production callers
+    /// use the shared autoscaler and the host's detected tier. The tier cap
+    /// is resolved lazily so the flag-off path never probes hardware.
+    static func mlxBatchEngineMaxBatchSize(
+        in userDefaults: UserDefaults,
+        runtime: VMLXServerRuntimeSettings,
+        model: String,
+        autoscaler: BatchAutoscaler? = nil,
+        tierCapOverride: Int? = nil
+    ) async -> Int {
+        guard autoBatchSizingEnabled(in: userDefaults, runtime: runtime) else {
+            return mlxBatchEngineMaxBatchSize(in: userDefaults, runtime: runtime)
+        }
+        let tierCap =
+            tierCapOverride
+            ?? BatchAutoscalerPolicy.tierCap(for: ChipProfile.current.tier)
+        let scaler = autoscaler ?? BatchAutoscaler.shared
+        return await scaler.recommendedBatchSize(for: model, tierCap: tierCap)
+    }
+
+    /// Production model-aware entry point (standard defaults + current
+    /// runtime settings snapshot).
+    static func mlxBatchEngineMaxBatchSize(model: String) async -> Int {
+        await mlxBatchEngineMaxBatchSize(
+            in: .standard,
+            runtime: ServerRuntimeSettingsStore.snapshot(),
+            model: model
+        )
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/InferenceFeatureFlags.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/InferenceFeatureFlags.swift
@@ -139,7 +139,7 @@ public enum InferenceFeatureFlags {
         }
         let tierCap =
             tierCapOverride
-            ?? BatchAutoscalerPolicy.tierCap(for: ChipProfile.current.tier)
+            ?? BatchAutoscalerPolicy.tierCap(for: ChipProfile.current.policyTier)
         let scaler = autoscaler ?? BatchAutoscaler.shared
         return await scaler.recommendedBatchSize(for: model, tierCap: tierCap)
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -498,6 +498,41 @@ struct MLXBatchAdapter {
             )
         }
 
+        /// Observed demand on the RESOLVED engine for `modelName`:
+        /// pending + active counts, or 0 when no engine exists. Peek only —
+        /// never creates an engine. This is the auto-batch-sizing overlap
+        /// signal source; it deliberately reads exactly one pending/active
+        /// pair so the hot path gains no extra cross-actor chatter.
+        func pendingAndActiveCount(for modelName: String) async -> Int {
+            guard let engine = await coalescer.resolvedValue(for: modelName) else { return 0 }
+            let pending = await engine.pendingCount
+            let active = await engine.activeCount
+            return pending + active
+        }
+
+        /// Auto-batch-sizing decay teardown: shut the engine down ONLY when
+        /// it is idle (pending == 0 && active == 0), so the next request
+        /// rebuilds fresh at `maxBatchSize == 1` and regains compiled-decode
+        /// eligibility (a hot-resize down does NOT recover the compiled
+        /// path — see the vmlx invariant cited in `InferenceFeatureFlags`).
+        /// Returns `true` when no engine exists or teardown completed;
+        /// `false` means "busy, retry later" (the `BatchAutoscaler` decay
+        /// loop retries).
+        ///
+        /// Known benign race: a request that acquired the engine handle but
+        /// has not yet submitted can land on the drained engine; vmlx then
+        /// finishes that stream cleanly with a `.cancelled` info event
+        /// (never restarts GPU work), and the caller's next request rebuilds
+        /// through the coalescer tombstone.
+        func shutdownEngineIfIdle(for modelName: String) async -> Bool {
+            guard let engine = await coalescer.resolvedValue(for: modelName) else { return true }
+            let pending = await engine.pendingCount
+            let active = await engine.activeCount
+            guard pending == 0, active == 0 else { return false }
+            await shutdownEngine(for: modelName)
+            return true
+        }
+
         /// Shut down and remove the engine for `modelName`. Safe to call
         /// when no engine exists. Pending requests on the engine receive a
         /// `.cancelled` info event before the actor exits.
@@ -988,6 +1023,34 @@ struct MLXBatchAdapter {
     ) async throws -> PreparedStream {
         let trace = generation.ttftTrace
         trace?.mark("batch_prepare_start")
+        // Auto batch sizing (opt-in): record this submission's observed
+        // demand and re-resolve the batch size BEFORE the solo lease. Both
+        // orderings are load-bearing:
+        //   * With `maxBatchSize == 1` the solo lease serializes overlapping
+        //     same-model requests upstream of the engine, so pending/active
+        //     counts read after the lease would never exceed 1 and overlap
+        //     could never be observed — the signal MUST be captured
+        //     pre-lease (one Registry peek + one pending/active read pair;
+        //     the +1 counts this submission).
+        //   * Re-resolving after recording lets the request that CREATES the
+        //     overlap escalate itself (skipping the solo lease and joining
+        //     the batch) instead of hot-resizing the engine down below live
+        //     demand with a stale single-slot value: the sample just
+        //     recorded keeps the recommendation >= the observed concurrency.
+        // When the flag is off this block does nothing and the resolved
+        // value from the caller is used unchanged.
+        var effectiveMaxBatchSize = maxBatchSize
+        if InferenceFeatureFlags.autoBatchSizingEnabled {
+            let observedDemand =
+                await Registry.shared.pendingAndActiveCount(for: modelName) + 1
+            await BatchAutoscaler.shared.recordSubmission(
+                model: modelName,
+                pendingAndActive: observedDemand
+            )
+            effectiveMaxBatchSize = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+                model: modelName
+            )
+        }
         // Prefill diagnostics: a generation step's clock starts HERE. The
         // solo-lease acquire below blocks until the PREVIOUS step's producer
         // task has released — and that release happens only after vmlx's
@@ -995,10 +1058,10 @@ struct MLXBatchAdapter {
         // exactly how long this step waited on the prior step's KV store.
         let genEnterAt = CFAbsoluteTimeGetCurrent()
         PrefillDebugLog.shared.log(
-            "==GEN GENERATE-ENTER model=\(modelName) maxBatch=\(maxBatchSize)"
+            "==GEN GENERATE-ENTER model=\(modelName) maxBatch=\(effectiveMaxBatchSize)"
         )
         let soloLease =
-            maxBatchSize == 1
+            effectiveMaxBatchSize == 1
             ? await Registry.shared.acquireSoloLease(for: modelName)
             : nil
         if Task.isCancelled {
@@ -1068,13 +1131,13 @@ struct MLXBatchAdapter {
         // Identifiers and counts only, never prompt content.
         CrashReportingService.recordBreadcrumb(
             category: "inference.generate",
-            message: "begin model=\(modelName) input_tokens=\(prepared.promptTokens.count) batch=\(maxBatchSize)"
+            message: "begin model=\(modelName) input_tokens=\(prepared.promptTokens.count) batch=\(effectiveMaxBatchSize)"
         )
 
         let engine = await Registry.shared.engine(
             for: modelName,
             container: container,
-            maxBatchSize: maxBatchSize
+            maxBatchSize: effectiveMaxBatchSize
         )
 
         // Honor the model's shipped generation defaults when the OpenAI-wire
@@ -1104,7 +1167,7 @@ struct MLXBatchAdapter {
             modelName: modelName,
             generation: generation,
             runtimeDefaults: runtime.generation,
-            maxBatchSize: maxBatchSize,
+            maxBatchSize: effectiveMaxBatchSize,
             modelDefaults: modelDefaults,
             draftStrategy: effectiveDraftStrategy,
             nativeMTPExplicitSamplingFallback: nativeMTPExplicitSamplingFallback,
@@ -1204,7 +1267,7 @@ struct MLXBatchAdapter {
         trace?.mark("batch_submit")
         CrashReportingService.recordBreadcrumb(
             category: "inference.generate",
-            message: "submit model=\(modelName) batch=\(maxBatchSize)"
+            message: "submit model=\(modelName) batch=\(effectiveMaxBatchSize)"
         )
         // Take the Metal gate's SHARED (generation) lock BEFORE submitting the
         // slot, so an external MLX user — the Model2Vec embedder behind

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -302,6 +302,30 @@ struct MLXBatchAdapter {
         private var nativeMTPWarmModels: Set<String> = []
         private var lastEffectiveGenerationSettings: [String: EffectiveGenerationSettings] = [:]
 
+        /// Per-model count of engine handles held by in-flight `generate`
+        /// calls. Incremented synchronously (via `beginGenerate`) at the top
+        /// of `engine(for:)` — before the first await, so the handle is
+        /// counted from the instant a request commits to submitting — and
+        /// decremented by `endGenerate(model:)` from the producer task once
+        /// the upstream stream has fully drained. Closes the TOCTOU in
+        /// `shutdownEngineIfIdle`: a request can hold the engine handle
+        /// across several awaits before its submission raises the engine's
+        /// pending/active counts; in that window pending == active == 0, and
+        /// a concurrent idle shutdown would make the submit return vmlx's
+        /// `.cancelled` info — the client would get an empty 200.
+        private var inFlightHandleCounts: [String: Int] = [:]
+
+        /// Models with an idle shutdown claimed but not yet completed. The
+        /// claim is inserted in the SAME actor slice as
+        /// `shutdownEngineIfIdle`'s final handle-count re-check, and
+        /// `engine(for:)` checks it in the SAME slice as its handle-count
+        /// increment — so either the request's handle lands first (the
+        /// shutdown observes it and declines) or the claim lands first (the
+        /// request parks until the doomed engine is fully drained, then
+        /// resolves a fresh one through the coalescer).
+        private var idleShutdownClaims: Set<String> = []
+        private var idleShutdownWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
         /// Returns the cached engine for `modelName`, creating it on first
         /// use from the supplied `ModelContainer`. The container's existing
         /// cache coordinator is captured automatically by `makeBatchEngine`.
@@ -320,6 +344,32 @@ struct MLXBatchAdapter {
         /// past this gate the upstream stream finishes cleanly instead of
         /// restarting GPU work.
         func engine(
+            for modelName: String,
+            container: ModelContainer,
+            maxBatchSize: Int
+        ) async -> BatchEngine {
+            // Count this caller's handle BEFORE the first await, in the same
+            // actor slice as the idle-shutdown claim check below. The
+            // matching decrement is `endGenerate(model:)`, called from the
+            // producer task after the upstream stream has fully drained.
+            beginGenerate(model: modelName)
+            // If an idle shutdown is mid-flight, park until it completes:
+            // the coalescer can still hand out the doomed engine until the
+            // drain tombstone lands, and a handle to it would surface as a
+            // spurious `.cancelled` (empty 200) on submit.
+            while idleShutdownClaims.contains(modelName) {
+                await withCheckedContinuation { continuation in
+                    idleShutdownWaiters[modelName, default: []].append(continuation)
+                }
+            }
+            return await resolveEngine(
+                for: modelName,
+                container: container,
+                maxBatchSize: maxBatchSize
+            )
+        }
+
+        private func resolveEngine(
             for modelName: String,
             container: ModelContainer,
             maxBatchSize: Int
@@ -360,8 +410,10 @@ struct MLXBatchAdapter {
                     // Rebuild via the same path. The new engine is
                     // constructed with `maxBatchSize` directly, so the
                     // resize check on the recursive call sees a match and
-                    // skips `updateMaxBatchSize`.
-                    return await self.engine(
+                    // skips `updateMaxBatchSize`. Recurse into
+                    // `resolveEngine` (not `engine(for:)`) so the caller's
+                    // handle is counted exactly once.
+                    return await self.resolveEngine(
                         for: modelName,
                         container: container,
                         maxBatchSize: maxBatchSize
@@ -510,26 +562,81 @@ struct MLXBatchAdapter {
             return pending + active
         }
 
+        /// Actual `maxBatchSize` of the RESOLVED engine for `modelName`, or
+        /// `nil` when no engine exists. Peek only — never creates an engine.
+        /// Used by the auto-batch-sizing path so a decayed recommendation
+        /// never hot-resizes a cached engine DOWN on the request path.
+        func resolvedEngineMaxBatchSize(for modelName: String) async -> Int? {
+            guard let engine = await coalescer.resolvedValue(for: modelName) else { return nil }
+            return await engine.maxBatchSize
+        }
+
+        /// Synchronous half of the in-flight-handle accounting: count one
+        /// engine handle for `modelName`. Called at the top of
+        /// `engine(for:)`; internal (not private) so the pairing with
+        /// `shutdownEngineIfIdle` is testable without a real `BatchEngine`.
+        func beginGenerate(model modelName: String) {
+            inFlightHandleCounts[modelName, default: 0] += 1
+        }
+
+        /// Balance for the handle counted in `engine(for:)` /
+        /// `beginGenerate(model:)`. Called from the `generate` producer task
+        /// after the upstream stream has fully drained — i.e. once all of
+        /// the request's engine work is done.
+        func endGenerate(model modelName: String) {
+            let remaining = (inFlightHandleCounts[modelName] ?? 0) - 1
+            if remaining > 0 {
+                inFlightHandleCounts[modelName] = remaining
+            } else {
+                inFlightHandleCounts[modelName] = nil
+            }
+        }
+
+        /// Number of engine handles currently held by in-flight `generate`
+        /// calls for `modelName`. Diagnostic/test accessor.
+        func inFlightHandleCount(for modelName: String) -> Int {
+            inFlightHandleCounts[modelName] ?? 0
+        }
+
         /// Auto-batch-sizing decay teardown: shut the engine down ONLY when
-        /// it is idle (pending == 0 && active == 0), so the next request
-        /// rebuilds fresh at `maxBatchSize == 1` and regains compiled-decode
-        /// eligibility (a hot-resize down does NOT recover the compiled
-        /// path — see the vmlx invariant cited in `InferenceFeatureFlags`).
-        /// Returns `true` when no engine exists or teardown completed;
-        /// `false` means "busy, retry later" (the `BatchAutoscaler` decay
-        /// loop retries).
+        /// it is fully idle — no in-flight handle (a request between
+        /// `engine(for:)` and its submission raising pending), no pending
+        /// work, and no active work — so the next request rebuilds fresh at
+        /// `maxBatchSize == 1` and regains compiled-decode eligibility (a
+        /// hot-resize down does NOT recover the compiled path — see the
+        /// vmlx invariant cited in `InferenceFeatureFlags`). Returns `true`
+        /// when no engine exists or teardown completed; `false` means
+        /// "busy, retry later" (the `BatchAutoscaler` decay loop retries).
         ///
-        /// Known benign race: a request that acquired the engine handle but
-        /// has not yet submitted can land on the drained engine; vmlx then
-        /// finishes that stream cleanly with a `.cancelled` info event
-        /// (never restarts GPU work), and the caller's next request rebuilds
-        /// through the coalescer tombstone.
+        /// TOCTOU discipline: the handle count is checked again in the SAME
+        /// actor slice that claims the shutdown (the pending/active reads
+        /// suspend this actor, so a request may have taken a handle
+        /// meanwhile), and `engine(for:)` increments its count in the same
+        /// slice as it checks the claim. A handle acquired before the claim
+        /// makes this method decline; one acquired after parks until the
+        /// drained engine is gone and then resolves a fresh engine — no
+        /// request can be left holding a handle to the torn-down engine, so
+        /// no submit can surface a spurious `.cancelled` (empty 200).
         func shutdownEngineIfIdle(for modelName: String) async -> Bool {
-            guard let engine = await coalescer.resolvedValue(for: modelName) else { return true }
+            guard inFlightHandleCounts[modelName, default: 0] == 0 else { return false }
+            guard let engine = await coalescer.resolvedValue(for: modelName) else {
+                // No engine — but re-verify no handle was taken while this
+                // actor was suspended on the peek (a first-fetch may be
+                // mid-creation through the coalescer).
+                return inFlightHandleCounts[modelName, default: 0] == 0
+            }
             let pending = await engine.pendingCount
             let active = await engine.activeCount
             guard pending == 0, active == 0 else { return false }
+            // Final handle re-check + shutdown claim in ONE actor slice
+            // (see the TOCTOU discipline note above).
+            guard inFlightHandleCounts[modelName, default: 0] == 0 else { return false }
+            idleShutdownClaims.insert(modelName)
             await shutdownEngine(for: modelName)
+            idleShutdownClaims.remove(modelName)
+            if let waiters = idleShutdownWaiters.removeValue(forKey: modelName) {
+                for waiter in waiters { waiter.resume() }
+            }
             return true
         }
 
@@ -977,6 +1084,18 @@ struct MLXBatchAdapter {
         }
     }
 
+    /// Auto-batch-sizing resolution of the size actually used for a
+    /// request: never below the cached engine's current size, so a decayed
+    /// recommendation cannot hot-resize an active engine down on the
+    /// request path (a resize down never restores compiled decode). With no
+    /// cached engine the recommendation is used as-is — the fresh build
+    /// (post decay-sweep teardown) is exactly how shrink-to-1 regains
+    /// compile eligibility.
+    static func autoEffectiveMaxBatchSize(recommended: Int, cachedEngineSize: Int?) -> Int {
+        guard let cachedEngineSize else { return recommended }
+        return max(recommended, cachedEngineSize)
+    }
+
     static func shouldEnableCompiledBatchDecode(modelName: String, maxBatchSize: Int) -> Bool {
         maxBatchSize == 1
             && !Hy3ReasoningProfile.matches(modelId: modelName)
@@ -1047,8 +1166,25 @@ struct MLXBatchAdapter {
                 model: modelName,
                 pendingAndActive: observedDemand
             )
-            effectiveMaxBatchSize = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            let recommended = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
                 model: modelName
+            )
+            // Decay-on-read must NOT hot-resize the cached engine DOWN on
+            // the request path: a resize down never restores compiled decode
+            // (vmlx Stage 1B invariant) — it only sheds slots mid-traffic.
+            // When the fresh recommendation is lower than the engine's
+            // actual size, keep serving this request at the cached size;
+            // shrink-to-1 belongs exclusively to the decay sweep's
+            // tombstoned shutdown+rebuild (`Registry.shutdownEngineIfIdle`).
+            // Reporting the cached size as `effectiveMaxBatchSize` also
+            // keeps `effectiveGenerationSettings.compiledBatchDecode`
+            // honest: it is computed from the size the engine actually
+            // runs at, not from a recommendation the engine never adopted.
+            effectiveMaxBatchSize = Self.autoEffectiveMaxBatchSize(
+                recommended: recommended,
+                cachedEngineSize: await Registry.shared.resolvedEngineMaxBatchSize(
+                    for: modelName
+                )
             )
         }
         // Prefill diagnostics: a generation step's clock starts HERE. The
@@ -1335,6 +1471,11 @@ struct MLXBatchAdapter {
             // the producer task always runs to completion, so the pair always
             // balances.
             await MetalGate.shared.exitGeneration(model: modelName)
+            // Balance the in-flight-handle count taken in
+            // `Registry.engine(for:)`. Only now — with the upstream stream
+            // fully drained — is it safe for an idle-shutdown sweep to tear
+            // this engine down.
+            await Registry.shared.endGenerate(model: modelName)
         }
 
         continuation.onTermination = { @Sendable _ in

--- a/Packages/OsaurusCore/Services/ModelRuntime/TaskCoalescer.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/TaskCoalescer.swift
@@ -289,4 +289,12 @@ public actor TaskCoalescer<Value: Sendable> {
     public func resolvedValues() -> [Value] {
         Array(values.values)
     }
+
+    /// Keyed peek at a resolved entry. Returns `nil` for absent, in-flight,
+    /// or draining keys — never joins a creation and never starts one. Used
+    /// by demand probes (auto batch sizing) that must not force an engine
+    /// into existence just to observe it.
+    public func resolvedValue(for key: String) -> Value? {
+        values[key]
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/BatchAutoscalerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/BatchAutoscalerTests.swift
@@ -123,6 +123,9 @@ struct BatchAutoscalerTests {
         #expect(BatchAutoscalerPolicy.decision(windowMax: 30, tierCap: 16, previous: 1) == 16)
         // Base/unknown cap of 1 means overlap can never escalate.
         #expect(BatchAutoscalerPolicy.decision(windowMax: 6, tierCap: 1, previous: 1) == 1)
+        // The cap is applied BEFORE the power-of-two round-up, so an absurd
+        // windowMax cannot overflow `nextPowerOfTwo`'s shift loop.
+        #expect(BatchAutoscalerPolicy.decision(windowMax: Int.max, tierCap: 8, previous: 1) == 8)
     }
 
     /// Never resize DOWN while the window still shows overlap: mid-burst
@@ -258,6 +261,77 @@ struct BatchAutoscalerTests {
         #expect(await recorder.models == ["m", "m"])
         await scaler.sweep(model: "m")
         #expect(await recorder.models == ["m", "m"])
+    }
+
+    // MARK: - Registry idle-shutdown handle accounting
+
+    /// TOCTOU fix: a request holds an "engine handle" from `engine(for:)`
+    /// entry (`beginGenerate`) until its producer drains (`endGenerate`);
+    /// during that whole window — including the awaits BEFORE the
+    /// submission raises the engine's pending/active counts —
+    /// `shutdownEngineIfIdle` must decline, or the submit would land on a
+    /// drained engine and surface as an empty 200.
+    @Test func shutdownEngineIfIdle_declinesWhileHandleHeld() async {
+        let registry = MLXBatchAdapter.Registry()
+        await registry.beginGenerate(model: "m")
+        #expect(await registry.inFlightHandleCount(for: "m") == 1)
+        #expect(await registry.shutdownEngineIfIdle(for: "m") == false)
+
+        // Handle released: teardown may proceed (no engine exists here, so
+        // "idle" is trivially true).
+        await registry.endGenerate(model: "m")
+        #expect(await registry.inFlightHandleCount(for: "m") == 0)
+        #expect(await registry.shutdownEngineIfIdle(for: "m") == true)
+    }
+
+    @Test func shutdownEngineIfIdle_countsOverlappingHandlesPerModel() async {
+        let registry = MLXBatchAdapter.Registry()
+        await registry.beginGenerate(model: "m")
+        await registry.beginGenerate(model: "m")
+        await registry.endGenerate(model: "m")
+        // One of two overlapping handles released — still held.
+        #expect(await registry.shutdownEngineIfIdle(for: "m") == false)
+        await registry.endGenerate(model: "m")
+        #expect(await registry.shutdownEngineIfIdle(for: "m") == true)
+
+        // Handles are tracked per model: another model's in-flight handle
+        // must not block this model's teardown.
+        await registry.beginGenerate(model: "other")
+        #expect(await registry.shutdownEngineIfIdle(for: "m") == true)
+        #expect(await registry.shutdownEngineIfIdle(for: "other") == false)
+    }
+
+    // MARK: - Auto path never hot-resizes a cached engine down
+
+    /// A decayed recommendation must not resize an active engine down on
+    /// the request path: the request keeps serving at the cached engine's
+    /// actual size (which also keeps `compiledBatchDecode` honest), and
+    /// shrink-to-1 is exclusively the decay sweep's shutdown+rebuild.
+    @Test func autoEffectiveSize_recommendationDropKeepsCachedEngineSize() {
+        #expect(MLXBatchAdapter.autoEffectiveMaxBatchSize(recommended: 1, cachedEngineSize: 4) == 4)
+        #expect(MLXBatchAdapter.autoEffectiveMaxBatchSize(recommended: 2, cachedEngineSize: 8) == 8)
+    }
+
+    /// Resize UP and the fresh post-teardown build stay untouched: with no
+    /// cached engine (the sweep tore it down) the recommendation is used
+    /// as-is, which is how shrink-to-1 regains compile eligibility.
+    @Test func autoEffectiveSize_allowsResizeUpAndFreshRebuild() {
+        #expect(MLXBatchAdapter.autoEffectiveMaxBatchSize(recommended: 8, cachedEngineSize: 4) == 8)
+        #expect(MLXBatchAdapter.autoEffectiveMaxBatchSize(recommended: 1, cachedEngineSize: nil) == 1)
+        #expect(MLXBatchAdapter.autoEffectiveMaxBatchSize(recommended: 4, cachedEngineSize: nil) == 4)
+        #expect(MLXBatchAdapter.autoEffectiveMaxBatchSize(recommended: 4, cachedEngineSize: 4) == 4)
+    }
+
+    /// `compiledBatchDecode` must follow the size actually used: a request
+    /// clamped up to a cached multi-slot engine reports compile OFF even
+    /// though the decayed recommendation was 1.
+    @Test func compiledBatchDecodeFollowsSizeActuallyUsed() {
+        #expect(
+            MLXBatchAdapter.shouldEnableCompiledBatchDecode(
+                modelName: "test/plain-model", maxBatchSize: 1))
+        #expect(
+            !MLXBatchAdapter.shouldEnableCompiledBatchDecode(
+                modelName: "test/plain-model", maxBatchSize: 4))
     }
 
     // MARK: - Recommendation-change log gating

--- a/Packages/OsaurusCore/Tests/Service/BatchAutoscalerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/BatchAutoscalerTests.swift
@@ -1,0 +1,388 @@
+//
+//  BatchAutoscalerTests.swift
+//  osaurusTests
+//
+//  Covers the auto batch-sizing pathway: the pure escalation/stickiness
+//  decision rules, the tier caps derived from ChipProfile, the actor's
+//  sliding-window behavior under an injected clock (escalate on overlap,
+//  stick during a busy window, decay to 1 after a full quiet window and
+//  tear the engine down so the compiled single-slot path can be rebuilt),
+//  and the InferenceFeatureFlags resolution contract: with the opt-in flag
+//  off (the default) behavior is bit-identical to the legacy path.
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct BatchAutoscalerTests {
+
+    // MARK: - Test doubles
+
+    /// Manually advanced clock so window expiry never needs wall time.
+    private final class ManualClock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: TimeInterval = 1_000
+
+        var now: TimeInterval {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+
+        func advance(by seconds: TimeInterval) {
+            lock.lock()
+            defer { lock.unlock() }
+            value += seconds
+        }
+    }
+
+    private actor TeardownRecorder {
+        private(set) var models: [String] = []
+        var result = true
+
+        func record(_ model: String) -> Bool {
+            models.append(model)
+            return result
+        }
+
+        func setResult(_ value: Bool) { result = value }
+    }
+
+    /// Parks the decay loop until cancellation so tests drive `sweep`
+    /// deterministically via the injected clock instead of real sleeps.
+    private static let parkedSleeper: BatchAutoscaler.Sleeper = { _ in
+        try? await Task.sleep(nanoseconds: 3_600 * 1_000_000_000)
+    }
+
+    private func makeAutoscaler(
+        clock: ManualClock,
+        recorder: TeardownRecorder? = nil
+    ) -> BatchAutoscaler {
+        BatchAutoscaler(
+            now: { clock.now },
+            sleep: Self.parkedSleeper,
+            onReturnToOne: { model in
+                guard let recorder else { return true }
+                return await recorder.record(model)
+            }
+        )
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suite = "BatchAutoscalerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    // MARK: - Tier caps
+
+    /// Base and unknown must NEVER escalate: on those dies the memory
+    /// bandwidth can't feed a second concurrent decode stream, so any
+    /// escalation would only forfeit the 9× compiled-decode TTFT win.
+    @Test func tierCapMapping() {
+        #expect(BatchAutoscalerPolicy.tierCap(for: .base) == 1)
+        #expect(BatchAutoscalerPolicy.tierCap(for: .pro) == 4)
+        #expect(BatchAutoscalerPolicy.tierCap(for: .max) == 8)
+        #expect(BatchAutoscalerPolicy.tierCap(for: .ultra) == 16)
+        #expect(BatchAutoscalerPolicy.tierCap(for: .unknown) == 1)
+    }
+
+    // MARK: - Pure decision rules
+
+    @Test func nextPowerOfTwo() {
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(0) == 1)
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(1) == 1)
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(2) == 2)
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(3) == 4)
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(5) == 8)
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(16) == 16)
+        #expect(BatchAutoscalerPolicy.nextPowerOfTwo(17) == 32)
+    }
+
+    @Test func decision_noOverlapAlwaysReturnsToOne() {
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 0, tierCap: 8, previous: 1) == 1)
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 1, tierCap: 8, previous: 1) == 1)
+        // Even a previously escalated recommendation falls back once the
+        // window is quiet — this is the ONLY downsizing path.
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 1, tierCap: 8, previous: 8) == 1)
+    }
+
+    @Test func decision_overlapRoundsUpToNextPowerOfTwo() {
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 2, tierCap: 8, previous: 1) == 2)
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 3, tierCap: 8, previous: 1) == 4)
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 5, tierCap: 16, previous: 1) == 8)
+    }
+
+    @Test func decision_respectsTierCap() {
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 9, tierCap: 8, previous: 1) == 8)
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 30, tierCap: 16, previous: 1) == 16)
+        // Base/unknown cap of 1 means overlap can never escalate.
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 6, tierCap: 1, previous: 1) == 1)
+    }
+
+    /// Never resize DOWN while the window still shows overlap: mid-burst
+    /// downsizing thrashes engine rebuilds without recovering compile.
+    @Test func decision_stickyWhileWindowStillHasOverlap() {
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 2, tierCap: 8, previous: 8) == 8)
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 3, tierCap: 8, previous: 4) == 4)
+        // A stale previous above the cap is still clamped.
+        #expect(BatchAutoscalerPolicy.decision(windowMax: 2, tierCap: 4, previous: 8) == 4)
+    }
+
+    // MARK: - Actor: window behavior under an injected clock
+
+    @Test func noOverlapRecommendsSingleSlot() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 1)
+        clock.advance(by: 5)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 1)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 1)
+    }
+
+    @Test func overlapOfThreeRecommendsFour() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 3)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+    }
+
+    @Test func tierCapBoundsTheRecommendation() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 7)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 4) == 4)
+        // Base tier (cap 1) never escalates regardless of demand.
+        #expect(await scaler.recommendedBatchSize(for: "other", tierCap: 1) == 1)
+        await scaler.recordSubmission(model: "other", pendingAndActive: 6)
+        #expect(await scaler.recommendedBatchSize(for: "other", tierCap: 1) == 1)
+    }
+
+    @Test func recommendationsAreTrackedPerModel() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+        await scaler.recordSubmission(model: "busy", pendingAndActive: 3)
+        await scaler.recordSubmission(model: "solo", pendingAndActive: 1)
+        #expect(await scaler.recommendedBatchSize(for: "busy", tierCap: 8) == 4)
+        #expect(await scaler.recommendedBatchSize(for: "solo", tierCap: 8) == 1)
+    }
+
+    /// During a busy window the recommendation never drops, even when the
+    /// window max itself has fallen (peak sample aged out, smaller overlap
+    /// remains).
+    @Test func stickyWithinBusyWindow() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 3)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+
+        // 40s later a smaller overlap arrives; 25s after that the original
+        // demand-3 sample has aged out (65s old) but the demand-2 sample is
+        // still in the window. windowMax == 2 would naively recommend 2 —
+        // sticky keeps 4.
+        clock.advance(by: 40)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 2)
+        clock.advance(by: 25)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+    }
+
+    @Test func decaysToOneAfterFullQuietWindow() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+        await scaler.recordSubmission(model: "m", pendingAndActive: 3)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+
+        // 59s of quiet: still inside the window, still escalated.
+        clock.advance(by: 59)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+
+        // Past the full 60s quiet window: back to the compile-friendly 1.
+        clock.advance(by: 2)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 1)
+    }
+
+    // MARK: - Decay teardown
+
+    /// Returning to 1 must shut the (idle) engine down so the next request
+    /// rebuilds fresh at 1: a hot-resize down does not recover the compiled
+    /// decode path.
+    @Test func decaySweepTriggersTeardownHookOnce() async {
+        let clock = ManualClock()
+        let recorder = TeardownRecorder()
+        let scaler = makeAutoscaler(clock: clock, recorder: recorder)
+
+        await scaler.recordSubmission(model: "m", pendingAndActive: 3)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+
+        // Mid-window sweep: still busy, no decay, no teardown.
+        clock.advance(by: 30)
+        await scaler.sweep(model: "m")
+        #expect(await recorder.models.isEmpty)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 4)
+
+        // Quiet window elapsed: sweep decays to 1 and tears down.
+        clock.advance(by: 31)
+        await scaler.sweep(model: "m")
+        #expect(await recorder.models == ["m"])
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 1)
+
+        // A second sweep must not double-shutdown.
+        await scaler.sweep(model: "m")
+        #expect(await recorder.models == ["m"])
+    }
+
+    /// A busy engine (pending/active work) defers the teardown; the flag
+    /// stays pending and a later sweep retries.
+    @Test func decayTeardownRetriesWhileEngineBusy() async {
+        let clock = ManualClock()
+        let recorder = TeardownRecorder()
+        await recorder.setResult(false)
+        let scaler = makeAutoscaler(clock: clock, recorder: recorder)
+
+        await scaler.recordSubmission(model: "m", pendingAndActive: 2)
+        #expect(await scaler.recommendedBatchSize(for: "m", tierCap: 8) == 2)
+
+        clock.advance(by: 61)
+        await scaler.sweep(model: "m")
+        #expect(await recorder.models == ["m"])
+
+        // Engine reported busy — the retrying sweep calls the hook again,
+        // and once it succeeds the pending flag clears.
+        await recorder.setResult(true)
+        await scaler.sweep(model: "m")
+        #expect(await recorder.models == ["m", "m"])
+        await scaler.sweep(model: "m")
+        #expect(await recorder.models == ["m", "m"])
+    }
+
+    // MARK: - Recommendation-change log gating
+
+    @Test func logsOnlyOnRecommendationChange() async {
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+
+        // Reads that keep returning 1 log nothing.
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        #expect(await scaler.recentChangeLogs.isEmpty)
+
+        // 1 → 4 logs exactly once, repeats stay silent.
+        await scaler.recordSubmission(model: "m", pendingAndActive: 3)
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        let afterEscalation = await scaler.recentChangeLogs
+        #expect(afterEscalation == ["[Osaurus] autobatch: model=m 1→4 (windowMax=3, tierCap=8)"])
+
+        // Decay 4 → 1 logs the second line.
+        clock.advance(by: 61)
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        _ = await scaler.recommendedBatchSize(for: "m", tierCap: 8)
+        let afterDecay = await scaler.recentChangeLogs
+        #expect(afterDecay.count == 2)
+        #expect(afterDecay.last == "[Osaurus] autobatch: model=m 4→1 (windowMax=0, tierCap=8)")
+    }
+
+    // MARK: - InferenceFeatureFlags resolution
+
+    /// The auto flag defaults to FALSE: resolution must be bit-identical to
+    /// the legacy path so nothing changes for anyone who hasn't opted in.
+    @Test func flagOffByDefault_resolutionMatchesLegacyPath() async {
+        let defaults = isolatedDefaults()
+        var runtime = VMLXServerRuntimeSettings()
+
+        #expect(!InferenceFeatureFlags.autoBatchSizingEnabled(in: defaults, runtime: runtime))
+        let resolvedDefault = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            in: defaults,
+            runtime: runtime,
+            model: "m"
+        )
+        #expect(
+            resolvedDefault
+                == InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(in: defaults, runtime: runtime)
+        )
+        #expect(resolvedDefault == 1)
+
+        // Legacy override still wins on the flag-off path.
+        defaults.set(8, forKey: "ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize")
+        let resolvedLegacy = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            in: defaults,
+            runtime: runtime,
+            model: "m"
+        )
+        #expect(resolvedLegacy == 8)
+
+        // Runtime override too.
+        runtime.concurrency.maxConcurrentSequences = 6
+        let resolvedRuntime = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            in: defaults,
+            runtime: runtime,
+            model: "m"
+        )
+        #expect(resolvedRuntime == 6)
+    }
+
+    /// Explicit sizing is a deliberate choice of the compile-vs-throughput
+    /// trade-off; auto never overrides it even when the flag is on.
+    @Test func explicitSizingDisablesAutoEvenWhenFlagOn() async {
+        let defaults = isolatedDefaults()
+        defaults.set(true, forKey: "ai.osaurus.scheduler.autoBatchSize")
+
+        var runtime = VMLXServerRuntimeSettings()
+        runtime.concurrency.maxConcurrentSequences = 6
+        #expect(!InferenceFeatureFlags.autoBatchSizingEnabled(in: defaults, runtime: runtime))
+        let resolved = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            in: defaults,
+            runtime: runtime,
+            model: "m"
+        )
+        #expect(resolved == 6)
+
+        // Legacy UserDefaults value also counts as explicit.
+        let legacyDefaults = isolatedDefaults()
+        legacyDefaults.set(true, forKey: "ai.osaurus.scheduler.autoBatchSize")
+        legacyDefaults.set(2, forKey: "ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize")
+        #expect(
+            !InferenceFeatureFlags.autoBatchSizingEnabled(
+                in: legacyDefaults,
+                runtime: VMLXServerRuntimeSettings()
+            )
+        )
+    }
+
+    @Test func flagOnWithNoExplicitSizing_resolvesViaAutoscaler() async {
+        let defaults = isolatedDefaults()
+        defaults.set(true, forKey: "ai.osaurus.scheduler.autoBatchSize")
+        let runtime = VMLXServerRuntimeSettings()
+        #expect(InferenceFeatureFlags.autoBatchSizingEnabled(in: defaults, runtime: runtime))
+
+        let clock = ManualClock()
+        let scaler = makeAutoscaler(clock: clock)
+
+        // No overlap observed yet: stays at the compiled-decode 1.
+        let coldValue = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            in: defaults,
+            runtime: runtime,
+            model: "m",
+            autoscaler: scaler,
+            tierCapOverride: 8
+        )
+        #expect(coldValue == 1)
+
+        // Observed overlap of 3 escalates to the next power of two.
+        await scaler.recordSubmission(model: "m", pendingAndActive: 3)
+        let busyValue = await InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
+            in: defaults,
+            runtime: runtime,
+            model: "m",
+            autoscaler: scaler,
+            tierCapOverride: 8
+        )
+        #expect(busyValue == 4)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ChipProfileTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ChipProfileTests.swift
@@ -1,0 +1,107 @@
+//
+//  ChipProfileTests.swift
+//  osaurusTests
+//
+//  Covers the pure brand-string parser (every shipped Apple Silicon tier,
+//  future generations, and non-Apple fallbacks) plus the invariants the
+//  policy layer will rely on: `policyTier` never returns `.unknown`, and
+//  the neural-accelerator flag flips exactly at the M5 generation.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ChipProfileTests {
+
+    // MARK: - Brand-string parsing
+
+    @Test func parsesEveryShippedTier() {
+        #expect(ChipProfile.parse(brandString: "Apple M1") == (1, .base))
+        #expect(ChipProfile.parse(brandString: "Apple M1 Pro") == (1, .pro))
+        #expect(ChipProfile.parse(brandString: "Apple M1 Max") == (1, .max))
+        #expect(ChipProfile.parse(brandString: "Apple M1 Ultra") == (1, .ultra))
+        #expect(ChipProfile.parse(brandString: "Apple M3 Pro") == (3, .pro))
+        #expect(ChipProfile.parse(brandString: "Apple M4") == (4, .base))
+        #expect(ChipProfile.parse(brandString: "Apple M5 Max") == (5, .max))
+        #expect(ChipProfile.parse(brandString: "Apple M5 Ultra") == (5, .ultra))
+    }
+
+    @Test func parsesFutureGenerationsWithoutACodeChange() {
+        #expect(ChipProfile.parse(brandString: "Apple M6 Pro") == (6, .pro))
+        #expect(ChipProfile.parse(brandString: "Apple M12") == (12, .base))
+    }
+
+    @Test func toleratesSurroundingWhitespace() {
+        #expect(ChipProfile.parse(brandString: "  Apple M2 Ultra\n") == (2, .ultra))
+    }
+
+    @Test func rejectsNonAppleSiliconBrandStrings() {
+        let intel = ChipProfile.parse(
+            brandString: "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz")
+        #expect(intel.generation == nil)
+        #expect(intel.tier == .unknown)
+
+        // Unknown suffixes and adulterated strings must not half-match:
+        // policy code prefers "unknown, be conservative" over a wrong tier.
+        #expect(ChipProfile.parse(brandString: "Apple M4 Extreme").tier == .unknown)
+        #expect(ChipProfile.parse(brandString: "VirtualApple M2 Pro").tier == .unknown)
+        #expect(ChipProfile.parse(brandString: "").tier == .unknown)
+    }
+
+    // MARK: - Policy invariants
+
+    @Test func policyTierNeverExposesUnknown() {
+        let unknown = ChipProfile(
+            brandString: "Intel(R) Xeon(R)",
+            generation: nil,
+            tier: .unknown,
+            physicalMemoryBytes: 8 << 30,
+            gpuCoreCount: nil,
+            recommendedMaxWorkingSetBytes: nil
+        )
+        #expect(unknown.policyTier == .base)
+
+        let known = ChipProfile(
+            brandString: "Apple M5 Max",
+            generation: 5,
+            tier: .max,
+            physicalMemoryBytes: 128 << 30,
+            gpuCoreCount: 40,
+            recommendedMaxWorkingSetBytes: 100 << 30
+        )
+        #expect(known.policyTier == .max)
+    }
+
+    @Test func neuralAcceleratorFlagFlipsAtM5() {
+        func profile(generation: Int?) -> ChipProfile {
+            ChipProfile(
+                brandString: "test",
+                generation: generation,
+                tier: .base,
+                physicalMemoryBytes: 16 << 30,
+                gpuCoreCount: nil,
+                recommendedMaxWorkingSetBytes: nil
+            )
+        }
+        #expect(!profile(generation: 4).hasGPUNeuralAccelerators)
+        #expect(profile(generation: 5).hasGPUNeuralAccelerators)
+        #expect(profile(generation: 6).hasGPUNeuralAccelerators)
+        #expect(!profile(generation: nil).hasGPUNeuralAccelerators)
+    }
+
+    // MARK: - Live detection smoke test (runs on whatever hardware CI has)
+
+    @Test func detectReturnsInternallyConsistentProfile() {
+        let profile = ChipProfile.detect()
+        #expect(!profile.brandString.isEmpty)
+        #expect(profile.physicalMemoryBytes > 0)
+        if let cores = profile.gpuCoreCount {
+            #expect(cores > 0)
+        }
+        // JSON surface must serialize (guards against a non-plist value
+        // sneaking into the /health object).
+        #expect(JSONSerialization.isValidJSONObject(profile.healthJSONObject()))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1139,9 +1139,12 @@ struct RuntimePolicySourceTests {
             "Eviction must call `coalescer.remove(_:dispose:)` so the tombstone stays alive across the defensive `engine.shutdown()` call (mirrors the shutdownEngine path)"
         )
         // After eviction, recurse so the next first-fetch builds fresh.
+        // Recursion targets `resolveEngine` (the resolution body) rather
+        // than `engine(for:)` so the caller's in-flight handle is counted
+        // exactly once across the rebuild.
         #expect(
-            adapter.contains("return await self.engine("),
-            "Post-eviction must recurse into engine(...) so the rebuild lands through the coalescer's first-fetch path"
+            adapter.contains("return await self.resolveEngine("),
+            "Post-eviction must recurse into resolveEngine(...) so the rebuild lands through the coalescer's first-fetch path without double-counting the caller's engine handle"
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2869,6 +2869,9 @@ struct RuntimePolicySourceTests {
             !adapter.contains("message: \"begin model=\\(modelName) promptTokens="),
             "Sentry scrubs breadcrumbs containing prompt-like fields as content; token counts must remain visible for OOM/context-growth triage"
         )
-        #expect(adapter.contains("submit model=\\(modelName) batch=\\(maxBatchSize)"))
+        // #1919 renamed the local to `effectiveMaxBatchSize` (auto batch sizing);
+        // the policy this pins — batch size stays visible in breadcrumbs — is
+        // unchanged.
+        #expect(adapter.contains("submit model=\\(modelName) batch=\\(effectiveMaxBatchSize)"))
     }
 }


### PR DESCRIPTION
## What

Opt-in **auto batch sizing** driven by observed demand, capped by hardware tier:

- **`BatchAutoscaler`** (actor + pure policy core): tracks a 60 s sliding window of observed concurrent demand per model; recommendation = 1 when no overlap, else `min(nextPowerOfTwo(windowMax), tierCap)`. Sticky during a busy window (mid-burst downsizing thrashes engine rebuilds); decays to 1 only after a full quiet window.
- **Tier caps from ChipProfile**: base/unknown → 1 (never escalate — the compiled-decode TTFT win outweighs concurrency that bandwidth can't feed), pro → 4, max → 8, ultra → 16.
- **Demand signal** recorded in `MLXBatchAdapter.generate` **before the solo lease** — deliberately: at `maxBatchSize == 1` the SoloGenerationGate serializes overlapping requests upstream of the engine, so post-lease counts can never exceed 1 and overlap would be structurally unobservable. One registry peek + one pending/active read pair, only when the flag is on.
- **Return-to-1 restores the compiled path correctly**: a hot-resize down does NOT recover compile eligibility (vmlx invariant), so the decay path shuts the engine down via the existing tombstoned `Registry.shutdownEngine` — only when idle (pending==0 && active==0), retrying while busy, off the request path — so the next request rebuilds fresh at 1 with compile eligibility.
- **Off by default**: `defaults write com.dinoki.osaurus ai.osaurus.scheduler.autoBatchSize -bool true`, and auto only engages when no explicit `maxConcurrentSequences`/legacy value is set (explicit settings always win). Flag off = behavior identical to today, covered by test.

**Stacked on #1861.**

## Why

`maxBatchSize` is the sharpest tradeoff in the runtime: 1 keeps vmlx's compiled decode (documented 9× TTFT on Mistral 3.5), >1 buys multi-client throughput but permanently loses compile for that engine. Today it's a static `defaults write` the user must reason about. The machine can decide instead: single-user chat stays on the compiled path; a machine that actually observes overlapping same-model requests escalates to what its memory bandwidth tier can feed, and returns to the compiled path when quiet.

## Measurement

- 18 autoscaler tests (tier caps incl. unknown; no-overlap → 1; overlap 3 → 4; cap respected; busy-window stickiness; quiet-window decay with injected clock) + MLXBatchAdapter/TaskCoalescer/ChipProfile regression suites: 90/90 green; build + lint clean on changed lines.
- Live multi-client throughput measurement deliberately deferred to the flag-flip evaluation: this PR ships the mechanism dark (flag off), so the measurable claim here is "no behavior change by default", which the tests pin.

## Risk & rollback

Flag-gated dark launch; explicit settings win; decay teardown reuses the existing tombstone-protected shutdown path and only fires on an idle engine (a straggler racing the shutdown gets vmlx's clean `.cancelled` + registry rebuild — the documented fail-closed behavior). Revert = one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)