### PR TITLE
Remote provider hardening: crash/hang fixes, endpoint trust, Router spend safety, streaming perf

### DIFF
--- a/Packages/OsaurusCore/Managers/InsightsService.swift
+++ b/Packages/OsaurusCore/Managers/InsightsService.swift
@@ -473,6 +473,39 @@ extension InsightsService {
         )
     }()
 
+    /// Upstream-provider credential regexes. The log ring buffer can capture
+    /// chat bodies forwarded to remote providers, and the request/response
+    /// detail pane echoes headers, so an Authorization/x-api-key header or an
+    /// `sk-`/JWT-shaped value could otherwise land in the buffer verbatim.
+    /// These mirror `ProviderDiagnosticRedactor` so the local log holds to the
+    /// same "no third-party secrets at rest" bar as the provider diagnostics.
+    private nonisolated static let upstreamRedactors: [(regex: NSRegularExpression, template: String)] = {
+        let specs: [(String, String)] = [
+            // Any Bearer token (not just Osaurus `osk-`): OpenAI/Anthropic/etc.
+            (#"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{8,}"#, "$1<redacted>"),
+            // `sk-…` / `sk-ant-…` style keys (JSON value, header, prose). The
+            // lookbehind keeps this from matching *inside* other token shapes
+            // — notably the `sk-` tail of Osaurus `osk-v1.…` keys, whose bare
+            // prose form is deliberately left alone (see redactor contract).
+            (#"(?<![A-Za-z0-9])sk-[A-Za-z0-9._-]{8,}"#, "<redacted>"),
+            // JSON-Web-Token shaped values (id/access tokens).
+            (#"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#, "<redacted>"),
+            // Header-style secret carriers: `x-api-key: v`, `api-key=v`,
+            // `x-goog-api-key: v`, and stringified `"authorization": "v"`.
+            // `Bearer …` authorization values are excluded: the Bearer regex
+            // above already scrubbed the token and must keep the scheme word
+            // visible (`Bearer <redacted>`), so redacting the first token of
+            // the value here would just eat the word "Bearer".
+            (
+                #"(?i)("?(?:x-api-key|x-goog-api-key|api-key|authorization)"?\s*[:=]\s*"?)(?!bearer\b)[^"\s,;}]+"#,
+                "$1<redacted>"
+            ),
+        ]
+        return specs.compactMap { pattern, template in
+            (try? NSRegularExpression(pattern: pattern, options: [])).map { ($0, template) }
+        }
+    }()
+
     /// Internal so tests can verify the redactor's surface independent of
     /// the ring buffer plumbing.
     nonisolated static func redactCredentials(_ body: String) -> String {
@@ -492,6 +525,14 @@ extension InsightsService {
                 options: [],
                 range: nsRange(redacted),
                 withTemplate: "\"<redacted>\""
+            )
+        }
+        for (regex, template) in upstreamRedactors {
+            redacted = regex.stringByReplacingMatches(
+                in: redacted,
+                options: [],
+                range: nsRange(redacted),
+                withTemplate: template
             )
         }
         return redacted

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import Foundation
+import Network
 
 /// Notification posted when remote provider connection status changes
 extension Foundation.Notification.Name {
@@ -82,6 +83,7 @@ public final class RemoteProviderManager: ObservableObject {
         }
 
         registerIdentityAndActivationObservers()
+        startNetworkRecoveryMonitor()
     }
 
     /// Test seam: overrides `OsaurusIdentity.exists()` for the identity-gated
@@ -323,7 +325,9 @@ public final class RemoteProviderManager: ObservableObject {
                     discoveredModels = discovery.models
                     osaurusRouterModelCatalog = discovery.catalog
                 } else {
-                    discoveredModels = try await RemoteProviderService.fetchModels(from: provider)
+                    discoveredModels = try await withRateLimitRetry {
+                        try await RemoteProviderService.fetchModels(from: provider)
+                    }
                 }
             } catch {
                 if provider.providerType == .azureOpenAI && !provider.manualModelIds.isEmpty {
@@ -348,6 +352,13 @@ public final class RemoteProviderManager: ObservableObject {
                 cachedOAuthTokens: cachedOAuthTokens
             )
             services[providerId] = service
+            if provider.providerType == .osaurusRouter {
+                // Push the vision-capability set so the service can gate
+                // multimodal user content per model on the Router wire.
+                await service.updateOsaurusRouterVisionModels(
+                    Self.visionModelIds(in: osaurusRouterModelCatalog)
+                )
+            }
 
             // Update state to connected
             state.isConnecting = false
@@ -356,6 +367,8 @@ public final class RemoteProviderManager: ObservableObject {
             state.lastConnectedAt = Date()
             state.lastError = nil
             state.lastReplayDiagnostics = nil
+            state.lastFailureWasTransient = false
+            state.requiresAuth = false
             providerStates[providerId] = state
 
             print("[Osaurus] Remote Provider '\(provider.name)': Connected with \(models.count) models")
@@ -364,6 +377,15 @@ public final class RemoteProviderManager: ObservableObject {
             notifyModelsChanged()
 
         } catch {
+            // Dead OAuth tokens (invalid_grant / 401): clear them and set the
+            // durable requiresAuth state instead of a generic connect error.
+            if Self.isPermanentOAuthFailure(error) {
+                handlePermanentOAuthFailure(providerId: providerId)
+                print(
+                    "[Osaurus] Remote Provider '\(provider.name)': OAuth refresh failed permanently — sign-in required"
+                )
+                throw error
+            }
             let errorMessage = userFacingErrorMessage(error, for: provider)
             // Update state with error
             state.isConnecting = false
@@ -371,6 +393,7 @@ public final class RemoteProviderManager: ObservableObject {
             state.lastError = errorMessage
             state.lastReplayDiagnostics = (error as? RemoteProviderServiceError)?.replayDiagnostics
             state.discoveredModels = []
+            state.lastFailureWasTransient = Self.isTransientConnectError(error)
             providerStates[providerId] = state
 
             // Clean up — invalidate URLSession before discarding
@@ -420,18 +443,36 @@ public final class RemoteProviderManager: ObservableObject {
     /// Connect to all enabled providers on app launch
     public func connectEnabledProviders() async {
         ensureManagedOsaurusRouterProviderIfNeeded()
-        for provider in configuration.enabledProviders {
-            // The managed Osaurus Router gets bounded retry so a transient
-            // launch failure (offline, server 5xx, cold start) doesn't leave
-            // the model picker without Osaurus options until a manual refresh.
-            if provider.id == Self.osaurusRouterProviderId {
-                await connectOsaurusRouterWithRetry()
-                continue
-            }
-            do {
-                try await connect(providerId: provider.id)
-            } catch {
-                print("[Osaurus] Failed to auto-connect to '\(provider.name)': \(error)")
+        // Honor the per-provider "Auto-connect" setting: only providers the
+        // user left enabled AND auto-connect connect at launch. A provider
+        // that is enabled but has auto-connect off stays dormant until the
+        // user (or the model picker) connects it explicitly. The managed
+        // Osaurus Router keeps `autoConnect: true`, so it's still included.
+        //
+        // Connects run in parallel: model discovery is network-bound and
+        // `connect`'s awaits suspend off the main actor, so N providers reach
+        // the picker in ~max(latency) instead of sum(latency) — and the
+        // router's bounded retry backoff no longer delays every other
+        // provider behind it. State writes stay on @MainActor inside
+        // `connect` itself.
+        await withTaskGroup(of: Void.self) { group in
+            for provider in configuration.autoConnectProviders {
+                // The managed Osaurus Router gets bounded retry so a transient
+                // launch failure (offline, server 5xx, cold start) doesn't leave
+                // the model picker without Osaurus options until a manual refresh.
+                if provider.id == Self.osaurusRouterProviderId {
+                    group.addTask { await self.connectOsaurusRouterWithRetry() }
+                    continue
+                }
+                let providerId = provider.id
+                let providerName = provider.name
+                group.addTask {
+                    do {
+                        try await self.connect(providerId: providerId)
+                    } catch {
+                        print("[Osaurus] Failed to auto-connect to '\(providerName)': \(error)")
+                    }
+                }
             }
         }
     }
@@ -512,7 +553,7 @@ public final class RemoteProviderManager: ObservableObject {
             } catch {
                 // Stop on terminal errors or once attempts are exhausted.
                 guard Self.isTransientConnectError(error), attempt < attempts else { return }
-                await routerRetryBackoff(forAttempt: attempt)
+                await routerRetryBackoff(forAttempt: attempt, after: error)
                 // Another path (picker/credits/activation/identity event) may
                 // have connected while we waited — don't pile on a duplicate.
                 if providerStates[Self.osaurusRouterProviderId]?.isConnected == true { return }
@@ -520,13 +561,72 @@ public final class RemoteProviderManager: ObservableObject {
         }
     }
 
-    /// Exponential backoff between router connect attempts; honors the test seam.
-    private func routerRetryBackoff(forAttempt attempt: Int) async {
-        let delay = Self.osaurusRouterConnectRetryBaseDelay * pow(2.0, Double(attempt - 1))
+    /// Backoff between router connect attempts: exponential, but never shorter
+    /// than the server's `Retry-After` hint when the failure was a typed
+    /// rate-limit (retrying earlier would just burn an attempt on a guaranteed
+    /// 429). Capped at `connectRateLimitMaxDelay` so a hostile hint can't pin
+    /// the connect task. Honors the test seam.
+    private func routerRetryBackoff(forAttempt attempt: Int, after error: Error? = nil) async {
+        let backoff = Self.osaurusRouterConnectRetryBaseDelay * pow(2.0, Double(attempt - 1))
+        let delay = min(
+            max(Self.retryAfterHint(from: error) ?? 0, backoff),
+            Self.connectRateLimitMaxDelay
+        )
         if let testRetrySleepOverride {
             await testRetrySleepOverride(delay)
         } else {
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+    }
+
+    /// Extract a server-provided Retry-After hint from a typed rate-limit
+    /// error, in seconds. Nil for every other error shape.
+    static func retryAfterHint(from error: Error?) -> TimeInterval? {
+        if let serviceError = error as? RemoteProviderServiceError,
+            case .rateLimited(let retryAfter, _) = serviceError
+        {
+            return retryAfter
+        }
+        if let routerError = error as? OsaurusRouterAPIError,
+            case .rateLimited(let retryAfter) = routerError
+        {
+            return retryAfter.flatMap(TimeInterval.init)
+        }
+        return nil
+    }
+
+    /// Total attempts (including the first) for the connect-phase model
+    /// discovery request when the provider answers 429/503.
+    static let connectRateLimitMaxAttempts = 3
+    /// Ceiling on any single Retry-After / backoff wait during connect, so a
+    /// hostile or misconfigured `Retry-After: 86400` can't pin the connect
+    /// task for a day.
+    static let connectRateLimitMaxDelay: TimeInterval = 15
+
+    /// Bounded retry for the *idempotent* connect-phase discovery request.
+    /// Retries only on the typed `.rateLimited` error (429, or 503 from the
+    /// discovery GET), waiting `max(Retry-After, exponential backoff)` capped
+    /// at `connectRateLimitMaxDelay`. Everything else propagates immediately.
+    func withRateLimitRetry<T: Sendable>(
+        _ operation: @MainActor () async throws -> T
+    ) async throws -> T {
+        var attempt = 1
+        while true {
+            do {
+                return try await operation()
+            } catch let error as RemoteProviderServiceError {
+                guard case .rateLimited(let retryAfter, _) = error,
+                    attempt < Self.connectRateLimitMaxAttempts
+                else { throw error }
+                let backoff = Self.osaurusRouterConnectRetryBaseDelay * pow(2.0, Double(attempt - 1))
+                let delay = min(max(retryAfter ?? backoff, backoff), Self.connectRateLimitMaxDelay)
+                if let testRetrySleepOverride {
+                    await testRetrySleepOverride(delay)
+                } else {
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                }
+                attempt += 1
+            }
         }
     }
 
@@ -559,14 +659,53 @@ public final class RemoteProviderManager: ObservableObject {
         }
         if let serviceError = error as? RemoteProviderServiceError {
             switch serviceError {
-            case .invalidResponse:
+            case .invalidResponse, .rateLimited:
                 return true
             case .invalidURL, .notConnected, .requestFailed, .requestFailedWithDiagnostics,
-                .streamingError, .noModelsAvailable:
+                .streamingError, .noModelsAvailable, .unsupportedParameter:
                 return false
             }
         }
         return false
+    }
+
+    /// True when an OAuth token-refresh failure means the stored tokens are
+    /// permanently dead (`invalid_grant` / `invalid_token` on HTTP 400/401)
+    /// and the user must sign in again. Mirrors
+    /// `MCPOAuthService.isPermanentAuthFailure` for the remote-provider OAuth
+    /// flavors (Codex, xAI). Errors from those services carry the upstream
+    /// status/body in their message (e.g. "HTTP 400: {\"error\":\"invalid_grant\"}").
+    nonisolated static func isPermanentOAuthFailure(_ error: Error) -> Bool {
+        let message: String
+        switch error {
+        case OpenAICodexOAuthError.tokenRequestFailed(let m): message = m
+        case XAIOAuthError.tokenRequestFailed(let m): message = m
+        default: return false
+        }
+        let lowered = message.lowercased()
+        guard lowered.contains("http 400") || lowered.contains("http 401") else { return false }
+        return lowered.contains("invalid_grant") || lowered.contains("invalid_token")
+    }
+
+    /// Permanent OAuth failure: clear the dead tokens and set a durable
+    /// `requiresAuth` state so the UI offers "Sign in again" instead of an
+    /// error message that retrying can never fix. Mirrors
+    /// `MCPProviderManager.handlePermanentOAuthFailure`.
+    public func handlePermanentOAuthFailure(providerId: UUID) {
+        RemoteProviderKeychain.deleteOAuthTokens(for: providerId)
+        if let service = services.removeValue(forKey: providerId) {
+            Task { await service.invalidateSession() }
+        }
+        var state = providerStates[providerId] ?? RemoteProviderState(providerId: providerId)
+        state.requiresAuth = true
+        state.isConnected = false
+        state.isConnecting = false
+        state.lastError = L("Session expired — please sign in again.")
+        state.lastFailureWasTransient = false
+        state.discoveredModels = []
+        providerStates[providerId] = state
+        notifyStatusChanged()
+        notifyModelsChanged()
     }
 
     /// Observe identity creation/wipe and app re-activation so the managed
@@ -616,6 +755,62 @@ public final class RemoteProviderManager: ObservableObject {
         await connectOsaurusRouterIfPossible()
     }
 
+    // MARK: - Network-recovery auto-reconnect
+
+    /// Path monitor driving auto-reconnect: when connectivity returns after an
+    /// outage, providers whose last connect failed *transiently* (see
+    /// `RemoteProviderState.lastFailureWasTransient`) are reconnected without
+    /// waiting for app re-activation or a manual toggle.
+    private nonisolated(unsafe) var networkPathMonitor: NWPathMonitor?
+    /// Last observed satisfied-ness; reconnects fire only on the
+    /// unsatisfied → satisfied edge, never on the initial baseline reading or
+    /// on repeated satisfied updates (interface changes, DNS churn, …).
+    private var lastNetworkPathWasSatisfied: Bool?
+    private var networkRecoveryTask: Task<Void, Never>?
+
+    private func startNetworkRecoveryMonitor() {
+        let monitor = NWPathMonitor()
+        networkPathMonitor = monitor
+        monitor.pathUpdateHandler = { [weak self] path in
+            let satisfied = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                self?.handleNetworkPathUpdate(satisfied: satisfied)
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "ai.osaurus.provider.pathmonitor"))
+    }
+
+    private func handleNetworkPathUpdate(satisfied: Bool) {
+        defer { lastNetworkPathWasSatisfied = satisfied }
+        // Only the recovery edge matters: we must have previously seen the
+        // network down, and now see it up.
+        guard satisfied, lastNetworkPathWasSatisfied == false else { return }
+        // Debounce flapping paths — replace any in-flight sweep.
+        networkRecoveryTask?.cancel()
+        networkRecoveryTask = Task { [weak self] in
+            // Give routing/DNS a moment to settle after the path flips; an
+            // immediate connect after wake often fails on stale DNS.
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
+            await self?.reconnectTransientlyFailedProviders()
+        }
+    }
+
+    /// Reconnect every auto-connect provider whose last failure was transient
+    /// and which isn't connected or mid-connect. Sequential like the launch
+    /// path; each `connect` re-evaluates state so concurrent triggers stay
+    /// idempotent.
+    func reconnectTransientlyFailedProviders() async {
+        for provider in configuration.autoConnectProviders {
+            guard !Task.isCancelled else { return }
+            let state = providerStates[provider.id]
+            guard state?.isConnected != true, state?.isConnecting != true,
+                state?.lastFailureWasTransient == true
+            else { continue }
+            try? await connect(providerId: provider.id)
+        }
+    }
+
     private var refreshConnectedTask: Task<Void, Never>?
 
     /// Connect kicked off by `setOsaurusRouterEnabled(true)`. Retained so tests
@@ -652,6 +847,11 @@ public final class RemoteProviderManager: ObservableObject {
                 // Refresh metadata even when the id set is unchanged: pricing or
                 // capabilities may have moved without a new/removed model.
                 osaurusRouterModelCatalog = discovery.catalog
+                if let service = services[providerId] {
+                    await service.updateOsaurusRouterVisionModels(
+                        Self.visionModelIds(in: discovery.catalog)
+                    )
+                }
             } else {
                 discovered = try await RemoteProviderService.fetchModels(from: provider)
             }
@@ -781,6 +981,13 @@ public final class RemoteProviderManager: ObservableObject {
     /// the only caller (`ModelPickerItemCache`) lives in this module.
     func osaurusRouterMetadata(for unprefixedModelId: String) -> OsaurusRouterModel? {
         osaurusRouterModelCatalog[unprefixedModelId]
+    }
+
+    /// Unprefixed model ids in `catalog` that advertise image/vision input.
+    /// Pushed to the router's `RemoteProviderService` so the wire layer can
+    /// keep user media multimodal only for models that accept it.
+    nonisolated static func visionModelIds(in catalog: [String: OsaurusRouterModel]) -> Set<String> {
+        Set(catalog.compactMap { id, model in model.supportsVision ? id : nil })
     }
 
     /// Find the service that handles a given model

--- a/Packages/OsaurusCore/Models/API/GeminiAPI.swift
+++ b/Packages/OsaurusCore/Models/API/GeminiAPI.swift
@@ -233,6 +233,11 @@ struct GeminiGenerationConfig: Codable, Sendable {
     let stopSequences: [String]?
     let responseModalities: [String]?
     let imageConfig: GeminiImageConfig?
+    /// Deterministic-sampling seed (maps OpenAI `seed`).
+    var seed: Int? = nil
+    /// `"application/json"` for JSON mode (maps OpenAI
+    /// `response_format: {type: json_object}`).
+    var responseMimeType: String? = nil
 }
 
 // MARK: - Response Models

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -723,6 +723,12 @@ struct ChatCompletionRequest: Codable, Sendable {
     /// `{"include_usage": true}` instructs the SSE producer to emit a
     /// final chunk carrying `usage` (prompt/completion/total tokens).
     var stream_options: StreamOptions? = nil
+    /// OpenAI `logprobs`/`top_logprobs`. Neither local MLX decode nor the
+    /// remote proxy surfaces token log-probabilities, so these are decoded
+    /// purely for request validation: a truthy value is rejected with a
+    /// typed 400 instead of being silently dropped.
+    var logprobs: Bool? = nil
+    var top_logprobs: Int? = nil
     /// Model-specific options from the active ModelProfile (not serialized to JSON).
     var modelOptions: [String: ModelOptionValue]? = nil
     /// Optional TTFT trace for diagnostic timing (not serialized to JSON).
@@ -795,6 +801,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         case frequency_penalty, presence_penalty, stop, n
         case tools, tool_choice, session_id
         case seed, response_format, stream_options
+        case logprobs, top_logprobs
         case enable_thinking, reasoning_effort
     }
 
@@ -833,6 +840,8 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.remoteAgentProviderId = remoteAgentProviderId
         copy.suppressProgressUI = suppressProgressUI
         copy.warmupPrefill = warmupPrefill
+        copy.logprobs = logprobs
+        copy.top_logprobs = top_logprobs
         return copy
     }
 
@@ -875,6 +884,8 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.remoteAgentProviderId = remoteAgentProviderId
         copy.suppressProgressUI = suppressProgressUI
         copy.warmupPrefill = warmupPrefill
+        copy.logprobs = logprobs
+        copy.top_logprobs = top_logprobs
         return copy
     }
 }
@@ -913,6 +924,8 @@ extension ChatCompletionRequest {
         seed = try container.decodeIfPresent(Int.self, forKey: .seed)
         response_format = try container.decodeIfPresent(ResponseFormat.self, forKey: .response_format)
         stream_options = try container.decodeIfPresent(StreamOptions.self, forKey: .stream_options)
+        logprobs = try container.decodeIfPresent(Bool.self, forKey: .logprobs)
+        top_logprobs = try container.decodeIfPresent(Int.self, forKey: .top_logprobs)
         enable_thinking = try container.decodeIfPresent(Bool.self, forKey: .enable_thinking)
         reasoning_effort = try container.decodeIfPresent(String.self, forKey: .reasoning_effort)
     }

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -166,11 +166,15 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     public var disableTimeout: Bool
     public var manualModelIds: [String]
 
-    /// Sentinel applied at runtime when `disableTimeout` is set. Finite by design:
-    /// `.infinity` / `.greatestFiniteMagnitude` would crash the streaming path
-    /// (`UInt64(timeout * 1e9)` overflows) and can't be JSON encoded. One year is
-    /// no limit for any real request while staying safely within those bounds.
-    public static let unboundedTimeout: TimeInterval = 60 * 60 * 24 * 365
+    /// Hard ceiling applied at runtime when `disableTimeout` is set. "No
+    /// timeout" is a UX statement about generation length, not a license for
+    /// a dead peer holding an open socket to pin a request task forever — so
+    /// the connect / request / stream-inactivity limits stay finite at 24
+    /// hours, which no legitimate single turn approaches. Finite is also
+    /// structurally required: `.infinity` / `.greatestFiniteMagnitude` would
+    /// crash the streaming path (`UInt64(timeout * 1e9)` overflows) and can't
+    /// be JSON encoded.
+    public static let unboundedTimeout: TimeInterval = 60 * 60 * 24
 
     // Keys for headers that should be stored in Keychain (not persisted in config)
     public var secretHeaderKeys: [String]
@@ -457,6 +461,19 @@ public struct RemoteProviderState: Sendable {
     public var lastReplayDiagnostics: ProviderReplayDiagnosticBundle?
     public var discoveredModels: [String]
     public var lastConnectedAt: Date?
+    /// True when the most recent connect attempt failed for a *transient*
+    /// reason (offline, timeout, DNS/TLS, server 5xx) rather than a terminal
+    /// one (auth, bad config). Drives network-recovery auto-reconnect so a
+    /// provider that failed while the machine was offline comes back on its
+    /// own when connectivity returns, without hammering providers whose keys
+    /// or endpoints are actually wrong.
+    public var lastFailureWasTransient: Bool
+    /// True when the provider's OAuth refresh failed permanently
+    /// (`invalid_grant` / 401): the stored tokens have been cleared and the
+    /// user must sign in again. Mirrors `MCPProviderState.requiresAuth` so
+    /// the UI can show a durable "Sign in again" affordance instead of a
+    /// transient connection error that retries can never fix.
+    public var requiresAuth: Bool
 
     public init(providerId: UUID) {
         self.providerId = providerId
@@ -466,6 +483,8 @@ public struct RemoteProviderState: Sendable {
         self.lastReplayDiagnostics = nil
         self.discoveredModels = []
         self.lastConnectedAt = nil
+        self.lastFailureWasTransient = false
+        self.requiresAuth = false
     }
 
     public var modelCount: Int {

--- a/Packages/OsaurusCore/Networking/HTTPCallerContext.swift
+++ b/Packages/OsaurusCore/Networking/HTTPCallerContext.swift
@@ -1,0 +1,25 @@
+//
+//  HTTPCallerContext.swift
+//  OsaurusCore
+//
+//  Task-local description of the HTTP caller whose request task is currently
+//  executing. Bound by `HTTPHandler.runRequestTask` for every request task the
+//  local server spawns, and absent everywhere else (app chat, plugins,
+//  evaluators, warmup). Downstream gates use it to distinguish "this inference
+//  was triggered by an inbound HTTP request" — and whether that caller proved
+//  possession of a valid Osaurus access key — from app-internal work, without
+//  threading a flag through every request struct.
+//
+
+import Foundation
+
+struct HTTPCallerContext: Sendable {
+    /// `true` when the caller presented a Bearer token that validated against
+    /// the configured access keys. Non-loopback callers can only reach a
+    /// handler with a valid key (the global auth gate rejects them otherwise);
+    /// loopback callers skip the gate, so this is `true` for them only when
+    /// they volunteered a key that validated.
+    let hasVerifiedAccessKey: Bool
+
+    @TaskLocal static var current: HTTPCallerContext?
+}

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -238,6 +238,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         /// all-agent key. Agent-scoped keys (`false`) are confined to their
         /// own agent's routes.
         var authedScopeIsMaster: Bool = false
+        /// `true` when the caller presented a Bearer token that validated
+        /// against the configured access keys. Set by the global auth gate
+        /// (non-loopback) or by the opportunistic loopback validation, and
+        /// carried into request tasks via `HTTPCallerContext` so credit-spend
+        /// gates (Osaurus Router) can tell keyed callers from key-less
+        /// loopback-trusted ones.
+        var callerHasVerifiedAccessKey: Bool = false
         /// Set when the request arrived as an encrypted `/secure/call`
         /// envelope and was rewritten to its inner request. Routes that
         /// hard-require end-to-end encryption (`/agents/{id}/run`,
@@ -308,9 +315,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let id = UUID()
         let requestTasks = requestTasks
         let operationBox = RequestTaskOperation(operation)
+        // Snapshot the caller's auth proof (event-loop-only state) into a
+        // task-local so downstream gates — ChatEngine's Osaurus Router
+        // credit-spend gate in particular — can tell keyed HTTP callers from
+        // key-less loopback-trusted ones without threading a flag through
+        // every request struct.
+        let callerContext = HTTPCallerContext(
+            hasVerifiedAccessKey: stateRef.value.callerHasVerifiedAccessKey
+        )
         let task = Task(priority: priority) {
             defer { requestTasks.remove(id: id) }
-            await operationBox.run()
+            await HTTPCallerContext.$current.withValue(callerContext) {
+                await operationBox.run()
+            }
         }
         channelCloseFuture.snapshot()?.whenComplete { _ in
             task.cancel()
@@ -330,6 +347,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             stateRef.value.isSecureChannel = false
             stateRef.value.authedAudience = nil
             stateRef.value.authedScopeIsMaster = false
+            stateRef.value.callerHasVerifiedAccessKey = false
             // Clear last request's attribution so a keep-alive connection's
             // next (possibly loopback / public) request can't inherit it.
             _inboundConnection.value = nil
@@ -500,6 +518,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     switch result {
                     case .valid(_, let audience, let keyNonce):
                         message = ""
+                        stateRef.value.callerHasVerifiedAccessKey = true
                         // Record the key's scope so agent-addressing routes can
                         // confine an agent-scoped key to its own agent.
                         stateRef.value.authedAudience = audience.lowercased()
@@ -546,6 +565,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     stateRef.value.requestHead = nil
                     stateRef.value.requestBodyBuffer = nil
                     return
+                }
+            }
+
+            // Loopback callers skip the auth gate entirely, but some
+            // downstream gates (Osaurus Router credit spend) require proof of
+            // a valid access key. Validate a volunteered Bearer token
+            // opportunistically — never rejecting the request, and never
+            // setting `authedAudience` (loopback trust must not suddenly gain
+            // agent-scope confinement just because a key was offered).
+            if isLoopback, !stateRef.value.callerHasVerifiedAccessKey {
+                let authHeader = head.headers.first(name: "Authorization") ?? ""
+                if authHeader.hasPrefix("Bearer ") {
+                    let token = String(authHeader.dropFirst(7))
+                    if case .valid = apiKeyValidator.validate(rawKey: token) {
+                        stateRef.value.callerHasVerifiedAccessKey = true
+                    }
                 }
             }
 
@@ -4760,6 +4795,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 Task { await ModelRuntime.shared.cancelGeneration(name: m) }
             }
         }
+        // Billing dedupe base for Router-bound loop steps: header-supplied or
+        // synthesized. Each loop iteration derives a per-step key from it.
+        let idempotencyBase = Self.httpIdempotencyKey(head: head)
 
         runRequestTask(priority: .userInitiated) {
             defer { admissionToken.release() }
@@ -5072,6 +5110,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // emits; later tool-result iterations are skipped by the
                     // engine's de-dup rule.
                     iterationReq.isAgentRequest = true
+                    // Per-step Router billing dedupe: the message count is
+                    // stable per logical step (tool loops append messages
+                    // between steps) and reproducible on a client retry of
+                    // the same run, so the derived key dedupes a re-POST of
+                    // any step without ever colliding across steps.
+                    iterationReq.idempotencyKey = "\(idempotencyBase)-s\(msgs.count)"
 
                     responseContent = ""
                     var contentCoalescer = Self.StreamDeltaCoalescer(
@@ -7149,6 +7193,23 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         return nil
     }
 
+    /// Resolve the billing idempotency key for an HTTP-origin inference
+    /// request. Honors a client-supplied `Idempotency-Key` header so
+    /// CLI/script retries of the same logical request dedupe Osaurus Router
+    /// billing on a re-POST; otherwise synthesizes a per-request key so the
+    /// provider service's idempotent connect-phase retries still dedupe.
+    /// The key rides only the Router wire (in the signed body — see
+    /// `RemoteProviderService.buildChatRequest`); no other upstream sees it.
+    nonisolated static func httpIdempotencyKey(head: HTTPRequestHead) -> String {
+        if let header = head.headers.first(name: "Idempotency-Key")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !header.isEmpty, header.count <= 128
+        {
+            return header
+        }
+        return "http-\(UUID().uuidString)"
+    }
+
     private func handleChatCompletions(
         head: HTTPRequestHead,
         context: ChannelHandlerContext,
@@ -7228,6 +7289,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         #endif
         let httpTrace = HTTPTraceRecorder(ttftTrace)
         req.ttftTrace = ttftTrace
+        // Billing dedupe for Router-bound requests: header-supplied or
+        // synthesized (see `httpIdempotencyKey`). Chat-UI requests set their
+        // own per-step key; HTTP-origin requests previously had none, so a
+        // client retry could double-bill.
+        req.idempotencyKey = Self.httpIdempotencyKey(head: head)
         httpTrace.mark("http_request_decoded")
         httpTrace.set("endpoint", "/chat/completions")
         httpTrace.set("model", model)
@@ -7919,7 +7985,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             requestBodyString = nil
         }
 
-        guard let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: data) else {
+        guard var decodedReq = try? JSONDecoder().decode(ChatCompletionRequest.self, from: data) else {
             sendResponse(
                 context: context,
                 version: head.version,
@@ -7938,6 +8004,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             )
             return
         }
+        decodedReq.idempotencyKey = Self.httpIdempotencyKey(head: head)
+        let req = decodedReq
 
         guard
             let admissionToken = acquireInferenceAdmissionOrReject(
@@ -8341,7 +8409,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             messages.append(ChatMessage(role: "system", content: system))
         }
         messages.append(ChatMessage(role: "user", content: ollama.prompt))
-        let chatRequest = ChatCompletionRequest(
+        var chatRequestDraft = ChatCompletionRequest(
             model: ollama.model,
             messages: messages,
             temperature: ollama.options?.temperature,
@@ -8356,6 +8424,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             tool_choice: nil,
             session_id: nil
         )
+        chatRequestDraft.idempotencyKey = Self.httpIdempotencyKey(head: head)
+        let chatRequest = chatRequestDraft
 
         guard
             let admissionToken = acquireInferenceAdmissionOrReject(
@@ -8728,7 +8798,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     nonisolated static func unsupportedSamplerReason(_ req: ChatCompletionRequest) -> String? {
         RequestValidator.unsupportedSamplerReason(
             n: req.n,
-            responseFormatType: req.response_format?.type
+            responseFormatType: req.response_format?.type,
+            logprobs: req.logprobs,
+            topLogprobs: req.top_logprobs
         )
     }
 
@@ -9738,7 +9810,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
 
         // Convert to internal format
-        let internalReq = anthropicReq.toChatCompletionRequest()
+        var internalReq = anthropicReq.toChatCompletionRequest()
+        internalReq.idempotencyKey = Self.httpIdempotencyKey(head: head)
 
         // Generate response ID
         let messageId = Self.shortId(prefix: "msg_")
@@ -10505,10 +10578,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         // Convert to internal format, preserving local Responses API
         // context when clients chain turns with `previous_response_id`.
-        let internalReq = Self.applyOpenResponsesContext(
+        var internalReq = Self.applyOpenResponsesContext(
             to: openResponsesReq.toChatCompletionRequest(),
             previousResponseId: openResponsesReq.previous_response_id
         )
+        internalReq.idempotencyKey = Self.httpIdempotencyKey(head: head)
 
         // Determine if streaming
         let wantsStream = openResponsesReq.stream ?? false

--- a/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
+++ b/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
@@ -717,6 +717,13 @@ public final class RelayTunnelManager: ObservableObject {
     ) -> URLRequest? {
         guard let url = URL(string: "http://127.0.0.1:\(localPort)\(frame.path)") else { return nil }
         var request = URLRequest(url: url)
+        // Explicit ceiling for the loopback hop. `URLSession.shared` would
+        // otherwise apply its 60s idle default — too tight for long local
+        // generation/tool turns — while an unbounded value would let a wedged
+        // local handler pin the proxy task (and its in-flight slot) forever.
+        // One hour of *idleness* (the timer resets on every received byte) is
+        // far beyond any legitimate silent stretch of a local run.
+        request.timeoutInterval = 60 * 60
         request.httpMethod = frame.method
         for (key, value) in frame.headers {
             request.setValue(value, forHTTPHeaderField: key)

--- a/Packages/OsaurusCore/Networking/RequestValidator.swift
+++ b/Packages/OsaurusCore/Networking/RequestValidator.swift
@@ -24,7 +24,9 @@ public enum RequestValidator {
     /// human-readable explanation suitable for the 400 body.
     public static func unsupportedSamplerReason(
         n: Int?,
-        responseFormatType: String?
+        responseFormatType: String?,
+        logprobs: Bool? = nil,
+        topLogprobs: Int? = nil
     ) -> String? {
         if let n, n > 1 {
             return "Parameter 'n' > 1 is not supported. Submit one request per completion."
@@ -37,6 +39,15 @@ public enum RequestValidator {
                 return
                     "response_format type '\(type)' is not supported. Use 'json_object' for JSON mode."
             }
+        }
+        // Neither local MLX decode nor the remote provider proxy surfaces
+        // token log-probabilities; reject explicitly instead of returning a
+        // response that silently lacks the requested field.
+        if logprobs == true {
+            return "Parameter 'logprobs' is not supported."
+        }
+        if let topLogprobs, topLogprobs > 0 {
+            return "Parameter 'top_logprobs' is not supported."
         }
         return nil
     }

--- a/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
@@ -43,10 +43,14 @@
 //      The ML re-scan covers `Send anyway` semantics: skipping a
 //      person/address/secret entity still blocks the send, since
 //      the post-scrub invariant uses the model not just regex.
-//    * Non-interactive caller (HTTP, plugin, agent) with no
-//      review presenter and `requireReviewForNonInteractive`
-//      enabled → `PrivacyReviewService.review` returns `.canceled`,
-//      which the pipeline lifts into `reviewCanceled`.
+//    * Non-interactive caller (HTTP, plugin, P2P — by request
+//      source, or any caller with no review presenter) with
+//      `requireReviewForNonInteractive` enabled →
+//      `PrivacyReviewService.review` returns
+//      `.blockedNonInteractive`, which the pipeline lifts into the
+//      typed `reviewRequiresInteractive` error (422 on the wire).
+//      Non-UI origins never suspend on the review sheet, even when
+//      a chat window has a presenter registered.
 //
 //  Inbound paths (`wrapInboundStream` / `unscrubInbound`) are
 //  separately documented but the same rule applies: never let a
@@ -92,6 +96,14 @@ enum PrivacyFilterPipelineError: Error, Equatable, LocalizedError {
     /// ever leaving this process. Send is blocked.
     case scrubLeaked(categoryCounts: [EntityCategory: Int])
 
+    /// A non-interactive caller (HTTP API, plugin, P2P) hit fresh PII
+    /// detections while `requireReviewForNonInteractive` is on. There
+    /// is no legitimate way to drive the review sheet for a request
+    /// the user didn't send from the chat window, so the send is
+    /// blocked with an actionable message instead of hanging the
+    /// client on a sheet (or silently auto-approving).
+    case reviewRequiresInteractive(detectionCount: Int)
+
     var errorDescription: String? {
         switch self {
         case .reviewCanceled:
@@ -104,6 +116,9 @@ enum PrivacyFilterPipelineError: Error, Equatable, LocalizedError {
                 "Privacy Filter: \(count) approved redaction(s) didn't apply (substitution mismatch). The message was not sent. This is a bug — please report."
         case .scrubLeaked(let counts):
             return Self.formatScrubLeaked(categoryCounts: counts)
+        case .reviewRequiresInteractive(let count):
+            return
+                "Privacy Filter detected \(count) item(s) of PII in this request. Non-interactive requests (HTTP API, plugins) cannot show the review sheet, so the send was blocked. Approve redactions in the Osaurus chat first, disable 'Require review for non-interactive requests' in Settings → Privacy, or disable the filter for this provider."
         }
     }
 
@@ -117,6 +132,7 @@ enum PrivacyFilterPipelineError: Error, Equatable, LocalizedError {
         case .engineUnavailable: return "privacy_filter_engine_unavailable"
         case .scrubNoOp: return "privacy_filter_scrub_no_op"
         case .scrubLeaked: return "privacy_filter_scrub_leaked"
+        case .reviewRequiresInteractive: return "privacy_filter_review_required"
         }
     }
 
@@ -129,7 +145,7 @@ enum PrivacyFilterPipelineError: Error, Equatable, LocalizedError {
         switch self {
         case .reviewCanceled: return 499  // client-closed-request analog
         case .engineUnavailable: return 503
-        case .scrubNoOp, .scrubLeaked: return 422
+        case .scrubNoOp, .scrubLeaked, .reviewRequiresInteractive: return 422
         }
     }
 
@@ -272,10 +288,20 @@ enum PrivacyFilterPipeline {
     /// Throws `PrivacyFilterPipelineError.reviewCanceled` when the
     /// user dismisses the redaction review sheet. Callers must catch
     /// this and abort the send.
+    ///
+    /// `requestSource` gates interactive review by origin: only
+    /// `.chatUI` requests may suspend on the review sheet. HTTP API,
+    /// plugin, and P2P requests never present UI — with fresh
+    /// detections they either fail closed
+    /// (`.reviewRequiresInteractive`, the default) or auto-approve
+    /// (when the user disabled `requireReviewForNonInteractive`).
+    /// The default `.httpAPI` is the conservative, never-interactive
+    /// choice for callers that don't thread a source explicitly.
     static func applyOutbound(
         messages: [ChatMessage],
         sessionId: String?,
-        providerId: UUID
+        providerId: UUID,
+        requestSource: RequestSource = .httpAPI
     ) async throws -> (messages: [ChatMessage], map: RedactionMap?) {
         let config = PrivacyFilterStore.snapshot()
         guard config.isEnabled(forProviderId: providerId) else {
@@ -479,19 +505,34 @@ enum PrivacyFilterPipeline {
         }
 
         // Hand only the newly-detected entities to the review service.
-        // When a UI presenter is registered + the session hasn't
-        // opted into auto-approve, this suspends until the user
-        // confirms. The background-caller path (HTTP API, plugin
-        // agents) auto-approves so non-interactive callers don't
-        // deadlock.
+        // Interactive (chat UI) requests suspend on the sheet until
+        // the user confirms; non-interactive origins (HTTP API,
+        // plugin, P2P) never present UI — even when a chat window has
+        // a presenter registered — so a server-origin request can't
+        // hang its client on a sheet the user isn't expecting. They
+        // fail closed (or auto-approve per the settings opt-out).
         let outcome = await PrivacyReviewService.shared.review(
             detections: newDetections,
-            sessionId: sid
+            sessionId: sid,
+            allowInteractive: requestSource == .chatUI
         )
         let approvedFromReview: [DetectedEntity]
         switch outcome {
         case .approved(let entities):
             approvedFromReview = entities
+        case .blockedNonInteractive:
+            // Fail-closed block for a non-UI caller. Same map rollback
+            // as the cancel branch (the interned detections never
+            // shipped), but a distinct typed error so the HTTP client
+            // gets an actionable 422 instead of an ambiguous cancel.
+            let freshOriginals = Set(newDetections.map(\.original))
+            await map.rollbackToSnapshot(
+                removingOriginals: freshOriginals,
+                counters: preDetectionCounters
+            )
+            throw PrivacyFilterPipelineError.reviewRequiresInteractive(
+                detectionCount: newDetections.count
+            )
         case .canceled:
             // User cancelled the send (Cancel button, sheet
             // dismissed, or the awaiting Task was cancelled by the

--- a/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyReviewService.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyReviewService.swift
@@ -29,6 +29,13 @@ enum PrivacyReviewOutcome: Sendable {
     case approved([DetectedEntity])
     /// User canceled — the send should be aborted upstream.
     case canceled
+    /// Fail-closed block for a non-interactive caller: the request
+    /// origin can't drive the review sheet (HTTP API, plugin, P2P — or
+    /// no presenter is registered at all) and
+    /// `requireReviewForNonInteractive` is on. Distinct from
+    /// `.canceled` so the pipeline can surface a typed, actionable
+    /// error to the API client instead of an ambiguous cancel.
+    case blockedNonInteractive
 }
 
 /// Opaque handle returned by `registerPresenter`. The chat window
@@ -88,9 +95,19 @@ final class PrivacyReviewService {
     /// Auto-approves when no presenter is registered, when the global
     /// "always approve" config flag is on, or when the session has
     /// opted into always-approve.
+    ///
+    /// `allowInteractive` is the request-origin gate: HTTP API,
+    /// plugin, and P2P callers pass `false` so a registered chat-window
+    /// presenter is NEVER used for a request the user didn't send from
+    /// that window. Without this, a server-origin request would pop
+    /// the review sheet over an unrelated chat and suspend the HTTP
+    /// response until the user notices — the client just hangs. Those
+    /// callers take the same fail-closed / opt-out branch as the
+    /// no-presenter case.
     func review(
         detections: [DetectedEntity],
-        sessionId: String
+        sessionId: String,
+        allowInteractive: Bool = true
     ) async -> PrivacyReviewOutcome {
         // Short circuit: nothing to review.
         if detections.isEmpty {
@@ -122,25 +139,32 @@ final class PrivacyReviewService {
             }
         }
 
-        guard let presenter = current?.closure else {
-            // No UI attached. Two paths:
+        guard allowInteractive, let presenter = current?.closure else {
+            // No usable UI — either the caller is non-interactive
+            // (HTTP API, plugin, P2P: `allowInteractive == false`) or
+            // no presenter is registered. Two paths:
             //
             //   * `requireReviewForNonInteractive == true` (default): a
             //     background caller (HTTP `/chat/completions`, plugin
             //     agent, headless tool) tried to ship PII through the
-            //     filter. With no UI to confirm, treat this as
-            //     `.canceled` so the pipeline aborts the send instead
-            //     of silently auto-approving. This is the fail-closed
-            //     posture documented in `docs/PRIVACY_FILTER.md`.
+            //     filter. With no UI to confirm, block the send with
+            //     `.blockedNonInteractive` — the pipeline lifts it into
+            //     a typed error instead of silently auto-approving.
+            //     This is the fail-closed posture documented in
+            //     `docs/PRIVACY_FILTER.md`.
             //
             //   * otherwise (power user opt-out): auto-approve so the
             //     send proceeds — same legacy behaviour as before this
             //     flag landed.
             if configSnapshot.requireReviewForNonInteractive {
+                let cause =
+                    allowInteractive
+                    ? "no review presenter is registered"
+                    : "request origin is non-interactive"
                 print(
-                    "[PrivacyFilter] BLOCKING non-interactive send: \(detections.count) detection(s) but no review presenter is registered."
+                    "[PrivacyFilter] BLOCKING non-interactive send: \(detections.count) detection(s) but \(cause)."
                 )
-                return .canceled
+                return .blockedNonInteractive
             }
             return .approved(detections)
         }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -122956,6 +122956,9 @@
         }
       }
     },
+    "Retry in about %llds." : {
+
+    },
     "Retry Load" : {
       "localizations" : {
         "de" : {
@@ -123093,6 +123096,9 @@
           }
         }
       }
+    },
+    "Retry shortly." : {
+
     },
     "Retry starting the server" : {
       "localizations" : {
@@ -133923,6 +133929,9 @@
           }
         }
       }
+    },
+    "Session expired — please sign in again." : {
+
     },
     "session-end (default)" : {
       "localizations" : {
@@ -148586,6 +148595,12 @@
           }
         }
       }
+    },
+    "The provider is temporarily unavailable (HTTP 503)." : {
+
+    },
+    "The provider rate-limited this request (HTTP %lld)." : {
+
     },
     "The receiver who accepted this invite will lose access immediately. Their access key will be revoked." : {
       "localizations" : {

--- a/Packages/OsaurusCore/Services/Auth/OAuthLoopbackServer.swift
+++ b/Packages/OsaurusCore/Services/Auth/OAuthLoopbackServer.swift
@@ -205,6 +205,32 @@ public final class OAuthLoopbackServer: @unchecked Sendable {
         }
     }
 
+    /// Default hard ceiling for browser sign-in flows. Long enough for a user
+    /// to complete MFA, short enough that an abandoned browser tab can't pin
+    /// the sign-in task (and the bound loopback port) forever.
+    public static let defaultSignInTimeout: TimeInterval = 300
+
+    /// Await the authorization callback with a hard deadline. If the browser
+    /// flow is abandoned (tab closed, user walks away), this throws
+    /// `OAuthLoopbackError.callbackTimeout` after `timeout` seconds instead
+    /// of suspending forever. The losing branch is cancelled either way —
+    /// the unbounded `waitForCallback()` resolves through its cancellation
+    /// handler, so no continuation is stranded.
+    public func waitForCallback(timeout: TimeInterval) async throws -> OAuthCallbackResult {
+        try await withThrowingTaskGroup(of: OAuthCallbackResult.self) { group in
+            group.addTask { try await self.waitForCallback() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw OAuthLoopbackError.callbackTimeout
+            }
+            guard let result = try await group.next() else {
+                throw OAuthLoopbackError.callbackTimeout
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+
     public func stop() {
         listener.cancel()
     }

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -54,6 +54,12 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             /// to model-string routing, which could silently retarget a
             /// different local provider. Maps to 503.
             case remoteAgentUnavailable
+            /// An HTTP-origin request routed to the Osaurus Router without
+            /// spend authorization. Router requests are signed with the
+            /// user's master key and spend real credits, so key-less
+            /// loopback-trusted callers are refused unless the user opted in.
+            /// Maps to 403.
+            case routerSpendNotAuthorized
         }
 
         let kind: Kind
@@ -66,6 +72,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 return "No service is currently available to handle model '\(requested)'."
             case .remoteAgentUnavailable:
                 return "The selected remote agent isn't connected. Reconnect to the agent and try again."
+            case .routerSpendNotAuthorized:
+                return
+                    "This model routes through the Osaurus Router and spends account credits. Include a valid Osaurus access key (Authorization: Bearer <key>), or enable 'Allow local API access without a key' for the Router in Osaurus Credits settings."
             }
         }
 
@@ -75,6 +84,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             case .modelNotFound: return 404
             case .noServiceAvailable: return 503
             case .remoteAgentUnavailable: return 503
+            case .routerSpendNotAuthorized: return 403
             }
         }
     }
@@ -225,6 +235,47 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             remoteServices: remoteServices
         )
         return Dispatch(route: route, params: params, remoteServices: remoteServices)
+    }
+
+    // MARK: - Osaurus Router spend gate
+
+    /// Pure decision core for the Router credit-spend gate, split out so the
+    /// policy is unit-testable without a live provider or HTTP channel.
+    ///
+    /// Osaurus Router requests are signed with the user's master key and
+    /// spend real credits, while the loopback HTTP API is deliberately
+    /// unauthenticated. Without this gate any local process could silently
+    /// drain the user's Router balance. Policy: HTTP-origin requests may
+    /// route to the Router only when the caller proved possession of a valid
+    /// access key, or the user explicitly opted in to key-less loopback
+    /// spend. App-internal sources (chat UI, plugins with their own
+    /// permission model, P2P) are not affected.
+    static func routerSpendAuthorizationError(
+        serviceIsOsaurusRouter: Bool,
+        source: InferenceSource,
+        callerHasVerifiedAccessKey: Bool,
+        allowsUnkeyedLoopbackSpend: Bool
+    ) -> EngineError? {
+        guard serviceIsOsaurusRouter, source == .httpAPI else { return nil }
+        if callerHasVerifiedAccessKey || allowsUnkeyedLoopbackSpend { return nil }
+        return EngineError(kind: .routerSpendNotAuthorized)
+    }
+
+    /// Enforce the Router spend gate for a resolved route. Must run in the
+    /// caller's task (before any detached producer) so the
+    /// `HTTPCallerContext` task-local bound by `HTTPHandler.runRequestTask`
+    /// is still visible.
+    private func checkRouterSpendAuthorization(service: ModelService) throws {
+        let isRouter =
+            (service as? RemoteProviderService)?.provider.providerType == .osaurusRouter
+        if let error = Self.routerSpendAuthorizationError(
+            serviceIsOsaurusRouter: isRouter,
+            source: inferenceSource,
+            callerHasVerifiedAccessKey: HTTPCallerContext.current?.hasVerifiedAccessKey == true,
+            allowsUnkeyedLoopbackSpend: OsaurusRouter.allowsUnkeyedLoopbackSpend
+        ) {
+            throw error
+        }
     }
 
     /// Emit the opt-in `message_sent` KPI event for a top-level chat turn.
@@ -622,6 +673,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
         switch route {
         case .service(let service, let effectiveModel):
+            try checkRouterSpendAuthorization(service: service)
             emitMessageSentIfPrimaryTurn(
                 request: request,
                 service: service,
@@ -1151,6 +1203,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
         switch route {
         case .service(let service, let effectiveModel):
+            try checkRouterSpendAuthorization(service: service)
             emitMessageSentIfPrimaryTurn(
                 request: request,
                 service: service,

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
@@ -226,20 +226,7 @@ public enum MCPOAuthService {
         // 6. Wait for callback (bounded so a closed browser tab can't hang forever).
         let callback: OAuthCallbackResult
         do {
-            callback = try await withThrowingTaskGroup(of: OAuthCallbackResult.self) { group in
-                group.addTask { try await server.waitForCallback() }
-                group.addTask {
-                    try await Task.sleep(
-                        nanoseconds: UInt64(Self.signInCallbackTimeout * 1_000_000_000)
-                    )
-                    throw OAuthLoopbackError.callbackTimeout
-                }
-                guard let result = try await group.next() else {
-                    throw OAuthLoopbackError.callbackTimeout
-                }
-                group.cancelAll()
-                return result
-            }
+            callback = try await server.waitForCallback(timeout: Self.signInCallbackTimeout)
         } catch let error as OAuthLoopbackError {
             throw MCPOAuthError.loopback(error)
         }

--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -513,7 +513,11 @@ public enum OpenAICodexOAuthService {
         }
 
         do {
-            return try await server.waitForCallback()
+            // Bounded wait: an abandoned browser tab must not pin this task
+            // (and the fixed loopback port) forever.
+            return try await server.waitForCallback(
+                timeout: OAuthLoopbackServer.defaultSignInTimeout
+            )
         } catch let error as OAuthLoopbackError {
             throw mapLoopbackError(error)
         } catch {

--- a/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
@@ -28,23 +28,73 @@ struct OpenAICompatibleStreamFramer {
         private var completedLines: [Data] = []
         private var nextOutputIndex = 0
 
+        /// Bulk newline scan: finds terminators with `memchr` and copies whole
+        /// line spans at once instead of appending byte-by-byte (the previous
+        /// per-byte loop dominated the SSE hot path on large deltas).
+        /// Semantics are identical: LF, CR, and CRLF all terminate a line, a
+        /// CRLF split across chunk boundaries yields one line, and a blank
+        /// line is emitted as an empty `Data` (SSE event boundary).
         mutating func append(_ data: Data) {
-            for byte in data {
-                switch byte {
-                case 0x0D:
-                    completedLines.append(lineBuffer)
-                    lineBuffer = Data()
-                    carriageReturnLast = true
-                case 0x0A:
-                    if carriageReturnLast {
-                        carriageReturnLast = false
+            guard !data.isEmpty else { return }
+            data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+                guard let rawBase = raw.baseAddress else { return }
+                let base = rawBase.assumingMemoryBound(to: UInt8.self)
+                let count = raw.count
+                var offset = 0
+                if carriageReturnLast {
+                    carriageReturnLast = false
+                    if base[0] == 0x0A { offset = 1 }
+                }
+                while offset < count {
+                    let remaining = count - offset
+                    let lfOffset = memchr(base + offset, 0x0A, remaining)
+                        .map { UnsafeRawPointer($0) - rawBase }
+                    let crOffset = memchr(base + offset, 0x0D, remaining)
+                        .map { UnsafeRawPointer($0) - rawBase }
+
+                    let terminatorOffset: Int
+                    let terminatorIsCR: Bool
+                    switch (lfOffset, crOffset) {
+                    case (nil, nil):
+                        // No terminator in the rest of the chunk — stash the
+                        // partial line and wait for more bytes.
+                        lineBuffer.append(base + offset, count: remaining)
+                        return
+                    case (let lf?, nil):
+                        terminatorOffset = lf
+                        terminatorIsCR = false
+                    case (nil, let cr?):
+                        terminatorOffset = cr
+                        terminatorIsCR = true
+                    case (let lf?, let cr?):
+                        terminatorIsCR = cr < lf
+                        terminatorOffset = min(lf, cr)
+                    }
+
+                    let lineLength = terminatorOffset - offset
+                    if lineBuffer.isEmpty {
+                        completedLines.append(Data(bytes: base + offset, count: lineLength))
                     } else {
+                        lineBuffer.append(base + offset, count: lineLength)
                         completedLines.append(lineBuffer)
                         lineBuffer = Data()
                     }
-                default:
-                    carriageReturnLast = false
-                    lineBuffer.append(byte)
+
+                    if terminatorIsCR {
+                        if terminatorOffset + 1 < count {
+                            // Swallow an immediately-following LF (CRLF).
+                            offset =
+                                base[terminatorOffset + 1] == 0x0A
+                                ? terminatorOffset + 2 : terminatorOffset + 1
+                        } else {
+                            // CR is the chunk's last byte: remember it so an
+                            // LF at the head of the next chunk is swallowed.
+                            carriageReturnLast = true
+                            offset = count
+                        }
+                    } else {
+                        offset = terminatorOffset + 1
+                    }
                 }
             }
         }
@@ -190,38 +240,46 @@ struct OpenAICompatibleToolCallAccumulator {
         from accumulated: [Int: RemoteProviderService.StreamingState.ToolSlot],
         finishMarker: String
     ) -> RemoteProviderService.AccumulatedToolCallResult {
-        guard let (invocation, wasRepaired) = makeToolInvocation(from: accumulated) else {
-            return .none
-        }
-        if wasRepaired {
+        let resolved = makeToolInvocations(from: accumulated)
+        guard !resolved.isEmpty else { return .none }
+        // Repaired args on ANY slot mean the stream was cut mid-argument —
+        // dispatching a partial batch would lock a half-real parallel call
+        // set into history, so the whole set is treated as truncated.
+        if let repaired = resolved.first(where: { $0.wasRepaired }) {
             return .truncated(
                 truncatedToolCallError(
                     from: accumulated,
-                    toolName: invocation.toolName,
+                    toolName: repaired.invocation.toolName,
                     finishMarker: finishMarker
                 )
             )
         }
-        return .ready(invocation)
+        return .ready(resolved.map(\.invocation))
     }
 
-    static func makeToolInvocation(
+    /// Every accumulated tool call in slot order. Parallel tool calling
+    /// (OpenAI `tool_calls[n]`, Anthropic multiple `tool_use` blocks, Gemini
+    /// multiple `functionCall` parts) fills several slots in one completion;
+    /// all of them are dispatched, matching the local vmlx path. Slots that
+    /// never received a function name cannot be dispatched and are skipped.
+    static func makeToolInvocations(
         from accumulated: [Int: RemoteProviderService.StreamingState.ToolSlot]
-    ) -> (invocation: ServiceToolInvocation, wasRepaired: Bool)? {
-        guard let first = accumulated.min(by: { $0.key < $1.key }),
-            let name = first.value.name
-        else { return nil }
-
-        let validated = validateToolCallJSON(first.value.args)
-        return (
-            ServiceToolInvocation(
-                toolName: name,
-                jsonArguments: validated.json,
-                toolCallId: first.value.id,
-                geminiThoughtSignature: first.value.thoughtSignature
-            ),
-            validated.wasRepaired
-        )
+    ) -> [(invocation: ServiceToolInvocation, wasRepaired: Bool)] {
+        accumulated
+            .sorted { $0.key < $1.key }
+            .compactMap { _, slot in
+                guard let name = slot.name else { return nil }
+                let validated = validateToolCallJSON(slot.args)
+                return (
+                    ServiceToolInvocation(
+                        toolName: name,
+                        jsonArguments: validated.json,
+                        toolCallId: slot.id,
+                        geminiThoughtSignature: slot.thoughtSignature
+                    ),
+                    validated.wasRepaired
+                )
+            }
     }
 
     @inline(__always)
@@ -440,7 +498,7 @@ struct OpenAICompatibleStreamParser {
     ) throws -> RemoteProviderService.StreamEventOutcome {
         switch options.decodeMode {
         case .strict:
-            let chunk = try JSONDecoder().decode(ChatCompletionChunk.self, from: jsonData)
+            let chunk = try state.decoder.decode(ChatCompletionChunk.self, from: jsonData)
             // OpenAI emits usage on a dedicated final chunk (empty `choices`)
             // when `stream_options.include_usage` was set; on every other chunk
             // `usage` is null. Capture whatever is present — surfaced at the
@@ -455,7 +513,7 @@ struct OpenAICompatibleStreamParser {
                 yield: yield
             )
         case .lenient:
-            let chunk = try JSONDecoder().decode(LenientChatCompletionChunk.self, from: jsonData)
+            let chunk = try state.decoder.decode(LenientChatCompletionChunk.self, from: jsonData)
             state.captureProviderUsage(chunk.usage)
             let choice = chunk.choices?.first
             if let message = choice?.message {

--- a/Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift
@@ -29,7 +29,7 @@ public enum OpenRouterOAuthError: LocalizedError, Sendable {
         case .invalidKeyResponse:
             return "OpenRouter returned an invalid key response"
         case .keyRequestFailed(let message):
-            return "OpenRouter key exchange failed: \(message)"
+            return "OpenRouter key exchange failed: \(ProviderDiagnosticRedactor.safe(message, maxLength: 400))"
         }
     }
 }
@@ -114,7 +114,11 @@ public enum OpenRouterOAuthService {
         }
 
         do {
-            return try await server.waitForCallback()
+            // Bounded wait: an abandoned browser tab must not pin this task
+            // (and the fixed loopback port) forever.
+            return try await server.waitForCallback(
+                timeout: OAuthLoopbackServer.defaultSignInTimeout
+            )
         } catch {
             throw OpenRouterOAuthError.invalidAuthorizationCallback
         }

--- a/Packages/OsaurusCore/Services/Provider/ProviderCredentialPromptService.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderCredentialPromptService.swift
@@ -54,19 +54,28 @@ public struct ProviderCredentialRequest: Sendable {
     public let providerName: String
     public let mode: ProviderCredentialPromptMode
     public let instructions: ProviderCredentialInstructions
+    /// Non-secret extra fields (e.g. `host`) the sheet should pre-populate
+    /// so the user *sees and tests* the endpoint the credentials will be
+    /// sent to. This is how a tool-supplied host override reaches the user
+    /// for approval instead of being applied silently after the sheet
+    /// closes (the bait-and-switch this closes). Keyed by the catalog field
+    /// id, matching `instructions.extraFields`.
+    public let prefilledExtraFields: [String: String]
 
     /// Preset-keyed primary path. Derives `providerType` and `instructions`
     /// from the preset. Pass this from new callers.
     public init(
         preset: ProviderPreset,
         providerName: String,
-        mode: ProviderCredentialPromptMode
+        mode: ProviderCredentialPromptMode,
+        prefilledExtraFields: [String: String] = [:]
     ) {
         self.preset = preset
         self.providerType = preset.configuration.providerType
         self.providerName = providerName
         self.mode = mode
         self.instructions = ProviderCredentialInstructionsCatalog.entry(for: preset)
+        self.prefilledExtraFields = prefilledExtraFields
     }
 
     /// Legacy entry for callers that only have a `RemoteProviderType` (the
@@ -79,8 +88,10 @@ public struct ProviderCredentialRequest: Sendable {
     public init(
         providerType: RemoteProviderType,
         providerName: String,
-        mode: ProviderCredentialPromptMode
+        mode: ProviderCredentialPromptMode,
+        prefilledExtraFields: [String: String] = [:]
     ) {
+        self.prefilledExtraFields = prefilledExtraFields
         if providerType == .osaurus {
             self.preset = nil
             self.providerType = .osaurus
@@ -113,8 +124,10 @@ public struct ProviderCredentialRequest: Sendable {
     public init(
         provider: RemoteProvider,
         providerName: String,
-        mode: ProviderCredentialPromptMode
+        mode: ProviderCredentialPromptMode,
+        prefilledExtraFields: [String: String] = [:]
     ) {
+        self.prefilledExtraFields = prefilledExtraFields
         if provider.providerType == .osaurus {
             self.preset = nil
             self.providerType = .osaurus

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -23,6 +23,13 @@ public enum RemoteProviderServiceError: LocalizedError {
     case invalidResponse
     case streamingError(String)
     case noModelsAvailable
+    /// Provider replied 429 (or 503 with a retry hint). `retryAfter` is the
+    /// parsed `Retry-After` header in seconds when present.
+    case rateLimited(retryAfter: TimeInterval?, statusCode: Int)
+    /// The request carries an input the provider's wire format cannot
+    /// express (e.g. audio/video parts on an Anthropic/Gemini route).
+    /// Rejecting loudly beats silently dropping the user's attachment.
+    case unsupportedParameter(String)
 
     public var errorDescription: String? {
         switch self {
@@ -39,9 +46,24 @@ public enum RemoteProviderServiceError: LocalizedError {
         case .invalidResponse:
             return L("Invalid response from provider")
         case .streamingError(let message):
-            return L("Streaming error: \(message)")
+            // Redact here (not in the associated value) so upstream error
+            // bodies surfaced mid-stream can't leak keys/tokens into the UI
+            // or logs, while `isTransientStreamRetryable` still matches on
+            // the raw sentinel text.
+            return L("Streaming error: \(ProviderDiagnosticRedactor.safe(message, maxLength: 500))")
         case .noModelsAvailable:
             return L("No models available from provider")
+        case .rateLimited(let retryAfter, let statusCode):
+            let condition =
+                statusCode == 503
+                ? L("The provider is temporarily unavailable (HTTP 503).")
+                : L("The provider rate-limited this request (HTTP \(statusCode)).")
+            if let retryAfter, retryAfter > 0 {
+                return condition + " " + L("Retry in about \(Int(retryAfter.rounded(.up)))s.")
+            }
+            return condition + " " + L("Retry shortly.")
+        case .unsupportedParameter(let message):
+            return L("\(message)")
         }
     }
 
@@ -67,9 +89,48 @@ public enum RemoteProviderServiceError: LocalizedError {
             return .requestFailedWithDiagnostics("Invalid response from provider", diagnostics)
         case .requestFailedWithDiagnostics:
             return self
-        case .invalidURL, .notConnected, .streamingError, .noModelsAvailable:
+        case .invalidURL, .notConnected, .streamingError, .noModelsAvailable, .rateLimited,
+            .unsupportedParameter:
             return self
         }
+    }
+
+    /// Typed rate-limit mapping for an HTTP response: 429 always qualifies;
+    /// 503 qualifies only when the server sent a `Retry-After` hint (a plain
+    /// 503 stays a `requestFailed` so real outages read as failures, not
+    /// throttles). Returns nil for every other status.
+    static func rateLimited(from httpResponse: HTTPURLResponse) -> RemoteProviderServiceError? {
+        let retryAfter = parseRetryAfterSeconds(
+            httpResponse.value(forHTTPHeaderField: "Retry-After")
+        )
+        switch httpResponse.statusCode {
+        case 429:
+            return .rateLimited(retryAfter: retryAfter, statusCode: 429)
+        case 503 where retryAfter != nil:
+            return .rateLimited(retryAfter: retryAfter, statusCode: 503)
+        default:
+            return nil
+        }
+    }
+
+    /// Parse a `Retry-After` header value: either delta-seconds ("120") or an
+    /// HTTP-date. Returns nil when absent/unparseable or non-positive.
+    static func parseRetryAfterSeconds(_ headerValue: String?) -> TimeInterval? {
+        guard let raw = headerValue?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else {
+            return nil
+        }
+        if let seconds = TimeInterval(raw) {
+            return seconds > 0 ? seconds : nil
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        if let date = formatter.date(from: raw) {
+            let delta = date.timeIntervalSinceNow
+            return delta > 0 ? delta : nil
+        }
+        return nil
     }
 }
 
@@ -83,26 +144,39 @@ public actor RemoteProviderService: ToolCapableService {
     private var session: URLSession
     private var cachedOAuthTokens: RemoteProviderOAuthTokens?
 
-    /// Race-resistant flag set by `invalidateSession()`. The connect-retry
-    /// loop in `connectWithRetry` MUST consult this before every
-    /// `URLSession.bytes(for:)` attempt: calling `bytes(for:)` on a session
-    /// that has already had `invalidateAndCancel()` called raises an
-    /// uncatchable Obj-C `NSInvalidArgumentException` from
-    /// `-[__NSURLSessionLocal taskForClassInfo:]` (synchronously, inside
-    /// the Swift-generated closure passed to `withTaskCancellationHandler`).
-    /// Swift `try`/`catch` does not catch Obj-C exceptions, so the
-    /// exception unwinds straight into `_objc_terminate` and `abort()`s
-    /// the entire xctest process — an entire test bundle dies. The flag
-    /// is checked across an actor boundary by a non-isolated, lock-backed
-    /// accessor so the producer task can read it without an `await` hop
-    /// (no actor reentrancy, no extra suspension point per retry attempt).
-    /// Closing the residual microsecond TOCTOU window between this check
-    /// and `bytes(for:)` requires an Obj-C `@try`/`@catch` bridge — left
-    /// out here because it would require restructuring the package as
-    /// mixed-source SPM. The flag-based mitigation eliminates the
-    /// dominant 200ms / 800ms backoff-window race that surfaces in
-    /// parallel CI test runs.
-    private let sessionInvalidatedFlag = OSAllocatedUnfairLock<Bool>(initialState: false)
+    /// Session lifecycle guard closing the invalidate-vs-task-creation race.
+    /// Calling `bytes(for:)`/`data(for:)` on a session that has already had
+    /// `invalidateAndCancel()` called raises an uncatchable Obj-C
+    /// `NSInvalidArgumentException` from
+    /// `-[__NSURLSessionLocal taskForClassInfo:]`. Swift `try`/`catch` does
+    /// not catch Obj-C exceptions, so the exception unwinds straight into
+    /// `_objc_terminate` and `abort()`s the entire process (in production:
+    /// whenever a provider is disabled/updated during active generation; in
+    /// CI: whole xctest bundles die).
+    ///
+    /// The guard makes the two operations mutually exclusive rather than
+    /// merely unlikely to collide:
+    /// - Every session task-creation call is bracketed by
+    ///   `beginSessionRequest()` / `endSessionRequest()`. `begin` atomically
+    ///   refuses (returns false) once invalidation has been requested.
+    /// - `invalidateSession()` atomically marks the session invalidated; if
+    ///   requests are in flight it *defers* the actual
+    ///   `invalidateAndCancel()` to the last `endSessionRequest()`, so the
+    ///   session can never be invalidated under a concurrent `bytes(for:)`.
+    ///
+    /// Iterating an already-connected `AsyncBytes` stream after invalidation
+    /// is safe — it throws a catchable `URLError.cancelled` — so only the
+    /// task-creation windows need bracketing, and a deferred
+    /// `invalidateAndCancel()` still tears down connected streams promptly.
+    private struct SessionLifecycle {
+        var invalidationRequested = false
+        var inFlightRequests = 0
+        /// The session to invalidate once `inFlightRequests` drains to zero.
+        var deferredInvalidation: URLSession?
+    }
+    private nonisolated let sessionLifecycle = OSAllocatedUnfairLock<SessionLifecycle>(
+        initialState: SessionLifecycle()
+    )
 
     nonisolated public var id: String {
         "remote-\(provider.id.uuidString)"
@@ -111,7 +185,34 @@ public actor RemoteProviderService: ToolCapableService {
     /// Lock-backed sync read of the session-invalidated flag. Safe to call
     /// from any thread / actor / Task without awaiting the actor.
     nonisolated public var isSessionInvalidated: Bool {
-        sessionInvalidatedFlag.withLock { $0 }
+        sessionLifecycle.withLock { $0.invalidationRequested }
+    }
+
+    /// Open a task-creation window on the session. Returns `false` when
+    /// invalidation has been requested — the caller must throw
+    /// `CancellationError` instead of touching the session. Every successful
+    /// `begin` MUST be paired with exactly one `endSessionRequest()`.
+    nonisolated func beginSessionRequest() -> Bool {
+        sessionLifecycle.withLock { state in
+            guard !state.invalidationRequested else { return false }
+            state.inFlightRequests += 1
+            return true
+        }
+    }
+
+    /// Close a task-creation window. Runs a deferred `invalidateAndCancel()`
+    /// if `invalidateSession()` was requested while this request was in
+    /// flight and this was the last one out.
+    nonisolated func endSessionRequest() {
+        let deferred: URLSession? = sessionLifecycle.withLock { state in
+            state.inFlightRequests -= 1
+            guard state.invalidationRequested, state.inFlightRequests == 0,
+                let session = state.deferredInvalidation
+            else { return nil }
+            state.deferredInvalidation = nil
+            return session
+        }
+        deferred?.invalidateAndCancel()
     }
 
     public init(
@@ -133,8 +234,9 @@ public actor RemoteProviderService: ToolCapableService {
         let config = URLSessionConfiguration.default
         // Request timeout must be generous: thinking models can pause for minutes
         // between tokens. The app-level streamInactivityTimeout handles stall detection.
-        // When the user opts into no-timeout mode, every limit is lifted (see
-        // RemoteProvider.unboundedTimeout) so long-running turns are never interrupted.
+        // When the user opts into no-timeout mode, limits are lifted to the 24h hard
+        // ceiling (see RemoteProvider.unboundedTimeout) so long-running turns are
+        // never interrupted but a dead socket can't pin a task forever.
         if provider.disableTimeout {
             config.timeoutIntervalForRequest = RemoteProvider.unboundedTimeout
             config.timeoutIntervalForResource = RemoteProvider.unboundedTimeout
@@ -228,21 +330,54 @@ public actor RemoteProviderService: ToolCapableService {
     /// Invalidate the URLSession to release its strong delegate reference.
     /// Must be called before discarding this service instance to avoid leaking.
     ///
-    /// Sets `sessionInvalidatedFlag` BEFORE `invalidateAndCancel()` so any
-    /// concurrent connect-retry loop in `connectWithRetry` observes the
-    /// flag on its next pre-attempt check and bails out with a Swift
-    /// `CancellationError` instead of calling `bytes(for:)` on the now-
-    /// invalidated session and triggering the uncatchable Obj-C
-    /// `NSException` abort. See the doc comment on
-    /// `sessionInvalidatedFlag` for the full hazard description.
+    /// Marks the session invalidated BEFORE any teardown so concurrent
+    /// producers observe it (`isSessionInvalidated` / a refused
+    /// `beginSessionRequest()`) and bail out with a Swift `CancellationError`
+    /// instead of calling `bytes(for:)` on an invalidated session and
+    /// triggering the uncatchable Obj-C `NSException` abort. When a
+    /// task-creation window is currently open, the actual
+    /// `invalidateAndCancel()` is deferred to the closing
+    /// `endSessionRequest()` — draining in-flight requests instead of
+    /// invalidating under them. See the `SessionLifecycle` doc comment for
+    /// the full hazard description.
     public func invalidateSession() {
-        sessionInvalidatedFlag.withLock { $0 = true }
-        session.invalidateAndCancel()
+        let currentSession = session
+        let invalidateNow: Bool = sessionLifecycle.withLock { state in
+            guard !state.invalidationRequested else { return false }
+            state.invalidationRequested = true
+            if state.inFlightRequests == 0 { return true }
+            state.deferredInvalidation = currentSession
+            return false
+        }
+        if invalidateNow {
+            currentSession.invalidateAndCancel()
+        }
+    }
+
+    /// `session.data(for:)` bracketed by the session-lifecycle guard, so a
+    /// concurrent `invalidateSession()` can never run `invalidateAndCancel()`
+    /// under the task-creation call (uncatchable Obj-C exception — see
+    /// `SessionLifecycle`).
+    private func trackedData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        guard beginSessionRequest() else { throw CancellationError() }
+        defer { endSessionRequest() }
+        return try await session.data(for: request)
     }
 
     /// Update available models (called when connection refreshes)
     public func updateModels(_ models: [String]) {
         self.availableModels = models
+    }
+
+    /// Unprefixed Osaurus Router model ids that advertise image/vision input
+    /// in the `/models` capability catalog. Pushed by `RemoteProviderManager`
+    /// on connect and on catalog refetch; consulted when normalizing user
+    /// media for the Router wire (non-vision upstream adapters reject
+    /// array-form user content). Empty for non-Router providers.
+    private var routerVisionModelIds: Set<String> = []
+
+    public func updateOsaurusRouterVisionModels(_ modelIds: Set<String>) {
+        routerVisionModelIds = modelIds
     }
 
     /// Get the prefixed model names for this provider
@@ -315,7 +450,8 @@ public actor RemoteProviderService: ToolCapableService {
             return try await PrivacyFilterPipeline.applyOutbound(
                 messages: messages,
                 sessionId: parameters.sessionId,
-                providerId: provider.id
+                providerId: provider.id,
+                requestSource: parameters.requestSource
             )
         } catch PrivacyFilterPipelineError.reviewCanceled {
             throw CancellationError()
@@ -384,7 +520,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         try await refreshCodexOAuthIfNeeded()
         try await refreshXAIOAuthIfNeeded()
-        let (data, response) = try await session.data(for: try await buildURLRequest(for: request))
+        let (data, response) = try await trackedData(for: try await buildURLRequest(for: request))
         WireTransportProbe.current?.replaceResponseBody(data)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -392,6 +528,7 @@ public actor RemoteProviderService: ToolCapableService {
         }
 
         if httpResponse.statusCode >= 400 {
+            if let rateLimited = RemoteProviderServiceError.rateLimited(from: httpResponse) { throw rateLimited }
             let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
             throw RemoteProviderServiceError.requestFailed("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
@@ -498,7 +635,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         try await refreshCodexOAuthIfNeeded()
         try await refreshXAIOAuthIfNeeded()
-        let (data, response) = try await session.data(for: try await buildURLRequest(for: request))
+        let (data, response) = try await trackedData(for: try await buildURLRequest(for: request))
         WireTransportProbe.current?.replaceResponseBody(data)
 
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -506,6 +643,7 @@ public actor RemoteProviderService: ToolCapableService {
         }
 
         if httpResponse.statusCode >= 400 {
+            if let rateLimited = RemoteProviderServiceError.rateLimited(from: httpResponse) { throw rateLimited }
             let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
             throw RemoteProviderServiceError.requestFailed("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
@@ -521,14 +659,17 @@ public actor RemoteProviderService: ToolCapableService {
             map: redactionMap
         )
 
-        // Check for tool calls
-        if let toolCalls = unscrubbedToolCalls, let firstCall = toolCalls.first {
-            throw ServiceToolInvocation(
-                toolName: firstCall.function.name,
-                jsonArguments: firstCall.function.arguments,
-                toolCallId: firstCall.id,
-                geminiThoughtSignature: firstCall.geminiThoughtSignature
-            )
+        // Check for tool calls — dispatch the whole (possibly parallel) batch.
+        if let toolCalls = unscrubbedToolCalls, !toolCalls.isEmpty {
+            let invocations = toolCalls.map { call in
+                ServiceToolInvocation(
+                    toolName: call.function.name,
+                    jsonArguments: call.function.arguments,
+                    toolCallId: call.id,
+                    geminiThoughtSignature: call.geminiThoughtSignature
+                )
+            }
+            throw Self.toolInvocationFinishError(invocations)
         }
 
         return unscrubbedContent ?? ""
@@ -697,32 +838,76 @@ public actor RemoteProviderService: ToolCapableService {
         }
     }
 
+    /// Bridges `URLSession.AsyncBytes` into line/4KB-batched `Data` chunks,
+    /// with an optional built-in inactivity watchdog.
+    ///
+    /// The watchdog is ONE long-lived task per stream that sleeps until a
+    /// deadline and re-arms whenever a chunk is delivered — replacing the
+    /// previous per-chunk `ThrowingTaskGroup` race, which spawned and
+    /// cancelled two child tasks for every chunk on the streaming hot path.
+    /// On inactivity it finishes the stream cleanly (the consumer sees `nil`,
+    /// exactly the old timeout contract) and cancels the pump so the byte
+    /// iteration stops.
     static func makeChunkStream(
-        from bytes: URLSession.AsyncBytes
+        from bytes: URLSession.AsyncBytes,
+        inactivityTimeout: TimeInterval? = nil
     ) -> AsyncThrowingStream<Data, Error> {
         AsyncThrowingStream<Data, Error> { continuation in
+            let lastActivity = OSAllocatedUnfairLock<ContinuousClock.Instant>(
+                initialState: ContinuousClock.now
+            )
             let pumpTask = Task {
-                var buffer = Data()
+                // Accumulate into a plain byte array (cheaper per-byte append
+                // than `Data`) and materialize one `Data` per flushed chunk.
+                var buffer = [UInt8]()
                 buffer.reserveCapacity(4096)
                 do {
                     for try await byte in bytes {
-                        if Task.isCancelled { break }
                         buffer.append(byte)
                         // Flush at line boundaries (LF) or when the buffer fills,
                         // so consumers see chunks promptly without per-byte awakens.
                         if byte == 0x0A || buffer.count >= 4096 {
-                            continuation.yield(buffer)
+                            // Cancellation check only at flush boundaries: the
+                            // per-byte check was pure hot-path overhead, and a
+                            // cancelled stream's socket is torn down via
+                            // `LiveURLSessionTaskBox` anyway, which ends this
+                            // byte iteration promptly.
+                            if Task.isCancelled { break }
+                            lastActivity.withLock { $0 = ContinuousClock.now }
+                            continuation.yield(Data(buffer))
                             buffer.removeAll(keepingCapacity: true)
                         }
                     }
-                    if !buffer.isEmpty { continuation.yield(buffer) }
+                    if !buffer.isEmpty { continuation.yield(Data(buffer)) }
                     continuation.finish()
                 } catch {
-                    if !buffer.isEmpty { continuation.yield(buffer) }
+                    if !buffer.isEmpty { continuation.yield(Data(buffer)) }
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { _ in pumpTask.cancel() }
+            let watchdogTask: Task<Void, Never>? = inactivityTimeout.map { timeoutSeconds in
+                let timeout = Duration.seconds(timeoutSeconds)
+                return Task {
+                    let clock = ContinuousClock()
+                    while !Task.isCancelled {
+                        let deadline = lastActivity.withLock { $0 }.advanced(by: timeout)
+                        if ContinuousClock.now >= deadline {
+                            // No bytes within the window: end the stream the
+                            // same way natural EOF does and stop the pump.
+                            continuation.finish()
+                            pumpTask.cancel()
+                            return
+                        }
+                        // Sleep to the current deadline; if a chunk arrives
+                        // meanwhile the next loop pass re-arms to the newer one.
+                        try? await clock.sleep(until: deadline)
+                    }
+                }
+            }
+            continuation.onTermination = { _ in
+                pumpTask.cancel()
+                watchdogTask?.cancel()
+            }
         }
     }
 
@@ -761,57 +946,34 @@ public actor RemoteProviderService: ToolCapableService {
         }
     }
 
-    /// Reads the next chunk from `ref`, racing against an inactivity timeout.
-    /// Returns `nil` if the stream ended naturally or the timeout fired.
-    /// Cancelling the local AsyncStream iterator is safe — buffered chunks
-    /// remain available for subsequent `next()` calls and the upstream
-    /// URLSession iterator (running in `makeChunkStream`'s pump task) is
-    /// unaffected.
-    static func nextChunk(
-        from ref: ChunkIteratorRef,
-        timeout: TimeInterval
-    ) async throws -> Data? {
-        try await withThrowingTaskGroup(of: Data?.self) { group in
-            group.addTask { try await ref.next() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                return nil
-            }
-            defer { group.cancelAll() }
-            guard let first = try await group.next() else {
-                return nil
-            }
-            return first
-        }
-    }
-
     /// Try to decode `jsonData` as a server-side error payload. Some providers
     /// stream a structured error event rather than closing the connection with
     /// a non-2xx HTTP status — without this check the parse failure was
     /// silently logged and the stream appeared to "end" with no diagnosis.
     static func tryDecodeStreamError(
         _ jsonData: Data,
-        providerType: RemoteProviderType
+        providerType: RemoteProviderType,
+        decoder: JSONDecoder = JSONDecoder()
     ) -> String? {
         if providerType == .osaurusRouter,
-            let routerError = try? JSONDecoder().decode(OsaurusRouterErrorEnvelope.self, from: jsonData)
+            let routerError = try? decoder.decode(OsaurusRouterErrorEnvelope.self, from: jsonData)
         {
             return "\(routerError.error.code): \(routerError.error.message)"
         }
 
         // Generic OpenAI-compatible error envelope: {"error":{"message":"..."}}
-        if let openAIError = try? JSONDecoder().decode(OpenAIError.self, from: jsonData) {
+        if let openAIError = try? decoder.decode(OpenAIError.self, from: jsonData) {
             return openAIError.error.message
         }
         switch providerType {
         case .anthropic:
             // Anthropic mid-stream error: {"type":"error","error":{"type":"...","message":"..."}}
-            if let anthropicError = try? JSONDecoder().decode(AnthropicStreamErrorEvent.self, from: jsonData) {
+            if let anthropicError = try? decoder.decode(AnthropicStreamErrorEvent.self, from: jsonData) {
                 return anthropicError.error.message
             }
         case .gemini:
             // Gemini error: {"error":{"code":...,"message":"...","status":"..."}}
-            if let geminiError = try? JSONDecoder().decode(GeminiErrorResponse.self, from: jsonData) {
+            if let geminiError = try? decoder.decode(GeminiErrorResponse.self, from: jsonData) {
                 return geminiError.error.message
             }
         default:
@@ -846,6 +1008,35 @@ public actor RemoteProviderService: ToolCapableService {
     private static func logRouterEmptyStreamIfNeeded(_ diagnostics: RouterStreamDiagnostics?) {
         guard let diagnostics, diagnostics.shouldLogEmptyTerminal else { return }
         print("[Osaurus][Router][EmptyStream] \(diagnostics.sanitizedSummary)")
+    }
+
+    /// Coarse per-event classification kind for the router diagnostics
+    /// counters. Production streams record only this (via `routerEventKind`,
+    /// a byte/substring sniff); the JSON decode + re-serialize work of
+    /// `routerEventDebugSummary` runs only when the debug flag is on.
+    enum RouterEventKind: String {
+        case doneMarker = "done-marker"
+        case summary
+        case usage
+        case choice
+        case error
+        case unrecognized
+    }
+
+    /// Cheap classification for the per-event diagnostics counters. Substring
+    /// sniffing is intentionally approximate (it's a counter, not a parser):
+    /// `"choices"` is checked first because every real content/tool delta has
+    /// it, so a content payload that merely *mentions* "osaurus" or "usage"
+    /// in its text still counts as a choice event.
+    static func routerEventKind(_ dataContent: String) -> RouterEventKind {
+        let trimmed = dataContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "[DONE]" { return .doneMarker }
+        guard trimmed.utf8.first == UInt8(ascii: "{") else { return .unrecognized }
+        if trimmed.contains("\"choices\"") { return .choice }
+        if trimmed.contains("\"osaurus\"") { return .summary }
+        if trimmed.contains("\"error\"") { return .error }
+        if trimmed.contains("\"usage\"") { return .usage }
+        return .unrecognized
     }
 
     private static func routerEventDebugSummary(_ dataContent: String) -> String {
@@ -904,8 +1095,12 @@ public actor RemoteProviderService: ToolCapableService {
             return "continue"
         case .finishNormal:
             return "finishNormal"
-        case .finishWithToolCall(let invocation):
-            return "finishWithToolCall(\(invocation.toolName), argsBytes=\(invocation.jsonArguments.utf8.count))"
+        case .finishWithToolCall(let invocations):
+            let summary =
+                invocations
+                .map { "\($0.toolName), argsBytes=\($0.jsonArguments.utf8.count)" }
+                .joined(separator: "; ")
+            return "finishWithToolCall(\(summary))"
         case .finishWithError(let error):
             return "finishWithError(\(error.localizedDescription))"
         }
@@ -996,21 +1191,29 @@ public actor RemoteProviderService: ToolCapableService {
             byteCount += chunk.count
         }
 
-        mutating func recordEvent(summary: String) {
+        /// Bump the per-event counters from the cheap `kind` classification.
+        /// `summary` is the expensive human-readable debug string — non-nil
+        /// only when the router debug flag is on; production events store the
+        /// compact kind label instead.
+        mutating func recordEvent(kind: RouterEventKind, summary: String? = nil) {
             eventCount += 1
-            lastEventSummary = summary
-            recentEventSummaries.append(summary)
+            let stored = summary ?? kind.rawValue
+            lastEventSummary = stored
+            recentEventSummaries.append(stored)
             if recentEventSummaries.count > 5 {
                 recentEventSummaries.removeFirst(recentEventSummaries.count - 5)
             }
-            if summary == "done-marker" {
+            switch kind {
+            case .doneMarker:
                 doneMarkerCount += 1
-            } else if summary.hasPrefix("summary ") {
+            case .summary:
                 summaryCount += 1
-            } else if summary.hasPrefix("usage ") {
+            case .usage:
                 usageOnlyCount += 1
-            } else if summary.hasPrefix("non-json") || summary.hasPrefix("object keys=") {
+            case .unrecognized:
                 unrecognizedEventCount += 1
+            case .choice, .error:
+                break
             }
         }
 
@@ -1159,6 +1362,12 @@ public actor RemoteProviderService: ToolCapableService {
         /// Stable router request id for local correlation. This is the signed
         /// idempotency key unless the router summary frame provides request_id.
         var routerRequestId: String?
+        /// Set when the Router's billing summary frame was decoded on this
+        /// stream. A router stream that reached the wire but terminated
+        /// without it triggers a debounced server-truth balance/usage
+        /// reconciliation (the optimistic local decrement never ran, yet the
+        /// server may have charged for partial generation).
+        var routerSummarySeen: Bool = false
 
         /// Non-nil only for providers that inline reasoning as `<think>` in the
         /// content rail (MiniMax). When set, content deltas are split so the
@@ -1176,6 +1385,13 @@ public actor RemoteProviderService: ToolCapableService {
 
         let stopSequences: [String]
         let trackContent: Bool
+
+        /// One decoder reused for every SSE event in this stream. `JSONDecoder`
+        /// construction is per-event overhead on the hot path (multiple
+        /// speculative decodes per event across the error/summary/chunk
+        /// envelopes); the state is owned by a single producer task, so
+        /// reuse is safe.
+        let decoder = JSONDecoder()
 
         /// Append yielded text to `accumulatedContent` if the caller cares
         /// about the inline-tool-detection fallback.
@@ -1205,17 +1421,30 @@ public actor RemoteProviderService: ToolCapableService {
         case `continue`
         /// Stream finished normally (provider sent a "done" marker without a tool call).
         case finishNormal
-        /// Provider signalled a tool call ready to dispatch.
-        case finishWithToolCall(ServiceToolInvocation)
+        /// Provider signalled one or more (parallel) tool calls ready to dispatch.
+        case finishWithToolCall([ServiceToolInvocation])
         /// Provider sent a structured error mid-stream.
         case finishWithError(Error)
     }
 
-    /// Resolution of any tool-call accumulated at a final dispatch site.
+    /// Resolution of any tool-call(s) accumulated at a final dispatch site.
     enum AccumulatedToolCallResult {
         case none
-        case ready(ServiceToolInvocation)
+        case ready([ServiceToolInvocation])
         case truncated(Error)
+    }
+
+    /// Finish a stream by throwing the resolved tool call(s) in the shape the
+    /// consumers expect: a bare `ServiceToolInvocation` for a single call
+    /// (long-standing contract), `ServiceToolInvocations` for a parallel
+    /// batch — matching the local vmlx path (`ModelRuntime.throwIfTools`), so
+    /// the agent loop dispatches every call instead of dropping all but the
+    /// first.
+    static func toolInvocationFinishError(_ invocations: [ServiceToolInvocation]) -> Error {
+        if invocations.count == 1, let only = invocations.first {
+            return only
+        }
+        return ServiceToolInvocations(invocations: invocations)
     }
 
     /// Inspect any tool-call accumulated by the provider event handler and
@@ -1246,9 +1475,21 @@ public actor RemoteProviderService: ToolCapableService {
         tools: [Tool],
         continuation: AsyncThrowingStream<String, Error>.Continuation
     ) -> Bool {
-        let eventSummary = routerEventDebugSummary(dataContent)
-        state.routerDiagnostics?.recordEvent(summary: eventSummary)
-        routerStreamDebug(providerType: providerType, "event \(eventSummary)")
+        // Per-event diagnostics are router-only, and the expensive debug
+        // summary (JSON decode + re-serialize of every SSE event) runs only
+        // when the debug flag is on. Production keeps the cheap sniffed
+        // counters; other providers skip this block entirely.
+        if providerType == .osaurusRouter {
+            let debugSummary =
+                routerStreamDebugEnabled ? routerEventDebugSummary(dataContent) : nil
+            state.routerDiagnostics?.recordEvent(
+                kind: routerEventKind(dataContent),
+                summary: debugSummary
+            )
+            if let debugSummary {
+                routerStreamDebug(providerType: providerType, "event \(debugSummary)")
+            }
+        }
 
         if dataContent.trimmingCharacters(in: .whitespaces) == "[DONE]" {
             routerStreamFinalDebug(providerType: providerType, marker: "[DONE]", state: state)
@@ -1297,8 +1538,9 @@ public actor RemoteProviderService: ToolCapableService {
         }
 
         if providerType == .osaurusRouter,
-            let summary = try? JSONDecoder().decode(OsaurusRouterSummaryEvent.self, from: jsonData)
+            let summary = try? state.decoder.decode(OsaurusRouterSummaryEvent.self, from: jsonData)
         {
+            state.routerSummarySeen = true
             Task { @MainActor in
                 OsaurusRouterAccountService.shared.noteRouterSummary(summary.osaurus)
             }
@@ -1356,8 +1598,8 @@ public actor RemoteProviderService: ToolCapableService {
                 continuation: continuation
             )
             return true
-        case .finishWithToolCall(let invocation):
-            continuation.finish(throwing: invocation)
+        case .finishWithToolCall(let invocations):
+            continuation.finish(throwing: Self.toolInvocationFinishError(invocations))
             return true
         case .finishWithError(let error):
             continuation.finish(throwing: error)
@@ -1374,7 +1616,11 @@ public actor RemoteProviderService: ToolCapableService {
         state: inout StreamingState,
         yield: (String) -> Void
     ) -> StreamEventOutcome {
-        if let errorMessage = tryDecodeStreamError(jsonData, providerType: providerType) {
+        if let errorMessage = tryDecodeStreamError(
+            jsonData,
+            providerType: providerType,
+            decoder: state.decoder
+        ) {
             return .finishWithError(RemoteProviderServiceError.requestFailed(errorMessage))
         }
 
@@ -1483,7 +1729,7 @@ public actor RemoteProviderService: ToolCapableService {
         state: inout StreamingState,
         yield: (String) -> Void
     ) throws -> StreamEventOutcome {
-        let chunk = try JSONDecoder().decode(GeminiGenerateContentResponse.self, from: jsonData)
+        let chunk = try state.decoder.decode(GeminiGenerateContentResponse.self, from: jsonData)
 
         if let parts = chunk.candidates?.first?.content?.parts {
             for part in parts {
@@ -1550,7 +1796,7 @@ public actor RemoteProviderService: ToolCapableService {
         state: inout StreamingState,
         yield: (String) -> Void
     ) throws -> StreamEventOutcome {
-        guard let event = try? JSONDecoder().decode(AnthropicSSEEvent.self, from: jsonData) else {
+        guard let event = try? state.decoder.decode(AnthropicSSEEvent.self, from: jsonData) else {
             return .continue
         }
 
@@ -1560,7 +1806,7 @@ public actor RemoteProviderService: ToolCapableService {
             // usage split. Log the cache read/write counts so the win from the
             // top-level `cache_control` in `toAnthropicRequest()` is observable
             // per turn (cache reads bill 0.1x input; writes 1.25x).
-            if let startEvent = try? JSONDecoder().decode(MessageStartEvent.self, from: jsonData) {
+            if let startEvent = try? state.decoder.decode(MessageStartEvent.self, from: jsonData) {
                 let usage = startEvent.message.usage
                 debugLog(
                     "[Cache][Anthropic] input=\(usage.input_tokens)"
@@ -1570,7 +1816,8 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "content_block_delta":
-            guard let deltaEvent = try? JSONDecoder().decode(ContentBlockDeltaEvent.self, from: jsonData)
+            guard
+                let deltaEvent = try? state.decoder.decode(ContentBlockDeltaEvent.self, from: jsonData)
             else { return .continue }
             if case .textDelta(let textDelta) = deltaEvent.delta {
                 let (truncated, hitStop) = applyStopSequences(
@@ -1592,7 +1839,8 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "content_block_start":
-            guard let startEvent = try? JSONDecoder().decode(ContentBlockStartEvent.self, from: jsonData)
+            guard
+                let startEvent = try? state.decoder.decode(ContentBlockStartEvent.self, from: jsonData)
             else { return .continue }
             if case .toolUse(let toolBlock) = startEvent.content_block {
                 let idx = startEvent.index
@@ -1604,7 +1852,7 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "message_delta":
-            if let deltaEvent = try? JSONDecoder().decode(MessageDeltaEvent.self, from: jsonData),
+            if let deltaEvent = try? state.decoder.decode(MessageDeltaEvent.self, from: jsonData),
                 let stopReason = deltaEvent.delta.stop_reason
             {
                 state.lastFinishReason = stopReason
@@ -1616,7 +1864,7 @@ public actor RemoteProviderService: ToolCapableService {
                 // honestly instead of an empty reply.
                 if stopReason == "refusal" {
                     let explanation =
-                        (try? JSONDecoder().decode(
+                        (try? state.decoder.decode(
                             AnthropicRefusalDeltaEvent.self,
                             from: jsonData
                         ))?.delta.stop_details?.explanation
@@ -1651,13 +1899,13 @@ public actor RemoteProviderService: ToolCapableService {
         state: inout StreamingState,
         yield: (String) -> Void
     ) throws -> StreamEventOutcome {
-        guard let event = try? JSONDecoder().decode(OpenResponsesSSEEvent.self, from: jsonData) else {
+        guard let event = try? state.decoder.decode(OpenResponsesSSEEvent.self, from: jsonData) else {
             return .continue
         }
 
         switch event.type {
         case "response.output_text.delta":
-            if let deltaEvent = try? JSONDecoder().decode(OutputTextDeltaEvent.self, from: jsonData) {
+            if let deltaEvent = try? state.decoder.decode(OutputTextDeltaEvent.self, from: jsonData) {
                 let (truncated, hitStop) = applyStopSequences(
                     deltaEvent.delta,
                     stopSequences: state.stopSequences
@@ -1681,7 +1929,7 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "response.output_item.added":
-            if let addedEvent = try? JSONDecoder().decode(OutputItemAddedEvent.self, from: jsonData),
+            if let addedEvent = try? state.decoder.decode(OutputItemAddedEvent.self, from: jsonData),
                 case .functionCall(let funcCall) = addedEvent.item
             {
                 let idx = addedEvent.output_index
@@ -1693,7 +1941,7 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "response.function_call_arguments.delta":
-            if let deltaEvent = try? JSONDecoder().decode(
+            if let deltaEvent = try? state.decoder.decode(
                 FunctionCallArgumentsDeltaEvent.self,
                 from: jsonData
             ) {
@@ -1709,7 +1957,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         case "response.function_call_arguments.done":
             // Authoritative complete arguments — overwrite accumulated deltas.
-            if let doneEvent = try? JSONDecoder().decode(
+            if let doneEvent = try? state.decoder.decode(
                 FunctionCallArgumentsDoneEvent.self,
                 from: jsonData
             ) {
@@ -1744,7 +1992,7 @@ public actor RemoteProviderService: ToolCapableService {
 
             // Final confirmed item — extract args from the completed function_call
             // when no `.delta` events landed first (common for short calls).
-            if let doneEvent = try? JSONDecoder().decode(OutputItemDoneEvent.self, from: jsonData) {
+            if let doneEvent = try? state.decoder.decode(OutputItemDoneEvent.self, from: jsonData) {
                 switch doneEvent.item {
                 case .functionCall(let funcCall):
                     let idx = doneEvent.output_index
@@ -1884,12 +2132,13 @@ public actor RemoteProviderService: ToolCapableService {
             from: state.accumulatedToolCalls,
             finishMarker: finishMarker
         ) {
-        case .ready(let invocation):
+        case .ready(let invocations):
             print(
-                "[Osaurus] Stream ended: emitting tool call '\(invocation.toolName)' "
+                "[Osaurus] Stream ended: emitting \(invocations.count) tool call(s) "
+                    + "'\(invocations.map(\.toolName).joined(separator: "', '"))' "
                     + "(finish_reason: \(state.lastFinishReason ?? "none"))"
             )
-            continuation.finish(throwing: invocation)
+            continuation.finish(throwing: Self.toolInvocationFinishError(invocations))
 
         case .truncated(let error):
             continuation.finish(throwing: error)
@@ -1973,10 +2222,14 @@ public actor RemoteProviderService: ToolCapableService {
 
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
 
-        // The producer runs in a `Task` whose closure inherits the
-        // calling task's locals (unlike `Task.detached`). Snapshot
-        // the probe here so the read happens once on producer
-        // entry and we don't re-touch the task-local on every chunk.
+        // The producer runs DETACHED from this actor: a `Task {}` here would
+        // inherit the actor's isolation, serializing every chunk of every
+        // concurrent stream to this provider through one executor. All state
+        // the producer needs is captured explicitly below; the only `self`
+        // touches are the lock-backed nonisolated `isSessionInvalidated` and
+        // the immutable `provider` let. `Task.detached` does not inherit
+        // task-locals, so snapshot the probe here (one read on producer
+        // entry, no per-chunk task-local touch).
         let probe = WireTransportProbe.current
 
         // Holds the connected URLSession task so stream teardown can close the
@@ -1984,12 +2237,28 @@ public actor RemoteProviderService: ToolCapableService {
         // a prompt close lets the peer cancel the in-flight remote agent run.
         let liveTaskBox = LiveURLSessionTaskBox()
 
-        let producerTask = Task {
+        let producerTask = Task.detached {
+            var state = StreamingState(stopSequences: stopSequences, trackContent: trackContent)
+            state.routerDiagnostics = initialRouterDiagnostics
+            state.routerRequestId = request.idempotencyKey
+            // True once a 2xx stream response was accepted (chunk loop
+            // entered). Connect-phase failures never reach the router's
+            // billed path, so they don't need reconciliation.
+            var routerStreamConnected = false
+            // Billing reconciliation: however this producer exits (natural
+            // end, finish marker, error, cancel), a connected router stream
+            // that never delivered its summary frame may still have been
+            // charged server-side — and the optimistic local balance
+            // decrement never ran. Ask the account service for a debounced
+            // server-truth balance/usage refresh.
+            defer {
+                if providerType == .osaurusRouter, routerStreamConnected, !state.routerSummarySeen {
+                    Task { @MainActor in
+                        OsaurusRouterAccountService.shared.reconcileAfterStreamWithoutSummary()
+                    }
+                }
+            }
             do {
-                var state = StreamingState(stopSequences: stopSequences, trackContent: trackContent)
-                state.routerDiagnostics = initialRouterDiagnostics
-                state.routerRequestId = request.idempotencyKey
-
                 // Idempotent connect-phase retry: only retries the
                 // `bytes(for:)` call (no stream data has been delivered
                 // upstream yet, so retrying is safe). Once we start
@@ -2010,30 +2279,44 @@ public actor RemoteProviderService: ToolCapableService {
                 connectLoop: while true {
                     attempt += 1
 
-                    var outboundRequest = urlRequest
+                    // Bracket the task-creation window (secure handshake +
+                    // connect) with the session-lifecycle guard: a concurrent
+                    // `invalidateSession()` either refuses this `begin` (we
+                    // bail with CancellationError) or defers its
+                    // `invalidateAndCancel()` until the matching `end`, so
+                    // the session can never be invalidated mid-`bytes(for:)`.
+                    guard self.beginSessionRequest() else { throw CancellationError() }
+                    let bytes: URLSession.AsyncBytes
+                    let response: URLResponse
                     var secureOpener: SecureResponseOpener? = nil
-                    if let secureProvider {
-                        // Seal per attempt: each call consumes a fresh
-                        // sequence number, so a retry can't be a replay.
-                        let wrapped = try await SecureChannelClient.shared.wrappedRequest(
-                            for: urlRequest,
-                            provider: secureProvider,
-                            urlSession: currentSession
-                        )
-                        outboundRequest = wrapped.request
-                        // Hold the opener; the decoder is built only once we
-                        // confirm the response is an encrypted SSE stream. A
-                        // buffered error envelope is decoded separately below.
-                        secureOpener = wrapped.opener
-                    }
-
-                    let (bytes, response) = try await Self.connectWithRetry(
-                        session: currentSession,
-                        urlRequest: outboundRequest,
-                        isCancelled: { [weak self] in
-                            self?.isSessionInvalidated ?? true
+                    do {
+                        var outboundRequest = urlRequest
+                        if let secureProvider {
+                            // Seal per attempt: each call consumes a fresh
+                            // sequence number, so a retry can't be a replay.
+                            let wrapped = try await SecureChannelClient.shared.wrappedRequest(
+                                for: urlRequest,
+                                provider: secureProvider,
+                                urlSession: currentSession
+                            )
+                            outboundRequest = wrapped.request
+                            // Hold the opener; the decoder is built only once we
+                            // confirm the response is an encrypted SSE stream. A
+                            // buffered error envelope is decoded separately below.
+                            secureOpener = wrapped.opener
                         }
-                    )
+                        (bytes, response) = try await Self.connectWithRetry(
+                            session: currentSession,
+                            urlRequest: outboundRequest,
+                            isCancelled: { [weak self] in
+                                self?.isSessionInvalidated ?? true
+                            }
+                        )
+                    } catch {
+                        self.endSessionRequest()
+                        throw error
+                    }
+                    self.endSessionRequest()
 
                     guard let httpResponse = response as? HTTPURLResponse else {
                         continuation.finish(throwing: RemoteProviderServiceError.invalidResponse)
@@ -2065,7 +2348,17 @@ public actor RemoteProviderService: ToolCapableService {
                             await SecureChannelClient.shared.invalidateSession(for: secureProvider)
                             continue connectLoop
                         }
-                        let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+                        if let rateLimited = RemoteProviderServiceError.rateLimited(from: httpResponse) {
+                            continuation.finish(throwing: rateLimited)
+                            return
+                        }
+                        // Parse the error envelope instead of dumping the raw
+                        // JSON body into chat; known upstream rejections map
+                        // to actionable copy.
+                        let errorMessage = Self.extractErrorMessage(
+                            from: errorData,
+                            statusCode: httpResponse.statusCode
+                        )
                         continuation.finish(
                             throwing: RemoteProviderServiceError.requestFailed(
                                 "HTTP \(httpResponse.statusCode): \(errorMessage)"
@@ -2126,6 +2419,7 @@ public actor RemoteProviderService: ToolCapableService {
                     }
 
                     connectedBytes = bytes
+                    routerStreamConnected = true
                     // Expose the live task so `onTermination` can hard-cancel
                     // it (closes the socket) the instant the consumer stops.
                     liveTaskBox.store(bytes.task)
@@ -2156,7 +2450,14 @@ public actor RemoteProviderService: ToolCapableService {
                 var routerChunkCount = 0
                 var routerByteCount = 0
                 var routerEventCount = 0
-                let chunkStream = Self.makeChunkStream(from: bytes)
+                // Inactivity is enforced by the chunk stream's built-in
+                // watchdog (single deadline-reset task; see `makeChunkStream`)
+                // — a timeout surfaces here as a clean `nil`, identical to
+                // natural EOF, so the loop below needs no per-chunk race.
+                let chunkStream = Self.makeChunkStream(
+                    from: bytes,
+                    inactivityTimeout: inactivityTimeout
+                )
                 let chunkIter = ChunkIteratorRef(chunkStream.makeAsyncIterator())
 
                 chunkLoop: while true {
@@ -2165,10 +2466,7 @@ public actor RemoteProviderService: ToolCapableService {
                         return
                     }
 
-                    let chunk = try await Self.nextChunk(
-                        from: chunkIter,
-                        timeout: inactivityTimeout
-                    )
+                    let chunk = try await chunkIter.next()
 
                     if let chunk = chunk {
                         if providerType == .osaurusRouter {
@@ -2436,6 +2734,16 @@ public actor RemoteProviderService: ToolCapableService {
         {
             request.promptCacheKey = "osaurus-session-\(sessionId)"
         }
+        // Parameter fidelity: forward the caller's deterministic seed and JSON
+        // mode instead of silently dropping them. Standard OpenAI fields on
+        // the chat-completions wire; Gemini remaps them in `toGeminiRequest`;
+        // Anthropic has no equivalent (documented in docs/REMOTE_PROVIDERS.md).
+        if !isAgentRun {
+            request.seed = parameters.seed.flatMap { Int(exactly: $0) }
+            if parameters.jsonMode {
+                request.response_format = ResponseFormat(type: "json_object")
+            }
+        }
         request.runAsRemoteAgent = parameters.runAsRemoteAgent
         return request
     }
@@ -2469,9 +2777,28 @@ public actor RemoteProviderService: ToolCapableService {
         }
         guard tokens.isExpired else { return }
 
-        let refreshed = try await OpenAICodexOAuthService.refresh(tokens)
+        let refreshed: RemoteProviderOAuthTokens
+        do {
+            refreshed = try await OpenAICodexOAuthService.refresh(tokens)
+        } catch {
+            notifyManagerIfPermanentOAuthFailure(error)
+            throw error
+        }
         cachedOAuthTokens = refreshed
         await RemoteProviderKeychain.saveOAuthTokensOffMainActor(refreshed, for: provider.id)
+    }
+
+    /// A mid-chat token refresh that fails with a *permanent* auth error
+    /// (`invalid_grant` / 401) means every future request is doomed until the
+    /// user signs in again. Tell the manager so it clears the dead tokens and
+    /// flips the durable `requiresAuth` state, rather than leaving a
+    /// connected-looking provider that errors on every turn.
+    private func notifyManagerIfPermanentOAuthFailure(_ error: Error) {
+        guard RemoteProviderManager.isPermanentOAuthFailure(error) else { return }
+        let providerId = provider.id
+        Task { @MainActor in
+            RemoteProviderManager.shared.handlePermanentOAuthFailure(providerId: providerId)
+        }
     }
 
     private func codexOAuthHeaders() throws -> [String: String] {
@@ -2493,7 +2820,13 @@ public actor RemoteProviderService: ToolCapableService {
         }
         guard tokens.isExpired else { return }
 
-        let refreshed = try await XAIOAuthService.refresh(tokens)
+        let refreshed: RemoteProviderOAuthTokens
+        do {
+            refreshed = try await XAIOAuthService.refresh(tokens)
+        } catch {
+            notifyManagerIfPermanentOAuthFailure(error)
+            throw error
+        }
         cachedOAuthTokens = refreshed
         await RemoteProviderKeychain.saveOAuthTokensOffMainActor(refreshed, for: provider.id)
     }
@@ -2540,7 +2873,16 @@ public actor RemoteProviderService: ToolCapableService {
 
         let producerTask = Task {
             do {
-                let (data, response) = try await currentSession.data(for: urlRequest)
+                guard self.beginSessionRequest() else { throw CancellationError() }
+                let data: Data
+                let response: URLResponse
+                do {
+                    (data, response) = try await currentSession.data(for: urlRequest)
+                } catch {
+                    self.endSessionRequest()
+                    throw error
+                }
+                self.endSessionRequest()
                 probe?.replaceResponseBody(data)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -2564,7 +2906,7 @@ public actor RemoteProviderService: ToolCapableService {
                 )
 
                 if let parts = geminiResponse.candidates?.first?.content?.parts {
-                    var pendingToolCall: ServiceToolInvocation?
+                    var pendingToolCalls: [ServiceToolInvocation] = []
 
                     for part in parts {
                         if part.thought == true { continue }
@@ -2577,19 +2919,23 @@ public actor RemoteProviderService: ToolCapableService {
                         case .inlineData(let imageData):
                             continuation.yield(Self.imageMarkdown(imageData, thoughtSignature: part.thoughtSignature))
                         case .functionCall(let funcCall):
-                            pendingToolCall = ServiceToolInvocation(
-                                toolName: funcCall.name,
-                                jsonArguments: Self.geminiArgsJSON(from: funcCall.args),
-                                toolCallId: Self.geminiToolCallId(),
-                                geminiThoughtSignature: funcCall.thoughtSignature
+                            // Gemini can return several functionCall parts in
+                            // one candidate (parallel calling) — keep them all.
+                            pendingToolCalls.append(
+                                ServiceToolInvocation(
+                                    toolName: funcCall.name,
+                                    jsonArguments: Self.geminiArgsJSON(from: funcCall.args),
+                                    toolCallId: Self.geminiToolCallId(),
+                                    geminiThoughtSignature: funcCall.thoughtSignature
+                                )
                             )
                         case .functionResponse:
                             break
                         }
                     }
 
-                    if let invocation = pendingToolCall {
-                        continuation.finish(throwing: invocation)
+                    if !pendingToolCalls.isEmpty {
+                        continuation.finish(throwing: Self.toolInvocationFinishError(pendingToolCalls))
                         return
                     }
                 }
@@ -2706,6 +3052,16 @@ public actor RemoteProviderService: ToolCapableService {
                     "Invalid Gemini model name '\(trimmedModel)': only letters, digits, '-', '_', '.', and '/' are allowed. Check provider settings."
                 )
             }
+            // `/` is allowed for legitimate parents (`tunedModels/…`,
+            // `models/…`), but a `..` segment would walk out of the
+            // `/models/` base and hit an unintended endpoint. Reject any
+            // relative-traversal segment explicitly.
+            let modelSegments = trimmedModel.split(separator: "/", omittingEmptySubsequences: false)
+            if modelSegments.contains("..") || modelSegments.contains(".") {
+                throw RemoteProviderServiceError.requestFailed(
+                    "Invalid Gemini model name '\(trimmedModel)': path traversal segments ('.'/'..') are not allowed. Check provider settings."
+                )
+            }
             let endpoint = "/models/\(trimmedModel):\(action)"
             guard let geminiURL = provider.url(for: endpoint) else {
                 throw RemoteProviderServiceError.invalidURL
@@ -2772,7 +3128,7 @@ public actor RemoteProviderService: ToolCapableService {
             // to avoid Keychain access issues from the actor's background executor.
             headers = cachedHeaders
         }
-        for (key, value) in headers {
+        for (key, value) in headers where Self.isSafeHeader(name: key, value: value) {
             urlRequest.setValue(value, forHTTPHeaderField: key)
         }
 
@@ -2780,11 +3136,15 @@ public actor RemoteProviderService: ToolCapableService {
         // (ds4, vLLM, sglang, Anthropic prompt cache, ...) hash the
         // rendered prompt — including inlined tool schemas — byte for
         // byte; see `JSONDeterminism.swift` / `docs/JSON_DETERMINISM.md`.
-        let encoder = JSONEncoder.osaurusCanonical(prettyPrinted: true)
+        // Compact output: sorted keys are what cache determinism needs;
+        // pretty-printing only inflated every request body (up to ~30% on
+        // tool-heavy payloads) for zero wire benefit.
+        let encoder = JSONEncoder.osaurusCanonical(prettyPrinted: false)
 
         let bodyData: Data
         switch requestProviderType {
         case .anthropic:
+            try Self.rejectDroppedMediaInputs(in: request.messages, wireName: "Anthropic")
             let anthropicRequest = request.toAnthropicRequest()
             bodyData = try encoder.encode(anthropicRequest)
         case .openResponses:
@@ -2793,6 +3153,7 @@ public actor RemoteProviderService: ToolCapableService {
         case .openAICodex:
             bodyData = try request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
         case .gemini:
+            try Self.rejectDroppedMediaInputs(in: request.messages, wireName: "Gemini")
             let geminiRequest = request.toGeminiRequest()
             bodyData = try encoder.encode(geminiRequest)
         case .openaiLegacy, .azureOpenAI, .osaurus, .osaurusRouter:
@@ -2806,7 +3167,10 @@ public actor RemoteProviderService: ToolCapableService {
                 model: request.model
             ).transformOutbound(outbound.messages)
             if requestProviderType == .osaurusRouter {
-                outbound.messages = Self.routerWireCompatibleMessages(outbound.messages)
+                outbound.messages = Self.routerWireCompatibleMessages(
+                    outbound.messages,
+                    modelSupportsImageInput: routerVisionModelIds.contains(request.model)
+                )
                 outbound.clamp_to_balance = false
             } else {
                 // Plain OpenAI-compat upstreams enforce tool pairing both ways
@@ -2861,6 +3225,31 @@ public actor RemoteProviderService: ToolCapableService {
     /// are merged here at the remote wire boundary — concatenating their text so
     /// the model still reads the notice — and never in local history.
     ///
+    /// The Anthropic and Gemini wire converters translate only text and image
+    /// content parts; audio (`input_audio`) and video (`video_url`) parts have
+    /// no mapping and were previously dropped without a trace — the model
+    /// answered as if the attachment never existed. Reject with a typed error
+    /// instead so the caller learns the modality is unsupported on this route.
+    static func rejectDroppedMediaInputs(in messages: [ChatMessage], wireName: String) throws {
+        for message in messages {
+            guard let parts = message.contentParts else { continue }
+            for part in parts {
+                switch part {
+                case .audioInput:
+                    throw RemoteProviderServiceError.unsupportedParameter(
+                        "Audio input is not supported on the \(wireName) provider route. Remove the audio attachment or use a provider/model that accepts audio."
+                    )
+                case .videoUrl:
+                    throw RemoteProviderServiceError.unsupportedParameter(
+                        "Video input is not supported on the \(wireName) provider route. Remove the video attachment or use a provider/model that accepts video."
+                    )
+                case .text, .imageUrl:
+                    continue
+                }
+            }
+        }
+    }
+
     /// Only adjacent same-id results within one run of consecutive `tool`
     /// messages merge; distinct ids in a parallel batch stay separate and the
     /// order is preserved, so Anthropic's "result immediately follows the
@@ -3103,10 +3492,24 @@ public actor RemoteProviderService: ToolCapableService {
 
     /// Router fan-out advertises one OpenAI-compatible request to many
     /// upstreams, so it uses the strictest shared chat-completions history
-    /// shape. User media stays multimodal; assistant history leaves Osaurus as
-    /// string `content` because several upstreams reject assistant arrays or
-    /// omitted assistant content on tool-call turns.
-    static func routerWireCompatibleMessages(_ messages: [ChatMessage]) -> [ChatMessage] {
+    /// shape. Assistant history leaves Osaurus as string `content` because
+    /// several upstreams reject assistant arrays or omitted assistant content
+    /// on tool-call turns.
+    ///
+    /// User media is capability-gated: image parts stay multimodal only when
+    /// the target model advertises image input (`modelSupportsImageInput`,
+    /// from the Router `/models` capability catalog). For non-vision models
+    /// the Router's upstream adapters (notably Anthropic/Claude) reject
+    /// array-form user content with HTTP 400 "user message content must be a
+    /// string" — and because history is replayed every turn, one media
+    /// message anywhere in the conversation used to fail every subsequent
+    /// turn. Audio/video parts have no mapping on any Router upstream and
+    /// are always flattened. Removed attachments are replaced with a visible
+    /// text notice (truthful removal) instead of being silently dropped.
+    static func routerWireCompatibleMessages(
+        _ messages: [ChatMessage],
+        modelSupportsImageInput: Bool = true
+    ) -> [ChatMessage] {
         // Collapse same-id tool results FIRST: the router fans out to Claude,
         // which rejects more than one tool_result per tool_use_id. THEN drop
         // any orphaned tool_use/tool_result half-pair (also a Claude 400) so
@@ -3117,8 +3520,13 @@ public actor RemoteProviderService: ToolCapableService {
         )
         let wireMessages = routerMessagesDroppingUnsupportedAssistantPrefill(deduped)
         return wireMessages.map { message in
-            guard requiresRouterAssistantStringContent(message) else { return message }
-            return routerAssistantWireMessage(message)
+            if requiresRouterAssistantStringContent(message) {
+                return routerAssistantWireMessage(message)
+            }
+            return routerUserWireMessage(
+                message,
+                modelSupportsImageInput: modelSupportsImageInput
+            )
         }
     }
 
@@ -3151,6 +3559,78 @@ public actor RemoteProviderService: ToolCapableService {
             reasoning_item_id: message.reasoning_item_id,
             reasoning_encrypted: message.reasoning_encrypted
         )
+    }
+
+    /// Normalize a user message's media parts for the Router wire. Returns the
+    /// message unchanged when it carries no unsupported media. Otherwise the
+    /// unsupported parts (audio/video always; images when the model lacks
+    /// image input) are removed and replaced with one visible text notice so
+    /// neither the model nor the user is silently lied to about what shipped.
+    /// When only supported image parts remain, the message stays multimodal;
+    /// when no media parts remain, it collapses to plain string content —
+    /// which is exactly the shape non-vision Router upstream adapters accept.
+    private static func routerUserWireMessage(
+        _ message: ChatMessage,
+        modelSupportsImageInput: Bool
+    ) -> ChatMessage {
+        guard message.role.lowercased() == "user", let parts = message.contentParts else {
+            return message
+        }
+
+        var keptParts: [MessageContentPart] = []
+        var removedKinds: [String] = []
+        for part in parts {
+            switch part {
+            case .text:
+                keptParts.append(part)
+            case .imageUrl:
+                if modelSupportsImageInput {
+                    keptParts.append(part)
+                } else {
+                    removedKinds.append("image")
+                }
+            case .audioInput:
+                removedKinds.append("audio")
+            case .videoUrl:
+                removedKinds.append("video")
+            }
+        }
+        guard !removedKinds.isEmpty else { return message }
+
+        let summary = Self.removedMediaSummary(removedKinds)
+        let notice = "[Osaurus: \(summary) removed — not supported by this model on Osaurus Router]"
+        wirePairingLogger.warning(
+            "Router wire: removed unsupported user media (\(summary, privacy: .public)) for non-capable model (truthful removal)"
+        )
+
+        let keptText = keptParts.compactMap { part -> String? in
+            if case .text(let text) = part { return text }
+            return nil
+        }
+        let hasRemainingMedia = keptParts.contains { part in
+            if case .text = part { return false }
+            return true
+        }
+        if hasRemainingMedia {
+            return ChatMessage(
+                role: message.role,
+                content: message.content,
+                contentParts: keptParts + [.text(notice)]
+            )
+        }
+        let flattened = (keptText + [notice]).joined(separator: "\n")
+        return ChatMessage(role: message.role, content: flattened)
+    }
+
+    /// "1 image", "2 images and 1 audio attachment" — compact removal summary
+    /// for the wire notice and log line.
+    private static func removedMediaSummary(_ kinds: [String]) -> String {
+        var counts: [String: Int] = [:]
+        for kind in kinds { counts[kind, default: 0] += 1 }
+        let parts = counts.sorted { $0.key < $1.key }.map { kind, count in
+            "\(count) \(kind) attachment\(count == 1 ? "" : "s")"
+        }
+        return parts.joined(separator: " and ")
     }
 
     /// Parse response based on provider type
@@ -3488,6 +3968,17 @@ struct RemoteChatRequest: Encodable {
     /// `supportsPromptCacheKey`) so strict third-party OpenAI-compat schemas
     /// never see an unknown field. Encoded only when non-nil.
     var promptCacheKey: String? = nil
+    /// OpenAI deterministic-sampling `seed`. Forwarded from the caller's
+    /// request on OpenAI-compatible chat-completions wires (standard field,
+    /// unknown-but-ignored elsewhere); Gemini maps it into
+    /// `generationConfig.seed` in `toGeminiRequest`. Anthropic has no seed
+    /// parameter, so it is omitted there. Encoded only when non-nil.
+    var seed: Int? = nil
+    /// OpenAI `response_format` (JSON mode). Set only for
+    /// `{type: json_object}` requests; Gemini maps it to
+    /// `generationConfig.responseMimeType` in `toGeminiRequest`. Anthropic
+    /// has no equivalent, so it is omitted there. Encoded only when non-nil.
+    var response_format: ResponseFormat? = nil
     /// Local-only routing marker (Mode 2). When true, `buildURLRequest` targets
     /// the peer's `/agents/{address}/run` endpoint instead of
     /// `/chat/completions`. Intentionally absent from `CodingKeys` so it never
@@ -3505,6 +3996,8 @@ struct RemoteChatRequest: Encodable {
         case veniceParameters = "venice_parameters"
         case streamOptions = "stream_options"
         case promptCacheKey = "prompt_cache_key"
+        case seed
+        case response_format
     }
 
     func encode(to encoder: Encoder) throws {
@@ -3556,6 +4049,8 @@ struct RemoteChatRequest: Encodable {
         try container.encodeIfPresent(veniceParameters, forKey: .veniceParameters)
         try container.encodeIfPresent(streamOptions, forKey: .streamOptions)
         try container.encodeIfPresent(promptCacheKey, forKey: .promptCacheKey)
+        try container.encodeIfPresent(seed, forKey: .seed)
+        try container.encodeIfPresent(response_format, forKey: .response_format)
         // `modelOptions` is intentionally not in `CodingKeys` — it stays
         // in-process for model-specific feature flags.
     }
@@ -3950,9 +4445,13 @@ struct RemoteChatRequest: Encodable {
             return GeminiImageConfig(aspectRatio: effectiveRatio, imageSize: effectiveSize)
         }()
 
+        // Map OpenAI parameter-fidelity fields into Gemini's generationConfig:
+        // `seed` carries over directly; JSON mode becomes `responseMimeType`.
+        let jsonMimeType: String? = response_format?.type == "json_object" ? "application/json" : nil
         var generationConfig: GeminiGenerationConfig?
         if temperature != nil || max_completion_tokens != nil || top_p != nil || stop != nil
             || responseModalities != nil || imageConfig != nil
+            || seed != nil || jsonMimeType != nil
         {
             generationConfig = GeminiGenerationConfig(
                 temperature: temperature.map { Double($0) },
@@ -3961,7 +4460,9 @@ struct RemoteChatRequest: Encodable {
                 topK: nil,
                 stopSequences: stop,
                 responseModalities: responseModalities,
-                imageConfig: imageConfig
+                imageConfig: imageConfig,
+                seed: seed,
+                responseMimeType: jsonMimeType
             )
         }
 
@@ -4452,6 +4953,17 @@ extension RemoteProviderService {
             responseData: data,
             configuredSecretHeaderKeys: provider.secretHeaderKeys
         )
+        // Typed rate-limit/unavailable before the generic decode path so the
+        // connect phase can honor Retry-After with a bounded retry. Model
+        // discovery is an idempotent GET, so a plain 503 (no Retry-After) is
+        // also safe to classify as retryable here — unlike the chat path,
+        // where only explicit throttle responses are typed.
+        if let rateLimited = RemoteProviderServiceError.rateLimited(from: httpResponse) {
+            throw rateLimited
+        }
+        if httpResponse.statusCode == 503 {
+            throw RemoteProviderServiceError.rateLimited(retryAfter: nil, statusCode: 503)
+        }
         do {
             return try decodeOpenAICompatibleModelsResponse(
                 data: data,
@@ -4506,11 +5018,29 @@ extension RemoteProviderService {
         request.timeoutInterval = modelDiscoveryTimeout(timeout)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        for (key, value) in headers {
+        for (key, value) in headers where isSafeHeader(name: key, value: value) {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
         return request
+    }
+
+    /// Reject header names/values that contain characters Foundation's
+    /// `URLRequest.setValue(_:forHTTPHeaderField:)` can choke on — CR/LF (the
+    /// classic header-injection / request-splitting vector) and other control
+    /// characters. Applied as defense-in-depth at the wire boundary so a
+    /// malformed custom header (from config or a paste) is dropped rather than
+    /// crashing the request or smuggling an extra header line upstream. An
+    /// empty name is also rejected.
+    static func isSafeHeader(name: String, value: String) -> Bool {
+        if name.isEmpty { return false }
+        let hasControl: (String) -> Bool = { text in
+            text.unicodeScalars.contains { scalar in
+                // Disallow C0 controls (incl. CR, LF, tab) and DEL.
+                scalar.value < 0x20 || scalar.value == 0x7F
+            }
+        }
+        return !hasControl(name) && !hasControl(value)
     }
 
     static func modelDiscoveryTimeout(_ timeout: TimeInterval) -> TimeInterval {
@@ -4944,12 +5474,15 @@ extension RemoteProviderService {
     }
 
     /// Extract a human-readable error message from API error response data
-    private static func extractErrorMessage(from data: Data, statusCode: Int) -> String {
+    static func extractErrorMessage(from data: Data, statusCode: Int) -> String {
         // Try to parse as JSON error response (OpenAI/xAI format)
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             // OpenAI/xAI format: {"error": {"message": "...", "type": "...", "code": "..."}}
             if let error = json["error"] as? [String: Any] {
                 if let message = error["message"] as? String {
+                    if let friendly = friendlyUpstreamRejection(message) {
+                        return friendly
+                    }
                     // Include error code if available for more context
                     if let code = error["code"] as? String {
                         return "\(message) (code: \(code))"
@@ -4975,5 +5508,19 @@ extension RemoteProviderService {
         }
 
         return "HTTP \(statusCode): Unknown error"
+    }
+
+    /// Rewrite known upstream-adapter rejections into actionable copy. The
+    /// Router's non-vision upstream adapters reject array-form user content
+    /// with a terse protocol message that means nothing to a user staring at
+    /// a chat bubble — translate it to what actually happened and how to
+    /// recover. Returns nil for everything else (message passes through).
+    static func friendlyUpstreamRejection(_ message: String) -> String? {
+        let lowered = message.lowercased()
+        if lowered.contains("user message content must be a string") {
+            return
+                "This model doesn't accept image, audio, or video attachments. Remove the attachment from the conversation (or start a new chat without it), or switch to a vision-capable model."
+        }
+        return nil
     }
 }

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -420,7 +420,11 @@ public enum XAIOAuthService {
         }
 
         do {
-            return try await server.waitForCallback()
+            // Bounded wait: an abandoned browser tab must not pin this task
+            // (and the bound loopback port) forever.
+            return try await server.waitForCallback(
+                timeout: OAuthLoopbackServer.defaultSignInTimeout
+            )
         } catch let error as OAuthLoopbackError {
             throw mapLoopbackError(error)
         } catch {

--- a/Packages/OsaurusCore/Services/Router/OsaurusRouterAccountService.swift
+++ b/Packages/OsaurusCore/Services/Router/OsaurusRouterAccountService.swift
@@ -205,4 +205,33 @@ final class OsaurusRouterAccountService: ObservableObject {
         balance = OsaurusRouterBalanceResponse(balanceMicro: String(updated), frozen: current.frozen)
         Task { await refreshUsage(reset: true) }
     }
+
+    // MARK: - Missing-summary reconciliation
+
+    /// Debounce window before the server-truth refresh fires. Long enough to
+    /// collapse a burst of failing streams (e.g. brief offline window, agent
+    /// loop erroring repeatedly) into one refresh pass, short enough that the
+    /// Credits UI catches up while the user is still looking at it.
+    nonisolated static let missingSummaryReconcileDebounce: TimeInterval = 5
+
+    private var missingSummaryReconcileTask: Task<Void, Never>?
+
+    /// A Router stream reached the wire but terminated without its billing
+    /// summary frame (mid-stream error, user cancel, truncation). The server
+    /// may still have charged for the partial generation, and the optimistic
+    /// local decrement (`noteRouterSummary`) never ran — so the cached
+    /// balance/usage can drift from server truth. Schedule a debounced
+    /// balance + usage refresh as reconciliation; the server is authoritative.
+    func reconcileAfterStreamWithoutSummary() {
+        guard OsaurusRouter.isEnabled else { return }
+        missingSummaryReconcileTask?.cancel()
+        missingSummaryReconcileTask = Task { [weak self] in
+            try? await Task.sleep(
+                nanoseconds: UInt64(Self.missingSummaryReconcileDebounce * 1_000_000_000)
+            )
+            guard !Task.isCancelled else { return }
+            await self?.refreshBalance()
+            await self?.refreshUsage(reset: true)
+        }
+    }
 }

--- a/Packages/OsaurusCore/Services/Router/OsaurusRouterTypes.swift
+++ b/Packages/OsaurusCore/Services/Router/OsaurusRouterTypes.swift
@@ -5,13 +5,21 @@ enum OsaurusRouter {
     static let stagingBaseURL = URL(string: "https://osaurus-router.fly.dev")!
 
     static var defaultBaseURL: URL {
-        if let override = UserDefaults.standard.string(forKey: "ai.osaurus.router.baseURL"),
-            let url = URL(string: override.trimmingCharacters(in: .whitespacesAndNewlines)),
-            url.scheme != nil,
-            url.host != nil
-        {
-            return url
-        }
+        // The UserDefaults override exists for staging/local Router testing
+        // only. Router requests are master-key-signed and credit-billed, so
+        // in release builds a writable base URL would let anything that can
+        // write this process's defaults (e.g. `defaults write`) redirect
+        // signed spend to an arbitrary host. DEBUG-only, hard-locked to
+        // production otherwise.
+        #if DEBUG
+            if let override = UserDefaults.standard.string(forKey: "ai.osaurus.router.baseURL"),
+                let url = URL(string: override.trimmingCharacters(in: .whitespacesAndNewlines)),
+                url.scheme != nil,
+                url.host != nil
+            {
+                return url
+            }
+        #endif
         return productionBaseURL
     }
 
@@ -31,6 +39,27 @@ enum OsaurusRouter {
     /// Persist the user's master on/off choice for the Osaurus Router.
     static func setEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: enabledDefaultsKey)
+    }
+
+    /// UserDefaults key backing the opt-in that lets *key-less* loopback API
+    /// callers route requests through the Osaurus Router.
+    static let allowUnkeyedLoopbackSpendDefaultsKey =
+        "ai.osaurus.router.allowUnkeyedLoopbackSpend"
+
+    /// Whether local (loopback) HTTP callers that did not present a valid
+    /// access key may route requests to the Osaurus Router. Router requests
+    /// are signed with the user's master key and spend real credits, so this
+    /// defaults to `false`: without the opt-in, any local process could spend
+    /// the user's balance through the unauthenticated loopback API. Keyed
+    /// callers (valid `Authorization: Bearer <access key>`) are always
+    /// allowed.
+    static var allowsUnkeyedLoopbackSpend: Bool {
+        UserDefaults.standard.bool(forKey: allowUnkeyedLoopbackSpendDefaultsKey)
+    }
+
+    /// Persist the user's explicit opt-in for key-less loopback Router spend.
+    static func setAllowsUnkeyedLoopbackSpend(_ allowed: Bool) {
+        UserDefaults.standard.set(allowed, forKey: allowUnkeyedLoopbackSpendDefaultsKey)
     }
 
     static let minimumTopUpMicro = 5_000_000

--- a/Packages/OsaurusCore/Tests/Chat/RouterSpendGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/RouterSpendGateTests.swift
@@ -1,0 +1,173 @@
+//
+//  RouterSpendGateTests.swift
+//  osaurusTests
+//
+//  Pins the Osaurus Router credit-spend gate for HTTP-origin requests:
+//  key-less loopback callers must not be able to route master-key-signed,
+//  credit-billed requests through the Router unless the user explicitly
+//  opted in. Keyed callers and app-internal sources are unaffected.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct RouterSpendGateTests {
+
+    // MARK: - Pure policy
+
+    @Test func blocksUnkeyedHTTPCallerWithoutOptIn() {
+        let error = ChatEngine.routerSpendAuthorizationError(
+            serviceIsOsaurusRouter: true,
+            source: .httpAPI,
+            callerHasVerifiedAccessKey: false,
+            allowsUnkeyedLoopbackSpend: false
+        )
+        #expect(error != nil)
+        #expect(error?.httpStatus == 403)
+    }
+
+    @Test func allowsKeyedHTTPCaller() {
+        let error = ChatEngine.routerSpendAuthorizationError(
+            serviceIsOsaurusRouter: true,
+            source: .httpAPI,
+            callerHasVerifiedAccessKey: true,
+            allowsUnkeyedLoopbackSpend: false
+        )
+        #expect(error == nil)
+    }
+
+    @Test func allowsUnkeyedCallerWithExplicitOptIn() {
+        let error = ChatEngine.routerSpendAuthorizationError(
+            serviceIsOsaurusRouter: true,
+            source: .httpAPI,
+            callerHasVerifiedAccessKey: false,
+            allowsUnkeyedLoopbackSpend: true
+        )
+        #expect(error == nil)
+    }
+
+    @Test func neverBlocksAppInternalSources() {
+        for source in [RequestSource.chatUI, .plugin, .p2p] {
+            let error = ChatEngine.routerSpendAuthorizationError(
+                serviceIsOsaurusRouter: true,
+                source: source,
+                callerHasVerifiedAccessKey: false,
+                allowsUnkeyedLoopbackSpend: false
+            )
+            #expect(error == nil, "source \(source) must not be gated")
+        }
+    }
+
+    @Test func neverBlocksNonRouterServices() {
+        let error = ChatEngine.routerSpendAuthorizationError(
+            serviceIsOsaurusRouter: false,
+            source: .httpAPI,
+            callerHasVerifiedAccessKey: false,
+            allowsUnkeyedLoopbackSpend: false
+        )
+        #expect(error == nil)
+    }
+
+    // MARK: - Engine wiring
+
+    private func makeRouterService() -> RemoteProviderService {
+        let provider = RemoteProvider(
+            name: "Osaurus",
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 1,  // Unroutable port: reaching the network at all is a bug.
+            basePath: "",
+            authType: .none,
+            providerType: .osaurusRouter
+        )
+        return RemoteProviderService(
+            provider: provider,
+            models: ["anthropic/claude-opus"],
+            resolvedHeaders: [:]
+        )
+    }
+
+    private func makeRequest() -> ChatCompletionRequest {
+        ChatCompletionRequest(
+            model: "osaurus/anthropic/claude-opus",
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            max_tokens: 8,
+            stream: true,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+    }
+
+    /// Without a caller context (or with an unkeyed one) an `.httpAPI` engine
+    /// must refuse to dispatch a router-bound stream before any network I/O.
+    @Test func streamChatFailsClosedForUnkeyedHTTPOrigin() async {
+        let defaults = UserDefaults.standard
+        let previous = defaults.object(forKey: OsaurusRouter.allowUnkeyedLoopbackSpendDefaultsKey)
+        defaults.removeObject(forKey: OsaurusRouter.allowUnkeyedLoopbackSpendDefaultsKey)
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: OsaurusRouter.allowUnkeyedLoopbackSpendDefaultsKey)
+            }
+        }
+
+        let router = makeRouterService()
+        let engine = ChatEngine(
+            services: [],
+            installedModelsProvider: { [] },
+            remoteServicesProvider: { [router] },
+            source: .httpAPI
+        )
+
+        await #expect(throws: ChatEngine.EngineError.self) {
+            _ = try await engine.streamChat(request: makeRequest())
+        }
+        do {
+            _ = try await engine.streamChat(request: makeRequest())
+            Issue.record("expected routerSpendNotAuthorized")
+        } catch let error as ChatEngine.EngineError {
+            #expect(error.httpStatus == 403)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
+    }
+
+    /// A bound caller context with a verified key must pass the gate. The
+    /// request then reaches the (unroutable) transport layer, so any failure
+    /// there must NOT be the 403 spend refusal.
+    @Test func streamChatPassesGateForKeyedHTTPOrigin() async {
+        let router = makeRouterService()
+        let engine = ChatEngine(
+            services: [],
+            installedModelsProvider: { [] },
+            remoteServicesProvider: { [router] },
+            source: .httpAPI
+        )
+
+        await HTTPCallerContext.$current.withValue(
+            HTTPCallerContext(hasVerifiedAccessKey: true)
+        ) {
+            do {
+                let stream = try await engine.streamChat(request: makeRequest())
+                for try await _ in stream {}
+            } catch let error as ChatEngine.EngineError {
+                #expect(
+                    error.httpStatus != 403,
+                    "keyed caller must not hit the spend gate"
+                )
+            } catch {
+                // Transport-level failure (connection refused) is expected;
+                // the gate itself passed.
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/MCPOAuth/OAuthLoopbackServerTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/OAuthLoopbackServerTests.swift
@@ -32,6 +32,52 @@ struct OAuthLoopbackServerTests {
         #expect(port > 1024, "ephemeral ports should be in the unprivileged range")
     }
 
+    @Test func boundedWait_timesOutWhenNoCallbackArrives() async throws {
+        // The provider sign-in flows (Codex/xAI/OpenRouter/MCP) all use the
+        // bounded variant so an abandoned browser tab can't pin the sign-in
+        // task forever. A short deadline with no incoming callback must
+        // throw `.callbackTimeout` rather than suspend.
+        let server = try OAuthLoopbackServer(
+            expectedState: "state-timeout",
+            port: .ephemeral,
+            callbackPath: "/callback"
+        )
+        try await server.start()
+        defer { server.stop() }
+
+        do {
+            _ = try await server.waitForCallback(timeout: 0.2)
+            Issue.record("Expected callbackTimeout to be thrown")
+        } catch let error as OAuthLoopbackError {
+            guard case .callbackTimeout = error else {
+                Issue.record("Expected .callbackTimeout, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test func boundedWait_deliversCallbackBeforeDeadline() async throws {
+        let server = try OAuthLoopbackServer(
+            expectedState: "state-bounded-ok",
+            port: .ephemeral,
+            callbackPath: "/callback"
+        )
+        try await server.start()
+        defer { server.stop() }
+
+        let port = try #require(server.boundPort)
+        let task = Task { try await server.waitForCallback(timeout: 10) }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let callbackURL = URL(
+            string: "http://127.0.0.1:\(port)/callback?state=state-bounded-ok&code=bounded-code"
+        )!
+        _ = try? await URLSession.shared.data(from: callbackURL)
+
+        let parsed = try await task.value
+        #expect(parsed.code == "bounded-code")
+    }
+
     @Test func successCallbackResolvesAwaiter() async throws {
         let server = try OAuthLoopbackServer(
             expectedState: "expected-state",

--- a/Packages/OsaurusCore/Tests/Networking/HTTPIdempotencyKeyTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPIdempotencyKeyTests.swift
@@ -1,0 +1,74 @@
+//
+//  HTTPIdempotencyKeyTests.swift
+//  osaurusTests
+//
+//  Pins the Router billing idempotency-key resolution for HTTP-origin
+//  requests: a client-supplied `Idempotency-Key` header is honored (so
+//  CLI/script retries dedupe billing on a re-POST), everything else gets a
+//  synthesized per-request key so the provider service's connect-phase
+//  retries still dedupe.
+//
+
+import Foundation
+import NIOHTTP1
+import Testing
+
+@testable import OsaurusCore
+
+struct HTTPIdempotencyKeyTests {
+
+    private func head(headers: [(String, String)] = []) -> HTTPRequestHead {
+        var httpHeaders = HTTPHeaders()
+        for (name, value) in headers {
+            httpHeaders.add(name: name, value: value)
+        }
+        return HTTPRequestHead(
+            version: .http1_1,
+            method: .POST,
+            uri: "/v1/chat/completions",
+            headers: httpHeaders
+        )
+    }
+
+    @Test func honorsClientSuppliedHeader() {
+        let key = HTTPHandler.httpIdempotencyKey(
+            head: head(headers: [("Idempotency-Key", "retry-abc-123")])
+        )
+        #expect(key == "retry-abc-123")
+    }
+
+    @Test func trimsSurroundingWhitespace() {
+        let key = HTTPHandler.httpIdempotencyKey(
+            head: head(headers: [("Idempotency-Key", "  spaced-key \t")])
+        )
+        #expect(key == "spaced-key")
+    }
+
+    @Test func synthesizesWhenHeaderAbsent() {
+        let key = HTTPHandler.httpIdempotencyKey(head: head())
+        #expect(key.hasPrefix("http-"))
+        #expect(key.count > "http-".count)
+    }
+
+    @Test func synthesizedKeysAreUniquePerRequest() {
+        let first = HTTPHandler.httpIdempotencyKey(head: head())
+        let second = HTTPHandler.httpIdempotencyKey(head: head())
+        #expect(first != second)
+    }
+
+    @Test func rejectsOversizedHeaderBySynthesizing() {
+        let oversized = String(repeating: "k", count: 200)
+        let key = HTTPHandler.httpIdempotencyKey(
+            head: head(headers: [("Idempotency-Key", oversized)])
+        )
+        #expect(key.hasPrefix("http-"))
+        #expect(key != oversized)
+    }
+
+    @Test func rejectsEmptyHeaderBySynthesizing() {
+        let key = HTTPHandler.httpIdempotencyKey(
+            head: head(headers: [("Idempotency-Key", "   ")])
+        )
+        #expect(key.hasPrefix("http-"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/RequestValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/RequestValidationTests.swift
@@ -20,7 +20,9 @@ struct RequestValidationTests {
 
     private func makeRequest(
         n: Int? = nil,
-        responseFormatType: String? = nil
+        responseFormatType: String? = nil,
+        logprobs: Bool? = nil,
+        topLogprobs: Int? = nil
     ) -> ChatCompletionRequest {
         var req = ChatCompletionRequest(
             model: "default",
@@ -40,6 +42,8 @@ struct RequestValidationTests {
         if let type = responseFormatType {
             req.response_format = ResponseFormat(type: type)
         }
+        req.logprobs = logprobs
+        req.top_logprobs = topLogprobs
         return req
     }
 
@@ -75,6 +79,34 @@ struct RequestValidationTests {
         let reason = HTTPHandler.unsupportedSamplerReason(req)
         #expect(reason != nil)
         #expect((reason ?? "").contains("json_schema"))
+    }
+
+    /// Log-probabilities are surfaced by neither local MLX decode nor the
+    /// remote provider proxy — a truthy `logprobs`/`top_logprobs` must be
+    /// rejected with a typed 400 instead of returning a response that
+    /// silently lacks the field.
+    @Test func logprobsTrueIsRejected() {
+        let req = makeRequest(logprobs: true)
+        let reason = HTTPHandler.unsupportedSamplerReason(req)
+        #expect(reason != nil)
+        #expect((reason ?? "").contains("logprobs"))
+    }
+
+    @Test func logprobsFalseIsAccepted() {
+        let req = makeRequest(logprobs: false)
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
+    }
+
+    @Test func topLogprobsPositiveIsRejected() {
+        let req = makeRequest(topLogprobs: 5)
+        let reason = HTTPHandler.unsupportedSamplerReason(req)
+        #expect(reason != nil)
+        #expect((reason ?? "").contains("top_logprobs"))
+    }
+
+    @Test func topLogprobsZeroIsAccepted() {
+        let req = makeRequest(topLogprobs: 0)
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
     }
 
     @Test func chatRequestIgnoresFIMFieldsWithoutDroppingTools() throws {

--- a/Packages/OsaurusCore/Tests/Networking/SSELineParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/SSELineParserTests.swift
@@ -101,6 +101,33 @@ struct SSELineParserTests {
         #expect(lines == ["a", "", ""])
     }
 
+    @Test func splitter_chunkingInvariance() {
+        // The bulk memchr-based scanner must produce identical output no
+        // matter how the byte stream is sliced into chunks — including
+        // 1-byte chunks that split every CRLF pair.
+        let payload = "data: a\r\ndata: b\rdata: c\n\r\n\ndata: {\"x\":\"y\"}\r\n"
+        let bytes = Array(payload.utf8)
+
+        var whole = RemoteProviderService.SSELineParser()
+        whole.append(Data(bytes))
+        whole.flushPending()
+        let expected = drain(&whole)
+
+        for chunkSize in [1, 2, 3, 5, 7] {
+            var chunked = RemoteProviderService.SSELineParser()
+            var index = 0
+            while index < bytes.count {
+                let end = min(index + chunkSize, bytes.count)
+                chunked.append(Data(bytes[index ..< end]))
+                index = end
+            }
+            chunked.flushPending()
+            let lines = drain(&chunked)
+            #expect(lines == expected, "chunkSize=\(chunkSize) diverged")
+        }
+        #expect(expected == ["data: a", "data: b", "data: c", "", "", "data: {\"x\":\"y\"}"])
+    }
+
     // MARK: - processSSELine (field parser)
 
     @Test func fieldParser_handlesDataWithSpace() {

--- a/Packages/OsaurusCore/Tests/PrivacyFilter/PrivacyReviewNonInteractiveTests.swift
+++ b/Packages/OsaurusCore/Tests/PrivacyFilter/PrivacyReviewNonInteractiveTests.swift
@@ -1,0 +1,182 @@
+//
+//  PrivacyReviewNonInteractiveTests.swift
+//  osaurus / PrivacyFilter Tests
+//
+//  Pins the request-origin gate on interactive privacy review: HTTP
+//  API / plugin / P2P requests must NEVER suspend on the review sheet,
+//  even when a chat window has registered a presenter. Before this
+//  gate, a server-origin `/v1/chat/completions` request that tripped
+//  PII detection would pop the sheet over an unrelated chat window and
+//  hang the HTTP client until the user noticed. Non-UI origins now
+//  either fail closed with the typed
+//  `PrivacyFilterPipelineError.reviewRequiresInteractive` (default) or
+//  auto-approve when `requireReviewForNonInteractive` is off.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// `.serialized` for the same reason as PrivacyReviewServiceTests:
+// every test mutates the shared presenter registry and the
+// PrivacyFilterStore snapshot cache.
+@Suite("Privacy review non-interactive gate", .serialized)
+@MainActor
+struct PrivacyReviewNonInteractiveTests {
+
+    private static func makeDetection(_ name: String = "Alice") async -> DetectedEntity {
+        let map = RedactionMap(conversationID: UUID())
+        let placeholder = await map.intern(name, as: .person)
+        return DetectedEntity(
+            category: .person,
+            original: name,
+            range: name.startIndex ..< name.endIndex,
+            placeholder: placeholder,
+            approved: true
+        )
+    }
+
+    /// Regex-only filter config so `applyOutbound` runs without the
+    /// on-device model. `alwaysApproveByDefault` stays OFF so fresh
+    /// detections actually reach the review gate.
+    private static func regexOnlyConfig(
+        requireReviewForNonInteractive: Bool
+    ) -> PrivacyFilterConfiguration {
+        var config = PrivacyFilterConfiguration()
+        config.enabled = true
+        config.aiDetectionEnabled = false
+        config.alwaysApproveByDefault = false
+        config.requireReviewForNonInteractive = requireReviewForNonInteractive
+        return config
+    }
+
+    // MARK: - PrivacyReviewService.review origin gate
+
+    /// The core hang fix: a registered presenter must NOT be used for
+    /// a non-interactive caller. With the fail-closed default on, the
+    /// outcome is the typed block — not a suspended continuation.
+    @Test func nonInteractive_withPresenterRegistered_blocksWithoutPresenting() async {
+        let guard_ = await acquirePrivacyStoreSandbox("NonInteractive-block")
+        defer { guard_.release() }
+
+        let service = PrivacyReviewService.shared
+        PrivacyFilterStore.save(PrivacyFilterConfiguration())  // requireReview default: true
+
+        var presenterFired = false
+        let token = service.registerPresenter { _ in presenterFired = true }
+        defer { service.unregisterPresenter(token) }
+
+        let detection = await Self.makeDetection()
+        let outcome = await service.review(
+            detections: [detection],
+            sessionId: "session-non-interactive-block",
+            allowInteractive: false
+        )
+        if case .blockedNonInteractive = outcome {
+            // Expected: fail closed, no sheet.
+        } else {
+            Issue.record("Expected .blockedNonInteractive, got \(outcome)")
+        }
+        #expect(presenterFired == false, "review sheet must never present for non-UI origins")
+    }
+
+    /// Power-user opt-out: with `requireReviewForNonInteractive` off,
+    /// the non-interactive caller auto-approves — still without ever
+    /// touching the presenter.
+    @Test func nonInteractive_withOptOut_autoApprovesWithoutPresenting() async {
+        let guard_ = await acquirePrivacyStoreSandbox("NonInteractive-optout")
+        defer { guard_.release() }
+
+        let service = PrivacyReviewService.shared
+        var config = PrivacyFilterConfiguration()
+        config.requireReviewForNonInteractive = false
+        PrivacyFilterStore.save(config)
+        defer { PrivacyFilterStore.save(PrivacyFilterConfiguration()) }
+
+        var presenterFired = false
+        let token = service.registerPresenter { _ in presenterFired = true }
+        defer { service.unregisterPresenter(token) }
+
+        let detection = await Self.makeDetection("Bob")
+        let outcome = await service.review(
+            detections: [detection],
+            sessionId: "session-non-interactive-optout",
+            allowInteractive: false
+        )
+        if case .approved(let entities) = outcome {
+            #expect(entities.count == 1)
+        } else {
+            Issue.record("Expected .approved, got \(outcome)")
+        }
+        #expect(presenterFired == false)
+    }
+
+    // MARK: - Pipeline typed error
+
+    /// End-to-end (regex-only): an HTTP-origin request with fresh PII
+    /// throws the typed `reviewRequiresInteractive` error instead of
+    /// suspending on the registered presenter. The error carries the
+    /// detection count and maps to a 422 with a stable code so API
+    /// clients can react programmatically.
+    @Test func applyOutbound_httpOrigin_failsClosedWithTypedError() async throws {
+        let guard_ = await acquirePrivacyStoreSandbox("NonInteractive-pipeline")
+        defer { guard_.release() }
+        PrivacyFilterStore.save(Self.regexOnlyConfig(requireReviewForNonInteractive: true))
+        defer { PrivacyFilterStore.save(PrivacyFilterConfiguration()) }
+
+        var presenterFired = false
+        let token = PrivacyReviewService.shared.registerPresenter { _ in presenterFired = true }
+        defer { PrivacyReviewService.shared.unregisterPresenter(token) }
+
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "user", content: "Contact me at pipeline-block@example.com.")
+        ]
+        do {
+            _ = try await PrivacyFilterPipeline.applyOutbound(
+                messages: messages,
+                sessionId: "pf-non-interactive-\(UUID().uuidString)",
+                providerId: UUID(),
+                requestSource: .httpAPI
+            )
+            Issue.record("Expected reviewRequiresInteractive to be thrown")
+        } catch let error as PrivacyFilterPipelineError {
+            guard case .reviewRequiresInteractive(let count) = error else {
+                Issue.record("Expected .reviewRequiresInteractive, got \(error)")
+                return
+            }
+            #expect(count == 1)
+            #expect(error.httpErrorCode == "privacy_filter_review_required")
+            #expect(error.httpStatus == 422)
+            #expect(!error.localizedDescription.isEmpty)
+        }
+        #expect(presenterFired == false, "HTTP-origin request must not pop the review sheet")
+    }
+
+    /// With the opt-out flipped, the same HTTP-origin request
+    /// auto-approves and ships scrubbed — no sheet, no error.
+    @Test func applyOutbound_httpOrigin_withOptOut_scrubsAndSends() async throws {
+        let guard_ = await acquirePrivacyStoreSandbox("NonInteractive-pipeline-optout")
+        defer { guard_.release() }
+        PrivacyFilterStore.save(Self.regexOnlyConfig(requireReviewForNonInteractive: false))
+        defer { PrivacyFilterStore.save(PrivacyFilterConfiguration()) }
+
+        var presenterFired = false
+        let token = PrivacyReviewService.shared.registerPresenter { _ in presenterFired = true }
+        defer { PrivacyReviewService.shared.unregisterPresenter(token) }
+
+        let email = "pipeline-optout@example.com"
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "user", content: "Contact me at \(email).")
+        ]
+        let (scrubbed, map) = try await PrivacyFilterPipeline.applyOutbound(
+            messages: messages,
+            sessionId: "pf-non-interactive-optout-\(UUID().uuidString)",
+            providerId: UUID(),
+            requestSource: .httpAPI
+        )
+        #expect(map != nil)
+        #expect(scrubbed.first?.content.map { !$0.contains(email) } == true)
+        #expect(presenterFired == false)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -64,11 +64,13 @@ struct OpenAICompatibleStreamParserTests {
             state: &state,
             yield: { yielded.append($0) }
         )
-        guard case .finishWithToolCall(let invocation) = finish else {
+        guard case .finishWithToolCall(let invocations) = finish, let invocation = invocations.first
+        else {
             Issue.record("Expected recovered tool call, got \(finish)")
             return
         }
 
+        #expect(invocations.count == 1)
         #expect(invocation.toolName == "sandbox_write_file")
         #expect(invocation.toolCallId == "call_1")
         #expect(invocation.jsonArguments == #"{"path":"tetris.html"}"#)
@@ -132,6 +134,44 @@ struct OpenAICompatibleStreamParserTests {
         #expect(state.accumulatedToolCalls[1]?.args == #"{"y":2}"#)
     }
 
+    @Test func parser_dispatchesAllParallelToolCallsAtFinish() throws {
+        // Regression: parallel tool calls used to be silently collapsed to the
+        // lowest-index call. All accumulated slots must dispatch, in slot order.
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: true)
+        let env = #""id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"m""#
+        let payloads = [
+            #"{\#(env),"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"a","type":"function","function":{"name":"toolA","arguments":"{\"x\":1}"}}]},"finish_reason":null}]}"#,
+            #"{\#(env),"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"b","type":"function","function":{"name":"toolB","arguments":"{\"y\":2}"}}]},"finish_reason":null}]}"#,
+        ]
+        for payload in payloads {
+            _ = try OpenAICompatibleStreamParser.handleEvent(
+                jsonData: Data(payload.utf8),
+                options: .strict,
+                state: &state,
+                yield: { _ in }
+            )
+        }
+
+        let finish = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(#"{\#(env),"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#.utf8),
+            options: .strict,
+            state: &state,
+            yield: { _ in }
+        )
+        guard case .finishWithToolCall(let invocations) = finish else {
+            Issue.record("Expected parallel tool-call finish, got \(finish)")
+            return
+        }
+        #expect(invocations.map(\.toolName) == ["toolA", "toolB"])
+        #expect(invocations.map(\.toolCallId) == ["a", "b"])
+        #expect(invocations.map(\.jsonArguments) == [#"{"x":1}"#, #"{"y":2}"#])
+
+        // The finish-by-throw shape must be the batch error for >1 call so the
+        // agent loop's `catch let invs as ServiceToolInvocations` sees them all.
+        let thrown = RemoteProviderService.toolInvocationFinishError(invocations)
+        #expect((thrown as? ServiceToolInvocations)?.invocations.count == 2)
+    }
+
     @Test func parser_lenientFullBodyMessageToolCallFinishesWithInvocation() throws {
         var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
         var yielded: [String] = []
@@ -164,10 +204,12 @@ struct OpenAICompatibleStreamParserTests {
             yield: { yielded.append($0) }
         )
 
-        guard case .finishWithToolCall(let invocation) = outcome else {
+        guard case .finishWithToolCall(let invocations) = outcome, let invocation = invocations.first
+        else {
             Issue.record("Expected full-body tool call, got \(outcome)")
             return
         }
+        #expect(invocations.count == 1)
         #expect(invocation.toolName == "sandbox_write_file")
         #expect(invocation.toolCallId == "call_1")
         #expect(invocation.jsonArguments == #"{"path":"tetris.html"}"#)

--- a/Packages/OsaurusCore/Tests/Provider/OsaurusRouterProviderTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OsaurusRouterProviderTests.swift
@@ -295,10 +295,12 @@ struct OsaurusRouterProviderTests {
             yield: { yielded.append($0) }
         )
 
-        guard case .finishWithToolCall(let invocation) = outcome else {
+        guard case .finishWithToolCall(let invocations) = outcome, let invocation = invocations.first
+        else {
             Issue.record("Expected full router body tool call, got \(outcome)")
             return
         }
+        #expect(invocations.count == 1)
         #expect(invocation.toolName == "sandbox_write_file")
         #expect(invocation.toolCallId == "call_1")
         #expect(invocation.jsonArguments == #"{"path":"tetris.html","content":"<html></html>"}"#)
@@ -358,10 +360,13 @@ struct OsaurusRouterProviderTests {
             yield: { yielded.append($0) }
         )
 
-        guard case .finishWithToolCall(let invocation) = finishOutcome else {
+        guard case .finishWithToolCall(let invocations) = finishOutcome,
+            let invocation = invocations.first
+        else {
             Issue.record("Expected tool-call finish, got \(finishOutcome)")
             return
         }
+        #expect(invocations.count == 1)
         #expect(invocation.toolName == "get_weather")
         #expect(invocation.toolCallId == "call_1")
         #expect(invocation.jsonArguments == #"{"city":"Irvine"}"#)
@@ -551,8 +556,45 @@ struct OsaurusRouterProviderTests {
         #expect(diagnostics.emptyClassification == "unrecognized-events")
         #expect(diagnostics.unrecognizedEventCount == 1)
         #expect(diagnostics.lastEventSummary == "done-marker")
-        #expect(diagnostics.recentEventSummaries.contains { $0.hasPrefix("object keys=") })
+        // Debug flag off in tests: production events store the compact kind
+        // label, not the JSON-decoded debug summary.
+        #expect(diagnostics.recentEventSummaries.contains("unrecognized"))
         #expect(diagnostics.shouldLogEmptyTerminal)
+    }
+
+    @Test func routerEventKind_cheapSniffClassification() {
+        typealias Kind = RemoteProviderService.RouterEventKind
+        #expect(RemoteProviderService.routerEventKind("[DONE]") == Kind.doneMarker)
+        #expect(RemoteProviderService.routerEventKind(" [DONE] ") == Kind.doneMarker)
+        #expect(
+            RemoteProviderService.routerEventKind(
+                #"{"osaurus":{"cost_micro":"12","status":"completed","token_source":"provider","input_tokens":1,"output_tokens":1}}"#
+            ) == Kind.summary
+        )
+        #expect(
+            RemoteProviderService.routerEventKind(
+                #"{"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}"#
+            ) == Kind.usage
+        )
+        #expect(
+            RemoteProviderService.routerEventKind(
+                #"{"choices":[{"delta":{"content":"hi"}}]}"#
+            ) == Kind.choice
+        )
+        // A content delta that merely *mentions* osaurus/usage still counts
+        // as a choice event — "choices" wins the sniff order.
+        #expect(
+            RemoteProviderService.routerEventKind(
+                #"{"choices":[{"delta":{"content":"the \"osaurus\" and \"usage\" words"}}]}"#
+            ) == Kind.choice
+        )
+        #expect(
+            RemoteProviderService.routerEventKind(
+                #"{"error":{"code":"X","message":"boom"}}"#
+            ) == Kind.error
+        )
+        #expect(RemoteProviderService.routerEventKind(#"{"unexpected":true}"#) == Kind.unrecognized)
+        #expect(RemoteProviderService.routerEventKind("not json") == Kind.unrecognized)
     }
 
     private func routerDiagnosticsState() -> RemoteProviderService.StreamingState {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -104,6 +104,106 @@ struct RemoteChatRequestEncodingTests {
         #expect(payload["stream_options"] == nil)
     }
 
+    // MARK: - Parameter fidelity: seed / response_format
+
+    /// Caller-supplied `seed` and JSON mode must reach the OpenAI-compat wire
+    /// instead of being silently dropped (parameter-fidelity contract).
+    @Test func encode_includesSeedAndResponseFormat_whenSet() throws {
+        var request = Self.makeRequest(model: "gpt-4o-mini", maxTokens: 256)
+        request.seed = 42
+        request.response_format = ResponseFormat(type: "json_object")
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["seed"] as? Int == 42)
+        let responseFormat = payload["response_format"] as? [String: Any]
+        #expect(responseFormat?["type"] as? String == "json_object")
+    }
+
+    /// Default (nil) omits both keys so existing wire bytes are unchanged for
+    /// requests that never set them (strict upstreams 422 on unknown nulls).
+    @Test func encode_omitsSeedAndResponseFormat_whenNil() throws {
+        let request = Self.makeRequest(model: "gpt-4o-mini", maxTokens: 256)
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["seed"] == nil)
+        #expect(payload["response_format"] == nil)
+    }
+
+    /// Gemini has no top-level OpenAI fields; seed and JSON mode map into
+    /// `generationConfig.seed` / `generationConfig.responseMimeType`.
+    @Test func geminiRequest_mapsSeedAndJSONModeIntoGenerationConfig() throws {
+        var request = Self.makeRequest(model: "gemini-2.0-flash", maxTokens: 256)
+        request.seed = 7
+        request.response_format = ResponseFormat(type: "json_object")
+        let payload = try Self.encodeAsDictionary(request.toGeminiRequest())
+
+        let config = payload["generationConfig"] as? [String: Any]
+        #expect(config?["seed"] as? Int == 7)
+        #expect(config?["responseMimeType"] as? String == "application/json")
+    }
+
+    /// Without seed/JSON mode, Gemini's generationConfig keeps its exact
+    /// current shape (no new keys appear).
+    @Test func geminiRequest_omitsSeedAndMimeType_whenUnset() throws {
+        let request = Self.makeRequest(model: "gemini-2.0-flash", maxTokens: 256)
+        let payload = try Self.encodeAsDictionary(request.toGeminiRequest())
+
+        let config = payload["generationConfig"] as? [String: Any]
+        #expect(config?["seed"] == nil)
+        #expect(config?["responseMimeType"] == nil)
+    }
+
+    // MARK: - Dropped-media rejection (Anthropic/Gemini wire)
+
+    /// Audio and video parts have no Anthropic/Gemini wire mapping and were
+    /// previously dropped without a trace; the guard must reject them with a
+    /// typed error instead.
+    @Test func rejectDroppedMediaInputs_throwsForAudioAndVideo() {
+        let audioMessage = ChatMessage(
+            role: "user",
+            content: "transcribe this",
+            contentParts: [
+                .text("transcribe this"),
+                .audioInput(data: "AAAA", format: "wav"),
+            ]
+        )
+        #expect(throws: RemoteProviderServiceError.self) {
+            try RemoteProviderService.rejectDroppedMediaInputs(
+                in: [audioMessage],
+                wireName: "Anthropic"
+            )
+        }
+
+        let videoMessage = ChatMessage(
+            role: "user",
+            content: nil,
+            contentParts: [.videoUrl(url: "data:video/mp4;base64,AAAA")]
+        )
+        #expect(throws: RemoteProviderServiceError.self) {
+            try RemoteProviderService.rejectDroppedMediaInputs(
+                in: [videoMessage],
+                wireName: "Gemini"
+            )
+        }
+    }
+
+    /// Text and image parts are fully supported on both wires and must pass.
+    @Test func rejectDroppedMediaInputs_allowsTextAndImages() throws {
+        let messages = [
+            ChatMessage(role: "user", content: "hello"),
+            ChatMessage(
+                role: "user",
+                content: "look at this",
+                contentParts: [
+                    .text("look at this"),
+                    .imageUrl(url: "data:image/png;base64,AAAA", detail: nil),
+                ]
+            ),
+        ]
+        try RemoteProviderService.rejectDroppedMediaInputs(in: messages, wireName: "Anthropic")
+        try RemoteProviderService.rejectDroppedMediaInputs(in: messages, wireName: "Gemini")
+    }
+
     /// Only the genuinely OpenAI Chat-Completions `/chat/completions` upstreams
     /// (xAI/Grok + OpenAI-compatible third parties via `.openaiLegacy`, and
     /// Azure OpenAI) request usage. The router carries billed tokens in its own
@@ -720,6 +820,114 @@ struct RemoteChatRequestEncodingTests {
 
         #expect(assistantJSON["content"] as? String == "I looked at the image.")
         #expect(userJSON["content"] is [[String: Any]])
+    }
+
+    /// Regression for the Router + Opus HTTP 400 "user message content must
+    /// be a string": once a media user turn exists anywhere in the history,
+    /// EVERY subsequent turn replays it, and non-vision Router upstream
+    /// adapters reject the array-form content on each one. For a model
+    /// without image input, user media must flatten to string content (with
+    /// a visible removal notice) across the whole replayed history.
+    @Test func routerWireCompatibleMessages_flattensUserImageForNonVisionModel() throws {
+        let imageTurn = ChatMessage(
+            role: "user",
+            content: "describe this",
+            contentParts: [
+                .text("describe this"),
+                .imageUrl(url: "data:image/png;base64,BBBB", detail: nil),
+            ]
+        )
+        let history: [ChatMessage] = [
+            ChatMessage(role: "system", content: "You are helpful."),
+            imageTurn,
+            ChatMessage(role: "assistant", content: "It's a chart.", tool_calls: nil, tool_call_id: nil),
+            ChatMessage(role: "user", content: "Now summarize it."),
+            ChatMessage(role: "assistant", content: "Summary done.", tool_calls: nil, tool_call_id: nil),
+            ChatMessage(role: "user", content: "Third message in the sequence."),
+        ]
+
+        let normalized = RemoteProviderService.routerWireCompatibleMessages(
+            history,
+            modelSupportsImageInput: false
+        )
+        let array = try Self.encodeAsArray(normalized)
+
+        // No message anywhere in the replayed history may carry array content.
+        for json in array {
+            #expect(!(json["content"] is [[String: Any]]), "array content leaked: \(json)")
+        }
+        let flattened = try #require(array.dropFirst().first)
+        let content = try #require(flattened["content"] as? String)
+        #expect(content.contains("describe this"))
+        #expect(content.contains("removed"), "removal notice must be visible, not silent")
+    }
+
+    /// Vision-capable Router models keep the documented "user media stays
+    /// multimodal" contract.
+    @Test func routerWireCompatibleMessages_keepsUserImageForVisionModel() throws {
+        let user = ChatMessage(
+            role: "user",
+            content: "describe this",
+            contentParts: [
+                .text("describe this"),
+                .imageUrl(url: "data:image/png;base64,BBBB", detail: nil),
+            ]
+        )
+        let normalized = RemoteProviderService.routerWireCompatibleMessages(
+            [user],
+            modelSupportsImageInput: true
+        )
+        let array = try Self.encodeAsArray(normalized)
+        #expect(try #require(array.first)["content"] is [[String: Any]])
+    }
+
+    /// Audio/video have no mapping on any Router upstream: they are removed
+    /// (with the notice) even for vision-capable models, while supported
+    /// image parts stay multimodal.
+    @Test func routerWireCompatibleMessages_stripsAudioEvenForVisionModel() throws {
+        let user = ChatMessage(
+            role: "user",
+            content: "listen and look",
+            contentParts: [
+                .text("listen and look"),
+                .imageUrl(url: "data:image/png;base64,BBBB", detail: nil),
+                .audioInput(data: "AAAA", format: "wav"),
+            ]
+        )
+        let normalized = RemoteProviderService.routerWireCompatibleMessages(
+            [user],
+            modelSupportsImageInput: true
+        )
+        let message = try #require(normalized.first)
+        let parts = try #require(message.contentParts)
+        #expect(message.audioInputs.isEmpty, "audio part must be removed")
+        #expect(message.imageUrls == ["data:image/png;base64,BBBB"], "image part must survive")
+        // The removal notice rides as a trailing text part.
+        let texts = parts.compactMap { part -> String? in
+            if case .text(let text) = part { return text }
+            return nil
+        }
+        #expect(texts.contains { $0.contains("removed") })
+    }
+
+    /// The terse Router upstream rejection maps to actionable user copy.
+    @Test func friendlyUpstreamRejection_mapsRouterStringContentError() {
+        let friendly = RemoteProviderService.friendlyUpstreamRejection(
+            "user message content must be a string"
+        )
+        #expect(friendly?.contains("attachment") == true)
+        #expect(
+            RemoteProviderService.friendlyUpstreamRejection("some other upstream error") == nil
+        )
+
+        // End-to-end through the error-envelope extractor, as the streaming
+        // path surfaces it.
+        let body = Data(
+            #"{"error":{"code":"*","message":"user message content must be a string"}}"#.utf8
+        )
+        let extracted = RemoteProviderService.extractErrorMessage(from: body, statusCode: 400)
+        #expect(extracted.contains("attachment"))
+        #expect(!extracted.contains("must be a string"))
     }
 
     @Test func routerWireCompatibleMessages_includesEmptyStringForAssistantToolHistory() throws {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteCompletionUsageTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteCompletionUsageTests.swift
@@ -117,10 +117,11 @@ struct RemoteCompletionUsageTests {
             yield: { _ in }
         )
 
-        guard case .finishWithToolCall(let inv) = finish else {
+        guard case .finishWithToolCall(let invs) = finish, let inv = invs.first else {
             Issue.record("non-deferred tool-call finish should dispatch, got \(finish)")
             return
         }
+        #expect(invs.count == 1)
         #expect(inv.toolName == "file_read")
     }
 

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerRouterConnectTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerRouterConnectTests.swift
@@ -77,6 +77,34 @@ struct RemoteProviderManagerRouterConnectTests {
         #expect(!RemoteProviderManager.isTransientConnectError(URLError(.userAuthenticationRequired)))
     }
 
+    // MARK: - Retry-After hint extraction
+
+    @Test func retryAfterHint_extractsTypedRateLimitHints() {
+        #expect(
+            RemoteProviderManager.retryAfterHint(
+                from: RemoteProviderServiceError.rateLimited(retryAfter: 7, statusCode: 429)
+            ) == 7
+        )
+        #expect(
+            RemoteProviderManager.retryAfterHint(
+                from: OsaurusRouterAPIError.rateLimited(retryAfter: "12")
+            ) == 12
+        )
+        // No hint: absent value, unparseable value, other error shapes.
+        #expect(
+            RemoteProviderManager.retryAfterHint(
+                from: OsaurusRouterAPIError.rateLimited(retryAfter: nil)
+            ) == nil
+        )
+        #expect(
+            RemoteProviderManager.retryAfterHint(
+                from: OsaurusRouterAPIError.rateLimited(retryAfter: "soon")
+            ) == nil
+        )
+        #expect(RemoteProviderManager.retryAfterHint(from: URLError(.timedOut)) == nil)
+        #expect(RemoteProviderManager.retryAfterHint(from: nil) == nil)
+    }
+
     // MARK: - connectOsaurusRouterWithRetry
 
     @Test func routerConnect_retriesTransientFailureThenSucceeds() async throws {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderOAuthStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderOAuthStateTests.swift
@@ -1,0 +1,114 @@
+//
+//  RemoteProviderOAuthStateTests.swift
+//  osaurusTests
+//
+//  Covers the durable requiresAuth state: classification of permanent OAuth
+//  refresh failures (invalid_grant / invalid_token on 400/401) and the
+//  manager's handlePermanentOAuthFailure state transition.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct RemoteProviderOAuthStateTests {
+
+    // MARK: - Classification
+
+    @Test func classifiesInvalidGrantOn400AsPermanent() {
+        let error = OpenAICodexOAuthError.tokenRequestFailed(
+            #"HTTP 400: {"error":"invalid_grant","error_description":"Token expired"}"#
+        )
+        #expect(RemoteProviderManager.isPermanentOAuthFailure(error))
+    }
+
+    @Test func classifiesInvalidTokenOn401AsPermanent() {
+        let error = XAIOAuthError.tokenRequestFailed(
+            #"HTTP 401: {"error":"invalid_token"}"#
+        )
+        #expect(RemoteProviderManager.isPermanentOAuthFailure(error))
+    }
+
+    @Test func networkErrorIsNotPermanent() {
+        let error = OpenAICodexOAuthError.tokenRequestFailed(
+            "Network error: The Internet connection appears to be offline."
+        )
+        #expect(!RemoteProviderManager.isPermanentOAuthFailure(error))
+    }
+
+    @Test func serverErrorIsNotPermanent() {
+        let error = XAIOAuthError.tokenRequestFailed("HTTP 503: upstream unavailable")
+        #expect(!RemoteProviderManager.isPermanentOAuthFailure(error))
+    }
+
+    @Test func http400WithoutOAuthErrorCodeIsNotPermanent() {
+        // A 400 that is not an OAuth grant failure (e.g. malformed request)
+        // should stay retryable rather than wiping the user's tokens.
+        let error = OpenAICodexOAuthError.tokenRequestFailed("HTTP 400: bad request shape")
+        #expect(!RemoteProviderManager.isPermanentOAuthFailure(error))
+    }
+
+    @Test func unrelatedErrorsAreNotPermanent() {
+        struct Boom: Error {}
+        #expect(!RemoteProviderManager.isPermanentOAuthFailure(Boom()))
+        #expect(!RemoteProviderManager.isPermanentOAuthFailure(URLError(.timedOut)))
+    }
+
+    // MARK: - State transition
+
+    @Test func handlePermanentOAuthFailure_setsDurableRequiresAuthState() async throws {
+        await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            let provider = RemoteProvider(
+                name: "Codex Test",
+                host: "127.0.0.1",
+                basePath: "/v1",
+                authType: .openAICodexOAuth,
+                providerType: .openaiLegacy
+            )
+            manager._testInstallConnectedProvider(provider, discoveredModels: ["gpt-test"])
+            defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+            manager.handlePermanentOAuthFailure(providerId: provider.id)
+
+            let state = manager.providerStates[provider.id]
+            #expect(state?.requiresAuth == true)
+            #expect(state?.isConnected == false)
+            #expect(state?.isConnecting == false)
+            #expect(state?.lastFailureWasTransient == false)
+            #expect(state?.discoveredModels.isEmpty == true)
+            #expect(state?.lastError?.isEmpty == false)
+        }
+    }
+
+    @Test func successfulConnectClearsRequiresAuth() async throws {
+        await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            let provider = RemoteProvider(
+                name: "Recovers",
+                host: "127.0.0.1",
+                basePath: "/v1",
+                authType: .none,
+                providerType: .openaiLegacy
+            )
+            manager._testInstallConnectedProvider(provider, discoveredModels: [])
+            defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+            var state = manager.providerStates[provider.id]!
+            state.requiresAuth = true
+            state.isConnected = false
+            manager._testSetState(state, for: provider.id)
+
+            manager.testFetchModelsOverride = { _ in ["model-a"] }
+            defer { manager.testFetchModelsOverride = nil }
+            try? await manager.connect(providerId: provider.id)
+
+            let after = manager.providerStates[provider.id]
+            #expect(after?.requiresAuth == false)
+            #expect(after?.isConnected == true)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderSessionLifecycleTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderSessionLifecycleTests.swift
@@ -1,0 +1,87 @@
+//
+//  RemoteProviderSessionLifecycleTests.swift
+//  osaurusTests
+//
+//  Pins the session-lifecycle guard that closes the invalidate-vs-`bytes(for:)`
+//  TOCTOU: task-creation windows are bracketed by begin/end, and
+//  `invalidateSession()` defers `invalidateAndCancel()` until in-flight
+//  requests drain instead of invalidating the session under them (which
+//  raises an uncatchable Obj-C exception and aborts the process).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct RemoteProviderSessionLifecycleTests {
+
+    private func makeService() -> RemoteProviderService {
+        let provider = RemoteProvider(
+            name: "Lifecycle Test",
+            host: "127.0.0.1",
+            basePath: "/v1",
+            authType: .none,
+            providerType: .openaiLegacy
+        )
+        return RemoteProviderService(provider: provider, models: [], resolvedHeaders: [:])
+    }
+
+    @Test func beginSucceedsBeforeInvalidation_andIsRefusedAfter() async {
+        let service = makeService()
+        #expect(service.beginSessionRequest())
+        service.endSessionRequest()
+
+        await service.invalidateSession()
+        #expect(service.isSessionInvalidated)
+        #expect(!service.beginSessionRequest(), "no new task-creation windows after invalidation")
+    }
+
+    @Test func invalidationIsDeferredWhileRequestInFlight() async {
+        let service = makeService()
+
+        // Open a task-creation window, then request invalidation while it is
+        // still open: the flag must flip immediately (new begins refused) but
+        // the actual invalidateAndCancel must wait for the matching end.
+        #expect(service.beginSessionRequest())
+        await service.invalidateSession()
+        #expect(service.isSessionInvalidated)
+        #expect(!service.beginSessionRequest())
+
+        // Closing the window runs the deferred invalidation; this must be
+        // safe to call from a nonisolated context and must not crash.
+        service.endSessionRequest()
+        #expect(service.isSessionInvalidated)
+        #expect(!service.beginSessionRequest())
+    }
+
+    @Test func doubleInvalidationIsIdempotent() async {
+        let service = makeService()
+        await service.invalidateSession()
+        await service.invalidateSession()
+        #expect(service.isSessionInvalidated)
+    }
+
+    @Test func concurrentBeginEndAndInvalidateDoNotRace() async {
+        // Hammer begin/end from many tasks while invalidation lands midway.
+        // The guard must never let a begin succeed after invalidation and the
+        // in-flight count must drain cleanly (no crash, no negative counts).
+        let service = makeService()
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0 ..< 200 {
+                group.addTask {
+                    if service.beginSessionRequest() {
+                        await Task.yield()
+                        service.endSessionRequest()
+                    }
+                }
+                if i == 100 {
+                    group.addTask { await service.invalidateSession() }
+                }
+            }
+        }
+        #expect(service.isSessionInvalidated)
+        #expect(!service.beginSessionRequest())
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderTimeoutCeilingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderTimeoutCeilingTests.swift
@@ -1,0 +1,39 @@
+//
+//  RemoteProviderTimeoutCeilingTests.swift
+//  osaurusTests
+//
+//  Pins the `disableTimeout` hard-ceiling contract: "no timeout" lifts the
+//  user-facing limits but stays finite (24h) so a dead peer holding an open
+//  socket can never pin a request task indefinitely, and the value remains
+//  safe for the streaming path's nanosecond conversion and JSON encoding.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct RemoteProviderTimeoutCeilingTests {
+
+    @Test func ceilingIsTwentyFourHours() {
+        #expect(RemoteProvider.unboundedTimeout == 60 * 60 * 24)
+    }
+
+    @Test func ceilingSurvivesNanosecondConversion() {
+        // The stream watchdog converts seconds to nanoseconds through
+        // UInt64; the ceiling must stay far away from overflow.
+        let nanos = RemoteProvider.unboundedTimeout * 1_000_000_000
+        #expect(nanos.isFinite)
+        #expect(nanos < Double(UInt64.max))
+        #expect(UInt64(nanos) > 0)
+    }
+
+    @Test func ceilingIsJSONEncodable() throws {
+        // `.infinity` would throw here — the sentinel must round-trip
+        // through provider config persistence.
+        let data = try JSONEncoder().encode([RemoteProvider.unboundedTimeout])
+        let decoded = try JSONDecoder().decode([TimeInterval].self, from: data)
+        #expect(decoded.first == RemoteProvider.unboundedTimeout)
+    }
+}

--- a/Packages/OsaurusCore/Tools/Configuration/ProviderConfigurationDomain.swift
+++ b/Packages/OsaurusCore/Tools/Configuration/ProviderConfigurationDomain.swift
@@ -239,8 +239,37 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
             )
         }
 
-        let hostOverride = args["host"] as? String
-        let request = makeRequest(resolution: resolution, displayName: displayName)
+        // A tool-supplied `host` must be shown to the user (and tested)
+        // before it becomes the endpoint their credentials are sent to —
+        // otherwise the model could steer a preset vendor's key to an
+        // attacker host after the user approves the sheet against the
+        // preset default. We only honor the override for presets that
+        // actually render a `host` field in the sheet (custom, Azure).
+        // For fixed-endpoint presets (Anthropic, OpenAI, Gemini, OAuth
+        // vendors) the sheet has no place to surface it, so we reject
+        // rather than apply it invisibly.
+        let hostOverride = (args["host"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var request = makeRequest(resolution: resolution, displayName: displayName)
+        if let hostOverride, !hostOverride.isEmpty {
+            let acceptsHostField = request.instructions.extraFields.contains { $0.key == "host" }
+            guard acceptsHostField else {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "`host` cannot be overridden for the `\(raw)` provider — its endpoint is "
+                        + "fixed. Use `provider: \"custom\"` to add an OpenAI-compatible server at a "
+                        + "specific host.",
+                    field: "host",
+                    tool: name
+                )
+            }
+            request = makeRequest(
+                resolution: resolution,
+                displayName: displayName,
+                prefilledExtraFields: ["host": hostOverride]
+            )
+        }
         let outcome = await ProviderCredentialPromptService.requestCredentials(request)
 
         if Task.isCancelled {
@@ -274,7 +303,6 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
                     displayName: displayName,
                     resolution: resolution,
                     storageAuthType: storageAuthType,
-                    hostOverride: hostOverride,
                     extraHeaders: headers,
                     apiKey: resolvedKey,
                     oauthTokens: nil
@@ -298,7 +326,6 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
                     displayName: displayName,
                     resolution: resolution,
                     storageAuthType: request.instructions.storageAuthType,
-                    hostOverride: hostOverride,
                     extraHeaders: nil,
                     apiKey: nil,
                     oauthTokens: tokens
@@ -338,16 +365,29 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
         let newManualModelIds = (args["manual_model_ids"] as? String)
             .map(OsaurusProviderTool.parseManualModelIds)
 
-        return await MainActor.run {
+        // Phase 1 (MainActor): resolve the provider, apply the patch to a
+        // local copy, and decide whether the change retargets the endpoint
+        // while a Keychain secret is stored. We do NOT persist yet — an
+        // endpoint move on a secret-bearing provider must be user-confirmed
+        // first so the model can't silently redirect a stored key/token to
+        // an attacker host on reconnect.
+        struct UpdatePlan: Sendable {
+            var provider: RemoteProvider
+            var requiresConfirmation: Bool
+            var oldEndpoint: String
+            var newEndpoint: String
+        }
+        enum PlanOutcome: Sendable {
+            case notFound
+            case plan(UpdatePlan)
+        }
+
+        let outcome: PlanOutcome = await MainActor.run {
             let mgr = RemoteProviderManager.shared
-            guard var provider = mgr.configuration.providers.first(where: { $0.id == id }) else {
-                return ToolEnvelope.failure(
-                    kind: .invalidArgs,
-                    message: "No provider found with id \(idStr).",
-                    field: "id",
-                    tool: name
-                )
+            guard let existing = mgr.configuration.providers.first(where: { $0.id == id }) else {
+                return .notFound
             }
+            var provider = existing
             if let v = newName { provider.name = v }
             if let v = newHost { provider.host = v }
             if let b = newEnabled { provider.enabled = b }
@@ -356,7 +396,57 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
             if let v = newBasePath { provider.basePath = v }
             if let t = newTimeout { provider.timeout = TimeInterval(t) }
             if let ids = newManualModelIds { provider.manualModelIds = ids }
-            mgr.updateProvider(provider, apiKey: nil, oauthTokens: nil)
+
+            let endpointChanged =
+                provider.host != existing.host
+                || provider.port != existing.port
+                || provider.basePath != existing.basePath
+                || provider.providerProtocol != existing.providerProtocol
+            let hasSecret = existing.hasAPIKey || existing.hasOAuthTokens
+            return .plan(
+                UpdatePlan(
+                    provider: provider,
+                    requiresConfirmation: endpointChanged && hasSecret,
+                    oldEndpoint: existing.displayEndpoint,
+                    newEndpoint: provider.displayEndpoint
+                )
+            )
+        }
+
+        guard case .plan(let plan) = outcome else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "No provider found with id \(idStr).",
+                field: "id",
+                tool: name
+            )
+        }
+
+        if plan.requiresConfirmation {
+            let approved = await ToolPermissionPromptService.requestApproval(
+                toolName: name,
+                description:
+                    "Move the stored credentials for “\(plan.provider.name)” to a new endpoint?\n\n"
+                    + "From: \(plan.oldEndpoint)\n"
+                    + "To: \(plan.newEndpoint)\n\n"
+                    + "The existing API key / sign-in stored in Keychain will be sent to the new "
+                    + "endpoint. Only approve if you recognize it.",
+                argumentsJSON: ""
+            )
+            if !approved {
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message:
+                        "Endpoint change declined. The provider still points at \(plan.oldEndpoint) "
+                        + "and its credentials were not moved.",
+                    tool: name,
+                    retryable: false
+                )
+            }
+        }
+
+        return await MainActor.run {
+            RemoteProviderManager.shared.updateProvider(plan.provider, apiKey: nil, oauthTokens: nil)
             return ToolEnvelope.success(
                 tool: name,
                 result: ["provider_id": id.uuidString, "status": "updated"]
@@ -454,15 +544,31 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
 
     private func makeRequest(
         resolution: ProviderToolResolution,
-        displayName: String
+        displayName: String,
+        prefilledExtraFields: [String: String] = [:]
     ) -> ProviderCredentialRequest {
         switch resolution {
         case .preset(let preset):
-            return ProviderCredentialRequest(preset: preset, providerName: displayName, mode: .addNew)
+            return ProviderCredentialRequest(
+                preset: preset,
+                providerName: displayName,
+                mode: .addNew,
+                prefilledExtraFields: prefilledExtraFields
+            )
         case .codexOAuth:
-            return ProviderCredentialRequest(providerType: .openAICodex, providerName: displayName, mode: .addNew)
+            return ProviderCredentialRequest(
+                providerType: .openAICodex,
+                providerName: displayName,
+                mode: .addNew,
+                prefilledExtraFields: prefilledExtraFields
+            )
         case .osaurusAgent:
-            return ProviderCredentialRequest(providerType: .osaurus, providerName: displayName, mode: .addNew)
+            return ProviderCredentialRequest(
+                providerType: .osaurus,
+                providerName: displayName,
+                mode: .addNew,
+                prefilledExtraFields: prefilledExtraFields
+            )
         }
     }
 
@@ -471,7 +577,6 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
         displayName: String,
         resolution: ProviderToolResolution,
         storageAuthType: RemoteProviderAuthType,
-        hostOverride: String?,
         extraHeaders: [String: String]?,
         apiKey: String?,
         oauthTokens: RemoteProviderOAuthTokens?
@@ -495,15 +600,15 @@ public final class OsaurusProviderTool: OsaurusTool, PermissionedTool, @unchecke
         // …) keyed by the catalog field id. Reserved keys map onto explicit
         // `RemoteProvider` fields below — anything else passes through as a
         // custom header for `.openaiLegacy` providers.
+        //
+        // A tool-supplied `host` override is prefilled into this same field
+        // before the sheet opens (see `handleAdd`), so whatever the user
+        // saw, edited, and tested is exactly what we persist here. There is
+        // deliberately no separate post-sheet override path — that was the
+        // bait-and-switch where a preset key could be pointed at an
+        // attacker host after approval.
         let sheetHost = extras["host"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let host: String
-        if let override = hostOverride, !override.isEmpty {
-            host = override
-        } else if !sheetHost.isEmpty {
-            host = sheetHost
-        } else {
-            host = defaults.host
-        }
+        let host = sheetHost.isEmpty ? defaults.host : sheetHost
 
         var headers: [String: String] = [:]
         if providerType == .openaiLegacy {

--- a/Packages/OsaurusCore/Views/Credits/CreditsView.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsView.swift
@@ -23,6 +23,7 @@ struct CreditsView: View {
     @State private var showTopUpSheet = false
     @State private var showDisableRouterConfirm = false
     @State private var showRouterUsageCenter = false
+    @State private var allowUnkeyedLoopbackSpend = OsaurusRouter.allowsUnkeyedLoopbackSpend
 
     /// User master switch state. When off, the Credits screen hides the
     /// balance/activity cards (the router is no longer polled) and shows the
@@ -49,6 +50,9 @@ struct CreditsView: View {
                         routerOffCard
                     }
                     routerToggleFooter
+                    if routerEnabled {
+                        localAPISpendFooter
+                    }
                 }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 24)
@@ -202,6 +206,44 @@ struct CreditsView: View {
                 .tint(theme.accentColor)
         }
         .padding(.top, 8)
+    }
+
+    /// Opt-in for key-less loopback Router spend. Off by default so a local
+    /// process can't spend credits through the unauthenticated loopback API;
+    /// callers with a valid access key are always allowed regardless.
+    private var localAPISpendFooter: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Allow local API access without a key", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                Text(
+                    "Lets local processes route requests through the Osaurus Router (spending credits) via the HTTP API without an access key. Keep this off unless you trust every process on this Mac.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Toggle(
+                "",
+                isOn: Binding(
+                    get: { allowUnkeyedLoopbackSpend },
+                    set: { newValue in
+                        allowUnkeyedLoopbackSpend = newValue
+                        OsaurusRouter.setAllowsUnkeyedLoopbackSpend(newValue)
+                    }
+                )
+            )
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .tint(theme.accentColor)
+        }
+        .padding(.top, 4)
     }
 
     /// Drives the footer switch. Enabling is immediate; disabling defers to the

--- a/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
+++ b/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
@@ -107,6 +107,24 @@ struct ProviderCredentialPromptSheet: View {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Seed `extraFieldValues` from a tool-supplied host override (or any
+    /// other prefilled extra field) exactly once, when the sheet appears.
+    /// This makes a tool-driven `host` visible and editable in the field —
+    /// and, crucially, part of what the inline "Test Connection" hits — so
+    /// the user approves the real endpoint their credentials will reach
+    /// instead of a preset host that gets swapped out after the sheet
+    /// closes.
+    private func seedPrefilledExtraFieldsIfNeeded() {
+        guard extraFieldValues.isEmpty, !request.prefilledExtraFields.isEmpty else { return }
+        for field in request.instructions.extraFields {
+            if let value = request.prefilledExtraFields[field.key],
+                !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                extraFieldValues[field.key] = value
+            }
+        }
+    }
+
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -168,6 +186,7 @@ struct ProviderCredentialPromptSheet: View {
             x: 0,
             y: 6
         )
+        .onAppear { seedPrefilledExtraFieldsIfNeeded() }
     }
 
     /// Hairline divider under the header. Matches the rule

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -2639,21 +2639,35 @@ struct HeaderEntry: Identifiable {
     var value: String
     var isSecret: Bool
 
-    /// Build a flat dictionary of non-empty headers.
+    /// Build a flat dictionary of non-empty headers. Entries whose name or
+    /// value contains CR/LF or other control characters are dropped so a
+    /// malformed header can't be persisted (and later crash or split the
+    /// upstream request); the wire layer enforces the same rule.
     static func buildHeaders(from entries: [HeaderEntry]) -> [String: String] {
         var headers: [String: String] = [:]
-        for entry in entries where !entry.key.isEmpty && !entry.value.isEmpty {
+        for entry in entries
+        where !entry.key.isEmpty && !entry.value.isEmpty
+            && RemoteProviderService.isSafeHeader(name: entry.key, value: entry.value)
+        {
             headers[entry.key] = entry.value
         }
         return headers
     }
 
     /// Partition entries into regular headers dict and secret key names.
+    /// Secret values live in Keychain, so only the name is validated for
+    /// secret entries; regular entries validate both name and value.
     static func partition(_ entries: [HeaderEntry]) -> (regular: [String: String], secretKeys: [String]) {
         var regular: [String: String] = [:]
         var secretKeys: [String] = []
         for entry in entries where !entry.key.isEmpty {
-            if entry.isSecret { secretKeys.append(entry.key) } else { regular[entry.key] = entry.value }
+            if entry.isSecret {
+                if RemoteProviderService.isSafeHeader(name: entry.key, value: "") {
+                    secretKeys.append(entry.key)
+                }
+            } else if RemoteProviderService.isSafeHeader(name: entry.key, value: entry.value) {
+                regular[entry.key] = entry.value
+            }
         }
         return (regular, secretKeys)
     }

--- a/docs/OSAURUS_ROUTER.md
+++ b/docs/OSAURUS_ROUTER.md
@@ -48,7 +48,11 @@ normalization in `RemoteProviderService.buildChatRequest`.
 Router-specific fields and transforms:
 
 - `idempotency_key` is sent only to Router. Other OpenAI-compatible providers do
-  not receive it because some reject unknown fields.
+  not receive it because some reject unknown fields. Chat-UI turns set a stable
+  per-logical-step key; HTTP-origin requests (`/v1/chat/completions`, `/chat`,
+  Ollama, Anthropic, Open Responses, `/agents/{id}/run` steps) honor a
+  client-supplied `Idempotency-Key` header, or synthesize a per-request key
+  when the header is absent, so CLI/script retries do not double-bill.
 - `clamp_to_balance` is explicitly set to `false` for Router.
 - User multimodal content parts are preserved.
 - Assistant history is normalized to string `content` because several upstreams
@@ -111,6 +115,22 @@ assistant text.
 
 The billing path is metadata-only. Prompt text, response text, tool arguments,
 and tool results must not be written to Router billing records.
+
+### Loopback spend gate
+
+Router requests are signed with the user's master key and spend real credits,
+while the local HTTP API trusts loopback connections without a token. To keep
+any local process from silently draining the balance, `ChatEngine` refuses to
+dispatch an HTTP-origin request to the `.osaurusRouter` provider (HTTP 403)
+unless one of these holds:
+
+- the caller presented a valid access key (`Authorization: Bearer <key>` —
+  validated opportunistically for loopback callers, mandatory for everyone
+  else), or
+- the user enabled "Allow local API access without a key" on the Credits
+  screen (`OsaurusRouter.allowsUnkeyedLoopbackSpend`, off by default).
+
+App-internal sources (chat UI, plugins, P2P) are not affected by this gate.
 
 ## On-Device Billing Ledger
 

--- a/docs/PRIVACY_FILTER.md
+++ b/docs/PRIVACY_FILTER.md
@@ -183,7 +183,7 @@ A custom rule may override the prefix with its own `placeholderLabel` (e.g. `[CU
 
 ## Fail-Closed Guarantees
 
-The pipeline throws — never silently sends — on five distinct failure modes. `RemoteProviderService` catches the typed `PrivacyFilterPipelineError` and surfaces a non-generic chat-bubble error instead of the standard "Error: …" rendering.
+The pipeline throws — never silently sends — on six distinct failure modes. `RemoteProviderService` catches the typed `PrivacyFilterPipelineError` and surfaces a non-generic chat-bubble error instead of the standard "Error: …" rendering.
 
 | Error case                | When it fires                                                                                          | What the user sees                                                  |
 | ------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
@@ -191,6 +191,7 @@ The pipeline throws — never silently sends — on five distinct failure modes.
 | `.engineUnavailable(d)`   | **AI detection on** but model bundle is missing / failed to load (regex-only sends never hit this — they don't load the model) | Points at **Settings → Privacy** to re-download or turn AI detection off |
 | `.scrubNoOp(count)`       | User approved N entities but the substitution produced zero changes (`entity.original` doesn't match the wire text — almost always a bug) | "N approved redaction(s) didn't apply. Please report."              |
 | `.scrubLeaked(counts)`    | Post-scrub re-scan of the outbound payload found PII the substitution missed. Send is blocked         | Per-category counts of what leaked, no raw values                   |
+| `.reviewRequiresInteractive(count)` | A non-interactive request (HTTP API, plugin, P2P) hit fresh detections with `requireReviewForNonInteractive` on. The review sheet is never presented for non-UI origins — even when a chat window is open — so the send fails closed instead of hanging the client | A 422 (`privacy_filter_review_required`) telling the client to approve in the app chat, flip the setting, or disable the filter for the provider |
 | (review cancel via Cmd-.) | `withTaskCancellationHandler` resolves the suspended continuation as `.canceled`                       | Same as `.reviewCanceled`                                            |
 
 The post-scrub invariant only re-scans categories whose built-in regex is enabled. A user who explicitly turned off `phone` detection won't trip the leak check on a phone number — consistent with the principle that the same toggle controls both halves.

--- a/docs/REMOTE_PROVIDERS.md
+++ b/docs/REMOTE_PROVIDERS.md
@@ -189,9 +189,34 @@ Useful rows:
   ChatGPT/Codex catalog.
 - **Request format** shows the outbound API format and endpoint family. Local
   OpenAI-compatible API validation returns typed 400 errors for unsupported
-  sampler settings such as `n > 1` or `response_format=json_schema`.
+  sampler settings such as `n > 1`, `response_format=json_schema`, `logprobs`,
+  or `top_logprobs` (log-probabilities are not surfaced by local MLX decode or
+  the remote proxy).
 - **Global proxy** shows whether provider requests use a validated proxy, use
   direct networking, or ignore an invalid saved proxy URL.
+
+### Parameter Fidelity on Remote Routes
+
+Caller-supplied `seed` and `response_format: {type: "json_object"}` are
+forwarded rather than silently dropped, with per-format support:
+
+- **OpenAI-compatible chat completions** (OpenAI, Azure, xAI, OpenRouter,
+  Mistral, DeepSeek, custom OpenAI-compatible, Osaurus Router, Osaurus peers):
+  `seed` and `response_format` are sent as standard OpenAI fields. Whether the
+  upstream honors them is provider-specific; unsupported values surface as
+  the upstream's own error.
+- **Gemini**: `seed` maps to `generationConfig.seed` and JSON mode maps to
+  `generationConfig.responseMimeType: "application/json"`.
+- **Anthropic**: the Messages API has no `seed` or `response_format`
+  equivalent, so both are omitted on that wire.
+- **Remote agent runs (Mode 2)**: all caller sampling fields, including seed
+  and JSON mode, are stripped — the remote agent owns its generation config.
+
+Media inputs follow the same reject-loudly rule: audio (`input_audio`) and
+video (`video_url`) content parts have no mapping on the Anthropic and Gemini
+wires and return a typed error instead of being dropped from the conversation.
+OpenAI-compatible routes forward multimodal content parts as-is and defer to
+the upstream's own validation.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the remote-provider hardening plan from the audit of remote providers, Osaurus Router usage, and the hang/crash hunt. Highlights by area:

**Crash & hang fixes**
- Fix the `URLSession` invalidation TOCTOU crash: in-flight streams are tracked and drained before `invalidateAndCancel()`, so disabling/updating a provider mid-generation no longer aborts the process.
- Privacy review no longer suspends HTTP/API-origin requests on the interactive sheet — non-UI contexts fail closed with a typed error.
- Codex/xAI/OpenRouter OAuth callbacks now have a bounded wait (mirrors the MCP OAuth pattern) instead of waiting forever.
- `disableTimeout` keeps a hard 24h connect/inactivity ceiling; relay loopback proxy requests get an explicit timeout.

**Security — endpoint trust for credentials**
- Credential prompts bind to the final resolved endpoint; tool-supplied host overrides can no longer be applied after the sheet is approved.
- Host/port/base-path/protocol changes on provider update require user confirmation before reconnecting with stored secrets.
- All upstream error bodies route through the diagnostic redactor; Insights log redaction extended to upstream key shapes (Bearer, `sk-*`, JWT, `x-api-key`-style headers).
- Custom headers reject CRLF at save time; Gemini model path validation tightened.

**Reported bug — Router + Opus HTTP 400 ("user message content must be a string")**
- User media messages are flattened/converted on the Router wire when the model lacks vision support, with a friendly, actionable error instead of the raw JSON body. Regression-tested with multi-turn history containing an image user turn.

**Osaurus Router billing & spend safety**
- Loopback spend gate: HTTP-origin requests to the Router require a verified access key (or an explicit opt-in toggle on the Credits page), so a local process can't silently drain credits.
- HTTP-origin requests honor a client `Idempotency-Key` header (or synthesize one) so CLI/script retries don't double-bill; `/agents/{id}/run` derives stable per-step keys.
- `ai.osaurus.router.baseURL` UserDefaults override restricted to DEBUG builds.
- Streams that end without a billing summary trigger a debounced balance/usage reconciliation; connect retries honor server `Retry-After` hints (capped).
- Per-event Router stream diagnostics gated behind the debug flag; production keeps cheap event-kind counters only.

**Functionality**
- `autoConnect` honored at launch; launch connects run in parallel.
- `NWPathMonitor`-driven auto-reconnect for transiently failed providers on network recovery.
- All parallel tool calls are dispatched (previously only the lowest-index call survived).
- Typed 429 errors honoring `Retry-After`, with bounded retry for idempotent connect-phase requests.
- Permanent OAuth refresh failure (invalid_grant/401) clears tokens and sets a durable `requiresAuth` state.
- `seed`/`response_format` forwarded where supported; typed 400 for silently-dropped params; docs updated.

**Performance — streaming hot path**
- Stream producer detached from the `RemoteProviderService` actor so concurrent streams to one provider don't serialize.
- Per-chunk `ThrowingTaskGroup` timeout replaced with a single deadline-reset watchdog per stream.
- Compact (non-pretty) canonical JSON for wire bodies; bulk newline scanning and `JSONDecoder` reuse in chunk/SSE parsing.

## Test plan

- [x] Targeted suites for every touched area pass together (434 tests across 39 suites: RemoteProvider*, OsaurusRouter*, RouterSpendGate, HTTPIdempotencyKey, HTTPAuthGate, HTTPHandlerChatStreaming, PrivacyReview*, OAuthLoopback, stream parser/encoding/validation/redaction, SecureChannelE2E).
- [x] New regression tests: Router spend gate, HTTP idempotency keys, Router multipart-user encoding, OAuth permanent-failure state, session lifecycle (invalidation race), timeout ceiling, non-interactive privacy review.
- [x] Full suite run and triaged: the only failures caused by this branch (2 redaction expectations) were fixed; remaining failures reproduce on clean HEAD (pre-existing `ChatSession.init` Combine crash, MLX metallib abort under the SwiftPM harness) or are keychain-gated suites that fail by design under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`.
- [ ] CI green on this PR.