### PR TITLE
Improve Telegram channel recovery diagnostics

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/RequestLog.swift
+++ b/Packages/OsaurusCore/Models/Chat/RequestLog.swift
@@ -26,10 +26,51 @@ struct ToolCallLog: Identifiable, Sendable {
     ) {
         self.id = id
         self.name = name
-        self.arguments = arguments
-        self.result = result
+        self.arguments = Self.redactedArguments(toolName: name, arguments: arguments)
+        self.result = Self.redactedResult(toolName: name, result: result)
         self.durationMs = durationMs
         self.isError = isError
+    }
+
+    private static func redactedArguments(toolName: String, arguments: String) -> String {
+        guard ToolRegistry.agentChannelToolNames.contains(toolName) else {
+            return arguments
+        }
+        guard let data = arguments.data(using: .utf8),
+            var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return #"{ "redaction": "agent_channel_arguments_redacted" }"#
+        }
+
+        // Keep this in sync with any future Agent Channel free-text tool fields.
+        let sensitiveKeys: Set<String> = [
+            "body",
+            "content",
+            "message",
+            "query",
+            "reply",
+            "text",
+        ]
+        for key in Array(object.keys) where sensitiveKeys.contains(key.lowercased()) {
+            object[key] = "[REDACTED:AGENT_CHANNEL_MESSAGE_CONTENT]"
+        }
+        guard let redactedData = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys]
+        ),
+            let redacted = String(data: redactedData, encoding: .utf8)
+        else {
+            return #"{ "redaction": "agent_channel_arguments_redacted" }"#
+        }
+        return redacted
+    }
+
+    private static func redactedResult(toolName: String, result: String?) -> String? {
+        guard ToolRegistry.agentChannelToolNames.contains(toolName) else {
+            return result
+        }
+        guard result != nil else { return nil }
+        return "[REDACTED:AGENT_CHANNEL_TOOL_RESULT]"
     }
 }
 
@@ -340,8 +381,7 @@ struct RequestLog: Identifiable, Sendable {
         guard let body = requestBody, let data = body.data(using: .utf8) else { return requestBody }
         if let json = try? JSONSerialization.jsonObject(with: data, options: []),
             let prettyData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
-            let prettyString = String(data: prettyData, encoding: .utf8)
-        {
+            let prettyString = String(data: prettyData, encoding: .utf8) {
             return prettyString
         }
         return body
@@ -352,8 +392,7 @@ struct RequestLog: Identifiable, Sendable {
         guard let body = responseBody, let data = body.data(using: .utf8) else { return responseBody }
         if let json = try? JSONSerialization.jsonObject(with: data, options: []),
             let prettyData = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
-            let prettyString = String(data: prettyData, encoding: .utf8)
-        {
+            let prettyString = String(data: prettyData, encoding: .utf8) {
             return prettyString
         }
         return body
@@ -374,8 +413,7 @@ struct RequestLog: Identifiable, Sendable {
                 withJSONObject: json,
                 options: [.prettyPrinted, .sortedKeys]
             ),
-            let prettyString = String(data: prettyData, encoding: .utf8)
-        {
+            let prettyString = String(data: prettyData, encoding: .utf8) {
             return prettyString
         }
         return body
@@ -396,8 +434,7 @@ struct RequestLog: Identifiable, Sendable {
                 withJSONObject: json,
                 options: [.prettyPrinted, .sortedKeys]
             ),
-            let prettyString = String(data: prettyData, encoding: .utf8)
-        {
+            let prettyString = String(data: prettyData, encoding: .utf8) {
             return prettyString
         }
         return body

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -28,12 +28,37 @@ struct TelegramWebhookDiagnostic: Equatable, Sendable {
     }
 }
 
+struct TelegramChatDiagnostic: Equatable, Sendable {
+    let id: String
+    let source: String
+    let readAllowed: Bool
+    let writeAllowed: Bool
+    let storedMessageCount: Int
+    let latestStoredAt: String?
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "id": id,
+            "source": source,
+            "read_allowed": readAllowed,
+            "write_allowed": writeAllowed,
+            "stored_message_count": storedMessageCount,
+        ]
+        if let latestStoredAt {
+            result["latest_stored_at"] = latestStoredAt
+        }
+        return result
+    }
+}
+
 struct TelegramConnectionDiagnostics: Equatable, Sendable {
     let tokenSaved: Bool
     let bot: TelegramUser?
     let readableChatIds: [String]
     let writableChatIds: [String]
     let senderAllowlist: [String]
+    let configuredChats: [TelegramChatDiagnostic]
+    let storedDiscoveredChats: [TelegramChatDiagnostic]
     let writeEnabled: Bool
     let receiveStorageEnabled: Bool
     let longPollingEnabled: Bool
@@ -49,6 +74,8 @@ struct TelegramConnectionDiagnostics: Equatable, Sendable {
         readableChatIds: [String],
         writableChatIds: [String],
         senderAllowlist: [String],
+        configuredChats: [TelegramChatDiagnostic] = [],
+        storedDiscoveredChats: [TelegramChatDiagnostic] = [],
         writeEnabled: Bool,
         receiveStorageEnabled: Bool = false,
         longPollingEnabled: Bool = false,
@@ -62,6 +89,8 @@ struct TelegramConnectionDiagnostics: Equatable, Sendable {
         self.readableChatIds = readableChatIds
         self.writableChatIds = writableChatIds
         self.senderAllowlist = senderAllowlist
+        self.configuredChats = configuredChats
+        self.storedDiscoveredChats = storedDiscoveredChats
         self.writeEnabled = writeEnabled
         self.receiveStorageEnabled = receiveStorageEnabled
         self.longPollingEnabled = longPollingEnabled
@@ -78,6 +107,15 @@ struct TelegramConnectionDiagnostics: Equatable, Sendable {
             "readable_chat_ids": readableChatIds,
             "writable_chat_ids": writableChatIds,
             "sender_allowlist": senderAllowlist,
+            "configured_chats": configuredChats.map(\.dictionary),
+            "stored_discovered_chats": storedDiscoveredChats.map(\.dictionary),
+            "chat_discovery_source": "configuration_and_local_message_store_only",
+            "authorization": [
+                "sender_allowlist": senderAllowlist,
+                "room_allowlist": readableChatIds,
+                "authorize_before_storage": true,
+                "authorize_before_dispatch": true,
+            ],
             "write_enabled": writeEnabled,
             "receive_storage_enabled": receiveStorageEnabled,
             "long_polling_enabled": longPollingEnabled,
@@ -148,6 +186,7 @@ enum TelegramConnectionServiceError: LocalizedError, Equatable, Sendable {
     case chatNotWritable(String)
     case writeDisabled
     case sendConfirmationRequired
+    case sendBackpressure(String)
     case messageTooLong
     case emptyMessage
     case configurationSaveFailed(String)
@@ -169,6 +208,8 @@ enum TelegramConnectionServiceError: LocalizedError, Equatable, Sendable {
             return "Telegram write access is disabled in settings."
         case .sendConfirmationRequired:
             return "`confirm_send` must be true before Osaurus posts to Telegram."
+        case .sendBackpressure(let chatId):
+            return "A Telegram send is already in flight for chat `\(chatId)`. Retry after the current send completes."
         case .messageTooLong:
             return "Telegram messages must fit Telegram's 4096-character limit."
         case .emptyMessage:
@@ -289,6 +330,20 @@ private enum TelegramReceivePendingResult {
     case event(TelegramNormalizedInboundEvent)
 }
 
+private actor TelegramPerChatSendGate {
+    private var inFlight = Set<String>()
+
+    func begin(chatId: String) -> Bool {
+        guard !inFlight.contains(chatId) else { return false }
+        inFlight.insert(chatId)
+        return true
+    }
+
+    func finish(chatId: String) {
+        inFlight.remove(chatId)
+    }
+}
+
 final class TelegramConnectionService: @unchecked Sendable {
     static let nativeConnectionId = TelegramUpdateNormalizer.connectionId
     static let updatesCursorRoomId = "__telegram_updates__"
@@ -305,6 +360,7 @@ final class TelegramConnectionService: @unchecked Sendable {
     private let credentialStore: any TelegramCredentialStorage
     private let messageStore: AgentChannelMessageStore?
     private let recordMessageSnapshotsInline: Bool
+    private let sendGate = TelegramPerChatSendGate()
     private let botIdentityLock = NSLock()
     private var cachedBotId: Int64?
 
@@ -356,6 +412,7 @@ final class TelegramConnectionService: @unchecked Sendable {
 
     func diagnostics() async -> TelegramConnectionDiagnostics {
         let config = configuration()
+        let chatReadiness = chatDiagnostics(config: config)
         guard let token = credentialStore.botToken() else {
             return TelegramConnectionDiagnostics(
                 tokenSaved: false,
@@ -363,6 +420,8 @@ final class TelegramConnectionService: @unchecked Sendable {
                 readableChatIds: config.readableChatIds,
                 writableChatIds: config.writableChatIds,
                 senderAllowlist: config.senderAllowlist,
+                configuredChats: chatReadiness.configured,
+                storedDiscoveredChats: chatReadiness.stored,
                 writeEnabled: config.writeEnabled,
                 receiveStorageEnabled: config.receiveStorageEnabled,
                 longPollingEnabled: config.longPollingEnabled,
@@ -481,6 +540,8 @@ final class TelegramConnectionService: @unchecked Sendable {
             readableChatIds: config.readableChatIds,
             writableChatIds: config.writableChatIds,
             senderAllowlist: config.senderAllowlist,
+            configuredChats: chatReadiness.configured,
+            storedDiscoveredChats: chatReadiness.stored,
             writeEnabled: config.writeEnabled,
             receiveStorageEnabled: config.receiveStorageEnabled,
             longPollingEnabled: config.longPollingEnabled,
@@ -523,6 +584,46 @@ final class TelegramConnectionService: @unchecked Sendable {
             return "A webhook is registered for this bot (\(TelegramSecurity.redact(info.url, token: token))). Remove the webhook in Telegram settings or disable long polling."
         }
         return "Another getUpdates consumer is polling this bot token (for example a plugin or a second Osaurus instance). Stop the other consumer and retry."
+    }
+
+    private func chatDiagnostics(
+        config: TelegramConnectionConfiguration
+    ) -> (configured: [TelegramChatDiagnostic], stored: [TelegramChatDiagnostic]) {
+        let summaries: [AgentChannelStoredRoomSummary] = {
+            guard let messageStore else { return [] }
+            do {
+                try messageStore.openIfNeeded()
+                return try messageStore.roomSummaries(connectionId: Self.connectionId)
+            } catch {
+                return []
+            }
+        }()
+        let summariesByRoom = Dictionary(uniqueKeysWithValues: summaries.map { ($0.roomId, $0) })
+        let formatter = ISO8601DateFormatter()
+
+        let configured = config.configuredChatIds.map {
+            let summary = summariesByRoom[$0]
+            return TelegramChatDiagnostic(
+                id: $0,
+                source: "configuration",
+                readAllowed: config.canRead(chatId: $0),
+                writeAllowed: config.canWrite(chatId: $0),
+                storedMessageCount: summary?.messageCount ?? 0,
+                latestStoredAt: summary?.latestReceivedAt.map { formatter.string(from: $0) }
+            )
+        }
+
+        let stored = summaries.map { summary in
+            TelegramChatDiagnostic(
+                id: summary.roomId,
+                source: "local_message_store",
+                readAllowed: config.canRead(chatId: summary.roomId),
+                writeAllowed: config.canWrite(chatId: summary.roomId),
+                storedMessageCount: summary.messageCount,
+                latestStoredAt: summary.latestReceivedAt.map { formatter.string(from: $0) }
+            )
+        }
+        return (configured, stored)
     }
 
     func messageStoreDiagnostics() -> [String: Any] {
@@ -670,19 +771,28 @@ final class TelegramConnectionService: @unchecked Sendable {
         let config = configuration()
         let chatId = try requireWritableChat(request.chatId, config: config)
         let text = try validateMessageContent(request.text)
-        let message = try await client.sendMessage(
-            chatId: chatId,
-            text: text,
-            replyToMessageId: request.replyToMessageId,
-            token: token
-        )
-        recordMessages([Self.storedMessage(message, roomId: chatId, direction: .outbound)])
-        return [
-            "kind": "telegram_message_sent",
-            "chat_id": chatId,
-            "delivery_status": TelegramDeliveryStatus.sent.rawValue,
-            "message": Self.messageDictionary(message),
-        ]
+        guard await sendGate.begin(chatId: chatId) else {
+            throw TelegramConnectionServiceError.sendBackpressure(chatId)
+        }
+        do {
+            let message = try await client.sendMessage(
+                chatId: chatId,
+                text: text,
+                replyToMessageId: request.replyToMessageId,
+                token: token
+            )
+            await sendGate.finish(chatId: chatId)
+            recordMessages([Self.storedMessage(message, roomId: chatId, direction: .outbound)])
+            return [
+                "kind": "telegram_message_sent",
+                "chat_id": chatId,
+                "delivery_status": TelegramDeliveryStatus.sent.rawValue,
+                "message": Self.messageDictionary(message),
+            ]
+        } catch {
+            await sendGate.finish(chatId: chatId)
+            throw error
+        }
     }
 
     func processWebhookPayload(

--- a/Packages/OsaurusCore/Storage/AgentChannelMessageStore.swift
+++ b/Packages/OsaurusCore/Storage/AgentChannelMessageStore.swift
@@ -81,6 +81,25 @@ public struct AgentChannelStoredMessage: Codable, Sendable, Equatable, Identifia
     }
 }
 
+public struct AgentChannelStoredRoomSummary: Codable, Sendable, Equatable {
+    public let connectionId: String
+    public let roomId: String
+    public let messageCount: Int
+    public let latestReceivedAt: Date?
+
+    public init(
+        connectionId: String,
+        roomId: String,
+        messageCount: Int,
+        latestReceivedAt: Date?
+    ) {
+        self.connectionId = connectionId
+        self.roomId = roomId
+        self.messageCount = messageCount
+        self.latestReceivedAt = latestReceivedAt
+    }
+}
+
 public enum AgentChannelReceiveDisposition: String, Codable, Sendable, Equatable {
     case accepted
     case duplicate
@@ -651,7 +670,7 @@ public final class AgentChannelMessageStore: @unchecked Sendable {
             SELECT \(Self.messageColumns)
             FROM channel_messages
             WHERE connection_id = ?1 AND room_id = ?2
-            ORDER BY received_at DESC
+            ORDER BY received_at DESC, rowid DESC
             LIMIT ?3
             """,
             bind: { stmt in
@@ -687,7 +706,7 @@ public final class AgentChannelMessageStore: @unchecked Sendable {
             SELECT \(Self.messageColumns)
             FROM channel_messages
             \(whereClause)
-            ORDER BY received_at DESC
+            ORDER BY received_at DESC, rowid DESC
             LIMIT ?
             """,
             bind: { stmt in
@@ -754,6 +773,39 @@ public final class AgentChannelMessageStore: @unchecked Sendable {
             }
         )
         return count
+    }
+
+    public func roomSummaries(connectionId: String) throws -> [AgentChannelStoredRoomSummary] {
+        let connection = Self.normalizedId(connectionId)
+        var rows: [AgentChannelStoredRoomSummary] = []
+        try prepareAndExecute(
+            """
+            SELECT connection_id, room_id, COUNT(*), MAX(received_at)
+            FROM channel_messages
+            WHERE connection_id = ?1
+            GROUP BY connection_id, room_id
+            ORDER BY MAX(received_at) DESC
+            """,
+            bind: { stmt in
+                Self.bindText(stmt, index: 1, value: connection)
+            },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    let latest = sqlite3_column_type(stmt, 3) == SQLITE_NULL
+                        ? nil
+                        : Date(timeIntervalSince1970: sqlite3_column_double(stmt, 3))
+                    rows.append(
+                        AgentChannelStoredRoomSummary(
+                            connectionId: Self.columnText(stmt, 0) ?? "",
+                            roomId: Self.columnText(stmt, 1) ?? "",
+                            messageCount: Int(sqlite3_column_int(stmt, 2)),
+                            latestReceivedAt: latest
+                        )
+                    )
+                }
+            }
+        )
+        return rows
     }
 
     @discardableResult
@@ -1104,7 +1156,7 @@ public final class AgentChannelMessageStore: @unchecked Sendable {
                   SELECT rowid
                   FROM channel_messages
                   WHERE connection_id = ?1 AND room_id = ?2
-                  ORDER BY received_at DESC
+                  ORDER BY received_at DESC, rowid DESC
                   LIMIT ?3
               )
             """

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -352,6 +352,25 @@ struct MCPHTTPHandlerTests {
         }
     }
 
+    @Test func stdio_mcp_execution_denies_agent_channel_tools() async throws {
+        for toolName in Self.agentChannelToolNames {
+            let text = try await MCPServerManager.executeToolAsExternalMCP(
+                name: toolName,
+                argumentsJSON: #"{"connection_id":"telegram","room_id":"-100111222333","content":"must not leak"}"#
+            )
+            let envelope = try JSONSerialization.jsonObject(
+                with: Data(text.utf8)
+            ) as? [String: Any]
+
+            #expect(envelope?["ok"] as? Bool == false, "\(toolName) should be denied")
+            #expect(envelope?["tool"] as? String == toolName)
+            #expect(EnvelopeAssertions.failureKind(text) == "rejected")
+            let message = EnvelopeAssertions.failureMessage(text) ?? ""
+            #expect(message.contains("external callers"))
+            #expect(!text.contains("must not leak"))
+        }
+    }
+
     @Test func mcp_call_rejects_disabled_tool() async throws {
         try await DynamicCatalogTestLock.shared.run {
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/Packages/OsaurusCore/Tests/Service/InsightsRedactionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/InsightsRedactionTests.swift
@@ -68,4 +68,38 @@ struct InsightsRedactionTests {
         let scrubbed = InsightsService.redactCredentials(body)
         #expect(scrubbed == body)
     }
+
+    @Test
+    func agentChannelToolArgumentsRedactMessageContent() {
+        let log = ToolCallLog(
+            name: "agent_channel_send_message",
+            arguments: #"{"connection_id":"telegram","room_id":"-100111222333","content":"ship the private incident note","confirm_send":true}"#,
+            result: #"{"message":{"content":"posted private incident note"}}"#
+        )
+
+        #expect(log.arguments.contains(#""room_id":"-100111222333""#))
+        #expect(log.arguments.contains("[REDACTED:AGENT_CHANNEL_MESSAGE_CONTENT]"))
+        #expect(!log.arguments.contains("private incident note"))
+        #expect(log.result == "[REDACTED:AGENT_CHANNEL_TOOL_RESULT]")
+    }
+
+    @Test
+    func agentChannelSearchArgumentsRedactQueryText() {
+        let log = ToolCallLog(
+            name: "agent_channel_search_messages",
+            arguments: #"{"connection_id":"telegram","room_ids":["-100111222333"],"query":"customer token pasted in chat"}"#
+        )
+
+        #expect(log.arguments.contains(#""connection_id":"telegram""#))
+        #expect(log.arguments.contains("[REDACTED:AGENT_CHANNEL_MESSAGE_CONTENT]"))
+        #expect(!log.arguments.contains("customer token"))
+    }
+
+    @Test
+    func nonChannelToolArgumentsRemainUnchanged() {
+        let arguments = #"{"text":"hello"}"#
+        let log = ToolCallLog(name: "echo", arguments: arguments)
+
+        #expect(log.arguments == arguments)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Telegram/TelegramConnectionTests.swift
@@ -530,6 +530,168 @@ struct TelegramConnectionTests {
         }
     }
 
+    @Test func diagnosticsAreReadOnlyAndDoNotAdvanceTelegramReceiveState() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+            try store.upsertCursor(
+                connectionId: "telegram",
+                roomId: "__telegram_updates__",
+                cursor: "77"
+            )
+
+            let token = "123456:telegram-bot-token-super-secret"
+            let fake = FakeTelegramAPIClient()
+            await fake.setWebhookInfo(
+                TelegramWebhookInfo(url: "https://hooks.example.test/telegram/\(token)")
+            )
+            await fake.setUpdates([
+                .fixture(updateId: 77, messageId: 77, chatId: -100111222333, text: "pending")
+            ])
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken(token)
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    senderAllowlist: ["7"],
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: true
+                )
+            )
+
+            let diagnostics = await service.diagnostics()
+            let diagnosticsData = try JSONSerialization.data(withJSONObject: diagnostics.dictionary)
+            let diagnosticsText = String(decoding: diagnosticsData, as: UTF8.self)
+
+            #expect(diagnostics.status == "connected_long_poll_webhook_conflict")
+            #expect(await fake.getMeCallCount() == 1)
+            #expect(await fake.getWebhookInfoCallCount() == 1)
+            #expect(await fake.getUpdatesCallCount() == 0)
+            #expect(await fake.deleteWebhookCallCount() == 0)
+            #expect(await fake.lastUpdateOffset() == nil)
+            #expect(try store.cursor(connectionId: "telegram", roomId: "__telegram_updates__") == "77")
+            #expect(try store.messageCount(connectionId: "telegram") == 0)
+            #expect(!diagnosticsText.contains(token))
+            #expect(!diagnosticsText.contains("pending"))
+        }
+    }
+
+    @Test func diagnosticsReportConfiguredAndStoredDiscoveredChatsWithoutMessageContent() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333"],
+                    writableChatIds: ["-100444555666"],
+                    senderAllowlist: ["7"],
+                    writeEnabled: true,
+                    receiveStorageEnabled: true,
+                    longPollingEnabled: false
+                )
+            )
+            _ = try await service.processUpdates(
+                [.fixture(updateId: 88, messageId: 88, chatId: -100111222333, text: "private stored text")],
+                source: "fixture"
+            )
+
+            let diagnostics = await service.diagnostics()
+            let configured = try #require(diagnostics.dictionary["configured_chats"] as? [[String: Any]])
+            let stored = try #require(diagnostics.dictionary["stored_discovered_chats"] as? [[String: Any]])
+            let diagnosticsData = try JSONSerialization.data(withJSONObject: diagnostics.dictionary)
+            let diagnosticsText = String(decoding: diagnosticsData, as: UTF8.self)
+
+            #expect(diagnostics.dictionary["chat_discovery_source"] as? String == "configuration_and_local_message_store_only")
+            #expect(configured.map { $0["id"] as? String }.contains("-100111222333"))
+            #expect(configured.map { $0["id"] as? String }.contains("-100444555666"))
+            let configuredReadable = try #require(configured.first { $0["id"] as? String == "-100111222333" })
+            #expect(configuredReadable["stored_message_count"] as? Int == 1)
+            let storedRoom = try #require(stored.first { $0["id"] as? String == "-100111222333" })
+            #expect(storedRoom["source"] as? String == "local_message_store")
+            #expect(storedRoom["stored_message_count"] as? Int == 1)
+            #expect(storedRoom["read_allowed"] as? Bool == true)
+            #expect(!diagnosticsText.contains("private stored text"))
+        }
+    }
+
+    @Test func diagnosticsOpenColdMessageStoreBeforeReportingStoredChats() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await withIsolatedTelegramStores { credentials in
+                let previousRoot = OsaurusPaths.overrideRoot
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-telegram-store-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                OsaurusPaths.overrideRoot = root
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                let writer = AgentChannelMessageStore()
+                try writer.open()
+                try writer.recordMessages([
+                    AgentChannelStoredMessage(
+                        connectionId: "telegram",
+                        roomId: "-100111222333",
+                        providerMessageId: "88",
+                        direction: .inbound,
+                        authorId: "7",
+                        authorName: "Mika",
+                        content: "stored text must stay private",
+                        payloadJSON: #"{"message":"stored text must stay private"}"#
+                    )
+                ])
+                writer.close()
+
+                let coldStore = AgentChannelMessageStore()
+                defer { coldStore.close() }
+                let service = TelegramConnectionService(
+                    client: FakeTelegramAPIClient(),
+                    credentialStore: credentials,
+                    messageStore: coldStore,
+                    recordMessageSnapshotsInline: true
+                )
+                try service.saveBotToken("123456:telegram-bot-token-super-secret")
+                try service.saveConfiguration(
+                    TelegramConnectionConfiguration(
+                        readableChatIds: ["-100111222333"],
+                        senderAllowlist: ["7"],
+                        receiveStorageEnabled: true
+                    )
+                )
+
+                let diagnostics = await service.diagnostics()
+                let configured = try #require(diagnostics.dictionary["configured_chats"] as? [[String: Any]])
+                let stored = try #require(diagnostics.dictionary["stored_discovered_chats"] as? [[String: Any]])
+                let configuredRoom = try #require(configured.first { $0["id"] as? String == "-100111222333" })
+                let storedRoom = try #require(stored.first { $0["id"] as? String == "-100111222333" })
+                let diagnosticsData = try JSONSerialization.data(withJSONObject: diagnostics.dictionary)
+                let diagnosticsText = String(decoding: diagnosticsData, as: UTF8.self)
+
+                #expect(coldStore.isOpen)
+                #expect(configuredRoom["stored_message_count"] as? Int == 1)
+                #expect(storedRoom["stored_message_count"] as? Int == 1)
+                #expect(!diagnosticsText.contains("stored text must stay private"))
+            }
+        }
+    }
+
     @Test func diagnosticsOmitEmptyReadsNoteWhenLongPollingEnabled() async throws {
         try await withIsolatedTelegramStores { credentials in
             let fake = FakeTelegramAPIClient()
@@ -1385,6 +1547,80 @@ struct TelegramConnectionTests {
         }
     }
 
+    @Test func processUpdatesPreservesBatchOrderForInterleavedTelegramChats() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let service = TelegramConnectionService(
+                client: FakeTelegramAPIClient(),
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    readableChatIds: ["-100111222333", "-100444555666"],
+                    senderAllowlist: ["7"]
+                )
+            )
+
+            let result = try await service.processUpdates(
+                [
+                    .fixture(updateId: 101, messageId: 1, chatId: -100111222333, text: "a1"),
+                    .fixture(updateId: 102, messageId: 1, chatId: -100444555666, text: "b1"),
+                    .fixture(updateId: 103, messageId: 2, chatId: -100111222333, text: "a2"),
+                    .fixture(updateId: 104, messageId: 2, chatId: -100444555666, text: "b2"),
+                ],
+                source: "fixture"
+            )
+
+            #expect(result.results.map(\.providerEventId) == ["101", "102", "103", "104"])
+            #expect(result.results.map(\.status) == [.accepted, .accepted, .accepted, .accepted])
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 2)
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100444555666") == 2)
+        }
+    }
+
+    @Test func recentTelegramMessagesHaveDeterministicOrderWhenTimestampsTie() async throws {
+        let store = AgentChannelMessageStore()
+        try store.openInMemory()
+        defer { store.close() }
+        let receivedAt = Date(timeIntervalSince1970: 1_800_000_900)
+
+        _ = try store.recordMessages([
+            AgentChannelStoredMessage(
+                connectionId: "telegram",
+                roomId: "-100111222333",
+                providerMessageId: "1",
+                direction: .inbound,
+                authorId: "7",
+                authorName: "Mika",
+                content: "first",
+                receivedAt: receivedAt
+            ),
+            AgentChannelStoredMessage(
+                connectionId: "telegram",
+                roomId: "-100111222333",
+                providerMessageId: "2",
+                direction: .inbound,
+                authorId: "7",
+                authorName: "Mika",
+                content: "second",
+                receivedAt: receivedAt
+            ),
+        ])
+
+        let rows = try store.recentMessages(
+            connectionId: "telegram",
+            roomId: "-100111222333",
+            limit: 2
+        )
+
+        #expect(rows.map(\.providerMessageId) == ["2", "1"])
+    }
+
     @Test func usernameAllowlistStoresAndReadsByConfiguredHandle() async throws {
         try await withIsolatedTelegramStores { credentials in
             let store = AgentChannelMessageStore()
@@ -1514,6 +1750,111 @@ struct TelegramConnectionTests {
             #expect(row.direction == .outbound)
             #expect(row.content == "ship it")
             #expect(!row.payloadJSON.localizedCaseInsensitiveContains("telegram-bot-token-super-secret"))
+        }
+    }
+
+    @Test func sendMessageReportsExplicitBackpressureForConcurrentSameChatSend() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            await fake.delaySends(nanoseconds: 250_000_000)
+            let service = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try service.saveBotToken("123456:telegram-bot-token-super-secret")
+            try service.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    writableChatIds: ["-100111222333"],
+                    writeEnabled: true
+                )
+            )
+
+            let firstSend = Task<Void, Error> {
+                _ = try await service.sendMessage(
+                    TelegramWriteRequest(
+                        chatId: "-100111222333",
+                        text: "first",
+                        replyToMessageId: nil,
+                        confirmSend: true
+                    )
+                )
+            }
+            let firstStarted = await waitForTransportCondition {
+                await fake.sendMessageCallCount() == 1
+            }
+            #expect(firstStarted)
+
+            await #expect(throws: TelegramConnectionServiceError.sendBackpressure("-100111222333")) {
+                _ = try await service.sendMessage(
+                    TelegramWriteRequest(
+                        chatId: "-100111222333",
+                        text: "second",
+                        replyToMessageId: nil,
+                        confirmSend: true
+                    )
+                )
+            }
+
+            try await firstSend.value
+            #expect(await fake.sendMessageCallCount() == 1)
+            #expect(try store.messageCount(connectionId: "telegram", roomId: "-100111222333") == 1)
+        }
+    }
+
+    @Test func agentChannelSendToolReportsTelegramBackpressureAsRetryable() async throws {
+        try await withIsolatedTelegramStores { credentials in
+            let store = AgentChannelMessageStore()
+            try store.openInMemory()
+            defer { store.close() }
+
+            let fake = FakeTelegramAPIClient()
+            await fake.delaySends(nanoseconds: 250_000_000)
+            let telegram = TelegramConnectionService(
+                client: fake,
+                credentialStore: credentials,
+                messageStore: store,
+                recordMessageSnapshotsInline: true
+            )
+            try telegram.saveBotToken("123456:telegram-bot-token-super-secret")
+            try telegram.saveConfiguration(
+                TelegramConnectionConfiguration(
+                    writableChatIds: ["-100111222333"],
+                    writeEnabled: true
+                )
+            )
+            let service = AgentChannelConnectionService(
+                discordService: DiscordConnectionService(
+                    client: FakeDiscordAPIClientForTelegramTests(),
+                    credentialStore: FakeDiscordCredentialStoreForTelegramTests()
+                ),
+                telegramService: telegram
+            )
+            let tool = AgentChannelSendMessageTool(service: service)
+            let firstSend = Task<String, Error> {
+                try await tool.execute(
+                    argumentsJSON:
+                        #"{"connection_id":"telegram","room_id":"-100111222333","content":"first","confirm_send":true}"#
+                )
+            }
+            let firstStarted = await waitForTransportCondition {
+                await fake.sendMessageCallCount() == 1
+            }
+            #expect(firstStarted)
+
+            let result = try await tool.execute(
+                argumentsJSON:
+                    #"{"connection_id":"telegram","room_id":"-100111222333","content":"second","confirm_send":true}"#
+            )
+
+            #expect(EnvelopeAssertions.failureKind(result) == "unavailable")
+            #expect(EnvelopeAssertions.failureRetryable(result) == true)
+            _ = try await firstSend.value
         }
     }
 
@@ -1697,9 +2038,12 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
     private var getUpdatesRateLimit: (message: String, retryAfter: Int?)?
     private var persistentGetUpdatesError: TelegramAPIError?
     private var hangGetUpdates = false
+    private var getMeCalls = 0
     private var getUpdatesCalls = 0
+    private var getWebhookInfoCalls = 0
     private var webhookInfo = TelegramWebhookInfo(url: "")
     private var deleteWebhookCalls = 0
+    private var sendDelayNanoseconds: UInt64 = 0
 
     func setUpdates(_ updates: [TelegramUpdate]) {
         self.updates = updates
@@ -1731,6 +2075,14 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
         getUpdatesCalls
     }
 
+    func getMeCallCount() -> Int {
+        getMeCalls
+    }
+
+    func getWebhookInfoCallCount() -> Int {
+        getWebhookInfoCalls
+    }
+
     func failNextGetMe() {
         getMeFailuresRemaining += 1
     }
@@ -1759,11 +2111,20 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
         sentMessages.last?.text
     }
 
+    func sendMessageCallCount() -> Int {
+        sentMessages.count
+    }
+
+    func delaySends(nanoseconds: UInt64) {
+        sendDelayNanoseconds = nanoseconds
+    }
+
     func lastReplyToMessageId() -> Int? {
         sentMessages.last?.replyToMessageId
     }
 
     func getMe(token: String) async throws -> TelegramUser {
+        getMeCalls += 1
         if getMeFailuresRemaining > 0 {
             getMeFailuresRemaining -= 1
             throw TelegramAPIError.requestFailed("temporary getMe failure")
@@ -1783,7 +2144,8 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
     }
 
     func getWebhookInfo(token: String) async throws -> TelegramWebhookInfo {
-        webhookInfo
+        getWebhookInfoCalls += 1
+        return webhookInfo
     }
 
     func deleteWebhook(token: String) async throws -> Bool {
@@ -1823,6 +2185,9 @@ private actor FakeTelegramAPIClient: TelegramAPIClientProtocol {
         token: String
     ) async throws -> TelegramMessage {
         sentMessages.append((chatId: chatId, text: text, replyToMessageId: replyToMessageId))
+        if sendDelayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: sendDelayNanoseconds)
+        }
         return TelegramMessage.fixture(
             messageId: 800 + sentMessages.count,
             chatId: Int64(chatId) ?? -100111222333,

--- a/Packages/OsaurusCore/Tools/AgentChannelTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentChannelTools.swift
@@ -225,6 +225,13 @@ private extension OsaurusTool {
                 return ToolEnvelope.failure(kind: .invalidArgs, message: error.localizedDescription, tool: tool)
             case .chatNotReadable, .chatNotWritable, .writeDisabled:
                 return ToolEnvelope.failure(kind: .rejected, message: error.localizedDescription, tool: tool)
+            case .sendBackpressure:
+                return ToolEnvelope.failure(
+                    kind: .unavailable,
+                    message: error.localizedDescription,
+                    tool: tool,
+                    retryable: true
+                )
             case .notConfigured, .messageStoreUnavailable:
                 return ToolEnvelope.failure(
                     kind: .unavailable,


### PR DESCRIPTION
## Summary
- Adds read-only Telegram Agent Channel diagnostics for configured and locally stored chats without exposing message bodies.
- Opens the channel message store on demand for diagnostics, reports stored counts/latest timestamps, and keeps configured/stored chat ordering deterministic.
- Redacts Agent Channel send/search arguments and results in request logs.
- Keeps Agent Channel tools out of stdio MCP execution and reports same-chat send backpressure as retryable.

## Validation
- `git diff --check origin/main...HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-pr1-postrebase swift test --package-path Packages/OsaurusCore --filter 'diagnosticsOpenColdMessageStoreBeforeReportingStoredChats|diagnosticsReportConfiguredAndStoredDiscoveredChatsWithoutMessageContent|sendMessageReportsExplicitBackpressureForConcurrentSameChatSend|agentChannelSendToolReportsTelegramBackpressureAsRetryable|stdio_mcp_execution_binds_external_surface|stdio_mcp_execution_denies_agent_channel_tools|agentChannelToolArgumentsRedactMessageContent|agentChannelSearchArgumentsRedactQueryText'`
- `swiftlint lint --strict Packages/OsaurusCore/Models/Chat/RequestLog.swift Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift Packages/OsaurusCore/Storage/AgentChannelMessageStore.swift Packages/OsaurusCore/Tools/AgentChannelTools.swift`

## Notes
- This is diagnostics and safety hardening for the native Telegram Agent Channel path. It does not change bot setup UI or Telegram plugin behavior.
