### PR TITLE
Credits UI improvements: composer wallet panel and refreshed Credits page

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -2157,6 +2157,7 @@
       }
     },
     "%@ router balance. Click to add credits." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2186,6 +2187,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 路由器餘額。點擊添加積分。"
+          }
+        }
+      }
+    },
+    "%@ router balance. Click to open the wallet." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Router-Guthaben. Klicken Sie, um das Wallet zu öffnen."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라우터 잔액 %@. 클릭하여 지갑을 여세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Баланс Router: %@. Нажмите, чтобы открыть кошелёк."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路由器余额 %@。点击打开钱包。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路由器餘額 %@。點擊打開錢包。"
           }
         }
       }
@@ -3694,6 +3729,7 @@
       }
     },
     "%lld model%@ ready" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -3716,12 +3752,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%1$lld модель готова"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -3732,6 +3762,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%1$lld моделей готово"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%1$lld модель готова"
                 }
               },
               "other" : {
@@ -3780,12 +3816,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld модель"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -3796,6 +3826,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%lld моделей"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модель"
                 }
               },
               "other" : {
@@ -3868,12 +3904,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%1$lld модель • %2$@"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -3884,6 +3914,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "%1$lld моделей • %2$@"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%1$lld модель • %2$@"
                 }
               },
               "other" : {
@@ -3905,6 +3941,112 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$lld 模型 • %2$@"
+          }
+        }
+      }
+    },
+    "%lld models ready" : {
+      "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%lld Modell bereit"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%lld Modelle bereit"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld model ready"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld models ready"
+                }
+              }
+            }
+          }
+        },
+        "ko" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld개의 모델 준비됨"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld개의 모델 준비됨"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модели готовы"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld моделей готово"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модель готова"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld модели готовы"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 个模型已就绪"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 个模型已就绪"
+                }
+              }
+            }
           }
         }
       }
@@ -10391,6 +10533,7 @@
     },
     "Add credits and see what each Osaurus Router request costs." : {
       "comment" : "Subtitle of the Credits view.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -11116,6 +11259,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "調整語音檢測的靈敏度"
+          }
+        }
+      }
+    },
+    "Adjustment" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korrektur"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "조정"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Корректировка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "调整"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調整"
           }
         }
       }
@@ -19544,6 +19721,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "可用"
+          }
+        }
+      }
+    },
+    "Available balance" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verfügbares Guthaben"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능한 잔액"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступный баланс"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用余额"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用餘額"
           }
         }
       }
@@ -30543,6 +30754,7 @@
     },
     "Click to add credits" : {
       "comment" : "Footer hint in the chat composer router-balance popover.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -40381,6 +40593,7 @@
     },
     "Credit balance" : {
       "comment" : "The label for the credit balance in the Credits view.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -40520,37 +40733,70 @@
         }
       }
     },
-    "Credits pay for cloud models and provider load-balancing routed through Osaurus." : {
-      "comment" : "Explanation of what Osaurus credits are used for.",
+    "Credits granted" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Credits pay for cloud models and provider load-balancing routed through Osaurus."
+            "state" : "translated",
+            "value" : "Credits gutgeschrieben"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "크레딧은 클라우드 모델 및 Osaurus를 통해 라우팅되는 제공자 로드 밸런싱에 사용됩니다."
+            "value" : "크레딧이 지급되었습니다"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Кредиты оплачивают облачные модели и балансировку нагрузки провайдеров через Osaurus."
+            "value" : "Кредиты начислены"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "积分用于支付通过Osaurs路由的云模型和提供商负载均衡。"
+            "value" : "积分已发放"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "積分用於支付通過Osaurs路由的雲模型和提供商負載均衡。"
+            "value" : "積分已發放"
+          }
+        }
+      }
+    },
+    "Credits let Osaurus transact on your behalf - cloud model access today, with more routed services to come." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit Credits kann Osaurus in Ihrem Namen Transaktionen durchführen – heute Zugang zu Cloud-Modellen, künftig weitere geroutete Dienste."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크레딧을 통해 Osaurus가 사용자를 대신해 결제합니다. 현재는 클라우드 모델 액세스이며, 더 많은 라우팅 서비스가 추가될 예정입니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кредиты позволяют Osaurus совершать операции от вашего имени: сегодня это доступ к облачным моделям, а в будущем — другие сервисы."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "积分让Osaurus代表您进行交易 - 目前用于云模型访问，未来将支持更多路由服务。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "積分讓Osaurus代表您進行交易 - 目前用於雲模型訪問，未來將支持更多路由服務。"
           }
         }
       }
@@ -70388,12 +70634,6 @@
         "ru" : {
           "variations" : {
             "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Установить %lld инструмент"
-                }
-              },
               "few" : {
                 "stringUnit" : {
                   "state" : "translated",
@@ -70404,6 +70644,12 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Установить %lld инструментов"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Установить %lld инструмент"
                 }
               },
               "other" : {
@@ -75256,6 +75502,40 @@
         }
       }
     },
+    "Lets Osaurus transact on your behalf - cloud models, provider load-balancing, and future routed services; requests spend credits. Keeping it on helps support Osaurus development - thank you." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ermöglicht Osaurus, in Ihrem Namen Transaktionen durchzuführen – Cloud-Modelle, Anbieter-Lastausgleich und künftige geroutete Dienste; Anfragen verbrauchen Credits. Eingeschaltet zu bleiben unterstützt die Entwicklung von Osaurus – danke."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Osaurus가 사용자를 대신해 결제할 수 있게 합니다. 클라우드 모델, 제공자 로드 밸런싱, 향후 라우팅 서비스가 포함되며 요청 시 크레딧이 소모됩니다. 이 기능을 켜두시면 Osaurus 개발에 도움이 됩니다. 감사합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Позволяет Osaurus совершать операции от вашего имени: облачные модели, балансировка нагрузки провайдеров и будущие сервисы; запросы расходуют кредиты. Оставляя эту функцию включённой, вы поддерживаете развитие Osaurus — спасибо."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让Osaurus代表您进行交易 - 云模型、提供商负载均衡以及未来的路由服务；请求会消耗积分。保持开启有助于支持 Osaurus 的开发 - 感谢。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讓Osaurus代表您進行交易 - 雲模型、提供商負載均衡以及未來的路由服務；請求會消耗積分。保持開啓有助於支持 Osaurus 的開發 - 感謝。"
+          }
+        }
+      }
+    },
     "Lets your dino install packages, run scripts, and work with files like a real machine." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -78698,6 +78978,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "維護"
+          }
+        }
+      }
+    },
+    "Make and check off your Reminders." : {
+      "comment" : "Onboarding plugin picker blurb for Reminders.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make and check off your Reminders."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make and check off your Reminders."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make and check off your Reminders."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создаёт напоминания и отмечает их выполненными."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Make and check off your Reminders."
           }
         }
       }
@@ -84133,6 +84448,74 @@
         }
       }
     },
+    "Model request" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modellanfrage"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델 요청"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запрос модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型请求"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型請求"
+          }
+        }
+      }
+    },
+    "Model requests and balance changes, newest first. Open the chat or Insights when this Mac has the matching copy." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modellanfragen und Guthabenänderungen, neueste zuerst. Öffnen Sie den Chat oder Insights, wenn dieser Mac die passende Kopie hat."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델 요청과 잔액 변동이며 최신순입니다. 이 Mac에 일치하는 사본이 있는 경우 채팅 또는 Insights를 엽니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запросы моделей и изменения баланса, сначала самые новые. Откройте чат или Insights, когда на этом Mac есть соответствующая копия."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型请求和余额变动，按最新排序。当此Mac有匹配的副本时，打开聊天或洞察。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型請求和餘額變動，按最新排序。當此Mac有匹配的副本時，打開聊天或洞察。"
+          }
+        }
+      }
+    },
     "Model residency" : {
       "localizations" : {
         "de" : {
@@ -87290,6 +87673,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有可用於存儲截圖的活動聊天會話。"
+          }
+        }
+      }
+    },
+    "No activity yet" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Aktivität"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 활동이 없습니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пока нет активности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無活動"
           }
         }
       }
@@ -97135,6 +97552,40 @@
         }
       }
     },
+    "Open the Credits tab for full usage and transaction history." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffnen Sie den Credits-Tab für die vollständige Nutzungs- und Transaktionshistorie."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 사용 및 거래 내역을 보려면 크레딧 탭을 여세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Откройте вкладку «Кредиты», чтобы увидеть полную историю использования и транзакций."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开积分标签页查看完整的使用和交易记录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開積分標籤頁查看完整的使用和交易記錄。"
+          }
+        }
+      }
+    },
     "Open the Images pane in Settings" : {
       "comment" : "Description text in the EmptyStateView for the \"Images\" tab.",
       "extractionState" : "stale",
@@ -104604,6 +105055,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PK"
+          }
+        }
+      }
+    },
+    "Place the task-progress notch overlay on the menu bar. When off, it sits just below the menu bar so it never covers the clock, battery, or other system status controls." : {
+      "comment" : "Description for the toggle that controls whether the task-progress notch overlay sits on or below the menu bar.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platziert das Notch-Overlay für den Aufgabenfortschritt in der Menüleiste. Wenn deaktiviert, sitzt es direkt unter der Menüleiste und verdeckt so nie Uhr, Batterie oder andere Systemstatus-Elemente."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 진행 상황 노치 오버레이를 메뉴 막대에 배치합니다. 끄면 메뉴 막대 바로 아래에 표시되어 시계, 배터리 또는 기타 시스템 상태 항목을 가리지 않습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размещает оверлей выреза с ходом выполнения задачи в строке меню. Когда выключено, он располагается прямо под строкой меню и не закрывает часы, батарею и другие элементы состояния системы."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将任务进度刘海浮层放置在菜单栏上。关闭时，它位于菜单栏正下方，因此绝不会遮挡时钟、电池或其他系统状态控件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將任務進度瀏海浮層放置在選單列上。關閉時，它位於選單列正下方，因此絕不會遮擋時鐘、電池或其他系統狀態控制項。"
           }
         }
       }
@@ -116610,6 +117096,40 @@
         }
       }
     },
+    "Refund" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rückerstattung"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환불"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Возврат"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退款"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退款"
+          }
+        }
+      }
+    },
     "Regenerate" : {
       "localizations" : {
         "de" : {
@@ -119888,6 +120408,7 @@
     },
     "Requests routed through Osaurus, newest first. Open the chat or Insights when this Mac has the matching copy." : {
       "comment" : "Subtitle for the recent activity list.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -123880,6 +124401,7 @@
       }
     },
     "Router balance" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -125528,42 +126050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隨處運行"
-          }
-        }
-      }
-    },
-    "Runs cloud models and provider load-balancing; requests spend credits. Keeping it on helps support Osaurus development - thank you." : {
-      "comment" : "A description of the function of the Osaurus Router.",
-      "isCommentAutoGenerated" : true,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Führt Cloud-Modelle und Anbieter-Lastausgleich aus; fordert Ausgabengutschriften an. Wenn man es anhält, unterstützt es die Entwicklung von Osaurus - danke."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "클라우드 모델 및 제공자 로드 밸런싱을 실행합니다. 요청 시 크레딧이 소모됩니다. 이 기능을 켜두시면 Osaurus 개발에 도움이 됩니다. 감사합니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запускает облачные модели и балансировку нагрузки провайдера; просит потратить кредиты. Сохранение его помогает поддерживать развитие Osaurus — спасибо."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "运行云模型和提供商负载均衡；消耗请求信用额度。保持开启有助于支持 Osaurus 的开发 - 感谢。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "運行雲模型和提供商負載均衡；消耗請求信用額度。保持開啓有助於支持 Osaurus 的開發 - 感謝。"
           }
         }
       }
@@ -131275,6 +131761,41 @@
         }
       }
     },
+    "See and create events on your Mac." : {
+      "comment" : "Onboarding plugin picker blurb for Calendar.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "See and create events on your Mac."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "See and create events on your Mac."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "See and create events on your Mac."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Просматривает и создаёт события на вашем Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "See and create events on your Mac."
+          }
+        }
+      }
+    },
     "See other options" : {
       "comment" : "Localized help text for the button that allows users to see more options for configuring a local model.",
       "extractionState" : "stale",
@@ -132440,6 +132961,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "發送崩潰報告"
+          }
+        }
+      }
+    },
+    "Send iMessages from your Mac." : {
+      "comment" : "Onboarding plugin picker blurb for Messages.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Send iMessages from your Mac."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Send iMessages from your Mac."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Send iMessages from your Mac."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправляет сообщения iMessage с вашего Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Send iMessages from your Mac."
           }
         }
       }
@@ -134794,6 +135350,41 @@
         }
       }
     },
+    "Shell" : {
+      "comment" : "Onboarding plugin picker display name for terminal command access.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shell"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Shell"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shell"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Терминал"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Shell"
+          }
+        }
+      }
+    },
     "Shell command run after dependencies are installed" : {
       "localizations" : {
         "de" : {
@@ -135493,41 +136084,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在選單列顯示瀏海浮層"
-          }
-        }
-      }
-    },
-    "Place the task-progress notch overlay on the menu bar. When off, it sits just below the menu bar so it never covers the clock, battery, or other system status controls." : {
-      "comment" : "Description for the toggle that controls whether the task-progress notch overlay sits on or below the menu bar.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Platziert das Notch-Overlay für den Aufgabenfortschritt in der Menüleiste. Wenn deaktiviert, sitzt es direkt unter der Menüleiste und verdeckt so nie Uhr, Batterie oder andere Systemstatus-Elemente."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "작업 진행 상황 노치 오버레이를 메뉴 막대에 배치합니다. 끄면 메뉴 막대 바로 아래에 표시되어 시계, 배터리 또는 기타 시스템 상태 항목을 가리지 않습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Размещает оверлей выреза с ходом выполнения задачи в строке меню. Когда выключено, он располагается прямо под строкой меню и не закрывает часы, батарею и другие элементы состояния системы."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将任务进度刘海浮层放置在菜单栏上。关闭时，它位于菜单栏正下方，因此绝不会遮挡时钟、电池或其他系统状态控件。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將任務進度瀏海浮層放置在選單列上。關閉時，它位於選單列正下方，因此絕不會遮擋時鐘、電池或其他系統狀態控制項。"
           }
         }
       }
@@ -150926,7 +151482,42 @@
         }
       }
     },
+    "This session" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Sitzung"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 세션"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эта сессия"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前会话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當前會話"
+          }
+        }
+      }
+    },
     "This Session" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -155172,6 +155763,36 @@
           }
         }
       }
+    },
+    "TurboQuant" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TurboQuant"
+          }
+        }
+      },
+      "shouldTranslate" : false
     },
     "TurboQuant compressions" : {
       "localizations" : {
@@ -160215,6 +160836,40 @@
         }
       }
     },
+    "View all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle anzeigen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 보기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看全部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看全部"
+          }
+        }
+      }
+    },
     "View All %lld Episodes" : {
       "localizations" : {
         "de" : {
@@ -161891,20 +162546,20 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Wallet"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Wallet"
+            "state" : "translated",
+            "value" : "지갑"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Wallet"
+            "state" : "translated",
+            "value" : "Кошелёк"
           }
         },
         "zh-Hans" : {
@@ -163534,6 +164189,40 @@
         }
       }
     },
+    "When you add credits or use an Osaurus Router model, it shows up here with its amount. If this Mac made a request, you can jump to the chat or Insights." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Sie Credits hinzufügen oder ein Osaurus-Router-Modell verwenden, erscheint es hier mit dem Betrag. Wenn dieser Mac eine Anfrage gestellt hat, können Sie zum Chat oder zu Insights springen."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크레딧을 추가하거나 Osaurus Router 모델을 사용하면 금액과 함께 여기에 표시됩니다. 이 Mac에서 요청을 한 경우 채팅 또는 Insights로 바로 이동할 수 있습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Когда вы пополняете баланс или используете модель Osaurus Router, это отображается здесь с суммой. Если запрос был сделан с этого Mac, можно перейти к чату или Insights."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当您添加积分或使用Osaurus路由器模型时，它会连同金额显示在这里。如果这台 Mac 提出了请求，您可以跳转到聊天或 Insights。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當您添加積分或使用Osaurus路由器模型時，它會連同金額顯示在這裡。如果這臺 Mac 提出了請求，您可以跳轉到聊天或 Insights。"
+          }
+        }
+      }
+    },
     "When you turn it on for an agent, Computer Use lets that agent operate macOS apps for you — working through a goal step by step and showing every action in a live feed." : {
       "localizations" : {
         "de" : {
@@ -163570,6 +164259,7 @@
     },
     "When you use an Osaurus Router model, each request shows up here with its cost and tokens. If this Mac made the request, you can jump to the chat or Insights." : {
       "comment" : "Empty-state body for the Credits activity list.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -166920,6 +167610,40 @@
         }
       }
     },
+    "Your wallet for Osaurus-routed services - add credits and track every request and top-up." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihr Wallet für über Osaurus geroutete Dienste – fügen Sie Credits hinzu und verfolgen Sie jede Anfrage und Aufladung."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Osaurus를 통해 라우팅되는 서비스를 위한 지갑입니다. 크레딧을 추가하고 모든 요청과 충전 내역을 확인하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваш кошелёк для сервисов, работающих через Osaurus: пополняйте баланс и отслеживайте каждый запрос и пополнение."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用于Osaurus路由服务的钱包 - 添加积分并跟踪每个请求和充值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用於Osaurus路由服務的錢包 - 添加積分並跟蹤每個請求和充值。"
+          }
+        }
+      }
+    },
     "Zip Bundle" : {
       "localizations" : {
         "de" : {
@@ -166956,282 +167680,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zip 捆綁包"
-          }
-        }
-      }
-    },
-    "TurboQuant" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "TurboQuant"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "TurboQuant"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "TurboQuant"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "TurboQuant"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
-    "Shell" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Shell"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shell"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Shell"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Терминал"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Shell"
-          }
-        }
-      },
-      "comment" : "Onboarding plugin picker display name for terminal command access."
-    },
-    "See and create events on your Mac." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "See and create events on your Mac."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "See and create events on your Mac."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "See and create events on your Mac."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Просматривает и создаёт события на вашем Mac."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "See and create events on your Mac."
-          }
-        }
-      },
-      "comment" : "Onboarding plugin picker blurb for Calendar."
-    },
-    "Make and check off your Reminders." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Make and check off your Reminders."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Make and check off your Reminders."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Make and check off your Reminders."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создаёт напоминания и отмечает их выполненными."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Make and check off your Reminders."
-          }
-        }
-      },
-      "comment" : "Onboarding plugin picker blurb for Reminders."
-    },
-    "Send iMessages from your Mac." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Send iMessages from your Mac."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Send iMessages from your Mac."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Send iMessages from your Mac."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправляет сообщения iMessage с вашего Mac."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Send iMessages from your Mac."
-          }
-        }
-      },
-      "comment" : "Onboarding plugin picker blurb for Messages."
-    },
-    "%lld models ready" : {
-      "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "%lld Modell bereit"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "%lld Modelle bereit"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld model ready"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld models ready"
-                }
-              }
-            }
-          }
-        },
-        "ko" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld개의 모델 준비됨"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld개의 모델 준비됨"
-                }
-              }
-            }
-          }
-        },
-        "ru" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld модель готова"
-                }
-              },
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld модели готовы"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld моделей готово"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld модели готовы"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hans" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 个模型已就绪"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 个模型已就绪"
-                }
-              }
-            }
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Router/CreditsActivityProjector.swift
+++ b/Packages/OsaurusCore/Services/Router/CreditsActivityProjector.swift
@@ -194,7 +194,8 @@ extension CreditsActivityRow {
 
     /// Map a raw server status onto the same vocabulary used for local outcomes,
     /// so a row reads the same whether or not this device has the local record.
-    private static func state(
+    /// Internal (not private) so `WalletActivityRow` shares the vocabulary.
+    static func state(
         forStatus status: String
     ) -> (label: String, kind: CreditsActivityStateKind) {
         switch status.lowercased() {

--- a/Packages/OsaurusCore/Services/Router/WalletActivityProjector.swift
+++ b/Packages/OsaurusCore/Services/Router/WalletActivityProjector.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Merges router usage items (billed model requests) and ledger transactions
+/// (top-ups today; agent-initiated purchases later — `entryType`/`refType`
+/// already discriminate them) into a single date-sorted "recent activity"
+/// list for the composer wallet panel. Kept out of the view so agent
+/// transaction row types have one place to land.
+struct WalletActivityProjector {
+    /// Newest-first merged rows, capped at `limit`. Ledger debits with an
+    /// unrecognized `entry_type` are dropped: they mirror per-request spend the
+    /// usage rows already list, and including both double-counts every charge.
+    func rows(
+        usageItems: [OsaurusRouterUsageItem],
+        transactions: [OsaurusRouterTransactionItem],
+        limit: Int = 4
+    ) -> [WalletActivityRow] {
+        let merged =
+            usageItems.map(WalletActivityRow.init(usage:))
+            + transactions
+                .filter(WalletActivityRow.isWalletVisible)
+                .map(WalletActivityRow.init(transaction:))
+        return Array(
+            merged
+                .sorted { ($0.date ?? .distantPast) > ($1.date ?? .distantPast) }
+                .prefix(max(0, limit))
+        )
+    }
+}
+
+/// One line in the wallet panel's recent-activity list.
+struct WalletActivityRow: Identifiable, Equatable {
+    enum Kind: Equatable {
+        /// A billed model request (from `/credits/usage`).
+        case usage
+        /// A ledger transaction (top-up, refund, future agent purchase).
+        case transaction
+    }
+
+    let id: String
+    let kind: Kind
+    /// Primary label. Plain English vocabulary like `CreditsActivityRow`'s
+    /// state labels; views localize via `LocalizedStringKey`.
+    let title: String
+    /// Signed display amount: "+$5.00" for balance credits, "-$0.0012" for
+    /// spend. Empty when the amount is unparseable.
+    let amountLabel: String
+    /// True when the amount adds to the balance (row tints as a credit).
+    let isCredit: Bool
+    let stateKind: CreditsActivityStateKind
+    /// Parsed timestamp used for merge ordering; nil when the server value is
+    /// unparseable (such rows sort last).
+    let date: Date?
+}
+
+extension WalletActivityRow {
+    init(usage item: OsaurusRouterUsageItem) {
+        self.id = "usage-\(item.id)"
+        self.kind = .usage
+        if !item.model.isEmpty {
+            self.title = item.model
+        } else if !item.provider.isEmpty {
+            self.title = item.provider
+        } else {
+            self.title = "Model request"
+        }
+        let micro = Int64(item.costMicro) ?? 0
+        self.amountLabel =
+            micro > 0
+            ? "-" + OsaurusRouter.formatMicroUSDPrecise(item.costMicro)
+            : OsaurusRouter.formatMicroUSDPrecise(item.costMicro)
+        self.isCredit = false
+        self.stateKind = CreditsActivityRow.state(forStatus: item.status).kind
+        self.date = CreditsActivityProjector.date(fromRouterTimestamp: item.createdAt)
+    }
+
+    init(transaction item: OsaurusRouterTransactionItem) {
+        self.id = "txn-\(item.id)"
+        self.kind = .transaction
+        let micro = Int64(item.amountMicro) ?? 0
+        self.isCredit = micro >= 0
+        self.title = Self.transactionTitle(entryType: item.entryType, isCredit: micro >= 0)
+        self.amountLabel =
+            micro >= 0
+            ? "+" + OsaurusRouter.formatMicroUSD(item.amountMicro)
+            : OsaurusRouter.formatMicroUSD(item.amountMicro)
+        self.stateKind = micro >= 0 ? .success : .secondary
+        self.date = CreditsActivityProjector.date(fromRouterTimestamp: item.createdAt)
+    }
+
+    /// Whether a ledger transaction belongs in the wallet's mini activity list.
+    /// Credits (top-ups, grants, refunds — including future agent purchases,
+    /// which add balance) always show; debits show only for recognized
+    /// balance-adjustment types. Unrecognized debits are the ledger's mirror of
+    /// per-request usage, which the usage rows already cover.
+    static func isWalletVisible(_ item: OsaurusRouterTransactionItem) -> Bool {
+        if (Int64(item.amountMicro) ?? 0) >= 0 { return true }
+        switch item.entryType.lowercased() {
+        case "refund", "adjustment":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Map a ledger `entry_type` onto the wallet vocabulary. Unknown credit
+    /// types fall back to "Credits added" so future server-side entry types
+    /// (e.g. agent purchases) render sensibly before this map learns about
+    /// them; unknown debits never reach here (see `isWalletVisible`).
+    private static func transactionTitle(entryType: String, isCredit: Bool) -> String {
+        switch entryType.lowercased() {
+        case "topup", "top_up", "top-up", "purchase", "deposit", "credit":
+            return "Credits added"
+        case "refund":
+            return "Refund"
+        case "promo", "promotion", "grant", "bonus":
+            return "Credits granted"
+        case "adjustment":
+            return "Adjustment"
+        default:
+            return "Credits added"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/WalletActivityProjectorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/WalletActivityProjectorTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct WalletActivityProjectorTests {
+    private static let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private static func timestamp(offset: TimeInterval) -> String {
+        ISO8601DateFormatter().string(from: baseDate.addingTimeInterval(offset))
+    }
+
+    private func usage(
+        id: String = "u1",
+        model: String = "venice/minimax-m3",
+        provider: String = "router",
+        cost: String = "1234",
+        status: String = "completed",
+        createdAt: String = WalletActivityProjectorTests.timestamp(offset: 0)
+    ) -> OsaurusRouterUsageItem {
+        OsaurusRouterUsageItem(
+            id: id,
+            requestId: nil,
+            model: model,
+            provider: provider,
+            inputTokens: 11,
+            outputTokens: 3,
+            costMicro: cost,
+            status: status,
+            tokenSource: "provider",
+            createdAt: createdAt
+        )
+    }
+
+    private func transaction(
+        id: String = "t1",
+        amount: String = "5000000",
+        entryType: String = "topup",
+        createdAt: String = WalletActivityProjectorTests.timestamp(offset: 0)
+    ) -> OsaurusRouterTransactionItem {
+        OsaurusRouterTransactionItem(
+            id: id,
+            amountMicro: amount,
+            entryType: entryType,
+            refType: nil,
+            refId: nil,
+            createdAt: createdAt
+        )
+    }
+
+    @Test func mergesUsageAndTransactionsNewestFirst() {
+        let rows = WalletActivityProjector().rows(
+            usageItems: [
+                usage(id: "u-old", createdAt: Self.timestamp(offset: -300)),
+                usage(id: "u-new", createdAt: Self.timestamp(offset: 100)),
+            ],
+            transactions: [
+                transaction(id: "t-mid", createdAt: Self.timestamp(offset: -100))
+            ]
+        )
+
+        #expect(rows.map(\.id) == ["usage-u-new", "txn-t-mid", "usage-u-old"])
+        #expect(rows.map(\.kind) == [.usage, .transaction, .usage])
+    }
+
+    @Test func capsRowCountAtLimit() {
+        let items = (0..<10).map { i in
+            usage(id: "u\(i)", createdAt: Self.timestamp(offset: TimeInterval(i)))
+        }
+        let rows = WalletActivityProjector().rows(usageItems: items, transactions: [], limit: 4)
+        #expect(rows.count == 4)
+        #expect(rows.first?.id == "usage-u9")
+    }
+
+    @Test func usageRowShowsSpendAsNegativeAmount() {
+        let row = WalletActivityProjector().rows(
+            usageItems: [usage(cost: "1234500")],
+            transactions: []
+        )[0]
+
+        #expect(row.title == "venice/minimax-m3")
+        #expect(row.amountLabel == "-$1.23")
+        #expect(row.isCredit == false)
+        #expect(row.stateKind == .success)
+    }
+
+    @Test func usageRowFallsBackToProviderThenPlaceholderTitle() {
+        let providerRow = WalletActivityProjector().rows(
+            usageItems: [usage(model: "")],
+            transactions: []
+        )[0]
+        #expect(providerRow.title == "router")
+
+        let placeholderRow = WalletActivityProjector().rows(
+            usageItems: [usage(model: "", provider: "")],
+            transactions: []
+        )[0]
+        #expect(placeholderRow.title == "Model request")
+    }
+
+    @Test func usageRowMapsServerStatusToStateKind() {
+        let rows = WalletActivityProjector().rows(
+            usageItems: [
+                usage(id: "ok", status: "completed", createdAt: Self.timestamp(offset: 3)),
+                usage(id: "stop", status: "aborted", createdAt: Self.timestamp(offset: 2)),
+                usage(id: "bad", status: "mystery", createdAt: Self.timestamp(offset: 1)),
+            ],
+            transactions: []
+        )
+        #expect(rows.map(\.stateKind) == [.success, .warning, .error])
+    }
+
+    @Test func topUpTransactionRendersAsCredit() {
+        let row = WalletActivityProjector().rows(
+            usageItems: [],
+            transactions: [transaction(amount: "5000000", entryType: "topup")]
+        )[0]
+
+        #expect(row.title == "Credits added")
+        #expect(row.amountLabel == "+$5.00")
+        #expect(row.isCredit)
+        #expect(row.stateKind == .success)
+    }
+
+    @Test func unknownCreditEntryTypesFallBackToCreditsAdded() {
+        let rows = WalletActivityProjector().rows(
+            usageItems: [],
+            transactions: [
+                transaction(
+                    id: "agent",
+                    amount: "2000000",
+                    entryType: "agent_purchase",
+                    createdAt: Self.timestamp(offset: 2)
+                )
+            ]
+        )
+
+        #expect(rows.count == 1)
+        #expect(rows[0].title == "Credits added")
+        #expect(rows[0].amountLabel == "+$2.00")
+        #expect(rows[0].isCredit)
+    }
+
+    @Test func unknownDebitEntryTypesAreHiddenAsUsageMirrors() {
+        let rows = WalletActivityProjector().rows(
+            usageItems: [usage(id: "u1", createdAt: Self.timestamp(offset: 2))],
+            transactions: [
+                // The ledger's per-request debit mirror of the usage row above;
+                // listing both would double-count the spend.
+                transaction(
+                    id: "mirror",
+                    amount: "-1234",
+                    entryType: "usage",
+                    createdAt: Self.timestamp(offset: 2)
+                ),
+                transaction(
+                    id: "fee",
+                    amount: "-500000",
+                    entryType: "mystery_fee",
+                    createdAt: Self.timestamp(offset: 1)
+                ),
+            ]
+        )
+
+        #expect(rows.map(\.id) == ["usage-u1"])
+    }
+
+    @Test func recognizedDebitEntryTypesStayVisible() {
+        let rows = WalletActivityProjector().rows(
+            usageItems: [],
+            transactions: [
+                transaction(
+                    id: "adj",
+                    amount: "-250000",
+                    entryType: "adjustment",
+                    createdAt: Self.timestamp(offset: 2)
+                ),
+                transaction(
+                    id: "ref",
+                    amount: "750000",
+                    entryType: "refund",
+                    createdAt: Self.timestamp(offset: 1)
+                ),
+            ]
+        )
+
+        #expect(rows.map(\.title) == ["Adjustment", "Refund"])
+        #expect(rows[0].amountLabel == "-$0.25")
+        #expect(rows[0].isCredit == false)
+        #expect(rows[1].amountLabel == "+$0.75")
+        #expect(rows[1].isCredit)
+    }
+
+    @Test func unparseableTimestampsSortLast() {
+        let rows = WalletActivityProjector().rows(
+            usageItems: [usage(id: "dated", createdAt: Self.timestamp(offset: -3600))],
+            transactions: [transaction(id: "undated", createdAt: "not-a-date")]
+        )
+        #expect(rows.map(\.id) == ["usage-dated", "txn-undated"])
+        #expect(rows[1].date == nil)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5687,7 +5687,7 @@ struct ChatView: View {
                                 estimatedContextTokens: observedSession.estimatedContextTokens,
                                 contextBreakdown: observedSession.estimatedContextBreakdown,
                                 sessionSpendMicro: observedSession.sessionRouterSpendMicro,
-                                showSessionSpend: observedSession.isOsaurusRouterSession,
+                                isRouterBilledSession: observedSession.isOsaurusRouterSession,
                                 imageComposerSettings: $observedSession.imageComposerSettings,
                                 onSend: { manualText in
                                     if let manualText = manualText {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -38,8 +38,11 @@ struct FloatingInputCard: View {
     var contextBreakdown: ContextBreakdown = .zero
     /// Total micro-USD spent on the Osaurus Router this session.
     var sessionSpendMicro: Int = 0
-    /// Whether to show the session spend chip (true only for Osaurus Router sessions).
-    var showSessionSpend: Bool = false
+    /// True when this session's spend is billed via the Osaurus Router (the
+    /// managed cloud provider is the selected model). Drives the credits chip's
+    /// low/empty escalation and the wallet panel's session-spend row; the chip
+    /// itself is shown in every session where the router is usable.
+    var isRouterBilledSession: Bool = false
     @Binding var imageComposerSettings: ImageComposerSettings
     let onSend: (String?) -> Void
     let onStop: () -> Void
@@ -77,7 +80,7 @@ struct FloatingInputCard: View {
     var onSendNow: (() -> Void)?
     /// Discard the queued send without sending it. Called by the chip's ×.
     var onCancelQueued: (() -> Void)?
-    /// Invoked when the user taps the credits chip (opens the top-up sheet).
+    /// Invoked by the wallet panel's "Add credits" button (opens the top-up sheet).
     var onAddCredits: (() -> Void)?
     /// Mode 2 (remote agent run): the model is pinned to the remote agent's own
     /// model and the user must not change it. Renders the model chip as a
@@ -128,7 +131,7 @@ struct FloatingInputCard: View {
         estimatedContextTokens: Int,
         contextBreakdown: ContextBreakdown = .zero,
         sessionSpendMicro: Int = 0,
-        showSessionSpend: Bool = false,
+        isRouterBilledSession: Bool = false,
         imageComposerSettings: Binding<ImageComposerSettings> = .constant(ImageComposerSettings()),
         onSend: @escaping (String?) -> Void,
         onStop: @escaping () -> Void,
@@ -169,7 +172,7 @@ struct FloatingInputCard: View {
         self.estimatedContextTokens = estimatedContextTokens
         self.contextBreakdown = contextBreakdown
         self.sessionSpendMicro = sessionSpendMicro
-        self.showSessionSpend = showSessionSpend
+        self.isRouterBilledSession = isRouterBilledSession
         self._imageComposerSettings = imageComposerSettings
         self.onSend = onSend
         self.onStop = onStop
@@ -203,9 +206,12 @@ struct FloatingInputCard: View {
     @ObservedObject private var sandboxState = SandboxManager.State.shared
     @ObservedObject private var clipboardService = ClipboardService.shared
     @ObservedObject private var appConfig = AppConfiguration.shared
-    /// Drives the composer credits chip (balance + low-balance tinting) for
-    /// Osaurus Router sessions.
+    /// Drives the composer credits chip (balance + low-balance tinting) and the
+    /// wallet panel's recent-activity list.
     @ObservedObject private var accountService = OsaurusRouterAccountService.shared
+    /// Master-switch mirror for the Osaurus Router; the credits chip shows in
+    /// every session while the router is usable (switch on + identity present).
+    @ObservedObject private var remoteProviders = RemoteProviderManager.shared
     /// Frontmost-app source + Accessibility status for the read-only
     /// screen-context chip (shown only on the empty/welcome screen). The opt-in
     /// gate is now per-agent (a child of Computer Use), read via `agentManager`.
@@ -273,8 +279,19 @@ struct FloatingInputCard: View {
     /// period to travel from the trigger into the popover (which lives in its
     /// own window, so hovering it doesn't keep the trigger "hovered").
     @State private var contextDismissTask: Task<Void, Never>?
-    @State private var showBalanceBreakdown = false
+    /// Wallet panel presentation. Hovering the credits chip opens it as a
+    /// passive preview (dismissed on hover exit); clicking pins it so its
+    /// actions (Add credits, View all) are reachable.
+    @State private var showWalletPanel = false
+    /// True when the wallet panel was opened by click; hover exit no longer
+    /// dismisses it, only outside-click / an action does.
+    @State private var walletPanelPinned = false
     @State private var balanceHoverTask: Task<Void, Never>?
+    /// Delayed dismiss for the hover-opened wallet panel. Gives the cursor a
+    /// grace period to travel from the chip into the panel (which lives in its
+    /// own window, so hovering it doesn't keep the chip "hovered"); the panel's
+    /// own hover cancels it so its buttons stay clickable.
+    @State private var walletDismissTask: Task<Void, Never>?
     @State private var isSandboxHovered = false
     @State private var sandboxPulseAmount: CGFloat = 1.0
     @State private var sandboxPulseTask: Task<Void, Never>? = nil
@@ -525,7 +542,16 @@ struct FloatingInputCard: View {
             || isSandboxAvailable
             || isDefaultConfigAgent
             || (appConfig.chatConfig.enableClipboardMonitoring && clipboardService.hasNewContent)
-            || showSessionSpend
+            || showCreditsChip
+    }
+
+    /// Whether the credits chip (and its wallet panel) is available at all:
+    /// the router master switch is on and a signing identity exists — the same
+    /// gate `RemoteProviderManager` uses for the managed router provider. Shown
+    /// in every session (not just router-billed ones) because credits are the
+    /// account-level wallet other routed services will draw from too.
+    private var showCreditsChip: Bool {
+        remoteProviders.isOsaurusRouterEnabled && OsaurusIdentity.existsCached()
     }
 
     private var mainContent: some View {
@@ -2011,7 +2037,7 @@ extension FloatingInputCard {
     private var metaCluster: some View {
         // Hide the balance/credits chip while a remote agent is connecting —
         // it's not actionable yet and competes with the connect affordance.
-        let showCredits = showSessionSpend && !remoteConnectionPending
+        let showCredits = showCreditsChip && !remoteConnectionPending
         // Mode 2 hides the context-budget chip + popover entirely: a remote
         // agent composes its own system prompt / tools server-side, so a local
         // token breakdown (system prompt, tools, history) doesn't reflect what
@@ -2040,7 +2066,8 @@ extension FloatingInputCard {
     /// text that blends into the meta cluster); low and empty escalate to an
     /// amber pill so a top-up is easy to notice. Empty/frozen reads as an "Add
     /// credits" call to action — deliberately amber, never error-red, so it
-    /// invites action instead of looking like a failure.
+    /// invites action instead of looking like a failure. The escalation only
+    /// applies to router-billed sessions; see `creditsStyle(for:)`.
     private enum BalanceLevel {
         case healthy
         case low
@@ -2074,6 +2101,20 @@ extension FloatingInputCard {
 
     private func creditsStyle(for level: BalanceLevel) -> CreditsChipStyle {
         let amber = theme.warningColor
+        // Outside router-billed sessions the chip never escalates: the balance
+        // doesn't block the current session, so a $0/unknown wallet reads as
+        // quiet muted "Add credits" text instead of an amber call to action.
+        guard isRouterBilledSession else {
+            return CreditsChipStyle(
+                iconName: "creditcard",
+                iconColor: theme.tertiaryText,
+                textColor: theme.secondaryText,
+                weight: .medium,
+                pill: nil,
+                glow: .clear,
+                showsAmount: level != .empty
+            )
+        }
         switch level {
         case .healthy:
             return CreditsChipStyle(
@@ -2118,18 +2159,20 @@ extension FloatingInputCard {
     }
 
     /// Accessibility text for the credits chip. Describes the router balance the
-    /// chip shows and the tap action; session spend lives in the popover.
+    /// chip shows and the tap action; session spend lives in the wallet panel.
     private var creditsHelpText: Text {
         if accountService.isFrozen {
             return Text("Account paused - add credits to resume.", bundle: .module)
         }
-        return Text("\(accountService.formattedBalance) router balance. Click to add credits.", bundle: .module)
+        return Text("\(accountService.formattedBalance) router balance. Click to open the wallet.", bundle: .module)
     }
 
-    /// Balance indicator for Osaurus Router sessions. Tapping opens the top-up
-    /// sheet; the balance best-effort refreshes on appear so it isn't blank.
-    /// Quiet plain text when funded, escalating to an amber pill / "Add credits"
-    /// CTA as the balance runs low or hits zero (see `BalanceLevel`).
+    /// Balance indicator shown in every session where the router is usable.
+    /// Hovering previews the wallet panel; clicking pins it so its actions
+    /// (Add credits → top-up sheet, View all → Credits tab) are reachable.
+    /// Quiet plain text normally, escalating to an amber pill / "Add credits"
+    /// CTA as the balance runs low or hits zero — router-billed sessions only
+    /// (see `BalanceLevel` / `creditsStyle(for:)`).
     @ViewBuilder
     private var creditsChip: some View {
         let level = balanceLevel
@@ -2140,7 +2183,18 @@ extension FloatingInputCard {
         let showIcon = !isCompact || level == .empty
 
         Button {
-            onAddCredits?()
+            // Click pins the wallet panel (rather than jumping straight to the
+            // top-up sheet) so its actions stay reachable; a second click while
+            // pinned closes it.
+            balanceHoverTask?.cancel()
+            walletDismissTask?.cancel()
+            if showWalletPanel && walletPanelPinned {
+                showWalletPanel = false
+                walletPanelPinned = false
+            } else {
+                walletPanelPinned = true
+                showWalletPanel = true
+            }
         } label: {
             HStack(spacing: 4) {
                 if showIcon {
@@ -2187,28 +2241,68 @@ extension FloatingInputCard {
         .onHover { hovering in
             balanceHoverTask?.cancel()
             if hovering {
+                walletDismissTask?.cancel()
                 balanceHoverTask = Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 300_000_000)
                     guard !Task.isCancelled else { return }
-                    showBalanceBreakdown = true
+                    showWalletPanel = true
                 }
-            } else {
-                showBalanceBreakdown = false
+            } else if !walletPanelPinned {
+                scheduleWalletDismiss()
             }
         }
-        .popover(isPresented: $showBalanceBreakdown, arrowEdge: .top) {
-            BalanceBreakdownPopover(
-                sessionSpend: sessionSpendDisplay,
-                balance: accountService.formattedBalance,
-                isAttention: level != .healthy,
-                isFrozen: accountService.isFrozen
+        .popover(isPresented: $showWalletPanel, arrowEdge: .top) {
+            WalletPopover(
+                sessionSpend: isRouterBilledSession ? sessionSpendDisplay : nil,
+                isAttention: isRouterBilledSession && level != .healthy,
+                onAddCredits: {
+                    closeWalletPanel()
+                    onAddCredits?()
+                },
+                onViewAll: {
+                    closeWalletPanel()
+                    AppDelegate.shared?.showManagementWindow(initialTab: .credits)
+                }
             )
+            // Keep the panel alive while the cursor is over it, so the user
+            // can travel from the chip and click Add credits / View all.
+            .onHover { hovering in
+                if hovering {
+                    walletDismissTask?.cancel()
+                } else if !walletPanelPinned {
+                    scheduleWalletDismiss()
+                }
+            }
         }
-        .task(id: showSessionSpend) {
-            if showSessionSpend {
+        .onChange(of: showWalletPanel) { _, isShown in
+            // Outside-click dismissal flips the binding directly; unpin so the
+            // next hover preview behaves normally.
+            if !isShown { walletPanelPinned = false }
+        }
+        .task(id: showCreditsChip) {
+            if showCreditsChip {
                 await accountService.refreshBalance()
             }
         }
+    }
+
+    /// Dismiss the hover-opened wallet panel after a grace period, giving the
+    /// cursor time to cross the gap into the panel window.
+    private func scheduleWalletDismiss() {
+        balanceHoverTask?.cancel()
+        walletDismissTask?.cancel()
+        walletDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+            showWalletPanel = false
+        }
+    }
+
+    private func closeWalletPanel() {
+        walletDismissTask?.cancel()
+        balanceHoverTask?.cancel()
+        showWalletPanel = false
+        walletPanelPinned = false
     }
 
     // MARK: - Context Indicator
@@ -5464,78 +5558,286 @@ private struct ContextBreakdownPopover: View {
 
 }
 
-// MARK: - Balance Breakdown Popover
+// MARK: - Wallet Popover
 
-/// Hover card for the composer balance chip, styled to match
-/// `ContextBreakdownPopover` (rounded glass card, 11pt header, hairline
-/// dividers, monospaced values). Replaces the plain OS tooltip so the router
-/// balance reads like the Context Budget breakdown beside it. The balance is
-/// the hero figure (paralleling the budget bar) and tints amber when low/empty.
-private struct BalanceBreakdownPopover: View {
-    let sessionSpend: String
-    let balance: String
+/// The composer wallet panel, styled to match `ContextBreakdownPopover`
+/// (rounded glass card, 11pt headers, hairline dividers, monospaced values).
+/// Opens from the credits chip as a hover preview or a pinned click-through
+/// panel: balance hero, per-session router spend, recent account activity
+/// (model requests + ledger transactions), and Add credits / View all actions.
+/// This is the surface agent-initiated credit transactions will land in — new
+/// ledger `entry_type`s render here via `WalletActivityProjector` without UI
+/// rework.
+private struct WalletPopover: View {
+    /// This session's router spend; nil outside router-billed sessions.
+    let sessionSpend: String?
+    /// True when a low/empty balance should tint amber (router-billed sessions
+    /// only — a $0 wallet doesn't block a local-model chat).
     let isAttention: Bool
-    let isFrozen: Bool
+    let onAddCredits: () -> Void
+    let onViewAll: () -> Void
 
+    @ObservedObject private var accountService = OsaurusRouterAccountService.shared
     @Environment(\.theme) private var theme
 
-    private var accent: Color { theme.accentColor }
+    /// Shared so each row doesn't allocate a formatter; relative labels like
+    /// "3h ago" only need minute resolution.
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
 
-    private var footerText: Text {
-        isFrozen
-            ? Text("Account paused - add credits to resume.", bundle: .module)
-            : Text("Click to add credits", bundle: .module)
+    private var rows: [WalletActivityRow] {
+        WalletActivityProjector().rows(
+            usageItems: accountService.usage,
+            transactions: accountService.transactions
+        )
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            header
+            if let sessionSpend {
+                divider
+                sessionSpendRow(sessionSpend)
+            }
+            divider
+            activitySection
+            divider
+            footerActions
+        }
+        .frame(width: 272)
+        .popoverCard()
+        .task {
+            await accountService.refreshBalance()
+            await accountService.refreshUsage(reset: true)
+            await accountService.refreshTransactions(reset: true)
+        }
+    }
+
+    // MARK: Sections
+
+    /// Hero balance over a soft accent wash — the "card face" of the wallet.
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 3) {
             HStack(spacing: 6) {
-                Image(systemName: "chart.bar.fill")
+                Image(systemName: "creditcard.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(theme.accentColor.opacity(0.85))
+                Text("Wallet", bundle: .module)
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(theme.secondaryText)
-                Text("This Session", bundle: .module)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.secondaryText)
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 8)
-
-            HStack(spacing: 8) {
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(accent.opacity(0.85))
-                    .frame(width: 3, height: 16)
-                Text(verbatim: sessionSpend)
-                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
-                    .foregroundColor(theme.primaryText)
+                    .textCase(.uppercase)
+                    .kerning(0.8)
                 Spacer(minLength: 0)
+                if accountService.isFrozen {
+                    Text("Paused", bundle: .module)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(theme.warningColor)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(theme.warningColor.opacity(0.14))
+                                .overlay(
+                                    Capsule().strokeBorder(
+                                        theme.warningColor.opacity(0.35), lineWidth: 1)
+                                )
+                        )
+                }
             }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 10)
+            .padding(.bottom, 5)
 
-            divider
-            HStack(spacing: 0) {
-                Text("Router balance", bundle: .module)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.secondaryText)
-                Spacer()
-                Text(verbatim: balance)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundColor(isAttention ? theme.warningColor : theme.primaryText)
+            Text(verbatim: accountService.formattedBalance)
+                .font(.system(size: 24, weight: .semibold, design: .monospaced))
+                .foregroundColor(
+                    (isAttention || accountService.isFrozen)
+                        ? theme.warningColor : theme.primaryText
+                )
+                .contentTransition(.numericText())
+
+            if accountService.isFrozen {
+                Text("Account paused - add credits to resume.", bundle: .module)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("Available balance", bundle: .module)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-
-            divider
-            footerText
-                .font(.system(size: 10))
-                .foregroundColor(theme.tertiaryText)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
         }
-        .frame(width: 200)
-        .popoverCard()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.top, 12)
+        .padding(.bottom, 11)
+        .background(
+            LinearGradient(
+                colors: [theme.accentColor.opacity(0.10), theme.accentColor.opacity(0.02)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+
+    private func sessionSpendRow(_ spend: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "chart.bar.fill")
+                .font(.system(size: 8))
+                .foregroundColor(theme.tertiaryText)
+            Text("This session", bundle: .module)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+            Spacer()
+            Text(verbatim: spend)
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundColor(theme.primaryText)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+
+    private var activitySection: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("Recent activity", bundle: .module)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+                .textCase(.uppercase)
+                .kerning(0.8)
+
+            if rows.isEmpty {
+                emptyActivity
+            } else {
+                VStack(alignment: .leading, spacing: 9) {
+                    ForEach(rows) { row in
+                        activityRow(row)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 10)
+        .padding(.bottom, 11)
+    }
+
+    private var emptyActivity: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "moon.zzz")
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText.opacity(0.7))
+            Text("No activity yet", bundle: .module)
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.vertical, 6)
+    }
+
+    private func activityRow(_ row: WalletActivityRow) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(badgeTint(for: row).opacity(0.13))
+                Image(systemName: iconName(for: row))
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(badgeTint(for: row))
+            }
+            .frame(width: 20, height: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                // Transaction titles are the projector's fixed vocabulary
+                // ("Credits added", ...) and localize via key lookup. Usage
+                // titles are model/provider ids and must render verbatim —
+                // LocalizedStringKey would treat underscores in ids as
+                // markdown emphasis.
+                Group {
+                    if row.kind == .transaction {
+                        Text(LocalizedStringKey(row.title), bundle: .module)
+                    } else {
+                        Text(verbatim: row.title)
+                    }
+                }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.primaryText)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                if let timeLabel = timeLabel(for: row) {
+                    Text(verbatim: timeLabel)
+                        .font(.system(size: 9))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Text(verbatim: row.amountLabel)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundColor(row.isCredit ? theme.successColor : theme.secondaryText)
+        }
+    }
+
+    private var footerActions: some View {
+        HStack(spacing: 8) {
+            Button(action: onAddCredits) {
+                HStack(spacing: 4) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .bold))
+                    Text("Add credits", bundle: .module)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Capsule().fill(theme.accentColor))
+            }
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+
+            Spacer(minLength: 0)
+
+            Button(action: onViewAll) {
+                HStack(spacing: 3) {
+                    Text("View all", bundle: .module)
+                        .font(.system(size: 11, weight: .medium))
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 7, weight: .semibold))
+                }
+                .foregroundColor(theme.secondaryText)
+            }
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+            .localizedHelp("Open the Credits tab for full usage and transaction history.")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: Row styling
+
+    private func iconName(for row: WalletActivityRow) -> String {
+        switch row.kind {
+        case .transaction:
+            return row.isCredit ? "arrow.down.left" : "arrow.up.right"
+        case .usage:
+            return "sparkles"
+        }
+    }
+
+    /// Badge + icon tint. Money-in reads green; spends stay neutral unless the
+    /// request itself needs attention (stopped/error states from the ledger).
+    private func badgeTint(for row: WalletActivityRow) -> Color {
+        if row.isCredit { return theme.successColor }
+        switch row.stateKind {
+        case .warning: return theme.warningColor
+        case .error: return theme.errorColor
+        case .success, .secondary: return theme.secondaryText
+        }
+    }
+
+    private func timeLabel(for row: WalletActivityRow) -> String? {
+        guard let date = row.date else { return nil }
+        return Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
     }
 
     private var divider: some View {

--- a/Packages/OsaurusCore/Views/Credits/CreditsView.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsView.swift
@@ -14,7 +14,7 @@ struct CreditsView: View {
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
     @State private var hasAppeared = false
-    @State private var usagePageIndex = 0
+    @State private var timelinePageIndex = 0
     @State private var ledgerEntries: [RouterBillingEntry] = []
     @State private var ledgerTotalCount = 0
     @State private var isLoadingLedger = false
@@ -111,7 +111,7 @@ struct CreditsView: View {
     private var headerView: some View {
         ManagerHeaderWithActions(
             title: L("Credits"),
-            subtitle: L("Add credits and see what each Osaurus Router request costs.")
+            subtitle: L("Your wallet for Osaurus-routed services - add credits and track every request and top-up.")
         ) {
             HeaderIconButton(
                 "arrow.clockwise",
@@ -185,7 +185,7 @@ struct CreditsView: View {
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(theme.secondaryText)
                 Text(
-                    "Runs cloud models and provider load-balancing; requests spend credits. Keeping it on helps support Osaurus development - thank you.",
+                    "Lets Osaurus transact on your behalf - cloud models, provider load-balancing, and future routed services; requests spend credits. Keeping it on helps support Osaurus development - thank you.",
                     bundle: .module
                 )
                 .font(.system(size: 11))
@@ -246,73 +246,117 @@ struct CreditsView: View {
         }
     }
 
+    /// The wallet card: same visual language as the composer wallet panel
+    /// (uppercase eyebrow, monospaced hero balance, "Available balance"
+    /// microcopy, soft accent wash) scaled up for the management page.
     private var balanceCard: some View {
-        card {
-            VStack(alignment: .leading, spacing: 16) {
-                HStack(alignment: .top) {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Credit balance", bundle: .module)
-                            .font(.system(size: 13, weight: .semibold))
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "creditcard.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(theme.accentColor.opacity(0.85))
+                        Text("Wallet", bundle: .module)
+                            .font(.system(size: 11, weight: .semibold))
                             .foregroundColor(theme.secondaryText)
-                        HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text(verbatim: accountService.formattedBalance)
-                                .font(.system(size: 34, weight: .bold, design: .rounded))
-                                .foregroundColor(theme.primaryText)
-                            if accountService.isLoadingBalance {
-                                ProgressView()
-                                    .scaleEffect(0.7)
-                            }
+                            .textCase(.uppercase)
+                            .kerning(0.8)
+                    }
+                    .padding(.bottom, 6)
+
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(verbatim: accountService.formattedBalance)
+                            .font(.system(size: 32, weight: .semibold, design: .monospaced))
+                            .foregroundColor(
+                                accountService.isFrozen ? theme.warningColor : theme.primaryText
+                            )
+                            .contentTransition(.numericText())
+                        if accountService.isLoadingBalance {
+                            ProgressView()
+                                .scaleEffect(0.7)
                         }
                     }
 
-                    Spacer()
-
                     if accountService.isFrozen {
-                        statusPill(L("On hold"), icon: "pause.circle.fill", color: theme.warningColor)
+                        Text("Account paused - add credits to resume.", bundle: .module)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.tertiaryText)
                     } else {
-                        statusPill(L("Active"), icon: "checkmark.circle.fill", color: theme.successColor)
+                        Text("Available balance", bundle: .module)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.tertiaryText)
                     }
                 }
 
-                Text(
-                    "Credits pay for cloud models and provider load-balancing routed through Osaurus.",
-                    bundle: .module
-                )
-                .font(.system(size: 12))
-                .foregroundColor(theme.secondaryText)
-                .fixedSize(horizontal: false, vertical: true)
+                Spacer()
 
-                Divider()
-
-                HStack(spacing: 12) {
-                    Label(localized: "Minimum top-up is $5.00", systemImage: "info.circle")
-                        .font(.system(size: 12))
-                        .foregroundColor(theme.secondaryText)
-
-                    Spacer()
-
-                    if accountService.isCreatingCheckout {
-                        ProgressView()
-                            .scaleEffect(0.7)
-                    }
-                    Button {
-                        showTopUpSheet = true
-                    } label: {
-                        Label(localized: "Add credits", systemImage: "creditcard.fill")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .disabled(!OsaurusIdentity.exists() || accountService.isCreatingCheckout)
-                }
-
-                if let error = accountService.lastError, !error.isEmpty {
-                    Text(error)
-                        .font(.system(size: 12))
-                        .foregroundColor(theme.errorColor)
-                        .fixedSize(horizontal: false, vertical: true)
+                if accountService.isFrozen {
+                    statusPill(L("Paused"), icon: "pause.circle.fill", color: theme.warningColor)
+                } else {
+                    statusPill(L("Active"), icon: "checkmark.circle.fill", color: theme.successColor)
                 }
             }
+
+            Text(
+                "Credits let Osaurus transact on your behalf - cloud model access today, with more routed services to come.",
+                bundle: .module
+            )
+            .font(.system(size: 12))
+            .foregroundColor(theme.secondaryText)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Divider()
+
+            HStack(spacing: 12) {
+                Label(localized: "Minimum top-up is $5.00", systemImage: "info.circle")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+
+                Spacer()
+
+                if accountService.isCreatingCheckout {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                }
+                Button {
+                    showTopUpSheet = true
+                } label: {
+                    Label(localized: "Add credits", systemImage: "creditcard.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(!OsaurusIdentity.exists() || accountService.isCreatingCheckout)
+            }
+
+            if let error = accountService.lastError, !error.isEmpty {
+                Text(error)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.errorColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(walletCardBackground)
+    }
+
+    /// Card chrome with the wallet panel's accent wash fading from the top.
+    private var walletCardBackground: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(theme.cardBackground)
+            .overlay(
+                LinearGradient(
+                    colors: [theme.accentColor.opacity(0.08), theme.accentColor.opacity(0.01)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(theme.cardBorder, lineWidth: 1)
+            )
     }
 
     // MARK: - Credits activity
@@ -326,7 +370,7 @@ struct CreditsView: View {
                             .font(.system(size: 15, weight: .semibold))
                             .foregroundColor(theme.primaryText)
                         Text(
-                            "Requests routed through Osaurus, newest first. Open the chat or Insights when this Mac has the matching copy.",
+                            "Model requests and balance changes, newest first. Open the chat or Insights when this Mac has the matching copy.",
                             bundle: .module
                         )
                         .font(.system(size: 12))
@@ -350,7 +394,7 @@ struct CreditsView: View {
                     .disabled(isExportingDiagnostics || ledgerTotalCount == 0)
                 }
 
-                if currentActivityRows.isEmpty {
+                if pagedTimelineEntries.isEmpty {
                     emptyActivityState
                 } else {
                     activityList
@@ -368,11 +412,18 @@ struct CreditsView: View {
     }
 
     private var activityList: some View {
-        let rows = currentActivityRows
+        let entries = pagedTimelineEntries
         return VStack(spacing: 0) {
-            ForEach(rows) { row in
-                activityRow(row)
-                if row.id != rows.last?.id {
+            ForEach(entries) { entry in
+                Group {
+                    switch entry {
+                    case .request(let row, _):
+                        activityRow(row)
+                    case .transaction(let row):
+                        transactionRow(row)
+                    }
+                }
+                if entry.id != entries.last?.id {
                     Divider()
                 }
             }
@@ -394,11 +445,11 @@ struct CreditsView: View {
                     .font(.system(size: 24))
                     .foregroundColor(theme.tertiaryText)
             }
-            Text("No requests yet", bundle: .module)
+            Text("No activity yet", bundle: .module)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(theme.primaryText)
             Text(
-                "When you use an Osaurus Router model, each request shows up here with its cost and tokens. If this Mac made the request, you can jump to the chat or Insights.",
+                "When you add credits or use an Osaurus Router model, it shows up here with its amount. If this Mac made a request, you can jump to the chat or Insights.",
                 bundle: .module
             )
             .font(.system(size: 12))
@@ -412,7 +463,7 @@ struct CreditsView: View {
 
     private var activityPaginationControls: some View {
         HStack(spacing: 10) {
-            Text(verbatim: usageRangeLabel)
+            Text(verbatim: timelineRangeLabel)
                 .font(.system(size: 12))
                 .foregroundColor(theme.secondaryText)
 
@@ -428,7 +479,7 @@ struct CreditsView: View {
             .disabled(!canGoToPreviousActivityPage || isLoadingCurrentActivity)
 
             Button {
-                goToNextUsagePage()
+                goToNextTimelinePage()
             } label: {
                 if isLoadingCurrentActivity {
                     ProgressView().scaleEffect(0.7)
@@ -444,50 +495,72 @@ struct CreditsView: View {
         }
     }
 
-    private var currentActivityRows: [CreditsActivityRow] {
-        CreditsActivityProjector(
+    /// The full merged timeline: billed model requests (with ledger matching
+    /// and chat/Insights references) interleaved with wallet-visible ledger
+    /// transactions (top-ups, grants, refunds — later agent purchases), newest
+    /// first. Uses the same visibility filter as the composer wallet panel so
+    /// per-request debit mirrors never double-count spend.
+    private var mergedTimeline: [CreditsTimelineEntry] {
+        let usageItems = accountService.usage
+        let requestRows = CreditsActivityProjector(
             hasInsightsLogForRequestId: { insightsService.hasLog(requestId: $0) },
             hasInsightsLogForTurnId: { insightsService.hasLog(turnId: $0) }
         )
-        .rows(usageItems: pagedUsageRows, ledgerEntries: ledgerEntries)
+        .rows(usageItems: usageItems, ledgerEntries: ledgerEntries)
+        let requests = zip(requestRows, usageItems).map { row, item in
+            CreditsTimelineEntry.request(
+                row,
+                date: CreditsActivityProjector.date(fromRouterTimestamp: item.createdAt)
+            )
+        }
+        let transactions = accountService.transactions
+            .filter(WalletActivityRow.isWalletVisible)
+            .map { CreditsTimelineEntry.transaction(WalletActivityRow(transaction: $0)) }
+        return (requests + transactions)
+            .sorted { ($0.date ?? .distantPast) > ($1.date ?? .distantPast) }
     }
 
-    private var pagedUsageRows: [OsaurusRouterUsageItem] {
-        let start = usagePageIndex * Self.activityPageSize
-        guard start < accountService.usage.count else { return [] }
-        let end = min(start + Self.activityPageSize, accountService.usage.count)
-        return Array(accountService.usage[start ..< end])
+    private var pagedTimelineEntries: [CreditsTimelineEntry] {
+        let timeline = mergedTimeline
+        let start = timelinePageIndex * Self.activityPageSize
+        guard start < timeline.count else { return [] }
+        let end = min(start + Self.activityPageSize, timeline.count)
+        return Array(timeline[start ..< end])
     }
 
     private var isLoadingCurrentActivity: Bool {
-        accountService.isLoadingUsage || isLoadingLedger
+        accountService.isLoadingUsage || accountService.isLoadingTransactions || isLoadingLedger
     }
 
     private var canGoToPreviousActivityPage: Bool {
-        usagePageIndex > 0
+        timelinePageIndex > 0
     }
 
     private var canGoToNextActivityPage: Bool {
-        let nextStart = (usagePageIndex + 1) * Self.activityPageSize
-        return nextStart < accountService.usage.count || accountService.nextUsageCursor != nil
+        let nextStart = (timelinePageIndex + 1) * Self.activityPageSize
+        return nextStart < mergedTimeline.count || hasMoreOnServer
+    }
+
+    private var hasMoreOnServer: Bool {
+        accountService.nextUsageCursor != nil || accountService.nextTransactionsCursor != nil
     }
 
     /// True only when the next page isn't already loaded but the server says more
     /// rows exist — i.e. the advance button should fetch instead of just paging.
     private var canLoadMoreFromServer: Bool {
-        let nextStart = (usagePageIndex + 1) * Self.activityPageSize
-        return nextStart >= accountService.usage.count && accountService.nextUsageCursor != nil
+        let nextStart = (timelinePageIndex + 1) * Self.activityPageSize
+        return nextStart >= mergedTimeline.count && hasMoreOnServer
     }
 
     /// Honest range over what we've actually loaded. The router never returns a
     /// true total, so "loaded" makes clear more may exist behind "Load more"
     /// rather than implying a misleading grand total.
-    private var usageRangeLabel: String {
-        let loaded = accountService.usage.count
+    private var timelineRangeLabel: String {
+        let loaded = mergedTimeline.count
         guard loaded > 0 else { return "" }
-        let start = usagePageIndex * Self.activityPageSize
-        let end = min(start + currentActivityRows.count, loaded)
-        if accountService.nextUsageCursor != nil {
+        let start = timelinePageIndex * Self.activityPageSize
+        let end = min(start + pagedTimelineEntries.count, loaded)
+        if hasMoreOnServer {
             return L("Showing \(start + 1)-\(end) of \(loaded) loaded")
         }
         return L("Showing \(start + 1)-\(end) of \(loaded)")
@@ -495,10 +568,10 @@ struct CreditsView: View {
 
     private func activityRow(_ row: CreditsActivityRow) -> some View {
         HStack(alignment: .top, spacing: 12) {
-            Circle()
-                .fill(stateColor(row.stateKind))
-                .frame(width: 8, height: 8)
-                .padding(.top, 5)
+            timelineBadge(
+                icon: "sparkles",
+                tint: requestBadgeTint(row.stateKind)
+            )
 
             VStack(alignment: .leading, spacing: 5) {
                 HStack(spacing: 8) {
@@ -523,14 +596,77 @@ struct CreditsView: View {
 
             Spacer(minLength: 12)
 
-            Text(verbatim: OsaurusRouter.formatMicroUSDPrecise(row.costMicro))
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundColor(theme.primaryText)
-                .monospacedDigit()
+            Text(verbatim: signedCostLabel(row.costMicro))
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundColor(theme.secondaryText)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
         .background(theme.cardBackground)
+    }
+
+    /// A balance-changing ledger transaction (top-up, grant, refund — later
+    /// agent purchases): the wallet panel's row vocabulary at timeline scale.
+    private func transactionRow(_ row: WalletActivityRow) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            timelineBadge(
+                icon: row.isCredit ? "arrow.down.left" : "arrow.up.right",
+                tint: row.isCredit ? theme.successColor : theme.secondaryText
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(LocalizedStringKey(row.title), bundle: .module)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                if let date = row.date {
+                    Text(verbatim: date.formatted(date: .abbreviated, time: .shortened))
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                }
+            }
+
+            Spacer(minLength: 12)
+
+            Text(verbatim: row.amountLabel)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundColor(row.isCredit ? theme.successColor : theme.secondaryText)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(theme.cardBackground)
+    }
+
+    /// Tinted circular icon badge shared by both timeline row types, matching
+    /// the composer wallet panel's row treatment.
+    private func timelineBadge(icon: String, tint: Color) -> some View {
+        ZStack {
+            Circle()
+                .fill(tint.opacity(0.13))
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(tint)
+        }
+        .frame(width: 26, height: 26)
+    }
+
+    /// Spends stay neutral (the outcome pill already carries status); only
+    /// attention states color the badge, mirroring the wallet panel.
+    private func requestBadgeTint(_ kind: CreditsActivityStateKind) -> Color {
+        switch kind {
+        case .warning: return theme.warningColor
+        case .error: return theme.errorColor
+        case .success, .secondary: return theme.secondaryText
+        }
+    }
+
+    /// Request costs render signed ("-$0.09") so the timeline reads like a
+    /// statement next to "+$5.00" transaction rows.
+    private func signedCostLabel(_ costMicro: String) -> String {
+        let formatted = OsaurusRouter.formatMicroUSDPrecise(costMicro)
+        if (Int64(costMicro) ?? 0) > 0 {
+            return "-" + formatted
+        }
+        return formatted
     }
 
     @ViewBuilder
@@ -610,23 +746,28 @@ struct CreditsView: View {
     }
 
     private func goToPreviousActivityPage() {
-        usagePageIndex = max(0, usagePageIndex - 1)
+        timelinePageIndex = max(0, timelinePageIndex - 1)
     }
 
-    private func goToNextUsagePage() {
-        let nextIndex = usagePageIndex + 1
+    private func goToNextTimelinePage() {
+        let nextIndex = timelinePageIndex + 1
         let nextStart = nextIndex * Self.activityPageSize
-        if nextStart < accountService.usage.count {
-            usagePageIndex = nextIndex
+        if nextStart < mergedTimeline.count {
+            timelinePageIndex = nextIndex
             return
         }
-        guard accountService.nextUsageCursor != nil else { return }
+        guard hasMoreOnServer else { return }
         Task {
-            let previousCount = accountService.usage.count
-            await accountService.loadMoreUsage()
-            if accountService.usage.count > previousCount {
+            let previousCount = mergedTimeline.count
+            if accountService.nextUsageCursor != nil {
+                await accountService.loadMoreUsage()
+            }
+            if accountService.nextTransactionsCursor != nil {
+                await accountService.loadMoreTransactions()
+            }
+            if mergedTimeline.count > previousCount {
                 await reloadLedger()
-                usagePageIndex = nextIndex
+                timelinePageIndex = nextIndex
             }
         }
     }
@@ -695,9 +836,12 @@ struct CreditsView: View {
 
     private func refreshCredits(resetPages: Bool) async {
         if resetPages {
-            usagePageIndex = 0
+            timelinePageIndex = 0
         }
         await accountService.refreshAll()
+        // Transactions feed the merged timeline (top-ups, grants, refunds)
+        // alongside the usage rows `refreshAll` already fetched.
+        await accountService.refreshTransactions(reset: true)
         await reloadLedger()
     }
 
@@ -764,4 +908,26 @@ struct CreditsView: View {
         }
     }
 
+}
+
+/// One row in the merged Credits timeline: a billed model request (projected
+/// with ledger matching and chat/Insights references) or a balance-changing
+/// ledger transaction reusing the composer wallet panel's row model.
+private enum CreditsTimelineEntry: Identifiable {
+    case request(CreditsActivityRow, date: Date?)
+    case transaction(WalletActivityRow)
+
+    var id: String {
+        switch self {
+        case .request(let row, _): return row.id
+        case .transaction(let row): return row.id
+        }
+    }
+
+    var date: Date? {
+        switch self {
+        case .request(_, let date): return date
+        case .transaction(let row): return row.date
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Makes the credit balance easier to see and act on. The composer's balance chip now shows in every chat session while the Osaurus Router is enabled (previously only when an Osaurus model was selected), and opens a compact wallet panel with the balance, per-session spend, recent activity, and top-up/Credits-tab actions. The Credits settings page adopts the same wallet styling and vocabulary, and its activity timeline now includes top-ups and other balance changes alongside model requests.

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

- Composer credits chip: visible whenever the router is usable; the low/empty amber escalation still applies only when the selected model bills through the router.
- New wallet panel on the chip (hover preview + click to pin): balance hero, session spend, last 4 activity rows, Add credits, View all.
- New `WalletActivityProjector` merges usage and ledger transactions into activity rows and filters per-request debit mirrors so spend isn't double-listed (unit tested).
- Credits page: wallet-style balance card, merged request/transaction timeline with pagination across both server cursors, tinted row badges, signed amounts.
- Updated copies and added de/ko/ru/zh-Hans/zh-Hant translations for all new strings.

## Test Plan

- `swift build --package-path Packages/OsaurusCore`
- `swift test --filter "WalletActivityProjectorTests|CreditsActivityProjectorTests"` (15 tests pass)
- Full `make test` run: my suites pass; remaining failures are the documented keychain-gated suites (run with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`) and unrelated timing-sensitive suites that pass in isolation.
- Manual: hover/click the composer chip with a local model and an Osaurus model selected; top up and confirm the transaction appears in both the panel and the Credits timeline.

## Screenshots

Wallet panel opens from the composer balance chip; Credits page balance card and timeline match its styling.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+