### PR TITLE
Repin vmlx to 0d3444ca (gemma4 parser fix #128) + fix reasoning-toggle default display

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8"
+        "revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -154,6 +154,18 @@ enum ModelProfileRegistry {
         }
         return option.inverted ? !value : value
     }
+
+    /// The reasoning state the chip should show when the user has made no
+    /// explicit choice. Requests intentionally send nothing in that case (see
+    /// `normalizedOptions`), so the engine runs the model's chat-template
+    /// default — ornith / qwen3.5 default thinking-ON, gemma-4 defaults OFF.
+    /// Reporting that here keeps the chip honest instead of the old hardcoded
+    /// "off" that lied for default-on models. Reads the local bundle's template
+    /// via `LocalReasoningCapability`, so it is a view-layer helper (potential
+    /// disk touch) rather than part of the pure registry lookups above.
+    static func thinkingDefaultOn(for modelId: String) -> Bool {
+        LocalReasoningCapability.capability(forModelId: modelId).defaultThinkingOn
+    }
 }
 
 // MARK: - DSV4 Reasoning Profile

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8"
+        "revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5e071fe20ddfb3a58de664d770d04e7975a336a8"
+            revision: "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -28,6 +28,16 @@ enum LocalReasoningCapability {
         /// tail. This is reported as metadata only; runtime code must not synthesize
         /// or prepend thinking tags to repair model output.
         let templateInjectsThinkTag: Bool
+        /// The template's DEFAULT thinking state — what the model does when the
+        /// caller passes NO `enable_thinking` kwarg. Drives the UI chip so it
+        /// reports the truth for a fresh/untouched model instead of a hardcoded
+        /// "off". Two real conventions produce opposite defaults:
+        ///   • Ornith / Qwen3: the non-thinking branch is gated on an explicit
+        ///     false (`enable_thinking is false`) → absent kwarg ⇒ thinking ON.
+        ///   • Gemma-4: the thinking branch is gated on an explicit truthy value
+        ///     (`... and enable_thinking`) → absent kwarg ⇒ thinking OFF.
+        /// Only meaningful when `isToggleableThinking` is true.
+        let defaultThinkingOn: Bool
         /// True when the template both exposes a toggle kwarg and uses
         /// reasoning markers the runtime recognizes.
         var isToggleableThinking: Bool { supportsThinking && hasEnableThinkingKwarg }
@@ -35,7 +45,8 @@ enum LocalReasoningCapability {
         static let none = Capability(
             supportsThinking: false,
             hasEnableThinkingKwarg: false,
-            templateInjectsThinkTag: false
+            templateInjectsThinkTag: false,
+            defaultThinkingOn: false
         )
     }
 
@@ -122,8 +133,48 @@ enum LocalReasoningCapability {
         return Capability(
             supportsThinking: hasOpen || hasClose,
             hasEnableThinkingKwarg: hasKwarg,
-            templateInjectsThinkTag: injects
+            templateInjectsThinkTag: injects,
+            defaultThinkingOn: detectDefaultThinkingOn(lower)
         )
+    }
+
+    /// Resolve the template's default thinking state (thinking when the
+    /// `enable_thinking` kwarg is absent). Pure and testable. See
+    /// `Capability.defaultThinkingOn` for the two conventions this recognizes.
+    static func detectDefaultThinkingOn(_ lower: String) -> Bool {
+        // An explicit Jinja `default(...)` filter is authoritative.
+        if lower.range(
+            of: #"enable_thinking\s*\|\s*default\(\s*true\s*\)"#,
+            options: .regularExpression
+        ) != nil {
+            return true
+        }
+        if lower.range(
+            of: #"enable_thinking\s*\|\s*default\(\s*false\s*\)"#,
+            options: .regularExpression
+        ) != nil {
+            return false
+        }
+        // Ternary default idiom (Nemotron-H):
+        //   `enable_thinking = enable_thinking if enable_thinking is defined else True`
+        // The `else <bool>` clause IS the default when the kwarg is absent.
+        if let match = lower.range(
+            of: #"enable_thinking\s+is\s+defined\s+else\s+(true|false)"#,
+            options: .regularExpression
+        ) {
+            return lower[match].contains("true")
+        }
+        // Negative gate: the OFF path requires `enable_thinking` to be explicitly
+        // false, so an absent kwarg falls through to thinking-ON (Ornith, Qwen3).
+        if lower.contains("enable_thinking is false")
+            || lower.contains("enable_thinking == false")
+            || lower.contains("not enable_thinking")
+        {
+            return true
+        }
+        // Otherwise the template only turns thinking ON when `enable_thinking` is
+        // explicitly truthy (Gemma-4), so an absent kwarg means thinking-OFF.
+        return false
     }
 
     private static func localDirectory(forModelId modelId: String) -> URL? {
@@ -190,7 +241,8 @@ enum LocalReasoningCapability {
         return Capability(
             supportsThinking: true,
             hasEnableThinkingKwarg: false,
-            templateInjectsThinkTag: false
+            templateInjectsThinkTag: false,
+            defaultThinkingOn: false
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
-        #expect(packageResolved.contains(#""revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
-        #expect(workspaceResolved.contains(#""revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
-        #expect(appResolved.contains(#""revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8""#))
+        #expect(packageSwift.contains(#"revision: "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
+        #expect(packageResolved.contains(#""revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
+        #expect(workspaceResolved.contains(#""revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
+        #expect(appResolved.contains(#""revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -104,6 +104,73 @@ struct LocalReasoningCapabilityTests {
         #expect(cap.isToggleableThinking)
     }
 
+    // MARK: - defaultThinkingOn (drives the UI chip for untouched models)
+
+    /// Ornith / Qwen3 gate the NON-thinking branch on an explicit false
+    /// (`enable_thinking is false`), so an absent kwarg means thinking-ON.
+    /// The chip must show ON for a fresh ornith, not the old hardcoded OFF.
+    @Test("Ornith/Qwen3 negative-gate template defaults thinking ON")
+    func ornithDefaultsThinkingOn() {
+        let template = """
+            {%- if enable_thinking is defined and enable_thinking is false %}
+                {{- '<think>\\n\\n</think>\\n\\n' }}
+            {%- else %}
+                {{- '<think>\\n' }}
+            {%- endif %}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(cap.isToggleableThinking)
+        #expect(cap.defaultThinkingOn)
+    }
+
+    /// Gemma-4 gates the THINKING branch on an explicit truthy value
+    /// (`... and enable_thinking`) with no `is false` form, so an absent
+    /// kwarg means thinking-OFF. The chip must show OFF for a fresh gemma.
+    @Test("Gemma-4 positive-gate template defaults thinking OFF")
+    func gemma4DefaultsThinkingOff() {
+        let template = """
+            {%- if (enable_thinking is defined and enable_thinking) or tools -%}
+                {%- if enable_thinking is defined and enable_thinking -%}
+                    {{- '<|think|>\\n' -}}
+                {%- endif -%}
+            {%- endif -%}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(cap.isToggleableThinking)
+        #expect(!cap.defaultThinkingOn)
+    }
+
+    /// An explicit Jinja `default(true)` filter is authoritative over the
+    /// gate-shape heuristic.
+    @Test("enable_thinking | default(true) ⇒ defaults ON")
+    func explicitDefaultTrue() {
+        let template = "{%- set et = enable_thinking | default(true) -%}<think>{%- endif -%}"
+        #expect(LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
+    }
+
+    /// `default(false)` filter ⇒ defaults OFF even if other markers exist.
+    @Test("enable_thinking | default(false) ⇒ defaults OFF")
+    func explicitDefaultFalse() {
+        let template = "{%- set et = enable_thinking | default(false) -%}<think>{%- endif -%}"
+        #expect(!LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
+    }
+
+    /// Nemotron-H uses a ternary default: the `else True` clause is the
+    /// value when the kwarg is absent ⇒ defaults thinking-ON.
+    @Test("Nemotron ternary `... is defined else True` ⇒ defaults ON")
+    func nemotronTernaryDefaultOn() {
+        let template =
+            "{%- set enable_thinking = enable_thinking if enable_thinking is defined else True %}<think>"
+        #expect(LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
+    }
+
+    @Test("Ternary `... is defined else False` ⇒ defaults OFF")
+    func ternaryDefaultOff() {
+        let template =
+            "{%- set enable_thinking = enable_thinking if enable_thinking is defined else False %}<think>"
+        #expect(!LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
+    }
+
     // MARK: - jang_config.json chat.reasoning fallback (DSV4-class bundles)
 
     /// DSV4-Flash ships NO chat_template in tokenizer_config.json — the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -685,7 +685,7 @@ struct RuntimePolicySourceTests {
         // SSM/hybrid mixer (vmlx-swift#126), and the ZAYA tool-aware template
         // activation from source_model.architecture (vmlx-swift#127) that
         // stops JANGTQ ZAYA bundles leaking raw tool-call XML.
-        let expectedRuntimeHardenedRevision = "5e071fe20ddfb3a58de664d770d04e7975a336a8"
+        let expectedRuntimeHardenedRevision = "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2508,7 +2508,7 @@ extension FloatingInputCard {
         {
             let isEnabled =
                 ModelProfileRegistry.thinkingEnabled(for: model, values: activeModelOptions)
-                ?? false
+                ?? ModelProfileRegistry.thinkingDefaultOn(for: model)
 
             SelectorChip(isActive: isEnabled) {
                 toggleThinking(id: thinkingOpt.id)
@@ -2553,9 +2553,13 @@ extension FloatingInputCard {
 
     private func toggleThinking(id: String) {
         let thinkingOpt = selectedModel.flatMap { ModelProfileRegistry.profile(for: $0)?.thinkingOption }
+        // Mirror the chip's displayed state (explicit choice, else the model's
+        // template default) so the first tap flips away from what the user sees
+        // rather than from a hardcoded "off".
         let currentEnabled =
             selectedModel.flatMap {
                 ModelProfileRegistry.thinkingEnabled(for: $0, values: activeModelOptions)
+                    ?? ModelProfileRegistry.thinkingDefaultOn(for: $0)
             } ?? false
         let newEnabled = !currentEnabled
         let newVal = thinkingOpt?.inverted == true ? !newEnabled : newEnabled

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5e071fe20ddfb3a58de664d770d04e7975a336a8"
+        "revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repin `vmlx-swift` to merged main **0d3444ca** and fix the reasoning "Thinking" chip so it reflects each model's true chat-template default.

### vmlx repin (parser fix)
Brings in the gemma-4 tool-call leak fix (**vmlx #128**): a stray or trailing `<` in prose before `<|tool_call>` no longer desyncs tag detection, so the tool-call envelope is extracted instead of leaking into visible content with empty `tool_calls`. Also carries hybrid-SSM prefix cache (#125), crash-guard sweep (#126), and ZAYA template (#127) from earlier repins.

### Reasoning-toggle default display fix
The chip's `thinkingEnabled(...) ?? false` reported **OFF** whenever no explicit `disableThinking` choice was stored. But requests intentionally send nothing in that case (`normalizedOptions` never synthesizes defaults), so the engine runs the model's chat-template default. For models that default thinking-**ON** (ornith / qwen3.5, Nemotron-H) the chip said OFF while the model reasoned — the "disabled but enabled" report.

`LocalReasoningCapability` now derives `defaultThinkingOn` from the template's gate shape:
- negative gate `enable_thinking is false` → default ON (ornith, qwen3.5)
- positive gate `… and enable_thinking` → default OFF (gemma-4)
- ternary `… is defined else True` → default ON (Nemotron-H)
- explicit `enable_thinking | default(…)` honored

`thinkingEnabled` falls back to it when no explicit choice exists, so the chip is truthful **without changing what reaches the wire**.

## Verification (live, dev-built app)
- **Detection**: `defaultThinkingOn` verified against every installed template family (ornith, gemma-4 12B/31B/E2B/26B, Qwen-AgentWorld, Qwen3.6 27B/35B, Nemotron, LFM2.5, MiniMax, Kanana).
- **Clean-slate GUI**: ornith-1.0-9b-mxfp8 chip **CHECKED** (reasons by default); gemma-4-12B-qat-MXFP4 chip **UNCHECKED** (no reasoning by default). Toggling between turns flips reasoning. No leaked tags.
- **Engine**: top-level `enable_thinking` honored both directions on ornith and gemma.
- **Streaming**: reasoning and tool-call deltas ride separate channels; zero leaked markup.
- **Tools**: gemma + ornith emit clean `get_weather{…}` with reasoning on and off, no envelope leak.
- Unit tests added for `defaultThinkingOn` detection.

## Not included
The ornith-9b hybrid-SSM prefill-reuse gap (identical-prompt repeats get no prefill reuse: gemma 68× vs ornith ~1×) is a vmlx SSM-rederive engine change, tracked separately by the team.
