### PR TITLE
Fix RAM banner false positives for resident and in-flight models

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1285,6 +1285,19 @@ public actor ModelRuntime {
         }
     }
 
+    /// True when no fresh cold load would happen for `canonicalName`, so the
+    /// tight-fit projection must not run: the model is already resident or a
+    /// load for it is in flight. Static and sequence-driven so unit tests can
+    /// exercise the alias/casing boundary without a real model load.
+    static func isProjectionSuppressed(
+        canonicalName: String,
+        residentNames: some Sequence<String>,
+        inflightNames: some Sequence<String>
+    ) -> Bool {
+        residentNames.contains { $0.caseInsensitiveCompare(canonicalName) == .orderedSame }
+            || inflightNames.contains { $0.caseInsensitiveCompare(canonicalName) == .orderedSame }
+    }
+
     /// Projected RAM feasibility for loading `name`, computed WITHOUT loading
     /// anything. Backs the chat input's tight-fit disclaimer and send gate.
     ///
@@ -1299,31 +1312,48 @@ public actor ModelRuntime {
         guard !trimmed.isEmpty else { return nil }
         guard modelCache[trimmed] == nil else { return nil }
         guard let found = ModelManager.findInstalledModel(named: trimmed) else { return nil }
+        // The runtime caches residents under the canonical installed-bundle
+        // name (lowercased repo, e.g. `qwen3-8b-4bit`), while the chat picker
+        // passes the full catalog id (`mlx-community/Qwen3-8B-4bit`). Checking
+        // only the raw string treated an already-resident model as a fresh
+        // cold load — its own footprint had shrunk `available`, so the banner
+        // warned that loading it "again" would be tight and never cleared.
+        // An in-flight load is likewise a decision already made; projecting
+        // "will it fit" against memory the load itself is consuming
+        // double-counts it, and the post-load re-check settles the banner.
+        guard
+            !Self.isProjectionSuppressed(
+                canonicalName: found.name,
+                residentNames: modelCache.keys,
+                inflightNames: inflightLoadWeights.keys
+            )
+        else { return nil }
         guard let localURL = Self.findLocalDirectory(forModelId: found.id) else { return nil }
 
         let physical = Int64(ProcessInfo.processInfo.physicalMemory)
         guard physical > 0 else { return nil }
-        let weightsBytes = candidateWeightsSizeBytes(modelName: trimmed, directory: localURL)
+        let weightsBytes = candidateWeightsSizeBytes(modelName: found.name, directory: localURL)
         guard weightsBytes > 0 else { return nil }
 
         let loadFootprintBytes = Self.effectiveLoadFootprintBytes(
             rawWeightsBytes: weightsBytes,
             modelDirectory: localURL,
-            modelName: trimmed
+            modelName: found.name
         )
         let kvHeadroom = Self.estimatedKVHeadroomBytes(
             forWeights: loadFootprintBytes,
             modelDirectory: localURL,
-            modelName: trimmed
+            modelName: found.name
         )
 
         // Strict single-model evicts the current resident before the load
         // starts, so the projection must not double-count it. Flexible
-        // (multi-model) residency keeps other models around.
+        // (multi-model) residency keeps other models around. Exclusions use
+        // the canonical name — the key the runtime actually caches under.
         let policy =
             await ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
-        let resident = policy == .strictSingleModel ? 0 : residentWeightBytes(excluding: trimmed)
-        let inflightOther = inflightLoadWeightBytes(excluding: trimmed)
+        let resident = policy == .strictSingleModel ? 0 : residentWeightBytes(excluding: found.name)
+        let inflightOther = inflightLoadWeightBytes(excluding: found.name)
 
         return Self.buildRAMFeasibility(
             modelName: trimmed,

--- a/Packages/OsaurusCore/Services/SystemMonitorService.swift
+++ b/Packages/OsaurusCore/Services/SystemMonitorService.swift
@@ -172,12 +172,19 @@ class SystemMonitorService: ObservableObject {
         host_page_size(hostPort, &rawPage)
         let pageSize = rawPage
         let totalMemory = Double(ProcessInfo.processInfo.physicalMemory)
-        let freeMemory = Double(vmInfo.free_count) * Double(pageSize)
-        let inactiveMemory = Double(vmInfo.inactive_count) * Double(pageSize)
-        let _ = Double(vmInfo.wire_count) * Double(pageSize)
-        let _ = Double(vmInfo.compressor_page_count) * Double(pageSize)
+        // "Available" mirrors the RAM feasibility gate in `ModelRuntime`
+        // (free + inactive + speculative + purgeable), so the percentage
+        // shown next to the tight-fit banner is the complement of the same
+        // number the gate compares against. Counting speculative/purgeable
+        // (largely file cache) as used overstated pressure versus Activity
+        // Monitor, which treats cached files as available.
+        let availableMemory =
+            (Double(vmInfo.free_count)
+                + Double(vmInfo.inactive_count)
+                + Double(vmInfo.speculative_count)
+                + Double(vmInfo.purgeable_count)) * Double(pageSize)
 
-        let usedMemory = totalMemory - freeMemory - inactiveMemory
+        let usedMemory = max(0.0, totalMemory - availableMemory)
         let percentage = (usedMemory / totalMemory) * 100.0
 
         let totalGB = totalMemory / (1024 * 1024 * 1024)

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -218,4 +218,57 @@ struct ModelRuntimeRAMFeasibilityTests {
         let empty = await ModelRuntime.shared.projectedLoadFeasibility(for: "   ")
         #expect(empty == nil)
     }
+
+    // MARK: - Projection suppression (resident / in-flight aliasing)
+
+    @Test("Resident model suppresses the projection regardless of casing")
+    func residentModelSuppressesProjection() {
+        // The runtime caches under the canonical lowercased repo name; the
+        // chat picker resolves a full catalog id down to the same canonical
+        // form. Both must hit the resident check.
+        #expect(
+            ModelRuntime.isProjectionSuppressed(
+                canonicalName: "qwen3.6-35b-a3b-mxfp4-mtp",
+                residentNames: ["qwen3.6-35b-a3b-mxfp4-mtp"],
+                inflightNames: []
+            )
+        )
+        // Defensive: a cache key that kept original casing still matches.
+        #expect(
+            ModelRuntime.isProjectionSuppressed(
+                canonicalName: "qwen3.6-35b-a3b-mxfp4-mtp",
+                residentNames: ["Qwen3.6-35B-A3B-MXFP4-MTP"],
+                inflightNames: []
+            )
+        )
+    }
+
+    @Test("In-flight load of the same model suppresses the projection")
+    func inflightLoadSuppressesProjection() {
+        #expect(
+            ModelRuntime.isProjectionSuppressed(
+                canonicalName: "qwen3.6-35b-a3b-mxfp4-mtp",
+                residentNames: [],
+                inflightNames: ["qwen3.6-35b-a3b-mxfp4-mtp"]
+            )
+        )
+    }
+
+    @Test("Other resident or in-flight models do not suppress the projection")
+    func otherModelsDoNotSuppressProjection() {
+        #expect(
+            !ModelRuntime.isProjectionSuppressed(
+                canonicalName: "qwen3.6-35b-a3b-mxfp4-mtp",
+                residentNames: ["gemma-4-12b-qat"],
+                inflightNames: ["llama-4-8b-4bit"]
+            )
+        )
+        #expect(
+            !ModelRuntime.isProjectionSuppressed(
+                canonicalName: "qwen3.6-35b-a3b-mxfp4-mtp",
+                residentNames: [],
+                inflightNames: []
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Users on machines with plenty of RAM (e.g. M1 Max / 64 GB) reported the chat input's "This model needs ~X GB to load and memory is at Y% of Z GB" banner staying up even though the selected model was already loaded and Activity Monitor showed lots of available memory.

Root cause: `ModelRuntime.projectedLoadFeasibility` checked residency with the raw picker string (full catalog id, e.g. `mlx-community/Qwen3.6-35B-A3B-MXFP4-MTP`), but the runtime caches residents under the canonical lowercased repo name (`qwen3.6-35b-a3b-mxfp4-mtp`). The already-resident model was therefore projected as a *fresh* cold load — and since its own footprint had already shrunk the free-page count, the `lowAvailable` check kept the banner up indefinitely. Exactly "load the model, then warn that loading it again would be tight."

Changes:

- **Canonicalize the projection's residency check** — resolve the picker string through `ModelManager.findInstalledModel` and suppress the projection when the canonical name is resident *or* its load is already in flight (a made decision; projecting against memory the load itself is consuming double-counts it). The resident/in-flight byte exclusions and bundle-size/KV lookups now also use the canonical name.
- **Align the banner's memory percentage with the gate** — `SystemMonitorService` previously computed `used = total − free − inactive`, counting cached files / speculative / purgeable pages as used. It now uses the same "available" definition as the feasibility gate (free + inactive + speculative + purgeable), which also matches Activity Monitor's treatment of cached files as available.
- **Tests** — new suppression-boundary tests (resident alias/casing, own in-flight load, unrelated models) in `ModelRuntimeRAMFeasibilityTests`.

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` compiles clean
- [x] `swift test --filter "ModelRuntimeRAMFeasibility"` — 12/12 pass
- [ ] Live check: load a large model, confirm the banner shows only during genuine pressure and clears once the model is resident