### PR TITLE
Fix Router 409 IDEMPOTENCY_CONFLICT on refunded agent-loop iterations

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5112,10 +5112,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     iterationReq.isAgentRequest = true
                     // Per-step Router billing dedupe: the message count is
                     // stable per logical step (tool loops append messages
-                    // between steps) and reproducible on a client retry of
-                    // the same run, so the derived key dedupes a re-POST of
-                    // any step without ever colliding across steps.
-                    iterationReq.idempotencyKey = "\(idempotencyBase)-s\(msgs.count)"
+                    // between steps), so a re-POST of the same step reuses its
+                    // key. The count alone is not collision-safe — compaction
+                    // can shrink the array back to a count an earlier step
+                    // used, and a client retry re-derives the same counts over
+                    // nondeterministic model/tool output — so the body
+                    // fingerprint suffix keys any changed body as a distinct
+                    // request instead of a router IDEMPOTENCY_CONFLICT (409).
+                    iterationReq.idempotencyKey =
+                        "\(idempotencyBase)-s\(msgs.count)-"
+                        + AgentToolLoop.stepIdempotencyFingerprint(messages: msgs)
 
                     responseContent = ""
                     var contentCoalescer = Self.StreamDeltaCoalescer(

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -31,6 +31,7 @@
 //  HTTP and plugin surfaces pass nonisolated ones.
 //
 
+import CryptoKit
 import Foundation
 
 // MARK: - Policy
@@ -958,6 +959,52 @@ enum AgentToolLoop {
         }
         let raw = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         return "call_" + String(raw.prefix(24))
+    }
+
+    /// Short, stable fingerprint of an outbound message array, for Router
+    /// billing idempotency keys. The loop's iteration counter alone is NOT a
+    /// safe key component: budget-refunded iterations (data-movement relief,
+    /// empty-turn retries) reuse the same counter value with a *different*
+    /// request body, which the Router rejects as `IDEMPOTENCY_CONFLICT`
+    /// (HTTP 409). Suffixing the key with this fingerprint keeps genuine
+    /// re-POSTs (`retryWithoutCharge` replays the identical messages)
+    /// deduping on the same key while any body change mints a fresh one.
+    ///
+    /// Covers every field that reaches the wire per message: role, content,
+    /// tool_call_id, reasoning content, tool calls (id/name/arguments), and
+    /// multimodal content parts. Field and message boundaries are separated
+    /// with control bytes so adjacent fields can't collide by concatenation.
+    static func stepIdempotencyFingerprint(messages: [ChatMessage]) -> String {
+        var hasher = SHA256()
+        func feed(_ value: String) {
+            hasher.update(data: Data(value.utf8))
+            hasher.update(data: Data([0x1F]))  // unit separator between fields
+        }
+        for message in messages {
+            feed(message.role)
+            feed(message.content ?? "")
+            feed(message.tool_call_id ?? "")
+            feed(message.reasoning_content ?? "")
+            for call in message.tool_calls ?? [] {
+                feed(call.id)
+                feed(call.function.name)
+                feed(call.function.arguments)
+            }
+            for part in message.contentParts ?? [] {
+                switch part {
+                case .text(let text):
+                    feed("text:" + text)
+                case .imageUrl(let url, let detail):
+                    feed("image:" + (detail ?? "") + ":" + url)
+                case .audioInput(let data, let format):
+                    feed("audio:" + format + ":" + data)
+                case .videoUrl(let url):
+                    feed("video:" + url)
+                }
+            }
+            hasher.update(data: Data([0x1E]))  // record separator between messages
+        }
+        return hasher.finalize().prefix(8).map { String(format: "%02x", $0) }.joined()
     }
 
     /// Run the canonical loop to completion. Errors thrown by

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -2760,8 +2760,14 @@ public actor RemoteProviderService: ToolCapableService {
             // Router-only: the body is signed, so this rides the existing
             // signature. Gated here so no other OpenAI-compat upstream receives
             // an unexpected `idempotency_key` field (some 422 on unknown keys).
+            // Surfaces that don't derive their own key (subagent runner,
+            // plugin completions, other headless dispatch) get a synthesized
+            // per-request key: the body is built once and connect-phase
+            // retries re-POST the same bytes, so the router can still dedupe
+            // a request it already received (e.g. a timeout after receipt)
+            // instead of billing it twice.
             idempotencyKey: provider.providerType == .osaurusRouter
-                ? parameters.idempotencyKey : nil
+                ? (parameters.idempotencyKey ?? "auto-\(UUID().uuidString)") : nil
         )
 
         // Ask OpenAI Chat-Completions upstreams to emit a final `usage` chunk so

--- a/Packages/OsaurusCore/Tests/Chat/AgentStepIdempotencyFingerprintTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentStepIdempotencyFingerprintTests.swift
@@ -1,0 +1,125 @@
+//
+//  AgentStepIdempotencyFingerprintTests.swift
+//  osaurusTests
+//
+//  Pins the body-fingerprint component of Router billing idempotency keys.
+//  The agent loop's iteration counter is reused by budget-refunded
+//  iterations (data-movement relief, empty-turn retries) whose request body
+//  CHANGED — the fingerprint must diverge there so the key does too
+//  (otherwise the Router rejects the step with 409 IDEMPOTENCY_CONFLICT),
+//  while identical re-POSTs (retryWithoutCharge) must keep the same
+//  fingerprint so billing dedupe still works.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct AgentStepIdempotencyFingerprintTests {
+
+    private static func baseMessages() -> [ChatMessage] {
+        [
+            ChatMessage(role: "system", content: "You are an agent."),
+            ChatMessage(role: "user", content: "refresh the github downloads"),
+            ChatMessage(
+                role: "assistant",
+                content: "Importing now.",
+                tool_calls: [
+                    ToolCall(
+                        id: "call_import_1",
+                        type: "function",
+                        function: ToolCallFunction(
+                            name: "db_import",
+                            arguments: #"{"table":"snapshots","path":"rows.json"}"#
+                        )
+                    )
+                ],
+                tool_call_id: nil
+            ),
+            ChatMessage(
+                role: "tool",
+                content: #"{"ok":true,"rows_imported":1262}"#,
+                tool_calls: nil,
+                tool_call_id: "call_import_1"
+            ),
+        ]
+    }
+
+    @Test func identicalMessages_produceIdenticalFingerprint() {
+        let first = AgentToolLoop.stepIdempotencyFingerprint(messages: Self.baseMessages())
+        let second = AgentToolLoop.stepIdempotencyFingerprint(messages: Self.baseMessages())
+        #expect(first == second)
+    }
+
+    @Test func fingerprintIsShortLowercaseHex() {
+        let fingerprint = AgentToolLoop.stepIdempotencyFingerprint(messages: Self.baseMessages())
+        #expect(fingerprint.count == 16)
+        #expect(fingerprint.allSatisfy { $0.isHexDigit && (!$0.isLetter || $0.isLowercase) })
+    }
+
+    /// The exact 409 trigger: a data-movement-refunded iteration reuses the
+    /// attempt counter, but its body carries the relief notice merged into
+    /// the trailing tool result. The fingerprint must diverge.
+    @Test func noticeAppendedToToolResult_changesFingerprint() {
+        let before = Self.baseMessages()
+        let after = AgentLoopBudget.appendingTransientNotices(
+            [AgentToolLoop.dataMovementReliefNotice(cap: 15)],
+            to: before
+        )
+        #expect(
+            AgentToolLoop.stepIdempotencyFingerprint(messages: before)
+                != AgentToolLoop.stepIdempotencyFingerprint(messages: after)
+        )
+    }
+
+    @Test func appendingToolResult_changesFingerprint() {
+        var grown = Self.baseMessages()
+        grown.append(
+            ChatMessage(
+                role: "tool",
+                content: #"{"ok":true,"rows_imported":10}"#,
+                tool_calls: nil,
+                tool_call_id: "call_import_2"
+            )
+        )
+        #expect(
+            AgentToolLoop.stepIdempotencyFingerprint(messages: Self.baseMessages())
+                != AgentToolLoop.stepIdempotencyFingerprint(messages: grown)
+        )
+    }
+
+    @Test func toolCallArguments_participateInFingerprint() {
+        var mutated = Self.baseMessages()
+        mutated[2] = ChatMessage(
+            role: "assistant",
+            content: "Importing now.",
+            tool_calls: [
+                ToolCall(
+                    id: "call_import_1",
+                    type: "function",
+                    function: ToolCallFunction(
+                        name: "db_import",
+                        arguments: #"{"table":"snapshots","path":"OTHER.json"}"#
+                    )
+                )
+            ],
+            tool_call_id: nil
+        )
+        #expect(
+            AgentToolLoop.stepIdempotencyFingerprint(messages: Self.baseMessages())
+                != AgentToolLoop.stepIdempotencyFingerprint(messages: mutated)
+        )
+    }
+
+    /// Field boundaries are separator-delimited, so content can't bleed into
+    /// the neighboring role/field and collide by concatenation.
+    @Test func fieldBoundaries_doNotCollideByConcatenation() {
+        let joined = [ChatMessage(role: "user", content: "ab")]
+        let split = [ChatMessage(role: "usera", content: "b")]
+        #expect(
+            AgentToolLoop.stepIdempotencyFingerprint(messages: joined)
+                != AgentToolLoop.stepIdempotencyFingerprint(messages: split)
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -2019,6 +2019,71 @@ struct RemoteChatRequestEncodingTests {
         #expect(noSessionReq.promptCacheKey == nil)
     }
 
+    /// Surfaces that don't derive a key (subagent runner, plugin
+    /// completions) still get a synthesized per-request `auto-` key on the
+    /// Router path, so `connectWithRetry` re-POSTs can be deduped
+    /// server-side instead of double-billing. Non-router upstreams must
+    /// keep omitting the field (some 422 on unknown keys).
+    @Test func buildChatRequest_synthesizesRouterIdempotencyKeyWhenNil() async throws {
+        func service(host: String, providerType: RemoteProviderType) -> RemoteProviderService {
+            RemoteProviderService(
+                provider: RemoteProvider(
+                    name: "p",
+                    host: host,
+                    providerProtocol: .https,
+                    port: nil,
+                    basePath: "/v1",
+                    authType: .none,
+                    providerType: providerType
+                ),
+                models: ["osaurus/minimax-m3"],
+                resolvedHeaders: [:]
+            )
+        }
+        let params = GenerationParameters(temperature: 0.7, maxTokens: 256)
+
+        let routerReq = await service(host: "router.osaurus.ai", providerType: .osaurusRouter)
+            .buildChatRequest(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                parameters: params,
+                model: "osaurus/minimax-m3",
+                stream: true,
+                tools: nil,
+                toolChoice: nil
+            )
+        let synthesized = try #require(routerReq.idempotencyKey)
+        #expect(synthesized.hasPrefix("auto-"))
+        #expect(synthesized.count > "auto-".count)
+
+        // A surface-supplied key is passed through untouched.
+        let suppliedReq = await service(host: "router.osaurus.ai", providerType: .osaurusRouter)
+            .buildChatRequest(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                parameters: GenerationParameters(
+                    temperature: 0.7,
+                    maxTokens: 256,
+                    idempotencyKey: "run-abc:2:deadbeef"
+                ),
+                model: "osaurus/minimax-m3",
+                stream: true,
+                tools: nil,
+                toolChoice: nil
+            )
+        #expect(suppliedReq.idempotencyKey == "run-abc:2:deadbeef")
+
+        // Non-router: still no key, even with none supplied.
+        let compatReq = await service(host: "api.x.ai", providerType: .openaiLegacy)
+            .buildChatRequest(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                parameters: params,
+                model: "grok-4",
+                stream: true,
+                tools: nil,
+                toolChoice: nil
+            )
+        #expect(compatReq.idempotencyKey == nil)
+    }
+
     @Test func wireBody_routerMatchesVeniceToolRequest_exceptRouterOnlyFields() throws {
         let priorCall = ToolCall(
             id: "call_write_1",

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4676,8 +4676,16 @@ final class ChatSession: ObservableObject {
                             // and the router dedupes the charge; a genuinely new
                             // step gets a fresh key and bills normally. A user
                             // Retry starts a new run (new runId) and re-bills by
-                            // design.
-                            req.idempotencyKey = "\(runId.uuidString):\(attempt)"
+                            // design. `attempt` alone is not collision-safe:
+                            // budget-refunded iterations (data-movement relief,
+                            // empty-turn nudges) also reuse the counter but with
+                            // a CHANGED body, which the router 409s as
+                            // IDEMPOTENCY_CONFLICT — the body fingerprint suffix
+                            // keys those as distinct requests while identical
+                            // retryWithoutCharge re-POSTs still dedupe.
+                            req.idempotencyKey =
+                                "\(runId.uuidString):\(attempt):"
+                                + AgentToolLoop.stepIdempotencyFingerprint(messages: msgs)
                             debugLog(
                                 "send: attempt=\(attempt) model=\(req.model) tools=\(req.tools?.count ?? 0) sessionId=\(req.session_id ?? "nil")"
                             )

--- a/docs/OSAURUS_ROUTER.md
+++ b/docs/OSAURUS_ROUTER.md
@@ -53,6 +53,16 @@ Router-specific fields and transforms:
   Ollama, Anthropic, Open Responses, `/agents/{id}/run` steps) honor a
   client-supplied `Idempotency-Key` header, or synthesize a per-request key
   when the header is absent, so CLI/script retries do not double-bill.
+  Agent-loop step keys (chat UI and `/agents/{id}/run`) additionally carry a
+  short SHA-256 fingerprint of the outbound message array
+  (`AgentToolLoop.stepIdempotencyFingerprint`): the loop's iteration counter is
+  reused by budget-refunded iterations (data-movement relief, empty-turn
+  retries) whose body CHANGED, and Router rejects a reused key with a
+  different body as `IDEMPOTENCY_CONFLICT` (HTTP 409). The fingerprint keeps
+  identical re-POSTs (transient stream retries) deduping on the same key while
+  any body change mints a fresh one. Surfaces that derive no key of their own
+  (subagent runner, plugin completions) get a synthesized per-request `auto-`
+  key in `buildChatRequest` so connect-phase retries still dedupe.
 - `clamp_to_balance` is explicitly set to `false` for Router.
 - User multimodal content parts are preserved.
 - Assistant history is normalized to string `content` because several upstreams


### PR DESCRIPTION
## Summary

- **Root cause:** the chat agent loop keyed Router billing idempotency as `runId:attempt`, but `AgentToolLoop.run` reuses the iteration counter on budget-refunded iterations (data-movement relief, empty-turn retries) whose request body *changed* — the Router correctly rejects a reused key with a different body as `IDEMPOTENCY_CONFLICT` (HTTP 409), aborting the run mid-task.
- **Fix:** suffix agent-loop step keys with a short SHA-256 fingerprint of the outbound message array (`AgentToolLoop.stepIdempotencyFingerprint`). Identical re-POSTs (`retryWithoutCharge` transient stream retries) keep the same key so billing dedupe still works; any body change mints a fresh key. Applied to both the chat UI key (`runId:attempt:fp`) and the `/agents/{id}/run` per-step key (`base-s{count}-fp`, which had the same collision class via compaction shrinking the message count and nondeterministic client retries).
- **Billing-dedupe gap closed alongside:** surfaces that never derive a key (subagent runner, plugin completions) now get a synthesized per-request `auto-<UUID>` key in `buildChatRequest`, so `connectWithRetry` re-POSTs of a request the Router may have already received can be deduped instead of double-billed. Still Router-only — no other upstream's wire bytes change.

## Test plan

- [x] New `AgentStepIdempotencyFingerprintTests` (6 tests): stable fingerprint for identical bodies; divergence when the data-movement relief notice is merged into the trailing tool result (the exact 409 trigger); divergence on appended tool results and changed tool arguments; field-boundary separator safety.
- [x] New `RemoteChatRequestEncodingTests` case pinning the `auto-` fallback, pass-through of supplied keys, and continued omission for non-Router providers.
- [x] Scoped local runs green: `AgentStepIdempotencyFingerprintTests` + `HTTPIdempotencyKeyTests` + `RemoteChatRequestEncodingTests` (132 tests), and `OsaurusRouterProviderTests` + `RemoteAgentRoutingTests` + `AgentToolLoop*` (103 tests). `swift build` clean.
- [ ] Full suite on CI.