### PR TITLE
Guardrail retry: recover from pre-content degeneration with safe settings

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2352,6 +2352,11 @@ public actor ModelRuntime {
     /// prefill, and post-generation cache store via the container-attached
     /// `CacheCoordinator` — osaurus does not need to plumb anything cache-
     /// related through this path.
+    /// - Parameter disableDraftStrategy: When true, the container's draft
+    ///   strategy (native MTP / speculative decoding) is dropped for this
+    ///   stream only. Used by the degeneration-retry path
+    ///   (`DegenerationRetry`): the retry forces sampling on, and drafting
+    ///   is tuned for the greedy decode that just looped.
     private func generateEventStream(
         chatBuilder: @Sendable () -> [MLXLMCommon.Chat.Message],
         rawPromptBuilder: (@Sendable () -> String)? = nil,
@@ -2360,7 +2365,8 @@ public actor ModelRuntime {
         tools: [Tool]?,
         toolChoice: ToolChoiceOption?,
         modelId: String,
-        modelName: String
+        modelName: String,
+        disableDraftStrategy: Bool = false
     ) async throws -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
         let trace = parameters.ttftTrace
         trace?.mark("runtime_start")
@@ -2457,7 +2463,7 @@ public actor ModelRuntime {
                 generation: parameters,
                 toolChoice: toolChoice,
                 stopSequences: stopSequences,
-                draftStrategy: holder.draftStrategy,
+                draftStrategy: disableDraftStrategy ? nil : holder.draftStrategy,
                 runtime: cfg,
                 maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
             )
@@ -2534,14 +2540,15 @@ public actor ModelRuntime {
             modelName: modelName
         )
         let augmented = ModelRuntime.applyJSONMode(forcedToolMessages, jsonMode: parameters.jsonMode)
-        let events = try await generateEventStream(
-            chatBuilder: {
-                ModelRuntime.mapOpenAIChatToMLX(
-                    augmented,
-                    trace: parameters.ttftTrace,
-                    preserveStructuredToolHistory: !tools.isEmpty
-                )
-            },
+        let chatBuilder: @Sendable () -> [MLXLMCommon.Chat.Message] = {
+            ModelRuntime.mapOpenAIChatToMLX(
+                augmented,
+                trace: parameters.ttftTrace,
+                preserveStructuredToolHistory: !tools.isEmpty
+            )
+        }
+        let rawEvents = try await generateEventStream(
+            chatBuilder: chatBuilder,
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -2549,6 +2556,30 @@ public actor ModelRuntime {
             modelId: modelId,
             modelName: modelName
         )
+        // Retry-once on a reasoning-channel degeneration abort (see
+        // DegenerationRetry.swift for the eligibility rule). Reasoning is
+        // dropped by this non-streaming API anyway, so an eligible retry is
+        // fully invisible here: `accumulated`/`pendingTools` are only fed by
+        // content-bearing events, which by the eligibility rule none of
+        // attempt 1's forwarded events were.
+        let events = DegenerationRetry.withRetry(
+            events: rawEvents,
+            modelName: modelName
+        ) {
+            try await self.generateEventStream(
+                chatBuilder: chatBuilder,
+                parameters: DegenerationRetry.safeParameters(
+                    retrying: parameters,
+                    modelName: modelName
+                ),
+                stopSequences: stopSequences,
+                tools: tools,
+                toolChoice: toolChoice,
+                modelId: modelId,
+                modelName: modelName,
+                disableDraftStrategy: true
+            )
+        }
         // Drain the entire stream so multiple tool invocations parsed by
         // vmlx-swift in a single completion are surfaced together
         // (`BatchEngine.generate` emits one `.toolCall` event per detected
@@ -2647,14 +2678,15 @@ public actor ModelRuntime {
             modelName: modelName
         )
         let augmented = ModelRuntime.applyJSONMode(forcedToolMessages, jsonMode: parameters.jsonMode)
-        let events = try await generateEventStream(
-            chatBuilder: {
-                ModelRuntime.mapOpenAIChatToMLX(
-                    augmented,
-                    trace: parameters.ttftTrace,
-                    preserveStructuredToolHistory: !tools.isEmpty
-                )
-            },
+        let chatBuilder: @Sendable () -> [MLXLMCommon.Chat.Message] = {
+            ModelRuntime.mapOpenAIChatToMLX(
+                augmented,
+                trace: parameters.ttftTrace,
+                preserveStructuredToolHistory: !tools.isEmpty
+            )
+        }
+        let rawEvents = try await generateEventStream(
+            chatBuilder: chatBuilder,
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -2662,6 +2694,29 @@ public actor ModelRuntime {
             modelId: modelId,
             modelName: modelName
         )
+        // Retry-once on a reasoning-channel degeneration abort. The splice
+        // keeps THIS outer stream open across the retry, so the HTTP/chat
+        // consumer never observes it; a degeneration after any content
+        // delta / tool event was already yielded propagates exactly as
+        // before. Eligibility rule + safe settings: DegenerationRetry.swift.
+        let events = DegenerationRetry.withRetry(
+            events: rawEvents,
+            modelName: modelName
+        ) {
+            try await self.generateEventStream(
+                chatBuilder: chatBuilder,
+                parameters: DegenerationRetry.safeParameters(
+                    retrying: parameters,
+                    modelName: modelName
+                ),
+                stopSequences: stopSequences,
+                tools: tools,
+                toolChoice: toolChoice,
+                modelId: modelId,
+                modelName: modelName,
+                disableDraftStrategy: true
+            )
+        }
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
             // Chat UI streaming should execute a parsed tool call as soon as

--- a/Packages/OsaurusCore/Services/ModelRuntime/DegenerationRetry.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/DegenerationRetry.swift
@@ -1,0 +1,227 @@
+//
+//  DegenerationRetry.swift
+//  osaurus
+//
+//  Caller-side retry-once-with-safe-settings for generation streams aborted
+//  by `StreamGuardrailError.degeneration` (the live guardrail in
+//  StreamDegenerationDetector.swift / GenerationEventMapper.swift). Composed
+//  by `ModelRuntime.streamWithTools` / `respondWithTools` between
+//  `generateEventStream` and their consumption loops, turning the dominant
+//  detected-loop case into a hiccup instead of a hard error.
+//
+//  ## Retry-eligibility rule (read this before changing anything)
+//
+//  Full transparency after a mid-stream abort is IMPOSSIBLE: the detector
+//  fires only after ~8 repeats, so by trigger time the consumer has already
+//  received several repeats of the loop on whatever channel it ran on.
+//  Deltas cannot be un-yielded. So the retry is attempted ONLY when the
+//  abort happens BEFORE any content-bearing event has been forwarded to the
+//  outer stream:
+//
+//    - content-bearing (blocks retry once forwarded): `.tokens`,
+//      `.toolInvocation`, `.toolCallProgress` — retrying after any of these
+//      would replay/append answer text or double-dispatch a tool call;
+//    - NOT content-bearing (retry stays eligible): `.reasoning`,
+//      `.prefillProgress` — the thinking channel is presentation-only
+//      (ChatView Think panel / `reasoning_content`), so a second attempt's
+//      reasoning appearing after the first attempt's truncated reasoning is
+//      honest "the model started over" UX, not corrupted output.
+//
+//  This deliberately covers exactly the dominant real-world case — loops
+//  that start inside the thinking channel (the documented `!!!!!…` inside
+//  reasoning) or within the very first content delta (which the mapper never
+//  yields when it triggers the abort) — and propagates the error unchanged,
+//  as before, whenever loop text has already reached the consumer.
+//
+//  One retry maximum: a second degeneration propagates.
+//
+//  ## Safe settings for attempt 2
+//
+//  Greedy/low-temperature decoding is what gets stuck in deterministic
+//  loops, so the retry re-runs with sampling forced on:
+//    - temperature: max(effective, 0.7),
+//    - repetitionPenalty: 1.1 when the request set none,
+//    - draft strategy disabled for the attempt (native MTP self-drafting is
+//      tuned for greedy decode; `generateEventStream(disableDraftStrategy:)`
+//      drops it before `MLXBatchAdapter.generate`).
+//
+//  The retried attempt naturally re-runs prefill, but the vmlx prefix cache
+//  makes that cheap: attempt 1 already stored the prompt's KV prefix, so
+//  attempt 2 restores it instead of re-prefilling from scratch.
+//
+
+import Foundation
+import MLXLMCommon
+import os.log
+
+private let retryLog = Logger(subsystem: "ai.osaurus", category: "Generation")
+
+enum DegenerationRetry {
+    /// UserDefaults key: `Bool`, default true. When off, a degeneration
+    /// abort propagates immediately exactly as before this policy existed.
+    static let flagKey = "ai.osaurus.guardrails.degenerationRetry"
+
+    /// Sampling floor for attempt 2 — greedy loops break under sampling.
+    static let retryTemperatureFloor: Float = 0.7
+    /// Applied on attempt 2 when the request carried no repetition penalty.
+    static let retryRepetitionPenalty: Float = 1.1
+
+    /// Read the flag, treating an absent key as ON. Injectable defaults for
+    /// tests (same pattern as `StreamGuardrailSettings.resolve`).
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: flagKey) as? Bool ?? true
+    }
+
+    // MARK: - Safe settings
+
+    /// Rebuild the request parameters for the retry attempt: temperature
+    /// raised to at least `retryTemperatureFloor` (measured against the same
+    /// per-request → model-shipped-default resolution the adapter uses, so
+    /// an already-hot request is never cooled down), a mild repetition
+    /// penalty when none was set, and `samplingParametersAreImplicit` forced
+    /// false — the retry explicitly chooses sampling, and acceleration paths
+    /// must honor it rather than rewrite it (this also disqualifies native
+    /// MTP's explicit-greedy gate independently of the draft-strategy knob).
+    ///
+    /// Server runtime defaults are deliberately not consulted here: they sit
+    /// below model defaults in the adapter's merge and only matter when both
+    /// the request and the bundle are silent, in which case the 0.7 floor is
+    /// the safe answer anyway.
+    static func safeParameters(
+        retrying generation: GenerationParameters,
+        modelDefaults: LocalGenerationDefaults.Defaults
+    ) -> GenerationParameters {
+        // Mirrors `MLXBatchAdapter.effectiveGenerationSettings`:
+        // `do_sample == false` means the bundle asked for greedy (temp 0).
+        let modelDefaultTemperature: Float? =
+            modelDefaults.doSample == false ? 0 : modelDefaults.temperature
+        let currentTemperature =
+            generation.temperature
+            ?? modelDefaultTemperature
+            ?? MLXLMCommon.GenerateParameters().temperature
+        return GenerationParameters(
+            temperature: max(currentTemperature, retryTemperatureFloor),
+            maxTokens: generation.maxTokens,
+            maxTokensExplicit: generation.maxTokensExplicit,
+            topPOverride: generation.topPOverride,
+            topKOverride: generation.topKOverride,
+            minPOverride: generation.minPOverride,
+            repetitionPenalty: generation.repetitionPenalty ?? retryRepetitionPenalty,
+            samplingParametersAreImplicit: false,
+            frequencyPenalty: generation.frequencyPenalty,
+            presencePenalty: generation.presencePenalty,
+            seed: generation.seed,
+            jsonMode: generation.jsonMode,
+            modelOptions: generation.modelOptions,
+            sessionId: generation.sessionId,
+            ttftTrace: generation.ttftTrace,
+            idempotencyKey: generation.idempotencyKey,
+            runAsRemoteAgent: generation.runAsRemoteAgent,
+            suppressProgressUI: generation.suppressProgressUI,
+            warmupPrefill: generation.warmupPrefill,
+            requestSource: generation.requestSource
+        )
+    }
+
+    /// Convenience overload resolving the model bundle's shipped sampling
+    /// defaults, exactly as `MLXBatchAdapter.generate` does.
+    static func safeParameters(
+        retrying generation: GenerationParameters,
+        modelName: String
+    ) -> GenerationParameters {
+        safeParameters(
+            retrying: generation,
+            modelDefaults: LocalGenerationDefaults.defaults(forModelId: modelName)
+        )
+    }
+
+    // MARK: - Stream splice
+
+    /// Wrap a mapped event stream with the retry-once policy described in
+    /// the file header. Events are forwarded unchanged; on a
+    /// `StreamGuardrailError.degeneration` thrown before any content-bearing
+    /// event was forwarded, `makeRetryStream` is invoked once (the caller
+    /// builds it with `safeParameters` + `disableDraftStrategy: true`) and
+    /// attempt 2's events are forwarded on the SAME outer stream — the
+    /// HTTP/chat consumer never observes the splice. Any error from attempt
+    /// 2, and any degeneration after content was forwarded, propagates
+    /// unchanged.
+    ///
+    /// With `isEnabled` false the input stream is returned untouched — the
+    /// pre-existing abort path, byte for byte.
+    static func withRetry(
+        events: AsyncThrowingStream<ModelRuntimeEvent, Error>,
+        modelName: String,
+        isEnabled: Bool = DegenerationRetry.isEnabled(),
+        makeRetryStream: @escaping @Sendable () async throws -> AsyncThrowingStream<
+            ModelRuntimeEvent, Error
+        >
+    ) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
+        guard isEnabled else { return events }
+        let (stream, continuation) = AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
+        let task = Task {
+            var current = events
+            var hasForwardedContent = false
+            var isRetryAttempt = false
+            while true {
+                do {
+                    for try await event in current {
+                        if !hasForwardedContent, Self.isContentBearing(event) {
+                            hasForwardedContent = true
+                        }
+                        continuation.yield(event)
+                    }
+                    if isRetryAttempt {
+                        retryLog.info(
+                            "[Osaurus] guardrail: retry succeeded model=\(modelName, privacy: .public)"
+                        )
+                    }
+                    continuation.finish()
+                    return
+                } catch StreamGuardrailError.degeneration(let fragment)
+                    where !isRetryAttempt && !hasForwardedContent && !Task.isCancelled {
+                    retryLog.error(
+                        "[Osaurus] guardrail: retrying model=\(modelName, privacy: .public) after reasoning-channel degeneration (fragment=\"\(fragment, privacy: .public)\")"
+                    )
+                    do {
+                        current = try await makeRetryStream()
+                        isRetryAttempt = true
+                    } catch {
+                        retryLog.error(
+                            "[Osaurus] guardrail: retry failed model=\(modelName, privacy: .public) — attempt 2 could not start: \(error.localizedDescription, privacy: .public)"
+                        )
+                        continuation.finish(throwing: error)
+                        return
+                    }
+                } catch {
+                    if isRetryAttempt {
+                        retryLog.error(
+                            "[Osaurus] guardrail: retry failed model=\(modelName, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                        )
+                    }
+                    continuation.finish(throwing: error)
+                    return
+                }
+            }
+        }
+        continuation.onTermination = { @Sendable _ in
+            task.cancel()
+        }
+        return stream
+    }
+
+    /// Content-bearing = anything a consumer could have committed to:
+    /// answer text, a dispatched (or previewing) tool call. Reasoning and
+    /// prefill progress are presentation-only and keep the retry eligible —
+    /// see the file header for the full rationale.
+    private static func isContentBearing(_ event: ModelRuntimeEvent) -> Bool {
+        switch event {
+        case .tokens(let text):
+            return !text.isEmpty
+        case .toolInvocation, .toolCallProgress:
+            return true
+        case .reasoning, .prefillProgress, .completionInfo:
+            return false
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -19,6 +19,11 @@
 //  stream with `.info(stopReason: .stop)`. Osaurus never inspects chunk
 //  text for stop-sequence matches.
 //
+//  The one exception to "purely a translation step" is the live guardrails
+//  (StreamDegenerationDetector.swift): text deltas are additionally fed to a
+//  per-stream degeneration detector (abort with a typed error) and template
+//  leak detector (log-only) — these observe, they never rewrite deltas.
+//
 
 import Foundation
 @preconcurrency import MLXLMCommon
@@ -37,11 +42,15 @@ enum GenerationEventMapper {
     ///   path, not in this translation layer. If a no-thinking request still
     ///   emits `.reasoning`, Osaurus keeps that signal visible for root-cause
     ///   debugging instead of merging or suppressing it.
+    /// - Parameter guardrails: Live-output guardrail switches, resolved from
+    ///   UserDefaults at call time by default; injectable so tests don't
+    ///   race on process-global defaults.
     static func map(
         events: AsyncStream<Generation>,
         modelName: String = "",
         trace: TTFTTrace? = nil,
-        suppressProgressUI: Bool = false
+        suppressProgressUI: Bool = false,
+        guardrails: StreamGuardrailSettings = .resolve()
     ) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
         let (stream, continuation) = AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
         let task = Task {
@@ -66,6 +75,33 @@ enum GenerationEventMapper {
             // STEP-DECODE line at stream end covers those steps instead.
             var firstOutputAt: CFAbsoluteTime?
             var sawToolCall = false
+            // Live guardrails (see StreamDegenerationDetector.swift): one
+            // detector instance per stream. Degeneration observes BOTH
+            // `.tokens` and `.reasoning` (loops routinely start in the
+            // thinking channel) and aborts on trigger; the leak detector
+            // observes content only and never touches the stream.
+            var degenerationDetector = StreamDegenerationDetector()
+            var leakDetector = StreamTemplateLeakDetector()
+            var guardrailAborted = false
+
+            // Abort-only by design: retry-with-safe-settings needs a
+            // caller-side policy (settings delta, attempt budget, stream
+            // splicing) and is a follow-up. The triggering delta is NOT
+            // yielded — by trigger time the caller has already received
+            // ~7 repeats of the loop; one more helps nobody.
+            func handleDegeneration(in text: String) -> Bool {
+                guard guardrails.degenerationDetection,
+                    let fragment = degenerationDetector.observe(text)
+                else { return false }
+                mapperLog.error(
+                    "[Osaurus] guardrail: degeneration detected model=\(modelName, privacy: .public) fragment=\"\(fragment, privacy: .public)\""
+                )
+                guardrailAborted = true
+                continuation.finish(
+                    throwing: StreamGuardrailError.degeneration(fragment: fragment)
+                )
+                return true
+            }
 
             func markFirstModelOutput() {
                 guard !markedFirstModelOutput else { return }
@@ -87,7 +123,7 @@ enum GenerationEventMapper {
                 }
             }
 
-            for await event in events {
+            eventLoop: for await event in events {
                 if case .info(let info) = event {
                     sawCompletionInfo = true
                     finalTokenCount = info.generationTokenCount
@@ -108,6 +144,16 @@ enum GenerationEventMapper {
                 switch event {
                 case .chunk(let text):
                     guard !text.isEmpty else { continue }
+                    // Log-only: a leaked special token means the template
+                    // fallback mismatched the family — surface it for the
+                    // capability ledger, never filter it out of the stream.
+                    if guardrails.templateLeakDetection,
+                        let token = leakDetector.observe(text) {
+                        mapperLog.error(
+                            "[Osaurus] guardrail: template leak model=\(modelName, privacy: .public) token=\"\(token, privacy: .public)\""
+                        )
+                    }
+                    if handleDegeneration(in: text) { break eventLoop }
                     markFirstModelOutput()
                     if firstChunk {
                         firstChunk = false
@@ -118,6 +164,10 @@ enum GenerationEventMapper {
 
                 case .reasoning(let text):
                     guard !text.isEmpty else { continue }
+                    // Degeneration only — the leak detector deliberately
+                    // skips reasoning deltas (family markers are legitimate
+                    // on the engine-internal thinking channel).
+                    if handleDegeneration(in: text) { break eventLoop }
                     markFirstModelOutput()
                     sawReasoning = true
                     estimatedTextTokens += max(1, text.count / 4)
@@ -194,7 +244,10 @@ enum GenerationEventMapper {
                 }
             }
 
-            if !sawCompletionInfo {
+            // A guardrail abort already finished the stream with a thrown
+            // error; synthesizing completion info would be a silent no-op
+            // yield and a misleading "stream ended without info" log line.
+            if !sawCompletionInfo && !guardrailAborted {
                 finalTokenCount = estimatedTextTokens
                 mapperLog.notice(
                     "generation stream ended without vmlx completion info; synthesizing stats model=\(modelName, privacy: .public) estimatedTokens=\(estimatedTextTokens, privacy: .public) unclosedReasoning=\(sawReasoning, privacy: .public)"
@@ -241,7 +294,9 @@ enum GenerationEventMapper {
             )
 
             reportPrefillFinished()
-            continuation.finish()
+            if !guardrailAborted {
+                continuation.finish()
+            }
         }
         continuation.onTermination = { @Sendable _ in
             task.cancel()

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -84,11 +84,13 @@ enum GenerationEventMapper {
             var leakDetector = StreamTemplateLeakDetector()
             var guardrailAborted = false
 
-            // Abort-only by design: retry-with-safe-settings needs a
-            // caller-side policy (settings delta, attempt budget, stream
-            // splicing) and is a follow-up. The triggering delta is NOT
-            // yielded — by trigger time the caller has already received
-            // ~7 repeats of the loop; one more helps nobody.
+            // Abort-only by design at THIS layer: retry-with-safe-settings
+            // is caller-side policy (`DegenerationRetry`, composed in
+            // `ModelRuntime.streamWithTools`/`respondWithTools`). The
+            // triggering delta is NOT yielded — by trigger time the caller
+            // has already received ~7 repeats of the loop; one more helps
+            // nobody. Not yielding it also keeps a first-content-delta loop
+            // retry-eligible (zero content forwarded downstream).
             func handleDegeneration(in text: String) -> Bool {
                 guard guardrails.degenerationDetection,
                     let fragment = degenerationDetector.observe(text)

--- a/Packages/OsaurusCore/Services/ModelRuntime/StreamDegenerationDetector.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/StreamDegenerationDetector.swift
@@ -32,8 +32,10 @@ import Foundation
 /// Callers get a real error instead of an endless stream of garbage.
 ///
 /// Deliberately abort-only in this layer: automatic retry-with-safe-settings
-/// needs caller-side design (which settings to change, how many attempts,
-/// how to splice the retried stream) and is tracked as a follow-up.
+/// is caller-side policy and lives in `DegenerationRetry`, composed by
+/// `ModelRuntime.streamWithTools` / `respondWithTools` around the mapped
+/// stream. When the retry is ineligible (content already reached the
+/// consumer) or disabled, this error propagates to the consumer unchanged.
 public enum StreamGuardrailError: Error, Equatable {
     /// The stream degenerated into a repetition loop. `fragment` carries the
     /// human-readable evidence (the repeating fragment and its counts).

--- a/Packages/OsaurusCore/Services/ModelRuntime/StreamDegenerationDetector.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/StreamDegenerationDetector.swift
@@ -6,21 +6,29 @@
 //  detection (abort) and template-leak detection (log-only), fed text deltas
 //  by `GenerationEventMapper` as they stream.
 //
-//  The degeneration detector is a port of the CLI gauntlet's batch-mode
-//  `DegenerationDetector` (Packages/OsaurusCLI/Sources/OsaurusCLICore/
-//  Commands/DegenerationDetector.swift). The two failure modes seen in the
-//  wild are a single character repeated forever (`!!!!!…`) and a short
-//  phrase looping (`idea idea idea…`), so both detectors target exactly
-//  those shapes:
+//  The degeneration detector is an adaptation of the CLI gauntlet's
+//  batch-mode `DegenerationDetector` (Packages/OsaurusCLI/Sources/
+//  OsaurusCLICore/Commands/DegenerationDetector.swift). The two failure
+//  modes seen in the wild are a single character repeated forever
+//  (`!!!!!…`) and a short phrase looping (`idea idea idea…`), so both
+//  detectors target exactly those shapes:
 //
-//    - any single character repeated `minCharacterRun` (64) or more times
-//      consecutively, and
+//    - a single non-whitespace character repeated consecutively past its
+//      per-class threshold (`minCharacterRun` = 64 for letters/digits,
+//      `minCharacterRunPunctuation` = 256 for punctuation/symbols), AND
+//      only when the run has GROWN in at least
+//      `minCharacterRunGrowthDeltas` (3) distinct deltas — a single-delta
+//      paste of a long divider / base64 blob is never a decode loop;
 //    - any n-gram of `minNGram`...`maxNGram` (3–12) whitespace-separated
-//      tokens occurring `minConsecutiveRepeats` (8) or more times
+//      tokens occurring `minConsecutiveRepeats` (12) or more times
 //      back-to-back.
 //
-//  KEEP IN SYNC: the CLI gauntlet's batch-mode sibling uses the same
-//  thresholds — if either side's thresholds change, change both.
+//  THRESHOLDS INTENTIONALLY DIVERGE from the CLI gauntlet's batch
+//  detector: this detector ABORTS live user streams and therefore needs
+//  anti-false-positive margins (markdown dividers, table padding, base64,
+//  "print 100 !", "repeat this 10 times" must all pass), while the
+//  gauntlet judges complete transcripts after the fact where a lower bar
+//  costs nothing. Do not "re-sync" them.
 //
 //  "Token" here means a whitespace-separated word, not a model token: the
 //  detector runs over streamed text and must not depend on any tokenizer.
@@ -88,26 +96,51 @@ public struct StreamGuardrailSettings: Sendable {
 /// accumulated text crosses a threshold, then latches (all later calls
 /// return nil — the caller aborts the stream on first trigger anyway).
 ///
-/// Thresholds are IDENTICAL to the CLI gauntlet's batch-mode
-/// `DegenerationDetector` and must stay in sync with it.
+/// Thresholds intentionally DIVERGE from the CLI gauntlet's batch-mode
+/// `DegenerationDetector`: streaming abort needs anti-false-positive
+/// margins, the gauntlet judges whole transcripts (see the file header).
 public struct StreamDegenerationDetector {
     /// Smallest and largest repeating unit considered, in whitespace tokens.
     public static let minNGram = 3
     public static let maxNGram = 12
-    /// An n-gram must occur this many times back-to-back to count as a loop.
-    public static let minConsecutiveRepeats = 8
-    /// A single character repeated this many times consecutively is a loop.
+    /// An n-gram must occur this many times back-to-back to count as a
+    /// loop. 12 (vs the gauntlet's 8): the documented failure loops repeat
+    /// hundreds of times, so detection stays fast, while a user's "repeat
+    /// this 10 times" request streams through untouched.
+    public static let minConsecutiveRepeats = 12
+    /// A single LETTER or DIGIT repeated this many times consecutively is a
+    /// loop (subject to the growth gate below). Whitespace never counts —
+    /// indentation, table padding, and blank runs are always legitimate.
     public static let minCharacterRun = 64
+    /// Punctuation/symbol runs need a higher bar: markdown dividers
+    /// (`----`, `====`), box-drawing, and requested bursts ("print 100 !")
+    /// are everyday shapes at 64–100 characters. A real decode loop blows
+    /// far past 256 anyway.
+    public static let minCharacterRunPunctuation = 256
+    /// A run only triggers when it has GROWN in at least this many distinct
+    /// `observe()` calls: a genuine loop dribbles out over many small
+    /// decode deltas, while a single-delta paste of an arbitrarily long
+    /// divider/base64 run is model-completed content, not a stuck decoder.
+    public static let minCharacterRunGrowthDeltas = 3
+
+    /// Per-class character-run threshold (see `minCharacterRun` /
+    /// `minCharacterRunPunctuation`).
+    static func characterRunThreshold(for character: Character) -> Int {
+        (character.isLetter || character.isNumber)
+            ? minCharacterRun
+            : minCharacterRunPunctuation
+    }
 
     /// Tail-buffer bound, in `Character`s. The largest window the n-gram
-    /// rule ever needs is `maxNGram × minConsecutiveRepeats` = 96 whitespace
-    /// tokens; 4096 characters covers that window for tokens averaging up to
-    /// ~42 characters (separator included) — an order of magnitude above the
+    /// rule ever needs is `maxNGram × minConsecutiveRepeats` = 144
+    /// whitespace tokens; 4096 characters covers that window for tokens
+    /// averaging up to ~28 characters (separator included) — well above the
     /// word/short-phrase loops seen in the wild — while keeping the
     /// per-delta rescan O(4 KB) no matter how long the stream runs.
     /// Character runs are tracked incrementally and are NOT bounded by this
-    /// buffer. A loop of period ≤ 12 whose unit is longer than ~340 chars
-    /// would escape the window; accepted as out of scope for this detector.
+    /// buffer. A loop of period ≤ 12 whose unit is longer than ~28 chars
+    /// per token could escape the window; accepted as out of scope for this
+    /// detector.
     public static let maxTailCharacters = 4096
 
     /// Accumulated recent text, trimmed to `maxTailCharacters` after each
@@ -118,6 +151,13 @@ public struct StreamDegenerationDetector {
     /// over many deltas is still caught.
     private var runCharacter: Character?
     private var runLength = 0
+    /// Monotonic `observe()` call counter plus per-run growth accounting
+    /// backing the ≥`minCharacterRunGrowthDeltas` gate: `runGrowthDeltas`
+    /// counts the DISTINCT observe() calls that extended the current run,
+    /// `lastGrowthCallIndex` dedupes growth within one delta.
+    private var observeCallIndex = 0
+    private var runGrowthDeltas = 0
+    private var lastGrowthCallIndex = -1
     private var triggered = false
 
     /// Test hook: current tail size, to assert the bound holds under long
@@ -132,6 +172,7 @@ public struct StreamDegenerationDetector {
     public mutating func observe(_ delta: String) -> String? {
         guard !triggered, !delta.isEmpty else { return nil }
 
+        observeCallIndex += 1
         if let evidence = updateCharacterRun(with: delta) {
             triggered = true
             return evidence
@@ -149,18 +190,44 @@ public struct StreamDegenerationDetector {
     // MARK: - Character runs
 
     /// Advance the cross-delta run counter one character at a time and
-    /// trigger the moment the run reaches the threshold — checking only at
-    /// delta end would miss a 64-run that ends mid-delta.
+    /// trigger the moment a run satisfies BOTH gates — checking only at
+    /// delta end would miss a run that crosses its threshold mid-delta.
+    ///
+    /// Gates (anti-false-positive, see the type/file docs):
+    ///   * whitespace is exempt entirely (indentation, table padding);
+    ///   * per-class length threshold — 64 for letters/digits, 256 for
+    ///     punctuation/symbols (dividers, requested `!` bursts);
+    ///   * the run must have grown in ≥ `minCharacterRunGrowthDeltas`
+    ///     distinct `observe()` calls, so a single-delta paste of a long
+    ///     divider or base64 run never aborts while a decoder stuck
+    ///     emitting the same character across many small deltas still does.
     private mutating func updateCharacterRun(with delta: String) -> String? {
         for character in delta {
+            if character.isWhitespace {
+                // Whitespace runs are always legitimate; also break any
+                // tracked run so `!  !  !` never accumulates.
+                runCharacter = nil
+                runLength = 0
+                runGrowthDeltas = 0
+                lastGrowthCallIndex = -1
+                continue
+            }
             if character == runCharacter {
                 runLength += 1
-                if runLength >= Self.minCharacterRun {
-                    return "character \"\(character)\" repeated \(runLength)x consecutively"
-                }
             } else {
                 runCharacter = character
                 runLength = 1
+                runGrowthDeltas = 0
+                lastGrowthCallIndex = -1
+            }
+            if lastGrowthCallIndex != observeCallIndex {
+                lastGrowthCallIndex = observeCallIndex
+                runGrowthDeltas += 1
+            }
+            if runGrowthDeltas >= Self.minCharacterRunGrowthDeltas,
+                runLength >= Self.characterRunThreshold(for: character) {
+                return
+                    "character \"\(character)\" repeated \(runLength)x consecutively across \(runGrowthDeltas) deltas"
             }
         }
         return nil

--- a/Packages/OsaurusCore/Services/ModelRuntime/StreamDegenerationDetector.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/StreamDegenerationDetector.swift
@@ -1,0 +1,278 @@
+//
+//  StreamDegenerationDetector.swift
+//  osaurus
+//
+//  Live output guardrails for the streaming path: incremental degeneration
+//  detection (abort) and template-leak detection (log-only), fed text deltas
+//  by `GenerationEventMapper` as they stream.
+//
+//  The degeneration detector is a port of the CLI gauntlet's batch-mode
+//  `DegenerationDetector` (Packages/OsaurusCLI/Sources/OsaurusCLICore/
+//  Commands/DegenerationDetector.swift). The two failure modes seen in the
+//  wild are a single character repeated forever (`!!!!!…`) and a short
+//  phrase looping (`idea idea idea…`), so both detectors target exactly
+//  those shapes:
+//
+//    - any single character repeated `minCharacterRun` (64) or more times
+//      consecutively, and
+//    - any n-gram of `minNGram`...`maxNGram` (3–12) whitespace-separated
+//      tokens occurring `minConsecutiveRepeats` (8) or more times
+//      back-to-back.
+//
+//  KEEP IN SYNC: the CLI gauntlet's batch-mode sibling uses the same
+//  thresholds — if either side's thresholds change, change both.
+//
+//  "Token" here means a whitespace-separated word, not a model token: the
+//  detector runs over streamed text and must not depend on any tokenizer.
+//
+
+import Foundation
+
+/// Typed failure a guardrail throws to finish a mapped generation stream.
+/// Callers get a real error instead of an endless stream of garbage.
+///
+/// Deliberately abort-only in this layer: automatic retry-with-safe-settings
+/// needs caller-side design (which settings to change, how many attempts,
+/// how to splice the retried stream) and is tracked as a follow-up.
+public enum StreamGuardrailError: Error, Equatable {
+    /// The stream degenerated into a repetition loop. `fragment` carries the
+    /// human-readable evidence (the repeating fragment and its counts).
+    case degeneration(fragment: String)
+}
+
+extension StreamGuardrailError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .degeneration(let fragment):
+            return "Generation aborted: output degenerated into repetition (\(fragment))"
+        }
+    }
+}
+
+/// Per-stream guardrail switches, resolved once at stream start.
+///
+/// Both flags default to **true**: for degeneration, detect+abort is
+/// strictly better than streaming unbounded garbage (a triggered stream was
+/// already unusable — aborting only converts a hang into a typed failure);
+/// for template leaks, detection is log-only and never mutates output, so
+/// having it on costs nothing and feeds the capability ledger.
+public struct StreamGuardrailSettings: Sendable {
+    /// UserDefaults key: `Bool`, default true. Aborts a stream (with
+    /// `StreamGuardrailError.degeneration`) when output starts looping.
+    public static let degenerationDetectionKey = "ai.osaurus.guardrails.degenerationDetection"
+    /// UserDefaults key: `Bool`, default true. Logs (never filters) leaked
+    /// chat-template special tokens found in content deltas.
+    public static let templateLeakDetectionKey = "ai.osaurus.guardrails.templateLeakDetection"
+
+    public var degenerationDetection: Bool
+    public var templateLeakDetection: Bool
+
+    public init(degenerationDetection: Bool, templateLeakDetection: Bool) {
+        self.degenerationDetection = degenerationDetection
+        self.templateLeakDetection = templateLeakDetection
+    }
+
+    /// Read the flags, treating an absent key as ON (see type doc for why
+    /// default-true). Injectable defaults for tests.
+    public static func resolve(from defaults: UserDefaults = .standard) -> Self {
+        Self(
+            degenerationDetection: defaults.object(forKey: degenerationDetectionKey) as? Bool ?? true,
+            templateLeakDetection: defaults.object(forKey: templateLeakDetectionKey) as? Bool ?? true
+        )
+    }
+}
+
+/// Incremental repetition detector for live streams. Feed it every text
+/// delta (`.tokens` AND `.reasoning` — loops routinely start inside the
+/// thinking channel); it returns evidence on the first delta at which the
+/// accumulated text crosses a threshold, then latches (all later calls
+/// return nil — the caller aborts the stream on first trigger anyway).
+///
+/// Thresholds are IDENTICAL to the CLI gauntlet's batch-mode
+/// `DegenerationDetector` and must stay in sync with it.
+public struct StreamDegenerationDetector {
+    /// Smallest and largest repeating unit considered, in whitespace tokens.
+    public static let minNGram = 3
+    public static let maxNGram = 12
+    /// An n-gram must occur this many times back-to-back to count as a loop.
+    public static let minConsecutiveRepeats = 8
+    /// A single character repeated this many times consecutively is a loop.
+    public static let minCharacterRun = 64
+
+    /// Tail-buffer bound, in `Character`s. The largest window the n-gram
+    /// rule ever needs is `maxNGram × minConsecutiveRepeats` = 96 whitespace
+    /// tokens; 4096 characters covers that window for tokens averaging up to
+    /// ~42 characters (separator included) — an order of magnitude above the
+    /// word/short-phrase loops seen in the wild — while keeping the
+    /// per-delta rescan O(4 KB) no matter how long the stream runs.
+    /// Character runs are tracked incrementally and are NOT bounded by this
+    /// buffer. A loop of period ≤ 12 whose unit is longer than ~340 chars
+    /// would escape the window; accepted as out of scope for this detector.
+    public static let maxTailCharacters = 4096
+
+    /// Accumulated recent text, trimmed to `maxTailCharacters` after each
+    /// scan (scan-then-trim, so a single oversized delta is still scanned
+    /// in full together with the previous tail).
+    private var tail = ""
+    /// Character-run state carried across delta boundaries so `!!!!…` split
+    /// over many deltas is still caught.
+    private var runCharacter: Character?
+    private var runLength = 0
+    private var triggered = false
+
+    /// Test hook: current tail size, to assert the bound holds under long
+    /// clean streams.
+    var tailCharacterCountForTesting: Int { tail.count }
+
+    public init() {}
+
+    /// Observe the next text delta. Returns the repeating-fragment evidence
+    /// on first trigger, nil otherwise (including on every call after a
+    /// trigger).
+    public mutating func observe(_ delta: String) -> String? {
+        guard !triggered, !delta.isEmpty else { return nil }
+
+        if let evidence = updateCharacterRun(with: delta) {
+            triggered = true
+            return evidence
+        }
+
+        tail.append(delta)
+        if let evidence = detectNGramLoop(in: tail) {
+            triggered = true
+            return evidence
+        }
+        trimTail()
+        return nil
+    }
+
+    // MARK: - Character runs
+
+    /// Advance the cross-delta run counter one character at a time and
+    /// trigger the moment the run reaches the threshold — checking only at
+    /// delta end would miss a 64-run that ends mid-delta.
+    private mutating func updateCharacterRun(with delta: String) -> String? {
+        for character in delta {
+            if character == runCharacter {
+                runLength += 1
+                if runLength >= Self.minCharacterRun {
+                    return "character \"\(character)\" repeated \(runLength)x consecutively"
+                }
+            } else {
+                runCharacter = character
+                runLength = 1
+            }
+        }
+        return nil
+    }
+
+    // MARK: - N-gram loops
+
+    /// Same algorithm as the CLI's `DegenerationDetector.detect`, applied to
+    /// the bounded tail. A pure single-word loop (`idea idea …`) is caught
+    /// by the 3-gram rule once it spans 24 words. The trailing (possibly
+    /// incomplete) word counts as a token; that can only trigger one delta
+    /// early on text that already looped `minConsecutiveRepeats − 1` full
+    /// times, which is degenerate for practical purposes.
+    private func detectNGramLoop(in text: String) -> String? {
+        let tokens = text.split(whereSeparator: \.isWhitespace)
+        for n in Self.minNGram...Self.maxNGram {
+            // A loop of period n needs at least n × repeats tokens; larger
+            // n needs strictly more, so once one n is impossible all are.
+            guard tokens.count >= n * Self.minConsecutiveRepeats else { break }
+            var start = 0
+            while start + n * Self.minConsecutiveRepeats <= tokens.count {
+                var occurrences = 1
+                var next = start + n
+                while next + n <= tokens.count,
+                    Self.blocksEqual(tokens, start, next, length: n) {
+                    occurrences += 1
+                    next += n
+                }
+                if occurrences >= Self.minConsecutiveRepeats {
+                    let fragment = tokens[start..<(start + n)].joined(separator: " ")
+                    return "\(n)-token n-gram \"\(Self.truncated(fragment))\" repeated \(occurrences)x consecutively"
+                }
+                start += 1
+            }
+        }
+        return nil
+    }
+
+    /// Keep the last `maxTailCharacters`, then drop through the first
+    /// whitespace so the buffer always starts at a real token boundary — a
+    /// truncated first word must not fabricate (or mask) an n-gram match.
+    private mutating func trimTail() {
+        guard tail.count > Self.maxTailCharacters else { return }
+        var trimmed = tail.suffix(Self.maxTailCharacters)
+        if let firstWhitespace = trimmed.firstIndex(where: \.isWhitespace) {
+            trimmed = trimmed[trimmed.index(after: firstWhitespace)...]
+        }
+        tail = String(trimmed)
+    }
+
+    private static func blocksEqual(
+        _ tokens: [Substring], _ a: Int, _ b: Int, length: Int
+    ) -> Bool {
+        for offset in 0..<length where tokens[a + offset] != tokens[b + offset] {
+            return false
+        }
+        return true
+    }
+
+    private static func truncated(_ fragment: String, limit: Int = 80) -> String {
+        fragment.count <= limit ? fragment : String(fragment.prefix(limit)) + "…"
+    }
+}
+
+/// Detect-and-log ONLY: scans content (`.tokens`) deltas for chat-template
+/// special tokens that should never reach user-visible output. A leaked
+/// marker means the template-fallback path mismatched the model family —
+/// that is data for the capability ledger, not something to hide by
+/// filtering, so this detector never mutates the stream.
+///
+/// Fed `.tokens` deltas only, NOT `.reasoning` — the reasoning channel is
+/// engine-internal and legitimately carries family markers.
+public struct StreamTemplateLeakDetector {
+    /// Exact leak list. `<think>` is deliberately EXCLUDED here (divergence
+    /// from the CLI gauntlet's leak list): some families legitimately emit
+    /// it in content on the fallback path and the engine owns
+    /// reasoning-channel routing, so its presence in content is not by
+    /// itself a template mismatch.
+    public static let leakTokens: [String] = [
+        "<|im_start|>",
+        "<|im_end|>",
+        "〈|EOS|〉",
+        "<tool_call>",
+        "]~!b[",
+        "[e~[",
+        "\u{FFFE}",  // sentinel char some templates use as an internal marker
+    ]
+
+    /// Carry one character less than the longest leak token so a token split
+    /// across delta boundaries still matches once the rest arrives. This is
+    /// the entire buffer — the detector never holds unbounded text.
+    private static let carryCharacters: Int = (leakTokens.map(\.count).max() ?? 12) - 1
+
+    private var tail = ""
+    private var triggered = false
+
+    public init() {}
+
+    /// Observe the next CONTENT delta. Returns the leaked token on the first
+    /// hit for this stream, nil otherwise (later hits stay silent — one log
+    /// line per stream is enough signal).
+    public mutating func observe(_ delta: String) -> String? {
+        guard !triggered, !delta.isEmpty else { return nil }
+        tail.append(delta)
+        if let token = Self.leakTokens.first(where: { tail.contains($0) }) {
+            triggered = true
+            tail = ""
+            return token
+        }
+        if tail.count > Self.carryCharacters {
+            tail = String(tail.suffix(Self.carryCharacters))
+        }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/DegenerationRetryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DegenerationRetryTests.swift
@@ -1,0 +1,349 @@
+//
+//  DegenerationRetryTests.swift
+//  osaurusTests
+//
+//  Caller-side degeneration retry (DegenerationRetry.swift): mapper-level
+//  integration with fake `Generation` event streams, mirroring the
+//  fake-stream pattern of StreamGuardrailsIntegrationTests. Attempt 1 flows
+//  through the real `GenerationEventMapper` (so the real detector triggers
+//  the real typed abort) and the splice must:
+//
+//    - retry once, transparently, when the abort precedes any
+//      content-bearing event (the reasoning-channel loop case);
+//    - propagate the error untouched once content was already forwarded;
+//    - propagate when the retry attempt degenerates too (one retry max);
+//    - do nothing at all when the flag is off.
+//
+//  Plus unit coverage for the safe-settings rebuild and the flag resolve.
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("DegenerationRetry splice")
+struct DegenerationRetrySpliceTests {
+
+    private static let guardrailsOn = StreamGuardrailSettings(
+        degenerationDetection: true,
+        templateLeakDetection: true
+    )
+
+    /// A degenerating reasoning-channel stream: the 3-gram rule trips on the
+    /// 8th consecutive repeat, well before the 12th delta.
+    private static let reasoningLoop: [Generation] =
+        Array(repeating: .reasoning("loop token here "), count: 12)
+
+    /// A clean second attempt with both channels active.
+    private static let cleanAttempt: [Generation] = [
+        .reasoning("fresh thinking "),
+        .chunk("The answer "),
+        .chunk("is 42."),
+    ]
+
+    /// Counts invocations of the retry closure across attempts.
+    private actor RetryProbe {
+        private(set) var calls = 0
+        func record() { calls += 1 }
+    }
+
+    private func makeGenerationStream(_ events: [Generation]) -> AsyncStream<Generation> {
+        AsyncStream { continuation in
+            for ev in events { continuation.yield(ev) }
+            continuation.finish()
+        }
+    }
+
+    /// Run fake upstream events through the REAL mapper (real detector, real
+    /// typed abort) — the splice under test consumes exactly what
+    /// `ModelRuntime` would hand it.
+    private func mapped(_ events: [Generation]) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
+        GenerationEventMapper.map(
+            events: makeGenerationStream(events),
+            modelName: "retry-test-model",
+            guardrails: Self.guardrailsOn
+        )
+    }
+
+    /// Hand-built ModelRuntimeEvent stream for shapes the mapper can't
+    /// easily fabricate (e.g. a tool invocation followed by an abort).
+    private func eventStream(
+        _ events: [ModelRuntimeEvent],
+        throwing error: Error? = nil
+    ) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
+        AsyncThrowingStream { continuation in
+            for ev in events { continuation.yield(ev) }
+            continuation.finish(throwing: error)
+        }
+    }
+
+    private func collect(
+        _ stream: AsyncThrowingStream<ModelRuntimeEvent, Error>
+    ) async throws -> [ModelRuntimeEvent] {
+        var out: [ModelRuntimeEvent] = []
+        for try await ev in stream { out.append(ev) }
+        return out
+    }
+
+    private func tokenDeltas(_ events: [ModelRuntimeEvent]) -> [String] {
+        events.compactMap { if case .tokens(let s) = $0 { s } else { nil } }
+    }
+
+    private func reasoningDeltas(_ events: [ModelRuntimeEvent]) -> [String] {
+        events.compactMap { if case .reasoning(let s) = $0 { s } else { nil } }
+    }
+
+    // MARK: - Eligible: transparent retry
+
+    @Test func reasoning_degeneration_with_zero_content_retries_transparently() async throws {
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped(Self.reasoningLoop),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        // No error reaches the consumer, and every content delta it sees is
+        // attempt 2's — attempt 1 aborted before yielding any content.
+        let out = try await collect(spliced)
+        #expect(tokenDeltas(out) == ["The answer ", "is 42."])
+        // Attempt 1's pre-trigger reasoning deltas were already forwarded
+        // (un-yielding is impossible); attempt 2's reasoning follows them.
+        #expect(reasoningDeltas(out).last == "fresh thinking ")
+        #expect(await probe.calls == 1)
+    }
+
+    @Test func degeneration_inside_first_content_delta_is_retry_eligible() async throws {
+        // The mapper checks the detector BEFORE yielding a content delta, so
+        // a loop contained entirely in the first chunk aborts with zero
+        // content forwarded — retry is transparent and therefore allowed.
+        let loopInOneDelta = String(repeating: "idea ", count: 30)
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped([.chunk(loopInOneDelta)]),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        let out = try await collect(spliced)
+        #expect(tokenDeltas(out) == ["The answer ", "is 42."])
+        #expect(await probe.calls == 1)
+    }
+
+    // MARK: - Ineligible: error propagates
+
+    @Test func content_already_yielded_propagates_without_retry() async {
+        // Clean content first, then a chunk-channel loop across many deltas:
+        // by trigger time the consumer has already received content, so the
+        // typed abort must propagate and the retry closure must not run.
+        let events: [Generation] =
+            [.chunk("Sure thing. ")] + Array(repeating: .chunk("idea "), count: 30)
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped(events),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        await #expect(throws: StreamGuardrailError.self) {
+            _ = try await self.collect(spliced)
+        }
+        #expect(await probe.calls == 0)
+    }
+
+    @Test func tool_invocation_already_yielded_propagates_without_retry() async {
+        // A forwarded tool call is content: retrying would double-dispatch
+        // it. Hand-built stream because the mapper can't fabricate this shape.
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: eventStream(
+                [.toolInvocation(name: "get_weather", argsJSON: "{}")],
+                throwing: StreamGuardrailError.degeneration(fragment: "post-tool loop")
+            ),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        await #expect(throws: StreamGuardrailError.self) {
+            _ = try await self.collect(spliced)
+        }
+        #expect(await probe.calls == 0)
+    }
+
+    @Test func retry_that_also_degenerates_propagates_the_second_error() async {
+        // One retry maximum: attempt 2's degeneration must reach the consumer.
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped(Self.reasoningLoop),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.reasoningLoop)
+        }
+        await #expect(throws: StreamGuardrailError.self) {
+            _ = try await self.collect(spliced)
+        }
+        #expect(await probe.calls == 1)
+    }
+
+    @Test func retry_stream_construction_failure_propagates() async {
+        struct RetryStartError: Error {}
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped(Self.reasoningLoop),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            throw RetryStartError()
+        }
+        await #expect(throws: RetryStartError.self) {
+            _ = try await self.collect(spliced)
+        }
+        #expect(await probe.calls == 1)
+    }
+
+    @Test func non_guardrail_errors_never_trigger_a_retry() async {
+        struct UpstreamError: Error {}
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: eventStream([.reasoning("thinking ")], throwing: UpstreamError()),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        await #expect(throws: UpstreamError.self) {
+            _ = try await self.collect(spliced)
+        }
+        #expect(await probe.calls == 0)
+    }
+
+    // MARK: - Flag off
+
+    @Test func flag_off_propagates_the_abort_without_retry() async {
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped(Self.reasoningLoop),
+            modelName: "retry-test-model",
+            isEnabled: false
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        await #expect(throws: StreamGuardrailError.self) {
+            _ = try await self.collect(spliced)
+        }
+        #expect(await probe.calls == 0)
+    }
+
+    // MARK: - Clean pass-through
+
+    @Test func clean_stream_passes_through_untouched_and_never_retries() async throws {
+        let probe = RetryProbe()
+        let spliced = DegenerationRetry.withRetry(
+            events: mapped(Self.cleanAttempt),
+            modelName: "retry-test-model",
+            isEnabled: true
+        ) {
+            await probe.record()
+            return self.mapped(Self.cleanAttempt)
+        }
+        let out = try await collect(spliced)
+        #expect(tokenDeltas(out) == ["The answer ", "is 42."])
+        #expect(reasoningDeltas(out) == ["fresh thinking "])
+        #expect(await probe.calls == 0)
+    }
+}
+
+@Suite("DegenerationRetry policy")
+struct DegenerationRetryPolicyTests {
+
+    // MARK: - Safe settings
+
+    @Test func safe_parameters_raise_greedy_temperature_and_add_repetition_penalty() {
+        let base = GenerationParameters(
+            temperature: 0,
+            maxTokens: 512,
+            seed: 7,
+            jsonMode: true,
+            sessionId: "session-1"
+        )
+        let safe = DegenerationRetry.safeParameters(retrying: base, modelDefaults: .empty)
+        #expect(safe.temperature == 0.7)
+        #expect(safe.repetitionPenalty == 1.1)
+        #expect(!safe.samplingParametersAreImplicit)
+        // Everything else must survive the rebuild untouched.
+        #expect(safe.maxTokens == 512)
+        #expect(safe.seed == 7)
+        #expect(safe.jsonMode)
+        #expect(safe.sessionId == "session-1")
+    }
+
+    @Test func safe_parameters_never_cool_down_an_already_hot_request() {
+        let base = GenerationParameters(temperature: 0.95, maxTokens: 128)
+        let safe = DegenerationRetry.safeParameters(retrying: base, modelDefaults: .empty)
+        #expect(safe.temperature == 0.95)
+    }
+
+    @Test func safe_parameters_preserve_an_explicit_repetition_penalty() {
+        let base = GenerationParameters(
+            temperature: nil,
+            maxTokens: 128,
+            repetitionPenalty: 1.3
+        )
+        let safe = DegenerationRetry.safeParameters(retrying: base, modelDefaults: .empty)
+        #expect(safe.repetitionPenalty == 1.3)
+    }
+
+    @Test func safe_parameters_resolve_current_temperature_from_model_defaults() {
+        // Request silent + bundle ships a hot default: keep the hotter value.
+        let hotDefaults = LocalGenerationDefaults.Defaults(temperature: 0.9)
+        let base = GenerationParameters(temperature: nil, maxTokens: 128)
+        let safe = DegenerationRetry.safeParameters(retrying: base, modelDefaults: hotDefaults)
+        #expect(safe.temperature == 0.9)
+
+        // `do_sample=false` means the bundle asked for greedy — that IS the
+        // loop-prone configuration, so the floor applies even when the
+        // bundle also ships a nominal temperature.
+        let greedyDefaults = LocalGenerationDefaults.Defaults(temperature: 0.9, doSample: false)
+        let safeGreedy = DegenerationRetry.safeParameters(
+            retrying: base,
+            modelDefaults: greedyDefaults
+        )
+        #expect(safeGreedy.temperature == 0.7)
+    }
+
+    // MARK: - Flag resolve
+
+    @Test func flag_defaults_to_on_when_key_is_absent() {
+        #expect(DegenerationRetry.isEnabled(defaults: isolatedDefaults()))
+    }
+
+    @Test func flag_honors_explicit_opt_out() {
+        let defaults = isolatedDefaults()
+        defaults.set(false, forKey: DegenerationRetry.flagKey)
+        #expect(!DegenerationRetry.isEnabled(defaults: defaults))
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "DegenerationRetryPolicyTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("could not create isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/DegenerationRetryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DegenerationRetryTests.swift
@@ -121,7 +121,7 @@ struct DegenerationRetrySpliceTests {
         // The mapper checks the detector BEFORE yielding a content delta, so
         // a loop contained entirely in the first chunk aborts with zero
         // content forwarded — retry is transparent and therefore allowed.
-        let loopInOneDelta = String(repeating: "idea ", count: 30)
+        let loopInOneDelta = String(repeating: "idea ", count: 60)
         let probe = RetryProbe()
         let spliced = DegenerationRetry.withRetry(
             events: mapped([.chunk(loopInOneDelta)]),
@@ -143,7 +143,7 @@ struct DegenerationRetrySpliceTests {
         // by trigger time the consumer has already received content, so the
         // typed abort must propagate and the retry closure must not run.
         let events: [Generation] =
-            [.chunk("Sure thing. ")] + Array(repeating: .chunk("idea "), count: 30)
+            [.chunk("Sure thing. ")] + Array(repeating: .chunk("idea "), count: 60)
         let probe = RetryProbe()
         let spliced = DegenerationRetry.withRetry(
             events: mapped(events),

--- a/Packages/OsaurusCore/Tests/Service/StreamDegenerationDetectorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamDegenerationDetectorTests.swift
@@ -4,12 +4,15 @@
 //
 //  Threshold tests for the live-stream degeneration detector: the two known
 //  failure modes (`!!!!!…` character runs and `idea idea idea…` phrase
-//  loops) must trip it, normal prose — including legitimate repetition just
-//  under the thresholds — must not, and the incremental adaptation must hold
-//  its guarantees (trigger across arbitrary delta splits, bounded tail).
+//  loops) must trip it, normal prose — including legitimate repetition and
+//  legitimate long runs (markdown dividers, requested bursts, base64,
+//  "repeat this 10 times") — must not, and the incremental adaptation must
+//  hold its guarantees (trigger across arbitrary delta splits, bounded
+//  tail).
 //
-//  The batch-mode boundary cases mirror the CLI gauntlet's
-//  DegenerationDetectorTests — thresholds are shared and must stay in sync.
+//  Thresholds intentionally DIVERGE from the CLI gauntlet's batch-mode
+//  DegenerationDetectorTests: aborting a live stream needs
+//  anti-false-positive margins the transcript judge doesn't.
 //
 
 import Foundation
@@ -38,14 +41,15 @@ struct StreamDegenerationDetectorTests {
         return nil
     }
 
-    // MARK: - Character runs (ported boundary cases)
+    // MARK: - Character runs
 
-    @Test func characterRunAtThresholdIsDetected() {
-        let text = "The explanation ends here " + String(repeating: "!", count: 64)
-        let evidence = observe(text)
+    @Test func letterRunGrowingAcrossDeltasIsDetected() {
+        // A letter run over the 64 threshold, dribbling in across many
+        // deltas (the live decode-loop shape), must trip.
+        let text = "aaaa " + String(repeating: "e", count: 100)
+        let evidence = observe(text, chunkSize: 10)
         #expect(evidence != nil)
-        #expect(evidence?.contains("\"!\"") == true, "evidence should name the character")
-        #expect(evidence?.contains("64") == true, "evidence should carry the run length")
+        #expect(evidence?.contains("\"e\"") == true, "evidence should name the character")
     }
 
     @Test func characterRunBelowThresholdIsClean() {
@@ -53,41 +57,99 @@ struct StreamDegenerationDetectorTests {
         #expect(observe(text) == nil)
     }
 
-    @Test func characterRunAtEndOfTextIsDetected() {
-        // The run must be caught even when the text ends mid-run.
-        let text = "aaaa" + String(repeating: "e", count: 100)
-        #expect(observe(text) != nil)
+    @Test func characterRunAtEndOfStreamIsDetected() {
+        // The run must be caught even when the stream ends mid-run.
+        let text = "aaaa " + String(repeating: "e", count: 100)
+        #expect(observe(text, chunkSize: 30) != nil)
+    }
+
+    // MARK: - Character runs: legitimate shapes must NOT abort
+
+    @Test func markdownDividerInOneDeltaIsClean() {
+        // An 80-char `-` divider pasted in one delta is everyday markdown,
+        // not a stuck decoder (single-delta growth < 3-delta gate).
+        #expect(observe("Section done.\n" + String(repeating: "-", count: 80) + "\n") == nil)
+        #expect(observe(String(repeating: "=", count: 80)) == nil)
+    }
+
+    @Test func requestedExclamationBurstInOneDeltaIsClean() {
+        // "print 100 !" — the model completes the request in one delta.
+        #expect(observe("Here you go: " + String(repeating: "!", count: 100)) == nil)
+    }
+
+    @Test func base64StyleRunInOneDeltaIsClean() {
+        // Base64/padding blobs can carry long same-character stretches;
+        // 200 identical letters in one delta must stream through.
+        #expect(observe(String(repeating: "A", count: 200)) == nil)
+    }
+
+    @Test func whitespaceRunsNeverCount() {
+        // Table padding / indentation: arbitrarily long whitespace runs are
+        // exempt entirely, however they arrive.
+        let text = "| a |" + String(repeating: " ", count: 400) + "| b |"
+        #expect(observe(text, chunkSize: 7) == nil)
+        #expect(observe(String(repeating: "\n", count: 300), chunkSize: 5) == nil)
+    }
+
+    @Test func punctuationRunUnderHigherThresholdIsCleanEvenAcrossDeltas() {
+        // Punctuation gets the 256 threshold: a 100-`!` burst split across
+        // deltas (growth gate satisfied) still must not abort.
+        #expect(observe("answer " + String(repeating: "!", count: 100), chunkSize: 5) == nil)
+    }
+
+    @Test func punctuationRunGrowingPastHigherThresholdIsDetected() {
+        // The true positive: a `!` run growing across many small deltas to
+        // 300+ is the documented `!!!!!…` failure mode.
+        let evidence = observe("answer " + String(repeating: "!", count: 320), chunkSize: 5)
+        #expect(evidence != nil)
+        #expect(evidence?.contains("\"!\"") == true)
     }
 
     // MARK: - N-gram loops (ported boundary cases)
 
     @Test func singleWordLoopIsDetectedViaTrigram() {
-        // 24 consecutive "idea" = the 3-gram "idea idea idea" occurring
-        // 8 times back-to-back.
+        // 36 consecutive "idea" = the 3-gram "idea idea idea" occurring
+        // 12 times back-to-back.
         let text = "The core concept is "
-            + Array(repeating: "idea", count: 24).joined(separator: " ")
+            + Array(repeating: "idea", count: 36).joined(separator: " ")
         let evidence = observe(text)
         #expect(evidence != nil)
         #expect(evidence?.contains("idea idea idea") == true)
     }
 
+    @Test func singleWordLoopFiftyTimesIsDetected() {
+        // The documented `idea idea idea…` failure mode repeats hundreds of
+        // times; ×50 must fire well before the loop ends.
+        let text = Array(repeating: "idea", count: 50).joined(separator: " ")
+        #expect(observe(text, chunkSize: 6) != nil)
+    }
+
     @Test func phraseLoopAtThresholdIsDetected() {
-        let text = Array(repeating: "the sky is blue because", count: 8).joined(separator: " ")
+        let text = Array(repeating: "the sky is blue because", count: 12).joined(separator: " ")
         let evidence = observe(text)
         #expect(evidence != nil)
         #expect(evidence?.contains("the sky is blue because") == true)
     }
 
-    @Test func phraseRepeatedSevenTimesIsClean() {
+    @Test func phraseRepeatedElevenTimesIsClean() {
         // One repeat under the threshold must not trip the detector.
-        let text = Array(repeating: "alpha beta gamma", count: 7).joined(separator: " ")
+        let text = Array(repeating: "alpha beta gamma", count: 11).joined(separator: " ")
         #expect(observe(text) == nil)
+    }
+
+    @Test func requestedTenfoldRepetitionIsClean() {
+        // "Repeat this sentence 10 times" is a legitimate user request; the
+        // 12-repeat bar clears it with margin, batch or streamed.
+        let text = Array(repeating: "I will repeat this sentence.", count: 10)
+            .joined(separator: " ")
+        #expect(observe(text) == nil)
+        #expect(observe(text, chunkSize: 4) == nil)
     }
 
     @Test func loopEmbeddedInProseIsDetected() {
         let text =
             "Rayleigh scattering explains the color. "
-            + Array(repeating: "shorter wavelengths scatter more", count: 9)
+            + Array(repeating: "shorter wavelengths scatter more", count: 13)
                 .joined(separator: " ")
             + " and that is why the sky is blue."
         #expect(observe(text) != nil)
@@ -96,7 +158,7 @@ struct StreamDegenerationDetectorTests {
     @Test func sevenWordPhraseLoopIsDetectedAsSevenGram() {
         // Repeating units longer than 3 words are caught by their own
         // n-gram size (here n=7), not just trigrams.
-        let text = Array(repeating: "blue sky today and calm sea tonight", count: 8)
+        let text = Array(repeating: "blue sky today and calm sea tonight", count: 12)
             .joined(separator: " ")
         #expect(observe(text) != nil)
     }
@@ -136,16 +198,17 @@ struct StreamDegenerationDetectorTests {
         // time (splitting words and separators arbitrarily), must still
         // trip — this is the live-stream shape.
         let text = "The core concept is "
-            + Array(repeating: "idea", count: 24).joined(separator: " ")
+            + Array(repeating: "idea", count: 36).joined(separator: " ")
         let evidence = observe(text, chunkSize: 3)
         #expect(evidence != nil)
         #expect(evidence?.contains("idea idea idea") == true)
     }
 
     @Test func characterRunSplitAcrossDeltasIsDetected() {
-        // `!!!!!` split into 5-char deltas crosses the 64 threshold on a
-        // delta boundary; the cross-delta run counter must carry.
-        let text = "answer " + String(repeating: "!", count: 70)
+        // `!!!!!` split into 5-char deltas crosses the 256 punctuation
+        // threshold on a delta boundary; the cross-delta run counter must
+        // carry, and the growth gate (many deltas) is satisfied.
+        let text = "answer " + String(repeating: "!", count: 300)
         let evidence = observe(text, chunkSize: 5)
         #expect(evidence != nil)
         #expect(evidence?.contains("\"!\"") == true)
@@ -181,10 +244,10 @@ struct StreamDegenerationDetectorTests {
         // The mapper aborts on first trigger; the latch guarantees no
         // duplicate evidence even if more deltas arrive.
         var detector = StreamDegenerationDetector()
-        let loop = Array(repeating: "idea", count: 24).joined(separator: " ")
+        let loop = Array(repeating: "idea", count: 36).joined(separator: " ")
         #expect(detector.observe(loop) != nil)
         #expect(detector.observe(loop) == nil)
-        #expect(detector.observe(String(repeating: "!", count: 100)) == nil)
+        #expect(detector.observe(String(repeating: "!", count: 300)) == nil)
     }
 
     @Test func loopArrivingAfterLongCleanPrefixIsStillDetected() {
@@ -196,7 +259,7 @@ struct StreamDegenerationDetectorTests {
             #expect(detector.observe("unique\(i) ") == nil)
         }
         var evidence: String?
-        for _ in 0..<24 where evidence == nil {
+        for _ in 0..<40 where evidence == nil {
             evidence = detector.observe("idea ")
         }
         #expect(evidence?.contains("idea idea idea") == true)

--- a/Packages/OsaurusCore/Tests/Service/StreamDegenerationDetectorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamDegenerationDetectorTests.swift
@@ -1,0 +1,204 @@
+//
+//  StreamDegenerationDetectorTests.swift
+//  osaurusTests
+//
+//  Threshold tests for the live-stream degeneration detector: the two known
+//  failure modes (`!!!!!…` character runs and `idea idea idea…` phrase
+//  loops) must trip it, normal prose — including legitimate repetition just
+//  under the thresholds — must not, and the incremental adaptation must hold
+//  its guarantees (trigger across arbitrary delta splits, bounded tail).
+//
+//  The batch-mode boundary cases mirror the CLI gauntlet's
+//  DegenerationDetectorTests — thresholds are shared and must stay in sync.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("StreamDegenerationDetector thresholds and incremental behaviour")
+struct StreamDegenerationDetectorTests {
+
+    /// Feed `text` to a fresh detector, either whole or split into fixed
+    /// `chunkSize`-character deltas, returning the first evidence (if any).
+    private func observe(_ text: String, chunkSize: Int? = nil) -> String? {
+        var detector = StreamDegenerationDetector()
+        guard let chunkSize else { return detector.observe(text) }
+        var index = text.startIndex
+        while index < text.endIndex {
+            let end =
+                text.index(index, offsetBy: chunkSize, limitedBy: text.endIndex)
+                ?? text.endIndex
+            if let evidence = detector.observe(String(text[index..<end])) {
+                return evidence
+            }
+            index = end
+        }
+        return nil
+    }
+
+    // MARK: - Character runs (ported boundary cases)
+
+    @Test func characterRunAtThresholdIsDetected() {
+        let text = "The explanation ends here " + String(repeating: "!", count: 64)
+        let evidence = observe(text)
+        #expect(evidence != nil)
+        #expect(evidence?.contains("\"!\"") == true, "evidence should name the character")
+        #expect(evidence?.contains("64") == true, "evidence should carry the run length")
+    }
+
+    @Test func characterRunBelowThresholdIsClean() {
+        let text = "Wow " + String(repeating: "!", count: 63) + " that is bright."
+        #expect(observe(text) == nil)
+    }
+
+    @Test func characterRunAtEndOfTextIsDetected() {
+        // The run must be caught even when the text ends mid-run.
+        let text = "aaaa" + String(repeating: "e", count: 100)
+        #expect(observe(text) != nil)
+    }
+
+    // MARK: - N-gram loops (ported boundary cases)
+
+    @Test func singleWordLoopIsDetectedViaTrigram() {
+        // 24 consecutive "idea" = the 3-gram "idea idea idea" occurring
+        // 8 times back-to-back.
+        let text = "The core concept is "
+            + Array(repeating: "idea", count: 24).joined(separator: " ")
+        let evidence = observe(text)
+        #expect(evidence != nil)
+        #expect(evidence?.contains("idea idea idea") == true)
+    }
+
+    @Test func phraseLoopAtThresholdIsDetected() {
+        let text = Array(repeating: "the sky is blue because", count: 8).joined(separator: " ")
+        let evidence = observe(text)
+        #expect(evidence != nil)
+        #expect(evidence?.contains("the sky is blue because") == true)
+    }
+
+    @Test func phraseRepeatedSevenTimesIsClean() {
+        // One repeat under the threshold must not trip the detector.
+        let text = Array(repeating: "alpha beta gamma", count: 7).joined(separator: " ")
+        #expect(observe(text) == nil)
+    }
+
+    @Test func loopEmbeddedInProseIsDetected() {
+        let text =
+            "Rayleigh scattering explains the color. "
+            + Array(repeating: "shorter wavelengths scatter more", count: 9)
+                .joined(separator: " ")
+            + " and that is why the sky is blue."
+        #expect(observe(text) != nil)
+    }
+
+    @Test func sevenWordPhraseLoopIsDetectedAsSevenGram() {
+        // Repeating units longer than 3 words are caught by their own
+        // n-gram size (here n=7), not just trigrams.
+        let text = Array(repeating: "blue sky today and calm sea tonight", count: 8)
+            .joined(separator: " ")
+        #expect(observe(text) != nil)
+    }
+
+    @Test func nonConsecutiveRepetitionIsClean() {
+        // The same fragment appearing often but always separated by a
+        // varying token is emphasis, not a loop: no 3–12-gram ever repeats
+        // immediately back-to-back.
+        let text = (0..<12).map { "blue sky number \($0) is lovely" }.joined(separator: " ")
+        #expect(observe(text) == nil)
+    }
+
+    @Test func normalProseIsClean() {
+        let text = """
+            The sky appears blue because sunlight entering the atmosphere is \
+            scattered by air molecules. Shorter wavelengths, such as blue and \
+            violet, scatter far more strongly than longer red wavelengths — \
+            this is Rayleigh scattering. Our eyes are more sensitive to blue \
+            than violet, and some violet is absorbed high in the atmosphere, \
+            so the dome overhead looks blue. A fair critique: this account \
+            ignores Mie scattering from aerosols, which whitens the horizon, \
+            and it does not explain why sunsets are red.
+            """
+        #expect(observe(text) == nil)
+    }
+
+    @Test func emptyAndTinyInputsAreClean() {
+        #expect(observe("") == nil)
+        #expect(observe("ok") == nil)
+        #expect(observe("one two three four") == nil)
+    }
+
+    // MARK: - Incremental behaviour
+
+    @Test func phraseLoopSplitAcrossManySmallDeltasIsDetected() {
+        // The same trigger text as the batch case, fed 3 characters at a
+        // time (splitting words and separators arbitrarily), must still
+        // trip — this is the live-stream shape.
+        let text = "The core concept is "
+            + Array(repeating: "idea", count: 24).joined(separator: " ")
+        let evidence = observe(text, chunkSize: 3)
+        #expect(evidence != nil)
+        #expect(evidence?.contains("idea idea idea") == true)
+    }
+
+    @Test func characterRunSplitAcrossDeltasIsDetected() {
+        // `!!!!!` split into 5-char deltas crosses the 64 threshold on a
+        // delta boundary; the cross-delta run counter must carry.
+        let text = "answer " + String(repeating: "!", count: 70)
+        let evidence = observe(text, chunkSize: 5)
+        #expect(evidence != nil)
+        #expect(evidence?.contains("\"!\"") == true)
+    }
+
+    @Test func cleanTextBelowThresholdNeverTriggersWhenStreamed() {
+        let text = "Wow " + String(repeating: "!", count: 63) + " that is bright."
+        #expect(observe(text, chunkSize: 4) == nil)
+    }
+
+    @Test func longCleanStreamNeverTriggersAndTailStaysBounded() {
+        // ~64 KB of unique-word text streamed in 1 KB deltas: no trigger,
+        // and the internal tail buffer must respect its documented bound at
+        // every step (the whole point of the incremental adaptation is that
+        // memory does not grow with stream length).
+        var detector = StreamDegenerationDetector()
+        var word = 0
+        for _ in 0..<64 {
+            var delta = ""
+            while delta.count < 1024 {
+                delta += "word\(word) "
+                word += 1
+            }
+            #expect(detector.observe(delta) == nil)
+            #expect(
+                detector.tailCharacterCountForTesting
+                    <= StreamDegenerationDetector.maxTailCharacters
+            )
+        }
+    }
+
+    @Test func detectorLatchesAfterFirstTrigger() {
+        // The mapper aborts on first trigger; the latch guarantees no
+        // duplicate evidence even if more deltas arrive.
+        var detector = StreamDegenerationDetector()
+        let loop = Array(repeating: "idea", count: 24).joined(separator: " ")
+        #expect(detector.observe(loop) != nil)
+        #expect(detector.observe(loop) == nil)
+        #expect(detector.observe(String(repeating: "!", count: 100)) == nil)
+    }
+
+    @Test func loopArrivingAfterLongCleanPrefixIsStillDetected() {
+        // The tail trim must not disable detection later in the stream: a
+        // loop that starts after several buffer-lengths of clean text still
+        // fits entirely inside the tail window and must trigger.
+        var detector = StreamDegenerationDetector()
+        for i in 0..<4096 {
+            #expect(detector.observe("unique\(i) ") == nil)
+        }
+        var evidence: String?
+        for _ in 0..<24 where evidence == nil {
+            evidence = detector.observe("idea ")
+        }
+        #expect(evidence?.contains("idea idea idea") == true)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/StreamGuardrailsIntegrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamGuardrailsIntegrationTests.swift
@@ -109,10 +109,10 @@ struct StreamGuardrailsMapperTests {
     // MARK: - Degeneration abort
 
     @Test func degenerating_chunk_stream_throws_typed_error() async {
-        // 30 "idea " chunks: the 3-gram rule trips at the 24th token; the
+        // 45 "idea " chunks: the 3-gram rule trips at the 36th token; the
         // mapped stream must finish with the typed guardrail error instead
         // of streaming the loop forever.
-        let events: [Generation] = Array(repeating: .chunk("idea "), count: 30)
+        let events: [Generation] = Array(repeating: .chunk("idea "), count: 45)
         do {
             _ = try await collect(events: events)
             Issue.record("expected StreamGuardrailError.degeneration to be thrown")
@@ -130,7 +130,7 @@ struct StreamGuardrailsMapperTests {
     @Test func degenerating_reasoning_stream_throws_typed_error() async {
         // Loops routinely start inside the thinking channel; `.reasoning`
         // deltas must feed the same detector.
-        let events: [Generation] = Array(repeating: .reasoning("loop token here "), count: 10)
+        let events: [Generation] = Array(repeating: .reasoning("loop token here "), count: 14)
         do {
             _ = try await collect(events: events)
             Issue.record("expected StreamGuardrailError.degeneration to be thrown")
@@ -146,10 +146,24 @@ struct StreamGuardrailsMapperTests {
     }
 
     @Test func character_run_split_across_chunks_throws() async {
-        let events: [Generation] = Array(repeating: .chunk("!!!!!!!"), count: 10)
+        // 50 × 7 = 350 `!` growing across many deltas: past the 256
+        // punctuation threshold with the ≥3-delta growth gate satisfied.
+        let events: [Generation] = Array(repeating: .chunk("!!!!!!!"), count: 50)
         await #expect(throws: StreamGuardrailError.self) {
             _ = try await collect(events: events)
         }
+    }
+
+    @Test func single_delta_divider_and_requested_burst_pass_through() async throws {
+        // Legitimate long runs must NOT abort: an 80-char divider pasted in
+        // one delta, and a requested 100-`!` burst in one delta.
+        let chunks = [
+            "Summary follows.\n",
+            String(repeating: "-", count: 80) + "\n",
+            "Here you go: " + String(repeating: "!", count: 100),
+        ]
+        let out = try await collect(events: chunks.map { .chunk($0) })
+        #expect(tokenDeltas(out) == chunks)
     }
 
     @Test func clean_stream_is_unaffected_byte_for_byte() async throws {
@@ -188,7 +202,7 @@ struct StreamGuardrailsMapperTests {
     // MARK: - Flags
 
     @Test func degeneration_flag_off_streams_the_loop_untouched() async throws {
-        let events: [Generation] = Array(repeating: .chunk("idea "), count: 30)
+        let events: [Generation] = Array(repeating: .chunk("idea "), count: 45)
         let out = try await collect(
             events: events,
             guardrails: StreamGuardrailSettings(
@@ -196,7 +210,7 @@ struct StreamGuardrailsMapperTests {
                 templateLeakDetection: true
             )
         )
-        #expect(tokenDeltas(out).count == 30)
+        #expect(tokenDeltas(out).count == 45)
     }
 
     @Test func leak_flag_off_streams_marker_untouched() async throws {

--- a/Packages/OsaurusCore/Tests/Service/StreamGuardrailsIntegrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamGuardrailsIntegrationTests.swift
@@ -1,0 +1,240 @@
+//
+//  StreamGuardrailsIntegrationTests.swift
+//  osaurusTests
+//
+//  Template-leak detector unit coverage plus the GenerationEventMapper
+//  wiring for both live guardrails: a degenerating stream must finish with
+//  a thrown `StreamGuardrailError`, a clean stream must pass through
+//  byte-for-byte, leak detection must be log-only (never mutate, never
+//  throw) and content-channel-only, and each flag must disable exactly its
+//  own detector.
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("StreamTemplateLeakDetector")
+struct StreamTemplateLeakDetectorTests {
+
+    @Test func tokenSplitAcrossTwoDeltasIsDetected() {
+        var detector = StreamTemplateLeakDetector()
+        #expect(detector.observe("Sure! <|im_st") == nil)
+        #expect(detector.observe("art|> hello") == "<|im_start|>")
+    }
+
+    @Test func everyLeakTokenIsDetectedWhole() {
+        for token in StreamTemplateLeakDetector.leakTokens {
+            var detector = StreamTemplateLeakDetector()
+            #expect(
+                detector.observe("prefix \(token) suffix") == token,
+                "leak token must be detected: \(token)"
+            )
+        }
+    }
+
+    @Test func detectorLatchesAfterFirstHit() {
+        // One log line per stream is enough signal; later hits stay silent.
+        var detector = StreamTemplateLeakDetector()
+        #expect(detector.observe("<|im_end|>") == "<|im_end|>")
+        #expect(detector.observe("<|im_end|>") == nil)
+        #expect(detector.observe("<tool_call>") == nil)
+    }
+
+    @Test func thinkTagIsDeliberatelyNotALeak() {
+        // Divergence from the CLI gauntlet's leak list: some families
+        // legitimately emit <think> in content on the fallback path and the
+        // engine owns reasoning-channel routing. If this expectation breaks,
+        // someone re-added <think> — read the leakTokens doc comment first.
+        var detector = StreamTemplateLeakDetector()
+        #expect(detector.observe("<think>reasoning in content</think>") == nil)
+    }
+
+    @Test func cleanTextWithNearMissesIsClean() {
+        var detector = StreamTemplateLeakDetector()
+        // Near-misses: unfinished/lookalike markers must not match, across
+        // many deltas (the bounded carry must not glue false positives —
+        // note adjacent deltas here never concatenate into a real token).
+        for delta in ["<|im_", "middle|>", " tool_call ", "]~! ", "b[ ", "[e~"] {
+            #expect(detector.observe(delta) == nil, "false positive on \(delta)")
+        }
+    }
+
+    @Test func sentinelCharacterIsDetected() {
+        var detector = StreamTemplateLeakDetector()
+        #expect(detector.observe("before\u{FFFE}after") == "\u{FFFE}")
+    }
+}
+
+@Suite("GenerationEventMapper guardrail wiring")
+struct StreamGuardrailsMapperTests {
+
+    private static let allOn = StreamGuardrailSettings(
+        degenerationDetection: true,
+        templateLeakDetection: true
+    )
+
+    private func makeStream(_ events: [Generation]) -> AsyncStream<Generation> {
+        AsyncStream { continuation in
+            for ev in events { continuation.yield(ev) }
+            continuation.finish()
+        }
+    }
+
+    private func collect(
+        events: [Generation],
+        modelName: String = "guardrail-test-model",
+        guardrails: StreamGuardrailSettings = Self.allOn
+    ) async throws -> [ModelRuntimeEvent] {
+        let mapped = GenerationEventMapper.map(
+            events: makeStream(events),
+            modelName: modelName,
+            guardrails: guardrails
+        )
+        var out: [ModelRuntimeEvent] = []
+        for try await ev in mapped { out.append(ev) }
+        return out
+    }
+
+    private func tokenDeltas(_ events: [ModelRuntimeEvent]) -> [String] {
+        events.compactMap { if case .tokens(let s) = $0 { s } else { nil } }
+    }
+
+    private func reasoningDeltas(_ events: [ModelRuntimeEvent]) -> [String] {
+        events.compactMap { if case .reasoning(let s) = $0 { s } else { nil } }
+    }
+
+    // MARK: - Degeneration abort
+
+    @Test func degenerating_chunk_stream_throws_typed_error() async {
+        // 30 "idea " chunks: the 3-gram rule trips at the 24th token; the
+        // mapped stream must finish with the typed guardrail error instead
+        // of streaming the loop forever.
+        let events: [Generation] = Array(repeating: .chunk("idea "), count: 30)
+        do {
+            _ = try await collect(events: events)
+            Issue.record("expected StreamGuardrailError.degeneration to be thrown")
+        } catch let error as StreamGuardrailError {
+            guard case .degeneration(let fragment) = error else {
+                Issue.record("expected .degeneration, got \(error)")
+                return
+            }
+            #expect(fragment.contains("idea idea idea"))
+        } catch {
+            Issue.record("expected StreamGuardrailError, got \(error)")
+        }
+    }
+
+    @Test func degenerating_reasoning_stream_throws_typed_error() async {
+        // Loops routinely start inside the thinking channel; `.reasoning`
+        // deltas must feed the same detector.
+        let events: [Generation] = Array(repeating: .reasoning("loop token here "), count: 10)
+        do {
+            _ = try await collect(events: events)
+            Issue.record("expected StreamGuardrailError.degeneration to be thrown")
+        } catch let error as StreamGuardrailError {
+            guard case .degeneration(let fragment) = error else {
+                Issue.record("expected .degeneration, got \(error)")
+                return
+            }
+            #expect(fragment.contains("loop token here"))
+        } catch {
+            Issue.record("expected StreamGuardrailError, got \(error)")
+        }
+    }
+
+    @Test func character_run_split_across_chunks_throws() async {
+        let events: [Generation] = Array(repeating: .chunk("!!!!!!!"), count: 10)
+        await #expect(throws: StreamGuardrailError.self) {
+            _ = try await collect(events: events)
+        }
+    }
+
+    @Test func clean_stream_is_unaffected_byte_for_byte() async throws {
+        let chunks = ["The sky ", "appears blue ", "because sunlight ", "is scattered."]
+        var events: [Generation] = [.reasoning("thinking "), .reasoning("more thinking ")]
+        events += chunks.map { .chunk($0) }
+        let out = try await collect(events: events)
+        // Every delta must arrive unmodified and unsplit — the guardrails
+        // observe, they never rewrite.
+        #expect(tokenDeltas(out) == chunks)
+        #expect(reasoningDeltas(out) == ["thinking ", "more thinking "])
+    }
+
+    // MARK: - Template leak (log-only)
+
+    @Test func leak_token_split_across_chunks_passes_through_unmodified() async throws {
+        // Detect-and-log ONLY: the leaked marker is template-mismatch data
+        // for the capability ledger, never something to hide by filtering.
+        let chunks = ["answer <|im_", "end|> trailing"]
+        let out = try await collect(events: chunks.map { .chunk($0) })
+        #expect(tokenDeltas(out) == chunks)
+    }
+
+    @Test func leak_token_in_reasoning_passes_through_and_does_not_trip_content_detector() async throws {
+        // The leak detector observes `.tokens` only — reasoning-channel
+        // markers are engine-internal and legitimate there.
+        let events: [Generation] = [
+            .reasoning("<|im_start|>internal"),
+            .chunk("clean answer"),
+        ]
+        let out = try await collect(events: events)
+        #expect(reasoningDeltas(out) == ["<|im_start|>internal"])
+        #expect(tokenDeltas(out) == ["clean answer"])
+    }
+
+    // MARK: - Flags
+
+    @Test func degeneration_flag_off_streams_the_loop_untouched() async throws {
+        let events: [Generation] = Array(repeating: .chunk("idea "), count: 30)
+        let out = try await collect(
+            events: events,
+            guardrails: StreamGuardrailSettings(
+                degenerationDetection: false,
+                templateLeakDetection: true
+            )
+        )
+        #expect(tokenDeltas(out).count == 30)
+    }
+
+    @Test func leak_flag_off_streams_marker_untouched() async throws {
+        let events: [Generation] = [.chunk("<|im_start|>leaked")]
+        let out = try await collect(
+            events: events,
+            guardrails: StreamGuardrailSettings(
+                degenerationDetection: true,
+                templateLeakDetection: false
+            )
+        )
+        #expect(tokenDeltas(out) == ["<|im_start|>leaked"])
+    }
+
+    @Test func settings_resolve_defaults_to_both_on() {
+        // Default-true is the contract: detection+abort beats unbounded
+        // garbage, and leak logging is free. Absent keys must read as ON.
+        let defaults = isolatedDefaults()
+        let settings = StreamGuardrailSettings.resolve(from: defaults)
+        #expect(settings.degenerationDetection)
+        #expect(settings.templateLeakDetection)
+    }
+
+    @Test func settings_resolve_honors_explicit_opt_out() {
+        let defaults = isolatedDefaults()
+        defaults.set(false, forKey: StreamGuardrailSettings.degenerationDetectionKey)
+        defaults.set(false, forKey: StreamGuardrailSettings.templateLeakDetectionKey)
+        let settings = StreamGuardrailSettings.resolve(from: defaults)
+        #expect(!settings.degenerationDetection)
+        #expect(!settings.templateLeakDetection)
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "StreamGuardrailsMapperTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("could not create isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
## Disposition

**Closure recommended. Do not merge this PR in its current form.**

## Reason

This branch retries a degeneration failure with hidden runtime changes: a temperature floor, a repetition penalty, and draft-strategy suppression. Those changes override the active model request and native generation contract in order to make a failed generation appear recoverable. That is no longer an acceptable Osaurus runtime policy.

A degeneration detector may still report a typed failure, but recovery must not silently alter model-native generation settings. Any future recovery design needs explicit user configuration and live model evidence rather than an invisible retry policy.

## State

- Kept as draft for historical reference.
- No remote branch has been deleted.
- Closing the PR requires explicit approval.