### PR TITLE
Fix Privacy Filter false "URLs were not scrubbed" send block

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Core/MessageScrubbing.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/MessageScrubbing.swift
@@ -138,7 +138,21 @@ extension ChatMessage {
             for call in calls {
                 let argsText = call.function.arguments
                 if !argsText.isEmpty {
-                    ChatMessage.appendCapped(argsText, into: &out)
+                    // Detection must see the DECODED string leaves,
+                    // not the raw serialized JSON: substitution
+                    // (`substituteJSONArguments`) parses the JSON and
+                    // replaces decoded leaves, so an original captured
+                    // from the raw text spanning an escape sequence
+                    // (`\n`, `\"`, `\\`) would never match at scrub
+                    // time — the substitution silently no-ops and the
+                    // post-scrub per-original assertion blocks the
+                    // send. Scanning the same decoded view keeps
+                    // detect and scrub symmetric. Falls back to the
+                    // raw string on parse failure, matching the
+                    // substitution fallback.
+                    for leaf in ChatMessage.jsonStringLeaves(argsText) {
+                        ChatMessage.appendCapped(leaf, into: &out)
+                    }
                 }
             }
         }
@@ -317,6 +331,43 @@ extension ChatMessage {
             }
         }
         return out
+    }
+
+    /// Decoded string leaves of a tool-call `arguments` JSON body, in
+    /// deterministic (sorted-key) order. Returns `[raw]` when the body
+    /// isn't valid JSON so detection scans the same text the
+    /// substitution fallback would rewrite. Keys are excluded — they
+    /// are schema-defined parameter names and `substituteJSONArguments`
+    /// never touches them, so detecting PII in a key could only
+    /// produce an unsubstitutable original.
+    fileprivate static func jsonStringLeaves(_ raw: String) -> [String] {
+        guard let data = raw.data(using: .utf8),
+            let value = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        else {
+            return [raw]
+        }
+        var out: [String] = []
+        collectStringLeaves(value, into: &out)
+        return out
+    }
+
+    private static func collectStringLeaves(_ value: Any, into out: inout [String]) {
+        switch value {
+        case let dict as [String: Any]:
+            // Sorted keys keep segment order deterministic across
+            // calls (JSONSerialization dictionaries are unordered).
+            for (_, leaf) in dict.sorted(by: { $0.key < $1.key }) {
+                collectStringLeaves(leaf, into: &out)
+            }
+        case let arr as [Any]:
+            for item in arr {
+                collectStringLeaves(item, into: &out)
+            }
+        case let str as String:
+            if !str.isEmpty { out.append(str) }
+        default:
+            break
+        }
     }
 
     /// Walk a tool-call `arguments` JSON string and substitute on

--- a/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
@@ -576,11 +576,24 @@ enum PrivacyFilterPipeline {
                 .filter { !$0.approved }
                 .map(\.original)
         )
+        // Scope the regex re-scan to the message range detection
+        // actually classified (the latest user turn onward). Carry-
+        // over substitution can dirty EARLIER history messages (a
+        // prior-turn placeholder re-applied to an old assistant
+        // reply); those messages were never in detection scope, so
+        // regex hits there (e.g. URLs the model itself emitted last
+        // turn) were never reviewable and must not block the send.
+        // Substitution failures in those messages are still caught
+        // by the per-original assertion below, which checks every
+        // approved original against the FULL scrubbed history.
+        let detectionStart = messages.lastIndex(where: { $0.role == "user" }) ?? 0
+        let scopedDirtyIndices = diff.dirtyIndices.filter { $0 >= detectionStart }
         let leaks = Self.scanForLeaks(
             in: scrubbed,
             ruleset: ruleset,
             ignoreOriginals: skippedOriginals,
-            dirtyIndices: diff.dirtyIndices
+            dirtyIndices: scopedDirtyIndices,
+            skipCodeBlocks: config.skipCodeBlocks
         )
 
         // Per-original assertion: every APPROVED entity should be
@@ -682,11 +695,20 @@ enum PrivacyFilterPipeline {
     /// were untouched by `applyingScrub` (no new text), so re-scanning
     /// them is pure cost. Pass `nil` to scan the whole history (used
     /// by tests and the lower-priority callers).
+    ///
+    /// `skipCodeBlocks` mirrors the detection pass's code masking.
+    /// Detection runs against a `CodeBlockMasker`-masked view (when
+    /// the setting is on), so PII inside fenced / inline / indented
+    /// code is never detected or reviewable. Re-scanning the RAW text
+    /// here would count those spans as "leaks" and block the send on
+    /// text the user was never shown — the invariant must see the
+    /// same masked view detection saw.
     static func scanForLeaks(
         in messages: [ChatMessage],
         ruleset: RegexEntityDetector.EffectiveRuleSet,
         ignoreOriginals: Set<String> = [],
-        dirtyIndices: Set<Int>? = nil
+        dirtyIndices: Set<Int>? = nil,
+        skipCodeBlocks: Bool = false
     ) -> [EntityCategory: Int] {
         var counts: [EntityCategory: Int] = [:]
         let scoped: [ChatMessage]
@@ -702,7 +724,8 @@ enum PrivacyFilterPipeline {
         }
         for text in scoped.scrubbableTexts() {
             if text.isEmpty { continue }
-            let matches = RegexEntityDetector.detect(in: text, ruleset: ruleset)
+            let scanText = skipCodeBlocks ? CodeBlockMasker.mask(text).masked : text
+            let matches = RegexEntityDetector.detect(in: scanText, ruleset: ruleset)
             for match in matches {
                 if ignoreOriginals.contains(match.original) { continue }
                 counts[match.category, default: 0] += 1

--- a/Packages/OsaurusCore/Tests/PrivacyFilter/PostScrubInvariantTests.swift
+++ b/Packages/OsaurusCore/Tests/PrivacyFilter/PostScrubInvariantTests.swift
@@ -108,6 +108,74 @@ struct PostScrubInvariantTests {
         #expect(leaks.isEmpty)
     }
 
+    // MARK: - Code-block masking symmetry
+
+    /// With `skipCodeBlocks: true` the scan must ignore PII inside
+    /// inline code spans — detection masked them out, so the user was
+    /// never shown (and could never review) those matches. Counting
+    /// them here false-positive-blocked sends whose only "leak" was a
+    /// URL in a backticked snippet (the reported "N URLs were not
+    /// scrubbed" bug, typically triggered by markdown-formatted MCP
+    /// tool results).
+    @Test func scan_urlInInlineCode_maskedScan_doesNotLeak() {
+        let messages: [ChatMessage] = [
+            ChatMessage(
+                role: "user",
+                content: "Run `curl https://internal.example.com/health` to check."
+            )
+        ]
+        let masked = PrivacyFilterPipeline.scanForLeaks(
+            in: messages,
+            ruleset: .allBuiltins(),
+            skipCodeBlocks: true
+        )
+        #expect(masked[.url] == nil)
+
+        // Unmasked scan still sees it — locks the pre-fix behavior so
+        // callers that intentionally scan raw text keep doing so.
+        let raw = PrivacyFilterPipeline.scanForLeaks(
+            in: messages,
+            ruleset: .allBuiltins(),
+            skipCodeBlocks: false
+        )
+        #expect(raw[.url] == 1)
+    }
+
+    /// Same symmetry for fenced and indented blocks — the shapes
+    /// `CodeBlockMasker` masks during detection.
+    @Test func scan_urlsInFencedAndIndentedCode_maskedScan_doNotLeak() {
+        let fenced = "Docs:\n```\nfetch(\"https://a.example.com/x\")\n```\ndone."
+        let indented = "Steps:\n\n    open https://b.example.com/y\n    then submit"
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "user", content: fenced),
+            ChatMessage(role: "user", content: indented),
+        ]
+        let masked = PrivacyFilterPipeline.scanForLeaks(
+            in: messages,
+            ruleset: .allBuiltins(),
+            skipCodeBlocks: true
+        )
+        #expect(masked[.url] == nil)
+    }
+
+    /// Masking must not weaken the invariant for PII in plain prose:
+    /// a URL outside any code span still counts as a leak with the
+    /// masked scan enabled.
+    @Test func scan_urlInProse_maskedScan_stillLeaks() {
+        let messages: [ChatMessage] = [
+            ChatMessage(
+                role: "user",
+                content: "See https://leak.example.com/profile and `safe_ident` here."
+            )
+        ]
+        let leaks = PrivacyFilterPipeline.scanForLeaks(
+            in: messages,
+            ruleset: .allBuiltins(),
+            skipCodeBlocks: true
+        )
+        #expect(leaks[.url] == 1)
+    }
+
     // MARK: - formatScrubLeaked
 
     /// One category. The formatter is localization-driven, so we
@@ -159,5 +227,140 @@ struct PostScrubInvariantTests {
         let c = PrivacyFilterPipelineError.scrubLeaked(categoryCounts: [.phone: 2])
         #expect(a == b)
         #expect(a != c)
+    }
+
+    // MARK: - applyOutbound end-to-end (regex-only)
+
+    /// Regex-only auto-approve config so `applyOutbound` runs without
+    /// the on-device model or a review presenter.
+    private static func regexOnlyAutoApproveConfig() -> PrivacyFilterConfiguration {
+        var config = PrivacyFilterConfiguration()
+        config.enabled = true
+        config.aiDetectionEnabled = false
+        config.alwaysApproveByDefault = true
+        return config
+    }
+
+    /// Carry-over substitution dirties an EARLIER assistant message
+    /// that contains URLs the detection pass never scanned (detection
+    /// only covers the latest user turn). Those URLs must not trip
+    /// the leak invariant — they were never reviewable. This was the
+    /// second path to the false "N URLs were not scrubbed" block.
+    @Test func applyOutbound_carryOverDirtiedHistory_doesNotBlockOnUnscannedURLs() async throws {
+        let guard_ = await acquirePrivacyStoreSandbox("PostScrubInvariant-carryOver")
+        defer { guard_.release() }
+        PrivacyFilterStore.save(Self.regexOnlyAutoApproveConfig())
+
+        let sid = "post-scrub-carryover-\(UUID().uuidString)"
+        let providerId = UUID()
+        let email = "carrytest@example.com"
+
+        // Turn 1: interns the email into the session map.
+        let turn1: [ChatMessage] = [
+            ChatMessage(role: "user", content: "Contact me at \(email) please.")
+        ]
+        let (scrubbed1, map1) = try await PrivacyFilterPipeline.applyOutbound(
+            messages: turn1,
+            sessionId: sid,
+            providerId: providerId
+        )
+        #expect(map1 != nil)
+        #expect(scrubbed1.first?.content.map { !$0.contains(email) } == true)
+
+        // Turn 2: the assistant's prior reply echoes the email (raw,
+        // as clients resend unscrubbed history) AND contains two URLs
+        // the model emitted itself. Carry-over substitution rewrites
+        // the email there, dirtying the message; the URLs were never
+        // in detection scope and must not block.
+        let turn2: [ChatMessage] = [
+            ChatMessage(role: "user", content: "Contact me at \(email) please."),
+            ChatMessage(
+                role: "assistant",
+                content:
+                    "Sent to \(email). See https://a.example.com/docs and https://b.example.com/faq for details."
+            ),
+            ChatMessage(role: "user", content: "Thanks, also call 949-238-0232."),
+        ]
+        let (scrubbed2, _) = try await PrivacyFilterPipeline.applyOutbound(
+            messages: turn2,
+            sessionId: sid,
+            providerId: providerId
+        )
+        let assistantBody = scrubbed2[1].content ?? ""
+        #expect(!assistantBody.contains(email), "carry-over email should be re-scrubbed")
+        #expect(assistantBody.contains("https://a.example.com/docs"), "historic URLs ship as-is")
+        let userBody = scrubbed2[2].content ?? ""
+        #expect(!userBody.contains("949-238-0232"), "latest-turn phone should be scrubbed")
+    }
+
+    /// A URL inside inline code sitting next to real (approved) PII in
+    /// the same message. Detection masks the code span, the email
+    /// substitution dirties the message, and the re-scan must not
+    /// count the masked URL as a leak. This was the primary path to
+    /// the false "N URLs were not scrubbed" block.
+    @Test func applyOutbound_urlInCodeSpanNextToApprovedPII_doesNotBlock() async throws {
+        let guard_ = await acquirePrivacyStoreSandbox("PostScrubInvariant-codeSpan")
+        defer { guard_.release() }
+        PrivacyFilterStore.save(Self.regexOnlyAutoApproveConfig())
+
+        let sid = "post-scrub-codespan-\(UUID().uuidString)"
+        let messages: [ChatMessage] = [
+            ChatMessage(
+                role: "user",
+                content:
+                    "Email codespan@example.com the snippet `curl https://internal.example.com/v1` today."
+            )
+        ]
+        let (scrubbed, _) = try await PrivacyFilterPipeline.applyOutbound(
+            messages: messages,
+            sessionId: sid,
+            providerId: UUID()
+        )
+        let body = scrubbed.first?.content ?? ""
+        #expect(!body.contains("codespan@example.com"), "email should be scrubbed")
+        #expect(body.contains("https://internal.example.com/v1"), "code-span URL ships as-is")
+    }
+
+    /// Tool-call arguments where the URL is followed by a JSON escape
+    /// sequence (`\n`) in the raw serialized text. Detection must scan
+    /// the DECODED string leaves (same view substitution rewrites) so
+    /// the original matches at scrub time; the old raw-JSON scan
+    /// captured `...path\nthen` verbatim, substitution no-op'd, and
+    /// the per-original assertion blocked the send as a URL leak.
+    @Test func applyOutbound_toolArgsWithJSONEscapes_scrubsCleanly() async throws {
+        let guard_ = await acquirePrivacyStoreSandbox("PostScrubInvariant-toolArgs")
+        defer { guard_.release() }
+        PrivacyFilterStore.save(Self.regexOnlyAutoApproveConfig())
+
+        let sid = "post-scrub-toolargs-\(UUID().uuidString)"
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "user", content: "Fetch my dashboard."),
+            ChatMessage(
+                role: "assistant",
+                content: nil,
+                tool_calls: [
+                    ToolCall(
+                        id: "call_1",
+                        type: "function",
+                        function: ToolCallFunction(
+                            name: "fetch",
+                            arguments: "{\"note\":\"open https://dash.example.com/u/42\\nthen report back\"}"
+                        ),
+                        geminiThoughtSignature: nil
+                    )
+                ],
+                tool_call_id: nil,
+                reasoning_content: nil
+            ),
+        ]
+        let (scrubbed, _) = try await PrivacyFilterPipeline.applyOutbound(
+            messages: messages,
+            sessionId: sid,
+            providerId: UUID()
+        )
+        let args = scrubbed[1].tool_calls?.first?.function.arguments ?? ""
+        #expect(!args.contains("https://dash.example.com"), "tool-arg URL should be scrubbed")
+        #expect(args.contains("[URL_"), "tool-arg URL should be replaced by a placeholder")
+        #expect(args.contains("then report back"), "non-PII leaf text preserved")
     }
 }


### PR DESCRIPTION
## Summary

Users hit `Privacy Filter: 2 URLs were not scrubbed. Send blocked. Please report this bug.` (`PrivacyFilterPipelineError.scrubLeaked`) on sends that leaked nothing. The post-scrub invariant re-scanned a stricter view of the payload than the detection pass ever saw, so it counted "leaks" the user could never review. This PR makes the invariant symmetric with detection while keeping it fail-closed for real substitution failures.

- **Code-mask the leak re-scan**: `scanForLeaks` now applies the same `CodeBlockMasker` view detection uses (when `skipCodeBlocks` is on). URLs inside fenced/inline/indented code — the typical shape of markdown MCP tool results — no longer count as leaks.
- **Scope the re-scan to detection's range**: the regex leak scan only covers dirty messages from the latest user turn onward. History messages dirtied purely by carry-over substitution (e.g. an old assistant reply containing model-emitted URLs) are excluded; substitution failures there remain covered by the per-original assertion, which checks every approved original against the full scrubbed history.
- **Detect on decoded tool-call arg leaves**: detection now scans the decoded JSON string leaves of `tool_calls[*].function.arguments` — the same view `substituteJSONArguments` rewrites — so an original spanning a JSON escape sequence (`\n`, `\"`) substitutes correctly instead of silently no-op'ing and tripping the per-original assertion as a URL leak.

## Test plan

- [x] 6 new tests in `PostScrubInvariantTests`: masked-scan symmetry for inline/fenced/indented code (plus a guard that prose URLs still leak), and three regex-only `applyOutbound` end-to-end regressions covering each false-block path (15/15 pass).
- [x] Related suites green: `MessageScrubbingTests`, `CodeBlockMaskerTests`, `ApplyOutboundE2ETests`, and all PrivacyFilter suites (65 tests).
- [x] `swift format lint` clean on changed files.
- [ ] Full `make test` suite (skipped per request; CI will run it).