### PR TITLE
Polish release UX details

### DIFF
--- a/App/osaurus/osaurusApp.swift
+++ b/App/osaurus/osaurusApp.swift
@@ -146,13 +146,55 @@ private extension osaurusApp {
             Divider()
 
             Menu {
-                ForEach(themeManager.installedThemes, id: \.metadata.id) { theme in
+                Button {
+                    themeManager.setAppearanceMode(.system, clearActiveTheme: true)
+                } label: {
+                    HStack {
+                        Text(verbatim: L("Follow System Appearance"))
+                        if themeManager.activeCustomTheme == nil && themeManager.appearanceMode == .system {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+
+                Button {
+                    themeManager.setAppearanceMode(.light, clearActiveTheme: true)
+                } label: {
+                    HStack {
+                        Text(verbatim: L("Light"))
+                        if themeManager.activeCustomTheme == nil && themeManager.appearanceMode == .light {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+
+                Button {
+                    themeManager.setAppearanceMode(.dark, clearActiveTheme: true)
+                } label: {
+                    HStack {
+                        Text(verbatim: L("Dark"))
+                        if themeManager.activeCustomTheme == nil && themeManager.appearanceMode == .dark {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+
+                Divider()
+
+                ForEach(themeMenuThemeItems, id: \.metadata.id) { theme in
                     Button {
-                        themeManager.applyCustomTheme(theme)
+                        if let mode = ThemeManager.appearanceMode(forBuiltInTheme: theme) {
+                            themeManager.setAppearanceMode(mode, clearActiveTheme: true)
+                        } else {
+                            themeManager.applyCustomTheme(theme)
+                        }
                     } label: {
                         HStack {
                             Text(theme.metadata.name)
-                            if themeManager.activeCustomTheme?.metadata.id == theme.metadata.id {
+                            if isThemeMenuItemActive(theme) {
                                 Spacer()
                                 Image(systemName: "checkmark")
                             }
@@ -171,6 +213,17 @@ private extension osaurusApp {
                 Text(verbatim: L("Theme"))
             }
         }
+    }
+
+    private func isThemeMenuItemActive(_ theme: CustomTheme) -> Bool {
+        if let mode = ThemeManager.appearanceMode(forBuiltInTheme: theme) {
+            return themeManager.activeCustomTheme == nil && themeManager.appearanceMode == mode
+        }
+        return themeManager.activeCustomTheme?.metadata.id == theme.metadata.id
+    }
+
+    private var themeMenuThemeItems: [CustomTheme] {
+        themeManager.installedThemes.filter { ThemeManager.appearanceMode(forBuiltInTheme: $0) == nil }
     }
 
     // MARK: Window Menu

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift
@@ -47,6 +47,12 @@ enum ServerConfigurationStore {
         }
     }
 
+    static func updateAppearanceMode(_ mode: AppearanceMode) {
+        var configuration = load() ?? ServerConfiguration.default
+        configuration.appearanceMode = mode
+        save(configuration)
+    }
+
     private static func configurationFileURL() -> URL {
         if let dir = overrideDirectory {
             return dir.appendingPathComponent("server.json")

--- a/Packages/OsaurusCore/Models/Theme/Theme.swift
+++ b/Packages/OsaurusCore/Models/Theme/Theme.swift
@@ -549,6 +549,14 @@ extension Notification.Name {
 @MainActor
 public class ThemeManager: ObservableObject {
     public static let shared = ThemeManager()
+    private static let builtInDarkThemeID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1))
+    private static let builtInLightThemeID = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2))
+
+    struct StartupThemeSelection {
+        var appearanceMode: AppearanceMode
+        var activeTheme: CustomTheme?
+        var shouldClearActiveTheme: Bool
+    }
 
     @Published var currentTheme: ThemeProtocol
     @Published var chatTheme: ThemeProtocol
@@ -564,6 +572,16 @@ public class ThemeManager: ObservableObject {
 
         // Load saved appearance mode (cheap config read).
         let config = ServerConfigurationStore.load() ?? ServerConfiguration.default
+        let savedActiveTheme = ThemeConfigurationStore.loadActiveTheme()
+        let startupSelection = Self.startupSelection(
+            savedActiveTheme: savedActiveTheme,
+            configuredAppearanceMode: config.appearanceMode
+        )
+
+        if startupSelection.shouldClearActiveTheme {
+            ThemeConfigurationStore.saveActiveThemeId(nil)
+            ServerConfigurationStore.updateAppearanceMode(startupSelection.appearanceMode)
+        }
 
         // Resolve the *initial* theme synchronously with as little disk work
         // as possible. `.shared` is constructed during `osaurusApp` struct
@@ -576,7 +594,7 @@ public class ThemeManager: ObservableObject {
         //  • Otherwise: seed the compiled-in Dark/Light default. The
         //    disk-installed built-in (identical palette) is swapped in by the
         //    deferred load below once it finishes — invisible to the user.
-        if let customTheme = ThemeConfigurationStore.loadActiveTheme() {
+        if let customTheme = startupSelection.activeTheme {
             print("[Osaurus] ThemeManager: Restoring active theme '\(customTheme.metadata.name)'")
             self.activeCustomTheme = customTheme
             let themeInstance = CustomizableTheme(config: customTheme)
@@ -584,7 +602,7 @@ public class ThemeManager: ObservableObject {
             self.chatTheme = themeInstance
         } else {
             let fallbackTheme =
-                Self.isDarkMode(for: config.appearanceMode) ? CustomTheme.darkDefault : CustomTheme.lightDefault
+                Self.isDarkMode(for: startupSelection.appearanceMode) ? CustomTheme.darkDefault : CustomTheme.lightDefault
             let themeInstance = CustomizableTheme(config: fallbackTheme)
             self.currentTheme = themeInstance
             self.chatTheme = themeInstance
@@ -592,7 +610,7 @@ public class ThemeManager: ObservableObject {
 
         // Now we can assign to self properties. `installedThemes` is published
         // empty and filled in by the deferred load.
-        self.appearanceMode = config.appearanceMode
+        self.appearanceMode = startupSelection.appearanceMode
         self.installedThemes = []
 
         // Observe system appearance changes (Distributed Notification)
@@ -610,7 +628,7 @@ public class ThemeManager: ObservableObject {
         // no longer blocks `osaurusApp` struct construction. It then publishes
         // `installedThemes` and upgrades the initial fallback to the disk
         // built-in when ready.
-        let appearanceMode = config.appearanceMode
+        let appearanceMode = startupSelection.appearanceMode
         Task { @MainActor [weak self] in
             ThemeConfigurationStore.installBuiltInThemesIfNeeded()
             // Decoding every installed theme's JSON synchronously on the main
@@ -629,8 +647,7 @@ public class ThemeManager: ObservableObject {
             // Only swap the live theme if the user hasn't picked a custom one;
             // matching the original synchronous built-in resolution.
             if self.activeCustomTheme == nil,
-                let builtIn = Self.resolveBuiltInTheme(for: appearanceMode, from: loaded)
-            {
+                let builtIn = Self.resolveBuiltInTheme(for: appearanceMode, from: loaded) {
                 let themeInstance = CustomizableTheme(config: builtIn)
                 self.currentTheme = themeInstance
                 self.chatTheme = themeInstance
@@ -640,40 +657,71 @@ public class ThemeManager: ObservableObject {
         print("[Osaurus] ThemeManager: Initialization complete")
     }
 
+    static func startupSelection(
+        savedActiveTheme: CustomTheme?,
+        configuredAppearanceMode: AppearanceMode
+    ) -> StartupThemeSelection {
+        guard let savedActiveTheme else {
+            return StartupThemeSelection(
+                appearanceMode: configuredAppearanceMode,
+                activeTheme: nil,
+                shouldClearActiveTheme: false
+            )
+        }
+        guard let builtInMode = appearanceMode(forBuiltInTheme: savedActiveTheme) else {
+            return StartupThemeSelection(
+                appearanceMode: configuredAppearanceMode,
+                activeTheme: savedActiveTheme,
+                shouldClearActiveTheme: false
+            )
+        }
+        return StartupThemeSelection(
+            appearanceMode: builtInMode,
+            activeTheme: nil,
+            shouldClearActiveTheme: true
+        )
+    }
+
     /// Find the appropriate built-in theme based on appearance mode
     private static func resolveBuiltInTheme(for mode: AppearanceMode, from themes: [CustomTheme]) -> CustomTheme? {
         // Find the built-in Dark or Light theme based on appearance
-        let targetId =
-            isDarkMode(for: mode)
-            ? UUID(uuidString: "00000000-0000-0000-0000-000000000001")  // Dark theme ID
-            : UUID(uuidString: "00000000-0000-0000-0000-000000000002")  // Light theme ID
+        let targetId = isDarkMode(for: mode) ? builtInDarkThemeID : builtInLightThemeID
 
         return themes.first { $0.metadata.id == targetId }
     }
 
+    public static func appearanceMode(forBuiltInTheme theme: CustomTheme) -> AppearanceMode? {
+        guard theme.isBuiltIn else { return nil }
+        switch theme.metadata.id {
+        case builtInDarkThemeID:
+            return .dark
+        case builtInLightThemeID:
+            return .light
+        default:
+            return nil
+        }
+    }
+
     /// Update the appearance mode and apply the theme
-    func setAppearanceMode(_ mode: AppearanceMode) {
+    public func setAppearanceMode(
+        _ mode: AppearanceMode,
+        clearActiveTheme: Bool = false,
+        persist: Bool = true
+    ) {
         appearanceMode = mode
+
+        if persist {
+            ServerConfigurationStore.updateAppearanceMode(mode)
+        }
+        if clearActiveTheme {
+            activeCustomTheme = nil
+            ThemeConfigurationStore.saveActiveThemeId(nil)
+        }
 
         // If a user-selected custom theme is active, don't change it based on appearance mode
         guard activeCustomTheme == nil else { return }
 
-        // Apply the appropriate built-in theme
-        if let builtInTheme = Self.resolveBuiltInTheme(for: mode, from: installedThemes) {
-            let themeInstance = CustomizableTheme(config: builtInTheme)
-            withAnimation(.easeInOut(duration: 0.3)) {
-                currentTheme = themeInstance
-                chatTheme = themeInstance
-            }
-        } else {
-            // Fallback to default CustomTheme
-            let fallbackTheme = Self.isDarkMode(for: mode) ? CustomTheme.darkDefault : CustomTheme.lightDefault
-            let themeInstance = CustomizableTheme(config: fallbackTheme)
-            withAnimation(.easeInOut(duration: 0.3)) {
-                currentTheme = themeInstance
-                chatTheme = themeInstance
-            }
-        }
+        applyResolvedTheme(for: mode, animated: true)
         NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
     }
 
@@ -711,33 +759,7 @@ public class ThemeManager: ObservableObject {
             ThemeConfigurationStore.saveActiveThemeId(nil)
         }
 
-        // Apply the appropriate built-in theme based on current appearance mode
-        if let builtInTheme = Self.resolveBuiltInTheme(for: appearanceMode, from: installedThemes) {
-            let themeInstance = CustomizableTheme(config: builtInTheme)
-            if animated {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    currentTheme = themeInstance
-                    chatTheme = themeInstance
-                }
-            } else {
-                currentTheme = themeInstance
-                chatTheme = themeInstance
-            }
-        } else {
-            // Fallback to default CustomTheme
-            let fallbackTheme =
-                Self.isDarkMode(for: appearanceMode) ? CustomTheme.darkDefault : CustomTheme.lightDefault
-            let themeInstance = CustomizableTheme(config: fallbackTheme)
-            if animated {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    currentTheme = themeInstance
-                    chatTheme = themeInstance
-                }
-            } else {
-                currentTheme = themeInstance
-                chatTheme = themeInstance
-            }
-        }
+        applyResolvedTheme(for: appearanceMode, animated: animated)
         NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
     }
 
@@ -827,23 +849,25 @@ public class ThemeManager: ObservableObject {
         // Only update if we're following system appearance and no user-selected theme is active
         guard appearanceMode == .system, activeCustomTheme == nil else { return }
 
-        // Apply the appropriate built-in theme
-        if let builtInTheme = Self.resolveBuiltInTheme(for: .system, from: installedThemes) {
-            let themeInstance = CustomizableTheme(config: builtInTheme)
+        applyResolvedTheme(for: .system, animated: true)
+        NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
+    }
+
+    private func applyResolvedTheme(for mode: AppearanceMode, animated: Bool) {
+        let resolvedTheme =
+            Self.resolveBuiltInTheme(for: mode, from: installedThemes)
+            ?? (Self.isDarkMode(for: mode) ? CustomTheme.darkDefault : CustomTheme.lightDefault)
+        let themeInstance = CustomizableTheme(config: resolvedTheme)
+
+        if animated {
             withAnimation(.easeInOut(duration: 0.3)) {
                 currentTheme = themeInstance
                 chatTheme = themeInstance
             }
         } else {
-            // Fallback to default CustomTheme
-            let fallbackTheme = Self.isDarkMode(for: .system) ? CustomTheme.darkDefault : CustomTheme.lightDefault
-            let themeInstance = CustomizableTheme(config: fallbackTheme)
-            withAnimation(.easeInOut(duration: 0.3)) {
-                currentTheme = themeInstance
-                chatTheme = themeInstance
-            }
+            currentTheme = themeInstance
+            chatTheme = themeInstance
         }
-        NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
     }
 
     // MARK: - Chat Theme (Agent-specific)

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -58896,6 +58896,40 @@
         }
       }
     },
+    "Follow System Appearance" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Systemdarstellung verwenden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 모양 따르기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следовать системному оформлению"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟随系统外观"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟隨系統外觀"
+          }
+        }
+      }
+    },
     "Folder" : {
       "localizations" : {
         "de" : {
@@ -62416,7 +62450,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "早上好"
+            "value" : "早安"
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Chat/PromptQueueTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptQueueTests.swift
@@ -183,4 +183,13 @@ struct PromptQueueTests {
             Issue.record("expected clarify to be current after advance")
         }
     }
+
+    @Test
+    func promptItemsOnlyObscureConversationForSecrets() {
+        let secret = makeSecret("API_KEY")
+        let clarify = makeClarify("Use Postgres or SQLite?")
+
+        #expect(PromptItem.secret(secret).obscuresConversation == true)
+        #expect(PromptItem.clarify(clarify).obscuresConversation == false)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
@@ -59,6 +59,33 @@ struct ServerConfigurationStoreTests {
         #expect(loaded == config)
     }
 
+    @Test @MainActor func updateAppearanceMode_preservesOtherServerSettings() async throws {
+        let base = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let dir = base.appendingPathComponent(
+            "osaurus-config-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        ServerConfigurationStore.overrideDirectory = dir
+        defer {
+            ServerConfigurationStore.overrideDirectory = nil
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        var config = ServerConfiguration.default
+        config.port = 5555
+        config.exposeToNetwork = true
+        config.appearanceMode = .dark
+        ServerConfigurationStore.save(config)
+
+        ServerConfigurationStore.updateAppearanceMode(.system)
+        let loaded = try #require(ServerConfigurationStore.load())
+
+        #expect(loaded.appearanceMode == .system)
+        #expect(loaded.port == 5555)
+        #expect(loaded.exposeToNetwork == true)
+    }
+
     /// Decoding pre-migration JSON files that contained now-removed cache*
     /// and gen* fields should succeed silently — unknown keys are ignored
     /// by the decoder. This test simulates that migration by feeding JSON

--- a/Packages/OsaurusCore/Tests/Theme/ThemeAppearanceModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeAppearanceModeTests.swift
@@ -1,0 +1,59 @@
+//
+//  ThemeAppearanceModeTests.swift
+//  osaurusTests
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ThemeAppearanceModeTests {
+    @Test
+    func appearanceModeOnlyMapsCanonicalLightAndDarkBuiltIns() {
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.darkDefault) == .dark)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.lightDefault) == .light)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.neonPreset) == nil)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.nordPreset) == nil)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.paperPreset) == nil)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.terminalPreset) == nil)
+    }
+
+    @Test
+    func startupSelectionNormalizesCanonicalBuiltInActiveThemes() {
+        let lightSelection = ThemeManager.startupSelection(
+            savedActiveTheme: CustomTheme.lightDefault,
+            configuredAppearanceMode: .system
+        )
+        #expect(lightSelection.appearanceMode == .light)
+        #expect(lightSelection.activeTheme == nil)
+        #expect(lightSelection.shouldClearActiveTheme)
+
+        let darkSelection = ThemeManager.startupSelection(
+            savedActiveTheme: CustomTheme.darkDefault,
+            configuredAppearanceMode: .light
+        )
+        #expect(darkSelection.appearanceMode == .dark)
+        #expect(darkSelection.activeTheme == nil)
+        #expect(darkSelection.shouldClearActiveTheme)
+    }
+
+    @Test
+    func startupSelectionPreservesCustomAndNonCanonicalBuiltIns() {
+        let neonSelection = ThemeManager.startupSelection(
+            savedActiveTheme: CustomTheme.neonPreset,
+            configuredAppearanceMode: .system
+        )
+        #expect(neonSelection.appearanceMode == .system)
+        #expect(neonSelection.activeTheme?.metadata.id == CustomTheme.neonPreset.metadata.id)
+        #expect(!neonSelection.shouldClearActiveTheme)
+
+        let emptySelection = ThemeManager.startupSelection(
+            savedActiveTheme: nil,
+            configuredAppearanceMode: .dark
+        )
+        #expect(emptySelection.appearanceMode == .dark)
+        #expect(emptySelection.activeTheme == nil)
+        #expect(!emptySelection.shouldClearActiveTheme)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5212,11 +5212,18 @@ struct ChatView: View {
     private var windowId: UUID { windowState.windowId }
 
     /// True while any prompt overlay (secret, clarify) is mounted.
-    /// Drives the dim/blur on the message thread + main input bar so
-    /// the prompt visibly takes the foreground. Single source of truth
-    /// is `session.promptQueue.current`.
+    /// Drives hit-testing on the message thread + main input bar so the
+    /// active card owns the interaction. Single source of truth is
+    /// `session.promptQueue.current`.
     private var isPromptOverlayActive: Bool {
         session.promptQueue.current != nil
+    }
+
+    /// Secret prompts intentionally obscure the thread; clarify prompts
+    /// do not, because the user often needs the previous assistant text
+    /// to understand why they are being asked to choose an option.
+    private var promptOverlayObscuresConversation: Bool {
+        session.promptQueue.current?.obscuresConversation == true
     }
 
     /// Picker items filtered to the active Bonjour provider's models when a
@@ -5509,7 +5516,11 @@ struct ChatView: View {
         ZStack {
             if current != nil {
                 Color.black
-                    .opacity(theme.isDark ? 0.28 : 0.18)
+                    .opacity(
+                        current?.obscuresConversation == true
+                            ? (theme.isDark ? 0.28 : 0.18)
+                            : (theme.isDark ? 0.10 : 0.06)
+                    )
                     .ignoresSafeArea()
                     .transition(.opacity)
                     .allowsHitTesting(true)
@@ -5626,10 +5637,10 @@ struct ChatView: View {
                                 // visibly takes the foreground without
                                 // letting taps leak through.
                                 messageThread(effectiveContentWidth)
-                                    .blur(radius: isPromptOverlayActive ? 1.5 : 0)
+                                    .blur(radius: promptOverlayObscuresConversation ? 1.5 : 0)
                                     .allowsHitTesting(!isPromptOverlayActive)
                                     .transition(.opacity.combined(with: .move(edge: .bottom)))
-                                    .animation(theme.springAnimation(), value: isPromptOverlayActive)
+                                    .animation(theme.springAnimation(), value: promptOverlayObscuresConversation)
                             }
 
                             // Mode 2 connection status (connecting / error +

--- a/Packages/OsaurusCore/Views/Chat/PromptQueue.swift
+++ b/Packages/OsaurusCore/Views/Chat/PromptQueue.swift
@@ -35,10 +35,23 @@ public enum PromptItem: Identifiable {
     case secret(SecretPromptState)
     case clarify(ClarifyPromptState)
 
-    public nonisolated var id: ObjectIdentifier {
+    nonisolated public var id: ObjectIdentifier {
         switch self {
         case .secret(let s): return ObjectIdentifier(s)
         case .clarify(let c): return ObjectIdentifier(c)
+        }
+    }
+
+    /// Whether the prompt contains sensitive input that should visually
+    /// obscure the conversation behind it. Clarify prompts need the prior
+    /// assistant reasoning readable while the user picks an option; secret
+    /// prompts still get the stronger privacy treatment.
+    nonisolated public var obscuresConversation: Bool {
+        switch self {
+        case .secret:
+            return true
+        case .clarify:
+            return false
         }
     }
 

--- a/Packages/OsaurusCore/Views/Theme/ThemesView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemesView.swift
@@ -914,7 +914,7 @@ struct ThemesView: View {
     }
 
     private func card(for themeItem: CustomTheme) -> some View {
-        let isActive = themeManager.activeCustomTheme?.metadata.id == themeItem.metadata.id
+        let isActive = isThemeActive(themeItem)
         return ThemePreviewCard(
             theme: themeItem,
             isActive: isActive,
@@ -922,7 +922,11 @@ struct ThemesView: View {
             validationReport: validationByID[themeItem.metadata.id],
             isDuplicate: duplicateIDs.contains(themeItem.metadata.id),
             onApply: {
-                themeManager.applyCustomTheme(themeItem)
+                if let mode = ThemeManager.appearanceMode(forBuiltInTheme: themeItem) {
+                    themeManager.setAppearanceMode(mode, clearActiveTheme: true)
+                } else {
+                    themeManager.applyCustomTheme(themeItem)
+                }
                 showToast(L("Applied \"\(themeItem.metadata.name)\""))
             },
             onEdit: { openEditor(for: themeItem) },
@@ -931,6 +935,13 @@ struct ThemesView: View {
             onDuplicate: { duplicateTheme(themeItem) },
             onDelete: themeItem.isBuiltIn ? nil : { confirmDelete(themeItem) }
         )
+    }
+
+    private func isThemeActive(_ themeItem: CustomTheme) -> Bool {
+        if let mode = ThemeManager.appearanceMode(forBuiltInTheme: themeItem) {
+            return themeManager.activeCustomTheme == nil && themeManager.appearanceMode == mode
+        }
+        return themeManager.activeCustomTheme?.metadata.id == themeItem.metadata.id
     }
 
     // MARK: - Empty / No-result States


### PR DESCRIPTION
## Summary
- Fixes #1888 by keeping clarify prompts readable while preserving secret prompt blur.
- Fixes #1846 by adding persisted system/light/dark appearance controls in the app theme menu and theme library.
- Fixes #1857 by using the more natural zh-Hant greeting for “Good morning”.
- Normalizes older saved canonical Light/Dark theme selections into appearance mode so upgrade users get correct checkmarks without reselecting a theme.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swiftlint lint App/osaurus/osaurusApp.swift Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift Packages/OsaurusCore/Models/Theme/Theme.swift Packages/OsaurusCore/Views/Theme/ThemesView.swift Packages/OsaurusCore/Views/Chat/ChatView.swift Packages/OsaurusCore/Views/Chat/PromptQueue.swift Packages/OsaurusCore/Tests/Chat/PromptQueueTests.swift Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift Packages/OsaurusCore/Tests/Theme/ThemeAppearanceModeTests.swift --quiet` (existing warnings remain in large touched files)
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-release-ux-polish-test4 swift test --package-path Packages/OsaurusCore --filter 'PromptQueueTests|ServerConfigurationStoreTests|ThemeAppearanceModeTests'`\n- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"` (existing project warnings and local CoreSimulator warning only)