### PR TITLE
Onboarding: demote LFM2.5-8B-A1B-MXFP8 (official bundle fails tool-calling) + Gemma spine verified

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -678,11 +678,21 @@ extension ModelManager {
     nonisolated fileprivate static let curatedSuggestedModels: [MLXModel] = [
         // MARK: Top Picks
 
+        // LFM2.5-8B-A1B demoted from Top Pick (2026-07-08): live-tested the
+        // OFFICIAL OsaurusAI/LFM2.5-8B-A1B-MXFP8 bundle in osaurus and it does
+        // NOT call tools — on a weather/multiply agent loop it refuses every
+        // turn ("I don't have access to real-time weather data or a function to
+        // check current temperature") instead of emitting a tool call, and it
+        // over-reasons + slips multi-turn recall. Onboarding only surfaces Top
+        // Picks, and osaurus is tool-first, so it stays in the catalog for
+        // plain chat but is no longer a recommended onboarding pick. (Matches
+        // the local-CRACK 3/7 no-tool-call finding — confirmed not a CRACK
+        // artifact.) Re-promote only after a bundle that passes the AgentLoop
+        // tool-use proof.
         curated(
             id: "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
             description:
-                "Liquid AI LFM2.5 8B hybrid MoE (~1B active), MXFP8 — high-precision, fast Apple Silicon chat. 128K context.",
-            isTopSuggestion: true,
+                "Liquid AI LFM2.5 8B hybrid MoE (~1B active), MXFP8 — fast Apple Silicon chat. Chat-only: does not reliably call tools. 128K context.",
             modelType: "lfm2_moe",
             releasedAt: date("2026-05-29"),
             useCase: .general

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -135,7 +135,11 @@ struct ModelManagerSuggestedTests {
 
             #expect(mxfp8 != nil)
             #expect(mxfp8?.modelType == "lfm2_moe")
-            #expect(mxfp8?.isTopSuggestion == true)
+            // Demoted from Top Pick 2026-07-08: the official OsaurusAI
+            // LFM2.5-8B-A1B-MXFP8 bundle does not reliably call tools when
+            // live-tested in osaurus (refuses the tool loop). It stays a
+            // catalog chat model but is no longer a recommended onboarding pick.
+            #expect(mxfp8?.isTopSuggestion == false)
             // Sizes now come from `ModelSizeCache` (empty here), not literals.
             #expect(mxfp8?.downloadSizeBytes == nil)
             #expect(mxfp8?.releasedAt != nil)


### PR DESCRIPTION
## Onboarding model curation — round 1: demote LFM2.5-8B-A1B-MXFP8

Per the Slack thread ("update onboarding suggestions… remove the ones that are known bads from the recommended picks… test each model with osaurus and make sure it's coherent and calls tools"). Onboarding only surfaces **Top Picks** (`isTopSuggestion`), so curation = the Top-Pick set.

### Change in this PR (official-bundle tested)
- **Demote `OsaurusAI/LFM2.5-8B-A1B-MXFP8` from Top Pick → catalog chat-only.**
  Live-tested the **official** bundle in osaurus on a weather→multiply agent loop: it **refuses to call the provided tools on every turn** ("I don't have access to real-time weather data or a function to check current temperature"), and slips multi-turn recall. It fails the "coherent **and calls tools**" bar. Confirms the local-CRACK 3/7 no-tool-call finding is **not** a CRACK artifact. Test updated to match.
- **Gemma-4 QAT auto-default spine re-verified & kept:** official `gemma-4-E2B/12B/31B-it-qat-MXFP4` all chained tools cleanly (weather→×3→recall), no tag leaks — the onboarding auto-default (`recommendedLocalPick`, largest dense Gemma QAT that fits) is solid.

### Top-Picks evidence matrix (basis for round 2)
Legend: ✅ official-tested good · ❌ official-tested bad · 🟢 local-equivalent good · 🟡 local-equivalent weak · ⬜ untested

| Top Pick | Evidence | Proposed |
|---|---|---|
| gemma-4-E2B / 12B / 31B qat-MXFP4 | ✅ official: tools clean, coherent | **keep** |
| gemma-4-E4B qat-MXFP4, 12B-MXFP8, 26B-A4B qat | 🟢 gemma family reliable (local) | keep (verify) |
| LFM2.5-8B-A1B-MXFP8 | ❌ official: no tool calls | **demoted (this PR)** |
| Qwen3.6-27B-MXFP4 | 🟡 local 5/7 dense mxfp4 (weaker than MXFP8-MTP sibling) | round-2 demote candidate |
| Qwen3.6-27B-MXFP8-MTP | 🟢 local 6/7 | keep |
| Qwen3.6-35B-A3B-MXFP8-MTP | 🟢 local 7/7, cache byte-proven | keep |
| Ornith-1.0-35B-MXFP8 | 🟢 9B 7/7; ⬜ 35B official | keep (verify) |
| Nemotron-3-Nano-Omni-30B-MXFP4 | 🟢 local 7/7 (Mamba-2) | keep |
| MiniMax-M2.7-JANGTQ4 | 🟢 Small 7/7; ⬜ JANGTQ4 official | keep (verify) |

### Co-test checklist (round 2 — "we can test it")
Download + live-test each **official** Top Pick for coherence + tool-calling before further demotions:
- [ ] Qwen3.6-27B-MXFP4 (round-2 demote candidate) · Qwen3.6-27B-MXFP8-MTP · Qwen3.6-35B-A3B-MXFP8-MTP
- [ ] Ornith-1.0-35B-MXFP8 · Nemotron-3-Nano-Omni-30B-MXFP4 · MiniMax-M2.7-JANGTQ4
- [ ] remaining gemma Top Picks (E4B qat, 12B-MXFP8, 26B-A4B qat)

Full test harnesses + the exhaustive local matrix: `~/cc/model-eval-suite/tool_cache_probe.py`, `HYBRID_SSM_VALIDATION.md`, `TOOLCALL_MATRIX_FINDINGS.md`, `MODEL_COVERAGE_STATUS.md`. Base is on merged vmlx `5e071fe2` (hybrid-SSM prefix cache + crash-guards + ZAYA, all validated 0 cache-induced issues).
