### PR TITLE
spawn_agent: carry the target agent's own tool policy into the child run

### DIFF
--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
@@ -272,8 +272,9 @@ enum AgentSubagentRunner {
                     let envelope = ToolEnvelope.failure(
                         kind: .rejected,
                         message:
-                            "Tool '\(invocation.toolName)' is not available inside a spawned subagent. "
-                            + "Subagent jobs are text-only.",
+                            "Tool '\(invocation.toolName)' is not available inside this spawned run — "
+                            + "it has no tools. Answer from the information you already have, and say "
+                            + "plainly when the task needs a tool you don't have.",
                         tool: invocation.toolName,
                         retryable: false
                     )

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -70,8 +70,17 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
     private var resolvedAgentId: UUID?
     private var systemPrompt: String = ""
     private var budgets = SubagentBudgets()
-    /// The launching agent's child-tool grant (`none` = text-only).
+    /// The launching agent's child-tool grant (`none` = no generic read-only
+    /// file tools; the target agent's OWN tools ride along regardless — see
+    /// `agentToolSpecs`).
     private var toolAccess: SpawnToolAccess = .none
+    /// Agent mode: the target agent's own enabled tools, resolved at
+    /// `resolveModel` time. This is what makes `spawn_agent` delegate to the
+    /// AGENT rather than to its bare prompt — a Calendar agent spawned without
+    /// its calendar tools either errors on an undispatchable envelope or
+    /// role-plays success while creating nothing (live report). Empty for
+    /// `spawn_model` and for agents with no tools enabled.
+    private var agentToolSpecs: [Tool] = []
     /// The target agent's user-set temperature override (agent mode only;
     /// `nil` keeps the model bundle's own generation defaults).
     private var temperature: Float?
@@ -206,6 +215,14 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         self.resolvedAgentName = agent.name
         self.resolvedAgentId = agent.id
         self.systemPrompt = agent.systemPrompt
+        // The persona's tool policy rides along with its prompt + model
+        // (the design contract: a subagent IS the agent, bounded). Tool
+        // EXECUTION still flows through `ToolRegistry.execute`, so per-tool
+        // permission gates apply exactly as they do in a direct chat with
+        // this agent.
+        self.agentToolSpecs = await MainActor.run {
+            Self.agentChildToolSpecs(agentId: agent.id)
+        }
         // The target agent's own sampling override rides along (a user-set
         // value, consistent with "defaults come from the model bundle unless
         // the user explicitly overrides").
@@ -310,7 +327,8 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         let toolset = await Self.makeToolset(
             access: toolAccess,
             maxToolCalls: budgets.maxToolCalls,
-            feed: feed
+            feed: feed,
+            agentSpecs: agentToolSpecs
         )
 
         let result = try await AgentSubagentRunner.run(
@@ -429,11 +447,38 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         }
     }
 
-    /// Build the child's curated read-only toolset when the launching agent
-    /// granted access; `nil` keeps the run text-only. The closure enforces the
-    /// allowlist and the per-run tool-call cap, dispatches through the shared
-    /// `ToolRegistry` (its permission gate + schema preflight included), and
-    /// narrates each call to the live feed.
+    /// Tool names never exposed inside a spawned child, on top of the target
+    /// agent's own policy:
+    /// - every subagent-capability tool (`spawn_agent`, `spawn_model`,
+    ///   `image`, computer-use, AppleScript): a bounded child must not fan out
+    ///   further — the recursion guard would refuse at runtime, but keeping
+    ///   the names out of the schema saves the wasted turns.
+    /// - `clarify`: it asks the USER a question, and a spawned child has no
+    ///   user surface — the question would strand the run until its deadline.
+    static func isExcludedChildTool(_ name: String) -> Bool {
+        if SubagentCapabilityRegistry.capability(forToolName: name) != nil { return true }
+        return name == "clarify"
+    }
+
+    /// The target agent's own enabled tools, as the child's schema. Uses the
+    /// same per-agent enabled list the direct-chat surface scopes to
+    /// (`effectiveEnabledToolNames`), so a spawned agent can do what it can do
+    /// in a direct chat — minus the exclusions above. `specs(forTools:)`
+    /// silently drops names that aren't registered right now, so the child
+    /// only ever sees live tools.
+    @MainActor
+    static func agentChildToolSpecs(agentId: UUID) -> [Tool] {
+        let names = AgentManager.shared.effectiveEnabledToolNames(for: agentId) ?? []
+        guard !names.isEmpty else { return [] }
+        return ToolRegistry.shared.specs(forTools: names.filter { !isExcludedChildTool($0) })
+    }
+
+    /// Build the child's toolset: the target agent's own tools (agent mode,
+    /// `agentSpecs`) plus the curated read-only file set when the launching
+    /// agent granted access; `nil` keeps the run text-only. The closure
+    /// enforces the allowlist and the per-run tool-call cap, dispatches
+    /// through the shared `ToolRegistry` (its permission gate + schema
+    /// preflight included), and narrates each call to the live feed.
     ///
     /// `specs` / `dispatch` are injection seams for unit tests (production
     /// passes nil → live registry lookup + registry dispatch).
@@ -441,17 +486,32 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         access: SpawnToolAccess,
         maxToolCalls: Int,
         feed: SubagentFeed?,
+        agentSpecs: [Tool] = [],
         specs specsOverride: [Tool]? = nil,
         dispatch: (@Sendable (ServiceToolInvocation) async -> String)? = nil
     ) async -> AgentSubagentToolset? {
-        guard access == .readOnly else { return nil }
-        let specs: [Tool]
-        if let specsOverride {
-            specs = specsOverride
-        } else {
-            specs = await MainActor.run {
-                ToolRegistry.shared.specs(forTools: readOnlyChildToolNames)
+        let readOnlySpecs: [Tool]
+        if access == .readOnly {
+            if let specsOverride {
+                readOnlySpecs = specsOverride
+            } else {
+                readOnlySpecs = await MainActor.run {
+                    ToolRegistry.shared.specs(forTools: readOnlyChildToolNames)
+                }
             }
+        } else if let specsOverride, agentSpecs.isEmpty {
+            // Test seam parity: an explicit override with no grant still
+            // yields nothing, exactly like the live registry path.
+            return nil
+        } else {
+            readOnlySpecs = []
+        }
+        // Agent tools first (the persona's own contract), read-only extras
+        // after; first spec wins on a name collision.
+        var specs: [Tool] = []
+        var seen = Set<String>()
+        for spec in agentSpecs + readOnlySpecs where seen.insert(spec.function.name).inserted {
+            specs.append(spec)
         }
         guard !specs.isEmpty else { return nil }
         let allowed = Set(specs.map { $0.function.name })

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnToolsetTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnToolsetTests.swift
@@ -125,6 +125,68 @@ struct SpawnToolsetTests {
         #expect(allowed == "ok")
     }
 
+    // MARK: - Agent-mode child tools (spawn_agent carries the persona's tool policy)
+
+    @Test("agent specs alone yield a toolset even without a read-only grant")
+    func agentSpecsWithoutGrant() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: SpawnToolAccess.none,
+            maxToolCalls: 4,
+            feed: nil,
+            agentSpecs: [spec("create_event"), spec("search_events")],
+            dispatch: { inv in "ran:\(inv.toolName)" }
+        )
+        let set = try #require(toolset)
+        #expect(set.specs.map(\.function.name).sorted() == ["create_event", "search_events"])
+
+        let ok = await set.execute(invocation("create_event"))
+        #expect(ok == "ran:create_event")
+        let refused = await set.execute(invocation("file_read"))
+        #expect(ToolEnvelope.isError(refused))
+    }
+
+    @Test("agent specs union with the read-only grant; agent spec wins a name collision")
+    func agentSpecsUnionReadOnly() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: .readOnly,
+            maxToolCalls: 8,
+            feed: nil,
+            agentSpecs: [spec("create_event"), spec("file_read")],
+            specs: [spec("file_read"), spec("file_search")],
+            dispatch: { inv in "ran:\(inv.toolName)" }
+        )
+        let set = try #require(toolset)
+        #expect(
+            set.specs.map(\.function.name).sorted() == ["create_event", "file_read", "file_search"])
+        let ok = await set.execute(invocation("create_event"))
+        #expect(ok == "ran:create_event")
+    }
+
+    @Test("agent-tool calls share the same per-run cap")
+    func agentToolsShareCap() async throws {
+        let toolset = await TextSubagentKind.makeToolset(
+            access: SpawnToolAccess.none,
+            maxToolCalls: 1,
+            feed: nil,
+            agentSpecs: [spec("create_event")],
+            dispatch: { _ in "ok" }
+        )
+        let set = try #require(toolset)
+        let first = await set.execute(invocation("create_event"))
+        let second = await set.execute(invocation("create_event"))
+        #expect(first == "ok")
+        #expect(ToolEnvelope.isError(second))
+    }
+
+    @Test("subagent-capability tools and clarify are excluded from a child schema")
+    func childExclusions() {
+        #expect(TextSubagentKind.isExcludedChildTool("spawn_agent"))
+        #expect(TextSubagentKind.isExcludedChildTool("spawn_model"))
+        #expect(TextSubagentKind.isExcludedChildTool("clarify"))
+        #expect(!TextSubagentKind.isExcludedChildTool("create_event"))
+        #expect(!TextSubagentKind.isExcludedChildTool("web_search"))
+    }
+
     @Test("cancel-reason mapping: user stop / parent cancel / deadline get distinct honest copy")
     func cancelReasonMapping() {
         // User stop → user_denied with "stopped by the user" (NOT a timeout).

--- a/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
@@ -16,9 +16,11 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
     public let name = SubagentCapabilityRegistry.spawnAgentToolName
     public let description =
         "Delegate a bounded subtask to a user-configured agent (runs on the target agent's own "
-        + "system prompt + model, local or remote) and get back only a compact result digest — the "
-        + "subagent transcript is not returned. The target agent must be in this agent's spawnable list. "
-        + "Use `spawn_model` instead to hand a task to a bare model with no agent attached."
+        + "system prompt + model + its enabled tools, local or remote) and get back only a compact "
+        + "result digest — the subagent transcript is not returned. The delegated agent can execute "
+        + "its own tools (e.g. a calendar agent can create events). The target agent must be in this "
+        + "agent's spawnable list. Use `spawn_model` instead to hand a task to a bare model with no "
+        + "agent attached."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),


### PR DESCRIPTION
## The report (Discord, vino1606, 0.21.13, qwen3.6-27b)

A Calendar Agent executes its tools perfectly in direct chat (`create_event`, `search_events`, …). Delegated via `spawn_agent` from a Workflow Orchestrator, it's broken: sometimes `execution_error: Stopped before completing.`, sometimes a success message ("Appointment successfully created") **with no event actually created**. They asked whether spawned agents are text-only.

They were — and it wasn't supposed to be that way.

## Root cause (exact location)

`TextSubagentKind` — and only there. `resolveAgentTarget` resolves the target agent's **system prompt + model + temperature but never its tool policy**, and `makeToolset` consults only the *launching* agent's `spawnToolAccess` grant (default `.none`; at best 4 curated read-only file tools). The child's `ChatCompletionRequest` goes out with **`tools: nil`** — the model receives no tool schema, so it either role-plays success or burns its 2-turn default budget and fails. Both reported symptoms, one cause.

Everything else is exonerated by construction: the engine/parser never see a tool schema (nothing to parse or mis-execute), sampling is irrelevant, and the residency handoff rejects **before** evicting, so model load/unload/RAM safety is not in the failure path. The intermittent "Stopped before completing" is downstream: a tool-less child produces an empty digest → failure envelope → the orchestrator gives up.

The design contract (`docs/SUBAGENT_PORTABLE_DESIGN.md`, "Piggyback on the agents system") explicitly lists the persona's **tool policy** (`toolSelectionMode` + `manualToolNames` + `toolsEnabled`) as part of what a subagent runs on. The implementation shipped without that row.

## The fix

Agent-mode spawns now resolve the target agent's enabled tools (`AgentManager.effectiveEnabledToolNames` — the same per-agent list the direct-chat surface scopes to) and run them through the **existing** child toolset machinery:

- dispatch via `ToolRegistry.execute` → per-tool permission gates apply exactly as in a direct chat with that agent
- the per-run tool-call cap and live-feed narration are unchanged
- exclusions on top of the agent's policy: every subagent-capability tool (no nested spawns from a bounded child) and `clarify` (a spawned child has no user surface)
- `spawn_model` stays bare-model text-only; the `readOnly` grant still adds the curated file tools, unioned after the agent's own specs (agent spec wins a name collision)

`spawn_agent`'s tool description now tells orchestrator models the delegate can execute its own tools, and the runner's refusal copy no longer claims all subagent jobs are text-only.

## Live proof (dev app, `/agents/{id}/run`, deterministic)

Target agent "TimeProof" with `manualToolNames: ["get_current_time"]` — a result the model cannot fabricate:

| run | result |
|---|---|
| direct (control) | reports wall-clock time exact to the minute |
| spawned, **before** | child self-reports "the agent lacks tools" (the reported failure class) |
| spawned, **after** | child executes its own tool — relayed ISO timestamp within **6 s of wall clock**, 3/3 consistent |
| spawned, **cross-model** (orchestrator ornith-1.0-9b → child gemma-4-e2b) | residency handoff (unload → child load → tool call → reload) returns the correct live time, `ramSafetyPreflightEnabled` on |

## Tests

`SpawnToolsetTests` +4 (agent specs without a grant; union with the read-only grant incl. collision precedence; shared per-run cap; child exclusions). **141/141 across the 16 subagent suites.** `AgentSubagentRunner.run` has exactly one call site, so this one fix covers both spawn tools; the `/agents/{id}/run|dispatch` surfaces already run the full agent stack with tools.
