### PR TITLE
Repin vmlx (for real this time) and push the memory-safety level to the cache-store gate

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "31b165cb0fa3ca49a8495971f8d906157906aeb6"
+        "revision" : "08234c17d1a5ed1381784d929ac517caddd164d1"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "31b165cb0fa3ca49a8495971f8d906157906aeb6"
+        "revision" : "08234c17d1a5ed1381784d929ac517caddd164d1"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "31b165cb0fa3ca49a8495971f8d906157906aeb6"
+            revision: "08234c17d1a5ed1381784d929ac517caddd164d1"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3010,6 +3010,11 @@ public actor ModelRuntime {
     ///    keeps MLX compile globally opt-in pending the PR #1173
     ///    model-switch corruption root cause; the per-request flag is set
     ///    in makeGenerateParameters)
+    ///  - memorySafety.mode -> CacheStoreBudget.policy (the prefix-cache store
+    ///    runs inside the decode loop and has no settings handle, so the user's
+    ///    safety level has to be pushed to it; without this the store gates
+    ///    against raw physical RAM and the Memory Safety section is decorative
+    ///    for that decision)
     nonisolated static func applyPerformancePolicy(_ settings: VMLXServerRuntimeSettings) {
         let perf = settings.effectivePerformance
         if let quant = perf.tiedHeadCodec.quantization {
@@ -3025,6 +3030,7 @@ public actor ModelRuntime {
         } else {
             unsetenv("VMLX_ENABLE_UNSAFE_COMPILE")
         }
+        CacheStoreBudget.policy = settings.memorySafety.mode.cacheStorePolicy
     }
 
     nonisolated static func makeGenerateParameters(

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "31b165cb0fa3ca49a8495971f8d906157906aeb6""#))
-        #expect(packageResolved.contains(#""revision" : "31b165cb0fa3ca49a8495971f8d906157906aeb6""#))
-        #expect(workspaceResolved.contains(#""revision" : "31b165cb0fa3ca49a8495971f8d906157906aeb6""#))
-        #expect(appResolved.contains(#""revision" : "31b165cb0fa3ca49a8495971f8d906157906aeb6""#))
+        #expect(packageSwift.contains(#"revision: "08234c17d1a5ed1381784d929ac517caddd164d1""#))
+        #expect(packageResolved.contains(#""revision" : "08234c17d1a5ed1381784d929ac517caddd164d1""#))
+        #expect(workspaceResolved.contains(#""revision" : "08234c17d1a5ed1381784d929ac517caddd164d1""#))
+        #expect(appResolved.contains(#""revision" : "08234c17d1a5ed1381784d929ac517caddd164d1""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -685,7 +685,22 @@ struct RuntimePolicySourceTests {
         // SSM/hybrid mixer (vmlx-swift#126), and the ZAYA tool-aware template
         // activation from source_model.architecture (vmlx-swift#127) that
         // stops JANGTQ ZAYA bundles leaking raw tool-call XML.
-        let expectedRuntimeHardenedRevision = "31b165cb0fa3ca49a8495971f8d906157906aeb6"
+        //
+        // Now also carries the cache-store memory budget on all four KV store
+        // paths and the Hunyuan bare-marker aliases (vmlx-swift#139), the
+        // host-scaled store margin plus the Hy3 reasoning-stamp demotion pin
+        // (#140), and the memory-safety level actually reaching the prefix-cache
+        // store (#141) -- the "Safety Level" slider used to be a stored field no
+        // resolver read, so it moved nothing.
+        //
+        // This assertion is a repin tripwire, and it earned its keep: PR #1986
+        // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
+        // gate run against that build proved only the osaurus-side change while
+        // appearing to bless the engine work too. Note the pin lives in FOUR
+        // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
+        // xcworkspace Package.resolved files. Miss one and the app resolves a
+        // revision nobody proved.
+        let expectedRuntimeHardenedRevision = "08234c17d1a5ed1381784d929ac517caddd164d1"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "31b165cb0fa3ca49a8495971f8d906157906aeb6"
+        "revision" : "08234c17d1a5ed1381784d929ac517caddd164d1"
       }
     },
     {


### PR DESCRIPTION
## The repin in #1986 was never actually there

#1986 was titled *"(+ vmlx repin)"* and **did not contain one**. `Package.swift` holds the authoritative `revision:` pin and was never touched; the only `Package.resolved` change in that merge was an `originHash` churn line.

So `main` has been building against vmlx **`31b165cb`** this whole time. Consequences:

- The live visual gate I ran against that build proved the **background-eviction fix and nothing else**.
- vmlx **#139** (cache-store memory budget, Hunyuan marker aliases) and **#140** (host-scaled margin, stamp-demotion pin) were **never in the binary**.
- HY3 loaded and answered cleanly in that gate because `31b165cb` already supports HY3 — not because the new engine code worked. A green gate on the wrong artifact is worse than no gate.

**The pin lives in three files, not two** — the third is the one that kept getting missed:

```
Packages/OsaurusCore/Package.swift                          <- authoritative
App/osaurus.xcodeproj/.../swiftpm/Package.resolved
osaurus.xcworkspace/.../swiftpm/Package.resolved            <- missed before
```

All three now carry vmlx **`08234c17`**, which contains #139, #140 and #141.

## Wire the Memory Safety section to the decision it could not reach

The prefix-cache store runs inside the decode loop with no settings handle, so vmlx gated it against **raw physical RAM** — identically whether the user asked for Performance or Strict. The Memory Safety section was decorative for that decision.

`applyPerformancePolicy` already runs before every model load and already pushes process-level engine policy (tied-head codec, compiled-decode gate). It now also pushes `CacheStoreBudget.policy`:

```swift
CacheStoreBudget.policy = settings.memorySafety.mode.cacheStorePolicy
```

| Level | Share of free headroom one cache store may take |
|---|---|
| Strict | 15% |
| Safe Auto (default) | 25% |
| Balanced | 35% |
| Performance | 45% |
| Diagnostic | 55% |

Without this line the vmlx change is inert in the app.

## Proof

`BUILD SUCCEEDED` against the new pin — and **that is itself evidence the repin landed**: `CacheStoreBudget.policy` and `VMLXMemorySafetyMode.cacheStorePolicy` exist **only** in vmlx `08234c17`. Against the old pin this would not compile.

Live visual multiturn gate on this build is running; this PR does not merge until it passes on an artifact that actually contains the engine changes.

Verification command, so this cannot recur:
```
git show origin/main:Packages/OsaurusCore/Package.swift | grep -A1 vmlx-swift
```