### PR TITLE
Harden search diagnostics and extraction

### DIFF
--- a/Packages/OsaurusCore/Services/Search/DeclarativeSearchBackend.swift
+++ b/Packages/OsaurusCore/Services/Search/DeclarativeSearchBackend.swift
@@ -21,7 +21,10 @@ struct DeclarativeSearchBackend: SearchBackend {
 
     func search(_ request: SearchRequest) async throws -> [SearchHit] {
         guard let endpoint = definition.endpoints?[request.category] else {
-            throw SearchBackendError("\(definition.name) does not support \(request.category) search")
+            throw SearchBackendError(
+                "\(definition.name) does not support \(request.category) search",
+                kind: .unsupportedCategory
+            )
         }
         try validateSecrets()
 
@@ -41,10 +44,11 @@ struct DeclarativeSearchBackend: SearchBackend {
             timeout: timeout
         )
         guard status == 200 else {
-            throw SearchBackendError("\(definition.name) returned status \(status)")
+            let kind: SearchFailureKind = (status == 401 || status == 403) ? .providerAuth : .providerHTTP
+            throw SearchBackendError("\(definition.name) returned status \(status)", kind: kind)
         }
         guard let json = try? JSONSerialization.jsonObject(with: data) else {
-            throw SearchBackendError("\(definition.name) returned a non-JSON response")
+            throw SearchBackendError("\(definition.name) returned a non-JSON response", kind: .providerHTTP)
         }
         return Self.mapResponse(
             json,
@@ -58,7 +62,7 @@ struct DeclarativeSearchBackend: SearchBackend {
         for field in definition.secrets ?? [] {
             let value = secrets[field.id]
             if value == nil || value?.isEmpty == true {
-                throw SearchBackendError("\(field.label) not configured")
+                throw SearchBackendError("\(field.label) not configured", kind: .providerAuth)
             }
         }
     }
@@ -106,7 +110,7 @@ struct DeclarativeSearchBackend: SearchBackend {
                 body[param.name] = resolved.jsonValue
             }
             guard let data = try? JSONSerialization.data(withJSONObject: body) else {
-                throw SearchBackendError("Failed to encode \(providerName) request")
+                throw SearchBackendError("Failed to encode \(providerName) request", kind: .providerHTTP)
             }
             bodyData = data
         }

--- a/Packages/OsaurusCore/Services/Search/NativeSearchBackends.swift
+++ b/Packages/OsaurusCore/Services/Search/NativeSearchBackends.swift
@@ -42,10 +42,10 @@ struct DDGScrapeBackend: SearchBackend {
         if let df = request.timeRange { url += "&df=\(df)" }
         let (status, data) = try await SearchHTTPClient.request(url: url)
         guard let html = String(data: data, encoding: .utf8), !html.isEmpty else {
-            throw SearchBackendError("DDG: empty response")
+            throw SearchBackendError("DDG: empty response", kind: .empty)
         }
         if Self.isChallengePage(status: status, html: html) {
-            throw SearchBackendError("DDG: challenge_page")
+            throw SearchBackendError("DDG: challenge_page", kind: .challenge)
         }
         let hits = Self.parseHTML(html, max: request.maxResults)
         return hits
@@ -114,10 +114,10 @@ struct DDGScrapeBackend: SearchBackend {
         let (_, bootData) = try await SearchHTTPClient.request(
             url: "https://duckduckgo.com/?q=\(q)&iax=images&ia=images")
         guard let bootHtml = String(data: bootData, encoding: .utf8) else {
-            throw SearchBackendError("DDG image bootstrap failed")
+            throw SearchBackendError("DDG image bootstrap failed", kind: .providerHTTP)
         }
         guard let vqd = SearchHTML.firstGroup(in: bootHtml, pattern: "vqd=([\"'])([^\"']+)\\1", group: 2) else {
-            throw SearchBackendError("Could not obtain DDG VQD token")
+            throw SearchBackendError("Could not obtain DDG VQD token", kind: .providerHTTP)
         }
 
         let url = "https://duckduckgo.com/i.js?l=wt-wt&o=json&q=\(q)&vqd=\(vqd)&p=1"
@@ -125,7 +125,12 @@ struct DDGScrapeBackend: SearchBackend {
             url: url, headers: ["Referer": "https://duckduckgo.com/"])
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let arr = json["results"] as? [[String: Any]]
-        else { throw SearchBackendError("DDG image API failed (status \(status))") }
+        else {
+            throw SearchBackendError(
+                "DDG image API failed (status \(status))",
+                kind: status == 401 || status == 403 ? .providerAuth : .providerHTTP
+            )
+        }
 
         return arr.prefix(request.maxResults).map { item in
             SearchHit(
@@ -156,10 +161,10 @@ struct BraveScrapeBackend: SearchBackend {
             : "https://search.brave.com/search?q=\(q)&source=web"
         let (_, data) = try await SearchHTTPClient.request(url: endpoint)
         guard let html = String(data: data, encoding: .utf8), !html.isEmpty else {
-            throw SearchBackendError("Brave HTML: empty response")
+            throw SearchBackendError("Brave HTML: empty response", kind: .empty)
         }
         if SearchHTML.isLikelyChallengePage(html) {
-            throw SearchBackendError("Brave HTML: challenge_page")
+            throw SearchBackendError("Brave HTML: challenge_page", kind: .challenge)
         }
         return Self.parseHTML(html, max: request.maxResults)
     }
@@ -240,10 +245,10 @@ struct BingScrapeBackend: SearchBackend {
             : "https://www.bing.com/search?q=\(q)&count=\(request.maxResults)"
         let (_, data) = try await SearchHTTPClient.request(url: endpoint)
         guard let html = String(data: data, encoding: .utf8), !html.isEmpty else {
-            throw SearchBackendError("Bing HTML: empty response")
+            throw SearchBackendError("Bing HTML: empty response", kind: .empty)
         }
         if Self.isChallengePage(html) {
-            throw SearchBackendError("Bing HTML: challenge_page")
+            throw SearchBackendError("Bing HTML: challenge_page", kind: .challenge)
         }
         return Self.parseHTML(html, max: request.maxResults)
     }

--- a/Packages/OsaurusCore/Services/Search/SearchEngine.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchEngine.swift
@@ -136,7 +136,12 @@ public struct SearchEngine: Sendable {
                 }
             case .failure(let error):
                 attempts.append(
-                    SearchAttempt(provider: snapshot.definition.id, ok: false, error: error.message))
+                    SearchAttempt(
+                        provider: snapshot.definition.id,
+                        ok: false,
+                        kind: error.kind,
+                        error: error.message
+                    ))
             }
             if !deduped.isEmpty { break }
         }
@@ -171,6 +176,7 @@ public struct SearchEngine: Sendable {
                     SearchAttempt(
                         provider: provider.definition.id,
                         ok: false,
+                        kind: .unsupportedCategory,
                         error: "\(provider.definition.name) does not support \(request.category) search"
                     )
                 ],
@@ -190,7 +196,14 @@ public struct SearchEngine: Sendable {
             return SearchEngineOutcome(
                 hits: [],
                 provider: nil,
-                attempts: [SearchAttempt(provider: provider.definition.id, ok: false, error: error.message)],
+                attempts: [
+                    SearchAttempt(
+                        provider: provider.definition.id,
+                        ok: false,
+                        kind: error.kind,
+                        error: error.message
+                    )
+                ],
                 elapsed: Date().timeIntervalSince(started)
             )
         }
@@ -203,16 +216,20 @@ public struct SearchEngine: Sendable {
         request: SearchRequest
     ) async -> Result<[SearchHit], SearchBackendError> {
         guard let backend = backendFactory(snapshot.definition, snapshot.secrets) else {
-            return .failure(SearchBackendError("No backend available for \(snapshot.definition.id)"))
+            return .failure(
+                SearchBackendError(
+                    "No backend available for \(snapshot.definition.id)",
+                    kind: .providerHTTP
+                ))
         }
         do {
             return .success(try await backend.search(request))
         } catch let error as SearchBackendError {
             return .failure(error)
         } catch is CancellationError {
-            return .failure(SearchBackendError("cancelled"))
+            return .failure(SearchBackendError("cancelled", kind: .cancelled))
         } catch {
-            return .failure(SearchBackendError(error.localizedDescription))
+            return .failure(SearchBackendError(error.localizedDescription, kind: .network))
         }
     }
 
@@ -265,14 +282,20 @@ public struct SearchEngine: Sendable {
             // provider triggered the early exit; both read as did_not_complete
             // to avoid implying the request itself timed out.
             attempts.append(
-                SearchAttempt(provider: snapshot.definition.id, ok: false, error: "did_not_complete"))
+                SearchAttempt(
+                    provider: snapshot.definition.id,
+                    ok: false,
+                    kind: .didNotComplete,
+                    error: "did_not_complete"
+                ))
         }
         for (id, result) in done {
             switch result {
             case .success(let h):
                 attempts.append(SearchAttempt(provider: id, ok: true, count: h.count))
             case .failure(let error):
-                attempts.append(SearchAttempt(provider: id, ok: false, error: error.message))
+                attempts.append(
+                    SearchAttempt(provider: id, ok: false, kind: error.kind, error: error.message))
             }
         }
 

--- a/Packages/OsaurusCore/Services/Search/SearchHTMLHelpers.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchHTMLHelpers.swift
@@ -7,6 +7,7 @@
 //  plugin source.
 //
 
+import Darwin
 import Foundation
 
 enum SearchHTML {
@@ -150,8 +151,8 @@ enum SearchHTML {
 
     /// Detects anti-bot interstitials and other useless responses (e.g. very
     /// small bodies that only contain a captcha shell).
-    static func isLikelyChallengePage(_ html: String) -> Bool {
-        if html.count < 2048 { return true }
+    static func isLikelyChallengePage(_ html: String, treatShortAsChallenge: Bool = true) -> Bool {
+        if treatShortAsChallenge && html.count < 2048 { return true }
         let lc = html.lowercased()
         if lc.contains("captcha") || lc.contains("just a moment") || lc.contains("checking your browser") {
             return true
@@ -168,6 +169,206 @@ enum SearchHTML {
             let pattern = "<meta[^>]*\\bproperty=[\"']\(property)[\"'][^>]*\\bcontent=[\"']([^\"']*)[\"']"
             if let v = firstGroup(in: s, pattern: pattern) { return decodeHTMLEntities(v) }
         }
+        return nil
+    }
+
+    static func canonicalURL(in html: String, baseURL: URL? = nil) -> String? {
+        guard let regex = try? NSRegularExpression(
+            pattern: "<link\\b[^>]*>",
+            options: .caseInsensitive
+        ) else { return nil }
+        let matches = regex.matches(in: html, range: NSRange(html.startIndex..., in: html))
+        for match in matches {
+            guard let range = Range(match.range, in: html) else { continue }
+            let tag = String(html[range])
+            let rel = firstAttr(inTag: tag, attr: "rel")?.lowercased() ?? ""
+            guard rel.split(whereSeparator: { $0.isWhitespace }).contains("canonical") else { continue }
+            guard let href = firstAttr(inTag: tag, attr: "href"), !href.isEmpty else { continue }
+            if let baseURL, let resolved = URL(string: href, relativeTo: baseURL)?.absoluteURL {
+                let value = resolved.absoluteString
+                return unsafeExtractionURLReason(value) == nil ? value : nil
+            }
+            return unsafeExtractionURLReason(href) == nil ? href : nil
+        }
+        return nil
+    }
+
+    private static func firstAttr(inTag tag: String, attr: String) -> String? {
+        let attrEsc = NSRegularExpression.escapedPattern(for: attr)
+        let pattern = "\\b\(attrEsc)=[\"']([^\"']+)[\"']"
+        return firstGroup(in: tag, pattern: pattern)
+    }
+
+    static func unsafeExtractionURLReason(_ rawURL: String) -> String? {
+        guard let url = URL(string: rawURL), let scheme = url.scheme?.lowercased() else {
+            return "invalid URL is blocked"
+        }
+        guard scheme == "http" || scheme == "https" else {
+            return "\(scheme) URLs are blocked"
+        }
+        guard let rawHost = url.host?.lowercased(), !rawHost.isEmpty else {
+            return "missing host is blocked"
+        }
+        return blockedHostReason(rawHost.trimmingCharacters(in: CharacterSet(charactersIn: "[]")))
+    }
+
+    static func resolvedUnsafeExtractionURLReason(_ rawURL: String) -> String? {
+        if let blocked = unsafeExtractionURLReason(rawURL) {
+            return blocked
+        }
+        guard let url = URL(string: rawURL), let host = url.host?.lowercased(), !host.isEmpty else {
+            return "invalid URL is blocked"
+        }
+        let normalizedHost = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        guard isResolvableHostname(normalizedHost) else { return nil }
+        return resolvedBlockedHostReason(normalizedHost, port: url.port)
+    }
+
+    private static func blockedHostReason(_ host: String) -> String? {
+        if host == "localhost" || host == "ip6-localhost" || host == "ip6-loopback"
+            || host.hasSuffix(".localhost") {
+            return "localhost is blocked"
+        }
+        if let octets = parsedIPv4(host) {
+            return blockedIPv4Reason(octets)
+        }
+        if let octets = parsedIPv6(host) {
+            return blockedIPv6Reason(octets)
+        }
+        if host.contains(":") {
+            return nil
+        }
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        if labels.count == 1, isNonCanonicalIPv4Literal(labels[0]) {
+            return "non-canonical IPv4 literal is blocked"
+        }
+        guard labels.count == 4 else {
+            return labels.allSatisfy { $0.allSatisfy(\.isNumber) }
+                ? "non-canonical IPv4 literal is blocked"
+                : nil
+        }
+        if labels.allSatisfy({ isCanonicalDecimalIPv4Octet($0) }) {
+            return blockedIPv4Reason(labels.compactMap(UInt8.init))
+        }
+        return labels.allSatisfy { $0.allSatisfy(\.isNumber) }
+            ? "non-canonical IPv4 literal is blocked"
+            : nil
+    }
+
+    private static func isCanonicalDecimalIPv4Octet(_ label: String) -> Bool {
+        guard !label.isEmpty, label.allSatisfy(\.isNumber) else { return false }
+        guard label == "0" || !label.hasPrefix("0") else { return false }
+        return UInt8(label) != nil
+    }
+
+    private static func isNonCanonicalIPv4Literal(_ host: String) -> Bool {
+        host.allSatisfy(\.isNumber) || host.lowercased().hasPrefix("0x")
+    }
+
+    private static func parsedIPv4(_ host: String) -> [UInt8]? {
+        var addr = in_addr()
+        guard host.withCString({ inet_pton(AF_INET, $0, &addr) }) == 1 else { return nil }
+        return withUnsafeBytes(of: addr) { Array($0) }
+    }
+
+    private static func parsedIPv6(_ host: String) -> [UInt8]? {
+        var addr = in6_addr()
+        guard host.withCString({ inet_pton(AF_INET6, $0, &addr) }) == 1 else { return nil }
+        return withUnsafeBytes(of: addr) { Array($0) }
+    }
+
+    private static func blockedIPv6Reason(_ octets: [UInt8]) -> String? {
+        guard octets.count == 16 else { return nil }
+        if octets.allSatisfy({ $0 == 0 }) {
+            return "unspecified IPv6 is blocked"
+        }
+        if octets.prefix(15).allSatisfy({ $0 == 0 }) && octets[15] == 1 {
+            return "loopback IPv6 is blocked"
+        }
+        if octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80 {
+            return "link-local IPv6 is blocked"
+        }
+        if (octets[0] & 0xfe) == 0xfc {
+            return "unique-local IPv6 is blocked"
+        }
+        if octets[0] == 0xff {
+            return "multicast IPv6 is blocked"
+        }
+        if octets.prefix(10).allSatisfy({ $0 == 0 }) && octets[10] == 0xff && octets[11] == 0xff {
+            let v4 = Array(octets[12...15])
+            if let blocked = blockedIPv4Reason(v4) {
+                return "IPv6-mapped \(blocked)"
+            }
+        }
+        if octets.prefix(12).allSatisfy({ $0 == 0 }) {
+            let v4 = Array(octets[12...15])
+            if let blocked = blockedIPv4Reason(v4) {
+                return "IPv6-compatible \(blocked)"
+            }
+        }
+        return nil
+    }
+
+    private static func isResolvableHostname(_ host: String) -> Bool {
+        guard parsedIPv4(host) == nil, parsedIPv6(host) == nil else { return false }
+        guard !host.isEmpty else { return false }
+        return host.range(of: #"^[A-Za-z0-9.-]+$"#, options: .regularExpression) != nil
+    }
+
+    private static func resolvedBlockedHostReason(_ host: String, port: Int?) -> String? {
+        var hints = addrinfo(
+            ai_flags: AI_ADDRCONFIG,
+            ai_family: AF_UNSPEC,
+            ai_socktype: SOCK_STREAM,
+            ai_protocol: 0,
+            ai_addrlen: 0,
+            ai_canonname: nil,
+            ai_addr: nil,
+            ai_next: nil
+        )
+        var result: UnsafeMutablePointer<addrinfo>?
+        let service = String(port ?? 443)
+        let status = getaddrinfo(host, service, &hints, &result)
+        guard status == 0, let result else { return nil }
+        defer { freeaddrinfo(result) }
+
+        var cursor: UnsafeMutablePointer<addrinfo>? = result
+        while let info = cursor {
+            if let blocked = blockedSockaddrReason(info.pointee.ai_addr) {
+                return "resolved \(blocked)"
+            }
+            cursor = info.pointee.ai_next
+        }
+        return nil
+    }
+
+    private static func blockedSockaddrReason(_ address: UnsafeMutablePointer<sockaddr>?) -> String? {
+        guard let address else { return nil }
+        switch Int32(address.pointee.sa_family) {
+        case AF_INET:
+            return address.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                blockedIPv4Reason(withUnsafeBytes(of: $0.pointee.sin_addr) { Array($0) })
+            }
+        case AF_INET6:
+            return address.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
+                blockedIPv6Reason(withUnsafeBytes(of: $0.pointee.sin6_addr) { Array($0) })
+            }
+        default:
+            return nil
+        }
+    }
+
+    private static func blockedIPv4Reason(_ octets: [UInt8]) -> String? {
+        guard octets.count == 4 else { return nil }
+        let (a, b) = (octets[0], octets[1])
+        if a == 127 { return "IPv4 loopback is blocked" }
+        if a == 10 { return "RFC1918 10.0.0.0/8 is blocked" }
+        if a == 172 && b >= 16 && b <= 31 { return "RFC1918 172.16.0.0/12 is blocked" }
+        if a == 192 && b == 168 { return "RFC1918 192.168.0.0/16 is blocked" }
+        if a == 0 { return "RFC1122 0.0.0.0/8 is blocked" }
+        if a == 169 && b == 254 { return "link-local/cloud metadata is blocked" }
+        if a == 100 && b >= 64 && b <= 127 { return "carrier-grade NAT is blocked" }
+        if a >= 224 && a <= 239 { return "multicast is blocked" }
         return nil
     }
 

--- a/Packages/OsaurusCore/Services/Search/SearchReadability.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchReadability.swift
@@ -9,37 +9,135 @@
 
 import Foundation
 
+enum SearchExtractionStatus: String, Sendable, Equatable {
+    case ok
+    case fetchFailed = "fetch_failed"
+    case challenge
+    case boilerplate
+    case empty
+    case blocked
+    case timeout
+    case cancelled
+    case tooLarge = "too_large"
+}
+
 enum SearchReadability {
+    static let maxMarkdownCharacters = 12_000
+    static let maxHTMLBytes = 5 * 1_024 * 1_024
+    private static let minUsefulWordCount = 20
+
     struct Extraction: Sendable {
         var markdown: String
         var wordCount: Int
         var title: String?
         var byline: String?
         var lang: String?
+        var canonicalURL: String?
+        var status: SearchExtractionStatus
+        var truncated: Bool
+        var message: String?
+        var totalWordCount: Int?
+
+        var extracted: Bool { status == .ok }
     }
 
-    /// Fetch `url` and extract the main content. Returns nil when the page
-    /// can't be fetched or decoded (callers mark the hit `extracted: false`).
-    static func extract(url: String, timeout: TimeInterval) async -> Extraction? {
-        guard
-            let (_, data) = try? await SearchHTTPClient.request(
-                url: url,
-                headers: ["Accept": "text/html,application/xhtml+xml"],
-                timeout: timeout
-            ),
-            let html = String(data: data, encoding: .utf8)
-        else { return nil }
-        return extract(html: html)
+    /// Fetch `url` and extract the main content. Always returns a typed status
+    /// so tool payloads can explain failures without raw network errors.
+    static func extract(
+        url: String,
+        timeout: TimeInterval,
+        configuration: URLSessionConfiguration = .ephemeral
+    ) async -> Extraction {
+        // Best-effort preflight for obvious unsafe targets. URLSession still
+        // resolves the hostname at connect time, so DNS-rebinding protection
+        // requires a future pinned-address transport.
+        if let blocked = SearchHTML.resolvedUnsafeExtractionURLReason(url) {
+            return failure(status: .blocked, message: blocked)
+        }
+        guard let requestURL = URL(string: url) else {
+            return failure(status: .blocked, message: "invalid URL is blocked")
+        }
+
+        var request = URLRequest(
+            url: requestURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout
+        )
+        request.httpMethod = "GET"
+        request.setValue(
+            SearchHTTPClient.userAgents.randomElement() ?? SearchHTTPClient.userAgents[0],
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.setValue("text/html,application/xhtml+xml", forHTTPHeaderField: "Accept")
+
+        let delegate = SearchReadabilityRedirectDelegate()
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        defer {
+            session.invalidateAndCancel()
+        }
+
+        do {
+            let (bytes, response) = try await session.bytes(for: request)
+            if let blocked = delegate.blockedReason {
+                return failure(status: .blocked, message: blocked)
+            }
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard (200 ... 299).contains(status) else {
+                return failure(status: .fetchFailed, message: "HTTP status \(status)")
+            }
+            if response.expectedContentLength > Int64(maxHTMLBytes) {
+                return failure(status: .tooLarge, message: "response exceeds \(maxHTMLBytes) bytes")
+            }
+            var data = Data()
+            data.reserveCapacity(
+                response.expectedContentLength > 0
+                    ? min(Int(response.expectedContentLength), maxHTMLBytes)
+                    : min(64 * 1_024, maxHTMLBytes)
+            )
+            for try await byte in bytes {
+                if data.count >= maxHTMLBytes {
+                    return failure(status: .tooLarge, message: "response exceeds \(maxHTMLBytes) bytes")
+                }
+                data.append(byte)
+                try Task.checkCancellation()
+            }
+            guard let html = String(data: data, encoding: .utf8), !html.isEmpty else {
+                return failure(status: .empty, message: "empty response")
+            }
+            return extract(html: html, sourceURL: requestURL)
+        } catch is CancellationError {
+            return failure(status: .cancelled, message: "cancelled")
+        } catch let error as URLError {
+            if error.code == .cancelled {
+                return failure(status: .cancelled, message: "cancelled")
+            }
+            if error.code == .timedOut {
+                return failure(status: .timeout, message: "timed out")
+            }
+            return failure(status: .fetchFailed, message: SearchDiagnostics.redact(error.localizedDescription))
+        } catch {
+            return failure(status: .fetchFailed, message: SearchDiagnostics.redact(error.localizedDescription))
+        }
     }
 
     /// Pure extraction from raw HTML (testable without network).
-    static func extract(html: String) -> Extraction {
+    static func extract(html: String, sourceURL: URL? = nil) -> Extraction {
         let title = SearchHTML.firstGroup(in: html, pattern: "<title[^>]*>([\\s\\S]*?)</title>")
             .map { SearchHTML.decodeHTMLEntities($0).trimmingCharacters(in: .whitespacesAndNewlines) }
         let byline =
             SearchHTML.metaContent(in: html, name: "author")
             ?? SearchHTML.metaContent(in: html, property: "article:author")
         let lang = SearchHTML.firstGroup(in: html, pattern: "<html[^>]*\\blang=[\"']([^\"']+)[\"']")
+        let canonical = SearchHTML.canonicalURL(in: html, baseURL: sourceURL)
+
+        if SearchHTML.isLikelyChallengePage(html, treatShortAsChallenge: false) {
+            return failure(
+                status: .challenge,
+                title: title,
+                canonicalURL: canonical,
+                message: "challenge_page"
+            )
+        }
 
         var content = SearchHTML.stripBlocks(
             html,
@@ -50,13 +148,88 @@ enum SearchReadability {
         if let main = SearchHTML.pickMainContainer(content) { content = main }
         let markdown = SearchHTML.htmlToMarkdown(content)
         let wordCount = markdown.split(whereSeparator: { $0.isWhitespace }).count
+        guard !markdown.isEmpty, wordCount > 0 else {
+            return failure(status: .empty, title: title, canonicalURL: canonical, message: "empty content")
+        }
+        guard wordCount >= minUsefulWordCount else {
+            return failure(
+                status: .boilerplate,
+                title: title,
+                canonicalURL: canonical,
+                message: "too little readable content"
+            )
+        }
+        let capped = SearchDiagnostics.truncate(markdown, maxCharacters: maxMarkdownCharacters)
+        let cappedWordCount = capped.text.split(whereSeparator: { $0.isWhitespace }).count
 
         return Extraction(
-            markdown: markdown,
-            wordCount: wordCount,
+            markdown: capped.text,
+            wordCount: cappedWordCount,
             title: title,
             byline: byline,
-            lang: lang
+            lang: lang,
+            canonicalURL: canonical,
+            status: .ok,
+            truncated: capped.truncated,
+            message: nil,
+            totalWordCount: capped.truncated ? wordCount : nil
         )
+    }
+
+    private static func failure(
+        status: SearchExtractionStatus,
+        title: String? = nil,
+        canonicalURL: String? = nil,
+        message: String? = nil
+    ) -> Extraction {
+        Extraction(
+            markdown: "",
+            wordCount: 0,
+            title: title,
+            byline: nil,
+            lang: nil,
+            canonicalURL: canonicalURL,
+            status: status,
+            truncated: false,
+            message: message.map(SearchDiagnostics.redact),
+            totalWordCount: nil
+        )
+    }
+}
+
+private final class SearchReadabilityRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var unsafeRedirectReason: String?
+
+    var blockedReason: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return unsafeRedirectReason
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void
+    ) {
+        guard let url = request.url else {
+            setBlockedReason("redirect to missing URL is blocked")
+            completionHandler(nil)
+            return
+        }
+        if let blocked = SearchHTML.resolvedUnsafeExtractionURLReason(url.absoluteString) {
+            setBlockedReason("redirect \(blocked)")
+            completionHandler(nil)
+            return
+        }
+        completionHandler(request)
+    }
+
+    private func setBlockedReason(_ reason: String) {
+        lock.lock()
+        unsafeRedirectReason = reason
+        lock.unlock()
     }
 }

--- a/Packages/OsaurusCore/Services/Search/SearchTypes.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchTypes.swift
@@ -116,9 +116,29 @@ public struct SearchHit: Sendable, Equatable {
 
 // MARK: - Errors / attempts
 
+public enum SearchFailureKind: String, Sendable, Equatable {
+    case success
+    case empty
+    case challenge
+    case providerHTTP = "provider_http"
+    case providerAuth = "provider_auth"
+    case network
+    case timeout
+    case cancelled
+    case didNotComplete = "did_not_complete"
+    case unsupportedCategory = "unsupported_category"
+    case extractionFailed = "extraction_failed"
+    case blockedURL = "blocked_url"
+}
+
 public struct SearchBackendError: Error, Sendable, Equatable {
     public let message: String
-    public init(_ message: String) { self.message = message }
+    public let kind: SearchFailureKind
+
+    public init(_ message: String, kind: SearchFailureKind? = nil) {
+        self.message = SearchDiagnostics.redact(message)
+        self.kind = kind ?? SearchDiagnostics.classifyFailure(message)
+    }
 }
 
 /// Diagnostic record of one provider attempt in a cascade run.
@@ -126,20 +146,135 @@ public struct SearchAttempt: Sendable, Equatable {
     public var provider: String
     public var ok: Bool
     public var count: Int
+    public var kind: SearchFailureKind
     public var error: String?
 
-    public init(provider: String, ok: Bool, count: Int = 0, error: String? = nil) {
+    public init(
+        provider: String,
+        ok: Bool,
+        count: Int = 0,
+        kind: SearchFailureKind? = nil,
+        error: String? = nil
+    ) {
         self.provider = provider
         self.ok = ok
         self.count = count
-        self.error = error
+        self.kind = kind ?? SearchDiagnostics.kind(ok: ok, count: count, error: error)
+        self.error = error.map(SearchDiagnostics.redact)
     }
 
     public func toDict() -> [String: Any] {
-        var d: [String: Any] = ["provider": provider, "ok": ok]
+        var d: [String: Any] = ["provider": provider, "ok": ok, "kind": kind.rawValue]
         if ok { d["count"] = count }
         if let error { d["error"] = error }
         return d
+    }
+}
+
+enum SearchDiagnostics {
+    static func kind(ok: Bool, count: Int, error: String?) -> SearchFailureKind {
+        if ok { return count > 0 ? .success : .empty }
+        return classifyFailure(error ?? "")
+    }
+
+    static func classifyFailure(_ message: String) -> SearchFailureKind {
+        let m = message.lowercased()
+        if m.contains("did_not_complete") { return .didNotComplete }
+        if m.contains("cancel") { return .cancelled }
+        if m.contains("timed out") || m.contains("timeout") { return .timeout }
+        if m.contains("challenge") || m.contains("captcha") || m.contains("just a moment")
+            || m.contains("checking your browser") || m.contains("anomaly") {
+            return .challenge
+        }
+        if m.contains("empty response") || m == "empty" { return .empty }
+        if m.contains("does not support") { return .unsupportedCategory }
+        if m.contains("blocked") || m.contains("ssrf") || m.contains("private")
+            || m.contains("loopback") || m.contains("link-local") || m.contains("metadata") {
+            return .blockedURL
+        }
+        if m.contains("401") || m.contains("403") || m.contains("unauthorized")
+            || m.contains("forbidden") || m.contains("api key") || m.contains("auth")
+            || m.contains("not configured") {
+            return .providerAuth
+        }
+        if m.contains("timedout") { return .timeout }
+        if m.contains("offline") || m.contains("cannot connect") || m.contains("could not connect")
+            || m.contains("not connected") || m.contains("dns") || m.contains("host")
+            || m.contains("connection") {
+            return .network
+        }
+        return .providerHTTP
+    }
+
+    static func redact(_ input: String) -> String {
+        guard !input.isEmpty else { return input }
+        var output = redactURLs(in: input)
+        output = replace(
+            output,
+            pattern: #"(?i)\b(authorization|x-api-key|x-subscription-token|api-key)\s*[:=]\s*(bearer|bot|token)?\s*[A-Za-z0-9._~+/=-]{4,}"#,
+            template: "$1: [REDACTED]"
+        )
+        output = replace(
+            output,
+            pattern: #"(?i)\b(bearer|bot|token)\s+[A-Za-z0-9._~+/=-]{6,}"#,
+            template: "$1 [REDACTED]"
+        )
+        output = replace(
+            output,
+            pattern: #"(?i)\b(key|api_key|cx|client_secret|access_token|token|password|secret)=([^&\s]+)"#,
+            template: "$1=[REDACTED]"
+        )
+        output = replace(
+            output,
+            pattern: #"\b(tvly-[A-Za-z0-9._-]+|sk-[A-Za-z0-9._-]+|AIza[A-Za-z0-9._-]+)\b"#,
+            template: "[REDACTED]"
+        )
+        output = replace(
+            output,
+            pattern: #"\b[A-Za-z0-9_-]{32,}\b"#,
+            template: "[REDACTED]"
+        )
+        return output
+    }
+
+    static func truncate(_ text: String, maxCharacters: Int) -> (text: String, truncated: Bool) {
+        guard text.count > maxCharacters else { return (text, false) }
+        let end = text.index(text.startIndex, offsetBy: maxCharacters)
+        return (String(text[..<end]), true)
+    }
+
+    private static func redactURLs(in input: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: #"https?://[^\s<>"')\]]+"#) else {
+            return input
+        }
+        let nsInput = input as NSString
+        let result = NSMutableString(string: input)
+        let matches = regex.matches(in: input, range: NSRange(input.startIndex..., in: input)).reversed()
+        for match in matches {
+            let raw = nsInput.substring(with: match.range)
+            let redacted = redactURL(raw)
+            result.replaceCharacters(in: match.range, with: redacted)
+        }
+        return result as String
+    }
+
+    private static func redactURL(_ raw: String) -> String {
+        guard var components = URLComponents(string: raw), components.queryItems?.isEmpty == false else {
+            return raw
+        }
+        components.queryItems = components.queryItems?.map {
+            URLQueryItem(name: $0.name, value: "[REDACTED]")
+        }
+        return components.string ?? raw
+    }
+
+    private static func replace(_ input: String, pattern: String, template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return input }
+        return regex.stringByReplacingMatches(
+            in: input,
+            range: NSRange(input.startIndex..., in: input),
+            withTemplate: template
+        )
     }
 }
 
@@ -172,7 +307,9 @@ enum SearchHTTPClient {
         body: Data? = nil,
         timeout: TimeInterval = 8
     ) async throws -> (status: Int, data: Data) {
-        guard let u = URL(string: url) else { throw SearchBackendError("Invalid URL: \(url)") }
+        guard let u = URL(string: url) else {
+            throw SearchBackendError("Invalid URL: \(url)", kind: .network)
+        }
         var req = URLRequest(url: u, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: timeout)
         req.httpMethod = method
         req.httpBody = body
@@ -190,8 +327,17 @@ enum SearchHTTPClient {
             return (status, data)
         } catch is CancellationError {
             throw CancellationError()
+        } catch let error as URLError {
+            let kind: SearchFailureKind = {
+                switch error.code {
+                case .timedOut: return .timeout
+                case .cancelled: return .cancelled
+                default: return .network
+                }
+            }()
+            throw SearchBackendError(error.localizedDescription, kind: kind)
         } catch {
-            throw SearchBackendError(error.localizedDescription)
+            throw SearchBackendError(error.localizedDescription, kind: .network)
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
@@ -1,0 +1,248 @@
+//
+//  SearchDiagnosticsExtractionTests.swift
+//  OsaurusCoreTests
+//
+//  Offline fixtures for native search diagnostics and extraction hardening:
+//  structured failure kinds, redacted attempt payloads, success-envelope
+//  compactness, typed extraction statuses, bounded markdown, and SSRF guards.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SearchDiagnosticsExtractionTests {
+
+    @Test func searchAttemptClassifiesAndRedactsProviderSecrets() {
+        let attempt = SearchAttempt(
+            provider: "google_cse",
+            ok: false,
+            error:
+                "Authorization: Bot secret-token-12345 failed at "
+                + "https://www.googleapis.com/customsearch/v1?key=g-key&cx=engine-id&q=swift "
+                + "with tvly-secret"
+        )
+        let dict = attempt.toDict()
+
+        #expect(dict["kind"] as? String == SearchFailureKind.providerAuth.rawValue)
+        let error = dict["error"] as? String ?? ""
+        #expect(!error.contains("secret-token-12345"))
+        #expect(!error.contains("g-key"))
+        #expect(!error.contains("engine-id"))
+        #expect(!error.contains("tvly-secret"))
+        #expect(error.contains("key=%5BREDACTED%5D") || error.contains("key=[REDACTED]"))
+        #expect(error.contains("cx=%5BREDACTED%5D") || error.contains("cx=[REDACTED]"))
+    }
+
+    @Test func noResultsFailureUsesStructuredRedactedAttempts() throws {
+        let outcome = SearchEngineOutcome(
+            hits: [],
+            provider: nil,
+            attempts: [
+                SearchAttempt(
+                    provider: "brave_api",
+                    ok: false,
+                    kind: .providerAuth,
+                    error: "X-Subscription-Token: brave-secret returned HTTP 401"
+                ),
+                SearchAttempt(provider: "bing_html", ok: true, count: 0),
+            ]
+        )
+        let payload = WebSearchResultFormatter.noResultsFailure(
+            tool: "web_search",
+            request: SearchRequest(query: "swift"),
+            outcome: outcome,
+            warnings: [],
+            hasConfiguredAPIProvider: true
+        )
+        let json = try Self.decodeObject(payload)
+        let attempts = try #require(json["attempts"] as? [[String: Any]])
+
+        #expect(attempts.count == 2)
+        #expect(attempts[0]["kind"] as? String == SearchFailureKind.providerAuth.rawValue)
+        #expect(attempts[1]["kind"] as? String == SearchFailureKind.empty.rawValue)
+        #expect(!payload.contains("brave-secret"))
+    }
+
+    @Test func successPayloadDoesNotIncludeAttemptsByDefault() {
+        let outcome = SearchEngineOutcome(
+            hits: [
+                SearchHit(title: "Swift", url: "https://swift.org", snippet: "Language", engine: "fixture")
+            ],
+            provider: "fixture",
+            attempts: [
+                SearchAttempt(provider: "fixture", ok: true, count: 1),
+                SearchAttempt(provider: "backup", ok: false, error: "HTTP 500"),
+            ]
+        )
+        let payload = WebSearchResultFormatter.resultsPayload(
+            request: SearchRequest(query: "swift"),
+            outcome: outcome
+        )
+
+        #expect(!payload.keys.contains("attempts"))
+        #expect(payload["results"] != nil)
+    }
+
+    @Test func extractionBlocksUnsafePrivateAndMetadataURLsBeforeFetch() async {
+        let urls = [
+            "http://localhost:8080/page",
+            "http://127.0.0.1/page",
+            "http://10.0.0.5/page",
+            "http://172.16.0.10/page",
+            "http://192.168.1.2/page",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[::1]/page",
+            "http://[0:0:0:0:0:0:0:1]/page",
+            "http://[::ffff:7f00:1]/page",
+            "http://[::ffff:a9fe:a9fe]/latest/meta-data",
+            "file:///etc/passwd",
+        ]
+
+        for url in urls {
+            let extraction = await SearchReadability.extract(url: url, timeout: 0.01)
+            #expect(extraction.status == .blocked, "Expected blocked extraction for \(url)")
+            #expect(extraction.extracted == false)
+        }
+    }
+
+    @Test func extractionRejectsOversizeResponsesBeforeBodyConversion() async {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SearchExtractionHTTPStubProtocol.self]
+        SearchExtractionHTTPStubProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "text/html; charset=utf-8",
+                    "Content-Length": "\(SearchReadability.maxHTMLBytes + 1)",
+                ]
+            )
+            return (try #require(response), Data("<html></html>".utf8))
+        }
+        defer { SearchExtractionHTTPStubProtocol.handler = nil }
+
+        let extraction = await SearchReadability.extract(
+            url: "http://198.51.100.1/oversize",
+            timeout: 1,
+            configuration: configuration
+        )
+
+        #expect(extraction.status == .tooLarge)
+        #expect(extraction.extracted == false)
+        #expect(extraction.message?.contains("\(SearchReadability.maxHTMLBytes)") == true)
+    }
+
+    @Test func extractionClassifiesChallengePage() {
+        let html = """
+            <!doctype html>
+            <html><head><title>Just a moment...</title></head>
+            <body><h1>Checking your browser</h1><p>Please solve this captcha.</p></body></html>
+            """
+        let extraction = SearchReadability.extract(html: html)
+
+        #expect(extraction.status == .challenge)
+        #expect(extraction.extracted == false)
+        #expect(extraction.message == "challenge_page")
+    }
+
+    @Test func extractionClassifiesBoilerplatePage() {
+        let html = """
+            <!doctype html>
+            <html><head><title>Shell</title></head>
+            <body><main><p>Subscribe for updates.</p></main></body></html>
+            """
+        let extraction = SearchReadability.extract(html: html)
+
+        #expect(extraction.status == .boilerplate)
+        #expect(extraction.extracted == false)
+        #expect(extraction.title == "Shell")
+    }
+
+    @Test func extractionIncludesCanonicalURLAndTruncatesMarkdown() {
+        let words = (0..<3_000).map { "word\($0)" }.joined(separator: " ")
+        let html = """
+            <!doctype html>
+            <html lang="en">
+            <head>
+              <title>Long Article</title>
+              <link rel="canonical" href="/article/canonical">
+              <meta name="author" content="Reporter">
+            </head>
+            <body><main><h1>Long Article</h1><p>\(words)</p></main></body>
+            </html>
+            """
+        let extraction = SearchReadability.extract(
+            html: html,
+            sourceURL: URL(string: "https://example.com/original?utm=secret")
+        )
+
+        #expect(extraction.status == .ok)
+        #expect(extraction.extracted)
+        #expect(extraction.title == "Long Article")
+        #expect(extraction.byline == "Reporter")
+        #expect(extraction.lang == "en")
+        #expect(extraction.canonicalURL == "https://example.com/article/canonical")
+        #expect(extraction.truncated)
+        #expect(extraction.markdown.count <= SearchReadability.maxMarkdownCharacters)
+        #expect(extraction.wordCount < (extraction.totalWordCount ?? 0))
+        #expect(extraction.totalWordCount ?? 0 > 2_000)
+    }
+
+    @Test func extractionDropsUnsafeCanonicalURL() {
+        let html = """
+            <!doctype html>
+            <html>
+            <head>
+              <title>Article</title>
+              <link rel="canonical" href="http://169.254.169.254/latest/meta-data">
+            </head>
+            <body><main><p>\(Array(repeating: "content", count: 30).joined(separator: " "))</p></main></body>
+            </html>
+            """
+        let extraction = SearchReadability.extract(
+            html: html,
+            sourceURL: URL(string: "https://example.com/article")
+        )
+
+        #expect(extraction.status == .ok)
+        #expect(extraction.canonicalURL == nil)
+    }
+
+    private static func decodeObject(_ json: String) throws -> [String: Any] {
+        let data = try #require(json.data(using: .utf8))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+private final class SearchExtractionHTTPStubProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        handler != nil
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Packages/OsaurusCore/Tools/WebSearchTools.swift
+++ b/Packages/OsaurusCore/Tools/WebSearchTools.swift
@@ -363,16 +363,29 @@ final class SearchAndExtractTool: OsaurusTool, @unchecked Sendable {
         for (index, hit) in outcome.hits.enumerated() {
             var entry = hit.toDict(rank: index + 1)
             let shouldExtract = index < extractCount && !hit.url.isEmpty && !Task.isCancelled
-            if shouldExtract,
-                let extraction = await SearchReadability.extract(url: hit.url, timeout: timeout) {
+            if shouldExtract {
+                let extraction = await SearchReadability.extract(url: hit.url, timeout: timeout)
                 if let title = extraction.title, !title.isEmpty { entry["title"] = title }
-                entry["markdown"] = extraction.markdown
+                if let canonicalURL = extraction.canonicalURL, !canonicalURL.isEmpty {
+                    entry["canonical_url"] = canonicalURL
+                }
+                entry["extract_status"] = extraction.status.rawValue
                 entry["word_count"] = extraction.wordCount
-                if let byline = extraction.byline { entry["byline"] = byline }
-                if let lang = extraction.lang { entry["lang"] = lang }
-                entry["extracted"] = true
+                if let total = extraction.totalWordCount {
+                    entry["word_count_total"] = total
+                }
+                entry["extracted"] = extraction.extracted
+                if extraction.extracted {
+                    entry["markdown"] = extraction.markdown
+                    entry["truncated"] = extraction.truncated
+                    if let byline = extraction.byline { entry["byline"] = byline }
+                    if let lang = extraction.lang { entry["lang"] = lang }
+                } else if let message = extraction.message, !message.isEmpty {
+                    entry["extract_error"] = message
+                }
             } else {
                 entry["extracted"] = false
+                if Task.isCancelled { entry["extract_status"] = SearchExtractionStatus.cancelled.rawValue }
             }
             enriched.append(entry)
         }


### PR DESCRIPTION
## Summary
- Adds structured search attempt failure kinds and redacted provider attempts for no-result diagnostics.
- Adds typed extraction statuses for success, fetch failure, challenge, boilerplate, empty, blocked, timeout, cancelled, and oversized responses.
- Caps extracted markdown and total HTML bytes, streams fetch bodies under a hard byte limit, and reports cancellation distinctly.
- Adds best-effort private-network preflight checks for extraction URLs, redirects, and canonical URLs, including IPv4, IPv6, and IPv4-mapped IPv6 literals.

## Validation
- `git diff --check origin/main...HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-pr5-postrebase swift test --package-path Packages/OsaurusCore --filter 'SearchDiagnosticsExtractionTests|SearchEngineCascadeTests|WebSearchToolTests|DeclarativeSearchBackendTests|NativeSearchBackendTests'`
- `swiftlint lint --strict Packages/OsaurusCore/Services/Search/DeclarativeSearchBackend.swift Packages/OsaurusCore/Services/Search/NativeSearchBackends.swift Packages/OsaurusCore/Services/Search/SearchEngine.swift Packages/OsaurusCore/Services/Search/SearchHTMLHelpers.swift Packages/OsaurusCore/Services/Search/SearchReadability.swift Packages/OsaurusCore/Services/Search/SearchTypes.swift Packages/OsaurusCore/Tools/WebSearchTools.swift`

## Known limitation
- The private-network check is a best-effort preflight and redirect guard. URLSession still resolves hostnames at connect time, so DNS-rebinding protection requires a future pinned-address transport. This PR should not be treated as complete end-to-end SSRF proof.
