### PR TITLE
Add `bench --calibrate` memory-bandwidth probe + decode estimates in `show`

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -200,6 +200,10 @@ public struct BenchCommand: Command {
 
         let gbps = MemoryBandwidthCalibration.measureBandwidthGBps(
             bufferBytes: bufferBytes, threads: threads)
+        guard gbps > 0, gbps.isFinite else {
+            fputs("Calibration returned an invalid bandwidth measurement; result was not saved.\n", stderr)
+            exit(EXIT_FAILURE)
+        }
         print(String(
             format: "Measured memory bandwidth: %.1f GB/s (aggregate over %d threads)",
             gbps, threads))

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -118,22 +118,13 @@ public struct BenchCommand: Command {
             exit(EXIT_FAILURE)
         }
 
-        let report: [String: Any] = [
-            "schema": "osaurus-bench/1",
-            "timestamp": ISO8601DateFormatter().string(from: Date()),
-            "model": model,
-            "max_tokens": options.maxTokens,
-            "runs": options.runs,
-            "hardware": (health["hardware"] as? [String: Any]) ?? NSNull(),
-            "scenarios": scenarios,
-            "methodology": [
-                "sampling": "temperature 0 (greedy)",
-                "token_counts": "server usage via stream_options.include_usage",
-                "ttft": "request start → first non-empty content delta",
-                "decode_tps": "(completion_tokens - 1) / (last delta - first delta)",
-                "prefill_tps": "prompt_tokens / uncached TTFT (includes template + tokenize)",
-            ],
-        ]
+        let report = makeReport(
+            model: model,
+            maxTokens: options.maxTokens,
+            runs: options.runs,
+            health: health,
+            scenarios: scenarios
+        )
 
         let data: Data
         do {
@@ -158,6 +149,34 @@ public struct BenchCommand: Command {
             print(String(bytes: data, encoding: .utf8) ?? "{}")
         }
         exit(EXIT_SUCCESS)
+    }
+
+    /// Single report contract for the normal benchmark lane. Calibration and
+    /// prefill tuning persist their own state but do not fork this schema.
+    static func makeReport(
+        model: String,
+        maxTokens: Int,
+        runs: Int,
+        health: [String: Any],
+        scenarios: [[String: Any]],
+        timestamp: String = ISO8601DateFormatter().string(from: Date())
+    ) -> [String: Any] {
+        [
+            "schema": "osaurus-bench/1",
+            "timestamp": timestamp,
+            "model": model,
+            "max_tokens": maxTokens,
+            "runs": runs,
+            "hardware": (health["hardware"] as? [String: Any]) ?? NSNull(),
+            "scenarios": scenarios,
+            "methodology": [
+                "sampling": "temperature 0 (greedy)",
+                "token_counts": "server usage via stream_options.include_usage",
+                "ttft": "request start → first non-empty content delta",
+                "decode_tps": "(completion_tokens - 1) / (last delta - first delta)",
+                "prefill_tps": "prompt_tokens / uncached TTFT (includes template + tokenize)",
+            ],
+        ]
     }
 
     // MARK: - Memory-bandwidth calibration (`--calibrate`)

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -41,12 +41,19 @@ public struct BenchCommand: Command {
         var port: Int
         var tunePrefill: Bool = false
         var tuneCandidates: [Int] = BenchCommand.defaultTuneCandidates
+        var calibrate: Bool = false
     }
 
     public static func execute(args: [String]) async {
         guard var options = parseOptions(args) else {
             printUsage()
             exit(EXIT_FAILURE)
+        }
+
+        if options.calibrate {
+            // Before the health check on purpose: bandwidth is a property of
+            // the machine, not the server, so no server is required.
+            calibrate()
         }
 
         let base = URL(string: "http://127.0.0.1:\(options.port)")!
@@ -150,6 +157,55 @@ public struct BenchCommand: Command {
         } else {
             print(String(bytes: data, encoding: .utf8) ?? "{}")
         }
+        exit(EXIT_SUCCESS)
+    }
+
+    // MARK: - Memory-bandwidth calibration (`--calibrate`)
+
+    /// Runs the parallel aggregate STREAM-copy bandwidth probe IN THIS
+    /// PROCESS (bandwidth is a machine property — measuring it in the CLI is
+    /// equivalent to measuring it in the server) and persists the result to
+    /// `~/.osaurus/config/chip-profile.json`, which the server re-reads
+    /// (mtime-checked, see `ChipProfileCalibration` in OsaurusCore) — no
+    /// restart needed. The probe allocates two large buffers and hammers
+    /// memory for ~2.4 s; it only ever runs from this explicit verb.
+    static func calibrate() -> Never {
+        let chip = MemoryBandwidthCalibration.chipBrandString()
+        let bufferBytes = MemoryBandwidthCalibration.defaultBufferBytes()
+        let threads = MemoryBandwidthCalibration.defaultThreadCount()
+        fputs(
+            "Calibrating memory bandwidth on \(chip) "
+                + "(STREAM copy: 2 × \(ByteCountFormatter.string(fromByteCount: Int64(bufferBytes), countStyle: .memory)) buffers, "
+                + "\(threads) threads, 3 trials × ~0.8 s)…\n",
+            stderr)
+
+        let gbps = MemoryBandwidthCalibration.measureBandwidthGBps(
+            bufferBytes: bufferBytes, threads: threads)
+        print(String(
+            format: "Measured memory bandwidth: %.1f GB/s (aggregate over %d threads)",
+            gbps, threads))
+        if let spec = MemoryBandwidthCalibration.specBandwidthGBps(brandString: chip) {
+            print(String(
+                format: "Spec bandwidth: %.0f GB/s → efficiency %.0f%%", spec, gbps / spec * 100))
+        }
+
+        let record = MemoryBandwidthCalibration.Record(
+            measuredBandwidthGBps: gbps,
+            chip: chip,
+            measuredAt: ISO8601DateFormatter().string(from: Date()),
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            probeThreads: threads
+        )
+        do {
+            try MemoryBandwidthCalibration.save(record)
+        } catch {
+            fputs("Cannot persist result: \(error.localizedDescription)\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+        fputs(
+            "Persisted to \(MemoryBandwidthCalibration.fileURL().path) — "
+                + "`osaurus show` and the server pick it up on next read.\n",
+            stderr)
         exit(EXIT_SUCCESS)
     }
 
@@ -486,7 +542,9 @@ public struct BenchCommand: Command {
         Double(to.uptimeNanoseconds - from.uptimeNanoseconds) / 1_000_000
     }
 
-    private static func fetchJSON(_ url: URL) async -> [String: Any]? {
+    /// Internal (not private): `ShowCommand` reuses this ~2 s-timeout fetch
+    /// to read the server's `/health` scan root for its decode estimate.
+    static func fetchJSON(_ url: URL) async -> [String: Any]? {
         var request = URLRequest(url: url)
         request.timeoutInterval = 2
         guard let (data, response) = try? await URLSession.shared.data(for: request),
@@ -536,6 +594,8 @@ public struct BenchCommand: Command {
                 options.port = n
             case "--tune-prefill":
                 options.tunePrefill = true
+            case "--calibrate":
+                options.calibrate = true
             case "--candidates":
                 guard let v = value() else { return nil }
                 let parsed = v.split(separator: ",").compactMap { Int($0) }.filter { $0 > 0 }
@@ -557,6 +617,7 @@ public struct BenchCommand: Command {
                                  [--max-tokens 128] [--runs 3] [--json <path>] [--port N]
                    osaurus bench --tune-prefill [--model <id>] [--candidates 512,1024,2048,4096]
                                  [--prompt-tokens 8192] [--runs 3]
+                   osaurus bench --calibrate
 
             Requires a running server (`osaurus serve`). Reports uncached/cached
             TTFT, prefill tok/s, and decode tok/s per prompt size as JSON.
@@ -564,6 +625,10 @@ public struct BenchCommand: Command {
             --tune-prefill measures the model's TTFT at each candidate prefill
             step size and persists the per-model winner (the optimum is
             model-architecture-dependent); the server applies it immediately.
+
+            --calibrate measures this machine's memory bandwidth (STREAM copy,
+            ~2 GiB transient allocation, a few seconds) and persists it for
+            decode-speed estimates (`osaurus show`). No server needed.
 
             """, stderr)
     }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Bench.swift
@@ -184,10 +184,10 @@ public struct BenchCommand: Command {
     /// Runs the parallel aggregate STREAM-copy bandwidth probe IN THIS
     /// PROCESS (bandwidth is a machine property — measuring it in the CLI is
     /// equivalent to measuring it in the server) and persists the result to
-    /// `~/.osaurus/config/chip-profile.json`, which the server re-reads
-    /// (mtime-checked, see `ChipProfileCalibration` in OsaurusCore) — no
-    /// restart needed. The probe allocates two large buffers and hammers
-    /// memory for ~2.4 s; it only ever runs from this explicit verb.
+    /// `~/.osaurus/config/chip-profile.json`, which `osaurus show` reads on
+    /// its next run and OsaurusCore can validate through
+    /// `ChipProfileCalibration`. The probe allocates two large buffers and
+    /// hammers memory for ~2.4 s; it only ever runs from this explicit verb.
     static func calibrate() -> Never {
         let chip = MemoryBandwidthCalibration.chipBrandString()
         let bufferBytes = MemoryBandwidthCalibration.defaultBufferBytes()
@@ -223,7 +223,7 @@ public struct BenchCommand: Command {
         }
         fputs(
             "Persisted to \(MemoryBandwidthCalibration.fileURL().path) — "
-                + "`osaurus show` and the server pick it up on next read.\n",
+                + "`osaurus show` picks it up on its next run.\n",
             stderr)
         exit(EXIT_SUCCESS)
     }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
@@ -307,7 +307,36 @@ public struct ShowCommand: Command {
         let baseDir = await modelsBaseDirectory(port: port)
         guard let modelDir = resolveLocalModelDirectory(forModelId: modelId, under: baseDir)
         else { return nil }
+        // MoE models activate only a fraction of their weights per token, so
+        // the all-weights-streamed decode formula understates them severalfold
+        // (a 35B-A3B bundle showing ~12 tok/s while really decoding ~10x that
+        // misleads worse than no estimate). Suppress until the estimator
+        // learns active-parameter bytes; dense models keep their line.
+        guard !isMoEBundle(at: modelDir) else { return nil }
         return weightsBytes(under: modelDir)
+    }
+
+    /// True when the bundle's config.json declares a mixture-of-experts
+    /// architecture (any of the expert-count keys used across families, at
+    /// the top level or under text_config).
+    static func isMoEBundle(at modelDir: URL) -> Bool {
+        let configURL = modelDir.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        let expertKeys = [
+            "num_experts", "n_routed_experts", "num_local_experts", "num_experts_per_tok",
+        ]
+        func declaresExperts(_ object: [String: Any]) -> Bool {
+            expertKeys.contains { key in
+                (object[key] as? Int).map { $0 > 1 } ?? false
+            }
+        }
+        if declaresExperts(root) { return true }
+        if let textConfig = root["text_config"] as? [String: Any], declaresExperts(textConfig) {
+            return true
+        }
+        return false
     }
 
     /// Models base directory, in order of authority:

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
@@ -152,6 +152,7 @@ public struct ShowCommand: Command {
             let decoder = JSONDecoder()
             let showResponse = try decoder.decode(ShowResponse.self, from: data)
             printFormattedOutput(modelArg: modelArg, response: showResponse)
+            await printDecodeEstimateIfAvailable(modelArg: modelArg, port: port)
             exit(EXIT_SUCCESS)
         } catch {
             fputs("Error: \(error.localizedDescription)\n", stderr)
@@ -258,6 +259,157 @@ public struct ShowCommand: Command {
                 }
             }
         }
+    }
+
+    // MARK: - Decode-speed estimate (memory-bandwidth-based)
+
+    /// Prints `Estimated decode: ~NN tok/s on this Mac (…)` when — and only
+    /// when — the model's weights are installed locally (size computable) AND
+    /// a bandwidth number exists: a calibration record from
+    /// `osaurus bench --calibrate`, else the chip's spec-sheet bandwidth.
+    /// Decode is memory-bound, so tok/s ≈ bandwidth × 0.7 ÷ weights bytes
+    /// (see `MemoryBandwidthCalibration`). Silent otherwise: a missing
+    /// estimate must never break `show` for remote or unknown models.
+    private static func printDecodeEstimateIfAvailable(modelArg: String, port: Int) async {
+        guard let weightsBytes = await localWeightsBytes(forModelId: modelArg, port: port),
+            weightsBytes > 0
+        else {
+            return
+        }
+        let bandwidthGBps: Double
+        let sourceLabel: String
+        if let record = MemoryBandwidthCalibration.readValidRecord() {
+            bandwidthGBps = record.measuredBandwidthGBps
+            sourceLabel = "measured"
+        } else if let spec = MemoryBandwidthCalibration.specBandwidthGBps(
+            brandString: MemoryBandwidthCalibration.chipBrandString()) {
+            bandwidthGBps = spec
+            sourceLabel = "spec"
+        } else {
+            return
+        }
+        let tps = MemoryBandwidthCalibration.estimatedDecodeTps(
+            weightsBytes: weightsBytes, bandwidthGBps: bandwidthGBps)
+        guard tps > 0, tps.isFinite else { return }
+        print("")
+        print(String(
+            format: "  Estimated decode: ~%.0f tok/s on this Mac (%@ %.0f GB/s × %.1f ÷ %.1f GB weights)",
+            tps, sourceLabel, bandwidthGBps,
+            MemoryBandwidthCalibration.decodeEfficiency,
+            Double(weightsBytes) / 1e9))
+    }
+
+    /// Sum of local `.safetensors` file sizes for the model, or nil when the
+    /// model directory can't be located (not installed locally). The
+    /// recursive walk covers sharded weights placed in subdirectories by
+    /// `osaurus pull`.
+    static func localWeightsBytes(forModelId modelId: String, port: Int) async -> Int64? {
+        let baseDir = await modelsBaseDirectory(port: port)
+        guard let modelDir = resolveLocalModelDirectory(forModelId: modelId, under: baseDir)
+        else { return nil }
+        return weightsBytes(under: modelDir)
+    }
+
+    /// Models base directory, in order of authority:
+    /// 1. The running server's own scan root (`/health` →
+    ///    `local_model_scan.root`) — authoritative, because the user can
+    ///    point the app at any folder (e.g. `~/MLXModels`) and only the
+    ///    scanning server knows which one it actually lists models from.
+    /// 2. The shared group-defaults path (mirrors
+    ///    `PullCommand.resolveLocalDirectory`).
+    /// 3. `~/.osaurus/models` (the default install location).
+    static func modelsBaseDirectory(port: Int) async -> URL {
+        if let healthURL = URL(string: "http://127.0.0.1:\(port)/health"),
+            let health = await BenchCommand.fetchJSON(healthURL),
+            let root = modelsRoot(fromHealth: health) {
+            return root
+        }
+        if let shared = UserDefaults(suiteName: "group.com.osaurus.shared"),
+            let storedPath = shared.string(forKey: "modelsDirectoryPath"),
+            !storedPath.isEmpty {
+            return URL(fileURLWithPath: storedPath, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".osaurus/models", isDirectory: true)
+    }
+
+    /// Extracts the server's local-model scan root from a `/health` payload.
+    /// Pure so the JSON contract is unit-testable against a fixture.
+    static func modelsRoot(fromHealth health: [String: Any]) -> URL? {
+        guard let scan = health["local_model_scan"] as? [String: Any],
+            let root = scan["root"] as? String,
+            !root.isEmpty
+        else { return nil }
+        return URL(fileURLWithPath: root, isDirectory: true)
+    }
+
+    /// Resolves the model's directory under `baseDir`, trying both name
+    /// forms:
+    /// 1. The id's `/`-components nested as-is (matches `osaurus pull`
+    ///    layout and fully-qualified `org/name` ids).
+    /// 2. A case-insensitive scan of the first two directory levels,
+    ///    comparing lowercased names — the server lists lowercased ids
+    ///    (e.g. `qwen3.6-35b-a3b-mxfp4-mtp`) while directories keep their
+    ///    original casing (`OsaurusAI/Qwen3.6-35B-A3B-MXFP4-MTP`), and a
+    ///    single-component id may name a repo nested one org level down.
+    ///    Two levels is enough: discovery supports flat and `org/repo`
+    ///    layouts; deeper multi-org roots are rare and this line is
+    ///    best-effort display, never an error.
+    static func resolveLocalModelDirectory(forModelId modelId: String, under baseDir: URL) -> URL? {
+        let fm = FileManager.default
+        func isDirectory(_ url: URL) -> Bool {
+            var isDir: ObjCBool = false
+            return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+        }
+        let components = modelId.split(separator: "/").map(String.init)
+        guard !components.isEmpty else { return nil }
+
+        // 1. Exact nesting of the id's components.
+        let exact = components.reduce(baseDir) { partial, component in
+            partial.appendingPathComponent(component, isDirectory: true)
+        }
+        if isDirectory(exact) { return exact }
+
+        // 2. Case-insensitive two-level scan.
+        func childDirectories(of url: URL) -> [URL] {
+            ((try? fm.contentsOfDirectory(at: url, includingPropertiesForKeys: [.isDirectoryKey]))
+                ?? [])
+                .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+        }
+        let loweredId = modelId.lowercased()
+        var leafMatch: URL?
+        for level1 in childDirectories(of: baseDir) {
+            let name1 = level1.lastPathComponent.lowercased()
+            if name1 == loweredId { return level1 }
+            for level2 in childDirectories(of: level1) {
+                let name2 = level2.lastPathComponent.lowercased()
+                // Full relative-path match wins over a bare leaf-name match.
+                if "\(name1)/\(name2)" == loweredId { return level2 }
+                if leafMatch == nil, name2 == loweredId { leafMatch = level2 }
+            }
+        }
+        return leafMatch
+    }
+
+    /// Recursive `.safetensors` byte sum, nil when `directory` is absent.
+    /// Split from the id-based resolver so tests can point it at a fixture
+    /// directory without touching user defaults or the home directory.
+    static func weightsBytes(under directory: URL) -> Int64? {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDir), isDir.boolValue else {
+            return nil
+        }
+        guard let enumerator = fm.enumerator(
+            at: directory, includingPropertiesForKeys: [.fileSizeKey]) else { return nil }
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator
+        where fileURL.pathExtension.lowercased() == "safetensors" {
+            if let size = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                total += Int64(size)
+            }
+        }
+        return total
     }
 
     private static func pad(_ string: String, to width: Int) -> String {

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
@@ -110,9 +110,10 @@ enum MemoryBandwidthCalibration {
 
     // MARK: - Decode-throughput estimator
 
-    /// Fraction of memcpy bandwidth a decode step achieves; see the Core copy
-    /// for the rationale (memcpy reaches 60–75% of theoretical, decode
-    /// streams weights close to memcpy patterns). Keep in sync with
+    /// Conservative utilization margin applied to either a measured STREAM
+    /// bandwidth or a spec-sheet fallback. It accounts for kernel overhead,
+    /// non-weight traffic, and non-ideal access; it is not a conversion from
+    /// theoretical bandwidth to measured memcpy bandwidth. Keep in sync with
     /// `ChipProfileCalibration.decodeEfficiency`.
     static let decodeEfficiency = 0.7
 
@@ -168,7 +169,8 @@ enum MemoryBandwidthCalibration {
         trials: Int = 3,
         threads: Int = defaultThreadCount()
     ) -> Double {
-        precondition(threads > 0 && bufferBytes >= threads && trials > 0)
+        precondition(
+            threads > 0 && bufferBytes >= threads && trials > 0 && secondsPerTrial > 0)
         let alignment = 16_384  // page-aligned
         let src = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)
         let dst = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
@@ -36,9 +36,9 @@ enum MemoryBandwidthCalibration {
         let probeThreads: Int
     }
 
-    /// `~/.osaurus/config/chip-profile.json` — the server-side reader is
-    /// `ChipProfileCalibration` (OsaurusCore), which re-reads on mtime change,
-    /// so a fresh calibration applies without a server restart.
+    /// `~/.osaurus/config/chip-profile.json` — the Core-side reader is
+    /// `ChipProfileCalibration` (OsaurusCore), while the CLI reads it fresh
+    /// each time `osaurus show` runs.
     static func fileURL() -> URL {
         Configuration.root()
             .appendingPathComponent("config", isDirectory: true)
@@ -67,10 +67,13 @@ enum MemoryBandwidthCalibration {
 
     /// Stored record, or nil when absent, undecodable, or measured on a
     /// different chip (same invalidation rule as the Core reader).
-    static func readValidRecord() -> Record? {
-        guard let data = try? Data(contentsOf: fileURL()),
+    static func readValidRecord(
+        at url: URL = fileURL(),
+        forChip liveChip: String = chipBrandString()
+    ) -> Record? {
+        guard let data = try? Data(contentsOf: url),
             let record = try? JSONDecoder().decode(Record.self, from: data),
-            record.chip == chipBrandString(),
+            record.chip == liveChip,
             record.measuredBandwidthGBps > 0,
             record.measuredBandwidthGBps.isFinite,
             record.probeThreads > 0

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
@@ -70,7 +70,10 @@ enum MemoryBandwidthCalibration {
     static func readValidRecord() -> Record? {
         guard let data = try? Data(contentsOf: fileURL()),
             let record = try? JSONDecoder().decode(Record.self, from: data),
-            record.chip == chipBrandString()
+            record.chip == chipBrandString(),
+            record.measuredBandwidthGBps > 0,
+            record.measuredBandwidthGBps.isFinite,
+            record.probeThreads > 0
         else { return nil }
         return record
     }
@@ -112,7 +115,7 @@ enum MemoryBandwidthCalibration {
 
     /// tok/s ≈ bandwidth × efficiency ÷ weights bytes read per token.
     static func estimatedDecodeTps(weightsBytes: Int64, bandwidthGBps: Double) -> Double {
-        guard weightsBytes > 0 else { return 0 }
+        guard weightsBytes > 0, bandwidthGBps > 0, bandwidthGBps.isFinite else { return 0 }
         return bandwidthGBps * 1e9 * decodeEfficiency / Double(weightsBytes)
     }
 

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/MemoryBandwidthCalibration.swift
@@ -1,0 +1,224 @@
+//
+//  MemoryBandwidthCalibration.swift
+//  osaurus
+//
+//  Standalone CLI copy of the memory-bandwidth calibration probe and the
+//  decode-throughput arithmetic.
+//
+//  Why a copy: the canonical implementation lives in OsaurusCore
+//  (Packages/OsaurusCore/Services/ChipProfileCalibration.swift — cross-
+//  referenced there), which the CLI does not link. This mirrors how
+//  Bench.swift writes the prefill-tuning JSON contract without linking
+//  `ModelPrefillTuningStore`. Bandwidth is a machine property, not a server
+//  property, so running the probe IN the CLI process measures exactly the
+//  same thing the server would see; the JSON record below is byte-compatible
+//  with the Core `CalibrationRecord` Codable (asserted by tests on both
+//  sides via a shared fixture string).
+//
+//  Keep the probe convention, the efficiency constant, and the spec table
+//  identical to the Core copy.
+//
+
+import Foundation
+
+enum MemoryBandwidthCalibration {
+    /// Mirrors `ChipProfileCalibration.CalibrationRecord` (OsaurusCore) —
+    /// same keys, same optionality. Do not rename fields without updating
+    /// the Core struct and both shape tests.
+    struct Record: Codable {
+        let measuredBandwidthGBps: Double
+        let chip: String
+        let measuredAt: String?
+        let osVersion: String?
+        /// Copy-thread count the aggregate probe ran with — auditable
+        /// provenance (a 1-thread number is not comparable to an 8-thread
+        /// one). Required, matching the Core Codable.
+        let probeThreads: Int
+    }
+
+    /// `~/.osaurus/config/chip-profile.json` — the server-side reader is
+    /// `ChipProfileCalibration` (OsaurusCore), which re-reads on mtime change,
+    /// so a fresh calibration applies without a server restart.
+    static func fileURL() -> URL {
+        Configuration.root()
+            .appendingPathComponent("config", isDirectory: true)
+            .appendingPathComponent("chip-profile.json")
+    }
+
+    // MARK: - Machine identity
+
+    /// Live chip brand string (`machdep.cpu.brand_string`), the calibration
+    /// record's invalidation key: a record written on other hardware
+    /// (Migration Assistant restore) must not be trusted.
+    static func chipBrandString() -> String {
+        var size = 0
+        guard sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0) == 0, size > 0 else {
+            return "unknown"
+        }
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0) == 0 else {
+            return "unknown"
+        }
+        // Truncate at the null terminator; sysctl strings are NUL-terminated.
+        return String(bytes: buffer.prefix(while: { $0 != 0 }), encoding: .utf8) ?? "unknown"
+    }
+
+    // MARK: - Record I/O
+
+    /// Stored record, or nil when absent, undecodable, or measured on a
+    /// different chip (same invalidation rule as the Core reader).
+    static func readValidRecord() -> Record? {
+        guard let data = try? Data(contentsOf: fileURL()),
+            let record = try? JSONDecoder().decode(Record.self, from: data),
+            record.chip == chipBrandString()
+        else { return nil }
+        return record
+    }
+
+    /// Atomic whole-file write; single machine-wide record, no merge needed.
+    static func save(_ record: Record) throws {
+        let url = fileURL()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try encoder.encode(record).write(to: url, options: .atomic)
+    }
+
+    // MARK: - Spec bandwidth table
+
+    /// Spec-sheet unified-memory bandwidth (GB/s) by exact brand string.
+    /// Display-only estimates, superseded by measurement. Keep identical to
+    /// `ChipProfileCalibration.specBandwidthGBps` (OsaurusCore); parity is
+    /// asserted by tests on both sides. Unknown chip → nil.
+    static func specBandwidthGBps(brandString: String) -> Double? {
+        let table: [String: Double] = [
+            "Apple M1": 68, "Apple M1 Pro": 200, "Apple M1 Max": 400, "Apple M1 Ultra": 800,
+            "Apple M2": 100, "Apple M2 Pro": 200, "Apple M2 Max": 400, "Apple M2 Ultra": 800,
+            "Apple M3": 100, "Apple M3 Pro": 150, "Apple M3 Max": 400, "Apple M3 Ultra": 819,
+            "Apple M4": 120, "Apple M4 Pro": 273, "Apple M4 Max": 546,
+            "Apple M5": 153, "Apple M5 Pro": 307, "Apple M5 Max": 614,
+        ]
+        return table[brandString.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    // MARK: - Decode-throughput estimator
+
+    /// Fraction of memcpy bandwidth a decode step achieves; see the Core copy
+    /// for the rationale (memcpy reaches 60–75% of theoretical, decode
+    /// streams weights close to memcpy patterns). Keep in sync with
+    /// `ChipProfileCalibration.decodeEfficiency`.
+    static let decodeEfficiency = 0.7
+
+    /// tok/s ≈ bandwidth × efficiency ÷ weights bytes read per token.
+    static func estimatedDecodeTps(weightsBytes: Int64, bandwidthGBps: Double) -> Double {
+        guard weightsBytes > 0 else { return 0 }
+        return bandwidthGBps * 1e9 * decodeEfficiency / Double(weightsBytes)
+    }
+
+    // MARK: - Bandwidth probe (STREAM copy)
+
+    /// ~1 GiB per buffer so the system-level cache cannot hide DRAM behind
+    /// the copy; 256 MiB when physical RAM ≤ 16 GiB, where a transient
+    /// ~2 GiB allocation risks memory pressure (256 MiB still far exceeds
+    /// any SLC, so it remains a DRAM measurement).
+    static func defaultBufferBytes(
+        physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Int {
+        physicalMemoryBytes <= (16 << 30) ? (256 << 20) : (1 << 30)
+    }
+
+    /// One copy thread cannot saturate the fabric on Pro/Max/Ultra tiers, so
+    /// the probe aggregates over threads, capped at 8 — memcpy saturates the
+    /// fabric well before core count on every M-series tier, more threads
+    /// past ~8 only add scheduler noise, and P/E-core asymmetry makes exact
+    /// core targeting not worth the complexity. Same rationale as the Core
+    /// copy (`ChipProfileCalibration.defaultProbeThreadCount`).
+    static func defaultThreadCount(
+        activeProcessorCount: Int = ProcessInfo.processInfo.activeProcessorCount
+    ) -> Int {
+        max(1, min(8, activeProcessorCount))
+    }
+
+    /// Parallel aggregate STREAM copy: the buffer pair is split into
+    /// `threads` disjoint contiguous slices; each thread repeats
+    /// `memcpy(dstSlice, srcSlice, n)` on its own slice against a shared
+    /// absolute deadline ~`secondsPerTrial` away. Aggregate bandwidth =
+    /// (Σ bytesCopied × 2) / trial wall time (each byte read once and
+    /// written once — STREAM counts both). `DispatchQueue.concurrentPerform`
+    /// is used because it is synchronous and schedules all iterations across
+    /// cores up front; the shared deadline (not a start barrier) provides
+    /// full overlap — all threads stop at the same instant, so start skew
+    /// only trims a sliver off a 0.8 s window. Result is the MAX over
+    /// `trials` — transient system activity only ever lowers a trial, so the
+    /// best trial is closest to the machine's true capability. Buffers are
+    /// freed deterministically.
+    ///
+    /// Keep byte-for-byte in sync with
+    /// `ChipProfileCalibration.measureMemoryBandwidthGBps` (OsaurusCore).
+    static func measureBandwidthGBps(
+        bufferBytes: Int = defaultBufferBytes(),
+        secondsPerTrial: Double = 0.8,
+        trials: Int = 3,
+        threads: Int = defaultThreadCount()
+    ) -> Double {
+        precondition(threads > 0 && bufferBytes >= threads && trials > 0)
+        let alignment = 16_384  // page-aligned
+        let src = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)
+        let dst = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)
+        defer {
+            src.deallocate()
+            dst.deallocate()
+        }
+
+        // Fault every page up front, then one warm pass.
+        memset(src, 0xA5, bufferBytes)
+        memset(dst, 0x5A, bufferBytes)
+        memcpy(dst, src, bufferBytes)
+
+        // Disjoint contiguous slices; integer division strands at most
+        // `threads - 1` trailing bytes, and the accounting uses the actual
+        // slice size, so the arithmetic stays exact. One counter slot per
+        // thread index — disjoint writes, no locks; `concurrentPerform`
+        // executes every index exactly once before returning.
+        let sliceBytes = bufferBytes / threads
+        let perThreadBytes = UnsafeMutablePointer<UInt64>.allocate(capacity: threads)
+        perThreadBytes.initialize(repeating: 0, count: threads)
+        defer { perThreadBytes.deallocate() }
+
+        // Raw pointers are not Sendable, so they cannot be captured by the
+        // `@Sendable` concurrentPerform closure directly. Sound here: thread
+        // `index` only touches its own disjoint slice and counter slot, and
+        // `concurrentPerform` returns only after all iterations finish.
+        struct Workspace: @unchecked Sendable {
+            let src: UnsafeMutableRawPointer
+            let dst: UnsafeMutableRawPointer
+            let counters: UnsafeMutablePointer<UInt64>
+        }
+        let workspace = Workspace(src: src, dst: dst, counters: perThreadBytes)
+
+        var best = 0.0
+        for _ in 0..<trials {
+            let start = DispatchTime.now().uptimeNanoseconds
+            let deadline = start &+ UInt64(secondsPerTrial * 1e9)
+            DispatchQueue.concurrentPerform(iterations: threads) { index in
+                let offset = index * sliceBytes
+                var copied: UInt64 = 0
+                repeat {
+                    memcpy(workspace.dst + offset, workspace.src + offset, sliceBytes)
+                    copied &+= UInt64(sliceBytes)
+                } while DispatchTime.now().uptimeNanoseconds < deadline
+                workspace.counters[index] = copied
+            }
+            let elapsedSeconds =
+                Double(DispatchTime.now().uptimeNanoseconds - start) / 1e9
+            var totalBytes: UInt64 = 0
+            for index in 0..<threads {
+                totalBytes &+= perThreadBytes[index]
+            }
+            let gbps = Double(totalBytes) * 2 / elapsedSeconds / 1e9
+            best = max(best, gbps)
+        }
+        return best
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
@@ -61,6 +61,29 @@ final class MemoryBandwidthCalibrationTests: XCTestCase {
         XCTAssertEqual(record.probeThreads, 8)
     }
 
+    func testReadValidRecordRejectsMismatchedChipAndInvalidBounds() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("calibration-record-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try Data(Self.recordFixtureJSON.utf8).write(to: url)
+        XCTAssertNotNil(
+            MemoryBandwidthCalibration.readValidRecord(at: url, forChip: "Apple M4 Pro"))
+        XCTAssertNil(
+            MemoryBandwidthCalibration.readValidRecord(at: url, forChip: "Apple M5 Max"))
+
+        let invalidRecords = [
+            #"{"measuredBandwidthGBps": 0, "chip": "Apple M4 Pro", "probeThreads": 8}"#,
+            #"{"measuredBandwidthGBps": -1, "chip": "Apple M4 Pro", "probeThreads": 8}"#,
+            #"{"measuredBandwidthGBps": 210, "chip": "Apple M4 Pro", "probeThreads": 0}"#,
+        ]
+        for json in invalidRecords {
+            try Data(json.utf8).write(to: url)
+            XCTAssertNil(
+                MemoryBandwidthCalibration.readValidRecord(at: url, forChip: "Apple M4 Pro"))
+        }
+    }
+
     /// Spec-table parity with the Core copy, pinned by hardcoded rows (the
     /// two tables are shared-by-convention, not by code).
     func testSpecTableParityRows() {

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
@@ -88,6 +88,39 @@ final class MemoryBandwidthCalibrationTests: XCTestCase {
         XCTAssertEqual(tps, 391e9 * 0.7 / 18.2e9, accuracy: 1e-9)
         XCTAssertEqual(
             MemoryBandwidthCalibration.estimatedDecodeTps(weightsBytes: 0, bandwidthGBps: 391), 0)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.estimatedDecodeTps(
+                weightsBytes: 1_000_000_000, bandwidthGBps: 0),
+            0)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.estimatedDecodeTps(
+                weightsBytes: 1_000_000_000, bandwidthGBps: -.infinity),
+            0)
+    }
+
+    func testBenchmarkReportRemainsVersionOneCompatible() throws {
+        let report = BenchCommand.makeReport(
+            model: "test/model",
+            maxTokens: 64,
+            runs: 2,
+            health: ["hardware": ["chip": "Apple M4 Pro"]],
+            scenarios: [["target_prompt_tokens": 1_024]],
+            timestamp: "2026-07-11T00:00:00Z"
+        )
+        let data = try JSONSerialization.data(withJSONObject: report, options: [.sortedKeys])
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["schema"] as? String, "osaurus-bench/1")
+        XCTAssertEqual(object["model"] as? String, "test/model")
+        XCTAssertEqual(object["max_tokens"] as? Int, 64)
+        XCTAssertEqual(object["runs"] as? Int, 2)
+        XCTAssertNotNil(object["hardware"] as? [String: Any])
+        XCTAssertEqual((object["scenarios"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(
+            Set(object.keys),
+            Set(["schema", "timestamp", "model", "max_tokens", "runs", "hardware", "scenarios", "methodology"])
+        )
     }
 
     /// Tiny-buffer smoke run only (full ~1 GiB probe is user-initiated via
@@ -137,6 +170,23 @@ final class MemoryBandwidthCalibrationTests: XCTestCase {
         XCTAssertNil(
             ShowCommand.weightsBytes(
                 under: dir.appendingPathComponent("missing", isDirectory: true)))
+    }
+
+    func testMoEBundlesAreDetectedForEstimateSuppression() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("show-moe-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let configURL = dir.appendingPathComponent("config.json")
+
+        try Data(#"{"num_experts": 64}"#.utf8).write(to: configURL)
+        XCTAssertTrue(ShowCommand.isMoEBundle(at: dir))
+
+        try Data(#"{"text_config": {"num_local_experts": 8}}"#.utf8).write(to: configURL)
+        XCTAssertTrue(ShowCommand.isMoEBundle(at: dir))
+
+        try Data(#"{"model_type": "gemma4", "num_experts": 1}"#.utf8).write(to: configURL)
+        XCTAssertFalse(ShowCommand.isMoEBundle(at: dir))
     }
 
     /// The server's `/health` scan root is the authoritative models base

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
@@ -1,0 +1,207 @@
+//
+//  MemoryBandwidthCalibrationTests.swift
+//  osaurus
+//
+//  The CLI carries a standalone copy of the calibration probe, spec table,
+//  and record shape (it does not link OsaurusCore — see the cross-reference
+//  in MemoryBandwidthCalibration.swift). These tests pin the copies to the
+//  Core originals: spec-table parity on hardcoded rows, and record-shape
+//  compatibility through the same JSON fixture string kept in
+//  ChipProfileCalibrationTests (OsaurusCore). No absolute bandwidth numbers
+//  are asserted anywhere — those are machine-dependent.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class MemoryBandwidthCalibrationTests: XCTestCase {
+
+    /// JSON contract fixture — keep byte-identical to the copy in
+    /// `ChipProfileCalibrationTests` (OsaurusCore), which decodes it into
+    /// the Core `CalibrationRecord`. Together the two tests freeze the
+    /// on-disk shape the CLI writes and the server reads.
+    private static let recordFixtureJSON = """
+        {"chip":"Apple M4 Pro","measuredAt":"2026-07-07T12:00:00Z",\
+        "measuredBandwidthGBps":210.5,"osVersion":"macOS 26.0","probeThreads":8}
+        """
+
+    /// Encoding the CLI record must reproduce the fixture object exactly —
+    /// same keys, same values — so the Core Codable can decode CLI output.
+    func testRecordEncodesToTheSharedFixtureShape() throws {
+        let record = MemoryBandwidthCalibration.Record(
+            measuredBandwidthGBps: 210.5,
+            chip: "Apple M4 Pro",
+            measuredAt: "2026-07-07T12:00:00Z",
+            osVersion: "macOS 26.0",
+            probeThreads: 8
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let encoded = try encoder.encode(record)
+
+        let encodedObject = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoded) as? NSDictionary)
+        let fixtureObject = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(Self.recordFixtureJSON.utf8))
+                as? NSDictionary)
+        XCTAssertEqual(encodedObject, fixtureObject)
+    }
+
+    /// And the mirrored struct must decode what Core (or an older CLI) wrote.
+    func testRecordDecodesTheSharedFixture() throws {
+        let record = try JSONDecoder().decode(
+            MemoryBandwidthCalibration.Record.self,
+            from: Data(Self.recordFixtureJSON.utf8))
+        XCTAssertEqual(record.measuredBandwidthGBps, 210.5)
+        XCTAssertEqual(record.chip, "Apple M4 Pro")
+        XCTAssertEqual(record.measuredAt, "2026-07-07T12:00:00Z")
+        XCTAssertEqual(record.osVersion, "macOS 26.0")
+        XCTAssertEqual(record.probeThreads, 8)
+    }
+
+    /// Spec-table parity with the Core copy, pinned by hardcoded rows (the
+    /// two tables are shared-by-convention, not by code).
+    func testSpecTableParityRows() {
+        XCTAssertEqual(MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M1"), 68)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M1 Ultra"), 800)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M3 Ultra"), 819)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M4 Max"), 546)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M5 Pro"), 307)
+        XCTAssertNil(
+            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M4 Extreme"))
+        XCTAssertNil(
+            MemoryBandwidthCalibration.specBandwidthGBps(
+                brandString: "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz"))
+    }
+
+    /// Estimator parity with the documented formula (same constant as Core).
+    func testEstimatorFormula() {
+        XCTAssertEqual(MemoryBandwidthCalibration.decodeEfficiency, 0.7)
+        let tps = MemoryBandwidthCalibration.estimatedDecodeTps(
+            weightsBytes: 18_200_000_000, bandwidthGBps: 391)
+        XCTAssertEqual(tps, 391e9 * 0.7 / 18.2e9, accuracy: 1e-9)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.estimatedDecodeTps(weightsBytes: 0, bandwidthGBps: 391), 0)
+    }
+
+    /// Tiny-buffer smoke run only (full ~1 GiB probe is user-initiated via
+    /// `osaurus bench --calibrate`, never run by tests). Runs the parallel
+    /// path (2 threads) so slice/aggregate arithmetic is exercised. Shape
+    /// only: > 0, finite — never an absolute number.
+    func testProbeSmokeWithTinyBuffers() {
+        let gbps = MemoryBandwidthCalibration.measureBandwidthGBps(
+            bufferBytes: 1 << 20, secondsPerTrial: 0.02, trials: 1, threads: 2)
+        XCTAssertGreaterThan(gbps, 0)
+        XCTAssertTrue(gbps.isFinite)
+    }
+
+    /// Thread-count parity with the Core copy (cap 8, floor 1).
+    func testDefaultThreadCountCapAndFloor() {
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.defaultThreadCount(activeProcessorCount: 16), 8)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.defaultThreadCount(activeProcessorCount: 4), 4)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.defaultThreadCount(activeProcessorCount: 0), 1)
+    }
+
+    func testDefaultBufferSizeFallsBackOnSmallRAM() {
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.defaultBufferBytes(physicalMemoryBytes: 16 << 30),
+            256 << 20)
+        XCTAssertEqual(
+            MemoryBandwidthCalibration.defaultBufferBytes(physicalMemoryBytes: 32 << 30),
+            1 << 30)
+    }
+
+    /// `osaurus show` prints the estimate only for locally installed models;
+    /// the weights sum is the recursive `.safetensors` total.
+    func testWeightsBytesSumsLocalSafetensors() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("show-weights-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let shardDir = dir.appendingPathComponent("shards", isDirectory: true)
+        try FileManager.default.createDirectory(at: shardDir, withIntermediateDirectories: true)
+        try Data(count: 1_024).write(to: dir.appendingPathComponent("model.safetensors"))
+        try Data(count: 2_048).write(
+            to: shardDir.appendingPathComponent("model-00001-of-00002.safetensors"))
+        try Data(count: 512).write(to: dir.appendingPathComponent("config.json"))
+
+        XCTAssertEqual(ShowCommand.weightsBytes(under: dir), 3_072)
+        XCTAssertNil(
+            ShowCommand.weightsBytes(
+                under: dir.appendingPathComponent("missing", isDirectory: true)))
+    }
+
+    /// The server's `/health` scan root is the authoritative models base
+    /// dir; this pins the JSON contract (`local_model_scan.root`).
+    func testModelsRootExtractionFromHealthJSON() throws {
+        let fixture = """
+            {"status":"healthy","local_model_scan":{"status":"finished",\
+            "root":"/Users/someone/MLXModels","root_exists":true,"model_count":5}}
+            """
+        let health = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(fixture.utf8)) as? [String: Any])
+        XCTAssertEqual(
+            ShowCommand.modelsRoot(fromHealth: health)?.path, "/Users/someone/MLXModels")
+
+        // Missing block, null root, and empty root all mean "unknown".
+        XCTAssertNil(ShowCommand.modelsRoot(fromHealth: ["status": "healthy"]))
+        XCTAssertNil(
+            ShowCommand.modelsRoot(fromHealth: ["local_model_scan": ["root": NSNull()]]))
+        XCTAssertNil(ShowCommand.modelsRoot(fromHealth: ["local_model_scan": ["root": ""]]))
+    }
+
+    /// The server lists lowercased ids while directories keep their casing;
+    /// resolution must try the exact nesting first, then a case-insensitive
+    /// two-level scan (org/repo layout).
+    func testResolveLocalModelDirectoryTriesBothNameForms() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("show-resolve-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let repo = base
+            .appendingPathComponent("OsaurusAI", isDirectory: true)
+            .appendingPathComponent("Qwen3.6-35B-A3B-MXFP4-MTP", isDirectory: true)
+        let flat = base.appendingPathComponent("gemma-4-E2B-it-4bit", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: flat, withIntermediateDirectories: true)
+
+        // Exact nesting (as `osaurus pull` lays out).
+        XCTAssertEqual(
+            ShowCommand.resolveLocalModelDirectory(
+                forModelId: "OsaurusAI/Qwen3.6-35B-A3B-MXFP4-MTP", under: base)?.lastPathComponent,
+            "Qwen3.6-35B-A3B-MXFP4-MTP")
+        // Lowercased forms must resolve to the same directories. Compare
+        // case-insensitively: on the (default) case-insensitive APFS the
+        // exact-nesting branch already matches and returns the caller's
+        // spelling, while on a case-sensitive volume the scan branch returns
+        // the on-disk casing — both point at the same directory.
+        // Single-component server id → level-2 leaf match.
+        XCTAssertEqual(
+            ShowCommand.resolveLocalModelDirectory(
+                forModelId: "qwen3.6-35b-a3b-mxfp4-mtp", under: base)?
+                .lastPathComponent.lowercased(),
+            "qwen3.6-35b-a3b-mxfp4-mtp")
+        // org/name id → full relative-path match.
+        XCTAssertEqual(
+            ShowCommand.resolveLocalModelDirectory(
+                forModelId: "osaurusai/qwen3.6-35b-a3b-mxfp4-mtp", under: base)?
+                .lastPathComponent.lowercased(),
+            "qwen3.6-35b-a3b-mxfp4-mtp")
+        // Flat id → level-1 match.
+        XCTAssertEqual(
+            ShowCommand.resolveLocalModelDirectory(
+                forModelId: "gemma-4-e2b-it-4bit", under: base)?
+                .lastPathComponent.lowercased(),
+            "gemma-4-e2b-it-4bit")
+        // Not installed → nil (silent skip upstream).
+        XCTAssertNil(
+            ShowCommand.resolveLocalModelDirectory(forModelId: "not-a-model", under: base))
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MemoryBandwidthCalibrationTests.swift
@@ -87,15 +87,17 @@ final class MemoryBandwidthCalibrationTests: XCTestCase {
     /// Spec-table parity with the Core copy, pinned by hardcoded rows (the
     /// two tables are shared-by-convention, not by code).
     func testSpecTableParityRows() {
-        XCTAssertEqual(MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M1"), 68)
-        XCTAssertEqual(
-            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M1 Ultra"), 800)
-        XCTAssertEqual(
-            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M3 Ultra"), 819)
-        XCTAssertEqual(
-            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M4 Max"), 546)
-        XCTAssertEqual(
-            MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M5 Pro"), 307)
+        let expected: [String: Double] = [
+            "Apple M1": 68, "Apple M1 Pro": 200, "Apple M1 Max": 400, "Apple M1 Ultra": 800,
+            "Apple M2": 100, "Apple M2 Pro": 200, "Apple M2 Max": 400, "Apple M2 Ultra": 800,
+            "Apple M3": 100, "Apple M3 Pro": 150, "Apple M3 Max": 400, "Apple M3 Ultra": 819,
+            "Apple M4": 120, "Apple M4 Pro": 273, "Apple M4 Max": 546,
+            "Apple M5": 153, "Apple M5 Pro": 307, "Apple M5 Max": 614,
+        ]
+        for (brand, bandwidth) in expected {
+            XCTAssertEqual(
+                MemoryBandwidthCalibration.specBandwidthGBps(brandString: brand), bandwidth)
+        }
         XCTAssertNil(
             MemoryBandwidthCalibration.specBandwidthGBps(brandString: "Apple M4 Extreme"))
         XCTAssertNil(
@@ -206,6 +208,9 @@ final class MemoryBandwidthCalibrationTests: XCTestCase {
         XCTAssertTrue(ShowCommand.isMoEBundle(at: dir))
 
         try Data(#"{"text_config": {"num_local_experts": 8}}"#.utf8).write(to: configURL)
+        XCTAssertTrue(ShowCommand.isMoEBundle(at: dir))
+
+        try Data(#"{"n_routed_experts": 64}"#.utf8).write(to: configURL)
         XCTAssertTrue(ShowCommand.isMoEBundle(at: dir))
 
         try Data(#"{"model_type": "gemma4", "num_experts": 1}"#.utf8).write(to: configURL)

--- a/Packages/OsaurusCore/Services/ChipProfile.swift
+++ b/Packages/OsaurusCore/Services/ChipProfile.swift
@@ -11,8 +11,9 @@
 //  Why not persist the result: every field is re-derivable in microseconds
 //  from sysctl/IOKit/Metal at launch, and a cached file would go stale when a
 //  Time Machine / Migration Assistant restore moves the install to different
-//  hardware. Persistence becomes worthwhile only for *measured* values
-//  (micro-benchmarked bandwidth/FLOPS), which are out of scope here.
+//  hardware. The one exception is a *measured* value — the micro-benchmarked
+//  memory bandwidth — which `ChipProfileCalibration` persists with the brand
+//  string as its invalidation key; `detect()` merely reads it back.
 //
 
 import Foundation
@@ -50,6 +51,13 @@ struct ChipProfile: Sendable, Equatable {
     /// answer to "how much GPU-visible memory may I comfortably use" and is
     /// the anchor for any future wired-memory policy.
     let recommendedMaxWorkingSetBytes: UInt64?
+    /// STREAM-copy memory bandwidth measured on THIS machine by
+    /// `osaurus bench --calibrate`, read back from
+    /// `ChipProfileCalibration` at `detect()` time. nil when the user never
+    /// calibrated or the stored record's chip no longer matches the live
+    /// brand string (Migration Assistant restore onto different hardware).
+    /// Defaults to nil so the memberwise init stays source-compatible.
+    var measuredBandwidthGBps: Double?
     /// The M5 family embeds matrix units ("Neural Accelerators") in each GPU
     /// core, which shifts the prefill/decode balance materially. Derived
     /// from `generation`, not probed — Metal exposes no direct capability
@@ -81,7 +89,10 @@ struct ChipProfile: Sendable, Equatable {
             physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
             gpuCoreCount: detectGPUCoreCount(),
             recommendedMaxWorkingSetBytes: MTLCreateSystemDefaultDevice()
-                .map { UInt64($0.recommendedMaxWorkingSetSize) }
+                .map { UInt64($0.recommendedMaxWorkingSetSize) },
+            // Read-only here: the probe itself is explicit-CLI-verb only
+            // (`osaurus bench --calibrate`); detect() never measures.
+            measuredBandwidthGBps: ChipProfileCalibration.measuredBandwidthGBps(forChip: brand)
         )
     }
 

--- a/Packages/OsaurusCore/Services/ChipProfileCalibration.swift
+++ b/Packages/OsaurusCore/Services/ChipProfileCalibration.swift
@@ -1,0 +1,297 @@
+//
+//  ChipProfileCalibration.swift
+//  osaurus
+//
+//  Measured memory bandwidth for the host machine, plus the decode-throughput
+//  estimate derived from it.
+//
+//  Decode speed for a memory-bound LLM is (bandwidth / bytes-of-weights-read
+//  -per-token), so a single machine-wide bandwidth number turns "how fast will
+//  this model run?" from a guess into arithmetic. Spec-sheet bandwidth is a
+//  ceiling, not what a real process achieves; the probe below measures what
+//  this machine actually sustains.
+//
+//  The probe NEVER runs automatically: it allocates ~2 GiB and hammers the
+//  memory subsystem for ~2.4 s, which is only acceptable when a user asks for
+//  it explicitly. The only entry point is `osaurus bench --calibrate`, which
+//  runs a standalone copy of the same arithmetic in the CLI process (see
+//  Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/
+//  MemoryBandwidthCalibration.swift — cross-referenced there) and writes the
+//  record this store reads. Bandwidth is a machine property, not a server
+//  property, so measuring it in the CLI process is equivalent.
+//
+//  File: ~/.osaurus/config/chip-profile.json — written by the CLI (a separate
+//  process), so reads are mtime-checked instead of cached forever, exactly
+//  like `ModelPrefillTuningStore`.
+//
+
+import Foundation
+import os.log
+
+private let calibrationLog = Logger(
+    subsystem: "com.dinoki.osaurus", category: "ChipProfileCalibration")
+
+enum ChipProfileCalibration {
+    /// One record for the whole machine (unlike prefill tuning, which is
+    /// per-model): bandwidth belongs to the hardware, not to any model.
+    struct CalibrationRecord: Codable, Sendable, Equatable {
+        /// STREAM-copy bandwidth in GB/s (decimal, 1e9 bytes/s), max of trials.
+        let measuredBandwidthGBps: Double
+        /// Brand string of the chip the measurement was taken on. Required —
+        /// it is the invalidation key: a record restored onto different
+        /// hardware by Migration Assistant must not be trusted.
+        let chip: String
+        /// Provenance for humans reading the file; not used for invalidation.
+        let measuredAt: String?
+        let osVersion: String?
+        /// Copy-thread count the aggregate probe ran with, so a record's
+        /// provenance is auditable (a 1-thread number is not comparable to
+        /// an 8-thread one). Required: records from the retired
+        /// single-threaded probe lack it, fail decode, and are re-measured.
+        let probeThreads: Int
+    }
+
+    // MARK: - Persistence (exact `ModelPrefillTuningStore` file pattern)
+
+    /// Test-only injection point, scoped per task tree (same pattern as
+    /// `ModelPrefillTuningStore.fileURLOverrideForTests`) so parallel tests
+    /// don't race.
+    @TaskLocal
+    static var fileURLOverrideForTests: URL?
+
+    static var fileURL: URL {
+        fileURLOverrideForTests
+            ?? OsaurusPaths.config().appendingPathComponent("chip-profile.json")
+    }
+
+    private struct CacheBox: @unchecked Sendable {
+        var record: CalibrationRecord?
+        var mtime: Date?
+        var checkedURL: URL?
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var cache = CacheBox()
+
+    /// Measured bandwidth for the machine, or nil when no valid record exists.
+    ///
+    /// Invalidation rule: a stored record is ignored when its `chip` differs
+    /// from the live brand string — Migration Assistant moves the file to new
+    /// hardware where the old measurement would be silently wrong.
+    static func measuredBandwidthGBps(forChip brandString: String) -> Double? {
+        guard let record = storedRecord(), record.chip == brandString else { return nil }
+        return record.measuredBandwidthGBps
+    }
+
+    /// Raw stored record, mtime-cached: one stat(2) per call, a re-decode only
+    /// when the CLI (a separate process) has rewritten the file.
+    static func storedRecord() -> CalibrationRecord? {
+        let url = fileURL
+        let mtime =
+            (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate])
+            as? Date
+
+        lock.lock()
+        defer { lock.unlock() }
+        if cache.checkedURL == url, cache.mtime == mtime {
+            return cache.record
+        }
+        var record: CalibrationRecord?
+        if mtime != nil,
+            let data = try? Data(contentsOf: url),
+            let decoded = try? JSONDecoder().decode(CalibrationRecord.self, from: data) {
+            record = decoded
+            calibrationLog.info(
+                "loaded calibration record: \(decoded.measuredBandwidthGBps, privacy: .public) GB/s on \(decoded.chip, privacy: .public)"
+            )
+        }
+        cache = CacheBox(record: record, mtime: mtime, checkedURL: url)
+        return record
+    }
+
+    /// Atomic whole-file write (single record, no merge needed — there is
+    /// exactly one machine). Used by tests; the CLI writes the same JSON
+    /// contract from its own process without linking OsaurusCore.
+    static func save(record: CalibrationRecord) throws {
+        let url = fileURL
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try encoder.encode(record).write(to: url, options: .atomic)
+    }
+
+    // MARK: - Spec bandwidth table
+
+    /// Spec-sheet unified-memory bandwidth (GB/s) by exact brand string.
+    ///
+    /// Display-only estimates, superseded by measurement: use these only when
+    /// no calibration record exists. Where Apple shipped binned variants
+    /// (e.g. M3 Max 300/400) the table carries the full-fat number.
+    ///
+    /// Shared-by-convention with the CLI copy in
+    /// Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/
+    /// MemoryBandwidthCalibration.swift — keep both tables identical
+    /// (parity is asserted by tests on both sides).
+    static func specBandwidthGBps(brandString: String) -> Double? {
+        let table: [String: Double] = [
+            "Apple M1": 68, "Apple M1 Pro": 200, "Apple M1 Max": 400, "Apple M1 Ultra": 800,
+            "Apple M2": 100, "Apple M2 Pro": 200, "Apple M2 Max": 400, "Apple M2 Ultra": 800,
+            "Apple M3": 100, "Apple M3 Pro": 150, "Apple M3 Max": 400, "Apple M3 Ultra": 819,
+            "Apple M4": 120, "Apple M4 Pro": 273, "Apple M4 Max": 546,
+            "Apple M5": 153, "Apple M5 Pro": 307, "Apple M5 Max": 614,
+        ]
+        return table[brandString.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
+
+    // MARK: - Decode-throughput estimator (pure)
+
+    /// Fraction of measured memcpy bandwidth a decode step achieves.
+    ///
+    /// Measured memcpy typically achieves 60–75% of theoretical bandwidth,
+    /// and decode streams weights in access patterns close to memcpy, so a
+    /// single mid-band factor gives a usable first-order estimate.
+    /// Calibration follow-ups can tune it per chip family.
+    static let decodeEfficiency = 0.7
+
+    /// tok/s ≈ bandwidth × efficiency ÷ bytes read per token. For a dense
+    /// model every weight byte is read once per token, so bytes-per-token is
+    /// simply the on-disk weights size. (MoE models activate fewer bytes per
+    /// token; this estimate is a floor for them.)
+    static func estimatedDecodeTps(weightsBytes: Int64, bandwidthGBps: Double) -> Double {
+        guard weightsBytes > 0 else { return 0 }
+        return bandwidthGBps * 1e9 * decodeEfficiency / Double(weightsBytes)
+    }
+
+    /// Profile-based variant: prefers the measured number (ground truth for
+    /// this machine) over the spec table, nil when neither is available.
+    static func estimatedDecodeTps(weightsBytes: Int64, profile: ChipProfile) -> Double? {
+        let bandwidth =
+            profile.measuredBandwidthGBps
+            ?? specBandwidthGBps(brandString: profile.brandString)
+        guard let bandwidth else { return nil }
+        return estimatedDecodeTps(weightsBytes: weightsBytes, bandwidthGBps: bandwidth)
+    }
+
+    // MARK: - Bandwidth probe (explicit CLI verb only — never automatic)
+
+    /// Buffer size for one of the two probe buffers: ~1 GiB, large enough
+    /// that the system-level cache (SLC) cannot hide DRAM behind the copy.
+    /// On machines with ≤ 16 GiB of RAM the transient ~2 GiB allocation
+    /// risks memory pressure, so fall back to 256 MiB — still far beyond
+    /// any SLC size, so the number stays a DRAM measurement.
+    static func defaultProbeBufferBytes(
+        physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Int {
+        physicalMemoryBytes <= (16 << 30) ? (256 << 20) : (1 << 30)
+    }
+
+    /// Probe parallelism: one copy thread cannot saturate the memory fabric
+    /// on Pro/Max/Ultra tiers (a single-core memcpy tops out around
+    /// 100–120 GB/s while an M-series Max carries 400–600+), so the probe
+    /// aggregates over threads. Capped at 8: memcpy saturates the fabric
+    /// well before core count on every M-series tier, more threads past ~8
+    /// only add scheduler noise, and P/E-core asymmetry makes exact core
+    /// targeting not worth the complexity.
+    static func defaultProbeThreadCount(
+        activeProcessorCount: Int = ProcessInfo.processInfo.activeProcessorCount
+    ) -> Int {
+        max(1, min(8, activeProcessorCount))
+    }
+
+    /// Parallel aggregate STREAM-copy bandwidth probe.
+    ///
+    /// Convention (documented so the number is comparable to published STREAM
+    /// results): the buffer pair is split into `threads` disjoint contiguous
+    /// slices; each thread repeats `memcpy(dstSlice, srcSlice, n)` on its own
+    /// slice against a shared absolute deadline ~`secondsPerTrial` away.
+    /// Aggregate bandwidth = (Σ bytesCopied over threads × 2) / trial wall
+    /// time — each copied byte is read once and written once, and STREAM
+    /// counts both directions.
+    ///
+    /// Threads run via `DispatchQueue.concurrentPerform`: it is synchronous
+    /// (usable from this non-async path, deterministic completion) and it
+    /// schedules all iterations across cores up front, so with `threads` ≤
+    /// core count every slice runs concurrently. Full overlap comes from the
+    /// shared absolute deadline rather than an explicit start barrier: all
+    /// threads stop at the same instant, so microsecond-scale start skew
+    /// only trims a sliver off one end of a 0.8 s window, and every byte
+    /// count is divided by the same wall interval.
+    ///
+    /// The result is the MAX over `trials`, not the mean: transient system
+    /// activity (other processes touching memory) only ever *lowers* a trial,
+    /// so the best trial is the closest to the machine's true capability.
+    ///
+    /// Buffers are freed deterministically via `defer` before returning.
+    /// Never called automatically — a ~2 GiB allocation plus sustained memory
+    /// hammering must be user-initiated (`osaurus bench --calibrate`).
+    static func measureMemoryBandwidthGBps(
+        bufferBytes: Int = defaultProbeBufferBytes(),
+        secondsPerTrial: Double = 0.8,
+        trials: Int = 3,
+        threads: Int = defaultProbeThreadCount()
+    ) -> Double {
+        precondition(threads > 0 && bufferBytes >= threads && trials > 0)
+        // Page-aligned so no trial pays for straddled cache lines at the ends.
+        let alignment = 16_384
+        let src = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)
+        let dst = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)
+        defer {
+            src.deallocate()
+            dst.deallocate()
+        }
+
+        // Touch every page (memset) so first-fault costs are paid up front,
+        // then one warm copy pass so trial 1 starts from steady state.
+        memset(src, 0xA5, bufferBytes)
+        memset(dst, 0x5A, bufferBytes)
+        memcpy(dst, src, bufferBytes)
+
+        // Disjoint contiguous slices. Integer division strands at most
+        // `threads - 1` trailing bytes; the byte accounting below uses the
+        // actual slice size, so the arithmetic stays exact regardless.
+        let sliceBytes = bufferBytes / threads
+        // One counter slot per thread index — disjoint writes, no locks.
+        // `concurrentPerform` executes every index exactly once, so each
+        // slot is written before the aggregation reads it.
+        let perThreadBytes = UnsafeMutablePointer<UInt64>.allocate(capacity: threads)
+        perThreadBytes.initialize(repeating: 0, count: threads)
+        defer { perThreadBytes.deallocate() }
+
+        // Raw pointers are not Sendable, so they cannot be captured by the
+        // `@Sendable` concurrentPerform closure directly. The unchecked
+        // wrapper is sound here: thread `index` only ever touches its own
+        // disjoint slice and its own counter slot, and `concurrentPerform`
+        // returns only after all iterations finish (no escape).
+        struct Workspace: @unchecked Sendable {
+            let src: UnsafeMutableRawPointer
+            let dst: UnsafeMutableRawPointer
+            let counters: UnsafeMutablePointer<UInt64>
+        }
+        let workspace = Workspace(src: src, dst: dst, counters: perThreadBytes)
+
+        var best = 0.0
+        for _ in 0..<trials {
+            let start = DispatchTime.now().uptimeNanoseconds
+            let deadline = start &+ UInt64(secondsPerTrial * 1e9)
+            DispatchQueue.concurrentPerform(iterations: threads) { index in
+                let offset = index * sliceBytes
+                var copied: UInt64 = 0
+                repeat {
+                    memcpy(workspace.dst + offset, workspace.src + offset, sliceBytes)
+                    copied &+= UInt64(sliceBytes)
+                } while DispatchTime.now().uptimeNanoseconds < deadline
+                workspace.counters[index] = copied
+            }
+            let elapsedSeconds =
+                Double(DispatchTime.now().uptimeNanoseconds - start) / 1e9
+            var totalBytes: UInt64 = 0
+            for index in 0..<threads {
+                totalBytes &+= perThreadBytes[index]
+            }
+            let gbps = Double(totalBytes) * 2 / elapsedSeconds / 1e9
+            best = max(best, gbps)
+        }
+        return best
+    }
+}

--- a/Packages/OsaurusCore/Services/ChipProfileCalibration.swift
+++ b/Packages/OsaurusCore/Services/ChipProfileCalibration.swift
@@ -150,18 +150,17 @@ enum ChipProfileCalibration {
 
     // MARK: - Decode-throughput estimator (pure)
 
-    /// Fraction of measured memcpy bandwidth a decode step achieves.
-    ///
-    /// Measured memcpy typically achieves 60–75% of theoretical bandwidth,
-    /// and decode streams weights in access patterns close to memcpy, so a
-    /// single mid-band factor gives a usable first-order estimate.
-    /// Calibration follow-ups can tune it per chip family.
+    /// Conservative utilization margin applied to either measured STREAM
+    /// bandwidth or a spec-sheet fallback. It accounts for kernel overhead,
+    /// non-weight traffic, and non-ideal access; it is not a conversion from
+    /// theoretical bandwidth to measured memcpy bandwidth.
     static let decodeEfficiency = 0.7
 
     /// tok/s ≈ bandwidth × efficiency ÷ bytes read per token. For a dense
     /// model every weight byte is read once per token, so bytes-per-token is
-    /// simply the on-disk weights size. (MoE models activate fewer bytes per
-    /// token; this estimate is a floor for them.)
+    /// approximated by on-disk weights size. Callers must suppress or label
+    /// architectures such as MoE and multimodal models where that assumption
+    /// does not represent active decode bytes.
     static func estimatedDecodeTps(weightsBytes: Int64, bandwidthGBps: Double) -> Double {
         guard weightsBytes > 0, bandwidthGBps > 0, bandwidthGBps.isFinite else { return 0 }
         return bandwidthGBps * 1e9 * decodeEfficiency / Double(weightsBytes)
@@ -235,7 +234,8 @@ enum ChipProfileCalibration {
         trials: Int = 3,
         threads: Int = defaultProbeThreadCount()
     ) -> Double {
-        precondition(threads > 0 && bufferBytes >= threads && trials > 0)
+        precondition(
+            threads > 0 && bufferBytes >= threads && trials > 0 && secondsPerTrial > 0)
         // Page-aligned so no trial pays for straddled cache lines at the ends.
         let alignment = 16_384
         let src = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: alignment)

--- a/Packages/OsaurusCore/Services/ChipProfileCalibration.swift
+++ b/Packages/OsaurusCore/Services/ChipProfileCalibration.swift
@@ -99,7 +99,11 @@ enum ChipProfileCalibration {
         var record: CalibrationRecord?
         if mtime != nil,
             let data = try? Data(contentsOf: url),
-            let decoded = try? JSONDecoder().decode(CalibrationRecord.self, from: data) {
+            let decoded = try? JSONDecoder().decode(CalibrationRecord.self, from: data),
+            decoded.measuredBandwidthGBps > 0,
+            decoded.measuredBandwidthGBps.isFinite,
+            decoded.probeThreads > 0,
+            !decoded.chip.isEmpty {
             record = decoded
             calibrationLog.info(
                 "loaded calibration record: \(decoded.measuredBandwidthGBps, privacy: .public) GB/s on \(decoded.chip, privacy: .public)"
@@ -159,7 +163,7 @@ enum ChipProfileCalibration {
     /// simply the on-disk weights size. (MoE models activate fewer bytes per
     /// token; this estimate is a floor for them.)
     static func estimatedDecodeTps(weightsBytes: Int64, bandwidthGBps: Double) -> Double {
-        guard weightsBytes > 0 else { return 0 }
+        guard weightsBytes > 0, bandwidthGBps > 0, bandwidthGBps.isFinite else { return 0 }
         return bandwidthGBps * 1e9 * decodeEfficiency / Double(weightsBytes)
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ChipProfileCalibrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ChipProfileCalibrationTests.swift
@@ -189,10 +189,16 @@ struct ChipProfileCalibrationTests {
     // MARK: - Spec table
 
     @Test func specTableCoversKnownChipsAndRejectsUnknown() {
-        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M1") == 68)
-        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M3 Ultra") == 819)
-        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M4 Max") == 546)
-        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M5 Pro") == 307)
+        let expected: [String: Double] = [
+            "Apple M1": 68, "Apple M1 Pro": 200, "Apple M1 Max": 400, "Apple M1 Ultra": 800,
+            "Apple M2": 100, "Apple M2 Pro": 200, "Apple M2 Max": 400, "Apple M2 Ultra": 800,
+            "Apple M3": 100, "Apple M3 Pro": 150, "Apple M3 Max": 400, "Apple M3 Ultra": 819,
+            "Apple M4": 120, "Apple M4 Pro": 273, "Apple M4 Max": 546,
+            "Apple M5": 153, "Apple M5 Pro": 307, "Apple M5 Max": 614,
+        ]
+        for (brand, bandwidth) in expected {
+            #expect(ChipProfileCalibration.specBandwidthGBps(brandString: brand) == bandwidth)
+        }
         #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "  Apple M2 \n") == 100)
         #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M4 Extreme") == nil)
         #expect(

--- a/Packages/OsaurusCore/Tests/Service/ChipProfileCalibrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ChipProfileCalibrationTests.swift
@@ -1,0 +1,207 @@
+//
+//  ChipProfileCalibrationTests.swift
+//  osaurusTests
+//
+//  Covers the machine-wide bandwidth calibration store (round-trip,
+//  chip-mismatch invalidation, mtime-based re-read of CLI writes), the pure
+//  decode-throughput estimator including its nil paths, the spec-bandwidth
+//  table, and a tiny-buffer smoke run of the probe. No test asserts an
+//  absolute bandwidth number — those are machine-dependent by definition.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ChipProfileCalibrationTests {
+
+    /// JSON contract fixture. The same string lives in the CLI test
+    /// (`MemoryBandwidthCalibrationTests` in OsaurusCLITests) — together they
+    /// pin the CLI writer and this Core reader to one on-disk shape.
+    private static let recordFixtureJSON = """
+        {"chip":"Apple M4 Pro","measuredAt":"2026-07-07T12:00:00Z",\
+        "measuredBandwidthGBps":210.5,"osVersion":"macOS 26.0","probeThreads":8}
+        """
+
+    private func withTempStore<T>(_ body: (URL) throws -> T) rethrows -> T {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chip-profile-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("chip-profile.json")
+        return try ChipProfileCalibration.$fileURLOverrideForTests.withValue(url) {
+            try body(url)
+        }
+    }
+
+    // MARK: - Store
+
+    @Test func missingFileMeansNoMeasurement() throws {
+        try withTempStore { _ in
+            #expect(ChipProfileCalibration.measuredBandwidthGBps(forChip: "Apple M4") == nil)
+            #expect(ChipProfileCalibration.storedRecord() == nil)
+        }
+    }
+
+    @Test func roundTripForMatchingChip() throws {
+        try withTempStore { _ in
+            try ChipProfileCalibration.save(
+                record: .init(
+                    measuredBandwidthGBps: 391.2, chip: "Apple M5 Max",
+                    measuredAt: "2026-07-07T12:00:00Z", osVersion: "macOS 26.0",
+                    probeThreads: 8))
+            #expect(
+                ChipProfileCalibration.measuredBandwidthGBps(forChip: "Apple M5 Max") == 391.2)
+        }
+    }
+
+    @Test func chipMismatchInvalidatesRecord() throws {
+        try withTempStore { _ in
+            // A Migration Assistant restore moves ~/.osaurus to new hardware;
+            // the stored measurement must not be trusted there.
+            try ChipProfileCalibration.save(
+                record: .init(
+                    measuredBandwidthGBps: 391.2, chip: "Apple M1",
+                    measuredAt: nil, osVersion: nil, probeThreads: 8))
+            #expect(ChipProfileCalibration.measuredBandwidthGBps(forChip: "Apple M5 Max") == nil)
+            // The raw record is still readable — only the validated
+            // accessor applies the invalidation rule.
+            #expect(ChipProfileCalibration.storedRecord()?.chip == "Apple M1")
+        }
+    }
+
+    @Test func externalWriteIsPickedUpByMtime() throws {
+        try withTempStore { url in
+            try ChipProfileCalibration.save(
+                record: .init(
+                    measuredBandwidthGBps: 100, chip: "Apple M4",
+                    measuredAt: nil, osVersion: nil, probeThreads: 8))
+            #expect(ChipProfileCalibration.measuredBandwidthGBps(forChip: "Apple M4") == 100)
+
+            // Simulate the CLI process rewriting the file (fresh JSON, no
+            // shared in-process state) with a bumped mtime.
+            let json = #"{"measuredBandwidthGBps": 250.0, "chip": "Apple M4", "probeThreads": 4}"#
+            try Data(json.utf8).write(to: url, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date().addingTimeInterval(2)], ofItemAtPath: url.path)
+
+            #expect(ChipProfileCalibration.measuredBandwidthGBps(forChip: "Apple M4") == 250)
+        }
+    }
+
+    @Test func decodesTheSharedCLIFixture() throws {
+        // Must stay decodable as long as the CLI-side test encodes the same
+        // fixture — the two tests jointly freeze the JSON contract.
+        let record = try JSONDecoder().decode(
+            ChipProfileCalibration.CalibrationRecord.self,
+            from: Data(Self.recordFixtureJSON.utf8))
+        #expect(record.measuredBandwidthGBps == 210.5)
+        #expect(record.chip == "Apple M4 Pro")
+        #expect(record.measuredAt == "2026-07-07T12:00:00Z")
+        #expect(record.osVersion == "macOS 26.0")
+        #expect(record.probeThreads == 8)
+    }
+
+    @Test func legacySingleThreadedRecordWithoutProbeThreadsIsIgnored() throws {
+        try withTempStore { url in
+            // A record from the retired single-threaded probe lacks
+            // `probeThreads` and its number is not comparable to aggregate
+            // measurements — it must fail decode and be re-measured.
+            let legacy = #"{"measuredBandwidthGBps": 119.1, "chip": "Apple M5 Max"}"#
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data(legacy.utf8).write(to: url, options: .atomic)
+            #expect(ChipProfileCalibration.storedRecord() == nil)
+            #expect(ChipProfileCalibration.measuredBandwidthGBps(forChip: "Apple M5 Max") == nil)
+        }
+    }
+
+    // MARK: - Estimator
+
+    @Test func estimatorMatchesTheDocumentedFormula() {
+        // 391 GB/s × 0.7 ÷ 18.2 GB weights.
+        let weights: Int64 = 18_200_000_000
+        let tps = ChipProfileCalibration.estimatedDecodeTps(
+            weightsBytes: weights, bandwidthGBps: 391)
+        #expect(abs(tps - (391e9 * 0.7 / 18.2e9)) < 1e-9)
+        // Degenerate weights must not divide by zero.
+        #expect(
+            ChipProfileCalibration.estimatedDecodeTps(weightsBytes: 0, bandwidthGBps: 391) == 0)
+    }
+
+    @Test func profileEstimatorPrefersMeasuredOverSpec() {
+        func profile(brand: String, measured: Double?) -> ChipProfile {
+            ChipProfile(
+                brandString: brand,
+                generation: nil,
+                tier: .unknown,
+                physicalMemoryBytes: 16 << 30,
+                gpuCoreCount: nil,
+                recommendedMaxWorkingSetBytes: nil,
+                measuredBandwidthGBps: measured
+            )
+        }
+        let weights: Int64 = 10_000_000_000
+
+        // Measured wins even when a spec entry exists (M4 Pro spec is 273).
+        let measured = ChipProfileCalibration.estimatedDecodeTps(
+            weightsBytes: weights, profile: profile(brand: "Apple M4 Pro", measured: 200))
+        #expect(measured == 200e9 * 0.7 / 10e9)
+
+        // No measurement → spec fallback.
+        let spec = ChipProfileCalibration.estimatedDecodeTps(
+            weightsBytes: weights, profile: profile(brand: "Apple M4 Pro", measured: nil))
+        #expect(spec == 273e9 * 0.7 / 10e9)
+
+        // Neither available (unknown chip, never calibrated) → nil.
+        #expect(
+            ChipProfileCalibration.estimatedDecodeTps(
+                weightsBytes: weights,
+                profile: profile(brand: "Intel(R) Xeon(R)", measured: nil)) == nil)
+    }
+
+    // MARK: - Spec table
+
+    @Test func specTableCoversKnownChipsAndRejectsUnknown() {
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M1") == 68)
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M3 Ultra") == 819)
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M4 Max") == 546)
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M5 Pro") == 307)
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "  Apple M2 \n") == 100)
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "Apple M4 Extreme") == nil)
+        #expect(
+            ChipProfileCalibration.specBandwidthGBps(
+                brandString: "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz") == nil)
+        #expect(ChipProfileCalibration.specBandwidthGBps(brandString: "") == nil)
+    }
+
+    // MARK: - Probe smoke test
+
+    /// Tiny buffers and short trials on purpose: the full ~1 GiB probe is a
+    /// user-initiated CLI action, never something a test suite runs. Runs
+    /// the parallel path (2 threads) so slice/aggregate arithmetic is
+    /// exercised. Only shape properties are asserted — never an absolute
+    /// bandwidth.
+    @Test func probeSmokeTestWithTinyBuffers() {
+        let gbps = ChipProfileCalibration.measureMemoryBandwidthGBps(
+            bufferBytes: 1 << 20, secondsPerTrial: 0.02, trials: 1, threads: 2)
+        #expect(gbps > 0)
+        #expect(gbps.isFinite)
+    }
+
+    @Test func probeBufferSizeFallsBackOnSmallRAMMachines() {
+        #expect(
+            ChipProfileCalibration.defaultProbeBufferBytes(physicalMemoryBytes: 16 << 30)
+                == 256 << 20)
+        #expect(
+            ChipProfileCalibration.defaultProbeBufferBytes(physicalMemoryBytes: 32 << 30)
+                == 1 << 30)
+    }
+
+    @Test func probeThreadCountIsCappedAtEightAndFloorsAtOne() {
+        #expect(ChipProfileCalibration.defaultProbeThreadCount(activeProcessorCount: 16) == 8)
+        #expect(ChipProfileCalibration.defaultProbeThreadCount(activeProcessorCount: 8) == 8)
+        #expect(ChipProfileCalibration.defaultProbeThreadCount(activeProcessorCount: 4) == 4)
+        #expect(ChipProfileCalibration.defaultProbeThreadCount(activeProcessorCount: 0) == 1)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ChipProfileCalibrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ChipProfileCalibrationTests.swift
@@ -116,6 +116,26 @@ struct ChipProfileCalibrationTests {
         }
     }
 
+    @Test func invalidCalibrationBoundsAreIgnored() throws {
+        try withTempStore { url in
+            let invalidRecords = [
+                #"{"measuredBandwidthGBps": 0, "chip": "Apple M5 Max", "probeThreads": 8}"#,
+                #"{"measuredBandwidthGBps": -1, "chip": "Apple M5 Max", "probeThreads": 8}"#,
+                #"{"measuredBandwidthGBps": 391, "chip": "Apple M5 Max", "probeThreads": 0}"#,
+                #"{"measuredBandwidthGBps": 391, "chip": "", "probeThreads": 8}"#,
+            ]
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            for (index, json) in invalidRecords.enumerated() {
+                try Data(json.utf8).write(to: url, options: .atomic)
+                try FileManager.default.setAttributes(
+                    [.modificationDate: Date().addingTimeInterval(Double(index + 1))],
+                    ofItemAtPath: url.path)
+                #expect(ChipProfileCalibration.storedRecord() == nil)
+            }
+        }
+    }
+
     // MARK: - Estimator
 
     @Test func estimatorMatchesTheDocumentedFormula() {
@@ -127,6 +147,12 @@ struct ChipProfileCalibrationTests {
         // Degenerate weights must not divide by zero.
         #expect(
             ChipProfileCalibration.estimatedDecodeTps(weightsBytes: 0, bandwidthGBps: 391) == 0)
+        #expect(
+            ChipProfileCalibration.estimatedDecodeTps(
+                weightsBytes: weights, bandwidthGBps: 0) == 0)
+        #expect(
+            ChipProfileCalibration.estimatedDecodeTps(
+                weightsBytes: weights, bandwidthGBps: .infinity) == 0)
     }
 
     @Test func profileEstimatorPrefersMeasuredOverSpec() {


### PR DESCRIPTION
## Summary

Adds explicit memory-bandwidth calibration and conservative dense-model decode estimates without changing runtime behavior or running expensive probes automatically.

- `osaurus bench --calibrate` runs a bounded parallel STREAM-copy probe only when requested and atomically stores the result in `~/.osaurus/config/chip-profile.json`.
- `osaurus show <model>` uses a valid same-chip measurement, or a clearly labeled specification fallback, to display a conservative estimate for installed dense models.
- MoE bundles are suppressed because total on-disk weights do not represent active bytes per token.
- Existing benchmark reports remain on the `osaurus-bench/1` schema.

## Correctness and safety

- Invalid, non-finite, legacy single-threaded, wrong-chip, and zero-thread calibration records are rejected.
- Probe duration, buffer, trial, and thread preconditions are explicit.
- The utilization factor is documented as a conservative source-independent margin for kernel overhead, non-weight traffic, and non-ideal access. It is not presented as measured generation throughput.
- Calibration is an explicit local CLI operation; it never runs during model loading, installation, or normal app startup.
- Model capability and measured runtime evidence remain authoritative over estimates.

## Validation

- 13 CLI calibration/report/model-path tests passed.
- 13 Core calibration/store/estimate tests passed.
- Tiny-buffer parallel probes exercised the real aggregation path without running the full multi-gigabyte hardware calibration.
- Release CLI build passed.
- `git diff --check` passed.
- Scoped SwiftLint introduced no violations.
- Final architecture and numerical reviews found no blocking correctness or security issues.
- GitHub `test-core`, `test-cli`, `test-evals`, `swiftlint`, `shellcheck`, and release-drafter checks are green.

## Limitations

- Estimates are display-only and are not proof of actual token throughput.
- MoE and other selective-activation bundles remain suppressed until active-parameter or measured runtime data is available.
- Multimodal or auxiliary weights can make dense estimates conservative because the current calculation uses installed safetensor size.
- The full hardware probe was not rerun during CI because it can allocate roughly 2 GiB and intentionally saturates memory bandwidth.
