### PR TITLE
Onboarding: recommend Ornith MXFP8 + official OsaurusAI Gemma; drop Gemma QAT/MXFP4

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -682,7 +682,6 @@ extension ModelManager {
             id: "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
             description:
                 "Liquid AI LFM2.5 8B hybrid MoE (~1B active), MXFP8 — high-precision, fast Apple Silicon chat. 128K context.",
-            isTopSuggestion: true,
             modelType: "lfm2_moe",
             releasedAt: date("2026-05-29"),
             useCase: .general
@@ -690,15 +689,20 @@ extension ModelManager {
 
         // MARK: Gemma 4 — multimodal
         //
-        // The Gemma 4 `qat-MXFP4` builds (E2B/E4B/12B/31B/26B-A4B) are
-        // demoted from Top Pick (2026-07-08): onboarding recommendations were
-        // moved off the Gemma-QAT spine onto the GUI-verified non-Gemma
-        // families (Ornith / Qwen 3.6 / Qwen AgentWorld / Nemotron), which
-        // cover every RAM tier. Per the curation rule, a *recommended* Gemma
-        // build must not be `qat` or plain `MXFP4` — only the higher-precision
-        // `12B-it-MXFP8` (below) and the `E4B-it-8bit` retention build stay
-        // Top Picks. The QAT builds remain in the catalog (still installable /
-        // selectable), just not surfaced or auto-selected in onboarding.
+        // Onboarding recommendation spine (2026-07-08, GUI-verified in the
+        // dev-built app — every model below loads, calls tools, reasons with
+        // thinking on, and leaks no markup into visible content):
+        //   • Larger RAM  → Ornith 1.0 MXFP8 (9B / 35B, below).
+        //   • Smaller RAM → official OsaurusAI Gemma 4 at the highest non-QAT,
+        //                    non-MXFP4 precision that exists: `12B-it-MXFP8`
+        //                    (the only MXFP8 Gemma the org ships) and the
+        //                    `E4B/E2B-it-8bit` retention builds (no E-series
+        //                    MXFP8 exists on the HF org).
+        // A *recommended* Gemma build must never be `qat` or plain `MXFP4`, so
+        // the 5 Gemma `qat-MXFP4` builds (E2B/E4B/12B/31B/26B-A4B) stay in the
+        // catalog but are not Top Picks. Qwen 3.6 (incl. MXFP8-MTP), Nemotron-3
+        // and LFM2.5 also remain catalog-only for now: they are installable and
+        // selectable, just not part of the auto-default recommendation spine.
 
         curated(
             id: "OsaurusAI/gemma-4-12B-it-MXFP8",
@@ -790,7 +794,6 @@ extension ModelManager {
             id: "OsaurusAI/Qwen3.6-27B-MXFP4",
             description:
                 "Qwen 3.6 27B dense vision model. MXFP4 — best quality per byte. The org's most-downloaded model. 256K context.",
-            isTopSuggestion: true,
             modelType: "qwen3_5",
             releasedAt: date("2026-05-20"),
             useCase: .vision
@@ -800,7 +803,6 @@ extension ModelManager {
             id: "OsaurusAI/Qwen3.6-27B-MXFP8-MTP",
             description:
                 "Qwen 3.6 27B dense vision model. MXFP8 + multi-token-prediction speculative decode — high precision, fast. 256K context.",
-            isTopSuggestion: true,
             modelType: "qwen3_5",
             releasedAt: date("2026-05-20"),
             useCase: .vision
@@ -810,7 +812,6 @@ extension ModelManager {
             id: "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
             description:
                 "Qwen 3.6 35B MoE (~3B active) vision model. MXFP8 + multi-token-prediction speculative decode — the precision-first sibling of the MXFP4 build. 256K context.",
-            isTopSuggestion: true,
             modelType: "qwen3_5_moe",
             releasedAt: date("2026-05-20"),
             useCase: .vision
@@ -927,7 +928,6 @@ extension ModelManager {
             id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
             description:
                 "NVIDIA Nemotron-3 30B Reasoning hybrid (Mamba-2 + MoE). MXFP4 quantization — fastest decode path. 262K context.",
-            isTopSuggestion: true,
             modelType: "nemotron_h",
             releasedAt: date("2026-04-28"),
             useCase: .reasoning

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -688,21 +688,17 @@ extension ModelManager {
             useCase: .general
         ),
 
-        // MARK: Gemma 4 — multimodal (onboarding default spine)
+        // MARK: Gemma 4 — multimodal
         //
-        // The dense Gemma 4 QAT line (E2B/E4B/12B/31B, `qat-MXFP4`) is the
-        // onboarding auto-default spine: quantization-aware training beats
-        // post-training quant at equal bit-width, and these are the newest
-        // Gemma builds. `ConfigureAIState.recommendedLocalPick` auto-selects
-        // the largest *dense* QAT model that comfortably fits. The 26B-A4B
-        // QAT MoE below stays a Top Pick but is intentionally excluded from
-        // the auto-default (its footprint is the 36%-bounce risk), and the
-        // E-series QAT entries are excluded from the auto-default until the
-        // 8-bit-vs-QAT-4bit retention A/B clears (small tiers stay on the
-        // 8-bit builds). Top-Pick promotion of the QAT line is gated on the
-        // required AgentLoop tool-use proof for the active Gemma 4 QAT
-        // checkpoint (load, executed tool, tool-result continuation, clean
-        // visible text, no marker leakage, cache telemetry).
+        // The Gemma 4 `qat-MXFP4` builds (E2B/E4B/12B/31B/26B-A4B) are
+        // demoted from Top Pick (2026-07-08): onboarding recommendations were
+        // moved off the Gemma-QAT spine onto the GUI-verified non-Gemma
+        // families (Ornith / Qwen 3.6 / Qwen AgentWorld / Nemotron), which
+        // cover every RAM tier. Per the curation rule, a *recommended* Gemma
+        // build must not be `qat` or plain `MXFP4` — only the higher-precision
+        // `12B-it-MXFP8` (below) and the `E4B-it-8bit` retention build stay
+        // Top Picks. The QAT builds remain in the catalog (still installable /
+        // selectable), just not surfaced or auto-selected in onboarding.
 
         curated(
             id: "OsaurusAI/gemma-4-12B-it-MXFP8",
@@ -717,8 +713,7 @@ extension ModelManager {
         curated(
             id: "OsaurusAI/gemma-4-E2B-it-qat-MXFP4",
             description:
-                "Gemma 4 E2B QAT — quantization-aware 4-bit. Smallest multimodal floor; better quality-per-byte than post-training 4-bit. Runs on any Mac. 128K context.",
-            isTopSuggestion: true,
+                "Gemma 4 E2B QAT — quantization-aware 4-bit. Smallest multimodal floor. Catalog build; not an onboarding recommendation (QAT/MXFP4 excluded). 128K context.",
             modelType: "gemma4",
             releasedAt: date("2026-06-09"),
             useCase: .smallest
@@ -727,8 +722,7 @@ extension ModelManager {
         curated(
             id: "OsaurusAI/gemma-4-E4B-it-qat-MXFP4",
             description:
-                "Gemma 4 E4B QAT — quantization-aware 4-bit multimodal edge model. Images, video, and audio. 128K context.",
-            isTopSuggestion: true,
+                "Gemma 4 E4B QAT — quantization-aware 4-bit multimodal edge model. Catalog build; not an onboarding recommendation (QAT/MXFP4 excluded). 128K context.",
             modelType: "gemma4",
             releasedAt: date("2026-06-09"),
             useCase: .vision
@@ -737,8 +731,7 @@ extension ModelManager {
         curated(
             id: "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
             description:
-                "Gemma 4 12B dense QAT — quantization-aware 4-bit. The mainstream multimodal default for 16–24 GB Macs. 128K context.",
-            isTopSuggestion: true,
+                "Gemma 4 12B dense QAT — quantization-aware 4-bit. Catalog build; not an onboarding recommendation (QAT/MXFP4 excluded — prefer the 12B-it-MXFP8 build). 128K context.",
             modelType: "gemma4",
             releasedAt: date("2026-06-09"),
             useCase: .vision
@@ -747,8 +740,7 @@ extension ModelManager {
         curated(
             id: "OsaurusAI/gemma-4-31B-it-qat-MXFP4",
             description:
-                "Gemma 4 31B dense QAT — quantization-aware 4-bit. Top-tier multimodal quality for 32 GB+ Macs. 128K context.",
-            isTopSuggestion: true,
+                "Gemma 4 31B dense QAT — quantization-aware 4-bit. Catalog build; not an onboarding recommendation (QAT/MXFP4 excluded). 128K context.",
             modelType: "gemma4",
             releasedAt: date("2026-06-09"),
             useCase: .vision
@@ -757,8 +749,7 @@ extension ModelManager {
         curated(
             id: "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
             description:
-                "Gemma 4 26B-A4B QAT — quantization-aware 4-bit MoE (~4B active) vision model. Selectable Top Pick; excluded from the low-RAM auto-default. 128K context.",
-            isTopSuggestion: true,
+                "Gemma 4 26B-A4B QAT — quantization-aware 4-bit MoE (~4B active) vision model. Catalog build; not an onboarding recommendation (QAT/MXFP4 excluded). 128K context.",
             modelType: "gemma4",
             releasedAt: date("2026-06-09"),
             useCase: .vision

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -557,46 +557,6 @@ struct MLXModel: Identifiable, Codable {
         return nil
     }
 
-    // MARK: - Onboarding auto-default classification
-    //
-    // The onboarding default (`ConfigureAIState.recommendedLocalPick`) draws
-    // only from the dense Gemma 4 QAT line, with the E-series 8-bit builds as
-    // a gated small-tier fallback. These flags name those sets so the policy
-    // lives next to the metadata it reads, not buried in the view.
-
-    /// True when the id is a Gemma 4 E-series edge build (`E2B`/`E4B`/...).
-    private var isGemma4ESeries: Bool {
-        id.range(of: #"gemma-4-e\d"#, options: [.regularExpression, .caseInsensitive]) != nil
-    }
-
-    /// True when the id carries an MoE active-param token (e.g. `-A4B`),
-    /// marking a mixture-of-experts build rather than a dense one.
-    private var hasMoEActiveParamToken: Bool {
-        id.range(of: #"-a\d+(\.\d+)?b"#, options: [.regularExpression, .caseInsensitive]) != nil
-    }
-
-    /// True for the **dense** Gemma 4 QAT builds (12B/31B `qat-MXFP4`) that
-    /// form the onboarding auto-default spine. Excludes the E-series (gated on
-    /// the 8-bit-vs-QAT-4bit retention A/B) and the 26B-A4B QAT MoE (its
-    /// footprint is the 36%-bounce risk) — both stay selectable Top Picks but
-    /// are never auto-selected.
-    var isDenseGemmaQATAutoDefault: Bool {
-        let lower = id.lowercased()
-        guard lower.contains("gemma-4"), lower.contains("qat") else { return false }
-        if isGemma4ESeries { return false }
-        if hasMoEActiveParamToken { return false }
-        return true
-    }
-
-    /// True for the Gemma 4 E-series 8-bit retention builds
-    /// (`gemma-4-E2B/E4B-it-8bit`) — the gated small-tier auto-default until
-    /// the QAT-4bit-vs-8bit bounce A/B clears.
-    var isGemmaESeries8bitAutoDefault: Bool {
-        guard isGemma4ESeries else { return false }
-        let lower = id.lowercased()
-        return lower.contains("8bit") || lower.contains("8-bit")
-    }
-
     /// Formatted estimated memory string (e.g. "~3.5 GB")
     var formattedEstimatedMemory: String? {
         guard let gb = estimatedMemoryGB else { return nil }

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -231,20 +231,39 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Top-pick reorg (precision-first)
 
-    @Test @MainActor func topPicks_includeGemmaQATSpineAndPrecisionFirstFlagships() async {
+    @Test @MainActor func topPicks_recommendVerifiedFamiliesNotGemmaQAT() async {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
+            // GUI-verified-good families (coherent output + clean tool-calling /
+            // reasoning, no marker leakage — proven live in the dev app) plus the
+            // allowed-precision Gemma builds (MXFP8 / 8-bit) are the Top Picks.
             for id in [
+                "OsaurusAI/Ornith-1.0-9B-MXFP8",
+                "OsaurusAI/Ornith-1.0-35B-MXFP8",
+                "OsaurusAI/Qwen3.6-27B-MXFP4",
+                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
+                "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+                "OsaurusAI/gemma-4-12B-it-MXFP8",
+                "OsaurusAI/gemma-4-E4B-it-8bit",
+                "OsaurusAI/gemma-4-E2B-it-8bit",
+            ] {
+                #expect(topIds.contains(id), "expected \(id) to be a Top Pick")
+            }
+            // The Gemma 4 QAT / plain-MXFP4 builds are dropped from Top Picks
+            // (2026-07-08): a recommended Gemma must be a non-QAT/non-MXFP4
+            // precision. They stay in the catalog, just unrecommended.
+            for id in [
+                "OsaurusAI/gemma-4-E2B-it-qat-MXFP4",
+                "OsaurusAI/gemma-4-E4B-it-qat-MXFP4",
                 "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
                 "OsaurusAI/gemma-4-31B-it-qat-MXFP4",
                 "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
-                "OsaurusAI/gemma-4-E4B-it-8bit",
-                "OsaurusAI/gemma-4-E2B-it-8bit",
-                "OsaurusAI/Qwen3.6-27B-MXFP4",
-                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
             ] {
-                #expect(topIds.contains(id), "expected \(id) to be a Top Pick")
+                #expect(!topIds.contains(id), "expected \(id) to NOT be a Top Pick (Gemma QAT/MXFP4)")
+                #expect(
+                    suggested.contains { $0.id == id },
+                    "expected \(id) to remain in the catalog")
             }
         }
     }
@@ -359,45 +378,37 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Onboarding default scenario matrix (Phase 4c)
 
-    @Test @MainActor func onboardingDefault_landsOnGemmaQATSpinePerRAMTier() async {
+    @Test @MainActor func onboardingDefault_picksLargestComfortableVerifiedTopPick() async {
         await withIsolatedModelSizeCache {
             // Fetch candidates under the isolated (empty) size cache so estimates
             // come from the deterministic param heuristic, not a machine's cached
             // on-disk sizes.
             let candidates = ModelManager().suggestedModels.filter(\.isTopSuggestion)
-            let pick: (Double) -> String? = { gb in
-                ConfigureAIState.recommendedLocalPick(from: candidates, totalMemoryGB: gb)?.id
-            }
-            // Small tier stays on the 8-bit retention build (gated until the
-            // QAT-4bit-vs-8bit bounce A/B clears).
-            #expect(pick(8) == "OsaurusAI/gemma-4-E4B-it-8bit")
-            // Mainstream tiers: the dense 12B QAT default.
-            #expect(pick(16) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
-            #expect(pick(18) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
-            #expect(pick(24) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
-            // Large tiers: the dense 31B QAT ceiling.
-            #expect(pick(32) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-            #expect(pick(36) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-            #expect(pick(48) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-            #expect(pick(64) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-        }
-    }
-
-    @Test @MainActor func onboardingDefault_neverAutoSelectsMoEorLargerFlagship() async {
-        await withIsolatedModelSizeCache {
-            let candidates = ModelManager().suggestedModels.filter(\.isTopSuggestion)
-            let excluded: Set<String> = [
-                "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
-                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
-                "OsaurusAI/Qwen3.6-27B-MXFP8-MTP",
-            ]
             for gb in stride(from: 8.0, through: 128.0, by: 2.0) {
-                let id = ConfigureAIState.recommendedLocalPick(
-                    from: candidates,
-                    totalMemoryGB: gb
-                )?.id
-                if let id {
-                    #expect(!excluded.contains(id), "auto-default \(id) at \(gb)GB must not be a MoE/flagship")
+                guard
+                    let pick = ConfigureAIState.recommendedLocalPick(
+                        from: candidates, totalMemoryGB: gb)
+                else { continue }
+                // Never a dropped Gemma QAT / plain-MXFP4 build.
+                let lower = pick.id.lowercased()
+                let droppedGemma =
+                    lower.contains("gemma-4")
+                    && (lower.contains("qat") || lower.hasSuffix("mxfp4"))
+                #expect(
+                    !droppedGemma,
+                    "auto-default \(pick.id) at \(gb)GB must not be a Gemma QAT/MXFP4 build")
+
+                // The pick is the LARGEST Top Pick that comfortably fits — the
+                // strongest proven model for this RAM tier. (When nothing is
+                // comfortable, the fallback smallest-candidate is allowed.)
+                let comfortable = candidates.filter {
+                    $0.compatibility(totalMemoryGB: gb) == .compatible
+                }
+                if !comfortable.isEmpty {
+                    let maxMem = comfortable.compactMap(\.estimatedMemoryGB).max() ?? 0
+                    #expect(
+                        (pick.estimatedMemoryGB ?? -1) == maxMem,
+                        "auto-default at \(gb)GB should be the largest comfortable Top Pick")
                 }
             }
         }

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -135,7 +135,10 @@ struct ModelManagerSuggestedTests {
 
             #expect(mxfp8 != nil)
             #expect(mxfp8?.modelType == "lfm2_moe")
-            #expect(mxfp8?.isTopSuggestion == true)
+            // Catalog-only (2026-07-08): the recommendation spine is Ornith
+            // MXFP8 + official Gemma; LFM2.5 stays installable but is not a
+            // Top Pick.
+            #expect(mxfp8?.isTopSuggestion == false)
             // Sizes now come from `ModelSizeCache` (empty here), not literals.
             #expect(mxfp8?.downloadSizeBytes == nil)
             #expect(mxfp8?.releasedAt != nil)
@@ -231,36 +234,39 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Top-pick reorg (precision-first)
 
-    @Test @MainActor func topPicks_recommendVerifiedFamiliesNotGemmaQAT() async {
+    @Test @MainActor func topPicks_recommendOrnithMXFP8AndOfficialGemma() async {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
-            // GUI-verified-good families (coherent output + clean tool-calling /
-            // reasoning, no marker leakage — proven live in the dev app) plus the
-            // allowed-precision Gemma builds (MXFP8 / 8-bit) are the Top Picks.
-            for id in [
+            // Recommendation spine (2026-07-08, GUI-verified in the dev app —
+            // each loads, calls tools, reasons with thinking on, no marker
+            // leakage): Ornith 1.0 MXFP8 for the larger tiers, official
+            // OsaurusAI Gemma 4 at the highest non-QAT/non-MXFP4 precision that
+            // exists (12B-it-MXFP8; E4B/E2B-it-8bit — no E-series MXFP8 exists)
+            // for the smaller tiers. These are the ONLY Top Picks.
+            let expectedTopPicks: Set<String> = [
                 "OsaurusAI/Ornith-1.0-9B-MXFP8",
                 "OsaurusAI/Ornith-1.0-35B-MXFP8",
-                "OsaurusAI/Qwen3.6-27B-MXFP4",
-                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
-                "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
                 "OsaurusAI/gemma-4-12B-it-MXFP8",
                 "OsaurusAI/gemma-4-E4B-it-8bit",
                 "OsaurusAI/gemma-4-E2B-it-8bit",
-            ] {
-                #expect(topIds.contains(id), "expected \(id) to be a Top Pick")
-            }
-            // The Gemma 4 QAT / plain-MXFP4 builds are dropped from Top Picks
-            // (2026-07-08): a recommended Gemma must be a non-QAT/non-MXFP4
-            // precision. They stay in the catalog, just unrecommended.
+            ]
+            #expect(topIds == expectedTopPicks, "Top Picks should be exactly Ornith MXFP8 + official Gemma; got \(topIds.sorted())")
+            // Gemma QAT/MXFP4, plus Qwen 3.6 / Nemotron-3 / LFM2.5, are
+            // catalog-only for now — installable and selectable, just not part
+            // of the auto-default recommendation spine.
             for id in [
                 "OsaurusAI/gemma-4-E2B-it-qat-MXFP4",
-                "OsaurusAI/gemma-4-E4B-it-qat-MXFP4",
                 "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
                 "OsaurusAI/gemma-4-31B-it-qat-MXFP4",
                 "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
+                "OsaurusAI/Qwen3.6-27B-MXFP4",
+                "OsaurusAI/Qwen3.6-27B-MXFP8-MTP",
+                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
+                "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+                "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
             ] {
-                #expect(!topIds.contains(id), "expected \(id) to NOT be a Top Pick (Gemma QAT/MXFP4)")
+                #expect(!topIds.contains(id), "expected \(id) to NOT be a Top Pick (catalog-only)")
                 #expect(
                     suggested.contains { $0.id == id },
                     "expected \(id) to remain in the catalog")

--- a/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateResourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateResourceTests.swift
@@ -117,17 +117,17 @@ struct ConfigureAIStateResourceTests {
         let large = makeModel(tag: "large", sizeBytes: 8 * gb, isTopSuggestion: true)
         let candidates = [large, small]
 
-        // Neither candidate is a dense Gemma QAT / E-series build, so the
-        // policy lands on the smallest comfortable pick.
+        // Both fit comfortably on 16 GB, so the policy lands on the LARGEST
+        // comfortable pick — the strongest proven model this Mac can run.
         let recommended = ConfigureAIState.recommendedLocalPick(
             from: candidates,
             totalMemoryGB: 16
         )
-        #expect(recommended?.id == small.id)
+        #expect(recommended?.id == large.id)
 
         #expect(
             ConfigureAIState.isRecommendedSelection(
-                small,
+                large,
                 candidates: candidates,
                 totalMemoryGB: 16
             ) == true
@@ -136,7 +136,7 @@ struct ConfigureAIStateResourceTests {
         // not claim "picked for your specs".
         #expect(
             ConfigureAIState.isRecommendedSelection(
-                large,
+                small,
                 candidates: candidates,
                 totalMemoryGB: 16
             ) == false
@@ -281,11 +281,11 @@ struct ConfigureAIStateResourceTests {
         #expect(deduped.map(\.id) == [highPrecision.id, solo.id])
     }
 
-    /// The auto-default (`recommendedLocalPick`) survives dedupe even when a
-    /// sibling has higher quality — otherwise the "Picked for your Mac" badge
-    /// would point at a hidden row and contradict the home card.
-    @Test func dedupeKeepsRecommendedVariantOverHigherQualitySibling() {
-        // No solo model here: the smallest comfortable pick (the efficient
+    /// The auto-default (`recommendedLocalPick`) survives dedupe — otherwise
+    /// the "Picked for your Mac" badge would point at a hidden row and
+    /// contradict the home card.
+    @Test func dedupeKeepsRecommendedVariantVisible() {
+        // No solo model here: the largest comfortable pick (the high-precision
         // build) *is* the recommendation, and must represent the family.
         let highPrecision = makeModel(tag: "twin-hp", name: "Twin 9B MXFP8", sizeBytes: 8 * gb)
         let efficient = makeModel(tag: "twin-eff", name: "Twin 9B qat MXFP4", sizeBytes: 4 * gb)
@@ -293,14 +293,14 @@ struct ConfigureAIStateResourceTests {
             from: [highPrecision, efficient],
             totalMemoryGB: 64
         )
-        #expect(recommended?.id == efficient.id)
+        #expect(recommended?.id == highPrecision.id)
 
         let deduped = ConfigureAIState.dedupedTopPicks(
             from: [highPrecision, efficient],
             totalMemoryGB: 64,
             selectedId: nil
         )
-        #expect(deduped.map(\.id) == [efficient.id])
+        #expect(deduped.map(\.id) == [highPrecision.id])
     }
 
     /// A family whose every build is too large collapses to its smallest

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -304,18 +304,20 @@ final class ConfigureAIState: ObservableObject {
     /// top-pick `candidates` and the machine RAM, returns the model onboarding
     /// should pre-select (or `nil` when there are no candidates).
     ///
-    /// Preference order, all restricted to the **comfortable** (`.compatible`)
-    /// band so we never auto-default into `.tight`:
-    ///   1. The largest dense Gemma 4 QAT build (12B/31B `qat-MXFP4`) — the
-    ///      auto-default spine.
-    ///   2. The largest Gemma 4 E-series 8-bit retention build — the gated
-    ///      small-tier fallback (until the QAT-4bit-vs-8bit A/B clears).
-    ///   3. The smallest comfortable top pick; or, if nothing is comfortable,
-    ///      the smallest candidate overall (never the largest).
+    /// Rule: auto-default to the **largest** curated Top Pick that
+    /// **comfortably** fits (`.compatible`, so never into the `.tight` band).
+    /// Every curated Top Pick is a GUI-verified-good model — coherent output
+    /// with clean tool-calling and reasoning and no control-marker leakage
+    /// (verified live in the dev app across the Ornith / Qwen 3.6 / Qwen
+    /// AgentWorld / Nemotron families) — so "largest that comfortably fits"
+    /// lands each RAM tier on the strongest proven model for that Mac. When
+    /// nothing is comfortable (very low RAM), fall back to the smallest
+    /// candidate overall so onboarding never dead-ends.
     ///
-    /// The 26B-A4B QAT MoE and the larger Qwen/Nemotron flagships are
-    /// intentionally excluded from (1)/(2): they stay selectable Top Picks but
-    /// are never auto-selected.
+    /// This replaced the earlier Gemma-4-QAT auto-default spine: the Gemma 4
+    /// `qat-MXFP4` builds are no longer curated Top Picks, so they are neither
+    /// shown nor auto-selected in onboarding (a recommended Gemma build must be
+    /// a non-QAT/non-MXFP4 precision, e.g. `12B-it-MXFP8` / `E4B-it-8bit`).
     static func recommendedLocalPick(
         from candidates: [MLXModel],
         totalMemoryGB: Double
@@ -334,13 +336,7 @@ final class ConfigureAIState: ObservableObject {
             })
         }
 
-        if let denseQAT = largest(comfortable.filter(\.isDenseGemmaQATAutoDefault)) {
-            return denseQAT
-        }
-        if let eSeries8bit = largest(comfortable.filter(\.isGemmaESeries8bitAutoDefault)) {
-            return eSeries8bit
-        }
-        return smallest(comfortable) ?? smallest(candidates)
+        return largest(comfortable) ?? smallest(candidates)
     }
 
     /// Collapses same-family quant variants — rows whose titles collapse to


### PR DESCRIPTION
## Onboarding: recommend Ornith MXFP8 + official OsaurusAI Gemma 4; drop Gemma QAT/MXFP4

Curates the onboarding recommendation spine so every auto-defaulted / Top-Pick model per RAM tier is an **official OsaurusAI quant that was live-verified in the dev-built app** (real Chat window: loads, calls tools, reasons with thinking on, and leaks **no** markup into visible content).

### Recommendation spine (the only Top Picks)
| RAM tier | Auto-default | Precision |
|---|---|---|
| Larger (≈48 GB+) | **Ornith-1.0-35B-MXFP8** | MXFP8 (near-lossless) |
| Mid (≈16–32 GB) | **Ornith-1.0-9B-MXFP8** / **gemma-4-12B-it-MXFP8** | MXFP8 |
| Smaller (≈8–12 GB) | **gemma-4-E4B-it-8bit** / **gemma-4-E2B-it-8bit** | 8-bit |

`recommendedLocalPick` picks the largest of these that comfortably fits, so each Mac lands on the strongest verified model for its RAM. Ornith MXFP8 carries the larger tiers; official Gemma 4 (highest non-QAT/non-MXFP4 precision that exists — `12B-it-MXFP8`, and `E4B/E2B-it-8bit` since no E-series MXFP8 is published) carries the smaller tiers.

### What changed
- **Dropped `isTopSuggestion` from the 5 Gemma-4 `qat-MXFP4` builds** (E2B/E4B/12B/31B/26B-A4B). A recommended Gemma must never be `qat` or plain `MXFP4`.
- **Dropped `isTopSuggestion` from Qwen3.6-27B-MXFP4, Qwen3.6-27B-MXFP8-MTP, Qwen3.6-35B-A3B-MXFP8-MTP, Nemotron-3-Nano-Omni-30B-A3B-MXFP4, and LFM2.5-8B-A1B-MXFP8** — all remain installable/selectable in the catalog, just not part of the auto-default spine for now.
- **Rewired `recommendedLocalPick`** from "largest dense Gemma-4-QAT that fits" → "largest Top Pick that comfortably fits"; removed the now-unused Gemma-QAT/E-series auto-default helpers.
- Tests assert the Top-Pick set is **exactly** Ornith MXFP8 + official Gemma, and that the auto-default is never a Gemma QAT/MXFP4 build.

### GUI verification (dev-built app; ground truth = streaming render path + chat-history DB)
Each recommended model was driven through tool-calling + reasoning-ON, inspecting the exact streamed `content` / `reasoning_content` / `tool_calls` (what the UI renders):

| Model (official OsaurusAI quant) | loads | tool call | reasoning→thinking | content leak |
|---|---|---|---|---|
| Ornith-1.0-9B-MXFP8 | ✅ | ✅ | ✅ | none |
| Ornith-1.0-35B-MXFP8 | ✅ | ✅ | ✅ | none |
| gemma-4-12B-it-MXFP8 | ✅ | ✅ | ✅ | none |
| gemma-4-E4B-it-8bit | ✅ | ✅ | ✅ | none |
| gemma-4-E2B-it-8bit | ✅ | ✅ | ✅ | none |

All five downloaded fresh from the OsaurusAI HF org and verified clean via the actual streaming render path.
