### PR TITLE
fix: Codex model discovery returned unusable gpt-5.5-*-wm slugs

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -84,7 +84,13 @@ public enum OpenAICodexOAuthService {
     public static let scope = "openid profile email offline_access"
     public static let codexBaseHost = "chatgpt.com"
     public static let codexBasePath = "/backend-api"
-    public static let modelsURL = URL(string: "https://\(codexBaseHost)\(codexBasePath)/models")!
+    /// Codex API base path, matching codex-rs's `CHATGPT_CODEX_BASE_URL`
+    /// (`https://chatgpt.com/backend-api/codex`). Model discovery must use this
+    /// path: the plain `/backend-api/models` endpoint is the ChatGPT web-app
+    /// catalog, which serves experiment slugs (e.g. "gpt-5.5-wm") that the
+    /// Codex Responses backend rejects.
+    public static let codexAPIBasePath = "\(codexBasePath)/codex"
+    public static let modelsURL = URL(string: "https://\(codexBaseHost)\(codexAPIBasePath)/models")!
 
     // MARK: - Provider Factory
 
@@ -199,7 +205,7 @@ public enum OpenAICodexOAuthService {
     ) async throws -> [String] {
         var components = URLComponents(url: modelsURL, resolvingAgainstBaseURL: false)!
         components.queryItems = [
-            URLQueryItem(name: "client_version", value: clientVersion())
+            URLQueryItem(name: "client_version", value: codexClientVersion)
         ]
 
         var request = URLRequest(url: components.url!)
@@ -394,15 +400,11 @@ public enum OpenAICodexOAuthService {
     // MARK: - Internals
 
     /// `client_version` query parameter sent to the Codex `/models` endpoint.
-    /// Mirrors what the Codex CLI does (it sends its own crate version) so the
-    /// backend can gate model availability per client.
-    private static func clientVersion() -> String {
-        let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        if let bundleVersion, !bundleVersion.isEmpty {
-            return "osaurus-\(bundleVersion)"
-        }
-        return "0.99.0"
-    }
+    /// Tracks the openai/codex CLI release: the backend silently filters the
+    /// catalog for older or unrecognized versions (non-semver values like
+    /// "osaurus-1.2.3" get the wrong subset entirely). Bump this to the
+    /// current Codex CLI release when new models stop appearing in discovery.
+    public static let codexClientVersion = "0.144.1"
 
     // MARK: Wire types
 

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
@@ -64,6 +64,32 @@ struct OpenAICodexOAuthServiceTests {
         #expect(tokens.isExpired)
     }
 
+    @Test func modelsURL_usesCodexAPICatalogPath() {
+        // Discovery must hit the Codex catalog (`/backend-api/codex/models`),
+        // matching codex-rs's CHATGPT_CODEX_BASE_URL. The plain
+        // `/backend-api/models` endpoint is the ChatGPT web-app catalog, which
+        // serves experiment slugs (e.g. "gpt-5.5-wm") that the Codex
+        // Responses backend rejects.
+        let components = URLComponents(
+            url: OpenAICodexOAuthService.modelsURL,
+            resolvingAgainstBaseURL: false
+        )
+        #expect(components?.scheme == "https")
+        #expect(components?.host == "chatgpt.com")
+        #expect(components?.path == "/backend-api/codex/models")
+    }
+
+    @Test func codexClientVersion_isPlainSemver() {
+        // The backend gates the catalog by `client_version` and expects a
+        // Codex CLI semver; non-semver values (like the old
+        // "osaurus-<version>" scheme) silently get the wrong model subset.
+        let version = OpenAICodexOAuthService.codexClientVersion
+        #expect(
+            version.range(of: #"^\d+\.\d+\.\d+$"#, options: .regularExpression) != nil,
+            "client_version \(version) must be a plain Codex CLI semver"
+        )
+    }
+
     @Test func supportedModels_containsCurrentCatalog() {
         let models = OpenAICodexOAuthService.supportedModels
         let expected = [


### PR DESCRIPTION
## Summary

Users signed in with ChatGPT/Codex auth reported their model list suddenly changed to `gpt-5.5-cca-wm` and `gpt-5.5-wm`, both unusable. Root cause: Osaurus fetched the model catalog from the wrong endpoint with a `client_version` the backend doesn't recognize.

- Model discovery now hits `https://chatgpt.com/backend-api/codex/models` (matching codex-rs's `CHATGPT_CODEX_BASE_URL`) instead of `https://chatgpt.com/backend-api/models`. The latter is the ChatGPT web-app catalog, which recently began serving internal experiment slugs (`*-wm`); those pass the `^gpt-\d+\.\d+` slug filter, fully replace the static fallback list, and then fail on `/backend-api/codex/responses`.
- `client_version` is now a pinned Codex CLI semver constant (`codexClientVersion = "0.144.1"`) instead of `osaurus-<bundle version>`. The backend silently filters the catalog for unknown/stale versions, so the constant is documented with when to bump it.
- Chat requests already used the correct `/backend-api/codex/responses` path; only discovery changed.

Added regression tests pinning the discovery URL path and the semver format of `client_version`.

## Test plan

- [x] `swift test --filter OpenAICodexOAuthServiceTests` — 14/14 pass (includes 2 new regression tests)
- [x] `swift test --filter "RemoteProviderManagerTestConnectionTests|ProviderNetworkDiagnosticsTests"` — 13/13 pass
- [ ] Live proof: sign in with ChatGPT, reconnect the provider, confirm the picker shows the real Codex catalog (gpt-5.5, gpt-5.4, gpt-5.3-codex, ...) and a chat turn succeeds