### PR TITLE
added toggle for notch overlay placement on or below the menu bar

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -75875,6 +75875,9 @@
         }
       }
     },
+    "Live catalog: %lld entries, %lld Codex-compatible." : {
+
+    },
     "Live chat" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -75947,9 +75950,6 @@
           }
         }
       }
-    },
-    "Live catalog: %lld entries, %lld Codex-compatible." : {
-
     },
     "Live Test" : {
       "extractionState" : "stale",
@@ -134494,9 +134494,6 @@
         }
       }
     },
-    "shell tool disabled" : {
-
-    },
     "Shell command run after dependencies are installed" : {
       "localizations" : {
         "de" : {
@@ -134564,6 +134561,9 @@
           }
         }
       }
+    },
+    "shell tool disabled" : {
+
     },
     "Short description" : {
       "localizations" : {
@@ -135158,6 +135158,76 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示模型元數據"
+          }
+        }
+      }
+    },
+    "Show Notch Overlay on Menu Bar" : {
+      "comment" : "Toggle that places the task-progress notch overlay on the menu bar instead of below it.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notch-Overlay in der Menüleiste anzeigen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메뉴 막대에 노치 오버레이 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать оверлей выреза в строке меню"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在菜单栏显示刘海浮层"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在選單列顯示瀏海浮層"
+          }
+        }
+      }
+    },
+    "Place the task-progress notch overlay on the menu bar. When off, it sits just below the menu bar so it never covers the clock, battery, or other system status controls." : {
+      "comment" : "Description for the toggle that controls whether the task-progress notch overlay sits on or below the menu bar.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platziert das Notch-Overlay für den Aufgabenfortschritt in der Menüleiste. Wenn deaktiviert, sitzt es direkt unter der Menüleiste und verdeckt so nie Uhr, Batterie oder andere Systemstatus-Elemente."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 진행 상황 노치 오버레이를 메뉴 막대에 배치합니다. 끄면 메뉴 막대 바로 아래에 표시되어 시계, 배터리 또는 기타 시스템 상태 항목을 가리지 않습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размещает оверлей выреза с ходом выполнения задачи в строке меню. Когда выключено, он располагается прямо под строкой меню и не закрывает часы, батарею и другие элементы состояния системы."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将任务进度刘海浮层放置在菜单栏上。关闭时，它位于菜单栏正下方，因此绝不会遮挡时钟、电池或其他系统状态控件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將任務進度瀏海浮層放置在選單列上。關閉時，它位於選單列正下方，因此絕不會遮擋時鐘、電池或其他系統狀態控制項。"
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
+++ b/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
@@ -108,6 +108,25 @@ struct NotchPanelPlacementTests {
         #expect(placement.frame.maxY == visibleFrame.maxY)
     }
 
+    @Test func panelAnchorsToScreenTopWhenPlacedOnMenuBar() {
+        // Opt-in on-menu-bar placement (issue #1951): the panel anchors to the
+        // physical top of the display, ignoring the visible-frame / auto-hide
+        // insets so it sits on the menu bar.
+        let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let visibleFrame = CGRect(x: 0, y: 0, width: 1440, height: 868)
+
+        let placement = NotchPanelPlacement.panelRect(
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame,
+            preferredSize: CGSize(width: 600, height: 500),
+            hiddenMenuBarInset: 32,
+            overMenuBar: true
+        )
+
+        #expect(placement.frame.maxY == screenFrame.maxY)
+        #expect(placement.frame.midX == screenFrame.midX)
+    }
+
     @Test func alertContentTopPaddingMatchesMenuBarGap() {
         let screenFrame = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let visibleFrame = CGRect(x: 0, y: 0, width: 1440, height: 868)

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -158,6 +158,20 @@ struct NotchView: View {
         }
     }
 
+    /// Extra top inset for the expanded card when the overlay is anchored on
+    /// the menu bar and the display has a physical notch. The panel's top edge
+    /// then sits at the very top of the screen, so the hardware notch cutout
+    /// overlaps the card's header; push the content down past it (issue #1951).
+    /// Zero for below-the-menu-bar placement, non-notch displays, and the
+    /// compact pill (whose icons are meant to straddle the cutout).
+    private var hardwareNotchTopInset: CGFloat {
+        guard expansion == .expanded,
+            metrics.hasHardwareNotch,
+            NotchOverlayPlacement.current == .onMenuBar
+        else { return 0 }
+        return metrics.notchHeight
+    }
+
     /// Compact: flush with bezel. Expanded: content-driven via fixedSize.
     private var notchHeight: CGFloat {
         switch expansion {
@@ -435,7 +449,7 @@ struct NotchView: View {
                 if sortedTasks.count > 1 { taskDotIndicators }
             }
             .padding(.horizontal, 16)
-            .padding(.top, 6)
+            .padding(.top, 6 + hardwareNotchTopInset)
             .padding(.bottom, 14)
             .opacity(contentRevealed ? 1 : 0)
             .offset(y: contentRevealed ? 0 : 8)

--- a/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
@@ -47,6 +47,29 @@ public struct NotchScreenMetrics: Equatable {
     }
 }
 
+// MARK: - Notch Overlay Placement Preference
+
+/// User-controlled vertical placement of the task-progress notch overlay.
+///
+/// `below` (default) keeps the overlay inside the visible frame so it never
+/// covers the menu bar / system status controls (issue that motivated #1874).
+/// `onMenuBar` anchors it to the physical top of the display so it sits on the
+/// menu bar for users who prefer that (issue #1951).
+public enum NotchOverlayPlacement: String {
+    case belowMenuBar
+    case onMenuBar
+
+    /// `UserDefaults` key backing the Chat settings toggle. Read by the
+    /// controller each time it repositions the panel.
+    public static let defaultsKey = "notchOverlayPlacement"
+
+    /// Current preference, defaulting to `.belowMenuBar` when unset.
+    public static var current: NotchOverlayPlacement {
+        UserDefaults.standard.string(forKey: defaultsKey)
+            .flatMap(NotchOverlayPlacement.init) ?? .belowMenuBar
+    }
+}
+
 // MARK: - Notch Panel Placement
 
 struct NotchPanelPlacement: Equatable {
@@ -56,7 +79,8 @@ struct NotchPanelPlacement: Equatable {
         screenFrame: CGRect,
         visibleFrame: CGRect,
         preferredSize: CGSize,
-        hiddenMenuBarInset: CGFloat = 0
+        hiddenMenuBarInset: CGFloat = 0,
+        overMenuBar: Bool = false
     ) -> NotchPanelPlacement {
         let safeFrame = visibleFrame.isEmpty ? screenFrame : visibleFrame
         let width = min(preferredSize.width, max(1, safeFrame.width))
@@ -65,14 +89,21 @@ struct NotchPanelPlacement: Equatable {
         let minX = safeFrame.minX
         let maxX = safeFrame.maxX - width
         let x = min(max(centeredX, minX), maxX)
-        // When the menu bar auto-hides, `visibleFrame` extends to the very top
-        // of the screen, which would place the panel exactly in the strip
-        // where the menu bar reappears — overlapping the clock / status icons
-        // whenever it reveals. Reserve that strip explicitly in that case.
-        let topY =
-            safeFrame.maxY >= screenFrame.maxY
-            ? safeFrame.maxY - hiddenMenuBarInset
-            : safeFrame.maxY
+        // Anchor the top edge. `overMenuBar` intentionally uses the physical
+        // top of the display so the overlay sits on the menu bar. Otherwise we
+        // stay inside the visible frame — and when the menu bar auto-hides,
+        // `visibleFrame` extends to the very top of the screen, which would
+        // place the panel exactly in the strip where the menu bar reappears
+        // (overlapping the clock / status icons on every reveal), so we reserve
+        // that strip explicitly in that case.
+        let topY: CGFloat
+        if overMenuBar {
+            topY = screenFrame.maxY
+        } else if safeFrame.maxY >= screenFrame.maxY {
+            topY = safeFrame.maxY - hiddenMenuBarInset
+        } else {
+            topY = safeFrame.maxY
+        }
         let y = topY - height
 
         return NotchPanelPlacement(frame: CGRect(x: x, y: y, width: width, height: height))
@@ -142,9 +173,10 @@ public final class NotchWindowController: NSObject, ObservableObject {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
-        // Keep task progress above regular app windows without covering macOS
-        // menu-bar/status-item windows.
-        panel.level = .floating
+        // Keep task progress above regular app windows. Below the menu bar by
+        // default; the user can opt into an on-menu-bar placement (issue #1951)
+        // which raises the level above the menu-bar window.
+        panel.level = basePanelLevel
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
         panel.isReleasedWhenClosed = false
         panel.hidesOnDeactivate = false
@@ -286,7 +318,7 @@ public final class NotchWindowController: NSObject, ObservableObject {
             alertActive
             ? screen.frame
             : panelRect(for: screen, metrics: NotchScreenMetrics.detect(for: screen))
-        let targetLevel = alertActive ? Self.alertPanelLevel : NSWindow.Level.floating
+        let targetLevel = alertActive ? Self.alertPanelLevel : basePanelLevel
         let targetPadding = alertActive
             ? NotchPanelPlacement.alertContentTopPadding(
                 screenFrame: screen.frame,
@@ -317,10 +349,30 @@ public final class NotchWindowController: NSObject, ObservableObject {
             screenFrame: screen.frame,
             visibleFrame: screen.visibleFrame,
             preferredSize: CGSize(width: Self.panelWidth, height: Self.panelHeight),
-            hiddenMenuBarInset: metrics.notchHeight
+            hiddenMenuBarInset: metrics.notchHeight,
+            overMenuBar: NotchOverlayPlacement.current == .onMenuBar
         ).frame
     }
 
+    /// Non-alert window level for the panel. `.onMenuBar` placement must sit
+    /// above the menu-bar window so the overlay actually renders on top of it;
+    /// `.belowMenuBar` uses `.floating` so it stays above app windows but below
+    /// the menu bar / status items.
+    private var basePanelLevel: NSWindow.Level {
+        NotchOverlayPlacement.current == .onMenuBar ? Self.onMenuBarPanelLevel : .floating
+    }
+
+    /// Re-read the placement preference and reposition the panel. Called when
+    /// the user flips the Chat settings toggle. No-ops while an alert has the
+    /// panel expanded to full screen; the next `syncAlertExpansion` restores
+    /// the correct level/frame once the alert clears.
+    public func refreshPlacement() {
+        guard notchPanel != nil, !isExpandedForAlert else { return }
+        notchPanel?.level = basePanelLevel
+        updatePanelScreen(forWindowId: ChatWindowManager.shared.lastFocusedWindowId)
+    }
+
+    private static let onMenuBarPanelLevel = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 1)
     private static let alertPanelLevel = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 3)
 }
 

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -57,6 +57,16 @@ struct ChatSettingsView: View {
     /// `AgentSettings.greetingPersona`.
     @State private var tempGreetingPersona: String = ""
 
+    /// Placement of the task-progress notch overlay. Off (default) keeps it
+    /// below the menu bar so it never covers the clock / battery / status
+    /// controls; on anchors it to the top of the display so it sits on the
+    /// menu bar (issue #1951). Bound to `UserDefaults` key
+    /// `NotchOverlayPlacement.defaultsKey`, stored as the enum raw value and
+    /// read by `NotchWindowController` when it repositions the panel. Applied
+    /// immediately, so it's excluded from the debounced save baseline.
+    @AppStorage(NotchOverlayPlacement.defaultsKey) private var notchPlacementRaw: String =
+        NotchOverlayPlacement.belowMenuBar.rawValue
+
     @State private var hasAppeared = false
     @State private var successMessage: String?
 
@@ -131,6 +141,21 @@ struct ChatSettingsView: View {
         .onDisappear { flushPendingSave() }
     }
 
+    /// Bridges the string-backed placement preference to the boolean
+    /// `SettingsToggle`. Writing flips the raw value and immediately asks the
+    /// notch controller to reposition so the change is visible without a
+    /// restart.
+    private var notchOnMenuBarBinding: Binding<Bool> {
+        Binding(
+            get: { notchPlacementRaw == NotchOverlayPlacement.onMenuBar.rawValue },
+            set: { isOn in
+                notchPlacementRaw =
+                    (isOn ? NotchOverlayPlacement.onMenuBar : .belowMenuBar).rawValue
+                NotchWindowController.shared.refreshPlacement()
+            }
+        )
+    }
+
     // MARK: - Header
 
     private var headerView: some View {
@@ -202,6 +227,14 @@ struct ChatSettingsView: View {
                         "Preload the selected local model and prefill your chat context so the first response starts faster. The model selector shows yellow while warming and green when ready.",
                     isOn: $tempWarmModelsOnLoad
                 )
+
+                SettingsToggle(
+                    title: L("Show Notch Overlay on Menu Bar"),
+                    description:
+                        "Place the task-progress notch overlay on the menu bar. When off, it sits just below the menu bar so it never covers the clock, battery, or other system status controls.",
+                    isOn: notchOnMenuBarBinding
+                )
+                .settingsLandingAnchor("settings.chat.notchPlacement")
 
                 SettingsDivider()
 


### PR DESCRIPTION
## Summary

addresses #1951. 

Some users want the task progress notch overlay on the menu bar, while an earlier issue (fixed in #1874) moved it below so it stopped covering system status controls like battery and clock. this PR adds a preference so both are supported, defaulting to below the menu bar

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
