### PR TITLE
Fix warm-up KV cache misses and sandbox tool-registration thrash

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -577,7 +577,14 @@ public struct SystemPromptComposer: Sendable {
             contextDisable: contextDisable,
             sizeClass: window.sizeClass,
             effectiveToolsOff: effectiveToolsOff,
-            capabilityPromptSectionsEnabled: !isTrivialInput,
+            // Tied to the tool-schema fast path, NOT to `isTrivialInput`
+            // alone: capability prose sections are static prefix content, so
+            // dropping them for a trivial query in a session that keeps its
+            // tool schema (sandbox mode, existing history, frozen state)
+            // would rewrite the cached prefix — busting the warm-up KV on a
+            // "hey" first send and the whole conversation KV on any
+            // mid-session "thanks"/"ok" turn, with zero prefill savings.
+            capabilityPromptSectionsEnabled: !suppressTrivialToolSchema,
             prefersCompactPrompt: window.prefersCompactPrompt
         )
     }
@@ -1111,9 +1118,17 @@ public struct SystemPromptComposer: Sendable {
         // current tool kit is incomplete. The gate follows the actual
         // schema, not the mode label: manual-mode agents still carry
         // `capabilities_discover` / `capabilities_load` as pragmatic
-        // always-loaded tools. Trivial first turns suppress this prompt
-        // section through `capabilityPromptSectionsEnabled` without hiding
-        // the callable discovery tools themselves.
+        // always-loaded tools.
+        //
+        // KV-cache stability: `capabilityPromptSectionsEnabled` goes false
+        // ONLY on the greeting-only cold first turn in `.none` mode where
+        // the whole tool schema is dropped too (the #1161 fast path — the
+        // `capabilities_discover` check below would fail there anyway). Like
+        // `pluginCreator`, this section must NOT vanish for a trivial query
+        // in a session that keeps its schema: warm-up composes with
+        // `query: ""` and includes it, so dropping it on a "hey" send (or a
+        // mid-session "thanks") would rewrite the static prefix and force a
+        // full re-prefill.
         if toolset.capabilityPromptSectionsEnabled,
             !effectiveToolsOff,
             tools.contains(where: { $0.function.name == "capabilities_discover" })
@@ -1737,12 +1752,12 @@ public struct SystemPromptComposer: Sendable {
     /// freeze.
     ///
     /// Known, deliberate divergence: `capabilityPromptSectionsEnabled` is
-    /// hardcoded `true` here, while a trivial first send ("hi", "thanks")
-    /// suppresses the capability nudge (see `isTrivialUserQuery`). The
-    /// popover therefore prices the prompt a *real task* will produce —
-    /// slightly overstating a greeting-only first turn is the honest side
-    /// to err on, and pricing against `""` already means "unknown next
-    /// input" rather than "greeting".
+    /// hardcoded `true` here, while a greeting-only cold first send in
+    /// `.none` mode drops the schema AND the capability nudge (see
+    /// `shouldSuppressTrivialToolSchema`). The popover therefore prices the
+    /// prompt a *real task* will produce — slightly overstating that one
+    /// fast-path turn is the honest side to err on, and pricing against
+    /// `""` already means "unknown next input" rather than "greeting".
     @MainActor
     private static func previewToolset(
         snapshot: AgentConfigSnapshot,

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1373,6 +1373,117 @@ struct MLXBatchAdapter {
         let promptTokens: [Int]
     }
 
+    /// Prepare a warm-up prompt as the send-invariant prefix of the NEXT
+    /// real send's rendering.
+    ///
+    /// The warm-up payload is history-only (system + completed turns); the
+    /// real send appends a user turn whose text is unknown at warm-up time.
+    /// Rendering the history alone is not template-safe: some native
+    /// templates require a user query (Ornith / qwen3_5 raises
+    /// `'No user query found in messages.'`) and the tokenizer bridge then
+    /// silently substitutes a built-in fallback template — the warm-up
+    /// stores KV for a byte sequence the real send never renders, and the
+    /// cache misses in full. Index-sensitive templates (reasoning replay
+    /// keyed off the last user index) have the same divergence in milder
+    /// form.
+    ///
+    /// Instead, render the history PLUS a probe user turn twice with two
+    /// different probe texts, and keep the longest common token prefix.
+    /// Whatever the template renders identically for both probes is by
+    /// construction independent of the user text — the exact prefix the
+    /// real send extends (system + tools + completed turns + the user-turn
+    /// header). No template shape is assumed and nothing user-text-derived
+    /// can leak into the stored prefix: any divergent token ends the LCP.
+    ///
+    /// Returns nil (caller falls back to
+    /// ``truncatingToCanonicalCacheBoundary``) when the chat carries media,
+    /// already ends in a user turn, a probe render fails, or the two probe
+    /// renders share no usable prefix.
+    static func prepareWarmupInputAtSendInvariantPrefix(
+        chat: [MLXLMCommon.Chat.Message],
+        toolsSpec: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable],
+        processor: any MLXLMCommon.UserInputProcessor
+    ) async -> LMInput? {
+        let hasMedia = chat.contains {
+            !$0.images.isEmpty || !$0.videos.isEmpty || !$0.audios.isEmpty
+        }
+        guard !hasMedia else { return nil }
+
+        let prefix = await warmupSendInvariantPrefixTokens(chat: chat) { probeText in
+            var probeChat = chat
+            probeChat.append(.user(probeText))
+            let input = MLXLMCommon.UserInput(
+                chat: probeChat,
+                processing: .init(),
+                tools: toolsSpec,
+                additionalContext: additionalContext
+            )
+            guard let prepared = try? await processor.prepare(input: input),
+                !prepared.hasMediaContent
+            else { return nil }
+            return prepared.text.tokenIds
+                ?? MLXCacheIOLock.withSerializedMLXCacheIO {
+                    prepared.text.tokens.asArray(Int.self)
+                }
+        }
+
+        guard let prefix else {
+            batchAdapterLog.info(
+                "warmupPrefill: probe renders unavailable or share no prefix; falling back to canonical boundary truncation"
+            )
+            return nil
+        }
+
+        // The scope salt is derived from additionalContext alone, so the
+        // probe render's salt matches the real send's.
+        let scopeSalt = MLXLMCommon.cacheScopeSalt(from: additionalContext)
+        batchAdapterLog.info(
+            "warmupPrefill: truncated prompt to send-invariant prefix of \(prefix.count, privacy: .public) tokens"
+        )
+        // Prompt tokens are batch-shaped [1, N] by processor contract (see
+        // `truncatingToCanonicalCacheBoundary`).
+        return LMInput(
+            tokens: MLXArray(prefix).expandedDimensions(axis: 0),
+            tokenIds: prefix,
+            cacheScopeSalt: scopeSalt,
+            cachePrefixTokenCounts: [],
+            toolSchemas: toolsSpec
+        )
+    }
+
+    /// Token-level core of ``prepareWarmupInputAtSendInvariantPrefix``:
+    /// render the history plus two different probe user turns and return
+    /// their longest common token prefix. Returns nil when the history
+    /// already ends in a user turn (the next send would not simply append
+    /// one), a probe render fails, or the renders share no usable prefix.
+    static func warmupSendInvariantPrefixTokens(
+        chat: [MLXLMCommon.Chat.Message],
+        renderProbe: (String) async -> [Int]?
+    ) async -> [Int]? {
+        guard chat.last?.role != .user else { return nil }
+        // Probe texts start with different characters so their first content
+        // tokens differ and the LCP ends exactly at the user-turn header.
+        guard let probeA = await renderProbe("0"),
+            let probeB = await renderProbe("z"),
+            let boundary = warmupSendInvariantBoundary(probeA: probeA, probeB: probeB)
+        else { return nil }
+        return Array(probeA.prefix(boundary))
+    }
+
+    /// Longest common token prefix of the two probe renders, or nil when it
+    /// is unusable: empty (renders diverge immediately — nothing stable to
+    /// store) or covering an entire probe render (the probes failed to
+    /// diverge, so the boundary cannot be proven to exclude probe-derived
+    /// tokens or the generation prompt).
+    static func warmupSendInvariantBoundary(probeA: [Int], probeB: [Int]) -> Int? {
+        let n = min(probeA.count, probeB.count)
+        var lcp = 0
+        while lcp < n, probeA[lcp] == probeB[lcp] { lcp += 1 }
+        guard lcp > 0, lcp < probeA.count, lcp < probeB.count else { return nil }
+        return lcp
+    }
+
     /// Truncate a warm-up prompt to the processor's canonical history cache
     /// boundary (the render WITHOUT the generation prompt).
     ///
@@ -1597,14 +1708,35 @@ struct MLXBatchAdapter {
 
                 trace?.mark("batch_tokenization_start")
                 do {
-                    let prepared = try await context.processor.prepare(input: userInput)
-                    lmInput = prepared.withToolSchemas(toolsSpec)
-                    if generation.warmupPrefill {
-                        lmInput = Self.truncatingToCanonicalCacheBoundary(
-                            lmInput,
-                            tokenizer: context.tokenizer,
-                            additionalContext: additionalContext
+                    // Warm-up prompts must be rendered exactly like the next
+                    // real send, then cut to the send-invariant prefix. The
+                    // probe path appends a synthetic user turn before
+                    // rendering, because several native templates (e.g.
+                    // Ornith / qwen3_5's `raise_exception('No user query
+                    // found in messages.')`) refuse a history-only message
+                    // list — the tokenizer bridge then silently renders with
+                    // a built-in fallback template whose bytes share nothing
+                    // with the real send, so the stored KV can never be
+                    // restored. See `prepareWarmupInputAtSendInvariantPrefix`.
+                    if generation.warmupPrefill,
+                        let probeTruncated = await Self.prepareWarmupInputAtSendInvariantPrefix(
+                            chat: chat,
+                            toolsSpec: toolsSpec,
+                            additionalContext: additionalContext,
+                            processor: context.processor
                         )
+                    {
+                        lmInput = probeTruncated
+                    } else {
+                        let prepared = try await context.processor.prepare(input: userInput)
+                        lmInput = prepared.withToolSchemas(toolsSpec)
+                        if generation.warmupPrefill {
+                            lmInput = Self.truncatingToCanonicalCacheBoundary(
+                                lmInput,
+                                tokenizer: context.tokenizer,
+                                additionalContext: additionalContext
+                            )
+                        }
                     }
                 } catch {
                     let detail =

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
@@ -78,6 +78,21 @@ public final class SandboxToolRegistrar {
     /// the second attempt or succeed.
     private static let provisioningRetryDelay: TimeInterval = 5
 
+    /// Memo of the last SUCCESSFUL builtin registration (agent + effective
+    /// exec config). Backs the idempotent fast path in `registerTools`:
+    /// warmups and sends call `registerTools` on every turn, and the slow
+    /// path tears the sandbox tools out of the registry, then suspends for
+    /// container work (provision + SOUL seed + package reconcile) before
+    /// re-registering them. Any prompt composition that lands in that
+    /// window — the budget preview, another window's warm-up payload —
+    /// resolves a schema WITHOUT the sandbox tools, which flaps the
+    /// composed shape, invalidates the warm KV fingerprint, and schedules
+    /// yet another warm-up whose `registerTools` punches the next hole
+    /// (observed as an endless 17–22 s re-prefill loop). When nothing
+    /// changed since the last successful registration, skip the cycle
+    /// entirely so the registry never transitions through the empty state.
+    private var registeredBuiltins: (agentId: UUID, config: AutonomousExecConfig?)?
+
     /// Returns the current unavailability reason for an agent, if any.
     public func unavailabilityReason(for agentId: UUID) -> UnavailabilityReason? {
         unavailability[agentId]
@@ -214,13 +229,38 @@ public final class SandboxToolRegistrar {
     /// system prompt can surface a clear message to the model instead of the
     /// model silently losing access to its sandbox tools.
     public func registerTools(for agentId: UUID, forceStart: Bool = false) async {
-        ToolRegistry.shared.unregisterAllBuiltinSandboxTools()
-
         let agent = AgentManager.shared.agent(for: agentId) ?? Agent.default
         let agentIdStr = agent.id.uuidString
         let agentName = SandboxAgentProvisioner.linuxName(for: agentIdStr)
         let execConfig = AgentManager.shared.effectiveAutonomousExec(for: agent.id)
         let autonomousEnabled = execConfig?.enabled == true
+
+        // Idempotent fast path (see `registeredBuiltins`): the desired end
+        // state is already installed — same agent, same effective config,
+        // container still running, no recorded failure, and the real
+        // builtin tools actually present in the registry (the registry
+        // check guards against out-of-band teardowns like the eval
+        // runner's `unregisterAllBuiltinSandboxTools`). Return without
+        // unregistering so concurrent composes never observe a schema
+        // with the sandbox tools missing. Restricted to the autonomous
+        // case: a matching memo then proves `ensureProvisioned` already
+        // succeeded for this agent, whereas with autonomous off a plugin
+        // that became ready since the memo was taken still needs its
+        // provisioning pass on the slow path.
+        if !forceStart,
+            autonomousEnabled,
+            let memo = registeredBuiltins,
+            memo.agentId == agent.id,
+            memo.config == execConfig,
+            SandboxManager.State.shared.status == .running,
+            unavailability[agent.id] == nil,
+            ToolRegistry.shared.builtInSandboxToolNamesSnapshot.contains("sandbox_read_file")
+        {
+            return
+        }
+
+        ToolRegistry.shared.unregisterAllBuiltinSandboxTools()
+        registeredBuiltins = nil
         let needsProvisioning =
             autonomousEnabled
             || SandboxPluginManager.shared.plugins(for: agentIdStr).contains { $0.status == .ready }
@@ -343,6 +383,7 @@ public final class SandboxToolRegistrar {
             agentName: agentName,
             config: execConfig
         )
+        registeredBuiltins = (agent.id, execConfig)
         realToolsRegistered = true
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -298,6 +298,83 @@ struct ContextBudgetPreviewTests {
         }
     }
 
+    /// Warm-up parity: warm-up composes with `query: ""` (never trivial), so
+    /// a trivial first send ("hey") in sandbox mode must render the exact
+    /// same static prefix — including the `capabilityNudge` section — or the
+    /// warmed KV misses and the model re-prefills from 0. Regression for the
+    /// live "green dot but full re-prefill on 'hey'" bug where the trivial
+    /// gate dropped just the Capability Discovery section while the tool
+    /// schema stayed.
+    @Test("compose: sandbox trivial first send matches warmup compose byte-for-byte")
+    func sandboxTrivialFirstSend_matchesWarmupCompose() async {
+        await withAgent(toolSelectionMode: .auto, autonomous: true) { agentId in
+            BuiltinSandboxTools.register(
+                agentId: agentId.uuidString,
+                agentName: "warmup-parity-test",
+                config: AutonomousExecConfig(enabled: true)
+            )
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+            let warmup = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .sandbox(hostRead: nil),
+                query: ""
+            )
+            let send = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .sandbox(hostRead: nil),
+                query: "hey"
+            )
+
+            #expect(SystemPromptComposer.isTrivialUserQuery("hey"))
+            // Sandbox mode keeps the schema (the trivial fast path is
+            // `.none`-only), so the nudge must stay too.
+            #expect(!send.tools.isEmpty)
+            #expect(sectionIds(send).contains("capabilityNudge"))
+            #expect(sectionIds(send) == sectionIds(warmup))
+            #expect(send.staticPrefix == warmup.staticPrefix)
+            #expect(send.prompt == warmup.prompt)
+            #expect(send.cacheHint == warmup.cacheHint)
+            // Same value the debug log prints as `Static prefix: N (hash: …)`
+            // — the live bug showed warmup f909bca1… vs send 931995ed….
+            #expect(send.manifest.prefixHash == warmup.manifest.prefixHash)
+        }
+    }
+
+    /// Mid-session KV stability: a trivial acknowledgement ("thanks") in a
+    /// session with history must not rewrite the system prompt — dropping the
+    /// `capabilityNudge` section there would bust the entire conversation KV
+    /// for zero prefill savings.
+    @Test("compose: trivial mid-conversation turn keeps capability nudge section")
+    func trivialMidConversation_keepsCapabilityNudgeSection() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let frozen = LoadedTools(
+                ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)
+            )
+            let messages = [ChatMessage(role: "user", content: "summarize this project")]
+            let steady = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "",
+                messages: messages,
+                frozenAlwaysLoadedNames: frozen
+            )
+            let thanks = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "thanks",
+                messages: messages,
+                frozenAlwaysLoadedNames: frozen
+            )
+
+            #expect(SystemPromptComposer.isTrivialUserQuery("thanks"))
+            #expect(sectionIds(thanks).contains("capabilityNudge"))
+            #expect(sectionIds(thanks) == sectionIds(steady))
+            #expect(thanks.staticPrefix == steady.staticPrefix)
+            #expect(thanks.prompt == steady.prompt)
+        }
+    }
+
     /// The loop cheat-sheet is schema-gated: it renders from the FIRST
     /// real turn whenever loop tools resolve into the schema, so the model
     /// sees the "when to call which" guide on its first multi-step task

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
@@ -188,4 +188,64 @@ struct SandboxDefaultEnablementTests {
             _ = await manager.delete(id: agent.id)
         }
     }
+
+    // MARK: - Idempotent fast path
+
+    /// `registerTools` is called on every warm-up and every send
+    /// (`prepareChatExecutionMode`). The slow path unregisters the builtin
+    /// sandbox tools FIRST and only re-registers them after async container
+    /// work, so any compose landing in that window resolves a schema without
+    /// the sandbox tools — flapping the composed shape and thrashing the
+    /// warm-up KV fingerprint. Pin the fast path: a repeat call with the
+    /// same agent/config and a running container must neither re-provision
+    /// nor transition the registry through the empty state.
+    @Test
+    func registerTools_repeatCallSameAgentAndConfig_skipsReprovision() async {
+        await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let registrar = SandboxToolRegistrar.shared
+            let registry = ToolRegistry.shared
+            let originalStatus = SandboxManager.State.shared.status
+            let originalProvisionOverride = registrar.provisionAgentOverride
+
+            let agent = Agent(
+                name: "FastPath Sandbox \(UUID().uuidString)",
+                agentAddress: "test-fastpath-sandbox-\(UUID().uuidString)",
+                autonomousExec: AutonomousExecConfig(enabled: true)
+            )
+            manager.add(agent)
+            SandboxManager.State.shared.status = .running
+
+            final class Counter: @unchecked Sendable {
+                var provisionCalls = 0
+            }
+            let counter = Counter()
+            registrar.provisionAgentOverride = { @MainActor _ in
+                counter.provisionCalls += 1
+            }
+
+            registry.unregisterAllBuiltinSandboxTools()
+            await registrar.registerTools(for: agent.id)
+            #expect(registry.builtInSandboxToolNamesSnapshot.contains("sandbox_exec"))
+            #expect(counter.provisionCalls == 1)
+
+            // Repeat call: same agent, same config, container running —
+            // must be a no-op (no re-provision, tools stay registered).
+            await registrar.registerTools(for: agent.id)
+            #expect(counter.provisionCalls == 1)
+            #expect(registry.builtInSandboxToolNamesSnapshot.contains("sandbox_exec"))
+
+            // Out-of-band teardown (eval runner) invalidates the fast path:
+            // the next call must take the slow path and re-register.
+            registry.unregisterAllBuiltinSandboxTools()
+            await registrar.registerTools(for: agent.id)
+            #expect(counter.provisionCalls == 2)
+            #expect(registry.builtInSandboxToolNamesSnapshot.contains("sandbox_exec"))
+
+            registry.unregisterAllSandboxTools()
+            SandboxManager.State.shared.status = originalStatus
+            registrar.provisionAgentOverride = originalProvisionOverride
+            _ = await manager.delete(id: agent.id)
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -2252,6 +2252,123 @@ struct MLXBatchAdapterTests {
         #expect(boundary == nil)
     }
 
+    // MARK: - Warm-up send-invariant prefix (probe renders)
+
+    @Test func warmupSendInvariantBoundary_cutsAtFirstDivergentToken() {
+        let boundary = MLXBatchAdapter.warmupSendInvariantBoundary(
+            probeA: [1, 2, 3, 50, 7, 90, 91],
+            probeB: [1, 2, 3, 50, 8, 90, 91]
+        )
+
+        #expect(boundary == 4)
+    }
+
+    @Test func warmupSendInvariantBoundary_rejectsImmediateDivergence() {
+        // Renders share nothing — e.g. one probe fell back to a different
+        // template family. There is no stable prefix worth storing.
+        let boundary = MLXBatchAdapter.warmupSendInvariantBoundary(
+            probeA: [9, 9, 9],
+            probeB: [1, 2, 3]
+        )
+
+        #expect(boundary == nil)
+    }
+
+    @Test func warmupSendInvariantBoundary_rejectsNonDivergingProbes() {
+        // Identical renders cannot prove where probe-derived tokens begin,
+        // and a probe that is a full prefix of the other proves nothing
+        // about the generation-prompt suffix either.
+        #expect(
+            MLXBatchAdapter.warmupSendInvariantBoundary(
+                probeA: [1, 2, 3],
+                probeB: [1, 2, 3]
+            ) == nil
+        )
+        #expect(
+            MLXBatchAdapter.warmupSendInvariantBoundary(
+                probeA: [1, 2],
+                probeB: [1, 2, 3]
+            ) == nil
+        )
+        #expect(
+            MLXBatchAdapter.warmupSendInvariantBoundary(probeA: [], probeB: []) == nil
+        )
+    }
+
+    /// Simulates the Ornith / qwen3_5 failure: the native template REQUIRES
+    /// a user message, so a history-only render silently falls back to a
+    /// different template whose bytes share nothing with the real send.
+    /// The probe path appends a user turn before rendering, so it always
+    /// renders native, and the stored prefix must be a true token-prefix of
+    /// the real send's render.
+    private enum UserQueryRequiredTemplate {
+        static let systemAndTools = [1, 2, 3, 4, 5, 6]
+        static let userHeader = [50]
+        static let userFooter = [80]
+        static let generationSuffix = [90, 91]
+        /// What the bridge's substituted fallback template renders for a
+        /// history-only message list (native raises 'No user query found').
+        static let fallbackRender = [7, 7, 7, 7, 7]
+
+        static func nativeRender(userText: String) -> [Int] {
+            systemAndTools + userHeader
+                + userText.unicodeScalars.map { Int($0.value) }
+                + userFooter + generationSuffix
+        }
+    }
+
+    @Test func warmupProbePrefix_isTruePrefixOfRealSendForUserQueryRequiredTemplate() async {
+        let chat: [MLXLMCommon.Chat.Message] = [.system("You are an agent.")]
+
+        let warmupTokens = await MLXBatchAdapter.warmupSendInvariantPrefixTokens(chat: chat) {
+            UserQueryRequiredTemplate.nativeRender(userText: $0)
+        }
+
+        // The invariant prefix is everything up to and including the
+        // user-turn header — nothing probe-derived and no generation suffix.
+        #expect(
+            warmupTokens
+                == UserQueryRequiredTemplate.systemAndTools
+                + UserQueryRequiredTemplate.userHeader
+        )
+
+        // The real send extends the stored prefix byte-for-byte.
+        let sendTokens = UserQueryRequiredTemplate.nativeRender(userText: "hey")
+        if let warmupTokens {
+            #expect(Array(sendTokens.prefix(warmupTokens.count)) == warmupTokens)
+        }
+
+        // The history-only render (what the old path would have stored)
+        // shares no prefix with the send — the regression this guards.
+        #expect(
+            Array(sendTokens.prefix(1))
+                != Array(UserQueryRequiredTemplate.fallbackRender.prefix(1))
+        )
+    }
+
+    @Test func warmupProbePrefix_bailsWhenHistoryEndsInUserTurn() async {
+        let chat: [MLXLMCommon.Chat.Message] = [
+            .system("You are an agent."),
+            .user("dangling"),
+        ]
+
+        let warmupTokens = await MLXBatchAdapter.warmupSendInvariantPrefixTokens(chat: chat) {
+            UserQueryRequiredTemplate.nativeRender(userText: $0)
+        }
+
+        #expect(warmupTokens == nil)
+    }
+
+    @Test func warmupProbePrefix_bailsWhenProbeRenderFails() async {
+        let chat: [MLXLMCommon.Chat.Message] = [.system("You are an agent.")]
+
+        let warmupTokens = await MLXBatchAdapter.warmupSendInvariantPrefixTokens(chat: chat) {
+            _ in nil
+        }
+
+        #expect(warmupTokens == nil)
+    }
+
     // MARK: - Laguna serving-loop defaults
 
     @Test func isLagunaFamily_matchesBothLinesAndRejectsLookalikes() {


### PR DESCRIPTION
## Summary

After warm-up, the first real chat send was missing the KV cache and re-prefilling the whole prompt. Three distinct causes, all fixed here:

- **Trivial-query prefix rewrite (`SystemPromptComposer`)**: `capabilityPromptSectionsEnabled` was gated on `isTrivialInput` alone, so a "hey" first send (or a mid-session "thanks") dropped the Capability Discovery section while keeping the tool schema — rewriting the static prefix and busting the warmed/conversation KV for zero prefill savings. Now tied to the tool-schema fast path (`shouldSuppressTrivialToolSchema`), which only fires on the greeting-only cold first turn in `.none` mode where the schema is dropped too.
- **Template fallback on history-only warm-up renders (`MLXBatchAdapter`)**: templates that require a user message (Ornith / qwen3_5's `raise_exception('No user query found in messages.')`) made the tokenizer bridge silently substitute a built-in fallback template for the history-only warm-up prompt — storing KV for a byte sequence the real send never renders (4140 vs 3624 tokens observed live). The warm-up path now renders the history plus two different probe user turns and stores their longest common token prefix: by construction the send-invariant prefix (system + tools + history + user-turn header) that the next real send extends byte-for-byte, with no template shape assumed. Falls back to the existing canonical-boundary truncation when probes fail.
- **Sandbox tool-registration thrash (`SandboxToolRegistrar`)**: `registerTools` runs on every warm-up and send, and unconditionally unregistered all builtin sandbox tools, suspended for container work (provision, SOUL seed, `pip list` / `package.json` reconcile), then re-registered. Composes landing in that window resolved a 7-tool schema instead of 15, flapping the composed shape, invalidating the warm fingerprint, and scheduling another warm-up whose `registerTools` punched the next hole — an endless loop of 17–22 s Ornith re-prefills. Added an idempotent fast path: same agent, same effective config, container running, tools actually present → return without touching the registry.

Verified live: Ornith first-send TTFT dropped from ~10 s+ (full 3.6k-token prefill) to ~1.1 s (suffix-only prefill on a warmed prefix), and the warm-up loop / `toolCount=7/15` log thrash is gone.

## Test plan

- [x] New: probe-boundary unit tests (`warmupSendInvariantBoundary_*`, `warmupProbePrefix_*`) including a simulated user-query-required template
- [x] New: warm-up/send compose parity tests (`sandboxTrivialFirstSend_matchesWarmupCompose`, `trivialMidConversation_keepsCapabilityNudgeSection`)
- [x] New: registrar fast-path test (`registerTools_repeatCallSameAgentAndConfig_skipsReprovision`)
- [x] Suites pass: `MLXBatchAdapterTests`, `ContextBudgetPreviewTests`, `SandboxDefaultEnablementTests`, `ChatViewSandboxTests`, `SandboxToolsOverrideTests`, `SystemPromptComposerToolResolutionTests`
- [x] Live verification on Gemma 4 12B and Ornith 1.0 9B (warm-up prefix restored on send; no re-warm loop)