### PR TITLE
Size model fit against the GPU working set, not physical RAM

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -116,15 +116,16 @@ final class ModelManager: NSObject, ObservableObject {
         /// hardware info and we let everything through until we know.
         enum PerformanceFilter: String, CaseIterable, Identifiable {
             /// Only include models whose `compatibility` is `.compatible`
-            /// (memory usage below the 75 % ratio threshold).
+            /// (working set at or below 85 % of the GPU memory budget).
             case runsWell = "Runs Well"
             /// Only include models whose `compatibility` is `.tight`
-            /// (memory usage between 75 % and 95 % of total RAM)
+            /// (working set between 85 % and 110 % of the GPU memory budget).
             case tightFit = "Tight Fit"
             /// Exclude models whose advisory `compatibility` is `.tooLarge`
-            /// (memory usage above the 95 % ratio threshold). This filter is
-            /// user-selected catalog triage only; runtime load/download does
-            /// not block RAM pressure from this estimate.
+            /// (working set above 110 % of the GPU memory budget — macOS would
+            /// page the weights). This filter is user-selected catalog triage
+            /// only; runtime load/download does not block RAM pressure from
+            /// this estimate.
             case hideTooLarge = "Hide Too Large"
 
             var id: String { rawValue }

--- a/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
+++ b/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
@@ -1,0 +1,78 @@
+//
+//  GPUMemoryBudget.swift
+//  OsaurusCore
+//
+//  The unified-memory ceiling a model's working set has to respect.
+//
+
+import Foundation
+
+#if canImport(Metal)
+    import Metal
+#endif
+
+/// How much unified memory a model may actually occupy before macOS starts
+/// paging it.
+///
+/// MLX holds weights in Metal buffers, and its allocator only refuses a
+/// request once it passes `min(1.5 × recommendedMaxWorkingSetSize, 0.95 × RAM)`.
+/// Everything between the recommended working set and that hard limit
+/// *allocates successfully* and is then paged in and out by the OS on every
+/// decode step. So a model sized against raw RAM can pass the check, load
+/// without a single error, and then emit roughly one character every ten
+/// seconds. Fit has to be judged against the GPU working set, not against
+/// `physicalMemory`.
+enum GPUMemoryBudget {
+
+    private static let bytesPerGB: Double = 1024 * 1024 * 1024
+
+    /// Apple's default split between the GPU working set and everything else.
+    /// Machines at or below 36 GB hold back proportionally more for the OS.
+    ///
+    /// This is deliberately the long-standing documented split rather than the
+    /// (larger) figure recent macOS releases advertise — an M5 Max on macOS 26
+    /// reports 84% of RAM. Pinning the catalog verdict to the conservative
+    /// number keeps it stable across OS releases and never optimistic, and the
+    /// `.tight` band below absorbs the difference.
+    static func defaultBudgetGB(physicalMemoryGB: Double) -> Double {
+        guard physicalMemoryGB > 0 else { return 0 }
+        return physicalMemoryGB * (physicalMemoryGB <= 36.5 ? (2.0 / 3.0) : 0.75)
+    }
+
+    /// Physical memory of the machine we're running on, in GB.
+    static let hostPhysicalMemoryGB: Double =
+        Double(ProcessInfo.processInfo.physicalMemory) / bytesPerGB
+
+    /// What Metal advertises as this machine's working-set budget, when that
+    /// is usable. `nil` on a paravirtual device, when the value exceeds
+    /// installed RAM, or where Metal is unavailable.
+    static let hostAdvertisedBudgetGB: Double? = {
+        #if canImport(Metal)
+            guard let device = MTLCreateSystemDefaultDevice() else { return nil }
+            let advertised = Double(device.recommendedMaxWorkingSetSize) / bytesPerGB
+            guard advertised > 0, advertised <= hostPhysicalMemoryGB else { return nil }
+            return advertised
+        #else
+            return nil
+        #endif
+    }()
+
+    /// Working-set budget for a Mac with `physicalMemoryGB` of unified memory.
+    ///
+    /// Metal is consulted only for the machine we're actually running on, and
+    /// only ever to *lower* the budget — a user who has pinned
+    /// `iogpu.wired_limit_mb` below the default split gets the tighter number,
+    /// but nobody gets a more optimistic one than `defaultBudgetGB`. Callers
+    /// passing a hypothetical RAM size (the catalog reasoning about another
+    /// machine, or a test) always land on the pure default, so the verdict
+    /// never depends on the host it was computed on.
+    static func budgetGB(physicalMemoryGB: Double) -> Double {
+        let base = defaultBudgetGB(physicalMemoryGB: physicalMemoryGB)
+        guard
+            base > 0,
+            abs(physicalMemoryGB - hostPhysicalMemoryGB) < 1.0,
+            let advertised = hostAdvertisedBudgetGB
+        else { return base }
+        return min(base, advertised)
+    }
+}

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -565,12 +565,34 @@ struct MLXModel: Identifiable, Codable {
             : String(format: "~%.1f GB", gb)
     }
 
-    /// Assess whether this model can run on the given hardware.
+    /// Comfortably inside the GPU working set, with room for a long-context KV
+    /// cache to grow.
+    private static let comfortableBudgetRatio: Double = 0.85
+    /// The most a working set may overshoot the budget and still be offered.
+    /// `GPUMemoryBudget.defaultBudgetGB` is the conservative split rather than
+    /// the larger one modern macOS advertises, and the recommended working set
+    /// is a recommendation rather than a cliff, so a small overshoot is
+    /// survivable — it just leaves nothing for other apps. Past this the
+    /// weights get paged.
+    private static let maxBudgetRatio: Double = 1.10
+
+    /// Assess whether this model can run on a Mac with `totalMemoryGB` of
+    /// unified memory.
+    ///
+    /// Sized against `GPUMemoryBudget`, not raw RAM. MLX loads weights into
+    /// Metal buffers and macOS silently pages anything past the GPU working
+    /// set, so a model measured against `physicalMemory` can look like it has
+    /// headroom to spare, load without a single error, and then decode at a
+    /// character every few seconds. A 35B MXFP8 bundle needs ~42 GB and a
+    /// 48 GB Mac budgets only ~36 GB to the GPU: 89% of RAM, but 119% of what
+    /// it can actually hold.
     func compatibility(totalMemoryGB: Double) -> ModelCompatibility {
         guard let required = estimatedMemoryGB, totalMemoryGB > 0 else { return .unknown }
-        let ratio = required / totalMemoryGB
-        if ratio < 0.75 { return .compatible }
-        if ratio < 0.95 { return .tight }
+        let budget = GPUMemoryBudget.budgetGB(physicalMemoryGB: totalMemoryGB)
+        guard budget > 0 else { return .unknown }
+        let ratio = required / budget
+        if ratio <= Self.comfortableBudgetRatio { return .compatible }
+        if ratio <= Self.maxBudgetRatio { return .tight }
         return .tooLarge
     }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -8847,6 +8847,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         "required_available_bytes": f.requiredAvailableBytes,
                         "soft_limit_bytes": f.softLimitBytes,
                         "hard_limit_bytes": f.hardLimitBytes,
+                        // What Metal actually keeps resident. A load past this
+                        // is paged by macOS rather than refused, so support
+                        // needs to see it to explain a "fits but crawls" model.
+                        "gpu_budget_bytes": f.gpuBudgetBytes,
+                        "exceeds_gpu_budget": f.exceedsGPUBudget,
                     ] as [String: Any]
             } else {
                 ramFeasibility = NSNull()

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -957,14 +957,25 @@ public actor ModelRuntime {
         public let requiredAvailableBytes: Int64
         public let softLimitBytes: Int64
         public let hardLimitBytes: Int64
+        /// What Metal will actually keep resident on this machine. Zero when
+        /// it can't be determined.
+        public let gpuBudgetBytes: Int64
         public let timestamp: Date
+
+        /// The load doesn't fit the GPU working set, so macOS pages the
+        /// weights on every decode step. Distinct from ordinary RAM pressure:
+        /// the budget is a fixed fraction of installed memory, so closing
+        /// other apps cannot make room — only a smaller model can.
+        public var exceedsGPUBudget: Bool {
+            gpuBudgetBytes > 0 && requiredAvailableBytes > gpuBudgetBytes
+        }
 
         /// UI severity for the chat input's tight-fit disclaimer.
         public enum LoadPressureSeverity: String, Sendable, Equatable {
             /// Comfortably within budget — no banner.
             case none
-            /// Above the soft threshold (or free pages look short): show the
-            /// disclaimer but allow sending.
+            /// The model is large relative to this Mac: show the disclaimer
+            /// but allow sending.
             case warn
             /// Above the hard ceiling, or the load can never fit in physical
             /// memory: block sending until memory frees.
@@ -979,9 +990,17 @@ public actor ModelRuntime {
             if projectedBytes > hardLimitBytes || requiredAvailableBytes > physicalMemoryBytes {
                 return .block
             }
-            if verdict != .ok || projectedBytes > softLimitBytes {
-                return .warn
-            }
+            // A working set past the GPU budget gets paged even on an
+            // otherwise idle Mac, so it warns no matter how much RAM happens
+            // to be free.
+            if exceedsGPUBudget { return .warn }
+            // Only the model's own size relative to the machine warrants a
+            // banner. Deliberately *not* `verdict != .ok`: the verdict also
+            // goes `.tight` on `lowAvailable`, and on macOS free pages are
+            // nearly always scarce — the compressor and file cache give the
+            // memory back on demand. Warning on that popped a disclaimer at
+            // every launch for models that fit with room to spare.
+            if projectedBytes > softLimitBytes { return .warn }
             return .none
         }
     }
@@ -1223,8 +1242,21 @@ public actor ModelRuntime {
             requiredAvailableBytes: requiredAvailable,
             softLimitBytes: softLimit,
             hardLimitBytes: hardLimit,
+            gpuBudgetBytes: Self.gpuBudgetBytes(physicalMemoryBytes: physical),
             timestamp: Date()
         )
+    }
+
+    /// The Metal working set available to a machine with `physicalMemoryBytes`
+    /// of unified memory. Weights that don't fit here get paged rather than
+    /// rejected, which reads as a catastrophically slow model rather than a
+    /// failed load — see `GPUMemoryBudget`.
+    static func gpuBudgetBytes(physicalMemoryBytes physical: Int64) -> Int64 {
+        let bytesPerGB: Double = 1024 * 1024 * 1024
+        let budgetGB = GPUMemoryBudget.budgetGB(
+            physicalMemoryGB: Double(physical) / bytesPerGB
+        )
+        return Int64(budgetGB * bytesPerGB)
     }
 
     /// Pre-load RAM feasibility assessment. Records `lastRAMFeasibility` for

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -160,6 +160,8 @@ struct ChatWarmupControllerRAMGateTests {
             requiredAvailableBytes: requiredAvailable,
             softLimitBytes: soft,
             hardLimitBytes: hard,
+            // Budget unknown, so it never influences these warmup assertions.
+            gpuBudgetBytes: 0,
             timestamp: Date()
         )
     }

--- a/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
@@ -1,0 +1,112 @@
+//
+//  GPUMemoryBudgetTests.swift
+//  OsaurusCoreTests
+//
+//  Model fit is judged against the GPU working set, not physical RAM.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("GPU memory budget")
+struct GPUMemoryBudgetTests {
+
+    private static let bytesPerGB: Double = 1024 * 1024 * 1024
+
+    private static func model(_ name: String, gbOnDisk: Double) -> MLXModel {
+        MLXModel(
+            id: "test/\(name)",
+            name: name,
+            description: "",
+            downloadURL: "https://example.com/\(name)",
+            downloadSizeBytes: Int64(gbOnDisk * bytesPerGB)
+        )
+    }
+
+    // MARK: - Budget
+
+    @Test("Machines at or below 36 GB hold back proportionally more for the OS")
+    func smallMachinesReserveMore() {
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 16) == 16 * (2.0 / 3.0))
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 36) == 36 * (2.0 / 3.0))
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 48) == 36.0)
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 128) == 96.0)
+    }
+
+    @Test("No physical memory yields no budget")
+    func zeroMemoryYieldsZeroBudget() {
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 0) == 0)
+        #expect(GPUMemoryBudget.budgetGB(physicalMemoryGB: 0) == 0)
+    }
+
+    /// Metal is consulted only for the host, and only ever to lower the
+    /// budget. Whatever machine this runs on, the verdict can never be more
+    /// optimistic than the conservative default split.
+    @Test("Metal can only tighten the host budget, never loosen it")
+    func metalOnlyTightens() {
+        let host = GPUMemoryBudget.hostPhysicalMemoryGB
+        #expect(
+            GPUMemoryBudget.budgetGB(physicalMemoryGB: host)
+                <= GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: host)
+        )
+    }
+
+    /// A hypothetical RAM size must resolve identically regardless of the
+    /// machine the catalog math happens to run on.
+    @Test("Hypothetical RAM sizes ignore the host's Metal device")
+    func hypotheticalSizesAreHostIndependent() {
+        for ram in [8.0, 16.0, 24.0, 32.0, 64.0, 192.0] where abs(ram - GPUMemoryBudget.hostPhysicalMemoryGB) >= 1.0 {
+            #expect(
+                GPUMemoryBudget.budgetGB(physicalMemoryGB: ram)
+                    == GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: ram)
+            )
+        }
+    }
+
+    // MARK: - Fit
+
+    /// The reported regression: Ornith-1.0-35B-MXFP8 is 34.17 GiB on disk,
+    /// so ~42.7 GB resident. On a 48 GB Mac that is 89% of RAM — which the
+    /// old physical-RAM ratio scored as a merely `.tight` fit and offered for
+    /// download — but 119% of the 36 GB the GPU can hold. macOS pages the
+    /// weights and decode collapses to about a character every ten seconds.
+    @Test("A 35B MXFP8 bundle is too large for a 48 GB Mac")
+    func ornith35BMXFP8DoesNotFit48GB() {
+        let ornith = Self.model("ornith-35b-mxfp8", gbOnDisk: 34.17)
+        #expect(ornith.compatibility(totalMemoryGB: 48) == .tooLarge)
+    }
+
+    @Test("The same bundle is tight at 64 GB and comfortable at 96 GB and up")
+    func ornith35BMXFP8FitsLargerMachines() {
+        let ornith = Self.model("ornith-35b-mxfp8", gbOnDisk: 34.17)
+        #expect(ornith.compatibility(totalMemoryGB: 64) == .tight)
+        #expect(ornith.compatibility(totalMemoryGB: 96) == .compatible)
+        #expect(ornith.compatibility(totalMemoryGB: 128) == .compatible)
+    }
+
+    @Test("Small bundles stay comfortable on base-RAM Macs")
+    func smallModelsRemainCompatible() {
+        // A ~2 GB 4-bit bundle: 2.5 GB resident against a 5.33 GB budget.
+        #expect(Self.model("e2b", gbOnDisk: 2.0).compatibility(totalMemoryGB: 8) == .compatible)
+        #expect(Self.model("e2b", gbOnDisk: 2.0).compatibility(totalMemoryGB: 16) == .compatible)
+        // A ~4.7 GB 8B-4bit bundle: 5.9 GB resident against 10.67 GB.
+        #expect(Self.model("8b-4bit", gbOnDisk: 4.7).compatibility(totalMemoryGB: 16) == .compatible)
+    }
+
+    @Test("A model with no size information stays unknown rather than blocked")
+    func unsizedModelIsUnknown() {
+        let unsized = MLXModel(
+            id: "test/unsized",
+            name: "unsized",
+            description: "",
+            downloadURL: "https://example.com/unsized"
+        )
+        #expect(unsized.compatibility(totalMemoryGB: 48) == .unknown)
+    }
+
+    @Test("Compatibility is unknown before the memory monitor reports")
+    func unknownBeforeMonitorReports() {
+        #expect(Self.model("any", gbOnDisk: 2.0).compatibility(totalMemoryGB: 0) == .unknown)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift
@@ -34,20 +34,21 @@ struct ModelFilterPerformanceTests {
 
     /// Sanity-check the fixtures: at 16 GB of RAM, our three sample
     /// models end up in the three compatibility buckets we want to
-    /// exercise. If MLXModel's overhead multiplier or the 0.75 / 0.95
-    /// ratio thresholds ever change and the fixtures drift, this test
-    /// catches it before any filter assertion fails mysteriously.
+    /// exercise. If MLXModel's overhead multiplier or the 0.85 / 1.10
+    /// budget-ratio thresholds ever change and the fixtures drift, this
+    /// test catches it before any filter assertion fails mysteriously.
     @Test("Fixture buckets land in compatible / tight / tooLarge at 16 GB total")
     func fixtureBucketsCorrect() {
-        // MLXModel applies a 1.25× overhead multiplier to disk-bytes.
-        // compatibility thresholds: <0.75 ratio → compatible,
-        // <0.95 → tight, ≥0.95 → tooLarge. At total=16 GB:
-        //   gbOnDisk=2  → 2.5 GB resident (ratio 0.156) → compatible
-        //   gbOnDisk=11 → 13.75 GB resident (ratio 0.859) → tight
-        //   gbOnDisk=14 → 17.5 GB resident (ratio 1.094) → tooLarge
+        // MLXModel applies a 1.25× overhead multiplier to disk-bytes, and
+        // compares the result against the GPU working set rather than RAM.
+        // A 16 GB Mac budgets 2/3 of that = 10.67 GB. Thresholds: ≤0.85 of
+        // budget → compatible, ≤1.10 → tight, above → tooLarge.
+        //   gbOnDisk=2  → 2.5 GB resident  (ratio 0.234) → compatible
+        //   gbOnDisk=8  → 10.0 GB resident (ratio 0.938) → tight
+        //   gbOnDisk=14 → 17.5 GB resident (ratio 1.641) → tooLarge
         let total = 16.0
         let small = Self.model("small", gbOnDisk: 2.0)
-        let mid = Self.model("mid", gbOnDisk: 11.0)
+        let mid = Self.model("mid", gbOnDisk: 8.0)
         let big = Self.model("big", gbOnDisk: 14.0)
         #expect(small.compatibility(totalMemoryGB: total) == .compatible)
         #expect(mid.compatibility(totalMemoryGB: total) == .tight)
@@ -61,7 +62,7 @@ struct ModelFilterPerformanceTests {
         let total = 16.0
         let models = [
             Self.model("small", gbOnDisk: 2.0),
-            Self.model("mid", gbOnDisk: 11.0),
+            Self.model("mid", gbOnDisk: 8.0),
             Self.model("big", gbOnDisk: 14.0),
         ]
         var state = ModelManager.ModelFilterState()
@@ -94,7 +95,7 @@ struct ModelFilterPerformanceTests {
         let total = 16.0
         let models = [
             Self.model("small", gbOnDisk: 2.0),
-            Self.model("mid", gbOnDisk: 11.0),
+            Self.model("mid", gbOnDisk: 8.0),
             Self.model("big", gbOnDisk: 14.0),
         ]
         var state = ModelManager.ModelFilterState()

--- a/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateResourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateResourceTests.swift
@@ -113,12 +113,13 @@ struct ConfigureAIStateResourceTests {
     // MARK: - "Picked for your Mac's specs" render rule
 
     @Test func recommendedSelectionRuleMatchesRecommendedPickOnly() {
-        let small = makeModel(tag: "small", sizeBytes: 4 * gb, isTopSuggestion: true)
-        let large = makeModel(tag: "large", sizeBytes: 8 * gb, isTopSuggestion: true)
+        let small = makeModel(tag: "small", sizeBytes: 2 * gb, isTopSuggestion: true)
+        let large = makeModel(tag: "large", sizeBytes: 6 * gb, isTopSuggestion: true)
         let candidates = [large, small]
 
-        // Both fit comfortably on 16 GB, so the policy lands on the LARGEST
-        // comfortable pick — the strongest proven model this Mac can run.
+        // Both fit comfortably inside a 16 GB Mac's 10.67 GB GPU budget (2.5 GB
+        // and 7.5 GB resident), so the policy lands on the LARGEST comfortable
+        // pick — the strongest proven model this Mac can run.
         let recommended = ConfigureAIState.recommendedLocalPick(
             from: candidates,
             totalMemoryGB: 16

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -68,9 +68,21 @@ struct ModelRuntimeRAMFeasibilityTests {
         let softLimit = Int64(Double(physical) * thresholds.soft)
         let hardLimit = Int64(Double(physical) * thresholds.hard)
 
+        // The soft threshold (0.80 of RAM) sits *above* the GPU working-set
+        // budget (0.75 of RAM on machines over 36 GB), so a single model sized
+        // at the soft limit is already past what Metal will keep resident.
+        // `verdict` keys off physical memory and stays `.ok`; the UI severity
+        // keys off the budget and warns.
         let atLimit = assess(footprint: softLimit, physical: physical, available: physical)
         #expect(atLimit.verdict == .ok)
-        #expect(atLimit.loadPressureSeverity == .none)
+        #expect(atLimit.exceedsGPUBudget)
+        #expect(atLimit.loadPressureSeverity == .warn)
+
+        // Well inside the GPU budget: neither signal fires.
+        let comfortable = assess(footprint: softLimit / 2, physical: physical, available: physical)
+        #expect(comfortable.verdict == .ok)
+        #expect(!comfortable.exceedsGPUBudget)
+        #expect(comfortable.loadPressureSeverity == .none)
 
         let justOver = assess(footprint: softLimit + 1, physical: physical, available: physical)
         #expect(justOver.verdict == .tight)
@@ -92,15 +104,19 @@ struct ModelRuntimeRAMFeasibilityTests {
         #expect(justOver.loadPressureSeverity == .block)
     }
 
-    @Test("Low free pages alone warns but never blocks")
-    func lowAvailableWarnsWithoutBlocking() {
+    @Test("Low free pages alone stays advisory and shows no banner")
+    func lowAvailableIsAdvisoryOnly() {
         let physical = 100 * gb
         let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
         let softLimit = Int64(Double(physical) * thresholds.soft)
 
-        // Projection is comfortably inside the soft limit, but immediately
-        // free pages are short — advisory tight, send still allowed (unified
-        // memory can compress/purge to make room).
+        // Projection is comfortably inside both the soft limit and the GPU
+        // budget, but immediately free pages are short. `verdict` records the
+        // pressure for health/logs and the load is never blocked — but the
+        // chat banner must stay silent: on macOS free pages are almost always
+        // scarce (the compressor and file cache return memory on demand), and
+        // warning here popped a disclaimer on every launch for models that fit
+        // with room to spare.
         let f = assess(
             footprint: softLimit / 2,
             physical: physical,
@@ -108,7 +124,8 @@ struct ModelRuntimeRAMFeasibilityTests {
         )
 
         #expect(f.verdict == .tight)
-        #expect(f.loadPressureSeverity == .warn)
+        #expect(!f.exceedsGPUBudget)
+        #expect(f.loadPressureSeverity == .none)
     }
 
     @Test("Shortfall within the on-demand reclaim slack stays ok")
@@ -182,13 +199,16 @@ struct ModelRuntimeRAMFeasibilityTests {
             requiredAvailableBytes: 95 * gb,
             softLimitBytes: 70 * gb,
             hardLimitBytes: 90 * gb,
+            // Isolate the byte math: no budget, so `exceedsGPUBudget` is false.
+            gpuBudgetBytes: 0,
             timestamp: Date()
         )
         #expect(f.loadPressureSeverity == .block)
 
-        // And a .tight verdict with bytes inside the soft limit still warns
-        // (low-available advisory case).
-        let warnOnly = ModelRuntime.RAMFeasibility(
+        // A `.tight` verdict driven only by scarce free pages must stay quiet.
+        // macOS hands memory back from the compressor and file cache on
+        // demand, so a small model on a busy Mac is not worth a banner.
+        let lowAvailableOnly = ModelRuntime.RAMFeasibility(
             modelName: "m",
             verdict: .tight,
             incomingWeightsBytes: 10 * gb,
@@ -201,9 +221,65 @@ struct ModelRuntimeRAMFeasibilityTests {
             requiredAvailableBytes: 10 * gb,
             softLimitBytes: 70 * gb,
             hardLimitBytes: 90 * gb,
+            gpuBudgetBytes: 75 * gb,
             timestamp: Date()
         )
-        #expect(warnOnly.loadPressureSeverity == .warn)
+        #expect(lowAvailableOnly.loadPressureSeverity == .none)
+    }
+
+    // MARK: - GPU working-set budget
+
+    /// Reported against 0.21.10: an M1 Max with 64 GB running Qwen3.6-35B-A3B
+    /// MXFP4 (~25.8 GB to load) got the RAM popup on every launch. The model
+    /// uses barely half the GPU budget and is nowhere near the soft limit —
+    /// only `lowAvailable` fired, because macOS keeps free pages scarce by
+    /// design. Nothing here should warn.
+    @Test("A comfortably-fitting model never warns just because free pages are scarce")
+    func comfortableModelOnBusyMacStaysQuiet() {
+        let physical = 64 * gb
+        let weights = Int64(18.8 * Double(gb))
+        let required = Int64(25.8 * Double(gb))
+        let f = ModelRuntime.buildRAMFeasibility(
+            modelName: "qwen3.6-35b-a3b-mxfp4-mtp",
+            incomingWeightsBytes: weights,
+            incomingLoadFootprintBytes: weights,
+            resident: 0,
+            inflightOther: 0,
+            kvHeadroom: required - weights,
+            physical: physical,
+            // 77% "used" — an ordinary idle macOS desktop.
+            available: Int64(0.23 * Double(physical))
+        )
+        #expect(f.requiredAvailableBytes == required)
+        #expect(!f.exceedsGPUBudget)
+        #expect(f.loadPressureSeverity == .none)
+    }
+
+    /// The Reddit report: a 35B MXFP8 bundle (~42.7 GB) on a 48 GB Mac. Free
+    /// RAM looks ample and every physical-memory threshold is satisfied, but
+    /// the weights don't fit the 36 GB GPU working set, so macOS pages them
+    /// and decode collapses to about a character every ten seconds.
+    @Test("A working set past the GPU budget warns even with RAM to spare")
+    func exceedingGPUBudgetWarnsOnIdleMac() {
+        let physical = 48 * gb
+        let required = Int64(42.7 * Double(gb))
+        let f = ModelRuntime.buildRAMFeasibility(
+            modelName: "ornith-1.0-35b-mxfp8",
+            incomingWeightsBytes: required,
+            incomingLoadFootprintBytes: required,
+            resident: 0,
+            inflightOther: 0,
+            kvHeadroom: 0,
+            physical: physical,
+            available: physical
+        )
+        #expect(f.exceedsGPUBudget)
+        #expect(f.loadPressureSeverity == .warn)
+    }
+
+    @Test("A 48 GB Mac budgets 36 GB to the GPU")
+    func gpuBudgetForFortyEightGigMac() {
+        #expect(ModelRuntime.gpuBudgetBytes(physicalMemoryBytes: 48 * gb) == 36 * gb)
     }
 
     // MARK: - projectedLoadFeasibility guards

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -3481,16 +3481,27 @@ extension FloatingInputCard {
         let usage = "\(ramBannerUsagePercent)"
         let total = "\(ramBannerTotalGB)"
 
-        let message: Text =
-            blocked
-            ? Text(
+        // Over the GPU budget, no amount of freed RAM helps: the working set is
+        // a fixed fraction of installed memory. Say so instead of offering
+        // advice that cannot work.
+        let message: Text
+        if feasibility.exceedsGPUBudget {
+            let budgetGB = Self.formatGigabytes(feasibility.gpuBudgetBytes)
+            message = Text(
+                "This model needs ~\(neededGB) GB, but this Mac can only keep ~\(budgetGB) GB on the GPU. macOS will page the weights and generation will be extremely slow — pick a smaller model or a lower-precision build.",
+                bundle: .module
+            )
+        } else if blocked {
+            message = Text(
                 "This model needs ~\(neededGB) GB to load, but memory is at \(usage)% of \(total) GB. Sending is paused until memory frees — close other apps or pick a smaller model.",
                 bundle: .module
             )
-            : Text(
+        } else {
+            message = Text(
                 "This model needs ~\(neededGB) GB to load and memory is at \(usage)% of \(total) GB. Close other apps for best performance.",
                 bundle: .module
             )
+        }
 
         // One continuous popover silhouette: the rounded rect and the pointer
         // triangle are a single shape, so the fill and the border flow around


### PR DESCRIPTION
## Why

Two user reports that look opposite but share one root cause: model fit was measured against **physical RAM** instead of the **GPU working set**.

**Report 1 — a model that "fits" but crawls.** A 48 GB M5 Pro installed Ornith-1.0-35B-MXFP8. Osaurus said "41 GB required, 63% of memory loaded, close other applications", then generated about one character every ten seconds with nothing else running.

That's not RAM pressure. MLX holds weights in Metal buffers, and its allocator only refuses a request once it passes `min(1.5 × recommendedMaxWorkingSetSize, 0.95 × RAM)` (`mlx/backend/metal/allocator.cpp:56`); `wired_limit_` defaults to `0`, so nothing is pinned in the residency set. Anything between the recommended working set and that hard limit **allocates successfully** and is then paged by macOS on every decode step. The model loads without a single error and is unusable.

The bundle is 34.17 GiB on disk → `estimatedMemoryGB` = ×1.25 = **42.7 GB**. Against physical RAM that's 42.7/48 = 0.890 → `.tight`, so we offered it. Against the ~36 GB a 48 GB Mac budgets to the GPU it's **1.19** → it can never run well.

**Report 2 — the RAM popup is too aggressive.** An M1 Max with 64 GB running Qwen3.6-35B-A3B-MXFP4 (~25.8 GB to load) got "This model needs ~25.8 GB to load and memory is at 77% of 64 GB. Close other apps for best performance." on every launch, with plenty of RAM free.

That model needs 25.8 GB against a 48 GB budget — a 0.54 ratio, comfortable by any measure. The banner fired only because of `lowAvailable`: `buildRAMFeasibility` sets `verdict = .tight` when free pages are short, and `loadPressureSeverity` warned on `verdict != .ok`. But on macOS free pages are *always* scarce — the compressor and file cache hand memory back on demand.

And "close other apps" is actively wrong for report 1: the GPU working set is a fixed fraction of installed RAM, so closing apps cannot make room.

## What changed

**New `GPUMemoryBudget`** — how much unified memory a model may actually occupy:

```
budget(RAM) = RAM × (RAM ≤ 36.5 ? 2/3 : 0.75)
budget      = min(budget(RAM), metalAdvertised)   // host only; only ever LOWERS
```

Metal's `recommendedMaxWorkingSetSize` is consulted only for the machine we're running on, and only to *lower* the budget — a user who pinned `iogpu.wired_limit_mb` below the default split gets the tighter number, but nobody gets a more optimistic one. A hypothetical RAM size (catalog math, tests) always resolves to the pure default, so a verdict never depends on the machine that computed it. This matters: an M5 Max on macOS 26 advertises **84%** of RAM (107.52 GB of 128 GB), not the classic 75%, so the fraction is not a constant worth hardcoding as truth.

**`MLXModel.compatibility`** now divides by the budget, not RAM:

| ratio | verdict |
|---|---|
| ≤ 0.85 | `.compatible` |
| ≤ 1.10 | `.tight` — runs, close other apps |
| > 1.10 | `.tooLarge` — macOS would page it |

The 1.10 band absorbs the conservative split (the recommended working set is a recommendation, not a cliff). `.tooLarge` stays advisory: it badges, deprioritises in sort order, excludes the model from `recommendedLocalPick`, and disables the onboarding radio row — it **never blocks a download**.

**`RAMFeasibility`** gains `gpuBudgetBytes` and `exceedsGPUBudget`, and `loadPressureSeverity` now warns on `exceedsGPUBudget` or `projected > softLimit` — no longer on `verdict != .ok`, which folded in the noisy `lowAvailable` signal. `verdict` still records that pressure for `/health` and logs, and the load path stays advisory exactly as before.

**Banner copy** tells the truth when over budget instead of suggesting something that cannot help:

> This model needs ~42.7 GB, but this Mac can only keep ~36 GB on the GPU. macOS will page the weights and generation will be extremely slow — pick a smaller model or a lower-precision build.

## Verdicts against real bundles

Measured on disk, `need = disk × 1.25`:

| bundle | disk | need | 16 | 24 | 32 | 48 | 64 | 96 | 128 |
|---|---|---|---|---|---|---|---|---|---|
| Ornith-1.0-35B-MXFP8 | 34.2 G | 42.7 G | too | too | too | **too** | tight | ok | ok |
| Ornith-1.0-9B-MXFP8 | 9.5 G | 11.8 G | too | ok | ok | ok | ok | ok | ok |
| Qwen3.6-35B-A3B-MXFP4-MTP | 18.5 G | 23.1 G | too | too | tight | ok | **ok** | ok | ok |
| gemma-3n-E2B | 7.6 G | 9.5 G | tight | ok | ok | ok | ok | ok | ok |

Row 1 column 48 is report 1 (now correctly refused as a recommendation). Row 3 column 64 is report 2 (comfortable — the new rule never touches it).

## Tests

- New `GPUMemoryBudgetTests` (9): the budget split, that Metal can only tighten and never loosen, that hypothetical RAM sizes are host-independent, and the 35B-MXFP8-on-48 GB regression.
- New in `ModelRuntimeRAMFeasibilityTests`: `comfortableModelOnBusyMacStaysQuiet()` pins report 2's exact byte counts; `exceedingGPUBudgetWarnsOnIdleMac()` pins report 1's.
- `softThresholdCrossingWarns` updated: the soft threshold (0.80 of RAM) sits *above* the GPU budget (0.75), so a single model at the soft limit is already past what Metal keeps resident. The physical soft/hard thresholds now only bind for multi-model residency, where `projected` includes `resident + inflightOther`.
- `lowAvailableWarnsWithoutBlocking` → `lowAvailableIsAdvisoryOnly`: encodes the fixed behaviour from report 2.
- Fixtures re-based where the old ones were only "comfortable" under the RAM ratio: `ModelFilterPerformanceTests` (`mid` 11 → 8 GB, since 11 GB is genuinely `.tooLarge` on a 16 GB Mac now) and `ConfigureAIStateResourceTests` (4/8 GB → 2/6 GB).

## Verified live

Built the dev app from this branch and ran against it on a 128 GB M5 Max (`/health` now reports the budget):

```
model                            ornith-1.0-9b-mxfp8
verdict                          ok
incoming_load_footprint_bytes        9.45 GB
kv_headroom_bytes                    1.89 GB
required_available_bytes            11.34 GB
gpu_budget_bytes                    96.00 GB    <- min(0.75 × 128, 107.52 advertised)
exceeds_gpu_budget               False
```

`required_available` of 11.34 GB against the catalog's ×1.25 estimate of 11.8 GB for the same bundle is an independent check that the heuristic tracks the runtime's config-derived KV sizing.

Cross-matrix over the architecture families (multiturn recall, tool call, reasoning toggle on/off, control-marker leak scan) — all pass, no leakage:

| model | arch | multiturn | tool call | think on/off | leaks |
|---|---|---|---|---|---|
| ornith-1.0-9b-mxfp8 | hybrid GDN | pass | `{"city":"Paris"}` | pass (rc 1093 ch) | none |
| gemma-4-e2b-it-4bit | dense sliding | pass | `{"city":"Paris"}` | pass (rc 881 ch) | none |
| qwen3.6-35b-a3b-mxfp8-crack-mtp | MoE + MTP | pass | `{"city":"Paris"}` | pass (rc 1218 ch) | none |
| lfm2.5-8b-a1b-mxfp8 | hybrid SSM | pass¹ | `{"city":"Paris"}` | pass (rc 895 ch) | none |

¹ needs `max_tokens ≥ 400`: at 80 it spends the whole budget on reasoning and returns `finish_reason=length` with empty content. Pre-existing, unrelated to this change.

The over-budget banner itself can't be exercised on a 128 GB host (no catalog model exceeds 96 GB); it is pinned by `exceedingGPUBudgetWarnsOnIdleMac()` and `gpuBudgetForFortyEightGigMac()` instead.

## Test note

`swift test` on `origin/main` already fails ~7 tests in a full run (tool-registry counts, gemma4 tokenizer surface, path resolver, chat-store flush, plus order-dependent flakes) and hangs partway. That is pre-existing and unrelated: the suites covering this change — `GPUMemoryBudget`, `ModelRuntimeRAMFeasibility`, `ChatWarmup`, `ModelFilterPerformance`, `ConfigureAIState`, `ModelManagerSuggested`, `FamilyGrouping`, `RuntimePolicySource`, `ImageGenerationBridge` — pass **218 tests / 21 suites**.
