### PR TITLE
docs: refresh translator leaderboard and promote Traditional Chinese to community-maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Osaurus is actively developed and we welcome contributions: bug fixes, new plugi
 Check out [Good First Issues](https://github.com/osaurus-ai/osaurus/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), read the [Contributing Guide](CONTRIBUTING.md), or join [Discord](https://discord.gg/osaurus). See [docs/FEATURES.md](docs/FEATURES.md) for the full feature inventory.
 
 > [!NOTE]
-> **🌐 Help translate Osaurus.** We're looking for contributors to localize the app into **Spanish**, **Japanese**, and **Traditional Chinese** -- these locales are already wired up in Xcode, so you can start translating right away. See [docs/TRANSLATORS.md](docs/TRANSLATORS.md) for how to contribute and the contributor leaderboard.
+> **🌐 Help translate Osaurus.** We're looking for contributors to localize the app into **Spanish** and **Japanese** -- these locales are already wired up in Xcode, so you can start translating right away. See [docs/TRANSLATORS.md](docs/TRANSLATORS.md) for how to contribute and the contributor leaderboard.
 
 ## Community
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -252,7 +252,7 @@ Use the "Feature request" issue template and describe:
 
 ## Localization
 
-Osaurus ships English (source), German, and Simplified Chinese, and we're actively seeking help with **Spanish, Korean, Japanese, and Traditional Chinese** (already enabled in Xcode and ready to translate). All UI strings live in the OsaurusCore string catalog; see **[LOCALIZATION.md](LOCALIZATION.md)** for how to add strings, add languages, and run validation. To pick up a language and get credited on the contributor leaderboard, see **[TRANSLATORS.md](TRANSLATORS.md)**.
+Osaurus ships English (source), German, Simplified Chinese, Korean, Russian, and community-maintained Traditional Chinese, and we're actively seeking help with **Spanish and Japanese** (already enabled in Xcode and ready to translate). All UI strings live in the OsaurusCore string catalog; see **[LOCALIZATION.md](LOCALIZATION.md)** for how to add strings, add languages, and run validation. To pick up a language and get credited on the contributor leaderboard, see **[TRANSLATORS.md](TRANSLATORS.md)**.
 
 ## Security
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -20,9 +20,9 @@ All SwiftUI and `String` UI text in **OsaurusCore** must resolve against the **p
 | Simplified Chinese | `zh-Hans` | Required |
 | Korean | `ko` | Required |
 | Russian | `ru` | Required |
+| Traditional Chinese | `zh-Hant` | Maintained (not yet CI-required) |
 | Spanish | `es` | Help wanted |
 | Japanese | `ja` | Help wanted |
-| Traditional Chinese | `zh-Hant` | Help wanted |
 
 All of the above are listed in the Xcode project's `knownRegions`, so the
 "help wanted" locales already have empty columns ready in the String Catalog
@@ -47,7 +47,7 @@ Helpers live in `Packages/OsaurusCore/Utils/`:
 Text(LocalizedStringKey(title), bundle: .module)
 ```
 
-After adding a key in code, add **de**, **zh-Hans**, **ko**, and **ru** in `Localizable.xcstrings` (Xcode String Catalog editor).
+After adding a key in code, add **de**, **zh-Hans**, **ko**, and **ru** in `Localizable.xcstrings` (Xcode String Catalog editor). Add **zh-Hant** too when you can — it is community-maintained and nearly complete, but not yet enforced by CI.
 
 Avoid raw `Text("…")`, `.help("…")`, `Button("…")`, `panel.title = "…"`, and `UNMutableNotificationContent.title = "…"` in `Packages/OsaurusCore`. CI flags these because they usually resolve against the wrong bundle.
 

--- a/docs/TRANSLATORS.md
+++ b/docs/TRANSLATORS.md
@@ -10,16 +10,17 @@ We are actively looking for help with these languages:
 | -------- | ---- | ------ |
 | Spanish | `es` | **Help wanted** |
 | Japanese | `ja` | **Help wanted** |
-| Traditional Chinese | `zh-Hant` | **Help wanted** |
 | German | `de` | Maintained |
 | Simplified Chinese | `zh-Hans` | Maintained |
 | Korean | `ko` | Maintained |
 | Russian | `ru` | Maintained |
+| Traditional Chinese | `zh-Hant` | Maintained (community) |
 | English | `en` | Source language |
 
-All three "help wanted" locales are already enabled in the Xcode project, so you
-can open the String Catalog editor and start translating immediately -- no setup
-required.
+Both "help wanted" locales are already enabled in the Xcode project, so you can
+open the String Catalog editor and start translating immediately -- no setup
+required. Traditional Chinese is nearly complete thanks to community
+contributions; help closing the last gap is welcome too.
 
 ## How to contribute a translation
 
@@ -64,12 +65,14 @@ python3 scripts/i18n/leaderboard.py --min-coverage 15
 
 <!-- LEADERBOARD:START -->
 
-_Last generated 2026-06-08 13:18 UTC by `scripts/i18n/leaderboard.py`. Coverage is the share of the app's translatable strings a contributor has translated; a language is listed at ≥10% coverage._
+_Last generated 2026-07-10 17:58 UTC by `scripts/i18n/leaderboard.py`. Coverage is the share of the app's translatable strings a contributor has translated; a language is listed at ≥10% coverage._
 
 | Contributor | Languages (coverage) | PRs |
 | ----------- | -------------------- | --- |
-| [@jiajun-dev](https://github.com/jiajun-dev) (zhuangjiajun) | Simplified Chinese (`zh-Hans`) 30% | [#857](https://github.com/osaurus-ai/osaurus/pull/857) |
-| [@HolliOnRoad](https://github.com/HolliOnRoad) | German (`de`) 27% | [#785](https://github.com/osaurus-ai/osaurus/pull/785) [#837](https://github.com/osaurus-ai/osaurus/pull/837) |
-| [@ftzahao](https://github.com/ftzahao) (师梦豪) | Simplified Chinese (`zh-Hans`) 26%, German (`de`) 11% | [#1354](https://github.com/osaurus-ai/osaurus/pull/1354) [#1373](https://github.com/osaurus-ai/osaurus/pull/1373) [#1380](https://github.com/osaurus-ai/osaurus/pull/1380) [#1414](https://github.com/osaurus-ai/osaurus/pull/1414) |
+| [@ftzahao](https://github.com/ftzahao) (师梦豪) | Simplified Chinese (`zh-Hans`) 94%, Traditional Chinese (`zh-Hant`) 92%, German (`de`) 67% | [#1354](https://github.com/osaurus-ai/osaurus/pull/1354) [#1373](https://github.com/osaurus-ai/osaurus/pull/1373) [#1380](https://github.com/osaurus-ai/osaurus/pull/1380) [#1414](https://github.com/osaurus-ai/osaurus/pull/1414) [#1437](https://github.com/osaurus-ai/osaurus/pull/1437) [#1466](https://github.com/osaurus-ai/osaurus/pull/1466) [#1470](https://github.com/osaurus-ai/osaurus/pull/1470) [#1491](https://github.com/osaurus-ai/osaurus/pull/1491) [#1520](https://github.com/osaurus-ai/osaurus/pull/1520) [#1553](https://github.com/osaurus-ai/osaurus/pull/1553) [#1579](https://github.com/osaurus-ai/osaurus/pull/1579) [#1596](https://github.com/osaurus-ai/osaurus/pull/1596) [#1607](https://github.com/osaurus-ai/osaurus/pull/1607) [#1633](https://github.com/osaurus-ai/osaurus/pull/1633) [#1659](https://github.com/osaurus-ai/osaurus/pull/1659) [#1720](https://github.com/osaurus-ai/osaurus/pull/1720) [#1762](https://github.com/osaurus-ai/osaurus/pull/1762) [#1820](https://github.com/osaurus-ai/osaurus/pull/1820) [#1858](https://github.com/osaurus-ai/osaurus/pull/1858) [#1909](https://github.com/osaurus-ai/osaurus/pull/1909) [#1947](https://github.com/osaurus-ai/osaurus/pull/1947) |
+| [@DrMaks22](https://github.com/DrMaks22) | Russian (`ru`) 86% | [#1782](https://github.com/osaurus-ai/osaurus/pull/1782) [#1822](https://github.com/osaurus-ai/osaurus/pull/1822) |
+| [@mimeding](https://github.com/mimeding) (Michael Meding) | Simplified Chinese (`zh-Hans`) 83%, Korean (`ko`) 81%, German (`de`) 67% | [#1304](https://github.com/osaurus-ai/osaurus/pull/1304) [#1372](https://github.com/osaurus-ai/osaurus/pull/1372) [#1477](https://github.com/osaurus-ai/osaurus/pull/1477) [#1518](https://github.com/osaurus-ai/osaurus/pull/1518) [#1529](https://github.com/osaurus-ai/osaurus/pull/1529) [#1531](https://github.com/osaurus-ai/osaurus/pull/1531) [#1559](https://github.com/osaurus-ai/osaurus/pull/1559) [#1565](https://github.com/osaurus-ai/osaurus/pull/1565) [#1570](https://github.com/osaurus-ai/osaurus/pull/1570) [#1572](https://github.com/osaurus-ai/osaurus/pull/1572) [#1586](https://github.com/osaurus-ai/osaurus/pull/1586) [#1588](https://github.com/osaurus-ai/osaurus/pull/1588) [#1616](https://github.com/osaurus-ai/osaurus/pull/1616) [#1739](https://github.com/osaurus-ai/osaurus/pull/1739) [#1743](https://github.com/osaurus-ai/osaurus/pull/1743) [#1931](https://github.com/osaurus-ai/osaurus/pull/1931) |
+| [@jiajun-dev](https://github.com/jiajun-dev) (zhuangjiajun) | Simplified Chinese (`zh-Hans`) 20% | [#857](https://github.com/osaurus-ai/osaurus/pull/857) [#1612](https://github.com/osaurus-ai/osaurus/pull/1612) |
+| [@HolliOnRoad](https://github.com/HolliOnRoad) | German (`de`) 17% | [#785](https://github.com/osaurus-ai/osaurus/pull/785) [#837](https://github.com/osaurus-ai/osaurus/pull/837) |
 
 <!-- LEADERBOARD:END -->


### PR DESCRIPTION
## Summary

- Regenerated the contributor leaderboard in `docs/TRANSLATORS.md` from the full merged-PR history (`--limit 2000`; the default 500-PR window was silently dropping older contributions). The board now credits 5 contributors, up from 3.
- Promoted **Traditional Chinese (`zh-Hant`)** from "help wanted" to **community-maintained** across `README.md`, `docs/CONTRIBUTING.md`, `docs/LOCALIZATION.md`, and `docs/TRANSLATORS.md` — it's now ~93% translated. It is *not yet CI-required*: the core catalog still has ~366 keys missing `zh-Hant`, so it stays out of `scripts/i18n/check.sh` until that gap closes.
- The active calls for help are now **Spanish (`es`)** and **Japanese (`ja`)** only. `CONTRIBUTING.md` also catches up on Korean and Russian being shipped languages.

## Huge thanks to our translators

This refresh is really a celebration of the community's work:

- @ftzahao — Simplified Chinese (94%), **Traditional Chinese (92%)**, German (67%) across 21 PRs. Traditional Chinese going from empty to nearly complete is almost entirely your doing.
- @DrMaks22 — Russian (86%), which is now a shipped, CI-required language.
- @mimeding — Simplified Chinese (83%), Korean (81%), German (67%) across 16 PRs.
- @jiajun-dev — Simplified Chinese (20%), including the very first big zh-Hans push in #857.
- @HolliOnRoad — German (17%), the earliest German contributions.

If anyone wants to help close the last ~7% of Traditional Chinese, or pick up Spanish or Japanese, see `docs/TRANSLATORS.md`.

## Test plan

- [x] `bash scripts/i18n/check.sh` passes (catalogs OK for de/zh-Hans/ko/ru, 0 suspect literals)
- [x] Verified `zh-Hant` would currently fail as a required locale (366 missing keys), hence "not yet CI-required"
- [x] Leaderboard generated by `scripts/i18n/leaderboard.py --limit 2000` against merged PRs