### PR TITLE
Repin vmlx-swift: default-on hybrid-SSM prefix cache reuse

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d0d95e05f0fda838ef0903d05d1213b97d561d49"
+        "revision" : "2a5b790d95f05bf1fa294af362bdd0242dee79da"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39"
+        "revision" : "d0d95e05f0fda838ef0903d05d1213b97d561d49"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2a5b790d95f05bf1fa294af362bdd0242dee79da"
+        "revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39"
+        "revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "aa14267b11840f89f1976a273e553a3b7bbedf39"
+            revision: "d0d95e05f0fda838ef0903d05d1213b97d561d49"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d0d95e05f0fda838ef0903d05d1213b97d561d49"
+            revision: "2a5b790d95f05bf1fa294af362bdd0242dee79da"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "2a5b790d95f05bf1fa294af362bdd0242dee79da"
+            revision: "5e071fe20ddfb3a58de664d770d04e7975a336a8"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
-        #expect(packageResolved.contains(#""revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
-        #expect(workspaceResolved.contains(#""revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
-        #expect(appResolved.contains(#""revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39""#))
+        #expect(packageSwift.contains(#"revision: "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
+        #expect(packageResolved.contains(#""revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
+        #expect(workspaceResolved.contains(#""revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
+        #expect(appResolved.contains(#""revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -677,7 +677,15 @@ struct RuntimePolicySourceTests {
         // results a failed MLX op returns inside a withError scope, and
         // non-trapping compiled-closure failure paths — so recorded MLX
         // errors surface instead of dying in Swift bounds checks.
-        let expectedRuntimeHardenedRevision = "aa14267b11840f89f1976a273e553a3b7bbedf39"
+        // Now also carries the default-on hybrid-SSM prefix-cache reuse
+        // (vmlx-swift#125, gen-suffix-stripped store + post-answer SSM
+        // re-derive, proven cache-ON == cache-OFF byte-identical on
+        // qwen3_5_moe GatedDeltaNet MoE + nemotron Mamba-2, inert on dense),
+        // the completed split-subscript crash-guard sweep across every
+        // SSM/hybrid mixer (vmlx-swift#126), and the ZAYA tool-aware template
+        // activation from source_model.architecture (vmlx-swift#127) that
+        // stops JANGTQ ZAYA bundles leaking raw tool-call XML.
+        let expectedRuntimeHardenedRevision = "5e071fe20ddfb3a58de664d770d04e7975a336a8"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d0d95e05f0fda838ef0903d05d1213b97d561d49"
+        "revision" : "2a5b790d95f05bf1fa294af362bdd0242dee79da"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aa14267b11840f89f1976a273e553a3b7bbedf39"
+        "revision" : "d0d95e05f0fda838ef0903d05d1213b97d561d49"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2a5b790d95f05bf1fa294af362bdd0242dee79da"
+        "revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8"
       }
     },
     {


### PR DESCRIPTION
Bumps `vmlx-swift` to `d0d95e05` — **osaurus-ai/vmlx-swift#125**.

## What it fixes

Hybrid-SSM chat models (Qwen3.5/3.6 & Ornith GatedDeltaNet, Nemotron-H Mamba-2, ZAYA CCA, LFM2) **never reused prefill across growing chat turns**. The stored prompt boundary ends in the chat template's generation-prompt suffix (`<|im_start|>assistant\n`, …), which the next turn replaces with the assistant reply + following user message — so the full-prompt cache key never matched as a prefix, and every turn recomputed the entire growing context.

The dependency fix additionally stores the **generation-prompt-stripped** boundary (everything before the final turn-start token), which the next turn contains as an exact prefix. KV is exact-sliceable; SSM/GatedDeltaNet state at that position is re-derived (not sliced, since SSM state is path-dependent). Wired across all three generation paths (solo, MTP, batch).

## Behavior
- **Default ON** for hybrid models; disable with `VMLX_HYBRID_STRIPPED_STORE=0`.
- **Text-only** — skips on media content, so VL image turns are unaffected.
- **No TTFT/token-rate cost** — the re-derive runs after the response is delivered.
- Dense / sliding-window models unchanged (they already reuse via the post-answer boundary).

## Proof (live, dev-built Release, default-on, no env var)

Growing 3-turn chat, disk cache cleared:

| Model | Result |
|---|---|
| `osaurusagent-35b-a3b-mxfp8` (GatedDeltaNet MoE) | **HIT stripped boundary=20/41, ssm=60**, coherent recall |
| `qwen3.6-27b-mxfp8-crack-mtp` (GDN MoE + D3 MTP, auto-MTP load) | **HIT boundary=20/41, ssm=96**, coherent recall |

`ssm=NN` confirms SSM state restored across all slots on the cross-turn HIT. Merge after vmlx-swift#125.