### PR TITLE
Flush pending stream text before tool-call frames; repin vmlx (stall + prose-cut fixes)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
+        "revision" : "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc"
       }
     },
     {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5140,8 +5140,38 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     } catch let invs as ServiceToolInvocations {
                         // Local models can emit multiple tool calls in a single
                         // completion; ServiceToolInvocations carries the batch.
+                        // Text can still be pending in the coalescer when the tool call
+                        // arrives (tool calls surface by throw, so the loop's own flush
+                        // never runs). Deliver it before the tool frames or the visible
+                        // answer ends mid-word.
+                        if let pending = contentCoalescer.flush() {
+                            hop {
+                                writerBound.value.writeContent(
+                                    pending,
+                                    model: model,
+                                    responseId: responseId,
+                                    created: created,
+                                    context: ctx.value
+                                )
+                            }
+                        }
                         return .toolCalls(invs.invocations)
                     } catch let inv as ServiceToolInvocation {
+                        // Text can still be pending in the coalescer when the tool call
+                        // arrives (tool calls surface by throw, so the loop's own flush
+                        // never runs). Deliver it before the tool frames or the visible
+                        // answer ends mid-word.
+                        if let pending = contentCoalescer.flush() {
+                            hop {
+                                writerBound.value.writeContent(
+                                    pending,
+                                    model: model,
+                                    responseId: responseId,
+                                    created: created,
+                                    context: ctx.value
+                                )
+                            }
+                        }
                         return .toolCalls([inv])
                     }
 
@@ -7356,6 +7386,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                     }
                 }
+                var contentCoalescer = Self.StreamDeltaCoalescer(
+                    interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
+                )
                 do {
                     httpTrace.mark("http_task_start")
                     let chatEngine = self.chatEngine
@@ -7393,9 +7426,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     if disconnected.value { throw CancellationError() }
                     var accumulatedContent = ""
                     var accumulatedReasoning = ""
-                    var contentCoalescer = Self.StreamDeltaCoalescer(
-                        interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
-                    )
                     var authoritativeCompletionTokens: Int?
                     var authoritativeTokensPerSecond: Double?
                     var streamFinishReason = "stop"
@@ -7570,6 +7600,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         finishReason: RequestLog.FinishReason(rawValue: finalStreamFinishReason) ?? .stop
                     )
                 } catch let invs as ServiceToolInvocations {
+                    // Text can still be pending in the coalescer when the tool call
+                    // arrives (tool calls surface by throw, so the loop's own flush
+                    // never runs). Deliver it before the tool frames or the visible
+                    // answer ends mid-word.
+                    if let pending = contentCoalescer.flush() {
+                        hop {
+                            writerBound.value.writeContent(
+                                pending,
+                                model: model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                        }
+                    }
                     // Multi-tool MLX completion: emit one tool_call delta
                     // per invocation, sharing one finish_reason="tool_calls".
                     // OpenAI clients deduplicate by `index`.
@@ -7634,6 +7679,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         finishReason: .toolCalls
                     )
                 } catch let inv as ServiceToolInvocation {
+                    // Text can still be pending in the coalescer when the tool call
+                    // arrives (tool calls surface by throw, so the loop's own flush
+                    // never runs). Deliver it before the tool frames or the visible
+                    // answer ends mid-word.
+                    if let pending = contentCoalescer.flush() {
+                        hop {
+                            writerBound.value.writeContent(
+                                pending,
+                                model: model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                        }
+                    }
                     // Single tool invocation — same emission as above.
                     httpTrace.markFirstSemanticDelta("tool_calls")
                     markSemanticDeltaIfConnected()
@@ -8002,14 +8062,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     }
                 }
             }
+            var contentCoalescer = Self.StreamDeltaCoalescer(
+                interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
+            )
             do {
                 let chatEngine = self.chatEngine
                 try Task.checkCancellation()
                 let stream = try await chatEngine.streamChat(request: req)
                 if disconnected.value { throw CancellationError() }
-                var contentCoalescer = Self.StreamDeltaCoalescer(
-                    interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
-                )
                 for try await delta in stream {
                     try Task.checkCancellation()
                     if disconnected.value { throw CancellationError() }
@@ -8069,6 +8129,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .stop
                 )
             } catch let invs as ServiceToolInvocations {
+                // Text can still be pending in the coalescer when the tool call
+                // arrives (tool calls surface by throw, so the loop's own flush
+                // never runs). Deliver it before the tool frames or the visible
+                // answer ends mid-word.
+                if let pending = contentCoalescer.flush() {
+                    hop {
+                        writerBound.value.writeContent(
+                            pending,
+                            model: req.model,
+                            responseId: "",
+                            created: Int(Date().timeIntervalSince1970),
+                            context: ctx.value
+                        )
+                    }
+                }
                 hop {
                     writerBound.value.writeToolCalls(invs.invocations, model: req.model, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
@@ -8090,6 +8165,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .toolCalls
                 )
             } catch let inv as ServiceToolInvocation {
+                // Text can still be pending in the coalescer when the tool call
+                // arrives (tool calls surface by throw, so the loop's own flush
+                // never runs). Deliver it before the tool frames or the visible
+                // answer ends mid-word.
+                if let pending = contentCoalescer.flush() {
+                    hop {
+                        writerBound.value.writeContent(
+                            pending,
+                            model: req.model,
+                            responseId: "",
+                            created: Int(Date().timeIntervalSince1970),
+                            context: ctx.value
+                        )
+                    }
+                }
                 hop {
                     writerBound.value.writeToolCalls([inv], model: req.model, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
@@ -9851,14 +9941,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     }
                 }
             }
+            var contentCoalescer = Self.StreamDeltaCoalescer(
+                interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
+            )
             do {
                 let chatEngine = self.chatEngine
                 try Task.checkCancellation()
                 let stream = try await chatEngine.streamChat(request: internalReq)
                 if disconnected.value { throw CancellationError() }
-                var contentCoalescer = Self.StreamDeltaCoalescer(
-                    interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
-                )
                 for try await delta in stream {
                     try Task.checkCancellation()
                     if disconnected.value { throw CancellationError() }
@@ -9912,6 +10002,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .stop
                 )
             } catch let invs as ServiceToolInvocations {
+                // Text can still be pending in the coalescer when the tool call
+                // arrives (tool calls surface by throw, so the loop's own flush
+                // never runs). Deliver it before the tool frames or the visible
+                // answer ends mid-word.
+                if let pending = contentCoalescer.flush() {
+                    hop {
+                        writerBound.value.writeTextDelta(pending, context: ctx.value)
+                    }
+                }
                 // Multi-tool MLX completion: one `tool_use` content block
                 // per invocation, then a single `tool_use` finish.
                 markSemanticDeltaIfChannelActive()
@@ -9937,6 +10036,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .toolCalls
                 )
             } catch let inv as ServiceToolInvocation {
+                // Text can still be pending in the coalescer when the tool call
+                // arrives (tool calls surface by throw, so the loop's own flush
+                // never runs). Deliver it before the tool frames or the visible
+                // answer ends mid-word.
+                if let pending = contentCoalescer.flush() {
+                    hop {
+                        writerBound.value.writeTextDelta(pending, context: ctx.value)
+                    }
+                }
                 // Single tool invocation — same emission path.
                 markSemanticDeltaIfChannelActive()
                 hop {
@@ -10643,14 +10751,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     }
                 }
             }
+            var contentCoalescer = Self.StreamDeltaCoalescer(
+                interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
+            )
             do {
                 let chatEngine = self.chatEngine
                 try Task.checkCancellation()
                 let stream = try await chatEngine.streamChat(request: internalReq)
                 if disconnected.value { throw CancellationError() }
-                var contentCoalescer = Self.StreamDeltaCoalescer(
-                    interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
-                )
                 for try await delta in stream {
                     try Task.checkCancellation()
                     if disconnected.value { throw CancellationError() }
@@ -10755,6 +10863,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .stop
                 )
             } catch let invs as ServiceToolInvocations {
+                // Text can still be pending in the coalescer when the tool call
+                // arrives (tool calls surface by throw, so the loop's own flush
+                // never runs). Deliver it before the tool frames or the visible
+                // answer ends mid-word.
+                if let pending = contentCoalescer.flush() {
+                    hop {
+                        writerBound.value.writeReasoningItemDone(context: ctx.value)
+                        if !messageItemOpen.value {
+                            messageItemOpen.value = true
+                            writerBound.value.writeMessageItemAdded(itemId: itemId, context: ctx.value)
+                            writerBound.value.writeContentPartAdded(context: ctx.value)
+                        }
+                        writerBound.value.writeTextDelta(pending, context: ctx.value)
+                    }
+                }
                 markSemanticDeltaIfChannelActive()
                 // Multi-tool MLX completion: emit one function_call item
                 // per invocation. Use the lazy `messageItemOpen` flag so
@@ -10794,6 +10917,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .toolCalls
                 )
             } catch let inv as ServiceToolInvocation {
+                // Text can still be pending in the coalescer when the tool call
+                // arrives (tool calls surface by throw, so the loop's own flush
+                // never runs). Deliver it before the tool frames or the visible
+                // answer ends mid-word.
+                if let pending = contentCoalescer.flush() {
+                    hop {
+                        writerBound.value.writeReasoningItemDone(context: ctx.value)
+                        if !messageItemOpen.value {
+                            messageItemOpen.value = true
+                            writerBound.value.writeMessageItemAdded(itemId: itemId, context: ctx.value)
+                            writerBound.value.writeContentPartAdded(context: ctx.value)
+                        }
+                        writerBound.value.writeTextDelta(pending, context: ctx.value)
+                    }
+                }
                 markSemanticDeltaIfChannelActive()
                 // Single tool invocation — same flow with one item.
                 hop {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
+        "revision" : "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
+            revision: "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
-        #expect(packageResolved.contains(#""revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
-        #expect(workspaceResolved.contains(#""revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
-        #expect(appResolved.contains(#""revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4""#))
+        #expect(packageSwift.contains(#"revision: "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc""#))
+        #expect(packageResolved.contains(#""revision" : "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc""#))
+        #expect(workspaceResolved.contains(#""revision" : "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc""#))
+        #expect(appResolved.contains(#""revision" : "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -685,7 +685,7 @@ struct RuntimePolicySourceTests {
         // SSM/hybrid mixer (vmlx-swift#126), and the ZAYA tool-aware template
         // activation from source_model.architecture (vmlx-swift#127) that
         // stops JANGTQ ZAYA bundles leaking raw tool-call XML.
-        let expectedRuntimeHardenedRevision = "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
+        let expectedRuntimeHardenedRevision = "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d3444cad48f658103789cbf8fc9b13f4b7a80d4"
+        "revision" : "c39192d9a8d2f56a35f053c7ca1ecba79ee802fc"
       }
     },
     {


### PR DESCRIPTION
## Two user reports, one PR

**1. "when it finishes the query, it doesn't always stop — it hangs around for a bit then closes, no looping, just open connection, no response"** (ornith)

For hybrid-SSM models, vmlx rebuilt the cross-turn cache boundary after the answer by replaying the entire stripped prefix through the model — a second full prefill — and `finish_reason`/`[DONE]` waited on it. Measured on `ornith-1.0-9b-mxfp8`: 0.42 s tail at 478-token prompts scaling to **6.58 s at 14k**. Fixed in vmlx #129 by capturing the boundary during the prefill that already passes through it (same tokens, same forwards, zero extra compute), pinned here.

**2. Agent runs: the assistant's sentence cuts off mid-word right before tool calls** — "…finalize the Pipe function in the right plac". Reproduced 4/8 turns at temp 0: "…removing the temporary director".

Layer tracing found losses on BOTH sides of the process boundary:

- **Engine** (vmlx #130, pinned here): the tool-call parser discarded the prose stashed ahead of the envelope when the call completed at end-of-stream (the normal case for Qwen3.5-family, which stops right after `</tool_call>`), and the stop-string matcher's held tail was emitted *after* the `.toolCall` event — where consumers rightly suppress it as post-tool text.
- **osaurus (this PR)**: every streaming handler batches text deltas through a `StreamDeltaCoalescer`, and tool calls surface by **throw** (`ServiceToolInvocation` out of the delta loop). The catches wrote the tool-call frames without flushing the coalescer — pending text died with the throw. The coalescer was also declared *inside* the `do`, so the catches couldn't have reached it. Live capture: engine emitted `…removing the temporary directory at /tmp/smoke.`, wire delivered `…removing the temporary director`.

### Changes

- `HTTPHandler`: hoist the coalescer ahead of the `do` and flush it in every `ServiceToolInvocation(s)` catch before writing tool frames — agents/run, chat completions, Ollama chat NDJSON, Anthropic messages, Open Responses. (Ollama generate dispatches no tools; non-streaming handlers aggregate differently and are unchanged.)
- vmlx pin `0d3444ca` → `c39192d9` (carries vmlx #129 + #130); pin constants updated in `RuntimePolicySourceTests` + `ImageGenerationBridgeContractTests` and all three `Package.resolved` files.

### Verification — live dev app built from THIS branch and the real pin (no path override), M5 Max

| check | before | after |
|---|---|---|
| prose-then-tool-call truncations (ornith, temp 0, 7-turn matrix) | 4/8 | **0/7** |
| post-answer stream tail @ ~14k tokens | 6.58 s | **0.31 s** |
| same, lfm2.5-8b (hybrid SSM) | 1.68 s | 0.09 s |
| dense gemma-4-e2b tail | 0.05 s | 0.05 s (unchanged) |
| growing-chat reuse TTFT turns 1→3 | — | 0.68 s → 0.17 s (still fires) |
| multi-turn recall | — | exact |
| cross-matrix (ornith / gemma-4-e2b / lfm2.5): recall, tools w/ args, reasoning on/off, control-marker leak scan | — | all clean |

Sample, same request before/after:

```
before: '…Let me clean up the smoke test artifacts by removing the temporary director'
after : '…Let me clean up the smoke test artifacts by removing the temporary directory at /tmp/smoke.'
```

`RuntimePolicySourceTests` + `ImageGenerationBridgeContractTests`: 91/91 green on this branch (pin constants validated).

vmlx PRs: osaurus-ai/vmlx-swift#129, osaurus-ai/vmlx-swift#130 (both merged).
