### PR TITLE
fixed sentry hangs & crashes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6"
+        "revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -992,9 +992,15 @@ public final class BackgroundTaskManager: ObservableObject {
         let previousCount = chatTurnCounts[taskId] ?? 0
         guard newCount > previousCount else { return }
 
+        // `$turns` emits on willSet, so `session.turns` still holds the OLD
+        // array here while `newCount` describes the incoming one. A session
+        // load that replaces a long history with a shorter array can leave
+        // `previousCount` past the readable bounds — clamp both ends or the
+        // range constructor traps.
         let turns = session.turns
-        let scanStart = max(0, previousCount - 1)
-        for turn in turns[scanStart ..< min(newCount, turns.count)] {
+        let scanEnd = min(newCount, turns.count)
+        let scanStart = min(max(0, previousCount - 1), scanEnd)
+        for turn in turns[scanStart ..< scanEnd] {
             if let toolCalls = turn.toolCalls {
                 for call in toolCalls {
                     state.appendActivity(kind: .tool, title: "Tool", detail: call.function.name)

--- a/Packages/OsaurusCore/Models/Configuration/AppConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/AppConfiguration.swift
@@ -18,11 +18,15 @@ public final class AppConfiguration: ObservableObject {
     public static let shared = AppConfiguration()
 
     @Published public private(set) var chatConfig: ChatConfiguration
-    public private(set) var foundationModelAvailable: Bool
+    @Published public private(set) var foundationModelAvailable: Bool
 
     private init() {
         self.chatConfig = Self.loadFromDisk()
-        self.foundationModelAvailable = FoundationModelService.isDefaultModelAvailable()
+        // The FoundationModels availability probe can block on XPC to the
+        // model daemon, and the first touch of `shared` happens on the main
+        // thread during launch — probe off-main and publish the result.
+        self.foundationModelAvailable = false
+        refreshFoundationModelAvailable()
     }
 
     // MARK: - Public API
@@ -39,7 +43,12 @@ public final class AppConfiguration: ObservableObject {
     }
 
     public func refreshFoundationModelAvailable() {
-        foundationModelAvailable = FoundationModelService.isDefaultModelAvailable()
+        Task.detached(priority: .userInitiated) {
+            let available = FoundationModelService.isDefaultModelAvailable()
+            await MainActor.run {
+                AppConfiguration.shared.foundationModelAvailable = available
+            }
+        }
     }
 
     // MARK: - Constants

--- a/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
+++ b/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
@@ -130,13 +130,39 @@ public enum GlobalProxySettings {
     /// `ServerConfigurationStore` is main-actor isolated because it is also
     /// used by SwiftUI state. Reading the same JSON file directly keeps
     /// session construction synchronous and side-effect free.
+    private struct ConfigCacheState {
+        let path: String
+        let modified: Date?
+        let configuration: ServerConfiguration?
+    }
+
+    /// Decoded-config cache validated by the file's modification date. Every
+    /// proxy lookup used to re-read and re-decode server.json — and lookups
+    /// run on the main thread (settings views, session builds), where the
+    /// read is an observed hang under disk pressure. A single stat per call
+    /// replaces the read+decode; an edit to the file still applies
+    /// immediately because the mtime changes.
+    private static let configCacheBox = OSAllocatedUnfairLock<ConfigCacheState?>(initialState: nil)
+
     static func diskBackedServerConfiguration() -> ServerConfiguration? {
         let url = OsaurusPaths.resolvePath(
             new: OsaurusPaths.serverConfigFile(),
             legacy: "ServerConfiguration.json"
         )
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return try? JSONDecoder().decode(ServerConfiguration.self, from: data)
+        let modified =
+            (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate]
+            as? Date
+        return configCacheBox.withLock { state in
+            if let state, state.path == url.path, state.modified == modified {
+                return state.configuration
+            }
+            var configuration: ServerConfiguration?
+            if let data = try? Data(contentsOf: url) {
+                configuration = try? JSONDecoder().decode(ServerConfiguration.self, from: data)
+            }
+            state = ConfigCacheState(path: url.path, modified: modified, configuration: configuration)
+            return configuration
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4305,10 +4305,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let formatter = ISO8601DateFormatter()
             let effectiveModels = await MainActor.run {
+                // Duplicate-tolerant: two agent files can share an id (a
+                // manually copied definition), and uniqueKeysWithValues traps.
                 Dictionary(
-                    uniqueKeysWithValues: agents.map {
+                    agents.map {
                         ($0.id, AgentManager.shared.effectiveModel(for: $0.id))
-                    }
+                    },
+                    uniquingKeysWith: { first, _ in first }
                 )
             }
             let items = agents.map { agent in

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6"
+        "revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -48,14 +48,18 @@ let package = Package(
         // .toolCallProgress`) so the app can show a live "preparing tool call"
         // card during a long buffered tool write (e.g. a large file) instead of
         // a frozen typing indicator. Additive — existing consumers unaffected.
-        // TESTING PIN: head of vmlx-swift fix/sentry-crashes (PR #123) —
-        // production crash-trap fixes (Qwen3VL position ids + rope deltas,
-        // Gemma4/NemotronH error-array guards, compiled-closure failure
-        // path). Contains the previous ff714f1 pin. Repoint to the merge
-        // commit once the PR lands.
+        // Now also carries #123 (production crash-trap fixes): Qwen3VL
+        // rotary embedding accepts low-rank position ids and the decode-path
+        // rope delta broadcasts per sequence (stale deltas fall back to cache
+        // offsets); Gemma4 maskedScatter and NemotronH mambaForward guard the
+        // rank-0/empty results a failed MLX op hands back inside a withError
+        // scope; the compile() overloads and innerCall degrade to empty
+        // results instead of trapping on a failed closure evaluation — so a
+        // recorded MLX error reaches the error-scope exit instead of dying in
+        // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a8c9b72f625e60d8b6b67b07f6b32cf1f173303e"
+            revision: "aa14267b11840f89f1976a273e553a3b7bbedf39"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -48,9 +48,14 @@ let package = Package(
         // .toolCallProgress`) so the app can show a live "preparing tool call"
         // card during a long buffered tool write (e.g. a large file) instead of
         // a frozen typing indicator. Additive — existing consumers unaffected.
+        // TESTING PIN: head of vmlx-swift fix/sentry-crashes (PR #123) —
+        // production crash-trap fixes (Qwen3VL position ids + rope deltas,
+        // Gemma4/NemotronH error-array guards, compiled-closure failure
+        // path). Contains the previous ff714f1 pin. Repoint to the merge
+        // commit once the PR lands.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ff714f1d0033768e85d48435fad2d244d80c91d6"
+            revision: "a8c9b72f625e60d8b6b67b07f6b32cf1f173303e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/HuggingFaceService.swift
+++ b/Packages/OsaurusCore/Services/HuggingFaceService.swift
@@ -640,7 +640,9 @@ actor HuggingFaceService {
             safePath
             .split(separator: "/")
             .reduce(base) { partial, component in
-                partial.appendingPathComponent(String(component))
+                // isDirectory: false avoids a per-component disk stat; this can
+                // run on the main thread during downloads.
+                partial.appendingPathComponent(String(component), isDirectory: false)
             }
             .standardizedFileURL
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -622,8 +622,16 @@ public actor ModelRuntime {
         }
 
         if !quit {
+            // Serialize this drain-sync against other GPU producers, same as
+            // every other synchronize/clearCache pair in this file. Ungated,
+            // it forces `end_encoding` on the shared stream while a gated
+            // producer (another model's generation, an image job) is
+            // mid-encode — observed null deref in
+            // `metal::Device::end_encoding` via `unload`.
+            await MetalGate.shared.enterModelTeardown(model: "loading-task-drain")
             Stream.gpu.synchronize()
             Memory.clearCache()
+            await MetalGate.shared.exitModelTeardown(model: "loading-task-drain")
         }
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
@@ -94,6 +94,16 @@ public actor ImageGenerationService {
     /// a custom models-dir bookmark. Image weights must stay on an
     /// SSD-resident volume (USB weights trip the GPU watchdog on first
     /// forward); all candidates here are internal-volume paths.
+    /// Memoized resolution, keyed on the effective models directory. The
+    /// candidate probing below lists up to three directories on disk, and
+    /// callers include @MainActor services (download bookkeeping, picker
+    /// cache) — under I/O pressure a fresh scan per call is an observed UI
+    /// hang. The key invalidates the cache when the user picks a new models
+    /// directory; bundle additions land in the resolved root itself, so a
+    /// stale "populated candidate" answer cannot point downloads elsewhere.
+    private static let rootCacheLock = NSLock()
+    nonisolated(unsafe) private static var rootCache: (key: String, url: URL)?
+
     public static func imageModelsRoot() -> URL {
         let env = ProcessInfo.processInfo.environment
         if let override = env["OSAURUS_IMAGE_MODELS_DIR"], !override.isEmpty {
@@ -114,14 +124,28 @@ public actor ImageGenerationService {
         }
         let osaurusImageDir = DirectoryPickerService.effectiveModelsDirectory()
             .appendingPathComponent("image", isDirectory: true)
+
+        let cacheKey = osaurusImageDir.path
+        rootCacheLock.lock()
+        if let cached = rootCache, cached.key == cacheKey {
+            rootCacheLock.unlock()
+            return cached.url
+        }
+        rootCacheLock.unlock()
+
         let userModelsImageDir = fm.homeDirectoryForCurrentUser
             .appendingPathComponent("models", isDirectory: true)
             .appendingPathComponent("image", isDirectory: true)
         let legacy = MLXStudioModelStore.defaultImageRoot
+        var resolved = osaurusImageDir
         for candidate in [osaurusImageDir, userModelsImageDir, legacy] where holdsBundles(candidate) {
-            return candidate
+            resolved = candidate
+            break
         }
-        return osaurusImageDir
+        rootCacheLock.lock()
+        rootCache = (key: cacheKey, url: resolved)
+        rootCacheLock.unlock()
+        return resolved
     }
 
     private func store() -> MLXStudioModelStore {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
-        #expect(packageResolved.contains(#""revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
-        #expect(workspaceResolved.contains(#""revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
-        #expect(appResolved.contains(#""revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6""#))
+        #expect(packageSwift.contains(#"revision: "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
+        #expect(packageResolved.contains(#""revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
+        #expect(workspaceResolved.contains(#""revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
+        #expect(appResolved.contains(#""revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -671,7 +671,13 @@ struct RuntimePolicySourceTests {
         // (vmlx-swift#119, `Generation.toolCallProgress`) that lets the
         // native chat show a live "Preparing tool call" card during a long
         // buffered tool write instead of a frozen typing indicator.
-        let expectedRuntimeHardenedRevision = "ff714f1d0033768e85d48435fad2d244d80c91d6"
+        // Now also carries vmlx-swift#123 (production crash-trap fixes):
+        // Qwen3VL low-rank position-id normalization + per-sequence rope
+        // delta broadcast, Gemma4/NemotronH guards against the rank-0/empty
+        // results a failed MLX op returns inside a withError scope, and
+        // non-trapping compiled-closure failure paths — so recorded MLX
+        // errors surface instead of dying in Swift bounds checks.
+        let expectedRuntimeHardenedRevision = "aa14267b11840f89f1976a273e553a3b7bbedf39"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tools/ToolOutputCompressor.swift
+++ b/Packages/OsaurusCore/Tools/ToolOutputCompressor.swift
@@ -58,7 +58,10 @@ public enum ToolOutputCompressor {
     /// O(n) passes would add latency there, and any payload this large is
     /// already past the universal cap (`ToolOutputCaps.universalResult`) and
     /// will be head/tail truncated regardless — crushing it first cannot save
-    /// it. Trailing-whitespace stripping is a single cheap pass and still runs.
+    /// it. The same bound gates the trailing-whitespace strip: an unbounded
+    /// scalar walk over a multi-hundred-MB payload on the main-actor registry
+    /// path is an observed multi-second UI hang, and anything past this bound
+    /// is truncated to the universal cap anyway.
     static let maximumJSONScanBytes = 512 * 1024
 
     /// Returns `raw` with insignificant formatting removed, preserving meaning
@@ -66,7 +69,7 @@ public enum ToolOutputCompressor {
     public static func compact(_ raw: String) -> String {
         guard isEnabled else { return raw }
         let byteCount = raw.utf8.count
-        guard byteCount >= minimumLength else { return raw }
+        guard byteCount >= minimumLength, byteCount <= maximumJSONScanBytes else { return raw }
 
         // Classify on the first non-whitespace scalar. JSON is the high-value,
         // provably-safe target; everything else only gets trailing-strip.
@@ -75,9 +78,7 @@ public enum ToolOutputCompressor {
             return raw
         }
         let first = scalars[firstIdx]
-        if (first == "{" || first == "["), byteCount <= maximumJSONScanBytes,
-            let crushed = crushedJSONIfValid(raw)
-        {
+        if (first == "{" || first == "["), let crushed = crushedJSONIfValid(raw) {
             return crushed
         }
         return strippedTrailingWhitespace(raw)

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -1397,9 +1397,16 @@ final class StreamingCursorOverlay: NSView {
     }
 
     func updateColor(_ color: NSColor) {
+        // Skip when unchanged: this is called on every 50ms idle tick, and a
+        // top-level explicit CATransaction.commit synchronously flushes the
+        // whole window's pending layer tree to the render server — an
+        // observed multi-second hang on memory-starved machines. The color
+        // only actually changes on a theme switch.
+        let cgColor = color.cgColor
+        guard dotLayer.fillColor != cgColor else { return }
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        dotLayer.fillColor = color.cgColor
+        dotLayer.fillColor = cgColor
         CATransaction.commit()
     }
 

--- a/Packages/OsaurusCore/Views/Management/ManagementView.swift
+++ b/Packages/OsaurusCore/Views/Management/ManagementView.swift
@@ -278,7 +278,14 @@ private extension ManagementView {
                 hasAppeared = true
             }
         }
-        updater.checkForUpdatesInBackground()
+        // First touch lazily creates SPUStandardUpdaterController, whose init
+        // reads bundle/defaults state off disk — and this appear fires during
+        // the launch-time management-window prewarm. Defer it past launch
+        // congestion instead of stalling the prewarm frame; a delayed
+        // background check is invisible to the user.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            updater.checkForUpdatesInBackground()
+        }
     }
 
     func handleTabChange(to newTab: ManagementTab) {

--- a/Packages/OsaurusCore/Views/Memory/MemoryView.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryView.swift
@@ -1007,7 +1007,12 @@ struct MemoryView: View {
             let agentEntries = (try? db.agentIdsWithPinnedFacts()) ?? []
 
             let agents = await MainActor.run { agentManager.agents }
-            let agentLookup = Dictionary(uniqueKeysWithValues: agents.map { ($0.id, $0) })
+            // Duplicate-tolerant: two agent files can share an id, and
+            // uniqueKeysWithValues traps.
+            let agentLookup = Dictionary(
+                agents.map { ($0.id, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
             let resolvedCounts: [(agent: Agent, count: Int)] = agentEntries.compactMap { pair in
                 guard let uuid = UUID(uuidString: pair.agentId),
                     !Agent.isDefaultAgentId(pair.agentId),

--- a/Packages/OsaurusCore/Views/Theme/ThemesView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemesView.swift
@@ -1108,7 +1108,12 @@ struct ThemesView: View {
         let custom = sorted.filter { !$0.isBuiltIn }
 
         let reports = ThemeLibraryManagementService.validationReports(for: sorted)
-        let reportMap = Dictionary(uniqueKeysWithValues: reports.map { ($0.themeID, $0) })
+        // Two installed theme files can share an ID (e.g. a manually copied
+        // built-in), so tolerate duplicate keys — uniqueKeysWithValues traps.
+        let reportMap = Dictionary(
+            reports.map { ($0.themeID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         let reviewIDs = Set(reports.filter { $0.needsReview }.map { $0.themeID })
 
         let groups = ThemeLibraryManagementService.duplicateGroups(in: sorted)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3e1ff0bda2fb40739fd509af946f74d76ed517e42acde77a162d8fe185909d2d",
+  "originHash" : "30860c6b2d5bb049938cb38da96a9fd7bea5ed60bb1ef0a7ee7ecadd15acefc7",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ff714f1d0033768e85d48435fad2d244d80c91d6"
+        "revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39"
       }
     },
     {


### PR DESCRIPTION
## Summary

Triage of all unresolved Sentry hangs and crashes. Every fix maps to a specific Sentry issue (referenced in the resolution comments on each issue); the noise tail was archived separately.

## Hang fixes

- Bounded the tool-output compaction scan to the same 512KB limit as the JSON crush; the trailing-whitespace strip previously walked payloads of unbounded size on the main-actor registry path (APPLE-MACOS-Y2, the most frequent hang on 0.21.7)
- Moved the FoundationModels availability probe off the main thread at launch; its XPC call to the model daemon ran inside the first touch of the shared configuration during app launch (APPLE-MACOS-C6)
- Passed an explicit directory flag when building download destination paths, eliminating a per-component disk stat during model downloads (APPLE-MACOS-YD)
- Deferred the Sparkle background update check 2 seconds past window appear; its lazy controller creation performed disk I/O inside the launch-time management-window prewarm (APPLE-MACOS-YT, BT)
- Memoized the image-models root resolution, keyed on the effective models directory; it previously re-listed up to three directories on every call from main-actor services (APPLE-MACOS-YF)
- Skipped redundant layer commits in the streaming cursor color update; an explicit CA transaction commit ran on every 50ms idle tick and synchronously flushed the whole window's layer tree (APPLE-MACOS-M0)
- Cached the decoded server configuration for proxy lookups with modification-date validation; every lookup previously re-read and re-decoded the config file on the main thread (APPLE-MACOS-Y5)

## Crash fixes

- Clamped the turn-scan range in the background task manager; the turns publisher emits on willSet, so a session load that shrinks history produced an invalid range and trapped (APPLE-MACOS-NM)
- Gated the loading-task drain sync behind the exclusive GPU teardown gate; it previously forced encoding to end on the shared Metal stream while another gated producer was mid-encode (APPLE-MACOS-11, XT, and the residual 0.21.6 command-buffer crashes)
- Tolerated duplicate IDs when building the theme validation report map and the two agent lookup maps; duplicated user files with the same ID trapped the unique-keys dictionary constructor (APPLE-MACOS-VT)

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
