### PR TITLE
Fix DeepSeek thinking-mode tool_choice HTTP 400

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -1154,17 +1154,17 @@ struct ToolFunction: Codable, Sendable {
 }
 
 /// tool_choice option
-enum ToolChoiceOption: Codable, Sendable {
+enum ToolChoiceOption: Codable, Sendable, Equatable {
     case auto
     case none
     case required
     case function(FunctionName)
 
-    struct FunctionName: Codable, Sendable {
+    struct FunctionName: Codable, Sendable, Equatable {
         let type: String
         let function: Name
     }
-    struct Name: Codable, Sendable { let name: String }
+    struct Name: Codable, Sendable, Equatable { let name: String }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -2331,12 +2331,26 @@ public actor RemoteProviderService: ToolCapableService {
         tools: [Tool]?,
         toolChoice: ToolChoiceOption?
     ) -> RemoteChatRequest {
-        let (effortValue, thinking) = Self.remoteChatReasoningControls(
+        let reasoningPolicy = RemoteReasoningPolicy.resolve(
             providerType: provider.providerType,
             host: provider.host,
-            model: model,
+            model: model
+        )
+        let (effortValue, thinking) = reasoningPolicy.controls(
             effort: parameters.modelOptions["reasoningEffort"]?.stringValue
         )
+        // DeepSeek thinking mode rejects forced tool choices (HTTP 400
+        // "Thinking mode does not support this tool_choice"); downgrade
+        // `.required`/`.function` to `.auto` there. See
+        // `RemoteReasoningPolicy.sanitizedToolChoice`.
+        let wireToolChoice = reasoningPolicy.sanitizedToolChoice(toolChoice, thinking: thinking)
+        if let toolChoice, wireToolChoice != toolChoice {
+            debugLog(
+                "[RemoteProviderService] tool_choice \(toolChoice) downgraded to "
+                    + "\(String(describing: wireToolChoice)) for thinking-mode provider "
+                    + "host=\(provider.host) model=\(model)"
+            )
+        }
         let allowsReasoningObject =
             Self.allowsChatCompletionsReasoningObject(
                 providerType: provider.providerType,
@@ -2388,7 +2402,7 @@ public actor RemoteProviderService: ToolCapableService {
             presence_penalty: isAgentRun ? nil : (isReasoningModel ? nil : parameters.presencePenalty),
             stop: nil,
             tools: wireTools,
-            tool_choice: toolChoice,
+            tool_choice: wireToolChoice,
             reasoning_effort: isAgentRun ? nil : effortValue,
             reasoning: isAgentRun
                 ? nil

--- a/Packages/OsaurusCore/Services/Provider/RemoteReasoningPolicy.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteReasoningPolicy.swift
@@ -207,6 +207,43 @@ struct RemoteReasoningPolicy {
         }
     }
 
+    /// Downgrade `tool_choice` values the provider rejects while thinking
+    /// mode is active.
+    ///
+    /// DeepSeek V4 (`deepseek-v4-pro`/`-flash`) enables thinking by default
+    /// and returns HTTP 400 `"Thinking mode does not support this
+    /// tool_choice"` for `tool_choice: "required"` and named-function
+    /// choices; only `"auto"`/`"none"` are accepted. Forced choices work
+    /// only in non-thinking mode, i.e. when `thinking: {"type":"disabled"}`
+    /// is on the wire. This is a wire-compatibility translation of the same
+    /// kind as the Anthropic `.required -> .any` mapping, not an
+    /// output-shaping guard: the caller's intent ("call a tool now") is
+    /// preserved as closely as the provider's thinking-mode contract allows.
+    func sanitizedToolChoice(
+        _ choice: ToolChoiceOption?,
+        thinking: ThinkingConfig?
+    ) -> ToolChoiceOption? {
+        guard let choice else { return nil }
+        switch providerType {
+        case .openaiLegacy, .azureOpenAI:
+            break
+        case .anthropic, .openResponses, .openAICodex, .gemini, .osaurus, .osaurusRouter:
+            return choice
+        }
+        guard Self.matches(needle: "deepseek", host: host, model: model) else {
+            return choice
+        }
+        // Thinking explicitly disabled (Instruct mode): forced choices are legal.
+        guard thinking?.type != "disabled" else { return choice }
+
+        switch choice {
+        case .required, .function:
+            return .auto
+        case .auto, .none:
+            return choice
+        }
+    }
+
     /// Translate the local DSV4 `reasoningEffort` value into the wire fields.
     ///
     /// `DSV4ReasoningProfile` exposes `instruct` / `high` / `max`, but DeepSeek's

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -2077,6 +2077,149 @@ struct RemoteChatRequestEncodingTests {
         #expect(payload["reasoning_effort"] as? String == "high")
     }
 
+    // MARK: - DeepSeek thinking-mode tool_choice sanitization
+    //
+    // DeepSeek V4 enables thinking by default and rejects forced tool
+    // choices with HTTP 400 "Thinking mode does not support this
+    // tool_choice"; only `auto`/`none` are legal while thinking is active.
+    // `buildChatRequest` must downgrade `.required`/`.function` to `.auto`
+    // there, and leave them intact when thinking is explicitly disabled
+    // (Instruct mode) or on non-DeepSeek hosts.
+
+    private static func makeService(host: String, model: String) -> RemoteProviderService {
+        RemoteProviderService(
+            provider: RemoteProvider(
+                name: "p",
+                host: host,
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/v1",
+                authType: .none,
+                providerType: .openaiLegacy
+            ),
+            models: [model],
+            resolvedHeaders: [:]
+        )
+    }
+
+    private static let namedFileReadChoice = ToolChoiceOption.function(
+        ToolChoiceOption.FunctionName(
+            type: "function",
+            function: ToolChoiceOption.Name(name: "get_weather")
+        )
+    )
+
+    @Test func buildChatRequest_deepSeekThinking_downgradesForcedToolChoiceToAuto() async throws {
+        let service = Self.makeService(host: "api.deepseek.com", model: "deepseek-v4-pro")
+        for effort in ["high", "max"] {
+            for forced in [ToolChoiceOption.required, Self.namedFileReadChoice] {
+                let req = await service.buildChatRequest(
+                    messages: [ChatMessage(role: "user", content: "read the file")],
+                    parameters: GenerationParameters(
+                        temperature: 0.7,
+                        maxTokens: 256,
+                        modelOptions: ["reasoningEffort": .string(effort)]
+                    ),
+                    model: "deepseek-v4-pro",
+                    stream: true,
+                    tools: [Self.weatherTool],
+                    toolChoice: forced
+                )
+                #expect(req.tool_choice == .auto)
+                #expect(req.reasoning_effort == effort)
+                #expect(req.thinking == nil)
+            }
+        }
+
+        // Wire body proof: tool_choice serializes as the string "auto".
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "read the file")],
+            parameters: GenerationParameters(
+                temperature: 0.7,
+                maxTokens: 256,
+                modelOptions: ["reasoningEffort": .string("high")]
+            ),
+            model: "deepseek-v4-pro",
+            stream: true,
+            tools: [Self.weatherTool],
+            toolChoice: .required
+        )
+        let payload = try Self.encodeAsDictionary(req)
+        #expect(payload["tool_choice"] as? String == "auto")
+        #expect(payload["reasoning_effort"] as? String == "high")
+    }
+
+    @Test func buildChatRequest_deepSeekThinkingDefault_downgradesWithoutEffort() async {
+        // No reasoningEffort at all: V4 still defaults to thinking mode, so
+        // forced choices must be downgraded.
+        let service = Self.makeService(host: "api.deepseek.com", model: "deepseek-v4-pro")
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "read the file")],
+            parameters: GenerationParameters(temperature: 0.7, maxTokens: 256),
+            model: "deepseek-v4-pro",
+            stream: true,
+            tools: [Self.weatherTool],
+            toolChoice: .required
+        )
+        #expect(req.tool_choice == .auto)
+    }
+
+    @Test func buildChatRequest_deepSeekInstruct_preservesForcedToolChoice() async throws {
+        let service = Self.makeService(host: "api.deepseek.com", model: "deepseek-v4-pro")
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "read the file")],
+            parameters: GenerationParameters(
+                temperature: 0.7,
+                maxTokens: 256,
+                modelOptions: ["reasoningEffort": .string("instruct")]
+            ),
+            model: "deepseek-v4-pro",
+            stream: true,
+            tools: [Self.weatherTool],
+            toolChoice: .required
+        )
+        #expect(req.tool_choice == .required)
+        #expect(req.thinking == ThinkingConfig(type: "disabled"))
+        #expect(req.reasoning_effort == nil)
+
+        let payload = try Self.encodeAsDictionary(req)
+        #expect(payload["tool_choice"] as? String == "required")
+        let thinking = try #require(payload["thinking"] as? [String: Any])
+        #expect(thinking["type"] as? String == "disabled")
+    }
+
+    @Test func buildChatRequest_nonDeepSeekHost_keepsForcedToolChoice() async {
+        let service = Self.makeService(host: "api.openai.com", model: "gpt-5.2")
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "read the file")],
+            parameters: GenerationParameters(
+                temperature: 0.7,
+                maxTokens: 256,
+                modelOptions: ["reasoningEffort": .string("high")]
+            ),
+            model: "gpt-5.2",
+            stream: true,
+            tools: [Self.weatherTool],
+            toolChoice: .required
+        )
+        #expect(req.tool_choice == .required)
+    }
+
+    @Test func buildChatRequest_deepSeekModelOnAggregatorHost_downgradesForcedToolChoice() async {
+        // OpenRouter-style hosts serve DeepSeek V4 ids; the upstream rejects
+        // forced choices identically and thinking cannot be disabled there.
+        let service = Self.makeService(host: "openrouter.ai", model: "deepseek/deepseek-v4-pro")
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "read the file")],
+            parameters: GenerationParameters(temperature: 0.7, maxTokens: 256),
+            model: "deepseek/deepseek-v4-pro",
+            stream: true,
+            tools: [Self.weatherTool],
+            toolChoice: .required
+        )
+        #expect(req.tool_choice == .auto)
+    }
+
     @Test func geminiRequest_stripsAdditionalPropertiesFromToolSchemas() throws {
         let request = Self.makeRequest(
             model: "gemini-2.5-pro",

--- a/Packages/OsaurusCore/Tests/Provider/RemoteReasoningPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteReasoningPolicyTests.swift
@@ -139,6 +139,79 @@ struct RemoteReasoningPolicyTests {
         #expect(controls.thinking == nil)
     }
 
+    // MARK: - sanitizedToolChoice (DeepSeek thinking-mode contract)
+
+    private static let namedChoice = ToolChoiceOption.function(
+        ToolChoiceOption.FunctionName(
+            type: "function",
+            function: ToolChoiceOption.Name(name: "file_read")
+        )
+    )
+
+    @Test func sanitizedToolChoice_deepSeekThinking_downgradesForcedChoices() {
+        let policy = RemoteReasoningPolicy.resolve(
+            providerType: .openaiLegacy,
+            host: "api.deepseek.com",
+            model: "deepseek-v4-pro"
+        )
+        // Thinking active on the wire (reasoning_effort high/max) or by
+        // default (no thinking object at all): forced choices become auto.
+        for thinking: ThinkingConfig? in [nil, ThinkingConfig(type: "enabled")] {
+            #expect(policy.sanitizedToolChoice(.required, thinking: thinking) == .auto)
+            #expect(policy.sanitizedToolChoice(Self.namedChoice, thinking: thinking) == .auto)
+            #expect(policy.sanitizedToolChoice(.auto, thinking: thinking) == .auto)
+            #expect(policy.sanitizedToolChoice(ToolChoiceOption.none, thinking: thinking) == ToolChoiceOption.none)
+            #expect(policy.sanitizedToolChoice(nil, thinking: thinking) == nil)
+        }
+    }
+
+    @Test func sanitizedToolChoice_deepSeekInstruct_preservesForcedChoices() {
+        let policy = RemoteReasoningPolicy.resolve(
+            providerType: .openaiLegacy,
+            host: "api.deepseek.com",
+            model: "deepseek-v4-pro"
+        )
+        let disabled = ThinkingConfig(type: "disabled")
+        #expect(policy.sanitizedToolChoice(.required, thinking: disabled) == .required)
+        #expect(policy.sanitizedToolChoice(Self.namedChoice, thinking: disabled) == Self.namedChoice)
+    }
+
+    @Test func sanitizedToolChoice_deepSeekModelOnAggregatorHost_downgrades() {
+        // OpenRouter/AtlasCloud serve DeepSeek models under a non-deepseek
+        // host; thinking cannot be disabled there, so forced choices would
+        // 400 at the upstream just the same.
+        let policy = RemoteReasoningPolicy.resolve(
+            providerType: .openaiLegacy,
+            host: "openrouter.ai",
+            model: "deepseek/deepseek-v4-pro"
+        )
+        #expect(policy.sanitizedToolChoice(.required, thinking: nil) == .auto)
+        #expect(policy.sanitizedToolChoice(Self.namedChoice, thinking: nil) == .auto)
+    }
+
+    @Test func sanitizedToolChoice_nonDeepSeekHosts_passThrough() {
+        for host in ["api.openai.com", "api.mistral.ai", "api.minimax.io", "api.x.ai"] {
+            let policy = RemoteReasoningPolicy.resolve(
+                providerType: .openaiLegacy,
+                host: host,
+                model: "some-model"
+            )
+            #expect(policy.sanitizedToolChoice(.required, thinking: nil) == .required)
+            #expect(policy.sanitizedToolChoice(Self.namedChoice, thinking: nil) == Self.namedChoice)
+        }
+    }
+
+    @Test func sanitizedToolChoice_nonOpenAICompatProviders_passThrough() {
+        for providerType: RemoteProviderType in [.anthropic, .openResponses, .openAICodex, .gemini, .osaurus, .osaurusRouter] {
+            let policy = RemoteReasoningPolicy.resolve(
+                providerType: providerType,
+                host: "api.deepseek.com",
+                model: "deepseek-v4-pro"
+            )
+            #expect(policy.sanitizedToolChoice(.required, thinking: nil) == .required)
+        }
+    }
+
     @Test func allowsReasoningObject_matchesLegacyRule() {
         #expect(
             RemoteReasoningPolicy.resolve(providerType: .openaiLegacy, host: "openrouter.ai", model: "x")


### PR DESCRIPTION
## Summary

- DeepSeek V4 (`deepseek-v4-pro`/`-flash`) enables thinking by default and rejects `tool_choice: "required"` and named-function choices with HTTP 400 `"Thinking mode does not support this tool_choice"`; only `auto`/`none` are legal while thinking is active. Osaurus triggered this itself: `ChatToolChoicePolicy` forces `.required` on attempt 1 when the prompt matches file/tool-intent heuristics, and `ChatEngine.localToolChoiceForDispatch` upgrades single-tool `.required` to a named `.function` choice — which is why the error appeared intermittently mid-session depending on prompt wording.
- Adds `RemoteReasoningPolicy.sanitizedToolChoice(_:thinking:)`: for OpenAI-compat requests where the host or model matches DeepSeek, forced choices (`.required`/`.function`) are downgraded to `.auto` whenever thinking is active (the V4 default, not just `reasoning_effort: high/max`). When Instruct mode puts `thinking: {"type":"disabled"}` on the wire, forced choices are preserved since non-thinking mode accepts them. Aggregator hosts serving DeepSeek model ids (OpenRouter, AtlasCloud) get the same treatment; all other providers/hosts pass through untouched.
- Applied in `RemoteProviderService.buildChatRequest` — the single choke point for outbound remote requests — so the chat UI, agent runs, and external API clients proxying through Osaurus are all covered. A `debugLog` line records every downgrade. `ToolChoiceOption` gains `Equatable` for the downgrade check.
- This is a wire-compatibility translation of the same kind as the existing Anthropic `.required -> .any` mapping, not an output-shaping guard. Other providers reviewed and left unchanged: Anthropic never receives extended-thinking params today so its documented thinking/tool_choice conflict cannot trigger; Gemini's `ANY` function-calling mode is accepted by its thinking models; OpenAI reasoning models accept `required`.

## Test plan

- [x] `RemoteReasoningPolicy` suite: 16/16 passing, incl. 5 new sanitizer cases (thinking active with/without effort, Instruct preserved, aggregator hosts, non-DeepSeek pass-through, non-OpenAI-compat pass-through)
- [x] `RemoteChatRequest encoding` suite: 109/109 passing, incl. 5 new wire-level `buildChatRequest` cases proving `"tool_choice":"auto"` on the encoded body in thinking mode and `"required"` + `thinking: disabled` preserved for Instruct
- [x] `RemoteAgentRouting` suite: 35/35 passing (also exercises `buildChatRequest`)
- [x] `swift build --package-path Packages/OsaurusCore` clean
- [ ] Full unit suite (`make test`) — running, result to be posted