### PR TITLE
Add guided provider setup and recovery

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -191359,6 +191359,411 @@
           }
         }
       }
+    },
+    "TurboQuant" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "Shell" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shell"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shell"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shell"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Терминал"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shell"
+          }
+        }
+      },
+      "comment" : "Onboarding plugin picker display name for terminal command access."
+    },
+    "See and create events on your Mac." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "See and create events on your Mac."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See and create events on your Mac."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "See and create events on your Mac."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Просматривает и создаёт события на вашем Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "See and create events on your Mac."
+          }
+        }
+      },
+      "comment" : "Onboarding plugin picker blurb for Calendar."
+    },
+    "Make and check off your Reminders." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make and check off your Reminders."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make and check off your Reminders."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make and check off your Reminders."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создаёт напоминания и отмечает их выполненными."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make and check off your Reminders."
+          }
+        }
+      },
+      "comment" : "Onboarding plugin picker blurb for Reminders."
+    },
+    "Send iMessages from your Mac." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Send iMessages from your Mac."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Send iMessages from your Mac."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Send iMessages from your Mac."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправляет сообщения iMessage с вашего Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Send iMessages from your Mac."
+          }
+        }
+      },
+      "comment" : "Onboarding plugin picker blurb for Messages."
+    },
+    "%lld models ready" : {
+      "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%lld Modell bereit"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%lld Modelle bereit"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld model ready"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld models ready"
+                }
+              }
+            }
+          }
+        },
+        "ko" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld개의 모델 준비됨"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld개의 모델 준비됨"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модель готова"
+                }
+              },
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модели готовы"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld моделей готово"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модели готовы"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 个模型已就绪"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 个模型已就绪"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Add manual model IDs if this OpenAI-compatible provider does not expose /models." : {
+      "shouldTranslate" : false
+    },
+    "Authentication rejected" : {
+      "shouldTranslate" : false
+    },
+    "Bad provider response" : {
+      "shouldTranslate" : false
+    },
+    "Check the endpoint certificate, HTTPS setting, and any TLS-intercepting proxy." : {
+      "shouldTranslate" : false
+    },
+    "Check the host, port, base path, DNS, VPN, and whether a local server is running." : {
+      "shouldTranslate" : false
+    },
+    "Confirm the endpoint returns an OpenAI-shaped model list or add manual model IDs." : {
+      "shouldTranslate" : false
+    },
+    "Copy diagnostics and include the redacted request evidence when reporting this issue." : {
+      "shouldTranslate" : false
+    },
+    "Copy diagnostics with the redacted response and check provider status or compatibility." : {
+      "shouldTranslate" : false
+    },
+    "Endpoint unreachable" : {
+      "shouldTranslate" : false
+    },
+    "HTTP %lld authentication rejection. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "HTTP %lld from provider. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "HTTP %lld from the models endpoint. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "HTTP %lld suggests the provider rejected the request shape. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "Invalid proxy" : {
+      "shouldTranslate" : false
+    },
+    "Likely failure" : {
+      "shouldTranslate" : false
+    },
+    "Missing credential" : {
+      "shouldTranslate" : false
+    },
+    "Model unavailable" : {
+      "shouldTranslate" : false
+    },
+    "Models endpoint unavailable" : {
+      "shouldTranslate" : false
+    },
+    "Models response mismatch" : {
+      "shouldTranslate" : false
+    },
+    "No API key or secret credential header is available for this provider." : {
+      "shouldTranslate" : false
+    },
+    "No OAuth tokens are available for this provider." : {
+      "shouldTranslate" : false
+    },
+    "OAuth token missing" : {
+      "shouldTranslate" : false
+    },
+    "Proxy connection failed" : {
+      "shouldTranslate" : false
+    },
+    "Request format rejected" : {
+      "shouldTranslate" : false
+    },
+    "Request timed out" : {
+      "shouldTranslate" : false
+    },
+    "Retry after confirming the endpoint is reachable and not blocked by a firewall or proxy." : {
+      "shouldTranslate" : false
+    },
+    "Review provider compatibility for unsupported request fields, tools, or response formats." : {
+      "shouldTranslate" : false
+    },
+    "Save an API key or secret credential header, then test again." : {
+      "shouldTranslate" : false
+    },
+    "Select a model exposed by this provider or add the correct manual model ID." : {
+      "shouldTranslate" : false
+    },
+    "Sign in again and test after OAuth tokens are saved." : {
+      "shouldTranslate" : false
+    },
+    "Test with the proxy disabled or verify the proxy host, port, and authentication." : {
+      "shouldTranslate" : false
+    },
+    "The models endpoint responded with an unexpected schema. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "The provider endpoint could not be reached. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "The provider rejected the selected model. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "The provider request timed out. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "The provider response did not match the expected schema. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "The request failed while the global proxy was active. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "TLS failure" : {
+      "shouldTranslate" : false
+    },
+    "TLS or certificate validation failed. Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "Unclassified failure" : {
+      "shouldTranslate" : false
+    },
+    "Verify the credential, account access, and provider-specific auth header." : {
+      "shouldTranslate" : false
+    },
+    "%@ Evidence: %@" : {
+      "shouldTranslate" : false
+    },
+    "%lld deployment/model ID(s) are available." : {
+      "shouldTranslate" : false
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -191651,6 +191651,12 @@
     "Check the host, port, base path, DNS, VPN, and whether a local server is running." : {
       "shouldTranslate" : false
     },
+    "Check this provider's model catalog format and try again." : {
+      "shouldTranslate" : false
+    },
+    "Check this provider's model catalog support and try again." : {
+      "shouldTranslate" : false
+    },
     "Confirm the endpoint returns an OpenAI-shaped model list or add manual model IDs." : {
       "shouldTranslate" : false
     },
@@ -191718,6 +191724,9 @@
       "shouldTranslate" : false
     },
     "Save an API key or secret credential header, then test again." : {
+      "shouldTranslate" : false
+    },
+    "Select a model exposed by this provider and try again." : {
       "shouldTranslate" : false
     },
     "Select a model exposed by this provider or add the correct manual model ID." : {

--- a/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
@@ -338,7 +338,8 @@ public enum ProviderConnectivityCenter {
         let severity = diagnostics.rows.map(\.severity).max(by: severityLessThan) ?? .info
         let status = status(for: provider, state: state, highestSeverity: severity)
         let firstActionableRow =
-            diagnostics.rows.first { $0.severity == .blocked }
+            diagnostics.rows.first { $0.id.hasPrefix("failure-") }
+            ?? diagnostics.rows.first { $0.severity == .blocked }
             ?? diagnostics.rows.first { $0.severity == .warning }
         let summaryRow = firstActionableRow ?? diagnostics.rows.first { $0.id == "connection" }
         let issueKinds = actionableIssueKinds(from: diagnostics.rows)

--- a/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
@@ -98,7 +98,10 @@ public struct ProviderConnectivityIssueKind: Sendable, Equatable, Hashable, Iden
     }
 
     public static func kind(forDiagnosticRowID rowID: String) -> ProviderConnectivityIssueKind {
-        knownByRowID[rowID] ?? ProviderConnectivityIssueKind(id: "\(unknownPrefix)\(rowID)")
+        if let failureKind = ProviderFailureClassifier.connectivityIssueKind(forFailureRowID: rowID) {
+            return failureKind
+        }
+        return knownByRowID[rowID] ?? ProviderConnectivityIssueKind(id: "\(unknownPrefix)\(rowID)")
     }
 
     private static let unknownPrefix = "unknown:"

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -57,7 +57,94 @@ struct ProviderFailureClassification: Sendable, Equatable {
     }
 }
 
+struct ProviderSetupFailure: Sendable, Equatable {
+    let classification: ProviderFailureClassification
+    let recoveryDetail: String?
+    let providerType: RemoteProviderType
+    let authType: RemoteProviderAuthType
+    let providerProtocol: RemoteProviderProtocol
+    let usesCustomPort: Bool
+    let hasBasePath: Bool
+    let apiKeyPresent: Bool
+    let oauthTokensPresent: Bool
+    let manualModelCount: Int
+    let proxyState: String
+
+    var userMessage: String {
+        [classification.title, recoveryDetail, classification.action]
+            .compactMap { $0 }
+            .joined(separator: ". ")
+    }
+
+    var pasteboardText: String {
+        [
+            "provider-setup-diagnostics",
+            "failure=\(classification.bucket.rawValue)",
+            "provider-type=\(providerType.rawValue)",
+            "auth-type=\(authType.rawValue)",
+            "scheme=\(providerProtocol.rawValue)",
+            "custom-port=\(usesCustomPort)",
+            "base-path-present=\(hasBasePath)",
+            "api-key-present=\(apiKeyPresent)",
+            "oauth-tokens-present=\(oauthTokensPresent)",
+            "manual-model-count=\(manualModelCount)",
+            "proxy=\(proxyState)",
+            "summary=\(classification.title)",
+            "action=\(classification.action)",
+        ].joined(separator: "\n")
+    }
+}
+
 enum ProviderFailureClassifier {
+    static func classifySetupFailure(
+        provider: RemoteProvider,
+        error: Error,
+        proxy: GlobalProxyDiagnosticState,
+        apiKeyPresent: Bool,
+        oauthTokensPresent: Bool,
+        diagnosticMessage: String? = nil
+    ) -> ProviderSetupFailure {
+        let credentialPresent =
+            apiKeyPresent || oauthTokensPresent || hasCredentialHeader(provider)
+        let missingOAuthTokens =
+            (provider.authType == .openAICodexOAuth || provider.authType == .xaiOAuth)
+            && !oauthTokensPresent
+        let result: ProviderFailureClassification
+        if let replay = (error as? RemoteProviderServiceError)?.replayDiagnostics,
+            let replayClassification = classifyReplay(
+                replay,
+                proxy: proxy,
+                credentialPresent: credentialPresent
+            ) {
+            result = replayClassification
+        } else if missingOAuthTokens {
+            result = classification(
+                .oauthTokenMissing,
+                detail: diagnosticMessage ?? error.localizedDescription
+            )
+        } else {
+            result = classifyMessage(
+                diagnosticMessage ?? error.localizedDescription,
+                proxy: proxy,
+                credentialPresent: credentialPresent
+            )
+        }
+
+        return ProviderSetupFailure(
+            classification: result,
+            recoveryDetail: diagnosticMessage,
+            providerType: provider.providerType,
+            authType: provider.authType,
+            providerProtocol: provider.providerProtocol,
+            usesCustomPort: provider.port != nil,
+            hasBasePath: !provider.basePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            apiKeyPresent: apiKeyPresent,
+            oauthTokensPresent: oauthTokensPresent,
+            manualModelCount: provider.manualModelIds.count,
+            proxyState: setupProxyState(proxy)
+        )
+    }
+
     static func classify(
         provider: RemoteProvider,
         state: RemoteProviderState?,
@@ -417,6 +504,17 @@ enum ProviderFailureClassifier {
                 $0,
                 configuredSecretHeaderKeys: provider.secretHeaderKeys
             )
+        }
+    }
+
+    private static func setupProxyState(_ proxy: GlobalProxyDiagnosticState) -> String {
+        switch proxy {
+        case .disabled:
+            return "disabled"
+        case .active:
+            return "active"
+        case .invalid:
+            return "invalid"
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -168,7 +168,7 @@ enum ProviderFailureClassifier {
         let phase = replay.phase.lowercased()
         let status = response.statusCode
 
-        if status == 401 || status == 403 {
+        if status == 401 {
             return classification(.authRejected, detail: L("HTTP \(status) from provider. Evidence: \(replay.summary)"))
         }
 
@@ -177,8 +177,11 @@ enum ProviderFailureClassifier {
         }
 
         if phase.contains("model") {
-            if status == 404 || status == 405 || status >= 500 {
+            if status == 404 || status == 405 || status == 501 {
                 return classification(.modelsEndpointUnavailable, detail: L("HTTP \(status) from the models endpoint. Evidence: \(replay.summary)"))
+            }
+            if status >= 500 {
+                return classification(.badResponse, detail: L("HTTP \(status) from the models endpoint. Evidence: \(replay.summary)"))
             }
             if status == 200 && bodyLooksLikeSchemaMismatch(body) {
                 return classification(.modelsSchemaMismatch, detail: L("The models endpoint responded with an unexpected schema. Evidence: \(replay.summary)"))
@@ -187,21 +190,20 @@ enum ProviderFailureClassifier {
 
         if body.contains("model_not_found")
             || body.contains("model not found")
-            || body.contains("does not exist")
             || body.contains("unsupported model") {
             return classification(.unsupportedModel, detail: L("The provider rejected the selected model. Evidence: \(replay.summary)"))
         }
 
-        if status == 400 || status == 422 || bodyLooksLikeRequestShapeRejection(body) {
+        if bodyLooksLikeRequestShapeRejection(body) {
             return classification(.requestRejected, detail: L("HTTP \(status) suggests the provider rejected the request shape. Evidence: \(replay.summary)"))
         }
 
-            if bodyLooksLikeSchemaMismatch(body) {
-                if phase.contains("model") {
-                    return classification(.modelsSchemaMismatch, detail: L("The models endpoint responded with an unexpected schema. Evidence: \(replay.summary)"))
-                }
-                return classification(.badResponse, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
+        if bodyLooksLikeSchemaMismatch(body) {
+            if phase.contains("model") {
+                return classification(.modelsSchemaMismatch, detail: L("The models endpoint responded with an unexpected schema. Evidence: \(replay.summary)"))
             }
+            return classification(.badResponse, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
+        }
 
         if status < 200 || status >= 300 {
             return classification(.badResponse, detail: L("HTTP \(status) from provider. Evidence: \(replay.summary)"))
@@ -223,7 +225,7 @@ enum ProviderFailureClassifier {
         if case .active = proxy, lower.contains("proxy") {
             return classification(.proxyConnectFailed, detail: detail)
         }
-        if lower.contains("http 401") || lower.contains("http 403") || lower.contains("unauthorized") {
+        if lower.contains("http 401") {
             return classification(.authRejected, detail: detail)
         }
         if bodyLooksLikeAuthRejection(lower) {
@@ -232,7 +234,7 @@ enum ProviderFailureClassifier {
         if lower.contains("oauth") && (lower.contains("token") || lower.contains("sign-in")) {
             return classification(.oauthTokenMissing, detail: detail)
         }
-        if lower.contains("api key") || lower.contains("apikey") || lower.contains("authorization") {
+        if lower.contains("api key") || lower.contains("apikey") {
             if credentialPresent {
                 return classification(.authRejected, detail: detail)
             }
@@ -256,16 +258,17 @@ enum ProviderFailureClassifier {
         if lower.contains("no models available") {
             return classification(.modelsSchemaMismatch, detail: detail)
         }
-        if lower.contains("invalid /models response") || lower.contains("invalid response") {
+        if lower.contains("invalid /models response") {
             return classification(.modelsSchemaMismatch, detail: detail)
         }
         if lower.contains("http 404") || lower.contains("http 405") {
             return classification(.modelsEndpointUnavailable, detail: detail)
         }
-        if lower.contains("http 400")
-            || lower.contains("http 422")
-            || bodyLooksLikeRequestShapeRejection(lower) {
+        if bodyLooksLikeRequestShapeRejection(lower) {
             return classification(.requestRejected, detail: detail)
+        }
+        if lower.contains("invalid response") {
+            return classification(.badResponse, detail: detail)
         }
 
         return classification(.unknown, detail: detail)
@@ -391,6 +394,7 @@ enum ProviderFailureClassifier {
     private static func bodyLooksLikeAuthRejection(_ body: String) -> Bool {
         body.contains("invalid_api_key")
             || body.contains("invalid api key")
+            || body.contains("incorrect api key")
             || body.contains("invalid authorization")
             || body.contains("authentication failed")
             || body.contains("auth failed")

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -1,0 +1,394 @@
+//
+//  ProviderFailureClassification.swift
+//  OsaurusCore
+//
+//  Pure, post-hoc classification for remote provider failures. This uses only
+//  existing state, replay evidence, and proxy diagnostics.
+//
+
+import Foundation
+
+enum ProviderFailureBucket: String, Sendable, Equatable, CaseIterable {
+    case missingCredential = "missing-credential"
+    case oauthTokenMissing = "oauth-token-missing"
+    case authRejected = "auth-rejected"
+    case endpointUnreachable = "endpoint-unreachable"
+    case tlsFailure = "tls-failure"
+    case timeout
+    case proxyConnectFailed = "proxy-connect-failed"
+    case modelsEndpointUnavailable = "models-endpoint-unavailable"
+    case modelsSchemaMismatch = "models-schema-mismatch"
+    case requestRejected = "request-rejected"
+    case unsupportedModel = "unsupported-model"
+    case badResponse = "bad-response"
+    case unknown
+}
+
+struct ProviderFailureClassification: Sendable, Equatable {
+    let bucket: ProviderFailureBucket
+    let title: String
+    let detail: String
+    let action: String
+    let severity: ProviderDiagnosticSeverity
+
+    var rowID: String {
+        switch bucket {
+        case .missingCredential, .authRejected:
+            return "failure-auth"
+        case .oauthTokenMissing:
+            return "failure-oauth"
+        case .endpointUnreachable:
+            return "failure-connection"
+        case .tlsFailure:
+            return "failure-tls"
+        case .timeout:
+            return "failure-timeout"
+        case .proxyConnectFailed:
+            return "failure-proxy"
+        case .modelsEndpointUnavailable, .modelsSchemaMismatch, .unsupportedModel:
+            return "failure-models"
+        case .requestRejected:
+            return "failure-format"
+        case .badResponse:
+            return "failure-response"
+        case .unknown:
+            return "failure-unknown"
+        }
+    }
+}
+
+enum ProviderFailureClassifier {
+    static func classify(
+        provider: RemoteProvider,
+        state: RemoteProviderState?,
+        proxy: GlobalProxyDiagnosticState,
+        apiKeyPresent: Bool,
+        oauthTokensPresent: Bool
+    ) -> ProviderFailureClassification? {
+        guard provider.enabled else { return nil }
+        if state?.isConnected == true {
+            return nil
+        }
+
+        guard hasActiveFailure(state) else { return nil }
+
+        switch provider.authType {
+        case .apiKey:
+            if !apiKeyPresent && !hasCredentialHeader(provider) {
+                return classification(
+                    .missingCredential,
+                    detail: L("No API key or secret credential header is available for this provider.")
+                )
+            }
+        case .openAICodexOAuth, .xaiOAuth:
+            if !oauthTokensPresent {
+                return classification(
+                    .oauthTokenMissing,
+                    detail: L("No OAuth tokens are available for this provider.")
+                )
+            }
+        case .none:
+            break
+        }
+
+        if let replay = state?.lastReplayDiagnostics,
+           let replayClassification = classifyReplay(replay, proxy: proxy) {
+            return replayClassification
+        }
+
+        if let error = state?.lastError, !error.isEmpty {
+            return classifyMessage(error, proxy: proxy)
+        }
+
+        return nil
+    }
+
+    static func connectivityIssueKind(forFailureRowID rowID: String) -> ProviderConnectivityIssueKind? {
+        switch rowID {
+        case "failure-auth":
+            return .authentication
+        case "failure-oauth":
+            return .oauthContext
+        case "failure-models":
+            return .models
+        case "failure-format":
+            return .format
+        case "failure-proxy":
+            return .proxy
+        case "failure-unknown":
+            return .uncategorized
+        case "failure-connection", "failure-tls", "failure-timeout", "failure-response":
+            return .connection
+        default:
+            return nil
+        }
+    }
+
+    private static func classifyReplay(
+        _ replay: ProviderReplayDiagnosticBundle,
+        proxy: GlobalProxyDiagnosticState
+    ) -> ProviderFailureClassification? {
+        if case .active = proxy,
+           let transportError = replay.transportError?.lowercased(),
+           transportError.contains("proxy") {
+            return classification(
+                .proxyConnectFailed,
+                detail: L("The request failed while the global proxy was active. Evidence: \(replay.summary)")
+            )
+        }
+
+        if let code = replay.transportErrorCode,
+           let transportClassification = classifyTransportErrorCode(code, summary: replay.summary) {
+            return transportClassification
+        }
+
+        if let transportError = replay.transportError, !transportError.isEmpty {
+            return classifyMessage(transportError, proxy: proxy, evidence: replay.summary)
+        }
+
+        guard let response = replay.response else { return nil }
+        let body = response.body?.lowercased() ?? ""
+        let phase = replay.phase.lowercased()
+        let status = response.statusCode
+
+        if status == 401 || status == 403 {
+            return classification(.authRejected, detail: L("HTTP \(status) from provider. Evidence: \(replay.summary)"))
+        }
+
+        if bodyLooksLikeAuthRejection(body) {
+            return classification(.authRejected, detail: L("HTTP \(status) authentication rejection. Evidence: \(replay.summary)"))
+        }
+
+        if phase.contains("model") {
+            if status == 404 || status == 405 || status >= 500 {
+                return classification(.modelsEndpointUnavailable, detail: L("HTTP \(status) from the models endpoint. Evidence: \(replay.summary)"))
+            }
+            if status == 200 && bodyLooksLikeSchemaMismatch(body) {
+                return classification(.modelsSchemaMismatch, detail: L("The models endpoint responded with an unexpected schema. Evidence: \(replay.summary)"))
+            }
+        }
+
+        if body.contains("model_not_found")
+            || body.contains("model not found")
+            || body.contains("does not exist")
+            || body.contains("unsupported model") {
+            return classification(.unsupportedModel, detail: L("The provider rejected the selected model. Evidence: \(replay.summary)"))
+        }
+
+        if status == 400 || status == 422 || bodyLooksLikeRequestShapeRejection(body) {
+            return classification(.requestRejected, detail: L("HTTP \(status) suggests the provider rejected the request shape. Evidence: \(replay.summary)"))
+        }
+
+        if bodyLooksLikeSchemaMismatch(body) {
+            return classification(.modelsSchemaMismatch, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
+        }
+
+        if status < 200 || status >= 300 {
+            return classification(.badResponse, detail: L("HTTP \(status) from provider. Evidence: \(replay.summary)"))
+        }
+
+        return nil
+    }
+
+    private static func classifyMessage(
+        _ message: String,
+        proxy: GlobalProxyDiagnosticState,
+        evidence: String? = nil
+    ) -> ProviderFailureClassification {
+        let safeMessage = ProviderDiagnosticRedactor.safe(message, maxLength: 240)
+        let lower = safeMessage.lowercased()
+        let detail = evidence.map { L("\(safeMessage) Evidence: \($0)") } ?? safeMessage
+
+        if case .active = proxy, lower.contains("proxy") {
+            return classification(.proxyConnectFailed, detail: detail)
+        }
+        if lower.contains("http 401") || lower.contains("http 403") || lower.contains("unauthorized") {
+            return classification(.authRejected, detail: detail)
+        }
+        if bodyLooksLikeAuthRejection(lower) {
+            return classification(.authRejected, detail: detail)
+        }
+        if lower.contains("oauth") && (lower.contains("token") || lower.contains("sign-in")) {
+            return classification(.oauthTokenMissing, detail: detail)
+        }
+        if lower.contains("api key") || lower.contains("apikey") || lower.contains("authorization") {
+            return classification(.missingCredential, detail: detail)
+        }
+        if lower.contains("timed out") || lower.contains("timeout") {
+            return classification(.timeout, detail: detail)
+        }
+        if lower.contains("tls") || lower.contains("ssl") || lower.contains("certificate") {
+            return classification(.tlsFailure, detail: detail)
+        }
+        if lower.contains("could not find host")
+            || lower.contains("cannot find host")
+            || lower.contains("could not connect")
+            || lower.contains("cannot connect")
+            || lower.contains("dns")
+            || lower.contains("offline")
+            || lower.contains("not connected to the internet") {
+            return classification(.endpointUnreachable, detail: detail)
+        }
+        if lower.contains("no models available") {
+            return classification(.modelsSchemaMismatch, detail: detail)
+        }
+        if lower.contains("invalid /models response") || lower.contains("invalid response") {
+            return classification(.modelsSchemaMismatch, detail: detail)
+        }
+        if lower.contains("http 404") || lower.contains("http 405") {
+            return classification(.modelsEndpointUnavailable, detail: detail)
+        }
+        if lower.contains("http 400")
+            || lower.contains("http 422")
+            || bodyLooksLikeRequestShapeRejection(lower) {
+            return classification(.requestRejected, detail: detail)
+        }
+
+        return classification(.unknown, detail: detail)
+    }
+
+    private static func classifyTransportErrorCode(
+        _ code: String,
+        summary: String
+    ) -> ProviderFailureClassification? {
+        switch code {
+        case "NSURLErrorDomain:-1001", "URLError:-1001":
+            return classification(.timeout, detail: L("The provider request timed out. Evidence: \(summary)"))
+        case "NSURLErrorDomain:-1003", "URLError:-1003",
+             "NSURLErrorDomain:-1004", "URLError:-1004",
+             "NSURLErrorDomain:-1005", "URLError:-1005",
+             "NSURLErrorDomain:-1009", "URLError:-1009":
+            return classification(.endpointUnreachable, detail: L("The provider endpoint could not be reached. Evidence: \(summary)"))
+        case "NSURLErrorDomain:-1200", "URLError:-1200",
+             "NSURLErrorDomain:-1202", "URLError:-1202",
+             "NSURLErrorDomain:-1203", "URLError:-1203",
+             "NSURLErrorDomain:-1204", "URLError:-1204",
+             "NSURLErrorDomain:-1205", "URLError:-1205",
+             "NSURLErrorDomain:-1206", "URLError:-1206":
+            return classification(.tlsFailure, detail: L("TLS or certificate validation failed. Evidence: \(summary)"))
+        default:
+            return nil
+        }
+    }
+
+    private static func classification(
+        _ bucket: ProviderFailureBucket,
+        detail: String
+    ) -> ProviderFailureClassification {
+        ProviderFailureClassification(
+            bucket: bucket,
+            title: title(for: bucket),
+            detail: ProviderDiagnosticRedactor.safe(detail, maxLength: 360),
+            action: action(for: bucket),
+            severity: bucket == .unknown ? .warning : .blocked
+        )
+    }
+
+    private static func title(for bucket: ProviderFailureBucket) -> String {
+        switch bucket {
+        case .missingCredential:
+            return L("Missing credential")
+        case .oauthTokenMissing:
+            return L("OAuth token missing")
+        case .authRejected:
+            return L("Authentication rejected")
+        case .endpointUnreachable:
+            return L("Endpoint unreachable")
+        case .tlsFailure:
+            return L("TLS failure")
+        case .timeout:
+            return L("Request timed out")
+        case .proxyConnectFailed:
+            return L("Proxy connection failed")
+        case .modelsEndpointUnavailable:
+            return L("Models endpoint unavailable")
+        case .modelsSchemaMismatch:
+            return L("Models response mismatch")
+        case .requestRejected:
+            return L("Request format rejected")
+        case .unsupportedModel:
+            return L("Model unavailable")
+        case .badResponse:
+            return L("Bad provider response")
+        case .unknown:
+            return L("Unclassified failure")
+        }
+    }
+
+    private static func action(for bucket: ProviderFailureBucket) -> String {
+        switch bucket {
+        case .missingCredential:
+            return L("Save an API key or secret credential header, then test again.")
+        case .oauthTokenMissing:
+            return L("Sign in again and test after OAuth tokens are saved.")
+        case .authRejected:
+            return L("Verify the credential, account access, and provider-specific auth header.")
+        case .endpointUnreachable:
+            return L("Check the host, port, base path, DNS, VPN, and whether a local server is running.")
+        case .tlsFailure:
+            return L("Check the endpoint certificate, HTTPS setting, and any TLS-intercepting proxy.")
+        case .timeout:
+            return L("Retry after confirming the endpoint is reachable and not blocked by a firewall or proxy.")
+        case .proxyConnectFailed:
+            return L("Test with the proxy disabled or verify the proxy host, port, and authentication.")
+        case .modelsEndpointUnavailable:
+            return L("Add manual model IDs if this OpenAI-compatible provider does not expose /models.")
+        case .modelsSchemaMismatch:
+            return L("Confirm the endpoint returns an OpenAI-shaped model list or add manual model IDs.")
+        case .requestRejected:
+            return L("Review provider compatibility for unsupported request fields, tools, or response formats.")
+        case .unsupportedModel:
+            return L("Select a model exposed by this provider or add the correct manual model ID.")
+        case .badResponse:
+            return L("Copy diagnostics with the redacted response and check provider status or compatibility.")
+        case .unknown:
+            return L("Copy diagnostics and include the redacted request evidence when reporting this issue.")
+        }
+    }
+
+    private static func bodyLooksLikeRequestShapeRejection(_ body: String) -> Bool {
+        body.contains("invalid request")
+            || body.contains("invalid_request")
+            || body.contains("unknown parameter")
+            || body.contains("unsupported parameter")
+            || body.contains("unsupported field")
+            || body.contains("tool_choice")
+            || body.contains("response_format")
+            || body.contains("json_schema")
+    }
+
+    private static func bodyLooksLikeSchemaMismatch(_ body: String) -> Bool {
+        body.contains("schema")
+            || body.contains("decode")
+            || body.contains("not valid json")
+            || body.contains("invalid json")
+    }
+
+    private static func bodyLooksLikeAuthRejection(_ body: String) -> Bool {
+        body.contains("invalid_api_key")
+            || body.contains("invalid api key")
+            || body.contains("invalid authorization")
+            || body.contains("authentication failed")
+            || body.contains("auth failed")
+            || body.contains("bad api key")
+            || body.contains("bad token")
+            || body.contains("invalid token")
+            || body.contains("expired token")
+            || body.contains("token expired")
+    }
+
+    private static func hasActiveFailure(_ state: RemoteProviderState?) -> Bool {
+        guard let state else { return false }
+        return state.lastError?.isEmpty == false || state.lastReplayDiagnostics != nil
+    }
+
+    private static func hasCredentialHeader(_ provider: RemoteProvider) -> Bool {
+        let names = Array(provider.customHeaders.keys) + provider.secretHeaderKeys
+        return names.contains {
+            RemoteProviderHeaderRedactor.isSensitiveHeader(
+                $0,
+                configuredSecretHeaderKeys: provider.secretHeaderKeys
+            )
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -60,6 +60,7 @@ struct ProviderFailureClassification: Sendable, Equatable {
 struct ProviderSetupFailure: Sendable, Equatable {
     let classification: ProviderFailureClassification
     let recoveryDetail: String?
+    let pasteboardDetail: String
     let providerType: RemoteProviderType
     let authType: RemoteProviderAuthType
     let providerProtocol: RemoteProviderProtocol
@@ -76,6 +77,11 @@ struct ProviderSetupFailure: Sendable, Equatable {
             .joined(separator: ". ")
     }
 
+    var detailForDisplay: String {
+        guard let recoveryDetail, !recoveryDetail.isEmpty else { return classification.detail }
+        return recoveryDetail
+    }
+
     var pasteboardText: String {
         [
             "provider-setup-diagnostics",
@@ -90,6 +96,7 @@ struct ProviderSetupFailure: Sendable, Equatable {
             "manual-model-count=\(manualModelCount)",
             "proxy=\(proxyState)",
             "summary=\(classification.title)",
+            "detail=\(pasteboardDetail)",
             "action=\(classification.action)",
         ].joined(separator: "\n")
     }
@@ -104,17 +111,18 @@ enum ProviderFailureClassifier {
         oauthTokensPresent: Bool,
         diagnosticMessage: String? = nil
     ) -> ProviderSetupFailure {
+        let oauthContext = usesOAuthTokens(provider.authType)
         let credentialPresent =
             apiKeyPresent || oauthTokensPresent || hasCredentialHeader(provider)
-        let missingOAuthTokens =
-            (provider.authType == .openAICodexOAuth || provider.authType == .xaiOAuth)
-            && !oauthTokensPresent
+        let missingOAuthTokens = oauthContext && !oauthTokensPresent
+        let replay = (error as? RemoteProviderServiceError)?.replayDiagnostics
         let result: ProviderFailureClassification
-        if let replay = (error as? RemoteProviderServiceError)?.replayDiagnostics,
+        if let replay,
             let replayClassification = classifyReplay(
                 replay,
                 proxy: proxy,
-                credentialPresent: credentialPresent
+                credentialPresent: credentialPresent,
+                oauthContext: oauthContext
             ) {
             result = replayClassification
         } else if missingOAuthTokens {
@@ -126,13 +134,15 @@ enum ProviderFailureClassifier {
             result = classifyMessage(
                 diagnosticMessage ?? error.localizedDescription,
                 proxy: proxy,
-                credentialPresent: credentialPresent
+                credentialPresent: credentialPresent,
+                oauthContext: oauthContext
             )
         }
 
         return ProviderSetupFailure(
             classification: result,
             recoveryDetail: diagnosticMessage,
+            pasteboardDetail: setupPasteboardDetail(classification: result, replay: replay),
             providerType: provider.providerType,
             authType: provider.authType,
             providerProtocol: provider.providerProtocol,
@@ -183,7 +193,8 @@ enum ProviderFailureClassifier {
             if let replayClassification = classifyReplay(
                 replay,
                 proxy: proxy,
-                credentialPresent: credentialPresent
+                credentialPresent: credentialPresent,
+                oauthContext: usesOAuthTokens(provider.authType)
             ) {
                 return replayClassification
             }
@@ -194,7 +205,8 @@ enum ProviderFailureClassifier {
             return classifyMessage(
                 error,
                 proxy: proxy,
-                credentialPresent: credentialPresent
+                credentialPresent: credentialPresent,
+                oauthContext: usesOAuthTokens(provider.authType)
             )
         }
 
@@ -225,7 +237,8 @@ enum ProviderFailureClassifier {
     private static func classifyReplay(
         _ replay: ProviderReplayDiagnosticBundle,
         proxy: GlobalProxyDiagnosticState,
-        credentialPresent: Bool
+        credentialPresent: Bool,
+        oauthContext: Bool
     ) -> ProviderFailureClassification? {
         if case .active = proxy,
            let transportError = replay.transportError?.lowercased(),
@@ -246,6 +259,7 @@ enum ProviderFailureClassifier {
                 transportError,
                 proxy: proxy,
                 credentialPresent: credentialPresent,
+                oauthContext: oauthContext,
                 evidence: replay.summary
             )
         }
@@ -254,6 +268,10 @@ enum ProviderFailureClassifier {
         let body = response.body?.lowercased() ?? ""
         let phase = replay.phase.lowercased()
         let status = response.statusCode
+
+        if oauthContext && messageLooksLikeOAuthTokenFailure(body) {
+            return classification(.oauthTokenMissing, detail: L("HTTP \(status) authentication rejection. Evidence: \(replay.summary)"))
+        }
 
         if status == 401 {
             return classification(.authRejected, detail: L("HTTP \(status) from provider. Evidence: \(replay.summary)"))
@@ -303,6 +321,7 @@ enum ProviderFailureClassifier {
         _ message: String,
         proxy: GlobalProxyDiagnosticState,
         credentialPresent: Bool = false,
+        oauthContext: Bool = false,
         evidence: String? = nil
     ) -> ProviderFailureClassification {
         let safeMessage = ProviderDiagnosticRedactor.safe(message, maxLength: 240)
@@ -312,14 +331,14 @@ enum ProviderFailureClassifier {
         if case .active = proxy, lower.contains("proxy") {
             return classification(.proxyConnectFailed, detail: detail)
         }
+        if oauthContext && messageLooksLikeOAuthTokenFailure(lower) {
+            return classification(.oauthTokenMissing, detail: detail)
+        }
         if lower.contains("http 401") {
             return classification(.authRejected, detail: detail)
         }
         if bodyLooksLikeAuthRejection(lower) {
             return classification(.authRejected, detail: detail)
-        }
-        if lower.contains("oauth") && (lower.contains("token") || lower.contains("sign-in")) {
-            return classification(.oauthTokenMissing, detail: detail)
         }
         if lower.contains("api key") || lower.contains("apikey") {
             if credentialPresent {
@@ -349,7 +368,10 @@ enum ProviderFailureClassifier {
             return classification(.modelsSchemaMismatch, detail: detail)
         }
         if lower.contains("http 404") || lower.contains("http 405") {
-            return classification(.modelsEndpointUnavailable, detail: detail)
+            let bucket: ProviderFailureBucket = messageHasModelDiscoveryContext(lower)
+                ? .modelsEndpointUnavailable
+                : .badResponse
+            return classification(bucket, detail: detail)
         }
         if bodyLooksLikeRequestShapeRejection(lower) {
             return classification(.requestRejected, detail: detail)
@@ -396,6 +418,29 @@ enum ProviderFailureClassifier {
             action: action(for: bucket),
             severity: bucket == .unknown ? .warning : .blocked
         )
+    }
+
+    private static func setupPasteboardDetail(
+        classification: ProviderFailureClassification,
+        replay: ProviderReplayDiagnosticBundle?
+    ) -> String {
+        let detail: String
+        if let replay {
+            var evidence = [
+                classification.title,
+                "method=\(replay.request.method)",
+                "endpoint=[redacted-endpoint]",
+            ]
+            if let statusCode = replay.response?.statusCode {
+                evidence.append("status=\(statusCode)")
+            } else if let transportErrorCode = replay.transportErrorCode {
+                evidence.append("transport-error-code=\(transportErrorCode)")
+            }
+            detail = evidence.joined(separator: "; ")
+        } else {
+            detail = classification.detail
+        }
+        return ProviderDiagnosticRedactor.safeForSetupCopy(detail, maxLength: 360)
     }
 
     private static func title(for bucket: ProviderFailureBucket) -> String {
@@ -490,6 +535,39 @@ enum ProviderFailureClassifier {
             || body.contains("invalid token")
             || body.contains("expired token")
             || body.contains("token expired")
+    }
+
+    private static func messageLooksLikeOAuthTokenFailure(_ message: String) -> Bool {
+        let explicitOAuthFailure = message.contains("oauth")
+            && (message.contains("token")
+                || message.contains("sign-in")
+                || message.contains("sign in")
+                || message.contains("reauthorize")
+                || message.contains("re-authorize"))
+        return explicitOAuthFailure
+            || message.contains("expired token")
+            || message.contains("token expired")
+            || message.contains("invalid token")
+            || message.contains("token invalid")
+            || message.contains("revoked token")
+            || message.contains("token revoked")
+            || message.contains("session expired")
+            || message.contains("expired session")
+            || message.contains("invalid_grant")
+            || message.contains("invalid grant")
+            || message.contains("unauthorized_client")
+    }
+
+    private static func messageHasModelDiscoveryContext(_ message: String) -> Bool {
+        message.contains("/models")
+            || message.contains("models endpoint")
+            || message.contains("model discovery")
+            || message.contains("model list")
+            || message.contains("list models")
+    }
+
+    private static func usesOAuthTokens(_ authType: RemoteProviderAuthType) -> Bool {
+        authType == .openAICodexOAuth || authType == .xaiOAuth
     }
 
     private static func hasActiveFailure(_ state: RemoteProviderState?) -> Bool {

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -91,13 +91,24 @@ enum ProviderFailureClassifier {
             break
         }
 
-        if let replay = state?.lastReplayDiagnostics,
-           let replayClassification = classifyReplay(replay, proxy: proxy) {
-            return replayClassification
+        if let replay = state?.lastReplayDiagnostics {
+            let credentialPresent = apiKeyPresent || oauthTokensPresent || hasCredentialHeader(provider)
+            if let replayClassification = classifyReplay(
+                replay,
+                proxy: proxy,
+                credentialPresent: credentialPresent
+            ) {
+                return replayClassification
+            }
         }
 
         if let error = state?.lastError, !error.isEmpty {
-            return classifyMessage(error, proxy: proxy)
+            let credentialPresent = apiKeyPresent || oauthTokensPresent || hasCredentialHeader(provider)
+            return classifyMessage(
+                error,
+                proxy: proxy,
+                credentialPresent: credentialPresent
+            )
         }
 
         return nil
@@ -126,7 +137,8 @@ enum ProviderFailureClassifier {
 
     private static func classifyReplay(
         _ replay: ProviderReplayDiagnosticBundle,
-        proxy: GlobalProxyDiagnosticState
+        proxy: GlobalProxyDiagnosticState,
+        credentialPresent: Bool
     ) -> ProviderFailureClassification? {
         if case .active = proxy,
            let transportError = replay.transportError?.lowercased(),
@@ -143,7 +155,12 @@ enum ProviderFailureClassifier {
         }
 
         if let transportError = replay.transportError, !transportError.isEmpty {
-            return classifyMessage(transportError, proxy: proxy, evidence: replay.summary)
+            return classifyMessage(
+                transportError,
+                proxy: proxy,
+                credentialPresent: credentialPresent,
+                evidence: replay.summary
+            )
         }
 
         guard let response = replay.response else { return nil }
@@ -193,6 +210,7 @@ enum ProviderFailureClassifier {
     private static func classifyMessage(
         _ message: String,
         proxy: GlobalProxyDiagnosticState,
+        credentialPresent: Bool = false,
         evidence: String? = nil
     ) -> ProviderFailureClassification {
         let safeMessage = ProviderDiagnosticRedactor.safe(message, maxLength: 240)

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -102,6 +102,15 @@ struct ProviderSetupFailure: Sendable, Equatable {
     }
 }
 
+/// Manual model recovery must describe a control the current surface actually
+/// exposes. Provider type is checked separately so native APIs never inherit an
+/// OpenAI-compatible workaround from an overly broad caller.
+enum ProviderManualModelRecovery: Sendable, Equatable {
+    case unavailable
+    case openAICompatibleModelIDs
+    case azureDeploymentIDs
+}
+
 enum ProviderFailureClassifier {
     static func classifySetupFailure(
         provider: RemoteProvider,
@@ -109,8 +118,12 @@ enum ProviderFailureClassifier {
         proxy: GlobalProxyDiagnosticState,
         apiKeyPresent: Bool,
         oauthTokensPresent: Bool,
-        diagnosticMessage: String? = nil
+        diagnosticMessage: String? = nil,
+        manualModelRecovery: ProviderManualModelRecovery = .unavailable
     ) -> ProviderSetupFailure {
+        let safeDiagnosticMessage = diagnosticMessage.map {
+            ProviderDiagnosticRedactor.safe($0, maxLength: 360)
+        }
         let oauthContext = usesOAuthTokens(provider.authType)
         let credentialPresent =
             apiKeyPresent || oauthTokensPresent || hasCredentialHeader(provider)
@@ -128,21 +141,26 @@ enum ProviderFailureClassifier {
         } else if missingOAuthTokens {
             result = classification(
                 .oauthTokenMissing,
-                detail: diagnosticMessage ?? error.localizedDescription
+                detail: safeDiagnosticMessage ?? error.localizedDescription
             )
         } else {
             result = classifyMessage(
-                diagnosticMessage ?? error.localizedDescription,
+                safeDiagnosticMessage ?? error.localizedDescription,
                 proxy: proxy,
                 credentialPresent: credentialPresent,
                 oauthContext: oauthContext
             )
         }
+        let contextualizedResult = applyingRecoveryContext(
+            to: result,
+            providerType: provider.providerType,
+            manualModelRecovery: manualModelRecovery
+        )
 
         return ProviderSetupFailure(
-            classification: result,
-            recoveryDetail: diagnosticMessage,
-            pasteboardDetail: setupPasteboardDetail(classification: result, replay: replay),
+            classification: contextualizedResult,
+            recoveryDetail: safeDiagnosticMessage,
+            pasteboardDetail: setupPasteboardDetail(classification: contextualizedResult, replay: replay),
             providerType: provider.providerType,
             authType: provider.authType,
             providerProtocol: provider.providerProtocol,
@@ -160,7 +178,8 @@ enum ProviderFailureClassifier {
         state: RemoteProviderState?,
         proxy: GlobalProxyDiagnosticState,
         apiKeyPresent: Bool,
-        oauthTokensPresent: Bool
+        oauthTokensPresent: Bool,
+        manualModelRecovery: ProviderManualModelRecovery = .unavailable
     ) -> ProviderFailureClassification? {
         guard provider.enabled else { return nil }
         if state?.isConnected == true {
@@ -172,16 +191,24 @@ enum ProviderFailureClassifier {
         switch provider.authType {
         case .apiKey:
             if !apiKeyPresent && !hasCredentialHeader(provider) {
-                return classification(
-                    .missingCredential,
-                    detail: L("No API key or secret credential header is available for this provider.")
+                return applyingRecoveryContext(
+                    to: classification(
+                        .missingCredential,
+                        detail: L("No API key or secret credential header is available for this provider.")
+                    ),
+                    providerType: provider.providerType,
+                    manualModelRecovery: manualModelRecovery
                 )
             }
         case .openAICodexOAuth, .xaiOAuth:
             if !oauthTokensPresent {
-                return classification(
-                    .oauthTokenMissing,
-                    detail: L("No OAuth tokens are available for this provider.")
+                return applyingRecoveryContext(
+                    to: classification(
+                        .oauthTokenMissing,
+                        detail: L("No OAuth tokens are available for this provider.")
+                    ),
+                    providerType: provider.providerType,
+                    manualModelRecovery: manualModelRecovery
                 )
             }
         case .none:
@@ -196,17 +223,25 @@ enum ProviderFailureClassifier {
                 credentialPresent: credentialPresent,
                 oauthContext: usesOAuthTokens(provider.authType)
             ) {
-                return replayClassification
+                return applyingRecoveryContext(
+                    to: replayClassification,
+                    providerType: provider.providerType,
+                    manualModelRecovery: manualModelRecovery
+                )
             }
         }
 
         if let error = state?.lastError, !error.isEmpty {
             let credentialPresent = apiKeyPresent || oauthTokensPresent || hasCredentialHeader(provider)
-            return classifyMessage(
-                error,
-                proxy: proxy,
-                credentialPresent: credentialPresent,
-                oauthContext: usesOAuthTokens(provider.authType)
+            return applyingRecoveryContext(
+                to: classifyMessage(
+                    error,
+                    proxy: proxy,
+                    credentialPresent: credentialPresent,
+                    oauthContext: usesOAuthTokens(provider.authType)
+                ),
+                providerType: provider.providerType,
+                manualModelRecovery: manualModelRecovery
             )
         }
 
@@ -367,7 +402,7 @@ enum ProviderFailureClassifier {
         if lower.contains("invalid /models response") {
             return classification(.modelsSchemaMismatch, detail: detail)
         }
-        if lower.contains("http 404") || lower.contains("http 405") {
+        if lower.contains("http 404") || lower.contains("http 405") || lower.contains("http 501") {
             let bucket: ProviderFailureBucket = messageHasModelDiscoveryContext(lower)
                 ? .modelsEndpointUnavailable
                 : .badResponse
@@ -417,6 +452,24 @@ enum ProviderFailureClassifier {
             detail: ProviderDiagnosticRedactor.safe(detail, maxLength: 360),
             action: action(for: bucket),
             severity: bucket == .unknown ? .warning : .blocked
+        )
+    }
+
+    private static func applyingRecoveryContext(
+        to classification: ProviderFailureClassification,
+        providerType: RemoteProviderType,
+        manualModelRecovery: ProviderManualModelRecovery
+    ) -> ProviderFailureClassification {
+        ProviderFailureClassification(
+            bucket: classification.bucket,
+            title: classification.title,
+            detail: classification.detail,
+            action: action(
+                for: classification.bucket,
+                providerType: providerType,
+                manualModelRecovery: manualModelRecovery
+            ),
+            severity: classification.severity
         )
     }
 
@@ -474,7 +527,11 @@ enum ProviderFailureClassifier {
         }
     }
 
-    private static func action(for bucket: ProviderFailureBucket) -> String {
+    private static func action(
+        for bucket: ProviderFailureBucket,
+        providerType: RemoteProviderType? = nil,
+        manualModelRecovery: ProviderManualModelRecovery = .unavailable
+    ) -> String {
         switch bucket {
         case .missingCredential:
             return L("Save an API key or secret credential header, then test again.")
@@ -491,18 +548,44 @@ enum ProviderFailureClassifier {
         case .proxyConnectFailed:
             return L("Test with the proxy disabled or verify the proxy host, port, and authentication.")
         case .modelsEndpointUnavailable:
-            return L("Add manual model IDs if this OpenAI-compatible provider does not expose /models.")
+            if providerSupportsOpenAIManualModels(providerType, recovery: manualModelRecovery) {
+                return L("Add manual model IDs if this OpenAI-compatible provider does not expose /models.")
+            }
+            if providerType == .azureOpenAI, manualModelRecovery == .azureDeploymentIDs {
+                return L("Add at least one deployment/model ID in Advanced.")
+            }
+            return L("Check this provider's model catalog support and try again.")
         case .modelsSchemaMismatch:
-            return L("Confirm the endpoint returns an OpenAI-shaped model list or add manual model IDs.")
+            if providerSupportsOpenAIManualModels(providerType, recovery: manualModelRecovery) {
+                return L("Confirm the endpoint returns an OpenAI-shaped model list or add manual model IDs.")
+            }
+            if providerType == .azureOpenAI, manualModelRecovery == .azureDeploymentIDs {
+                return L("Add at least one deployment/model ID in Advanced.")
+            }
+            return L("Check this provider's model catalog format and try again.")
         case .requestRejected:
             return L("Review provider compatibility for unsupported request fields, tools, or response formats.")
         case .unsupportedModel:
-            return L("Select a model exposed by this provider or add the correct manual model ID.")
+            if providerSupportsOpenAIManualModels(providerType, recovery: manualModelRecovery) {
+                return L("Select a model exposed by this provider or add the correct manual model ID.")
+            }
+            if providerType == .azureOpenAI, manualModelRecovery == .azureDeploymentIDs {
+                return L("Add at least one deployment/model ID in Advanced.")
+            }
+            return L("Select a model exposed by this provider and try again.")
         case .badResponse:
             return L("Copy diagnostics with the redacted response and check provider status or compatibility.")
         case .unknown:
             return L("Copy diagnostics and include the redacted request evidence when reporting this issue.")
         }
+    }
+
+    private static func providerSupportsOpenAIManualModels(
+        _ providerType: RemoteProviderType?,
+        recovery: ProviderManualModelRecovery
+    ) -> Bool {
+        guard recovery == .openAICompatibleModelIDs else { return false }
+        return providerType == .openaiLegacy || providerType == .openResponses
     }
 
     private static func bodyLooksLikeRequestShapeRejection(_ body: String) -> Bool {

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -196,12 +196,12 @@ enum ProviderFailureClassifier {
             return classification(.requestRejected, detail: L("HTTP \(status) suggests the provider rejected the request shape. Evidence: \(replay.summary)"))
         }
 
-        if bodyLooksLikeSchemaMismatch(body) {
-            if phase.contains("model") {
-                return classification(.modelsSchemaMismatch, detail: L("The models endpoint response did not match the expected schema. Evidence: \(replay.summary)"))
+            if bodyLooksLikeSchemaMismatch(body) {
+                if phase.contains("model") {
+                    return classification(.modelsSchemaMismatch, detail: L("The models endpoint responded with an unexpected schema. Evidence: \(replay.summary)"))
+                }
+                return classification(.badResponse, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
             }
-            return classification(.badResponse, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
-        }
 
         if status < 200 || status >= 300 {
             return classification(.badResponse, detail: L("HTTP \(status) from provider. Evidence: \(replay.summary)"))

--- a/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderFailureClassification.swift
@@ -197,7 +197,10 @@ enum ProviderFailureClassifier {
         }
 
         if bodyLooksLikeSchemaMismatch(body) {
-            return classification(.modelsSchemaMismatch, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
+            if phase.contains("model") {
+                return classification(.modelsSchemaMismatch, detail: L("The models endpoint response did not match the expected schema. Evidence: \(replay.summary)"))
+            }
+            return classification(.badResponse, detail: L("The provider response did not match the expected schema. Evidence: \(replay.summary)"))
         }
 
         if status < 200 || status >= 300 {
@@ -230,6 +233,9 @@ enum ProviderFailureClassifier {
             return classification(.oauthTokenMissing, detail: detail)
         }
         if lower.contains("api key") || lower.contains("apikey") || lower.contains("authorization") {
+            if credentialPresent {
+                return classification(.authRejected, detail: detail)
+            }
             return classification(.missingCredential, detail: detail)
         }
         if lower.contains("timed out") || lower.contains("timeout") {

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -473,7 +473,8 @@ public enum ProviderNetworkDiagnostics {
             state: state,
             proxy: proxy,
             apiKeyPresent: apiKeyPresent,
-            oauthTokensPresent: oauthTokensPresent
+            oauthTokensPresent: oauthTokensPresent,
+            manualModelRecovery: provider.providerType == .azureOpenAI ? .azureDeploymentIDs : .unavailable
         ) else {
             return nil
         }

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -104,12 +104,21 @@ public enum ProviderNetworkDiagnostics {
         ) {
             rows.append(oauthContext)
         }
+        if let failure = remoteFailureClassificationRow(
+            provider: provider,
+            state: state,
+            proxy: proxy,
+            apiKeyPresent: apiKeyPresent,
+            oauthTokensPresent: oauthTokensPresent
+        ) {
+            rows.append(failure)
+        }
         if let replay = remoteReplayDiagnosticsRow(state: state) {
             rows.append(replay)
         }
         rows.append(
             contentsOf: [
-                remoteModelDiscoveryRow(provider: provider),
+                remoteModelDiscoveryRow(provider: provider, state: state),
                 remoteRequestFormatRow(provider: provider),
                 proxyRow(proxy, appliesTo: "Remote provider requests"),
             ]
@@ -316,7 +325,10 @@ public enum ProviderNetworkDiagnostics {
         return detail
     }
 
-    private static func remoteModelDiscoveryRow(provider: RemoteProvider) -> ProviderDiagnosticRow {
+    private static func remoteModelDiscoveryRow(
+        provider: RemoteProvider,
+        state: RemoteProviderState?
+    ) -> ProviderDiagnosticRow {
         guard let modelsURL = provider.url(for: provider.providerType.modelsEndpoint) else {
             return ProviderDiagnosticRow(
                 id: "models",
@@ -338,6 +350,15 @@ public enum ProviderNetworkDiagnostics {
                 detail: codexModelDiscoveryDetail()
             )
         case .azureOpenAI:
+            if state?.isConnected == true {
+                return ProviderDiagnosticRow(
+                    id: "models",
+                    title: L("Model discovery"),
+                    value: L("Connected"),
+                    severity: .ok,
+                    detail: L("\(state?.modelCount ?? 0) deployment/model ID(s) are available.")
+                )
+            }
             let hasManual = !provider.mergedModelIds(discovered: []).isEmpty
             return ProviderDiagnosticRow(
                 id: "models",
@@ -429,13 +450,40 @@ public enum ProviderNetworkDiagnostics {
 
     private static func remoteReplayDiagnosticsRow(state: RemoteProviderState?) -> ProviderDiagnosticRow? {
         guard let diagnostics = state?.lastReplayDiagnostics else { return nil }
+        let hasActiveFailure = state?.isConnected != true && state?.lastError?.isEmpty == false
         return ProviderDiagnosticRow(
             id: "request-evidence",
             title: L("Request evidence"),
             value: diagnostics.summary,
-            severity: .warning,
+            severity: hasActiveFailure ? .warning : .info,
             detail: diagnostics.pasteboardText,
             action: L("Copy diagnostics and include this redacted request/response evidence with the report.")
+        )
+    }
+
+    private static func remoteFailureClassificationRow(
+        provider: RemoteProvider,
+        state: RemoteProviderState?,
+        proxy: GlobalProxyDiagnosticState,
+        apiKeyPresent: Bool,
+        oauthTokensPresent: Bool
+    ) -> ProviderDiagnosticRow? {
+        guard let classification = ProviderFailureClassifier.classify(
+            provider: provider,
+            state: state,
+            proxy: proxy,
+            apiKeyPresent: apiKeyPresent,
+            oauthTokensPresent: oauthTokensPresent
+        ) else {
+            return nil
+        }
+        return ProviderDiagnosticRow(
+            id: classification.rowID,
+            title: L("Likely failure"),
+            value: classification.title,
+            severity: classification.severity,
+            detail: classification.detail,
+            action: classification.action
         )
     }
 

--- a/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
@@ -32,6 +32,7 @@ public struct ProviderReplayDiagnosticBundle: Sendable, Equatable {
     public let request: ProviderReplayDiagnosticRequest
     public let response: ProviderReplayDiagnosticResponse?
     public let transportError: String?
+    public let transportErrorCode: String?
 
     public init(
         phase: String,
@@ -69,6 +70,7 @@ public struct ProviderReplayDiagnosticBundle: Sendable, Equatable {
         self.transportError = transportError.map {
             ProviderDiagnosticRedactor.safe($0.localizedDescription, maxLength: 500)
         }
+        self.transportErrorCode = ProviderReplayDiagnosticBundle.transportErrorCode(transportError)
     }
 
     public var summary: String {
@@ -102,7 +104,19 @@ public struct ProviderReplayDiagnosticBundle: Sendable, Equatable {
         if let transportError {
             lines.append("transport_error: \(transportError)")
         }
+        if let transportErrorCode {
+            lines.append("transport_error_code: \(transportErrorCode)")
+        }
         return lines.joined(separator: "\n")
+    }
+
+    private static func transportErrorCode(_ error: Error?) -> String? {
+        guard let error else { return nil }
+        if let urlError = error as? URLError {
+            return "URLError:\(urlError.errorCode)"
+        }
+        let nsError = error as NSError
+        return "\(ProviderDiagnosticRedactor.safe(nsError.domain, maxLength: 120)):\(nsError.code)"
     }
 
     private func formatSeconds(_ value: TimeInterval) -> String {
@@ -214,6 +228,8 @@ enum ProviderDiagnosticRedactor {
             (#"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"#, "jwt=***"),
             (#"\bsk-[A-Za-z0-9._-]{8,}\b"#, "sk-***"),
             (#"\bosk-[A-Za-z0-9._-]{8,}\b"#, "osk-***"),
+            (#"(?i)file://(?:localhost)?/(Users|private/var|var/folders|private/tmp|tmp|var/root)[^,;:(){}\[\]<>"'\r\n]*"#, "file://[redacted-local-path]"),
+            (#"(?i)/(Users|private/var|var/folders|private/tmp|tmp|var/root)/[^,;:(){}\[\]<>"'\r\n]*"#, "/[redacted-local-path]"),
         ]
 
         for replacement in replacements {

--- a/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
@@ -229,7 +229,18 @@ enum ProviderDiagnosticRedactor {
             (#"\bsk-[A-Za-z0-9._-]{8,}\b"#, "sk-***"),
             (#"\bosk-[A-Za-z0-9._-]{8,}\b"#, "osk-***"),
             (#"(?i)file://(?:localhost)?/(Users|private/var|var/folders|private/tmp|tmp|var/root)[^,;:(){}\[\]<>"'\r\n]*"#, "file://[redacted-local-path]"),
-            (#"(?i)/(Users|private/var|var/folders|private/tmp|tmp|var/root)/[^,;:(){}\[\]<>"'\r\n]*"#, "/[redacted-local-path]"),
+            (
+                #"(?i)(^|[\s"'\(\)\[\]\{\}\;,:=\r\n\t=<])/(Users|private/var|var/folders|private/tmp|tmp|var/root)/[^,;:(){}\[\]<>\"'\r\n]*"#,
+                "$1/[redacted-local-path]"
+            ),
+            (
+                #"(?i)(^|[\s"'\(\)\[\]\{\}\;,:=\r\n\t=<])([A-Za-z_][A-Za-z0-9_-]*)=/(Users|private/var|var/folders|private/tmp|tmp|var/root)/[^,;:(){}\[\]<>\"'\r\n]*"#,
+                "$1/[redacted-local-path]"
+            ),
+            (
+                #"(?i)(^|[\s"'\(\)\[\]\{\}\;,:=\r\n\t=<])(at|path|home|file|dir|folder|location|log)/(Users|private/var|var/folders|private/tmp|tmp|var/root)/[^,;:(){}\[\]<>\"'\r\n]*"#,
+                "$1/[redacted-local-path]"
+            ),
         ]
 
         for replacement in replacements {

--- a/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
@@ -265,6 +265,23 @@ enum ProviderDiagnosticRedactor {
         return String(value.prefix(maxLength)) + "..."
     }
 
+    /// Setup diagnostics are a minimal shareable payload, so endpoint identity
+    /// is removed after the standard secret/path pass. Keeping this order also
+    /// strips endpoint fragments when `safe` truncates in the middle of a URL.
+    static func safeForSetupCopy(_ raw: String, maxLength: Int = 360) -> String {
+        var value = safe(raw, maxLength: maxLength)
+        let endpointPatterns = [
+            #"(?i)\bhttps?://[^\s,;(){}\[\]<>\"'\r\n]*"#,
+            #"(?i)\b(?:(?:[a-z0-9-]+\.)+[a-z]{2,}|(?:\d{1,3}\.){3}\d{1,3}|localhost)(?::\d{1,5})?(?:/[^\s,;:(){}\[\]<>\"'\r\n]*)?"#,
+            #"(?i)\b[a-z0-9-]+:\d{1,5}(?:/[^\s,;:(){}\[\]<>\"'\r\n]*)?"#,
+            #"\[[0-9A-Fa-f:]+\](?::\d{1,5})?(?:/[^\s,;:(){}\[\]<>\"'\r\n]*)?"#,
+        ]
+        for pattern in endpointPatterns {
+            value = replaceMatches(in: value, pattern: pattern, template: "[redacted-endpoint]")
+        }
+        return value
+    }
+
     private static func isSensitiveFieldName(_ name: String) -> Bool {
         let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !normalized.isEmpty else { return false }

--- a/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateOAuthCompletionTests.swift
+++ b/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateOAuthCompletionTests.swift
@@ -1,0 +1,116 @@
+//
+//  ConfigureAIStateOAuthCompletionTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for stale browser sign-in completions. OAuth callbacks
+//  return credentials asynchronously, so they must not write secrets into a
+//  provider form after the user backs out or switches providers.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ConfigureAIStateOAuthCompletionTests {
+    @Test func currentOpenRouterCompletionWritesKey() throws {
+        let state = ConfigureAIState()
+        state.showBYOK()
+        state.selectAPIPreset(.openrouter)
+        let identity = try setupIdentity(for: state, authMethod: .oauth(.openRouter))
+        let requestID = UUID()
+        state.apiTestRequestID = requestID
+        state.isTesting = true
+
+        let applied = state.applyOAuthCompletionIfCurrent(
+            .apiKey("or-live-key"),
+            requestID: requestID,
+            identity: identity
+        )
+
+        #expect(applied)
+        #expect(state.apiKey == "or-live-key")
+    }
+
+    @Test func staleOpenRouterCompletionAfterBackDoesNotWriteKey() throws {
+        let state = ConfigureAIState()
+        state.showBYOK()
+        state.selectAPIPreset(.openrouter)
+        let identity = try setupIdentity(for: state, authMethod: .oauth(.openRouter))
+        let requestID = UUID()
+        state.apiTestRequestID = requestID
+        state.isTesting = true
+
+        state.popFormToPicker(for: .openrouter)
+        let applied = state.applyOAuthCompletionIfCurrent(
+            .apiKey("or-stale-key"),
+            requestID: requestID,
+            identity: identity
+        )
+
+        #expect(!applied)
+        #expect(state.apiKey.isEmpty)
+        #expect(state.oauthTokens == nil)
+    }
+
+    @Test func staleOpenRouterCompletionAfterProviderSwitchDoesNotWriteKey() throws {
+        let state = ConfigureAIState()
+        state.showBYOK()
+        state.selectAPIPreset(.openrouter)
+        let identity = try setupIdentity(for: state, authMethod: .oauth(.openRouter))
+        let requestID = UUID()
+        state.apiTestRequestID = requestID
+        state.isTesting = true
+
+        state.selectAPIPreset(.openai)
+        let applied = state.applyOAuthCompletionIfCurrent(
+            .apiKey("or-wrong-provider-key"),
+            requestID: requestID,
+            identity: identity
+        )
+
+        #expect(!applied)
+        #expect(state.apiKey.isEmpty)
+        #expect(state.isTesting == false)
+    }
+
+    @Test func staleTokenCompletionAfterProviderSwitchDoesNotWriteTokens() throws {
+        let state = ConfigureAIState()
+        state.showBYOK()
+        state.selectAPIPreset(.openai)
+        let identity = try setupIdentity(for: state, authMethod: .oauth(.openAICodex))
+        let requestID = UUID()
+        state.apiTestRequestID = requestID
+        state.isTesting = true
+
+        state.selectAPIPreset(.xai)
+        let tokens = RemoteProviderOAuthTokens(
+            accessToken: "stale-access",
+            refreshToken: "stale-refresh",
+            expiresAt: Date().addingTimeInterval(3_600),
+            accountId: "acct-stale"
+        )
+        let applied = state.applyOAuthCompletionIfCurrent(
+            .oauthTokens(tokens),
+            requestID: requestID,
+            identity: identity
+        )
+
+        #expect(!applied)
+        #expect(state.oauthTokens == nil)
+        #expect(state.isTesting == false)
+    }
+
+    private func setupIdentity(
+        for state: ConfigureAIState,
+        authMethod: ProviderPickerAuthMethod
+    ) throws -> ProviderSetupTestIdentity {
+        let config = try #require(state.resolvedAPIConfig())
+        return ProviderSetupTestIdentity(
+            config: config,
+            authMethod: authMethod,
+            apiKeyInput: authMethod == .apiKey ? state.apiKey : nil
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/CustomProviderSetupSuccessGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/CustomProviderSetupSuccessGateTests.swift
@@ -1,0 +1,124 @@
+//
+//  CustomProviderSetupSuccessGateTests.swift
+//  OsaurusCoreTests
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct CustomProviderSetupSuccessGateTests {
+    @Test func unchangedGreenSnapshotAllowsAdd() {
+        let tested = Self.snapshot()
+        var gate = CustomProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        #expect(gate.allowsAdd(current: tested))
+    }
+
+    @Test func greenTestThenOrdinaryHostEditRefusesAdd() {
+        let tested = Self.snapshot()
+        var gate = CustomProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+        var edited = tested
+        edited.hostInput = "api.changed.example"
+        edited.provider.host = "api.changed.example"
+
+        #expect(!gate.allowsAdd(current: edited))
+    }
+
+    @Test func greenTestThenOrdinaryPortEditRefusesAdd() {
+        let tested = Self.snapshot()
+        var gate = CustomProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+        var edited = tested
+        // Both strings resolve to the same numeric port, so the raw field must
+        // remain part of the tested identity.
+        edited.portInput = "0443"
+
+        #expect(!gate.allowsAdd(current: edited))
+    }
+
+    @Test func greenTestThenOrdinaryBasePathEditRefusesAdd() {
+        let tested = Self.snapshot()
+        var gate = CustomProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+        var edited = tested
+        edited.basePathInput = "/v2"
+        edited.provider.basePath = "/v2"
+
+        #expect(!gate.allowsAdd(current: edited))
+    }
+
+    @Test func credentialHeaderTimeoutModelAndConnectionDriftRefuseAdd() {
+        let tested = Self.snapshot()
+        var gate = CustomProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        var apiKey = tested
+        apiKey.apiKeyInput = "sk-new-key-123456789"
+        #expect(!gate.allowsAdd(current: apiKey))
+
+        var authType = tested
+        authType.provider.authType = .none
+        #expect(!gate.allowsAdd(current: authType))
+
+        var header = tested
+        header.headers[0].value = "changed-header"
+        #expect(!gate.allowsAdd(current: header))
+
+        var timeout = tested
+        timeout.provider.timeout = 120
+        #expect(!gate.allowsAdd(current: timeout))
+
+        var disableTimeout = tested
+        disableTimeout.provider.disableTimeout = true
+        #expect(!gate.allowsAdd(current: disableTimeout))
+
+        var models = tested
+        models.manualModelIdsInput = "model-b"
+        models.provider.manualModelIds = ["model-b"]
+        #expect(!gate.allowsAdd(current: models))
+
+        var providerProtocol = tested
+        providerProtocol.provider.providerProtocol = .http
+        #expect(!gate.allowsAdd(current: providerProtocol))
+    }
+
+    @Test func aNewTestInvalidatesThePreviousGreenSnapshot() {
+        let tested = Self.snapshot()
+        var gate = CustomProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+        gate.invalidate()
+
+        #expect(!gate.allowsAdd(current: tested))
+    }
+
+    private static func snapshot() -> CustomProviderSetupTestSnapshot {
+        let headers = [HeaderEntry(key: "X-Tenant", value: "tenant-a", isSecret: false)]
+        let provider = RemoteProvider(
+            name: "Example",
+            host: "api.example.com",
+            providerProtocol: .https,
+            port: 443,
+            basePath: "/v1",
+            customHeaders: HeaderEntry.partition(headers).regular,
+            authType: .apiKey,
+            providerType: .openaiLegacy,
+            timeout: 60,
+            disableTimeout: false,
+            manualModelIds: ["model-a"]
+        )
+        return CustomProviderSetupTestSnapshot(
+            provider: provider,
+            nameInput: "Example",
+            hostInput: "api.example.com",
+            portInput: "443",
+            basePathInput: "/v1",
+            apiKeyInput: "sk-tested-key-123456789",
+            manualModelIdsInput: "model-a",
+            headers: headers
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/KnownProviderSetupSuccessGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/KnownProviderSetupSuccessGateTests.swift
@@ -1,0 +1,183 @@
+//
+//  KnownProviderSetupSuccessGateTests.swift
+//  OsaurusCoreTests
+//
+
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct KnownProviderSetupSuccessGateTests {
+    @Test func unchangedGreenSnapshotIsVerified() {
+        let tested = Self.snapshot()
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        let authorization = gate.authorization(
+            current: tested,
+            hasSuccessfulResult: true,
+            allowsUnverifiedAzureSave: false
+        )
+
+        #expect(authorization == .verified)
+        #expect(authorization.allowsSave)
+    }
+
+    @Test func protocolEditInvalidatesVerifiedKnownProvider() {
+        let tested = Self.snapshot()
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+        var edited = tested
+        edited.provider.providerProtocol = .http
+
+        #expect(Self.authorization(gate, current: edited) == .denied)
+    }
+
+    @Test func timeoutEditsInvalidateVerifiedKnownProvider() {
+        let tested = Self.snapshot()
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        var timeout = tested
+        timeout.provider.timeout = 120
+        #expect(Self.authorization(gate, current: timeout) == .denied)
+
+        var disableTimeout = tested
+        disableTimeout.provider.disableTimeout = true
+        #expect(Self.authorization(gate, current: disableTimeout) == .denied)
+    }
+
+    @Test func customHeaderEditsInvalidateVerifiedKnownProvider() {
+        let tested = Self.snapshot()
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        var value = tested
+        value.headers[0].value = "tenant-b"
+        value.provider.customHeaders["X-Tenant"] = "tenant-b"
+        #expect(Self.authorization(gate, current: value) == .denied)
+
+        var secret = tested
+        secret.headers[0].isSecret = true
+        secret.provider.customHeaders = [:]
+        secret.provider.secretHeaderKeys = ["X-Tenant"]
+        #expect(Self.authorization(gate, current: secret) == .denied)
+
+        var added = tested
+        added.headers.append(HeaderEntry(key: "X-Region", value: "us-east", isSecret: false))
+        added.provider.customHeaders["X-Region"] = "us-east"
+        #expect(Self.authorization(gate, current: added) == .denied)
+    }
+
+    @Test func endpointCredentialAndModelEditsInvalidateVerifiedKnownProvider() {
+        let tested = Self.snapshot()
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        var host = tested
+        host.provider.host = "gateway.example.com"
+        #expect(Self.authorization(gate, current: host) == .denied)
+
+        var port = tested
+        port.provider.port = 8443
+        #expect(Self.authorization(gate, current: port) == .denied)
+
+        var basePath = tested
+        basePath.provider.basePath = "/v2"
+        #expect(Self.authorization(gate, current: basePath) == .denied)
+
+        var credential = tested
+        credential.credential = .apiKey("sk-replacement-123456789")
+        #expect(Self.authorization(gate, current: credential) == .denied)
+
+        var models = tested
+        models.provider.manualModelIds = ["model-b"]
+        #expect(Self.authorization(gate, current: models) == .denied)
+    }
+
+    @Test func directSaveGuardRequiresCurrentGreenSnapshot() {
+        let tested = Self.snapshot()
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        let missingGreenResult = gate.authorization(
+            current: tested,
+            hasSuccessfulResult: false,
+            allowsUnverifiedAzureSave: false
+        )
+        var stale = tested
+        stale.provider.timeout = 180
+        let staleGreenResult = gate.authorization(
+            current: stale,
+            hasSuccessfulResult: true,
+            allowsUnverifiedAzureSave: false
+        )
+
+        #expect(missingGreenResult == .denied)
+        #expect(!missingGreenResult.allowsSave)
+        #expect(staleGreenResult == .denied)
+        #expect(!staleGreenResult.allowsSave)
+    }
+
+    @Test func browserOAuthIdentityDoesNotDependOnMintedCredentialValue() {
+        let tested = Self.snapshot(credential: .oauth(.openRouter))
+        var gate = KnownProviderSetupSuccessGate()
+        gate.recordSuccess(tested)
+
+        #expect(Self.authorization(gate, current: tested) == .verified)
+    }
+
+    @Test func azureManualModelBypassRemainsExplicitlyUnverified() {
+        let current = Self.snapshot(preset: .azureOpenAI)
+        let gate = KnownProviderSetupSuccessGate()
+
+        let authorization = gate.authorization(
+            current: current,
+            hasSuccessfulResult: false,
+            allowsUnverifiedAzureSave: true
+        )
+
+        #expect(authorization == .unverifiedAzureManualModels)
+        #expect(authorization.allowsSave)
+        #expect(authorization != .verified)
+    }
+
+    private static func authorization(
+        _ gate: KnownProviderSetupSuccessGate,
+        current: KnownProviderSetupTestSnapshot
+    ) -> KnownProviderSetupSaveAuthorization {
+        gate.authorization(
+            current: current,
+            hasSuccessfulResult: true,
+            allowsUnverifiedAzureSave: false
+        )
+    }
+
+    private static func snapshot(
+        preset: ProviderPreset = .anthropic,
+        credential: KnownProviderSetupCredentialIdentity = .apiKey("sk-tested-key-123456789")
+    ) -> KnownProviderSetupTestSnapshot {
+        let headers = [HeaderEntry(key: "X-Tenant", value: "tenant-a", isSecret: false)]
+        let provider = RemoteProvider(
+            name: "Anthropic",
+            host: "api.anthropic.com",
+            providerProtocol: .https,
+            port: 443,
+            basePath: "/v1",
+            customHeaders: HeaderEntry.partition(headers).regular,
+            authType: .apiKey,
+            providerType: .anthropic,
+            timeout: 60,
+            disableTimeout: false,
+            manualModelIds: ["model-a"]
+        )
+        return KnownProviderSetupTestSnapshot(
+            preset: preset,
+            provider: provider,
+            credential: credential,
+            headers: headers
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/OpenRouterReauthorizationSessionTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenRouterReauthorizationSessionTests.swift
@@ -1,0 +1,92 @@
+//
+//  OpenRouterReauthorizationSessionTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct OpenRouterReauthorizationSessionTests {
+    @Test func currentCompletionSucceedsAndIgnoresUnchangedBindingEcho() {
+        var session = OpenRouterReauthorizationSession()
+        let requestID = UUID()
+        session.begin(requestID: requestID, apiKeyInput: "old-key")
+
+        let accepted = session.acceptCompletion(
+            requestID: requestID,
+            currentAPIKeyInput: "old-key"
+        )
+
+        #expect(accepted)
+        #expect(session.status == .succeeded)
+
+        let treatedAsManualEdit = session.manualAPIKeyDidChange(
+            from: "new-oauth-key",
+            to: "new-oauth-key"
+        )
+
+        #expect(!treatedAsManualEdit)
+        #expect(session.status == .succeeded)
+    }
+
+    @Test func manualEditCancelsRequestAndRejectsLateCompletion() {
+        var session = OpenRouterReauthorizationSession()
+        let requestID = UUID()
+        session.begin(requestID: requestID, apiKeyInput: "")
+
+        let treatedAsManualEdit = session.manualAPIKeyDidChange(from: "", to: "typed-key")
+        let acceptedLateCompletion = session.acceptCompletion(
+            requestID: requestID,
+            currentAPIKeyInput: "typed-key"
+        )
+
+        #expect(treatedAsManualEdit)
+        #expect(session.status == .idle)
+        #expect(session.requestID == nil)
+        #expect(!acceptedLateCompletion)
+    }
+
+    @Test func changedInputRejectsCompletionEvenWithoutManualCancellation() {
+        var session = OpenRouterReauthorizationSession()
+        let requestID = UUID()
+        session.begin(requestID: requestID, apiKeyInput: "old-key")
+
+        let accepted = session.acceptCompletion(
+            requestID: requestID,
+            currentAPIKeyInput: "typed-key"
+        )
+
+        #expect(!accepted)
+        #expect(session.status == .idle)
+        #expect(session.requestID == nil)
+    }
+
+    @Test func staleFailureCannotReplaceNewerRequestState() {
+        var session = OpenRouterReauthorizationSession()
+        let staleRequestID = UUID()
+        let currentRequestID = UUID()
+        session.begin(requestID: staleRequestID, apiKeyInput: "old-key")
+        session.begin(requestID: currentRequestID, apiKeyInput: "old-key")
+
+        let acceptedStaleFailure = session.acceptFailure(
+            requestID: staleRequestID,
+            currentAPIKeyInput: "old-key",
+            message: "stale failure"
+        )
+
+        #expect(!acceptedStaleFailure)
+        #expect(session.status == .signingIn)
+        #expect(session.requestID == currentRequestID)
+        let acceptedCurrentFailure = session.acceptFailure(
+            requestID: currentRequestID,
+            currentAPIKeyInput: "old-key",
+            message: "current failure"
+        )
+
+        #expect(acceptedCurrentFailure)
+        #expect(session.status == .failed("current failure"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/OpenRouterReauthorizationSessionTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenRouterReauthorizationSessionTests.swift
@@ -89,4 +89,31 @@ struct OpenRouterReauthorizationSessionTests {
         #expect(acceptedCurrentFailure)
         #expect(session.status == .failed("current failure"))
     }
+
+    @Test func currentFailureRedactsCredentialHeaderAndLocalPathCanaries() throws {
+        var session = OpenRouterReauthorizationSession()
+        let requestID = UUID()
+        session.begin(requestID: requestID, apiKeyInput: "old-key")
+        let secret = "sk-or-v1-private-123456789"
+        let localPath = "/Users/mmeding/Secrets/openrouter.json"
+        let bearer = "private-bearer-token-123456789"
+
+        let accepted = session.acceptFailure(
+            requestID: requestID,
+            currentAPIKeyInput: "old-key",
+            message: "Exchange failed for \(secret) at \(localPath); Authorization: Bearer \(bearer)"
+        )
+
+        #expect(accepted)
+        guard case .failed(let message) = session.status else {
+            Issue.record("Expected the current failure to be stored")
+            return
+        }
+        #expect(!message.contains(secret))
+        #expect(!message.contains(localPath))
+        #expect(!message.contains(bearer))
+        #expect(message.contains("sk-***"))
+        #expect(message.contains("/[redacted-local-path]"))
+        #expect(message.contains("Authorization=***"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
@@ -107,6 +107,15 @@ struct ProviderConnectivityCenterTests {
         #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "proxy") == .proxy)
         #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "transport") == .transport)
         #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "repro") == .repro)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-auth") == .authentication)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-oauth") == .oauthContext)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-connection") == .connection)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-tls") == .connection)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-timeout") == .connection)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-models") == .models)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-format") == .format)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-proxy") == .proxy)
+        #expect(ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "failure-response") == .connection)
 
         let unknown = ProviderConnectivityIssueKind.kind(forDiagnosticRowID: "future-row")
         #expect(unknown.id == "unknown:future-row")
@@ -124,11 +133,55 @@ struct ProviderConnectivityCenterTests {
             "repro",
             "request-evidence",
             "transport",
+            "failure-auth",
+            "failure-oauth",
+            "failure-connection",
+            "failure-tls",
+            "failure-timeout",
+            "failure-models",
+            "failure-format",
+            "failure-proxy",
+            "failure-response",
         ]
 
         for rowID in emittedIDs {
             #expect(!ProviderConnectivityIssueKind.kind(forDiagnosticRowID: rowID).isUnknown)
         }
+    }
+
+    @Test func connectedProviderWithStaleReplayEvidenceDoesNotNeedAttention() throws {
+        let provider = RemoteProvider(
+            name: "Recovered API",
+            host: "api.example.test",
+            authType: .none,
+            providerType: .openaiLegacy
+        )
+        let url = try #require(URL(string: "https://api.example.test/v1/models"))
+        var request = URLRequest(url: url)
+        request.setValue("Bearer sk-old-secret-12345", forHTTPHeaderField: "Authorization")
+        var state = RemoteProviderState(providerId: provider.id)
+        state.isConnected = true
+        state.discoveredModels = ["model-a"]
+        state.lastReplayDiagnostics = ProviderReplayDiagnosticBundle(
+            phase: "previous_failure",
+            request: request,
+            transportError: URLError(.timedOut)
+        )
+
+        let report = ProviderConnectivityCenter.providerReport(
+            provider: provider,
+            state: state,
+            proxy: .disabled,
+            credentialPresence: RemoteProviderCredentialPresence()
+        )
+
+        #expect(report.status == .connected)
+        #expect(report.highestSeverity == .info)
+        #expect(report.issueKinds.isEmpty)
+        #expect(report.primaryIssueKind == nil)
+        #expect(!report.isAttentionWorthy)
+        #expect(report.diagnostics.rows.first { $0.id == "request-evidence" }?.severity == .info)
+        #expect(!report.diagnostics.pasteboardText.contains("sk-old-secret-12345"))
     }
 
     @Test func unknownIssueBucketsKeepCountsReconciled() {
@@ -302,22 +355,30 @@ struct ProviderConnectivityCenterTests {
         let url = try #require(URL(string: "http://127.0.0.1:8000/api/v1/models?access_token=url-secret"))
         var request = URLRequest(url: url)
         request.setValue("Bearer sk-report-secret-12345", forHTTPHeaderField: "Authorization")
+        request.setValue("custom-report-secret", forHTTPHeaderField: "X-Provider-Debug")
         let response = try #require(
             HTTPURLResponse(
                 url: url,
                 statusCode: 401,
                 httpVersion: nil,
-                headerFields: ["Content-Type": "application/json"]
+                headerFields: [
+                    "Content-Type": "application/json",
+                    "X-Provider-Debug": "response-custom-secret",
+                ]
             )
         )
         let diagnostics = ProviderReplayDiagnosticBundle(
             phase: "model_discovery",
             request: request,
             response: response,
-            responseData: Data(#"{"error":{"message":"invalid api_key=sk-report-body-12345"}}"#.utf8)
+            responseData: Data(
+                #"{"error":{"message":"invalid api_key=sk-report-body-12345 at /Users/mmeding/.osaurus/private.json file:///Users/mmeding/.ssh/id_rsa"}}"#
+                    .utf8
+            ),
+            configuredSecretHeaderKeys: ["X-Provider-Debug"]
         )
         var state = RemoteProviderState(providerId: provider.id)
-        state.lastError = #"HTTP 401: {"access_token":"state-secret"}"#
+        state.lastError = #"HTTP 401: {"access_token":"state-secret"} /Users/mmeding/.osaurus/token.json"#
         state.lastReplayDiagnostics = diagnostics
 
         let snapshot = ProviderConnectivityCenter.snapshot(
@@ -330,13 +391,23 @@ struct ProviderConnectivityCenterTests {
         )
 
         let copied = snapshot.groupedPasteboardText(issueKind: .connection)
+        let allCopied = snapshot.pasteboardText
         #expect(copied.contains("provider-connectivity-issue-diagnostics"))
         #expect(copied.contains("Local API"))
         #expect(copied.contains("Provider request evidence:"))
-        #expect(!copied.contains("url-secret"))
-        #expect(!copied.contains("sk-report-secret-12345"))
-        #expect(!copied.contains("sk-report-body-12345"))
-        #expect(!copied.contains("state-secret"))
+        for text in [copied, allCopied] {
+            #expect(!text.contains("url-secret"))
+            #expect(!text.contains("sk-report-secret-12345"))
+            #expect(!text.contains("sk-report-body-12345"))
+            #expect(!text.contains("state-secret"))
+            #expect(!text.contains("custom-report-secret"))
+            #expect(!text.contains("response-custom-secret"))
+            #expect(!text.contains("/Users/mmeding"))
+            #expect(!text.contains("file:///Users"))
+            #expect(!text.contains("id_rsa"))
+            #expect(!text.contains("private.json"))
+            #expect(!text.contains("token.json"))
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
@@ -68,8 +68,8 @@ struct ProviderConnectivityCenterTests {
         #expect(snapshot.filtered(by: .disabled).map(\.provider.name) == ["Azure"])
         #expect(snapshot.filtered(by: .attention).contains { $0.provider.name == "Lemonade" })
         #expect(!snapshot.filtered(by: .attention).contains { $0.provider.name == "Azure" })
-        #expect(snapshot.issueKindCounts[.connection] == 1)
-        #expect(snapshot.groupedReportsByPrimaryIssueKind[.connection]?.map(\.provider.name) == ["Lemonade"])
+        #expect(snapshot.issueKindCounts[.authentication] == 1)
+        #expect(snapshot.groupedReportsByPrimaryIssueKind[.authentication]?.map(\.provider.name) == ["Lemonade"])
         #expect(snapshot.pasteboardText.contains("Provider connectivity diagnostics"))
         #expect(snapshot.pasteboardText.contains("https://proxy.example.com:8443"))
         #expect(!snapshot.pasteboardText.contains("secret-token"))
@@ -268,19 +268,40 @@ struct ProviderConnectivityCenterTests {
             provider: provider,
             state: state,
             proxy: .invalid("Proxy host 'localhost' is reserved for local networking."),
-            credentialPresence: RemoteProviderCredentialPresence(apiKeyPresent: false)
+            credentialPresence: RemoteProviderCredentialPresence(apiKeyPresent: true)
         )
 
         #expect(report.issueKinds == [.authentication, .connection, .proxy])
-        #expect(report.primaryIssueKind == .connection)
-        #expect(report.summary.contains("Connection"))
-        #expect(report.recommendedAction?.contains("Test") == true)
+        #expect(report.primaryIssueKind == .authentication)
+        #expect(report.summary.contains("Authentication rejected"))
+        #expect(report.recommendedAction?.contains("Verify the credential") == true)
 
         let snapshot = ProviderConnectivitySnapshot(reports: [report], proxy: .disabled)
         #expect(snapshot.issueKindCounts == [.authentication: 1, .connection: 1, .proxy: 1])
         #expect(snapshot.filtered(by: .attention, issueKind: .authentication).map(\.provider.name) == ["Broken API"])
         #expect(snapshot.filtered(by: .attention, issueKind: .connection).map(\.provider.name) == ["Broken API"])
         #expect(snapshot.filtered(by: .attention, issueKind: .proxy).map(\.provider.name) == ["Broken API"])
+    }
+
+    @Test func classifiedTimeoutOverridesGenericConnectionGuidance() {
+        let provider = RemoteProvider(
+            name: "Slow API",
+            host: "api.example.test",
+            authType: .none
+        )
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = "The request timed out."
+
+        let report = ProviderConnectivityCenter.providerReport(
+            provider: provider,
+            state: state,
+            proxy: .disabled,
+            credentialPresence: RemoteProviderCredentialPresence()
+        )
+
+        #expect(report.primaryIssueKind == .connection)
+        #expect(report.summary.contains("Request timed out"))
+        #expect(report.recommendedAction?.contains("Retry") == true)
     }
 
     @Test func infoRowsDoNotBecomeReportIssues() {

--- a/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
@@ -280,6 +280,15 @@ struct ProviderNetworkDiagnosticsTests {
                 .modelsSchemaMismatch
             ),
             (
+                "models-upstream-failure",
+                provider,
+                replayState(provider, url: url, statusCode: 503, body: #"{"error":"upstream unavailable"}"#),
+                .disabled,
+                false,
+                false,
+                .badResponse
+            ),
+            (
                 "request-shape",
                 provider,
                 replayState(provider, url: url, statusCode: 400, body: #"{"error":"unknown parameter tool_choice"}"#),
@@ -322,7 +331,49 @@ struct ProviderNetworkDiagnosticsTests {
                 .disabled,
                 true,
                 false,
-                .authRejected
+                .unknown
+            ),
+            (
+                "model-permission-wording-is-not-auth",
+                provider,
+                errorState(provider, message: "unauthorized for this model or region"),
+                .disabled,
+                true,
+                false,
+                .unknown
+            ),
+            (
+                "forbidden-entitlement-is-not-auth",
+                provider,
+                replayState(provider, url: url, statusCode: 403, body: #"{"error":"plan entitlement required"}"#),
+                .disabled,
+                true,
+                false,
+                .badResponse
+            ),
+            (
+                "generic-400-is-not-request-shape",
+                provider,
+                replayState(provider, url: url, statusCode: 400, body: #"{"error":"billing account unavailable"}"#),
+                .disabled,
+                true,
+                false,
+                .badResponse
+            ),
+            (
+                "non-model-resource-does-not-exist",
+                provider,
+                replayState(
+                    provider,
+                    url: url,
+                    phase: "chat-completion",
+                    statusCode: 409,
+                    body: #"{"error":"resource does not exist"}"#
+                ),
+                .disabled,
+                true,
+                false,
+                .badResponse
             ),
             (
                 "json-schema-in-chat-phase",
@@ -334,6 +385,24 @@ struct ProviderNetworkDiagnosticsTests {
                     statusCode: 200,
                     body: #"{"error":"schema mismatch"}"#
                 ),
+                .disabled,
+                false,
+                false,
+                .badResponse
+            ),
+            (
+                "invalid-response-format-message",
+                provider,
+                errorState(provider, message: "Invalid response_format for this endpoint"),
+                .disabled,
+                false,
+                false,
+                .requestRejected
+            ),
+            (
+                "generic-invalid-response-message",
+                provider,
+                errorState(provider, message: "Invalid response from provider"),
                 .disabled,
                 false,
                 false,
@@ -408,6 +477,43 @@ struct ProviderNetworkDiagnosticsTests {
         // "/models" appears in the detail text across all localizations.
         #expect(row("models", in: report).detail?.contains("/models") == true)
         #expect(row("format", in: report).detail?.contains("response_format=json_schema") == true)
+    }
+
+    @Test func remoteReportEmitsSpecificFailureRowForTransportAndHTTPFailures() throws {
+        let provider = RemoteProvider(
+            name: "OpenAI Compatible",
+            host: "api.example.test",
+            authType: .apiKey,
+            providerType: .openaiLegacy
+        )
+        let url = try #require(URL(string: "https://api.example.test/v1/models"))
+
+        let timeoutReport = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: replayState(provider, url: url, transportError: URLError(.timedOut)),
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+        let timeout = row("failure-timeout", in: timeoutReport)
+        #expect(timeout.value == L("Request timed out"))
+        #expect(timeout.action?.contains("Retry") == true)
+
+        let authReport = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: replayState(
+                provider,
+                url: url,
+                statusCode: 400,
+                body: #"{"error":{"message":"Incorrect API key provided","code":"invalid_api_key"}}"#
+            ),
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+        let auth = row("failure-auth", in: authReport)
+        #expect(auth.value == L("Authentication rejected"))
+        #expect(auth.action?.contains("Verify the credential") == true)
     }
 
     @Test func proxyDiagnosticDistinguishesInvalidConfiguredProxy() {

--- a/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
@@ -316,6 +316,30 @@ struct ProviderNetworkDiagnosticsTests {
                 .badResponse
             ),
             (
+                "auth-word-with-credential-present",
+                provider,
+                errorState(provider, message: "authorization service unavailable"),
+                .disabled,
+                true,
+                false,
+                .authRejected
+            ),
+            (
+                "json-schema-in-chat-phase",
+                provider,
+                replayState(
+                    provider,
+                    url: url,
+                    phase: "chat-completion",
+                    statusCode: 200,
+                    body: #"{"error":"schema mismatch"}"#
+                ),
+                .disabled,
+                false,
+                false,
+                .badResponse
+            ),
+            (
                 "unknown",
                 provider,
                 errorState(provider, message: "Provider returned an unexpected upstream condition."),
@@ -476,6 +500,7 @@ struct ProviderNetworkDiagnosticsTests {
     private func replayState(
         _ provider: RemoteProvider,
         url: URL,
+        phase: String = "test_model_discovery",
         statusCode: Int? = nil,
         body: String? = nil,
         transportError: Error? = nil
@@ -493,7 +518,7 @@ struct ProviderNetworkDiagnosticsTests {
         var state = RemoteProviderState(providerId: provider.id)
         state.lastError = transportError?.localizedDescription ?? "HTTP \(statusCode ?? 500)"
         state.lastReplayDiagnostics = ProviderReplayDiagnosticBundle(
-            phase: "test_model_discovery",
+            phase: phase,
             request: request,
             response: response,
             responseData: body.map { Data($0.utf8) },

--- a/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
@@ -129,6 +129,237 @@ struct ProviderNetworkDiagnosticsTests {
         #expect(!report.pasteboardText.contains("secret-token"))
     }
 
+    @Test func guidedFailureClassificationUsesStableBuckets() throws {
+        let provider = RemoteProvider(
+            name: "OpenAI Compatible",
+            host: "api.example.test",
+            authType: .none,
+            providerType: .openaiLegacy
+        )
+        let keyedProvider = RemoteProvider(
+            name: "Keyed",
+            host: "api.example.test",
+            authType: .apiKey,
+            providerType: .openaiLegacy
+        )
+        let oauthProvider = XAIOAuthService.makeProvider(id: UUID())
+        let url = try #require(URL(string: "https://api.example.test/v1/models"))
+
+        let fixtures: [(String, RemoteProvider, RemoteProviderState?, GlobalProxyDiagnosticState, Bool, Bool, ProviderFailureBucket)] = [
+            (
+                "missing-key",
+                keyedProvider,
+                errorState(keyedProvider, message: "API key missing"),
+                .disabled,
+                false,
+                false,
+                .missingCredential
+            ),
+            (
+                "oauth-missing",
+                oauthProvider,
+                errorState(oauthProvider, message: "OAuth token missing"),
+                .disabled,
+                false,
+                false,
+                .oauthTokenMissing
+            ),
+            (
+                "dns",
+                provider,
+                replayState(provider, url: url, transportError: URLError(.cannotFindHost)),
+                .disabled,
+                false,
+                false,
+                .endpointUnreachable
+            ),
+            (
+                "timeout",
+                provider,
+                replayState(provider, url: url, transportError: URLError(.timedOut)),
+                .disabled,
+                false,
+                false,
+                .timeout
+            ),
+            (
+                "origin-timeout-with-invalid-proxy",
+                provider,
+                replayState(provider, url: url, transportError: URLError(.timedOut)),
+                .invalid("bad proxy"),
+                false,
+                false,
+                .timeout
+            ),
+            (
+                "tls",
+                provider,
+                replayState(provider, url: url, transportError: URLError(.secureConnectionFailed)),
+                .disabled,
+                false,
+                false,
+                .tlsFailure
+            ),
+            (
+                "proxy-connect",
+                provider,
+                replayState(
+                    provider,
+                    url: url,
+                    transportError: NSError(
+                        domain: "ProxyError",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Proxy CONNECT tunnel failed"]
+                    )
+                ),
+                .active("https://proxy.example.com:8443"),
+                false,
+                false,
+                .proxyConnectFailed
+            ),
+            (
+                "origin-timeout-with-active-proxy",
+                provider,
+                replayState(provider, url: url, transportError: URLError(.timedOut)),
+                .active("https://proxy.example.com:8443"),
+                false,
+                false,
+                .timeout
+            ),
+            (
+                "provider-tunnel-word-with-active-proxy",
+                provider,
+                replayState(
+                    provider,
+                    url: url,
+                    transportError: NSError(
+                        domain: "ProviderError",
+                        code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "Cloudflare Tunnel timed out"]
+                    )
+                ),
+                .active("https://proxy.example.com:8443"),
+                false,
+                false,
+                .timeout
+            ),
+            (
+                "auth-rejected",
+                provider,
+                replayState(provider, url: url, statusCode: 401, body: #"{"error":"unauthorized"}"#),
+                .disabled,
+                false,
+                false,
+                .authRejected
+            ),
+            (
+                "models-missing",
+                provider,
+                replayState(provider, url: url, statusCode: 404, body: #"{"error":"not found"}"#),
+                .disabled,
+                false,
+                false,
+                .modelsEndpointUnavailable
+            ),
+            (
+                "models-does-not-exist",
+                provider,
+                replayState(provider, url: url, statusCode: 404, body: #"{"error":"resource does not exist"}"#),
+                .disabled,
+                false,
+                false,
+                .modelsEndpointUnavailable
+            ),
+            (
+                "models-schema",
+                provider,
+                replayState(provider, url: url, statusCode: 200, body: #"{"schema":"expected data array"}"#),
+                .disabled,
+                false,
+                false,
+                .modelsSchemaMismatch
+            ),
+            (
+                "request-shape",
+                provider,
+                replayState(provider, url: url, statusCode: 400, body: #"{"error":"unknown parameter tool_choice"}"#),
+                .disabled,
+                false,
+                false,
+                .requestRejected
+            ),
+            (
+                "auth-rejected-on-400",
+                provider,
+                replayState(provider, url: url, statusCode: 400, body: #"{"error":"invalid_api_key"}"#),
+                .disabled,
+                false,
+                false,
+                .authRejected
+            ),
+            (
+                "unsupported-model",
+                provider,
+                replayState(provider, url: url, statusCode: 400, body: #"{"error":"model_not_found"}"#),
+                .disabled,
+                false,
+                false,
+                .unsupportedModel
+            ),
+            (
+                "unexpected-upstream-response",
+                provider,
+                replayState(provider, url: url, statusCode: 429, body: #"{"error":"unexpected upstream condition"}"#),
+                .disabled,
+                false,
+                false,
+                .badResponse
+            ),
+            (
+                "unknown",
+                provider,
+                errorState(provider, message: "Provider returned an unexpected upstream condition."),
+                .disabled,
+                false,
+                false,
+                .unknown
+            ),
+        ]
+
+        for (name, provider, state, proxy, apiKeyPresent, oauthTokensPresent, bucket) in fixtures {
+            let classification = try #require(
+                ProviderFailureClassifier.classify(
+                    provider: provider,
+                    state: state,
+                    proxy: proxy,
+                    apiKeyPresent: apiKeyPresent,
+                    oauthTokensPresent: oauthTokensPresent
+                ),
+                "Missing classification for \(name)"
+            )
+            #expect(classification.bucket == bucket, "Wrong bucket for \(name)")
+            #expect(!classification.action.isEmpty, "Missing action for \(name)")
+        }
+
+        let invalidProxyOnly = ProviderFailureClassifier.classify(
+            provider: provider,
+            state: nil,
+            proxy: .invalid("bad proxy"),
+            apiKeyPresent: false,
+            oauthTokensPresent: false
+        )
+        #expect(invalidProxyOnly == nil)
+
+        let missingKeyWithoutFailure = ProviderFailureClassifier.classify(
+            provider: keyedProvider,
+            state: nil,
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: false
+        )
+        #expect(missingKeyWithoutFailure == nil)
+    }
+
     @Test func openAICompatibleReportExplainsManualModelFallbackAndRequestValidation() {
         let provider = RemoteProvider(
             name: "Lemonade",
@@ -234,5 +465,40 @@ struct ProviderNetworkDiagnosticsTests {
             return ProviderDiagnosticRow(id: id, title: "missing", value: "missing", severity: .blocked)
         }
         return found
+    }
+
+    private func errorState(_ provider: RemoteProvider, message: String) -> RemoteProviderState {
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = message
+        return state
+    }
+
+    private func replayState(
+        _ provider: RemoteProvider,
+        url: URL,
+        statusCode: Int? = nil,
+        body: String? = nil,
+        transportError: Error? = nil
+    ) -> RemoteProviderState {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        let response = statusCode.map {
+            HTTPURLResponse(
+                url: url,
+                statusCode: $0,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+        }
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = transportError?.localizedDescription ?? "HTTP \(statusCode ?? 500)"
+        state.lastReplayDiagnostics = ProviderReplayDiagnosticBundle(
+            phase: "test_model_discovery",
+            request: request,
+            response: response,
+            responseData: body.map { Data($0.utf8) },
+            transportError: transportError
+        )
+        return state
     }
 }

--- a/Packages/OsaurusCore/Tests/Provider/ProviderReplayDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderReplayDiagnosticsTests.swift
@@ -181,7 +181,7 @@ struct ProviderReplayDiagnosticsTests {
             code: 4,
             userInfo: [
                 NSLocalizedDescriptionKey:
-                    "Could not read (/Users/mmeding/Library/Application Support/osaurus/Secrets/token.json), at:/Users/mmeding/My Documents/keys/id_rsa, path/Users/mmeding/secrets.json, or /var/root/token.txt",
+                    "Could not read (/Users/mmeding/Library/Application Support/osaurus/Secrets/token.json), at:/Users/mmeding/My Documents/keys/id_rsa, path/Users/mmeding/secrets.json, HOME=/Users/mmeding/.env, path=/Users/mmeding/env.path, or /var/root/token.txt",
             ]
         )
 
@@ -209,6 +209,8 @@ struct ProviderReplayDiagnosticsTests {
             "private.json",
             "id_rsa",
             "secrets.json",
+            "path.env",
+            ".env",
             "token.txt",
             "custom-secret-value",
             "sk-local-path-body-secret",
@@ -216,5 +218,24 @@ struct ProviderReplayDiagnosticsTests {
         ] {
             #expect(!copied.contains(leak))
         }
+    }
+
+    @Test func redactedBodyDoesNotOverRedactRemoteURIs() {
+        let remotePayload = "Could not connect to https://api.example.com/v1/users/me because the network failed"
+        let safeRemotePayload = ProviderDiagnosticRedactor.safe(remotePayload)
+
+        #expect(safeRemotePayload.contains("/v1/users/me"))
+        #expect(!safeRemotePayload.contains("redacted-local-path"))
+
+        let remoteTmpPayload =
+            "Could not fetch https://cdn.example.com/tmp/build/artifact.tar.gz from artifact cache"
+        let safeRemoteTmpPayload = ProviderDiagnosticRedactor.safe(remoteTmpPayload)
+        #expect(safeRemoteTmpPayload.contains("/tmp/build/artifact.tar.gz"))
+        #expect(!safeRemoteTmpPayload.contains("redacted-local-path"))
+
+        let localPayload = "Could not read /Users/example/Library/Application Support/osaurus/config.json"
+        let safeLocalPayload = ProviderDiagnosticRedactor.safe(localPayload)
+        #expect(safeLocalPayload.contains("/[redacted-local-path]"))
+        #expect(!safeLocalPayload.contains("/Users/example/Library/Application"))
     }
 }

--- a/Packages/OsaurusCore/Tests/Provider/ProviderReplayDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderReplayDiagnosticsTests.swift
@@ -164,4 +164,57 @@ struct ProviderReplayDiagnosticsTests {
         #expect(lines.filter { $0.hasPrefix("request_headers:") }.count == 1)
         #expect(lines.filter { $0.hasPrefix("response_body:") }.count == 1)
     }
+
+    @Test func bundleRedactsLocalPathsFileURLsAndCustomHeaders() throws {
+        let url = try #require(
+            URL(string: "file:///Users/mmeding/.osaurus/provider-cache.json?token=file-query-secret")
+        )
+        var request = URLRequest(url: url)
+        request.setValue("visible", forHTTPHeaderField: "X-Debug")
+        request.setValue("custom-secret-value", forHTTPHeaderField: "X-Provider-Debug")
+        request.httpBody = Data(
+            #"{"log_path":"/Users/mmeding/Library/Application Support/osaurus/Secrets/private.json","file":"file:///Users/mmeding/My Documents/keys/id_rsa","api_key":"sk-local-path-body-secret"}"#
+                .utf8
+        )
+        let error = NSError(
+            domain: NSCocoaErrorDomain,
+            code: 4,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Could not read (/Users/mmeding/Library/Application Support/osaurus/Secrets/token.json), at:/Users/mmeding/My Documents/keys/id_rsa, path/Users/mmeding/secrets.json, or /var/root/token.txt",
+            ]
+        )
+
+        let bundle = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery /Users/mmeding/Library/Application Support/osaurus/Secrets/provider-cache.json",
+            request: request,
+            transportError: error,
+            configuredSecretHeaderKeys: ["X-Provider-Debug"]
+        )
+        let copied = bundle.pasteboardText
+
+        #expect(copied.contains("file://[redacted-local-path]"))
+        #expect(copied.contains("/[redacted-local-path]"))
+        #expect(copied.contains("X-Provider-Debug=***"))
+        #expect(copied.contains("X-Debug=visible"))
+        #expect(copied.contains(#""api_key":"***""#))
+        #expect(copied.contains("transport_error_code: NSCocoaErrorDomain:4"))
+        for leak in [
+            "/Users/mmeding",
+            "file:///Users",
+            "Application Support",
+            "My Documents",
+            "Secrets",
+            "provider-cache.json",
+            "private.json",
+            "id_rsa",
+            "secrets.json",
+            "token.txt",
+            "custom-secret-value",
+            "sk-local-path-body-secret",
+            "file-query-secret",
+        ] {
+            #expect(!copied.contains(leak))
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Provider/ProviderSetupRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderSetupRecoveryTests.swift
@@ -45,7 +45,10 @@ struct ProviderSetupRecoveryTests {
         #expect(!failure.pasteboardText.contains("sk-supersecret123"))
         #expect(!failure.pasteboardText.contains("private.internal.example"))
         #expect(!failure.pasteboardText.contains("/tenant/models"))
-        #expect(!failure.pasteboardText.contains("detail="))
+        #expect(failure.pasteboardText.contains("detail="))
+        #expect(failure.pasteboardText.contains("method=GET"))
+        #expect(failure.pasteboardText.contains("status=401"))
+        #expect(failure.pasteboardText.contains("endpoint=[redacted-endpoint]"))
         #expect(failure.pasteboardText.contains("api-key-present=true"))
     }
 
@@ -66,9 +69,10 @@ struct ProviderSetupRecoveryTests {
         #expect(failure.classification.bucket == .oauthTokenMissing)
         #expect(failure.classification.detail.contains("ChatGPT/Codex sign-in"))
         #expect(failure.recoveryDetail == "ChatGPT/Codex sign-in callback timed out")
+        #expect(failure.detailForDisplay == failure.recoveryDetail)
         #expect(failure.userMessage.contains("callback timed out"))
         #expect(failure.userMessage.contains("Sign in again"))
-        #expect(!failure.pasteboardText.contains("callback timed out"))
+        #expect(failure.pasteboardText.contains("detail=ChatGPT/Codex sign-in callback timed out"))
     }
 
     @Test func oauthFailureWithStoredTokensDoesNotClaimTokensAreMissing() {
@@ -89,13 +93,83 @@ struct ProviderSetupRecoveryTests {
         #expect(failure.classification.bucket != .oauthTokenMissing)
     }
 
+    @Test func oauthTokenFailuresBeatGenericAuthenticationRejection() {
+        let messages = [
+            "Access token expired",
+            "HTTP 401: invalid OAuth token",
+        ]
+
+        for message in messages {
+            let failure = ProviderFailureClassifier.classifySetupFailure(
+                provider: Self.provider(authType: .openAICodexOAuth),
+                error: NSError(
+                    domain: "ProviderSetupRecoveryTests",
+                    code: 5,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                ),
+                proxy: .disabled,
+                apiKeyPresent: false,
+                oauthTokensPresent: true
+            )
+
+            #expect(failure.classification.bucket == .oauthTokenMissing)
+            #expect(failure.detailForDisplay == failure.classification.detail)
+        }
+    }
+
+    @Test func apiKeyTokenFailureRemainsAuthenticationRejection() {
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(),
+            error: NSError(
+                domain: "ProviderSetupRecoveryTests",
+                code: 6,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP 401: invalid token"]
+            ),
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+
+        #expect(failure.classification.bucket == .authRejected)
+    }
+
+    @Test func oauthReplayTokenExpiryBeatsHTTP401() throws {
+        let url = try #require(URL(string: "https://api.example.test/v1/models"))
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        )
+        let replay = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: URLRequest(url: url),
+            response: response,
+            responseData: Data(#"{"error":"access token expired"}"#.utf8)
+        )
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(authType: .xaiOAuth),
+            error: RemoteProviderServiceError.requestFailedWithDiagnostics("HTTP 401", replay),
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: true
+        )
+
+        #expect(failure.classification.bucket == .oauthTokenMissing)
+    }
+
     @Test func stringFailuresMapToTypedRecoveryBuckets() {
         let cases: [(String, ProviderFailureBucket)] = [
             ("The request timed out", .timeout),
             ("TLS certificate validation failed", .tlsFailure),
             ("Could not find host", .endpointUnreachable),
             ("No models available from provider", .modelsSchemaMismatch),
-            ("HTTP 404", .modelsEndpointUnavailable),
+            ("HTTP 404", .badResponse),
+            ("HTTP 405", .badResponse),
+            ("HTTP 404 from /models", .modelsEndpointUnavailable),
+            ("HTTP 405 from the models endpoint", .modelsEndpointUnavailable),
             ("invalid request: unsupported field", .requestRejected),
             ("unexpected provider failure", .unknown),
         ]
@@ -114,6 +188,32 @@ struct ProviderSetupRecoveryTests {
             )
             #expect(failure.classification.bucket == expected)
         }
+    }
+
+    @Test func modelDiscoveryReplayStillClassifiesMissingEndpoint() throws {
+        let url = try #require(URL(string: "https://api.example.test/v1/models"))
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        )
+        let replay = ProviderReplayDiagnosticBundle(
+            phase: "model_discovery",
+            request: URLRequest(url: url),
+            response: response
+        )
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(),
+            error: RemoteProviderServiceError.requestFailedWithDiagnostics("HTTP 404", replay),
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+
+        #expect(failure.classification.bucket == .modelsEndpointUnavailable)
     }
 
     @Test func proxyFailureStaysDistinctFromOriginFailure() {
@@ -145,7 +245,10 @@ struct ProviderSetupRecoveryTests {
             error: NSError(
                 domain: "ProviderSetupRecoveryTests",
                 code: 3,
-                userInfo: [NSLocalizedDescriptionKey: "API key sk-private-123 was rejected"]
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "API key sk-private-123 was rejected by api.internal.corp:8443/v2/models while reading /Users/mmeding/Secrets/provider.json"
+                ]
             ),
             proxy: .invalid("password secret-proxy-value"),
             apiKeyPresent: true,
@@ -156,7 +259,14 @@ struct ProviderSetupRecoveryTests {
         #expect(!failure.pasteboardText.contains("secret-path"))
         #expect(!failure.pasteboardText.contains("private-model"))
         #expect(!failure.pasteboardText.contains("sk-private-123"))
+        #expect(!failure.pasteboardText.contains("api.internal.corp"))
+        #expect(!failure.pasteboardText.contains("/v2/models"))
+        #expect(!failure.pasteboardText.contains("/Users/mmeding"))
+        #expect(!failure.pasteboardText.contains("provider.json"))
         #expect(!failure.pasteboardText.contains("secret-proxy-value"))
+        #expect(failure.pasteboardText.contains("sk-***"))
+        #expect(failure.pasteboardText.contains("[redacted-endpoint]"))
+        #expect(failure.pasteboardText.contains("[redacted-local-path]"))
         #expect(failure.pasteboardText.contains("manual-model-count=1"))
     }
 

--- a/Packages/OsaurusCore/Tests/Provider/ProviderSetupRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderSetupRecoveryTests.swift
@@ -75,6 +75,34 @@ struct ProviderSetupRecoveryTests {
         #expect(failure.pasteboardText.contains("detail=ChatGPT/Codex sign-in callback timed out"))
     }
 
+    @Test func recoveryDetailRedactsCredentialHeaderAndLocalPathCanaries() throws {
+        let secret = "sk-private-recovery-123456789"
+        let localPath = "/Users/mmeding/Secrets/provider.json"
+        let bearer = "private-bearer-token-123456789"
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(authType: .openAICodexOAuth),
+            error: NSError(
+                domain: "ProviderSetupRecoveryTests",
+                code: 7,
+                userInfo: [NSLocalizedDescriptionKey: "OAuth failed"]
+            ),
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: false,
+            diagnosticMessage: "OAuth failed for \(secret) at \(localPath); Authorization: Bearer \(bearer)"
+        )
+
+        let recoveryDetail = try #require(failure.recoveryDetail)
+        for projection in [recoveryDetail, failure.detailForDisplay, failure.userMessage, failure.pasteboardText] {
+            #expect(!projection.contains(secret))
+            #expect(!projection.contains(localPath))
+            #expect(!projection.contains(bearer))
+        }
+        #expect(recoveryDetail.contains("sk-***"))
+        #expect(recoveryDetail.contains("/[redacted-local-path]"))
+        #expect(recoveryDetail.contains("Authorization=***"))
+    }
+
     @Test func oauthFailureWithStoredTokensDoesNotClaimTokensAreMissing() {
         let failure = ProviderFailureClassifier.classifySetupFailure(
             provider: Self.provider(authType: .openAICodexOAuth),
@@ -168,8 +196,10 @@ struct ProviderSetupRecoveryTests {
             ("No models available from provider", .modelsSchemaMismatch),
             ("HTTP 404", .badResponse),
             ("HTTP 405", .badResponse),
+            ("HTTP 501", .badResponse),
             ("HTTP 404 from /models", .modelsEndpointUnavailable),
             ("HTTP 405 from the models endpoint", .modelsEndpointUnavailable),
+            ("HTTP 501 during model discovery", .modelsEndpointUnavailable),
             ("invalid request: unsupported field", .requestRejected),
             ("unexpected provider failure", .unknown),
         ]
@@ -214,6 +244,122 @@ struct ProviderSetupRecoveryTests {
         )
 
         #expect(failure.classification.bucket == .modelsEndpointUnavailable)
+    }
+
+    @Test func nativeProviderModelDiscoveryFailuresDoNotSuggestOpenAIManualModelWorkaround() {
+        let providerTypes: [RemoteProviderType] = [.anthropic, .gemini, .openAICodex]
+        let statuses = [404, 405, 501]
+
+        for providerType in providerTypes {
+            for status in statuses {
+                let failure = ProviderFailureClassifier.classifySetupFailure(
+                    provider: Self.provider(providerType: providerType),
+                    error: NSError(
+                        domain: "ProviderSetupRecoveryTests",
+                        code: status,
+                        userInfo: [NSLocalizedDescriptionKey: "HTTP \(status) from /models"]
+                    ),
+                    proxy: .disabled,
+                    apiKeyPresent: true,
+                    oauthTokensPresent: false
+                )
+
+                #expect(failure.classification.bucket == .modelsEndpointUnavailable)
+                #expect(!failure.classification.action.localizedCaseInsensitiveContains("manual model"))
+                #expect(!failure.classification.action.localizedCaseInsensitiveContains("openai-compatible"))
+            }
+        }
+    }
+
+    @Test func manualModelGuidanceRequiresCompatibleProviderAndExposedFlow() {
+        let error = NSError(
+            domain: "ProviderSetupRecoveryTests",
+            code: 404,
+            userInfo: [NSLocalizedDescriptionKey: "HTTP 404 from /models"]
+        )
+        let openAIWithEditor = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(providerType: .openaiLegacy),
+            error: error,
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false,
+            manualModelRecovery: .openAICompatibleModelIDs
+        )
+        let openAIWithoutEditor = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(providerType: .openaiLegacy),
+            error: error,
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false,
+            manualModelRecovery: .unavailable
+        )
+        let anthropicWithWrongCapability = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(providerType: .anthropic),
+            error: error,
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false,
+            manualModelRecovery: .openAICompatibleModelIDs
+        )
+        let azureWithDeployments = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(providerType: .azureOpenAI),
+            error: error,
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false,
+            manualModelRecovery: .azureDeploymentIDs
+        )
+
+        #expect(openAIWithEditor.classification.action.localizedCaseInsensitiveContains("manual model"))
+        #expect(!openAIWithoutEditor.classification.action.localizedCaseInsensitiveContains("manual model"))
+        #expect(!anthropicWithWrongCapability.classification.action.localizedCaseInsensitiveContains("manual model"))
+        #expect(azureWithDeployments.classification.action.localizedCaseInsensitiveContains("deployment/model"))
+        #expect(!azureWithDeployments.classification.action.localizedCaseInsensitiveContains("openai-compatible"))
+    }
+
+    @Test func onboardingContextNeverOffersManualModelRecovery() {
+        let providerTypes: [RemoteProviderType] = [.openaiLegacy, .openResponses, .anthropic, .gemini, .openAICodex]
+
+        for providerType in providerTypes {
+            let failure = ProviderFailureClassifier.classifySetupFailure(
+                provider: Self.provider(providerType: providerType),
+                error: NSError(
+                    domain: "ProviderSetupRecoveryTests",
+                    code: 501,
+                    userInfo: [NSLocalizedDescriptionKey: "HTTP 501 during model discovery"]
+                ),
+                proxy: .disabled,
+                apiKeyPresent: true,
+                oauthTokensPresent: false,
+                manualModelRecovery: .unavailable
+            )
+
+            #expect(failure.classification.bucket == .modelsEndpointUnavailable)
+            #expect(!failure.classification.action.localizedCaseInsensitiveContains("manual model"))
+            #expect(!failure.classification.action.localizedCaseInsensitiveContains("deployment/model"))
+        }
+    }
+
+    @Test func ongoingNativeProviderDiagnosticsDoNotSuggestManualModelRecovery() throws {
+        for providerType in [RemoteProviderType.anthropic, .gemini, .openAICodex] {
+            let provider = Self.provider(providerType: providerType)
+            var state = RemoteProviderState(providerId: provider.id)
+            state.lastError = "HTTP 405 from the models endpoint"
+
+            let classification = try #require(
+                ProviderFailureClassifier.classify(
+                    provider: provider,
+                    state: state,
+                    proxy: .disabled,
+                    apiKeyPresent: true,
+                    oauthTokensPresent: false
+                )
+            )
+
+            #expect(classification.bucket == .modelsEndpointUnavailable)
+            #expect(!classification.action.localizedCaseInsensitiveContains("manual model"))
+            #expect(!classification.action.localizedCaseInsensitiveContains("openai-compatible"))
+        }
     }
 
     @Test func proxyFailureStaysDistinctFromOriginFailure() {
@@ -274,7 +420,8 @@ struct ProviderSetupRecoveryTests {
         host: String = "api.example.com",
         basePath: String = "/v1",
         manualModelIds: [String] = [],
-        authType: RemoteProviderAuthType = .apiKey
+        authType: RemoteProviderAuthType = .apiKey,
+        providerType: RemoteProviderType = .openaiLegacy
     ) -> RemoteProvider {
         RemoteProvider(
             name: "Example",
@@ -282,7 +429,7 @@ struct ProviderSetupRecoveryTests {
             providerProtocol: .https,
             basePath: basePath,
             authType: authType,
-            providerType: .openaiLegacy,
+            providerType: providerType,
             manualModelIds: manualModelIds
         )
     }

--- a/Packages/OsaurusCore/Tests/Provider/ProviderSetupRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderSetupRecoveryTests.swift
@@ -1,0 +1,179 @@
+//
+//  ProviderSetupRecoveryTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct ProviderSetupRecoveryTests {
+    @Test func replayFailureUsesExistingAuthClassification() throws {
+        let url = try #require(URL(string: "https://private.internal.example/tenant/models?token=sk-supersecret123"))
+        let request = URLRequest(url: url)
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: ["Authorization": "Bearer sk-supersecret123"]
+            )
+        )
+        let replay = ProviderReplayDiagnosticBundle(
+            phase: "models",
+            request: request,
+            response: response,
+            responseData: Data("{\"error\":\"invalid_api_key sk-supersecret123\"}".utf8)
+        )
+        let error = RemoteProviderServiceError.requestFailedWithDiagnostics(
+            "request rejected sk-supersecret123",
+            replay
+        )
+
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(),
+            error: error,
+            proxy: .disabled,
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+
+        #expect(failure.classification.bucket == .authRejected)
+        #expect(failure.userMessage.contains(failure.classification.action))
+        #expect(!failure.pasteboardText.contains("sk-supersecret123"))
+        #expect(!failure.pasteboardText.contains("private.internal.example"))
+        #expect(!failure.pasteboardText.contains("/tenant/models"))
+        #expect(!failure.pasteboardText.contains("detail="))
+        #expect(failure.pasteboardText.contains("api-key-present=true"))
+    }
+
+    @Test func oauthFailuresPreserveCuratedSignInRecovery() {
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(authType: .openAICodexOAuth),
+            error: NSError(
+                domain: "OAuthLoopback",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "The browser callback timed out"]
+            ),
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: false,
+            diagnosticMessage: "ChatGPT/Codex sign-in callback timed out"
+        )
+
+        #expect(failure.classification.bucket == .oauthTokenMissing)
+        #expect(failure.classification.detail.contains("ChatGPT/Codex sign-in"))
+        #expect(failure.recoveryDetail == "ChatGPT/Codex sign-in callback timed out")
+        #expect(failure.userMessage.contains("callback timed out"))
+        #expect(failure.userMessage.contains("Sign in again"))
+        #expect(!failure.pasteboardText.contains("callback timed out"))
+    }
+
+    @Test func oauthFailureWithStoredTokensDoesNotClaimTokensAreMissing() {
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(authType: .openAICodexOAuth),
+            error: NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorTimedOut,
+                userInfo: [NSLocalizedDescriptionKey: "The request timed out"]
+            ),
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: true,
+            diagnosticMessage: "ChatGPT/Codex sign-in failed: The request timed out"
+        )
+
+        #expect(failure.classification.bucket == .timeout)
+        #expect(failure.classification.bucket != .oauthTokenMissing)
+    }
+
+    @Test func stringFailuresMapToTypedRecoveryBuckets() {
+        let cases: [(String, ProviderFailureBucket)] = [
+            ("The request timed out", .timeout),
+            ("TLS certificate validation failed", .tlsFailure),
+            ("Could not find host", .endpointUnreachable),
+            ("No models available from provider", .modelsSchemaMismatch),
+            ("HTTP 404", .modelsEndpointUnavailable),
+            ("invalid request: unsupported field", .requestRejected),
+            ("unexpected provider failure", .unknown),
+        ]
+
+        for (message, expected) in cases {
+            let failure = ProviderFailureClassifier.classifySetupFailure(
+                provider: Self.provider(),
+                error: NSError(
+                    domain: "ProviderSetupRecoveryTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                ),
+                proxy: .disabled,
+                apiKeyPresent: true,
+                oauthTokensPresent: false
+            )
+            #expect(failure.classification.bucket == expected)
+        }
+    }
+
+    @Test func proxyFailureStaysDistinctFromOriginFailure() {
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: Self.provider(),
+            error: NSError(
+                domain: "ProviderSetupRecoveryTests",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "proxy connection refused"]
+            ),
+            proxy: .active("socks5://proxy.example:1080"),
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+
+        #expect(failure.classification.bucket == .proxyConnectFailed)
+        #expect(failure.proxyState == "active")
+        #expect(!failure.pasteboardText.contains("proxy.example"))
+    }
+
+    @Test func setupEvidenceIsAllowlistedAndContainsNoEndpointOrCredentialValues() {
+        let provider = Self.provider(
+            host: "private.internal.example",
+            basePath: "/tenant/secret-path",
+            manualModelIds: ["private-model"]
+        )
+        let failure = ProviderFailureClassifier.classifySetupFailure(
+            provider: provider,
+            error: NSError(
+                domain: "ProviderSetupRecoveryTests",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "API key sk-private-123 was rejected"]
+            ),
+            proxy: .invalid("password secret-proxy-value"),
+            apiKeyPresent: true,
+            oauthTokensPresent: false
+        )
+
+        #expect(!failure.pasteboardText.contains("private.internal.example"))
+        #expect(!failure.pasteboardText.contains("secret-path"))
+        #expect(!failure.pasteboardText.contains("private-model"))
+        #expect(!failure.pasteboardText.contains("sk-private-123"))
+        #expect(!failure.pasteboardText.contains("secret-proxy-value"))
+        #expect(failure.pasteboardText.contains("manual-model-count=1"))
+    }
+
+    private static func provider(
+        host: String = "api.example.com",
+        basePath: String = "/v1",
+        manualModelIds: [String] = [],
+        authType: RemoteProviderAuthType = .apiKey
+    ) -> RemoteProvider {
+        RemoteProvider(
+            name: "Example",
+            host: host,
+            providerProtocol: .https,
+            basePath: basePath,
+            authType: authType,
+            providerType: .openaiLegacy,
+            manualModelIds: manualModelIds
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -801,7 +801,8 @@ final class ConfigureAIState: ObservableObject {
                         proxy: GlobalProxySettings.currentDiagnostic(),
                         apiKeyPresent: !self.apiKey.isEmpty,
                         oauthTokensPresent: self.oauthTokens != nil,
-                        diagnosticMessage: diagnosticMessage
+                        diagnosticMessage: diagnosticMessage,
+                        manualModelRecovery: .unavailable
                     )
                 )
                 self.isTesting = false

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -61,6 +61,11 @@ struct ProviderSetupTestIdentity: Equatable {
     let apiKeyInput: String?
 }
 
+enum ProviderSetupOAuthCompletion: Equatable {
+    case apiKey(String)
+    case oauthTokens(RemoteProviderOAuthTokens)
+}
+
 // MARK: - Resolved provider config
 
 struct ResolvedProviderConfig: Equatable {
@@ -654,6 +659,7 @@ final class ConfigureAIState: ObservableObject {
         customForm.reset()
         testResult = nil
         apiTestRequestID = nil
+        isTesting = false
         hasFinalizedAPI = false
     }
 
@@ -733,23 +739,34 @@ final class ConfigureAIState: ObservableObject {
 
         Task { @MainActor [weak self] in
             guard let self = self else { return }
-            let result: APITestResult
             do {
                 switch testedIdentity.authMethod {
                 case .oauth(.openAICodex):
                     let tokens = try await OpenAICodexOAuthService.signIn()
-                    self.oauthTokens = tokens
+                    guard self.applyOAuthCompletionIfCurrent(
+                        .oauthTokens(tokens),
+                        requestID: requestID,
+                        identity: testedIdentity
+                    ) else { return }
                 case .oauth(.openRouter):
                     // The browser sign-in IS the test: it returns a freshly minted
-                    // OpenRouter API key, which we stash in `apiKey` for the save
-                    // step to persist via the standard apiKey path.
+                    // OpenRouter API key. Keep it local until the same form is
+                    // still active, then stash it for the standard save path.
                     let key = try await OpenRouterOAuthService.signIn()
-                    self.apiKey = key
+                    guard self.applyOAuthCompletionIfCurrent(
+                        .apiKey(key),
+                        requestID: requestID,
+                        identity: testedIdentity
+                    ) else { return }
                 case .oauth(.xai):
                     // Grok sign-in returns access/refresh tokens stashed for the
                     // save step to persist via the `.xaiOAuth` path.
                     let tokens = try await XAIOAuthService.signIn()
-                    self.oauthTokens = tokens
+                    guard self.applyOAuthCompletionIfCurrent(
+                        .oauthTokens(tokens),
+                        requestID: requestID,
+                        identity: testedIdentity
+                    ) else { return }
                 case .apiKey, .none:
                     _ = try await RemoteProviderManager.shared.testConnection(
                         host: config.host,
@@ -762,8 +779,11 @@ final class ConfigureAIState: ObservableObject {
                         headers: [:]
                     )
                 }
-                result = .success(testedIdentity)
+                guard self.setupTestIsCurrent(requestID: requestID, identity: testedIdentity) else { return }
+                self.testResult = .success(testedIdentity)
+                self.isTesting = false
             } catch {
+                guard self.setupTestIsCurrent(requestID: requestID, identity: testedIdentity) else { return }
                 let draft = self.setupDraftProvider(config, authMethod: testedIdentity.authMethod)
                 let diagnosticMessage: String?
                 switch testedIdentity.authMethod {
@@ -774,7 +794,7 @@ final class ConfigureAIState: ObservableObject {
                 case .oauth(.openRouter), .apiKey, .none:
                     diagnosticMessage = nil
                 }
-                result = .failure(
+                self.testResult = .failure(
                     ProviderFailureClassifier.classifySetupFailure(
                         provider: draft,
                         error: error,
@@ -784,15 +804,35 @@ final class ConfigureAIState: ObservableObject {
                         diagnosticMessage: diagnosticMessage
                     )
                 )
-            }
-            guard self.apiTestRequestID == requestID else { return }
-            guard self.currentSetupTestIdentity() == testedIdentity else {
                 self.isTesting = false
-                return
             }
-            self.testResult = result
-            self.isTesting = false
         }
+    }
+
+    @discardableResult
+    func applyOAuthCompletionIfCurrent(
+        _ completion: ProviderSetupOAuthCompletion,
+        requestID: UUID,
+        identity: ProviderSetupTestIdentity
+    ) -> Bool {
+        guard setupTestIsCurrent(requestID: requestID, identity: identity) else { return false }
+        switch completion {
+        case .apiKey(let key):
+            apiKey = key
+        case .oauthTokens(let tokens):
+            oauthTokens = tokens
+        }
+        return true
+    }
+
+    @discardableResult
+    func setupTestIsCurrent(requestID: UUID, identity: ProviderSetupTestIdentity) -> Bool {
+        guard apiTestRequestID == requestID else { return false }
+        guard currentSetupTestIdentity() == identity else {
+            isTesting = false
+            return false
+        }
+        return true
     }
 
     private func setupTestIdentity(_ config: ResolvedProviderConfig) -> ProviderSetupTestIdentity {

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -51,13 +51,19 @@ enum APISubstate: Equatable {
 }
 
 enum APITestResult: Equatable {
-    case success
-    case failure(String)
+    case success(ProviderSetupTestIdentity)
+    case failure(ProviderSetupFailure)
+}
+
+struct ProviderSetupTestIdentity: Equatable {
+    let config: ResolvedProviderConfig
+    let authMethod: ProviderPickerAuthMethod
+    let apiKeyInput: String?
 }
 
 // MARK: - Resolved provider config
 
-struct ResolvedProviderConfig {
+struct ResolvedProviderConfig: Equatable {
     let name: String
     let host: String
     let port: Int?
@@ -197,6 +203,7 @@ final class ConfigureAIState: ObservableObject {
     @Published var isTesting = false
     @Published var isSaving = false
     @Published var testResult: APITestResult? = nil
+    var apiTestRequestID: UUID?
     /// One-shot latch so the auto-advance-on-green and a manual CTA press can't
     /// both finalize. Reset whenever credentials are cleared (back / reselect).
     var hasFinalizedAPI = false
@@ -612,15 +619,17 @@ final class ConfigureAIState: ObservableObject {
     }
 
     var isAPISuccess: Bool {
-        if case .success = testResult { return true }
+        if case .success(let identity) = testResult {
+            return currentSetupTestIdentity() == identity
+        }
         return false
     }
 
     var apiButtonState: OnboardingButtonState {
         if isTesting || isSaving { return .loading }
         switch testResult {
-        case .success: return .success
-        case .failure(let m): return .error(m)
+        case .success: return isAPISuccess ? .success : .idle
+        case .failure(let failure): return .error(failure.userMessage)
         case nil: return .idle
         }
     }
@@ -644,6 +653,7 @@ final class ConfigureAIState: ObservableObject {
         addedProviderId = nil
         customForm.reset()
         testResult = nil
+        apiTestRequestID = nil
         hasFinalizedAPI = false
     }
 
@@ -715,6 +725,9 @@ final class ConfigureAIState: ObservableObject {
 
     func testAPIConnection() {
         guard let config = resolvedAPIConfig() else { return }
+        let testedIdentity = setupTestIdentity(config)
+        let requestID = UUID()
+        apiTestRequestID = requestID
         isTesting = true
         testResult = nil
 
@@ -722,7 +735,7 @@ final class ConfigureAIState: ObservableObject {
             guard let self = self else { return }
             let result: APITestResult
             do {
-                switch self.selectedAuthMethod {
+                switch testedIdentity.authMethod {
                 case .oauth(.openAICodex):
                     let tokens = try await OpenAICodexOAuthService.signIn()
                     self.oauthTokens = tokens
@@ -749,13 +762,71 @@ final class ConfigureAIState: ObservableObject {
                         headers: [:]
                     )
                 }
-                result = .success
+                result = .success(testedIdentity)
             } catch {
-                result = .failure(error.localizedDescription)
+                let draft = self.setupDraftProvider(config, authMethod: testedIdentity.authMethod)
+                let diagnosticMessage: String?
+                switch testedIdentity.authMethod {
+                case .oauth(.openAICodex):
+                    diagnosticMessage = OpenAICodexOAuthService.diagnosticMessage(for: error)
+                case .oauth(.xai):
+                    diagnosticMessage = XAIOAuthService.diagnosticMessage(for: error)
+                case .oauth(.openRouter), .apiKey, .none:
+                    diagnosticMessage = nil
+                }
+                result = .failure(
+                    ProviderFailureClassifier.classifySetupFailure(
+                        provider: draft,
+                        error: error,
+                        proxy: GlobalProxySettings.currentDiagnostic(),
+                        apiKeyPresent: !self.apiKey.isEmpty,
+                        oauthTokensPresent: self.oauthTokens != nil,
+                        diagnosticMessage: diagnosticMessage
+                    )
+                )
+            }
+            guard self.apiTestRequestID == requestID else { return }
+            guard self.currentSetupTestIdentity() == testedIdentity else {
+                self.isTesting = false
+                return
             }
             self.testResult = result
             self.isTesting = false
         }
+    }
+
+    private func setupTestIdentity(_ config: ResolvedProviderConfig) -> ProviderSetupTestIdentity {
+        ProviderSetupTestIdentity(
+            config: config,
+            authMethod: selectedAuthMethod,
+            apiKeyInput: selectedAuthMethod == .apiKey ? apiKey : nil
+        )
+    }
+
+    private func currentSetupTestIdentity() -> ProviderSetupTestIdentity? {
+        guard let config = resolvedAPIConfig() else { return nil }
+        return setupTestIdentity(config)
+    }
+
+    private func setupDraftProvider(
+        _ config: ResolvedProviderConfig,
+        authMethod: ProviderPickerAuthMethod
+    ) -> RemoteProvider {
+        let authType: RemoteProviderAuthType
+        switch authMethod {
+        case .oauth(.openAICodex): authType = .openAICodexOAuth
+        case .oauth(.xai): authType = .xaiOAuth
+        default: authType = config.authType
+        }
+        return RemoteProvider(
+            name: config.name,
+            host: config.host,
+            providerProtocol: config.providerProtocol,
+            port: config.port,
+            basePath: config.basePath,
+            authType: authType,
+            providerType: config.providerType
+        )
     }
 
     func saveProviderAndContinue(onComplete: () -> Void) {
@@ -1887,8 +1958,9 @@ struct ConfigureAICTA: View {
                 switch state.apiSubstate {
                 case .keyForm, .customForm:
                     Task {
-                        try? await Task.sleep(nanoseconds: 400_000_000)
+                        try? await Task.sleep(nanoseconds: 800_000_000)
                         await MainActor.run {
+                            guard state.isAPISuccess else { return }
                             state.saveProviderAndContinue(onComplete: onComplete)
                         }
                     }

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -165,6 +165,7 @@ private struct AddProviderFlow: View {
     @State private var isTesting = false
     @State private var testResult: ProviderTestResult?
     @State private var testRequestID: UUID?
+    @State private var customTestGate = CustomProviderSetupSuccessGate()
     @State private var draftProviderID = UUID()
     @State private var hasAppeared = false
     /// Guards against saving twice: a successful test auto-finalizes the add,
@@ -602,7 +603,7 @@ private struct AddProviderFlow: View {
 
             // Footer
             sheetFooter(canProceed: canTestCustom) {
-                if testResult?.isSuccess == true {
+                if hasCurrentSuccessfulTest {
                     saveCustomProvider()
                 } else {
                     testCustomProvider()
@@ -628,6 +629,7 @@ private struct AddProviderFlow: View {
                 oauthTokens = nil
                 selectedAuthMethod = .apiKey
                 testResult = nil
+                customTestGate.invalidate()
                 customName = ""
                 customHost = ""
                 customPort = ""
@@ -1300,7 +1302,7 @@ private struct AddProviderFlow: View {
 
     @ViewBuilder
     private var testResultBadge: some View {
-        if let result = testResult {
+        if let result = testResultForDisplay {
             HStack(spacing: 6) {
                 switch result {
                 case .success(let models):
@@ -1362,7 +1364,7 @@ private struct AddProviderFlow: View {
     private var actionButtonTitle: String {
         let oauthKind = selectedOAuthKind
         if isTesting { return oauthKind != nil ? L("Signing in...") : L("Testing...") }
-        if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest { return L("Add Provider") }
+        if hasCurrentSuccessfulTest || canSaveKnownProviderWithoutSuccessfulTest { return L("Add Provider") }
         if case .failure = testResult { return L("Retry") }
         if let oauthKind {
             return NSLocalizedString(oauthKind.ctaTitle, bundle: .module, comment: "")
@@ -1371,9 +1373,20 @@ private struct AddProviderFlow: View {
     }
 
     private var actionButtonColor: Color {
-        if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest { return theme.successColor }
+        if hasCurrentSuccessfulTest || canSaveKnownProviderWithoutSuccessfulTest { return theme.successColor }
         if case .failure = testResult { return theme.errorColor }
         return theme.accentColor
+    }
+
+    private var hasCurrentSuccessfulTest: Bool {
+        guard testResult?.isSuccess == true else { return false }
+        guard selectedPreset == .custom else { return true }
+        return customTestGate.allowsAdd(current: currentCustomTestSnapshot())
+    }
+
+    private var testResultForDisplay: ProviderTestResult? {
+        guard selectedPreset == .custom, testResult?.isSuccess == true else { return testResult }
+        return hasCurrentSuccessfulTest ? testResult : nil
     }
 
     private var canTestCustom: Bool {
@@ -1530,7 +1543,8 @@ private struct AddProviderFlow: View {
                         proxy: GlobalProxySettings.currentDiagnostic(),
                         apiKeyPresent: !apiKey.isEmpty,
                         oauthTokensPresent: oauthTokens != nil,
-                        diagnosticMessage: diagnosticMessage
+                        diagnosticMessage: diagnosticMessage,
+                        manualModelRecovery: preset == .azureOpenAI ? .azureDeploymentIDs : .unavailable
                     )
                     withAnimation {
                         testResult = .failure(failure); isTesting = false
@@ -1586,43 +1600,39 @@ private struct AddProviderFlow: View {
     }
 
     func testCustomProvider() {
-        let trimmedHost = customHost.trimmingCharacters(in: .whitespaces)
-        let trimmedBasePath = customBasePath.trimmingCharacters(in: .whitespaces)
-        let port: Int? = customPort.trimmingCharacters(in: .whitespaces).isEmpty ? nil : Int(customPort)
-        let testApiKey = customAuthType == .apiKey && !apiKey.isEmpty ? apiKey : nil
-        let testedProvider = draftCustomProvider()
-        let testedAPIKeyInput = apiKey
-        let testedHeaders = customHeaders
+        let testedSnapshot = currentCustomTestSnapshot()
+        let testedProvider = testedSnapshot.provider
+        let testApiKey = testedProvider.authType == .apiKey && !testedSnapshot.apiKeyInput.isEmpty
+            ? testedSnapshot.apiKeyInput
+            : nil
 
         isTesting = true
         testResult = nil
+        customTestGate.invalidate()
         let requestID = UUID()
         testRequestID = requestID
 
         Task {
             do {
                 let models = try await RemoteProviderManager.shared.testConnection(
-                    host: trimmedHost,
-                    providerProtocol: customProtocol,
-                    port: port,
-                    basePath: trimmedBasePath.isEmpty ? "/v1" : trimmedBasePath,
-                    authType: customAuthType,
-                    providerType: .openaiLegacy,
+                    host: testedProvider.host,
+                    providerProtocol: testedProvider.providerProtocol,
+                    port: testedProvider.port,
+                    basePath: testedProvider.basePath,
+                    authType: testedProvider.authType,
+                    providerType: testedProvider.providerType,
                     apiKey: testApiKey,
-                    headers: HeaderEntry.buildHeaders(from: testedHeaders),
+                    headers: HeaderEntry.buildHeaders(from: testedSnapshot.headers),
                     manualModelIds: testedProvider.manualModelIds
                 )
                 await MainActor.run {
                     guard testRequestID == requestID else { return }
-                    guard matchesCustomTestInputs(
-                        provider: testedProvider,
-                        apiKeyInput: testedAPIKeyInput,
-                        headers: testedHeaders
-                    ) else {
+                    guard currentCustomTestSnapshot() == testedSnapshot else {
                         isTesting = false
                         return
                     }
                     withAnimation {
+                        customTestGate.recordSuccess(testedSnapshot)
                         testResult = .success(models); isTesting = false
                     }
                 }
@@ -1631,11 +1641,7 @@ private struct AddProviderFlow: View {
                 await MainActor.run {
                     guard testRequestID == requestID else { return }
                     guard testResult?.isSuccess == true,
-                        matchesCustomTestInputs(
-                            provider: testedProvider,
-                            apiKeyInput: testedAPIKeyInput,
-                            headers: testedHeaders
-                        )
+                        customTestGate.allowsAdd(current: currentCustomTestSnapshot())
                     else { return }
                     saveCustomProvider()
                 }
@@ -1645,15 +1651,12 @@ private struct AddProviderFlow: View {
                     error: error,
                     proxy: GlobalProxySettings.currentDiagnostic(),
                     apiKeyPresent: testApiKey != nil,
-                    oauthTokensPresent: false
+                    oauthTokensPresent: false,
+                    manualModelRecovery: .unavailable
                 )
                 await MainActor.run {
                     guard testRequestID == requestID else { return }
-                    guard matchesCustomTestInputs(
-                        provider: testedProvider,
-                        apiKeyInput: testedAPIKeyInput,
-                        headers: testedHeaders
-                    ) else {
+                    guard currentCustomTestSnapshot() == testedSnapshot else {
                         isTesting = false
                         return
                     }
@@ -1666,29 +1669,9 @@ private struct AddProviderFlow: View {
     }
 
     private func saveCustomProvider() {
-        guard !hasFinalized else { return }
+        guard !hasFinalized, hasCurrentSuccessfulTest else { return }
         hasFinalized = true
-        let trimmedName = customName.trimmingCharacters(in: .whitespaces)
-        let trimmedHost = customHost.trimmingCharacters(in: .whitespaces)
-        let trimmedBasePath = customBasePath.trimmingCharacters(in: .whitespaces)
-        let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
-
-        let remoteProvider = RemoteProvider(
-            name: trimmedName.isEmpty ? "Custom Provider" : trimmedName,
-            host: trimmedHost,
-            providerProtocol: customProtocol,
-            port: Int(customPort),
-            basePath: trimmedBasePath.isEmpty ? "/v1" : trimmedBasePath,
-            customHeaders: regularHeaders,
-            authType: customAuthType,
-            providerType: .openaiLegacy,
-            enabled: true,
-            autoConnect: true,
-            timeout: timeout,
-            disableTimeout: disableTimeout,
-            manualModelIds: parseManualModelIds(manualModelIdsText),
-            secretHeaderKeys: secretKeys
-        )
+        let remoteProvider = currentCustomTestSnapshot().provider
 
         saveSecretHeaders(for: remoteProvider.id)
         let savedApiKey = customAuthType == .apiKey && !apiKey.isEmpty ? apiKey : nil
@@ -1771,6 +1754,7 @@ private struct AddProviderFlow: View {
 
     private func draftCustomProvider() -> RemoteProvider {
         let trimmedName = customName.trimmingCharacters(in: .whitespaces)
+        let trimmedPort = customPort.trimmingCharacters(in: .whitespaces)
         let trimmedBasePath = customBasePath.trimmingCharacters(in: .whitespaces)
         let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
         return RemoteProvider(
@@ -1778,7 +1762,7 @@ private struct AddProviderFlow: View {
             name: trimmedName.isEmpty ? "Custom Provider" : trimmedName,
             host: customHost.trimmingCharacters(in: .whitespaces),
             providerProtocol: customProtocol,
-            port: Int(customPort),
+            port: trimmedPort.isEmpty ? nil : Int(trimmedPort),
             basePath: trimmedBasePath.isEmpty ? "/v1" : trimmedBasePath,
             customHeaders: regularHeaders,
             authType: customAuthType,
@@ -1790,14 +1774,17 @@ private struct AddProviderFlow: View {
         )
     }
 
-    private func matchesCustomTestInputs(
-        provider testedProvider: RemoteProvider,
-        apiKeyInput testedAPIKeyInput: String,
-        headers testedHeaders: [HeaderEntry]
-    ) -> Bool {
-        draftCustomProvider() == testedProvider
-            && apiKey == testedAPIKeyInput
-            && customHeaders == testedHeaders
+    private func currentCustomTestSnapshot() -> CustomProviderSetupTestSnapshot {
+        CustomProviderSetupTestSnapshot(
+            provider: draftCustomProvider(),
+            nameInput: customName,
+            hostInput: customHost,
+            portInput: customPort,
+            basePathInput: customBasePath,
+            apiKeyInput: apiKey,
+            manualModelIdsInput: manualModelIdsText,
+            headers: customHeaders
+        )
     }
 
     private func copySetupFailure(_ failure: ProviderSetupFailure) {
@@ -1880,7 +1867,7 @@ struct OpenRouterReauthorizationSession: Sendable, Equatable {
         guard consumeCurrentRequest(requestID: requestID, currentAPIKeyInput: currentAPIKeyInput) else {
             return false
         }
-        status = .failed(message)
+        status = .failed(ProviderDiagnosticRedactor.safe(message, maxLength: 360))
         return true
     }
 
@@ -2859,6 +2846,8 @@ private struct EditProviderFlow: View {
         let testedHeaders = customHeaders
         let testedAPIKeyPresent = testApiKey != nil || apiKeyPresent
         let testedOAuthTokensPresent = oauthTokensPresent
+        let testedManualModelRecovery: ProviderManualModelRecovery =
+            matchedPreset == .azureOpenAI ? .azureDeploymentIDs : .unavailable
 
         Task {
             do {
@@ -2907,7 +2896,8 @@ private struct EditProviderFlow: View {
                     proxy: GlobalProxySettings.currentDiagnostic(),
                     apiKeyPresent: testedAPIKeyPresent,
                     oauthTokensPresent: testedOAuthTokensPresent,
-                    diagnosticMessage: diagnosticMessage
+                    diagnosticMessage: diagnosticMessage,
+                    manualModelRecovery: testedManualModelRecovery
                 )
                 await MainActor.run {
                     guard testRequestID == requestID else { return }
@@ -3124,6 +3114,38 @@ struct HeaderEntry: Identifiable, Equatable {
             }
         }
         return (regular, secretKeys)
+    }
+}
+
+/// Exact custom-provider inputs bound to a successful connection test. Raw text
+/// fields stay alongside the normalized provider so semantically equivalent
+/// edits (for example `443` to `0443`) still require a fresh test.
+struct CustomProviderSetupTestSnapshot: Equatable {
+    var provider: RemoteProvider
+    var nameInput: String
+    var hostInput: String
+    var portInput: String
+    var basePathInput: String
+    var apiKeyInput: String
+    var manualModelIdsInput: String
+    var headers: [HeaderEntry]
+}
+
+/// A green custom-provider result authorizes Add only while every current input
+/// still equals the snapshot used by that test.
+struct CustomProviderSetupSuccessGate: Equatable {
+    private(set) var successfulSnapshot: CustomProviderSetupTestSnapshot?
+
+    mutating func recordSuccess(_ snapshot: CustomProviderSetupTestSnapshot) {
+        successfulSnapshot = snapshot
+    }
+
+    mutating func invalidate() {
+        successfulSnapshot = nil
+    }
+
+    func allowsAdd(current snapshot: CustomProviderSetupTestSnapshot) -> Bool {
+        successfulSnapshot == snapshot
     }
 }
 

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -265,7 +265,10 @@ private struct AddProviderFlow: View {
             }
             withAnimation { hasAppeared = true }
         }
-        .onDisappear { testRequestID = nil }
+        .onDisappear {
+            testRequestID = nil
+            isTesting = false
+        }
         .themedAlert(
             "Disable request timeout?",
             isPresented: $showNoTimeoutWarning,
@@ -619,6 +622,8 @@ private struct AddProviderFlow: View {
                 // sub-list) before the reset below clears it.
                 showingAPIKeyPicker = !selectedAuthMethod.isOAuth && selectedPreset != nil
                 selectedPreset = nil
+                testRequestID = nil
+                isTesting = false
                 apiKey = ""
                 oauthTokens = nil
                 selectedAuthMethod = .apiKey
@@ -679,6 +684,8 @@ private struct AddProviderFlow: View {
 
     private func initializeKnownConnection(for preset: ProviderPreset) {
         let config = preset.configuration
+        testRequestID = nil
+        isTesting = false
         knownHost = config.host
         knownProtocol = config.providerProtocol
         knownPort = config.port.map(String.init) ?? ""
@@ -1396,19 +1403,38 @@ private struct AddProviderFlow: View {
                 let models: [String]
                 if oauthKind == .openAICodex {
                     let tokens = try await OpenAICodexOAuthService.signIn()
-                    await MainActor.run {
+                    let didApply = await MainActor.run {
+                        guard knownTestIsCurrent(
+                            requestID: requestID,
+                            preset: preset,
+                            provider: testedProvider,
+                            oauthKind: oauthKind,
+                            apiKeyInput: testedAPIKeyInput,
+                            headers: testedHeaders
+                        ) else { return false }
                         oauthTokens = tokens
+                        return true
                     }
+                    guard didApply else { return }
                     models = await OpenAICodexOAuthService.availableModels(for: tokens)
                 } else if oauthKind == .openRouter {
                     // The browser sign-in mints a regular OpenRouter API key.
-                    // Stash it in `apiKey` so `saveKnownProvider` persists it
-                    // via the same path as a pasted key, then verify by
-                    // running the usual /models probe with the new key.
+                    // Keep it local until this is still the form that launched
+                    // sign-in; only then expose it for the save path.
                     let key = try await OpenRouterOAuthService.signIn()
-                    await MainActor.run {
+                    let didApply = await MainActor.run {
+                        guard knownTestIsCurrent(
+                            requestID: requestID,
+                            preset: preset,
+                            provider: testedProvider,
+                            oauthKind: oauthKind,
+                            apiKeyInput: testedAPIKeyInput,
+                            headers: testedHeaders
+                        ) else { return false }
                         apiKey = key
+                        return true
                     }
+                    guard didApply else { return }
                     models = try await RemoteProviderManager.shared.testConnection(
                         host: connection.host,
                         providerProtocol: connection.providerProtocol,
@@ -1427,9 +1453,19 @@ private struct AddProviderFlow: View {
                     // models (HTTP 403), so we surface the built-in catalog
                     // rather than probing /models.
                     let tokens = try await XAIOAuthService.signIn()
-                    await MainActor.run {
+                    let didApply = await MainActor.run {
+                        guard knownTestIsCurrent(
+                            requestID: requestID,
+                            preset: preset,
+                            provider: testedProvider,
+                            oauthKind: oauthKind,
+                            apiKeyInput: testedAPIKeyInput,
+                            headers: testedHeaders
+                        ) else { return false }
                         oauthTokens = tokens
+                        return true
                     }
+                    guard didApply else { return }
                     models = XAIOAuthService.supportedModels
                 } else {
                     models = try await RemoteProviderManager.shared.testConnection(
@@ -1445,17 +1481,14 @@ private struct AddProviderFlow: View {
                     )
                 }
                 await MainActor.run {
-                    guard testRequestID == requestID else { return }
-                    guard matchesKnownTestInputs(
+                    guard knownTestIsCurrent(
+                        requestID: requestID,
                         preset: preset,
                         provider: testedProvider,
                         oauthKind: oauthKind,
                         apiKeyInput: testedAPIKeyInput,
                         headers: testedHeaders
-                    ) else {
-                        isTesting = false
-                        return
-                    }
+                    ) else { return }
                     withAnimation {
                         testResult = .success(models); isTesting = false
                     }
@@ -1465,9 +1498,9 @@ private struct AddProviderFlow: View {
                 // press. The brief pause lets the green success state register.
                 try? await Task.sleep(nanoseconds: 800_000_000)
                 await MainActor.run {
-                    guard testRequestID == requestID else { return }
                     guard testResult?.isSuccess == true,
-                        matchesKnownTestInputs(
+                        knownTestIsCurrent(
+                            requestID: requestID,
                             preset: preset,
                             provider: testedProvider,
                             oauthKind: oauthKind,
@@ -1478,32 +1511,29 @@ private struct AddProviderFlow: View {
                     saveKnownProvider()
                 }
             } catch {
-                let diagnosticMessage: String?
-                switch oauthKind {
-                case .openAICodex: diagnosticMessage = OpenAICodexOAuthService.diagnosticMessage(for: error)
-                case .xai: diagnosticMessage = XAIOAuthService.diagnosticMessage(for: error)
-                default: diagnosticMessage = nil
-                }
-                let failure = ProviderFailureClassifier.classifySetupFailure(
-                    provider: testedProvider,
-                    error: error,
-                    proxy: GlobalProxySettings.currentDiagnostic(),
-                    apiKeyPresent: !apiKey.isEmpty,
-                    oauthTokensPresent: oauthTokens != nil,
-                    diagnosticMessage: diagnosticMessage
-                )
                 await MainActor.run {
-                    guard testRequestID == requestID else { return }
-                    guard matchesKnownTestInputs(
+                    guard knownTestIsCurrent(
+                        requestID: requestID,
                         preset: preset,
                         provider: testedProvider,
                         oauthKind: oauthKind,
                         apiKeyInput: testedAPIKeyInput,
                         headers: testedHeaders
-                    ) else {
-                        isTesting = false
-                        return
+                    ) else { return }
+                    let diagnosticMessage: String?
+                    switch oauthKind {
+                    case .openAICodex: diagnosticMessage = OpenAICodexOAuthService.diagnosticMessage(for: error)
+                    case .xai: diagnosticMessage = XAIOAuthService.diagnosticMessage(for: error)
+                    default: diagnosticMessage = nil
                     }
+                    let failure = ProviderFailureClassifier.classifySetupFailure(
+                        provider: testedProvider,
+                        error: error,
+                        proxy: GlobalProxySettings.currentDiagnostic(),
+                        apiKeyPresent: !apiKey.isEmpty,
+                        oauthTokensPresent: oauthTokens != nil,
+                        diagnosticMessage: diagnosticMessage
+                    )
                     withAnimation {
                         testResult = .failure(failure); isTesting = false
                     }
@@ -1701,6 +1731,29 @@ private struct AddProviderFlow: View {
         )
     }
 
+    @MainActor
+    private func knownTestIsCurrent(
+        requestID: UUID,
+        preset: ProviderPreset,
+        provider testedProvider: RemoteProvider,
+        oauthKind testedOAuthKind: ProviderOAuthKind?,
+        apiKeyInput testedAPIKeyInput: String,
+        headers testedHeaders: [HeaderEntry]
+    ) -> Bool {
+        guard testRequestID == requestID else { return false }
+        guard matchesKnownTestInputs(
+            preset: preset,
+            provider: testedProvider,
+            oauthKind: testedOAuthKind,
+            apiKeyInput: testedAPIKeyInput,
+            headers: testedHeaders
+        ) else {
+            isTesting = false
+            return false
+        }
+        return true
+    }
+
     private func matchesKnownTestInputs(
         preset: ProviderPreset,
         provider testedProvider: RemoteProvider,
@@ -1837,6 +1890,7 @@ private struct EditProviderFlow: View {
     // OpenRouter re-authorization. Collapsed to a single state so we can't
     // accidentally render both "succeeded" and "failed" feedback at once.
     @State private var reauthorizeState: ReauthorizeState = .idle
+    @State private var reauthorizeRequestID: UUID?
 
     enum ReauthorizeState: Equatable {
         case idle
@@ -1891,7 +1945,10 @@ private struct EditProviderFlow: View {
             Task { await refreshCredentialState() }
             withAnimation { hasAppeared = true }
         }
-        .onDisappear { testRequestID = nil }
+        .onDisappear {
+            testRequestID = nil
+            reauthorizeRequestID = nil
+        }
         .themedAlert(
             "Disable request timeout?",
             isPresented: $showNoTimeoutWarning,
@@ -2007,16 +2064,17 @@ private struct EditProviderFlow: View {
                     .foregroundColor(theme.tertiaryText)
                 }
 
-                ProviderSecureField(placeholder: "Leave blank to keep current", text: $apiKey)
-                    .onChange(of: apiKey) { _, _ in
-                        testResult = nil
-                        // User edited the field manually — clear any prior
-                        // re-authorize confirmation/error so we don't show
-                        // stale feedback against a typed key.
-                        if reauthorizeState != .idle && !reauthorizeState.isSigningIn {
-                            reauthorizeState = .idle
+                    ProviderSecureField(placeholder: "Leave blank to keep current", text: $apiKey)
+                        .onChange(of: apiKey) { _, _ in
+                            testResult = nil
+                            // User edited the field manually — clear any prior
+                            // re-authorize attempt or feedback so a late OAuth
+                            // callback cannot overwrite a typed key.
+                            reauthorizeRequestID = nil
+                            if reauthorizeState != .idle {
+                                reauthorizeState = .idle
+                            }
                         }
-                    }
             }
 
             if preset == .azureOpenAI {
@@ -2131,15 +2189,31 @@ private struct EditProviderFlow: View {
     }
 
     private func reauthorizeOpenRouter() {
+        let requestID = UUID()
+        let testedAPIKeyInput = apiKey
+        let testedAuthType = authType
+        let testedProviderType = providerType
+        reauthorizeRequestID = requestID
         reauthorizeState = .signingIn
         Task { @MainActor in
             do {
                 let key = try await OpenRouterOAuthService.signIn()
+                guard reauthorizeRequestID == requestID else { return }
+                guard apiKey == testedAPIKeyInput,
+                    authType == testedAuthType,
+                    providerType == testedProviderType
+                else {
+                    reauthorizeRequestID = nil
+                    reauthorizeState = .idle
+                    return
+                }
                 apiKey = key
                 reauthorizeState = .succeeded
             } catch {
+                guard reauthorizeRequestID == requestID else { return }
                 reauthorizeState = .failed(error.localizedDescription)
             }
+            reauthorizeRequestID = nil
         }
     }
 
@@ -2756,8 +2830,7 @@ private struct EditProviderFlow: View {
             } catch {
                 let diagnosticMessage: String?
                 if testedProvider.authType == .openAICodexOAuth
-                    || testedProvider.providerType == .openAICodex
-                {
+                    || testedProvider.providerType == .openAICodex {
                     diagnosticMessage = OpenAICodexOAuthService.diagnosticMessage(for: error)
                 } else if testedProvider.authType == .xaiOAuth {
                     diagnosticMessage = XAIOAuthService.diagnosticMessage(for: error)

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -165,6 +165,7 @@ private struct AddProviderFlow: View {
     @State private var isTesting = false
     @State private var testResult: ProviderTestResult?
     @State private var testRequestID: UUID?
+    @State private var knownTestGate = KnownProviderSetupSuccessGate()
     @State private var customTestGate = CustomProviderSetupSuccessGate()
     @State private var draftProviderID = UUID()
     @State private var hasAppeared = false
@@ -523,7 +524,7 @@ private struct AddProviderFlow: View {
 
             // Footer
             sheetFooter(canProceed: canTest) {
-                if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest {
+                if knownProviderSaveAuthorization.allowsSave {
                     saveKnownProvider()
                 } else {
                     testKnownProvider()
@@ -629,6 +630,7 @@ private struct AddProviderFlow: View {
                 oauthTokens = nil
                 selectedAuthMethod = .apiKey
                 testResult = nil
+                knownTestGate.invalidate()
                 customTestGate.invalidate()
                 customName = ""
                 customHost = ""
@@ -694,6 +696,7 @@ private struct AddProviderFlow: View {
         knownBasePath = config.basePath
         manualModelIdsText = config.defaultManualModelIds.joined(separator: "\n")
         testResult = nil
+        knownTestGate.invalidate()
     }
 
     private var azureConnectionSection: some View {
@@ -1364,7 +1367,7 @@ private struct AddProviderFlow: View {
     private var actionButtonTitle: String {
         let oauthKind = selectedOAuthKind
         if isTesting { return oauthKind != nil ? L("Signing in...") : L("Testing...") }
-        if hasCurrentSuccessfulTest || canSaveKnownProviderWithoutSuccessfulTest { return L("Add Provider") }
+        if hasCurrentSuccessfulTest || knownProviderSaveAuthorization.allowsSave { return L("Add Provider") }
         if case .failure = testResult { return L("Retry") }
         if let oauthKind {
             return NSLocalizedString(oauthKind.ctaTitle, bundle: .module, comment: "")
@@ -1373,19 +1376,31 @@ private struct AddProviderFlow: View {
     }
 
     private var actionButtonColor: Color {
-        if hasCurrentSuccessfulTest || canSaveKnownProviderWithoutSuccessfulTest { return theme.successColor }
+        if hasCurrentSuccessfulTest { return theme.successColor }
+        if knownProviderSaveAuthorization == .unverifiedAzureManualModels { return theme.accentColor }
         if case .failure = testResult { return theme.errorColor }
         return theme.accentColor
     }
 
     private var hasCurrentSuccessfulTest: Bool {
         guard testResult?.isSuccess == true else { return false }
-        guard selectedPreset == .custom else { return true }
-        return customTestGate.allowsAdd(current: currentCustomTestSnapshot())
+        if selectedPreset == .custom {
+            return customTestGate.allowsAdd(current: currentCustomTestSnapshot())
+        }
+        return knownProviderSaveAuthorization == .verified
+    }
+
+    private var knownProviderSaveAuthorization: KnownProviderSetupSaveAuthorization {
+        guard let preset = selectedPreset, preset != .custom else { return .denied }
+        return knownTestGate.authorization(
+            current: currentKnownTestSnapshot(for: preset),
+            hasSuccessfulResult: testResult?.isSuccess == true,
+            allowsUnverifiedAzureSave: canSaveKnownProviderWithoutSuccessfulTest
+        )
     }
 
     private var testResultForDisplay: ProviderTestResult? {
-        guard selectedPreset == .custom, testResult?.isSuccess == true else { return testResult }
+        guard testResult?.isSuccess == true else { return testResult }
         return hasCurrentSuccessfulTest ? testResult : nil
     }
 
@@ -1400,12 +1415,14 @@ private struct AddProviderFlow: View {
         let config = preset.configuration
         let connection = knownProviderConnection(for: preset)
         let oauthKind = selectedOAuthKind
-        let testedProvider = draftKnownProvider(for: preset)
+        let testedSnapshot = currentKnownTestSnapshot(for: preset)
+        let testedProvider = testedSnapshot.provider
         let testedAPIKeyInput = apiKey
-        let testedHeaders = customHeaders
+        let testedHeaders = testedSnapshot.headers
 
         isTesting = true
         testResult = nil
+        knownTestGate.invalidate()
         let requestID = UUID()
         testRequestID = requestID
 
@@ -1417,11 +1434,7 @@ private struct AddProviderFlow: View {
                     let didApply = await MainActor.run {
                         guard knownTestIsCurrent(
                             requestID: requestID,
-                            preset: preset,
-                            provider: testedProvider,
-                            oauthKind: oauthKind,
-                            apiKeyInput: testedAPIKeyInput,
-                            headers: testedHeaders
+                            snapshot: testedSnapshot
                         ) else { return false }
                         oauthTokens = tokens
                         return true
@@ -1436,11 +1449,7 @@ private struct AddProviderFlow: View {
                     let didApply = await MainActor.run {
                         guard knownTestIsCurrent(
                             requestID: requestID,
-                            preset: preset,
-                            provider: testedProvider,
-                            oauthKind: oauthKind,
-                            apiKeyInput: testedAPIKeyInput,
-                            headers: testedHeaders
+                            snapshot: testedSnapshot
                         ) else { return false }
                         apiKey = key
                         return true
@@ -1467,11 +1476,7 @@ private struct AddProviderFlow: View {
                     let didApply = await MainActor.run {
                         guard knownTestIsCurrent(
                             requestID: requestID,
-                            preset: preset,
-                            provider: testedProvider,
-                            oauthKind: oauthKind,
-                            apiKeyInput: testedAPIKeyInput,
-                            headers: testedHeaders
+                            snapshot: testedSnapshot
                         ) else { return false }
                         oauthTokens = tokens
                         return true
@@ -1494,13 +1499,10 @@ private struct AddProviderFlow: View {
                 await MainActor.run {
                     guard knownTestIsCurrent(
                         requestID: requestID,
-                        preset: preset,
-                        provider: testedProvider,
-                        oauthKind: oauthKind,
-                        apiKeyInput: testedAPIKeyInput,
-                        headers: testedHeaders
+                        snapshot: testedSnapshot
                     ) else { return }
                     withAnimation {
+                        knownTestGate.recordSuccess(testedSnapshot)
                         testResult = .success(models); isTesting = false
                     }
                 }
@@ -1512,11 +1514,7 @@ private struct AddProviderFlow: View {
                     guard testResult?.isSuccess == true,
                         knownTestIsCurrent(
                             requestID: requestID,
-                            preset: preset,
-                            provider: testedProvider,
-                            oauthKind: oauthKind,
-                            apiKeyInput: testedAPIKeyInput,
-                            headers: testedHeaders
+                            snapshot: testedSnapshot
                         )
                     else { return }
                     saveKnownProvider()
@@ -1525,11 +1523,7 @@ private struct AddProviderFlow: View {
                 await MainActor.run {
                     guard knownTestIsCurrent(
                         requestID: requestID,
-                        preset: preset,
-                        provider: testedProvider,
-                        oauthKind: oauthKind,
-                        apiKeyInput: testedAPIKeyInput,
-                        headers: testedHeaders
+                        snapshot: testedSnapshot
                     ) else { return }
                     let diagnosticMessage: String?
                     switch oauthKind {
@@ -1555,7 +1549,7 @@ private struct AddProviderFlow: View {
     }
 
     private func saveKnownProvider() {
-        guard !hasFinalized else { return }
+        guard !hasFinalized, knownProviderSaveAuthorization.allowsSave else { return }
         guard let preset = selectedPreset else { return }
         hasFinalized = true
         let config = preset.configuration
@@ -1715,41 +1709,28 @@ private struct AddProviderFlow: View {
     @MainActor
     private func knownTestIsCurrent(
         requestID: UUID,
-        preset: ProviderPreset,
-        provider testedProvider: RemoteProvider,
-        oauthKind testedOAuthKind: ProviderOAuthKind?,
-        apiKeyInput testedAPIKeyInput: String,
-        headers testedHeaders: [HeaderEntry]
+        snapshot testedSnapshot: KnownProviderSetupTestSnapshot
     ) -> Bool {
         guard testRequestID == requestID else { return false }
-        guard matchesKnownTestInputs(
-            preset: preset,
-            provider: testedProvider,
-            oauthKind: testedOAuthKind,
-            apiKeyInput: testedAPIKeyInput,
-            headers: testedHeaders
-        ) else {
+        guard selectedPreset == testedSnapshot.preset,
+            currentKnownTestSnapshot(for: testedSnapshot.preset) == testedSnapshot
+        else {
             isTesting = false
             return false
         }
         return true
     }
 
-    private func matchesKnownTestInputs(
-        preset: ProviderPreset,
-        provider testedProvider: RemoteProvider,
-        oauthKind testedOAuthKind: ProviderOAuthKind?,
-        apiKeyInput testedAPIKeyInput: String,
-        headers testedHeaders: [HeaderEntry]
-    ) -> Bool {
-        guard selectedOAuthKind == testedOAuthKind,
-            draftKnownProvider(for: preset) == testedProvider,
-            customHeaders == testedHeaders
-        else { return false }
-
-        // Browser sign-in is expected to populate credentials while the test
-        // is running. Pasted-key flows must retain the exact tested input.
-        return testedOAuthKind != nil || apiKey == testedAPIKeyInput
+    private func currentKnownTestSnapshot(for preset: ProviderPreset) -> KnownProviderSetupTestSnapshot {
+        let credential: KnownProviderSetupCredentialIdentity = selectedOAuthKind.map {
+            .oauth($0)
+        } ?? .apiKey(apiKey)
+        return KnownProviderSetupTestSnapshot(
+            preset: preset,
+            provider: draftKnownProvider(for: preset),
+            credential: credential,
+            headers: customHeaders
+        )
     }
 
     private func draftCustomProvider() -> RemoteProvider {
@@ -3114,6 +3095,58 @@ struct HeaderEntry: Identifiable, Equatable {
             }
         }
         return (regular, secretKeys)
+    }
+}
+
+/// Credential identity used by a known-provider test. Browser OAuth is stable
+/// while sign-in populates a key or token; pasted-key flows bind the exact text.
+enum KnownProviderSetupCredentialIdentity: Equatable {
+    case apiKey(String)
+    case oauth(ProviderOAuthKind)
+}
+
+/// The same complete input identity used to reject stale async known-provider
+/// completions, retained after success so footer saves cannot bypass that check.
+struct KnownProviderSetupTestSnapshot: Equatable {
+    var preset: ProviderPreset
+    var provider: RemoteProvider
+    var credential: KnownProviderSetupCredentialIdentity
+    var headers: [HeaderEntry]
+}
+
+enum KnownProviderSetupSaveAuthorization: Equatable {
+    case denied
+    case verified
+    case unverifiedAzureManualModels
+
+    var allowsSave: Bool {
+        self != .denied
+    }
+}
+
+struct KnownProviderSetupSuccessGate: Equatable {
+    private(set) var successfulSnapshot: KnownProviderSetupTestSnapshot?
+
+    mutating func recordSuccess(_ snapshot: KnownProviderSetupTestSnapshot) {
+        successfulSnapshot = snapshot
+    }
+
+    mutating func invalidate() {
+        successfulSnapshot = nil
+    }
+
+    func authorization(
+        current snapshot: KnownProviderSetupTestSnapshot,
+        hasSuccessfulResult: Bool,
+        allowsUnverifiedAzureSave: Bool
+    ) -> KnownProviderSetupSaveAuthorization {
+        if hasSuccessfulResult, successfulSnapshot == snapshot {
+            return .verified
+        }
+        if allowsUnverifiedAzureSave {
+            return .unverifiedAzureManualModels
+        }
+        return .denied
     }
 }
 

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -1335,12 +1335,10 @@ private struct AddProviderFlow: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(failure.classification.title)
                     .font(.system(size: 11, weight: .semibold))
-                if let detail = failure.recoveryDetail {
-                    Text(detail)
-                        .font(.system(size: 10))
-                        .foregroundColor(theme.secondaryText)
-                        .lineLimit(2)
-                }
+                Text(failure.detailForDisplay)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(2)
                 Text(failure.classification.action)
                     .font(.system(size: 10))
                     .foregroundColor(theme.secondaryText)
@@ -1833,6 +1831,81 @@ private struct AddProviderFlow: View {
 
 // MARK: - Edit Provider Flow (simplified)
 
+struct OpenRouterReauthorizationSession: Sendable, Equatable {
+    enum Status: Sendable, Equatable {
+        case idle
+        case signingIn
+        case succeeded
+        case failed(String)
+
+        var isSigningIn: Bool {
+            if case .signingIn = self { return true }
+            return false
+        }
+    }
+
+    private(set) var status: Status = .idle
+    private(set) var requestID: UUID?
+    private var apiKeyInput: String?
+
+    @discardableResult
+    mutating func begin(requestID: UUID = UUID(), apiKeyInput: String) -> UUID {
+        self.requestID = requestID
+        self.apiKeyInput = apiKeyInput
+        status = .signingIn
+        return requestID
+    }
+
+    /// Manual field writes and OAuth completions use separate call sites. An
+    /// unchanged binding echo is not a user edit and must preserve feedback.
+    mutating func manualAPIKeyDidChange(from currentValue: String, to newValue: String) -> Bool {
+        guard newValue != currentValue else { return false }
+        cancel()
+        return true
+    }
+
+    mutating func acceptCompletion(requestID: UUID, currentAPIKeyInput: String) -> Bool {
+        guard consumeCurrentRequest(requestID: requestID, currentAPIKeyInput: currentAPIKeyInput) else {
+            return false
+        }
+        status = .succeeded
+        return true
+    }
+
+    mutating func acceptFailure(
+        requestID: UUID,
+        currentAPIKeyInput: String,
+        message: String
+    ) -> Bool {
+        guard consumeCurrentRequest(requestID: requestID, currentAPIKeyInput: currentAPIKeyInput) else {
+            return false
+        }
+        status = .failed(message)
+        return true
+    }
+
+    mutating func cancel(requestID: UUID? = nil) {
+        if let requestID, self.requestID != requestID { return }
+        self.requestID = nil
+        apiKeyInput = nil
+        status = .idle
+    }
+
+    private mutating func consumeCurrentRequest(
+        requestID: UUID,
+        currentAPIKeyInput: String
+    ) -> Bool {
+        guard self.requestID == requestID else { return false }
+        guard apiKeyInput == currentAPIKeyInput else {
+            cancel(requestID: requestID)
+            return false
+        }
+        self.requestID = nil
+        apiKeyInput = nil
+        return true
+    }
+}
+
 private struct EditProviderFlow: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @Environment(\.dismiss) private var dismiss
@@ -1887,22 +1960,9 @@ private struct EditProviderFlow: View {
     @State private var apiKeyPresent = false
     @State private var oauthTokensPresent = false
 
-    // OpenRouter re-authorization. Collapsed to a single state so we can't
-    // accidentally render both "succeeded" and "failed" feedback at once.
-    @State private var reauthorizeState: ReauthorizeState = .idle
-    @State private var reauthorizeRequestID: UUID?
-
-    enum ReauthorizeState: Equatable {
-        case idle
-        case signingIn
-        case succeeded
-        case failed(String)
-
-        var isSigningIn: Bool {
-            if case .signingIn = self { return true }
-            return false
-        }
-    }
+    // OpenRouter re-authorization keeps request identity and mutually exclusive
+    // feedback in one state value.
+    @State private var reauthorization = OpenRouterReauthorizationSession()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1947,7 +2007,7 @@ private struct EditProviderFlow: View {
         }
         .onDisappear {
             testRequestID = nil
-            reauthorizeRequestID = nil
+            reauthorization.cancel()
         }
         .themedAlert(
             "Disable request timeout?",
@@ -2041,6 +2101,17 @@ private struct EditProviderFlow: View {
 
     // MARK: - Known Provider Edit
 
+    private var knownProviderAPIKeyBinding: Binding<String> {
+        Binding(
+            get: { apiKey },
+            set: { newValue in
+                guard reauthorization.manualAPIKeyDidChange(from: apiKey, to: newValue) else { return }
+                apiKey = newValue
+                testResult = nil
+            }
+        )
+    }
+
     private func knownProviderEditContent(preset: ProviderPreset) -> some View {
         VStack(alignment: .leading, spacing: 20) {
             if preset == .openrouter {
@@ -2064,17 +2135,10 @@ private struct EditProviderFlow: View {
                     .foregroundColor(theme.tertiaryText)
                 }
 
-                    ProviderSecureField(placeholder: "Leave blank to keep current", text: $apiKey)
-                        .onChange(of: apiKey) { _, _ in
-                            testResult = nil
-                            // User edited the field manually — clear any prior
-                            // re-authorize attempt or feedback so a late OAuth
-                            // callback cannot overwrite a typed key.
-                            reauthorizeRequestID = nil
-                            if reauthorizeState != .idle {
-                                reauthorizeState = .idle
-                            }
-                        }
+                ProviderSecureField(
+                    placeholder: "Leave blank to keep current",
+                    text: knownProviderAPIKeyBinding
+                )
             }
 
             if preset == .azureOpenAI {
@@ -2127,7 +2191,7 @@ private struct EditProviderFlow: View {
 
                 Spacer()
 
-                let signingIn = reauthorizeState.isSigningIn
+                let signingIn = reauthorization.status.isSigningIn
                 Button(action: reauthorizeOpenRouter) {
                     HStack(spacing: 6) {
                         if signingIn {
@@ -2163,7 +2227,7 @@ private struct EditProviderFlow: View {
 
     @ViewBuilder
     private var reauthorizeStatusLine: some View {
-        switch reauthorizeState {
+        switch reauthorization.status {
         case .succeeded:
             HStack(spacing: 6) {
                 Image(systemName: "checkmark.circle.fill")
@@ -2189,31 +2253,33 @@ private struct EditProviderFlow: View {
     }
 
     private func reauthorizeOpenRouter() {
-        let requestID = UUID()
         let testedAPIKeyInput = apiKey
         let testedAuthType = authType
         let testedProviderType = providerType
-        reauthorizeRequestID = requestID
-        reauthorizeState = .signingIn
+        let requestID = reauthorization.begin(apiKeyInput: testedAPIKeyInput)
         Task { @MainActor in
             do {
                 let key = try await OpenRouterOAuthService.signIn()
-                guard reauthorizeRequestID == requestID else { return }
                 guard apiKey == testedAPIKeyInput,
                     authType == testedAuthType,
                     providerType == testedProviderType
                 else {
-                    reauthorizeRequestID = nil
-                    reauthorizeState = .idle
+                    reauthorization.cancel(requestID: requestID)
                     return
                 }
+                guard reauthorization.acceptCompletion(
+                    requestID: requestID,
+                    currentAPIKeyInput: apiKey
+                ) else { return }
                 apiKey = key
-                reauthorizeState = .succeeded
+                testResult = nil
             } catch {
-                guard reauthorizeRequestID == requestID else { return }
-                reauthorizeState = .failed(error.localizedDescription)
+                _ = reauthorization.acceptFailure(
+                    requestID: requestID,
+                    currentAPIKeyInput: apiKey,
+                    message: error.localizedDescription
+                )
             }
-            reauthorizeRequestID = nil
         }
     }
 
@@ -2687,11 +2753,9 @@ private struct EditProviderFlow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(failure.classification.title)
                     .font(.system(size: 12, weight: .semibold))
-                if let detail = failure.recoveryDetail {
-                    Text(detail)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.secondaryText)
-                }
+                Text(failure.detailForDisplay)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
                 Text(failure.classification.action)
                     .font(.system(size: 11))
                     .foregroundColor(theme.secondaryText)

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -164,6 +164,8 @@ private struct AddProviderFlow: View {
     @State private var oauthTokens: RemoteProviderOAuthTokens?
     @State private var isTesting = false
     @State private var testResult: ProviderTestResult?
+    @State private var testRequestID: UUID?
+    @State private var draftProviderID = UUID()
     @State private var hasAppeared = false
     /// Guards against saving twice: a successful test auto-finalizes the add,
     /// but the footer button is also still tappable during the brief green
@@ -263,6 +265,7 @@ private struct AddProviderFlow: View {
             }
             withAnimation { hasAppeared = true }
         }
+        .onDisappear { testRequestID = nil }
         .themedAlert(
             "Disable request timeout?",
             isPresented: $showNoTimeoutWarning,
@@ -510,6 +513,10 @@ private struct AddProviderFlow: View {
                 .padding(24)
             }
 
+            if case .failure(let failure) = testResult {
+                setupFailureBanner(failure)
+            }
+
             // Footer
             sheetFooter(canProceed: canTest) {
                 if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest {
@@ -584,6 +591,10 @@ private struct AddProviderFlow: View {
                     advancedSettingsSection
                 }
                 .padding(24)
+            }
+
+            if case .failure(let failure) = testResult {
+                setupFailureBanner(failure)
             }
 
             // Footer
@@ -1296,10 +1307,9 @@ private struct AddProviderFlow: View {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 12))
                         .foregroundColor(theme.errorColor)
-                    Text(error)
-                        .font(.system(size: 11))
+                    Text(error.classification.title)
+                        .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(theme.errorColor)
-                        .lineLimit(2)
                 }
             }
             .padding(.horizontal, 10)
@@ -1309,6 +1319,39 @@ private struct AddProviderFlow: View {
                     .fill(result.isSuccess ? theme.successColor.opacity(0.1) : theme.errorColor.opacity(0.1))
             )
         }
+    }
+
+    private func setupFailureBanner(_ failure: ProviderSetupFailure) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(theme.errorColor)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(failure.classification.title)
+                    .font(.system(size: 11, weight: .semibold))
+                if let detail = failure.recoveryDetail {
+                    Text(detail)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(2)
+                }
+                Text(failure.classification.action)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            Button {
+                copySetupFailure(failure)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.plain)
+            .localizedHelp("Copy diagnostics")
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.errorColor.opacity(0.06))
     }
 
     private var actionButtonTitle: String {
@@ -1338,20 +1381,26 @@ private struct AddProviderFlow: View {
         guard let preset = selectedPreset else { return }
         let config = preset.configuration
         let connection = knownProviderConnection(for: preset)
+        let oauthKind = selectedOAuthKind
+        let testedProvider = draftKnownProvider(for: preset)
+        let testedAPIKeyInput = apiKey
+        let testedHeaders = customHeaders
 
         isTesting = true
         testResult = nil
+        let requestID = UUID()
+        testRequestID = requestID
 
         Task {
             do {
                 let models: [String]
-                if selectedOAuthKind == .openAICodex {
+                if oauthKind == .openAICodex {
                     let tokens = try await OpenAICodexOAuthService.signIn()
                     await MainActor.run {
                         oauthTokens = tokens
                     }
                     models = await OpenAICodexOAuthService.availableModels(for: tokens)
-                } else if selectedOAuthKind == .openRouter {
+                } else if oauthKind == .openRouter {
                     // The browser sign-in mints a regular OpenRouter API key.
                     // Stash it in `apiKey` so `saveKnownProvider` persists it
                     // via the same path as a pasted key, then verify by
@@ -1368,10 +1417,10 @@ private struct AddProviderFlow: View {
                         authType: .apiKey,
                         providerType: config.providerType,
                         apiKey: key,
-                        headers: HeaderEntry.buildHeaders(from: customHeaders),
-                        manualModelIds: parseManualModelIds(manualModelIdsText)
+                        headers: HeaderEntry.buildHeaders(from: testedHeaders),
+                        manualModelIds: testedProvider.manualModelIds
                     )
-                } else if selectedOAuthKind == .xai {
+                } else if oauthKind == .xai {
                     // Grok sign-in returns access/refresh tokens; stash them so
                     // `saveKnownProvider` persists them as `.xaiOAuth`. The
                     // browser sign-in IS the test — xAI OAuth tokens cannot list
@@ -1390,12 +1439,23 @@ private struct AddProviderFlow: View {
                         basePath: connection.basePath,
                         authType: .apiKey,
                         providerType: config.providerType,
-                        apiKey: apiKey,
-                        headers: HeaderEntry.buildHeaders(from: customHeaders),
-                        manualModelIds: parseManualModelIds(manualModelIdsText)
+                        apiKey: testedAPIKeyInput,
+                        headers: HeaderEntry.buildHeaders(from: testedHeaders),
+                        manualModelIds: testedProvider.manualModelIds
                     )
                 }
                 await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard matchesKnownTestInputs(
+                        preset: preset,
+                        provider: testedProvider,
+                        oauthKind: oauthKind,
+                        apiKeyInput: testedAPIKeyInput,
+                        headers: testedHeaders
+                    ) else {
+                        isTesting = false
+                        return
+                    }
                     withAnimation {
                         testResult = .success(models); isTesting = false
                     }
@@ -1403,18 +1463,49 @@ private struct AddProviderFlow: View {
                 // Auto-complete on green: a successful test/sign-in is the
                 // confirmation, so finalize without a second "Add Provider"
                 // press. The brief pause lets the green success state register.
-                try? await Task.sleep(nanoseconds: 450_000_000)
-                await MainActor.run { saveKnownProvider() }
-            } catch {
-                let message: String
-                switch selectedOAuthKind {
-                case .openAICodex: message = OpenAICodexOAuthService.diagnosticMessage(for: error)
-                case .xai: message = XAIOAuthService.diagnosticMessage(for: error)
-                default: message = error.localizedDescription
-                }
+                try? await Task.sleep(nanoseconds: 800_000_000)
                 await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard testResult?.isSuccess == true,
+                        matchesKnownTestInputs(
+                            preset: preset,
+                            provider: testedProvider,
+                            oauthKind: oauthKind,
+                            apiKeyInput: testedAPIKeyInput,
+                            headers: testedHeaders
+                        )
+                    else { return }
+                    saveKnownProvider()
+                }
+            } catch {
+                let diagnosticMessage: String?
+                switch oauthKind {
+                case .openAICodex: diagnosticMessage = OpenAICodexOAuthService.diagnosticMessage(for: error)
+                case .xai: diagnosticMessage = XAIOAuthService.diagnosticMessage(for: error)
+                default: diagnosticMessage = nil
+                }
+                let failure = ProviderFailureClassifier.classifySetupFailure(
+                    provider: testedProvider,
+                    error: error,
+                    proxy: GlobalProxySettings.currentDiagnostic(),
+                    apiKeyPresent: !apiKey.isEmpty,
+                    oauthTokensPresent: oauthTokens != nil,
+                    diagnosticMessage: diagnosticMessage
+                )
+                await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard matchesKnownTestInputs(
+                        preset: preset,
+                        provider: testedProvider,
+                        oauthKind: oauthKind,
+                        apiKeyInput: testedAPIKeyInput,
+                        headers: testedHeaders
+                    ) else {
+                        isTesting = false
+                        return
+                    }
                     withAnimation {
-                        testResult = .failure(message); isTesting = false
+                        testResult = .failure(failure); isTesting = false
                     }
                 }
             }
@@ -1471,9 +1562,14 @@ private struct AddProviderFlow: View {
         let trimmedBasePath = customBasePath.trimmingCharacters(in: .whitespaces)
         let port: Int? = customPort.trimmingCharacters(in: .whitespaces).isEmpty ? nil : Int(customPort)
         let testApiKey = customAuthType == .apiKey && !apiKey.isEmpty ? apiKey : nil
+        let testedProvider = draftCustomProvider()
+        let testedAPIKeyInput = apiKey
+        let testedHeaders = customHeaders
 
         isTesting = true
         testResult = nil
+        let requestID = UUID()
+        testRequestID = requestID
 
         Task {
             do {
@@ -1485,21 +1581,56 @@ private struct AddProviderFlow: View {
                     authType: customAuthType,
                     providerType: .openaiLegacy,
                     apiKey: testApiKey,
-                    headers: HeaderEntry.buildHeaders(from: customHeaders),
-                    manualModelIds: parseManualModelIds(manualModelIdsText)
+                    headers: HeaderEntry.buildHeaders(from: testedHeaders),
+                    manualModelIds: testedProvider.manualModelIds
                 )
                 await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard matchesCustomTestInputs(
+                        provider: testedProvider,
+                        apiKeyInput: testedAPIKeyInput,
+                        headers: testedHeaders
+                    ) else {
+                        isTesting = false
+                        return
+                    }
                     withAnimation {
                         testResult = .success(models); isTesting = false
                     }
                 }
                 // Auto-complete on green (see `testKnownProvider`).
-                try? await Task.sleep(nanoseconds: 450_000_000)
-                await MainActor.run { saveCustomProvider() }
-            } catch {
+                try? await Task.sleep(nanoseconds: 800_000_000)
                 await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard testResult?.isSuccess == true,
+                        matchesCustomTestInputs(
+                            provider: testedProvider,
+                            apiKeyInput: testedAPIKeyInput,
+                            headers: testedHeaders
+                        )
+                    else { return }
+                    saveCustomProvider()
+                }
+            } catch {
+                let failure = ProviderFailureClassifier.classifySetupFailure(
+                    provider: testedProvider,
+                    error: error,
+                    proxy: GlobalProxySettings.currentDiagnostic(),
+                    apiKeyPresent: testApiKey != nil,
+                    oauthTokensPresent: false
+                )
+                await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard matchesCustomTestInputs(
+                        provider: testedProvider,
+                        apiKeyInput: testedAPIKeyInput,
+                        headers: testedHeaders
+                    ) else {
+                        isTesting = false
+                        return
+                    }
                     withAnimation {
-                        testResult = .failure(error.localizedDescription); isTesting = false
+                        testResult = .failure(failure); isTesting = false
                     }
                 }
             }
@@ -1527,6 +1658,7 @@ private struct AddProviderFlow: View {
             autoConnect: true,
             timeout: timeout,
             disableTimeout: disableTimeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
 
@@ -1540,6 +1672,87 @@ private struct AddProviderFlow: View {
         for header in customHeaders where header.isSecret && !header.key.isEmpty && !header.value.isEmpty {
             RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: providerId)
         }
+    }
+
+    private func draftKnownProvider(for preset: ProviderPreset) -> RemoteProvider {
+        let config = preset.configuration
+        let connection = knownProviderConnection(for: preset)
+        let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
+        let authType: RemoteProviderAuthType
+        switch selectedOAuthKind {
+        case .openAICodex: authType = .openAICodexOAuth
+        case .xai: authType = .xaiOAuth
+        default: authType = config.authType
+        }
+        return RemoteProvider(
+            id: draftProviderID,
+            name: config.name,
+            host: connection.host,
+            providerProtocol: connection.providerProtocol,
+            port: connection.port,
+            basePath: connection.basePath,
+            customHeaders: regularHeaders,
+            authType: authType,
+            providerType: config.providerType,
+            timeout: timeout,
+            disableTimeout: disableTimeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
+            secretHeaderKeys: secretKeys
+        )
+    }
+
+    private func matchesKnownTestInputs(
+        preset: ProviderPreset,
+        provider testedProvider: RemoteProvider,
+        oauthKind testedOAuthKind: ProviderOAuthKind?,
+        apiKeyInput testedAPIKeyInput: String,
+        headers testedHeaders: [HeaderEntry]
+    ) -> Bool {
+        guard selectedOAuthKind == testedOAuthKind,
+            draftKnownProvider(for: preset) == testedProvider,
+            customHeaders == testedHeaders
+        else { return false }
+
+        // Browser sign-in is expected to populate credentials while the test
+        // is running. Pasted-key flows must retain the exact tested input.
+        return testedOAuthKind != nil || apiKey == testedAPIKeyInput
+    }
+
+    private func draftCustomProvider() -> RemoteProvider {
+        let trimmedName = customName.trimmingCharacters(in: .whitespaces)
+        let trimmedBasePath = customBasePath.trimmingCharacters(in: .whitespaces)
+        let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
+        return RemoteProvider(
+            id: draftProviderID,
+            name: trimmedName.isEmpty ? "Custom Provider" : trimmedName,
+            host: customHost.trimmingCharacters(in: .whitespaces),
+            providerProtocol: customProtocol,
+            port: Int(customPort),
+            basePath: trimmedBasePath.isEmpty ? "/v1" : trimmedBasePath,
+            customHeaders: regularHeaders,
+            authType: customAuthType,
+            providerType: .openaiLegacy,
+            timeout: timeout,
+            disableTimeout: disableTimeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
+            secretHeaderKeys: secretKeys
+        )
+    }
+
+    private func matchesCustomTestInputs(
+        provider testedProvider: RemoteProvider,
+        apiKeyInput testedAPIKeyInput: String,
+        headers testedHeaders: [HeaderEntry]
+    ) -> Bool {
+        draftCustomProvider() == testedProvider
+            && apiKey == testedAPIKeyInput
+            && customHeaders == testedHeaders
+    }
+
+    private func copySetupFailure(_ failure: ProviderSetupFailure) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(failure.pasteboardText, forType: .string)
     }
 
     /// Resolve the connection for a known preset, applying the user's endpoint
@@ -1614,6 +1827,7 @@ private struct EditProviderFlow: View {
     // UI state
     @State private var isTesting = false
     @State private var testResult: ProviderTestResult?
+    @State private var testRequestID: UUID?
     @State private var hasAppeared = false
 
     // Diagnostics credential presence (drives the diagnostics report)
@@ -1648,6 +1862,10 @@ private struct EditProviderFlow: View {
                         customProviderEditContent
                     }
 
+                    if case .failure(let failure) = testResult {
+                        setupFailureCallout(failure)
+                    }
+
                     // Cancel the surrounding 24pt inset so diagnostics rows span
                     // the full sheet width (they carry their own internal padding).
                     ProviderDiagnosticsRowsView(report: diagnosticsReport, maxRows: nil)
@@ -1673,6 +1891,7 @@ private struct EditProviderFlow: View {
             Task { await refreshCredentialState() }
             withAnimation { hasAppeared = true }
         }
+        .onDisappear { testRequestID = nil }
         .themedAlert(
             "Disable request timeout?",
             isPresented: $showNoTimeoutWarning,
@@ -1790,6 +2009,7 @@ private struct EditProviderFlow: View {
 
                 ProviderSecureField(placeholder: "Leave blank to keep current", text: $apiKey)
                     .onChange(of: apiKey) { _, _ in
+                        testResult = nil
                         // User edited the field manually — clear any prior
                         // re-authorize confirmation/error so we don't show
                         // stale feedback against a typed key.
@@ -2386,6 +2606,40 @@ private struct EditProviderFlow: View {
         return L("Test")
     }
 
+    private func setupFailureCallout(_ failure: ProviderSetupFailure) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(theme.errorColor)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(failure.classification.title)
+                    .font(.system(size: 12, weight: .semibold))
+                if let detail = failure.recoveryDetail {
+                    Text(detail)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                }
+                Text(failure.classification.action)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
+            }
+            Spacer(minLength: 8)
+            Button {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(failure.pasteboardText, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.plain)
+            .localizedHelp("Copy diagnostics")
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.errorColor.opacity(0.08))
+        )
+    }
+
     private var testButtonColor: Color {
         guard let result = testResult else { return theme.secondaryText }
         return result.isSuccess ? theme.successColor : theme.errorColor
@@ -2455,14 +2709,18 @@ private struct EditProviderFlow: View {
     }
 
     func testConnection() {
+        let requestID = UUID()
+        testRequestID = requestID
         isTesting = true
         testResult = nil
 
-        let trimmedHost = host.trimmingCharacters(in: .whitespaces)
-        let trimmedBasePath = basePath.trimmingCharacters(in: .whitespaces)
-        let port: Int? = portString.trimmingCharacters(in: .whitespaces).isEmpty ? nil : Int(portString)
         let testApiKey =
             authType == .apiKey ? (!apiKey.isEmpty ? apiKey : RemoteProviderKeychain.getAPIKey(for: provider.id)) : nil
+        let testedProvider = draftEditedProvider()
+        let testedAPIKeyInput = apiKey
+        let testedHeaders = customHeaders
+        let testedAPIKeyPresent = testApiKey != nil || apiKeyPresent
+        let testedOAuthTokensPresent = oauthTokensPresent
 
         Task {
             do {
@@ -2471,36 +2729,94 @@ private struct EditProviderFlow: View {
                 // Passing the provider id lets ChatGPT/Codex use the stored
                 // OAuth tokens to query the live catalog when signed in.
                 let models = try await RemoteProviderManager.shared.testConnection(
-                    host: trimmedHost,
-                    providerProtocol: providerProtocol,
-                    port: port,
-                    basePath: trimmedBasePath,
-                    authType: authType,
-                    providerType: providerType,
+                    host: testedProvider.host,
+                    providerProtocol: testedProvider.providerProtocol,
+                    port: testedProvider.port,
+                    basePath: testedProvider.basePath,
+                    authType: testedProvider.authType,
+                    providerType: testedProvider.providerType,
                     apiKey: testApiKey,
-                    headers: HeaderEntry.buildHeaders(from: customHeaders),
-                    manualModelIds: parseManualModelIds(manualModelIdsText),
+                    headers: HeaderEntry.buildHeaders(from: testedHeaders),
+                    manualModelIds: testedProvider.manualModelIds,
                     providerId: provider.id
                 )
                 await MainActor.run {
+                    guard testRequestID == requestID else { return }
+                    guard matchesEditedTestInputs(
+                        provider: testedProvider,
+                        apiKeyInput: testedAPIKeyInput,
+                        headers: testedHeaders
+                    ) else {
+                        isTesting = false
+                        return
+                    }
                     testResult = .success(models)
                     isTesting = false
                 }
             } catch {
-                let message: String
-                if authType == .openAICodexOAuth || providerType == .openAICodex {
-                    message = OpenAICodexOAuthService.diagnosticMessage(for: error)
-                } else if authType == .xaiOAuth {
-                    message = XAIOAuthService.diagnosticMessage(for: error)
+                let diagnosticMessage: String?
+                if testedProvider.authType == .openAICodexOAuth
+                    || testedProvider.providerType == .openAICodex
+                {
+                    diagnosticMessage = OpenAICodexOAuthService.diagnosticMessage(for: error)
+                } else if testedProvider.authType == .xaiOAuth {
+                    diagnosticMessage = XAIOAuthService.diagnosticMessage(for: error)
                 } else {
-                    message = error.localizedDescription
+                    diagnosticMessage = nil
                 }
+                let failure = ProviderFailureClassifier.classifySetupFailure(
+                    provider: testedProvider,
+                    error: error,
+                    proxy: GlobalProxySettings.currentDiagnostic(),
+                    apiKeyPresent: testedAPIKeyPresent,
+                    oauthTokensPresent: testedOAuthTokensPresent,
+                    diagnosticMessage: diagnosticMessage
+                )
                 await MainActor.run {
-                    testResult = .failure(message)
+                    guard testRequestID == requestID else { return }
+                    guard matchesEditedTestInputs(
+                        provider: testedProvider,
+                        apiKeyInput: testedAPIKeyInput,
+                        headers: testedHeaders
+                    ) else {
+                        isTesting = false
+                        return
+                    }
+                    testResult = .failure(failure)
                     isTesting = false
                 }
             }
         }
+    }
+
+    private func draftEditedProvider() -> RemoteProvider {
+        let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
+        return RemoteProvider(
+            id: provider.id,
+            name: name.trimmingCharacters(in: .whitespaces),
+            host: host.trimmingCharacters(in: .whitespaces),
+            providerProtocol: providerProtocol,
+            port: Int(portString),
+            basePath: basePath.trimmingCharacters(in: .whitespaces),
+            customHeaders: regularHeaders,
+            authType: authType,
+            providerType: providerType,
+            enabled: provider.enabled,
+            timeout: timeout,
+            disableTimeout: disableTimeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
+            secretHeaderKeys: secretKeys
+        )
+    }
+
+    private func matchesEditedTestInputs(
+        provider testedProvider: RemoteProvider,
+        apiKeyInput testedAPIKeyInput: String,
+        headers testedHeaders: [HeaderEntry]
+    ) -> Bool {
+        draftEditedProvider() == testedProvider
+            && apiKey == testedAPIKeyInput
+            && customHeaders == testedHeaders
     }
 
     private func save() {
@@ -2626,7 +2942,7 @@ private struct SegmentedToggleButton: View {
 
 private enum ProviderTestResult {
     case success([String])
-    case failure(String)
+    case failure(ProviderSetupFailure)
 
     var isSuccess: Bool {
         if case .success = self { return true }
@@ -2634,7 +2950,7 @@ private enum ProviderTestResult {
     }
 }
 
-struct HeaderEntry: Identifiable {
+struct HeaderEntry: Identifiable, Equatable {
     let id = UUID()
     var key: String
     var value: String


### PR DESCRIPTION
## Summary
- Classifies provider setup failures into actionable credential, OAuth, endpoint, TLS, proxy, timeout, model-discovery, and request-compatibility outcomes.
- Applies the same recovery model to provider onboarding, add, and edit flows.
- Binds successful saves to the exact endpoint, credential input, headers, timeout, and model configuration that was tested, so late or stale results cannot authorize a changed setup.
- Preserves manually entered model IDs for custom providers.
- Keeps copied diagnostics allowlisted and redacted: credentials, authorization values, endpoint host/path, query/fragment data, model IDs, proxy URLs, response bodies, and raw error detail are excluded.

## Validation
- 69 focused provider, OAuth, recovery, connectivity, replay-redaction, and stale-result tests passed.
- Adversarial canaries cover secrets in credentials, authorization headers, OAuth URLs, endpoint paths, proxy URLs, model identifiers, and provider error bodies.
- Known-provider and custom-provider save gates are tested against credential, protocol, host, path, header, timeout, and model changes made after a successful check.
- `bash scripts/i18n/check.sh`
- scoped SwiftLint with only three pre-existing opening-brace findings
- `git diff --check origin/main...HEAD`
- unsigned Release CLI and app build with `CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Keychain-free native launch reached and logged creation of the management window.

## Draft Gate
- The native add/edit/onboarding click-through and screenshots still need to be rerun in a single-instance Osaurus session. Another unrelated Osaurus process on this host owns foreground activation; it was left untouched, so the refreshed branch window could not be surfaced honestly for visual evidence.
- A credentialed provider/OAuth smoke is still required before this is presented as fully tested product behavior.

## Risk
This changes provider setup and diagnostics. It does not change provider request routing, model generation, prompts, tools, or agent-loop behavior.