### PR TITLE
Add safe skill support file inventory

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -720,7 +720,51 @@ public final class SkillManager {
             }
         }
 
+        let supportInventory = await buildSupportFileInventory(for: skill)
+        if !supportInventory.isEmpty {
+            sections.append("\n## Skill Package Files\n\n\(supportInventory)")
+        }
+
         return sections.joined(separator: "\n")
+    }
+
+    private func buildSupportFileInventory(for skill: Skill) async -> String {
+        let supportFiles = await Task.detached(priority: .utility) {
+            SkillStore.supportFiles(from: skill)
+        }.value
+        guard !supportFiles.isEmpty else { return "" }
+
+        var lines = [
+            "Supporting files are listed for orientation only; loading a skill never executes them or reads their contents from scripts, assets, or templates.",
+            "Reference materials, when present, are loaded separately above.",
+            "Paths are relative to the skill package root. Inspect text scripts before running them, and run helper scripts only through an enabled execution tool when the user explicitly asks for execution.",
+            "The inventory is capped at \(SkillStore.supportFileInventoryLimit) support files.",
+            "",
+        ]
+
+        for file in supportFiles {
+            lines.append("- \(promptSafeSkillPath(file.relativePath)) (\(formatSize(file.size)))")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func promptSafeSkillPath(_ path: String) -> String {
+        let directionalFormattingControls = CharacterSet(
+            charactersIn: "\u{202A}\u{202B}\u{202C}\u{202D}\u{202E}\u{2066}\u{2067}\u{2068}\u{2069}"
+        )
+        var sanitized = String.UnicodeScalarView()
+        for scalar in path.unicodeScalars {
+            let shouldReplace = CharacterSet.controlCharacters.contains(scalar)
+                || CharacterSet.newlines.contains(scalar)
+                || directionalFormattingControls.contains(scalar)
+            if shouldReplace {
+                sanitized.append(contentsOf: "?".unicodeScalars)
+            } else {
+                sanitized.append(scalar)
+            }
+        }
+        return String(sanitized)
     }
 
     private func loadReferenceContents(for skill: Skill) async -> String {

--- a/Packages/OsaurusCore/Models/Agent/SkillStore.swift
+++ b/Packages/OsaurusCore/Models/Agent/SkillStore.swift
@@ -23,6 +23,8 @@ public enum SkillStoreFileError: Error, LocalizedError, Sendable, Equatable {
 }
 
 public enum SkillStore {
+    public static let supportFileInventoryLimit = 200
+    public static let supportFileInventoryDepthLimit = 8
 
     // MARK: - Public API
 
@@ -266,6 +268,37 @@ public enum SkillStore {
         return try Data(contentsOf: fileURL)
     }
 
+    /// List supporting files stored beside a skill. This is intentionally
+    /// metadata-only: callers can tell the model which helpers/templates exist
+    /// without reading or executing arbitrary files.
+    public static func supportFiles(
+        from skill: Skill,
+        subdirectories: [String] = ["scripts", "assets", "templates"],
+        maxFiles: Int = supportFileInventoryLimit,
+        maxDepth: Int = supportFileInventoryDepthLimit
+    ) -> [SkillFile] {
+        guard maxFiles > 0, maxDepth >= 0 else { return [] }
+        let effectiveMaxFiles = min(maxFiles, supportFileInventoryLimit)
+        let effectiveMaxDepth = min(maxDepth, supportFileInventoryDepthLimit)
+        let skillDir = skillDirectory(for: skill)
+        var files: [SkillFile] = []
+        var remaining = effectiveMaxFiles
+        for subdirectory in subdirectories {
+            guard (try? normalizedRelativeSkillFilePath(subdirectory)) == subdirectory else { continue }
+            files.append(
+                contentsOf: loadSupportFilesFromSubdirectory(
+                    skillDir,
+                    subdirectory: subdirectory,
+                    remainingLimit: &remaining,
+                    depth: 0,
+                    maxDepth: effectiveMaxDepth
+                )
+            )
+            if remaining <= 0 { break }
+        }
+        return files.sorted { $0.relativePath < $1.relativePath }
+    }
+
     // MARK: - Private
 
     private static func skillsDirectory() -> URL {
@@ -399,6 +432,91 @@ public enum SkillStore {
     private static func loadFilesFromSubdirectory(_ skillDir: URL, subdirectory: String) -> [SkillFile] {
         let subDir = skillDir.appendingPathComponent(subdirectory)
         return loadFiles(in: subDir, relativeTo: skillDir)
+    }
+
+    private static func loadSupportFilesFromSubdirectory(
+        _ skillDir: URL,
+        subdirectory: String,
+        remainingLimit: inout Int,
+        depth: Int,
+        maxDepth: Int
+    ) -> [SkillFile] {
+        let subDir = skillDir.appendingPathComponent(subdirectory, isDirectory: true)
+        return loadSupportFiles(
+            in: subDir,
+            relativeTo: skillDir,
+            remainingLimit: &remainingLimit,
+            depth: depth,
+            maxDepth: maxDepth
+        )
+    }
+
+    private static func loadSupportFiles(
+        in directory: URL,
+        relativeTo skillDir: URL,
+        remainingLimit: inout Int,
+        depth: Int,
+        maxDepth: Int
+    ) -> [SkillFile] {
+        guard remainingLimit > 0, depth <= maxDepth else { return [] }
+        let baseURL = skillDir.standardizedFileURL
+        let directoryURL = directory.standardizedFileURL
+        guard isContained(directoryURL, in: baseURL),
+            !isSymbolicLink(directoryURL)
+        else {
+            return []
+        }
+
+        guard
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+
+        var files: [SkillFile] = []
+        for entry in entries.sorted(by: { $0.path < $1.path }) where remainingLimit > 0 {
+            guard
+                let values = try? entry.resourceValues(
+                    forKeys: [.fileSizeKey, .isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey]
+                ),
+                values.isSymbolicLink == false
+            else {
+                continue
+            }
+
+            if values.isDirectory == true {
+                files.append(
+                    contentsOf: loadSupportFiles(
+                        in: entry,
+                        relativeTo: skillDir,
+                        remainingLimit: &remainingLimit,
+                        depth: depth + 1,
+                        maxDepth: maxDepth
+                    )
+                )
+                continue
+            }
+
+            guard values.isRegularFile == true,
+                let relativePath = relativePath(for: entry, in: skillDir)
+            else {
+                continue
+            }
+
+            files.append(
+                SkillFile(
+                    name: entry.lastPathComponent,
+                    relativePath: relativePath,
+                    size: Int64(values.fileSize ?? 0)
+                )
+            )
+            remainingLimit -= 1
+        }
+        return files
     }
 
     private static func loadFiles(in directory: URL, relativeTo skillDir: URL) -> [SkillFile] {

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -1052,9 +1052,10 @@ public final class ClaudePluginInstaller {
 
     /// Decide whether a file should land under `references/` (indexed and
     /// loaded into context by `SkillManager.loadReferenceContents`) or
-    /// `assets/` (carried alongside the skill but not surfaced as part of
-    /// the prompt). Text-y extensions go to references so the agent can
-    /// read them; everything else goes to assets.
+    /// `assets/` (carried alongside the skill and surfaced only as metadata
+    /// in the support-file inventory). Text-y extensions, including helper
+    /// scripts, go to references so the agent can read them; everything else
+    /// goes to assets.
     nonisolated fileprivate static func shouldStoreAsReference(_ name: String) -> Bool {
         let textExtensions: Set<String> = [
             "md", "txt", "json", "yaml", "yml", "xml", "html", "css",

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -82,8 +82,6 @@ struct ModelPickerItemCacheTests {
             // doesn't false-positive.
             _ = await cache.buildModelPickerItems()
             guard !cache.items.isEmpty else { return }
-            let initialCount = cache.items.count
-
             // Spam many notifications. Each one schedules an observer Task
             // that calls `buildModelPickerItems()`. Pre-fix, each Task would
             // first set `items = []` and `isLoaded = false`.
@@ -110,11 +108,11 @@ struct ModelPickerItemCacheTests {
             )
 
             // After the burst settles, the cache should still hold a
-            // populated list (state hasn't actually changed, so it should
-            // match the initial count).
+            // populated list. Remote/provider availability can legitimately
+            // settle while the rebuilds run, so the stable invariant is
+            // non-empty continuity rather than exact count equality.
             let final = await cache.buildModelPickerItems()
             #expect(!final.isEmpty)
-            #expect(final.count == initialCount)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Skill/SkillRuntimeAffordanceTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillRuntimeAffordanceTests.swift
@@ -1,0 +1,213 @@
+//
+//  SkillRuntimeAffordanceTests.swift
+//  OsaurusCoreTests
+//
+//  Verifies that skills can advertise helper files without auto-running or
+//  reading untrusted scripts into the prompt.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SkillRuntimeAffordanceTests {
+
+    @Test func supportFilesListScriptsAssetsAndTemplatesOnlyAsMetadata() async throws {
+        try await Self.withTempSkill { _, skill in
+            try Self.writeSkillFile("scripts/main.py", in: skill, contents: "print('hello')")
+            try Self.writeSkillFile("scripts/utils/helper.py", in: skill, contents: "print('nested')")
+            try Self.writeSkillFile("assets/template.txt", in: skill, contents: "template")
+            try Self.writeSkillFile("templates/report.md", in: skill, contents: "# Report")
+
+            let scriptsDir = SkillStore.skillDirectory(for: skill).appendingPathComponent("scripts")
+            let templatesDir = SkillStore.skillDirectory(for: skill).appendingPathComponent("templates")
+            let secret = OsaurusPaths.skills().appendingPathComponent("outside-script.txt")
+            try "secret".write(to: secret, atomically: true, encoding: .utf8)
+            try FileManager.default.createSymbolicLink(
+                at: scriptsDir.appendingPathComponent("linked-secret.txt"),
+                withDestinationURL: secret
+            )
+            let outsideTemplates = OsaurusPaths.skills().appendingPathComponent("outside-templates", isDirectory: true)
+            try FileManager.default.createDirectory(at: outsideTemplates, withIntermediateDirectories: true)
+            try "outside".write(
+                to: outsideTemplates.appendingPathComponent("outside-template.txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try FileManager.default.createSymbolicLink(
+                at: templatesDir.appendingPathComponent("linked-outside"),
+                withDestinationURL: outsideTemplates
+            )
+
+            let files = SkillStore.supportFiles(from: skill)
+            let paths = files.map(\.relativePath)
+
+            #expect(
+                paths == [
+                    "assets/template.txt",
+                    "scripts/main.py",
+                    "scripts/utils/helper.py",
+                    "templates/report.md",
+                ]
+            )
+            #expect(!paths.contains("scripts/linked-secret.txt"))
+            #expect(!paths.contains("templates/linked-outside/outside-template.txt"))
+            #expect(files.first(where: { $0.relativePath == "scripts/main.py" })?.size == 14)
+        }
+    }
+
+    @Test func supportFilesStopsAtConfiguredLimit() async throws {
+        try await Self.withTempSkill { _, skill in
+            for index in 0..<6 {
+                try Self.writeSkillFile("scripts/file-\(index).py", in: skill, contents: "\(index)")
+            }
+
+            let files = SkillStore.supportFiles(from: skill, maxFiles: 3)
+
+            #expect(files.count == 3)
+            #expect(files.map(\.relativePath).allSatisfy { $0.hasPrefix("scripts/") })
+        }
+    }
+
+    @Test func supportFilesExcludeReferencesByDefaultAndIgnoreInvalidSubdirectories() async throws {
+        try await Self.withTempSkill { _, skill in
+            try await SkillStore.addReference(to: skill, name: "guide.md", content: Data("reference body".utf8))
+            try Self.writeSkillFile("scripts/main.py", in: skill, contents: "print('hello')")
+
+            let defaultPaths = SkillStore.supportFiles(from: skill).map(\.relativePath)
+            let invalidPaths = SkillStore.supportFiles(
+                from: skill,
+                subdirectories: ["../references", "/tmp", ""],
+                maxFiles: 10
+            )
+
+            #expect(defaultPaths == ["scripts/main.py"])
+            #expect(invalidPaths.isEmpty)
+        }
+    }
+
+    @Test func supportFilesRespectDepthLimit() async throws {
+        try await Self.withTempSkill { _, skill in
+            try Self.writeSkillFile("scripts/root.py", in: skill, contents: "root")
+            try Self.writeSkillFile("scripts/nested/helper.py", in: skill, contents: "nested")
+
+            let paths = SkillStore.supportFiles(from: skill, maxDepth: 0).map(\.relativePath)
+
+            #expect(paths == ["scripts/root.py"])
+        }
+    }
+
+    @Test @MainActor
+    func fullInstructionsIncludeReferencesAndSupportInventoryWithoutScriptBody() async throws {
+        try await Self.withTempSkill { root, skill in
+            try await SkillStore.addReference(to: skill, name: "guide.md", content: Data("reference body".utf8))
+            try Self.writeSkillFile("scripts/main.py", in: skill, contents: "print('hello')")
+            try Self.writeSkillFile("assets/template.txt", in: skill, contents: "template body")
+            try Self.writeSkillFile("assets/bad\nname.txt", in: skill, contents: "bad name body")
+            try Self.writeSkillFile("assets/bidi\u{202E}name.txt", in: skill, contents: "bidi body")
+
+            let loaded = try #require(await SkillStore.load(id: skill.id))
+            let rendered = await SkillManager.shared.buildFullInstructions(for: loaded)
+
+            #expect(rendered.contains("reference body"))
+            #expect(rendered.contains("## Skill Package Files"))
+            #expect(rendered.contains("scripts/main.py"))
+            #expect(rendered.contains("assets/template.txt"))
+            #expect(rendered.contains("assets/bad?name.txt"))
+            #expect(rendered.contains("assets/bidi?name.txt"))
+            #expect(rendered.contains("Reference materials, when present, are loaded separately above."))
+            #expect(rendered.contains("The inventory is capped at 200 support files."))
+            #expect(rendered.contains("loading a skill never executes"))
+            #expect(!rendered.contains("print('hello')"))
+            #expect(!rendered.contains("template body"))
+            #expect(!rendered.contains("bad\nname.txt"))
+            #expect(!rendered.contains("bad name body"))
+            #expect(!rendered.contains("bidi\u{202E}name.txt"))
+            #expect(!rendered.contains("bidi body"))
+            #expect(!rendered.contains(root.path))
+        }
+    }
+
+    @Test @MainActor
+    func capabilitiesLoadSkillUsesFullInstructionsAndSupportInventory() async throws {
+        try await Self.withTempSkill { root, skill in
+            try await SkillStore.addReference(to: skill, name: "guide.md", content: Data("reference body".utf8))
+            try Self.writeSkillFile("scripts/main.py", in: skill, contents: "print('hello')")
+
+            await SkillManager.shared.refresh()
+            let agent = Agent(
+                name: "SkillRuntime-\(UUID().uuidString.prefix(6))",
+                agentAddress: "skill-runtime-\(UUID().uuidString)",
+                manualToolNames: []
+            )
+            await AgentManager.shared.add(agent)
+
+            let result: String
+            do {
+                result = try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
+                    try await CapabilitiesLoadTool().execute(
+                        argumentsJSON: "{\"ids\": [\"skill/\(skill.name)\"]}"
+                    )
+                }
+            } catch {
+                _ = await AgentManager.shared.delete(id: agent.id)
+                throw error
+            }
+            _ = await AgentManager.shared.delete(id: agent.id)
+
+            #expect(result.contains("## Skill: Runtime Demo"))
+            #expect(result.contains("reference body"))
+            #expect(result.contains("scripts/main.py"))
+            #expect(result.contains("loading a skill never executes"))
+            #expect(!result.contains("print('hello')"))
+            #expect(!result.contains(root.path))
+        }
+
+        await SkillManager.shared.refresh()
+    }
+
+    private static func withTempSkill<T: Sendable>(
+        _ body: @Sendable (URL, Skill) async throws -> T
+    ) async throws -> T {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-skill-runtime-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousRoot = OsaurusPaths.overrideRoot
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = root
+
+            let skill = Skill(
+                name: "Runtime Demo",
+                instructions: "Use the helper files when the user explicitly asks.",
+                directoryName: "runtime-demo"
+            )
+            await SkillStore.save(skill)
+
+            do {
+                let value = try await body(root, skill)
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+                await SkillManager.shared.refresh()
+                return value
+            } catch {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+                await SkillManager.shared.refresh()
+                throw error
+            }
+        }
+    }
+
+    private static func writeSkillFile(_ relativePath: String, in skill: Skill, contents: String) throws {
+        let url = SkillStore.skillDirectory(for: skill).appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -781,14 +781,14 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             }
 
             if !method.skillsUsed.isEmpty {
-                let skills: [(String, String)] = await MainActor.run {
+                let skills: [(String, Skill)] = await MainActor.run {
                     method.skillsUsed.compactMap { name in
-                        SkillManager.shared.skill(named: name).map { (name, $0.instructions) }
+                        SkillManager.shared.skill(named: name).map { (name, $0) }
                     }
                 }
-                for (name, instructions) in skills {
+                for (name, skill) in skills {
                     output += "\n## Skill: \(name)\n"
-                    output += instructions
+                    output += await SkillManager.shared.buildFullInstructions(for: skill)
                     output += "\n\n"
                 }
             }
@@ -1029,7 +1029,7 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         if !skill.description.isEmpty {
             output += "*\(skill.description)*\n\n"
         }
-        output += skill.instructions
+        output += await SkillManager.shared.buildFullInstructions(for: skill)
         output += "\n\n"
 
         // A plugin skill governs its sibling tools, so auto-load the plugin's
@@ -1136,7 +1136,7 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             if !skill.description.isEmpty {
                 output += "*\(skill.description)*\n\n"
             }
-            output += skill.instructions
+            output += await SkillManager.shared.buildFullInstructions(for: skill)
             output += "\n\n"
         }
 


### PR DESCRIPTION
## Summary
- Add a bounded support-file inventory for skill `scripts/`, `assets`, and `templates` directories so runtime-loaded skills expose packaged helpers as affordances.
- Use full skill instructions for direct skill loads, plugin skill loads, and method-attached skill loads so references and package inventories are surfaced consistently.
- Keep support files metadata-only: skill loading lists relative paths and sizes but does not read support-file bodies or execute helper files.
- Stabilize the model picker notification-burst regression test so it asserts non-empty continuity without assuming the remote provider model count is static during rebuilds.

## Security
- Invalid support subdirectories are ignored.
- Symlinked support files and symlinked directories are skipped before inventorying.
- Inventory traversal is bounded by file count and depth.
- Paths shown in prompts are sanitized for control characters and bidi formatting characters.
- Filesystem walking is offloaded from the main actor.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-skill-runtime-fixed swift test --package-path Packages/OsaurusCore --filter SkillRuntimeAffordanceTests`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-skill-containment-fixed swift test --package-path Packages/OsaurusCore --filter SkillStoreFileContainmentTests`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-skill-capability-fixed swift test --package-path Packages/OsaurusCore --filter skillLoadAutoLoadsPluginToolGroup`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-model-picker-isolated-fixed swift test --package-path Packages/OsaurusCore --filter ModelPickerItemCacheTests/notificationBurst_doesNotTransientlyEmptyItems`
- `git diff --check`
- `swiftlint lint Packages/OsaurusCore/Managers/SkillManager.swift Packages/OsaurusCore/Models/Agent/SkillStore.swift Packages/OsaurusCore/Tools/CapabilityTools.swift Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift Packages/OsaurusCore/Tests/Skill/SkillRuntimeAffordanceTests.swift Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift`

## Full-suite status
- Local `make test` was attempted after the repair, but it is not used as pass evidence because unrelated suites failed locally (`DatabaseToolsTests.pathResolverReadsFromHostWorkingFolder`, `ToolExposureControlCenterTests.exposureSnapshotClassifiesSourcesStatesAndReasons`) before the runner produced a clean terminal pass.
- Keeping this PR draft until GitHub CI provides the required check signal and the merge state is clean.
