### PR TITLE
Key the prefix cache to the weights, not just the model's name

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -73,6 +73,9 @@ public actor ModelRuntime {
         let name: String
         let container: ModelContainer
         let weightsSizeBytes: Int64
+        /// Identifies the *weights that are actually loaded*, so a prefix-cache
+        /// entry cannot outlive them. See `weightsFingerprint(for:)`.
+        let weightsFingerprint: String
         let isVLM: Bool
         let draftStrategy: MLXLMCommon.DraftStrategy?
         let nativeMTPStatus: String?
@@ -82,6 +85,7 @@ public actor ModelRuntime {
             name: String,
             container: ModelContainer,
             weightsSizeBytes: Int64,
+            weightsFingerprint: String,
             isVLM: Bool = false,
             draftStrategy: MLXLMCommon.DraftStrategy? = nil,
             nativeMTPStatus: String? = nil,
@@ -90,6 +94,7 @@ public actor ModelRuntime {
             self.name = name
             self.container = container
             self.weightsSizeBytes = weightsSizeBytes
+            self.weightsFingerprint = weightsFingerprint
             self.isVLM = isVLM
             self.draftStrategy = draftStrategy
             self.nativeMTPStatus = nativeMTPStatus
@@ -1971,6 +1976,7 @@ public actor ModelRuntime {
                 name: name,
                 container: container,
                 weightsSizeBytes: loadFootprintBytes,
+                weightsFingerprint: Self.weightsFingerprint(for: localURL),
                 isVLM: isVLM,
                 draftStrategy: mtpPlan.draftStrategy,
                 nativeMTPStatus: mtpPlan.statusLine,
@@ -2071,6 +2077,7 @@ public actor ModelRuntime {
     /// file-level comment for rationale on each knob.
     private nonisolated static func buildCacheCoordinatorConfig(
         modelName: String,
+        weightsFingerprint: String,
         cacheTopology: ModelCacheTopologySnapshot? = nil
     ) -> CacheCoordinatorConfig {
         let settings = ServerRuntimeSettingsStore.snapshot()
@@ -2126,6 +2133,7 @@ public actor ModelRuntime {
         let scopedKey = Self.cacheCoordinatorModelKey(
             modelName: modelName,
             kvModeTag: kvModeTag,
+            weightsFingerprint: weightsFingerprint,
             cacheTopology: cacheTopology
         )
 
@@ -2337,13 +2345,81 @@ public actor ModelRuntime {
         return false
     }
 
+    /// Identity of the weights on disk, cheap enough to recompute on every load.
+    ///
+    /// The prefix cache is keyed by model *name*, and a name is not an identity: a
+    /// re-quantized bundle installed over the old one (MXFP4 -> MXFP8, a re-bake,
+    /// any weight edit) keeps its name, its layer count, its head dims and its KV
+    /// mode — every tag the key carried. The key was therefore byte-identical
+    /// across the swap, and the new weights would restore the OLD weights' KV and
+    /// continue generating from activations that never came from them. Silent, and
+    /// exactly the kind of thing that reads as "the quant is bad".
+    ///
+    /// `stat` per shard, not a content hash: digesting 94 GB on every load is not
+    /// affordable, and (size, mtime) over the shard set already changes on any real
+    /// re-bake. This is a cache *invalidation* key, not a security boundary — the
+    /// cost of a false miss is one slow prefill, so erring toward missing is right.
+    nonisolated static func weightsFingerprint(for directory: URL) -> String {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey],
+                options: [.skipsHiddenFiles])
+        else {
+            // Unreadable bundle: fall back to a value that never matches a previous
+            // load, so we take a cold prefill rather than risk a wrong-weights hit.
+            return "unknown-\(UUID().uuidString)"
+        }
+
+        // Weights and the files that change how they are interpreted. A tokenizer or
+        // config edit changes token ids / rope / quant metadata, which invalidates a
+        // stored KV just as surely as a weight edit does.
+        let interesting = entries.filter { url in
+            let name = url.lastPathComponent
+            return name.hasSuffix(".safetensors")
+                || name == "config.json"
+                || name == "tokenizer.json"
+                || name == "tokenizer_config.json"
+        }
+
+        let parts =
+            interesting
+            .map { url -> String in
+                let values = try? url.resourceValues(forKeys: [
+                    .fileSizeKey, .contentModificationDateKey,
+                ])
+                let size = values?.fileSize ?? -1
+                let mtime = values?.contentModificationDate?.timeIntervalSince1970 ?? -1
+                return "\(url.lastPathComponent):\(size):\(Int(mtime))"
+            }
+            .sorted()
+
+        guard !parts.isEmpty else { return "empty" }
+
+        // FNV-1a, not `hashValue`: Swift seeds `Hasher` per process, so a
+        // `hashValue`-derived key would differ on every launch and the prefix cache
+        // would never hit again — trading a correctness bug for a performance one.
+        // This must be stable across launches and across machines.
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in parts.joined(separator: "|").utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0100_0000_01b3
+        }
+        return String(format: "%016llx", hash)
+    }
+
     nonisolated static func cacheCoordinatorModelKey(
         modelName: String,
         kvModeTag: String,
+        weightsFingerprint: String,
         cacheTopology: ModelCacheTopologySnapshot? = nil
     ) -> String {
         var tags = [
             modelName,
+            // A name is not an identity — see `weightsFingerprint(for:)`. Without
+            // this, re-baking a pack under the same name serves the old pack's KV.
+            "weights=\(weightsFingerprint)",
             "kv=\(kvModeTag)",
             // vmlx `TQDiskSerializer.currentFormatVersion == 2` at the
             // pinned runtime. Keep this in the host key so older L2 records
@@ -2398,6 +2474,7 @@ public actor ModelRuntime {
         holder.cacheTopology = cacheTopology
         let cacheConfig = Self.buildCacheCoordinatorConfig(
             modelName: holder.name,
+            weightsFingerprint: holder.weightsFingerprint,
             cacheTopology: cacheTopology
         )
         await holder.container.enableCachingAsync(config: cacheConfig)

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -609,26 +609,105 @@ struct MLXBatchAdapterTests {
         #expect(effective.repetitionPenalty == engineDefaults.repetitionPenalty)
     }
 
+    /// A model name is not a model identity.
+    ///
+    /// Re-bake a pack (MXFP4 -> MXFP8, a re-quant, any weight edit) and install it
+    /// over the old one under the same name: the layer count, head dims and KV mode
+    /// are all unchanged, so every tag the cache key used to carry is unchanged too.
+    /// The key was therefore byte-identical across the swap, and the NEW weights
+    /// would restore the OLD weights' KV and keep generating from activations that
+    /// never came from them — silently, and looking for all the world like a bad
+    /// quant. Re-quantizing under a stable name is a routine operation here, so this
+    /// was reachable in normal use.
+    @Test func cacheCoordinatorModelKey_isolatesWeightsRebakedUnderTheSameName() {
+        let beforeRebake = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "Ornith-1.0-9B",
+            kvModeTag: "fp16",
+            weightsFingerprint: "aaaaaaaaaaaaaaaa"
+        )
+        let afterRebake = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "Ornith-1.0-9B",  // same name, same topology, new weights
+            kvModeTag: "fp16",
+            weightsFingerprint: "bbbbbbbbbbbbbbbb"
+        )
+
+        #expect(
+            beforeRebake != afterRebake,
+            "re-baked weights under the same name must not inherit the old pack's KV cache")
+        #expect(beforeRebake.contains("weights=aaaaaaaaaaaaaaaa"))
+        #expect(afterRebake.contains("weights=bbbbbbbbbbbbbbbb"))
+
+        // ...and the same weights must still hit, or we have traded a correctness
+        // bug for a cache that never warms.
+        let reload = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "Ornith-1.0-9B",
+            kvModeTag: "fp16",
+            weightsFingerprint: "aaaaaaaaaaaaaaaa"
+        )
+        #expect(reload == beforeRebake, "an unchanged pack must still reuse its cache")
+    }
+
+    /// The fingerprint has to survive a relaunch. Swift seeds `Hasher` per process,
+    /// so a `hashValue`-derived key would change on every launch and the prefix
+    /// cache would never hit again — a correctness fix that quietly becomes a
+    /// performance bug. FNV-1a is stable; this pins that it stays that way.
+    @Test func weightsFingerprint_isStableAndDeterministic() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try Data("weights".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: dir.appendingPathComponent("config.json"))
+
+        let first = ModelRuntime.weightsFingerprint(for: dir)
+        let second = ModelRuntime.weightsFingerprint(for: dir)
+        #expect(first == second, "the same bundle must fingerprint identically every time")
+        #expect(first.count == 16, "a 64-bit hex digest")
+        #expect(first != "empty")
+
+        // Editing a shard must change it, or a re-bake still slips through.
+        try Data("different weights entirely".utf8)
+            .write(to: dir.appendingPathComponent("model.safetensors"))
+        #expect(
+            ModelRuntime.weightsFingerprint(for: dir) != first,
+            "a changed shard must invalidate the cache")
+    }
+
+    /// An unreadable bundle must take a cold prefill rather than risk reusing some
+    /// other pack's KV: fail toward a slow request, never toward a wrong one.
+    @Test func weightsFingerprint_unreadableBundleNeverMatches() {
+        let missing = URL(fileURLWithPath: "/nonexistent-\(UUID().uuidString)")
+        let a = ModelRuntime.weightsFingerprint(for: missing)
+        let b = ModelRuntime.weightsFingerprint(for: missing)
+        #expect(a != b, "an unreadable bundle must never produce a reusable cache key")
+    }
+
     @Test func cacheCoordinatorModelKey_namespacesPathDependentCacheTopologies() {
         let dsv4 = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "DeepSeek-V4-Flash-JANGTQ2",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
         let zaya = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "ZAYA1-8B-JANGTQ4",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
         let ling = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "Ling-2.6-flash-JANGTQ2-CRACK",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
         let omni = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "Nemotron-Omni-Nano-JANGTQ4-CRACK",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
         let generic = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "Mistral-Medium-3.5-128B-MXFP4",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
 
         #expect(dsv4.contains("kv=fp16"))
@@ -821,7 +900,8 @@ struct MLXBatchAdapterTests {
         ] {
             let key = ModelRuntime.cacheCoordinatorModelKey(
                 modelName: name,
-                kvModeTag: "fp16"
+                kvModeTag: "fp16",
+                weightsFingerprint: "testfp"
             )
             #expect(
                 key.contains("layers=hybrid-ssm"),
@@ -831,14 +911,16 @@ struct MLXBatchAdapterTests {
 
         let omni = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "Nemotron-Omni-Nano-JANGTQ4-CRACK",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
         #expect(omni.contains("layers=hybrid-ssm"))
         #expect(omni.contains("media=omni-audio-video"))
 
         let zaya = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "ZAYA1-8B-JANGTQ4",
-            kvModeTag: "fp16"
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp"
         )
         #expect(zaya.contains("layers=zayaCCA"))
         #expect(!zaya.contains("layers=hybrid-ssm"))
@@ -859,6 +941,7 @@ struct MLXBatchAdapterTests {
         let key = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "unrecognized-local-bundle",
             kvModeTag: "turbo(4,3)",
+            weightsFingerprint: "testfp",
             cacheTopology: topology
         )
 
@@ -887,6 +970,7 @@ struct MLXBatchAdapterTests {
         let key = ModelRuntime.cacheCoordinatorModelKey(
             modelName: "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
             kvModeTag: "fp16",
+            weightsFingerprint: "testfp",
             cacheTopology: topology
         )
 


### PR DESCRIPTION
## A model name is not a model identity

The prefix-cache key was:

```
modelName | kv=<mode> | cachefmt=2 | restore=fullhit-trim-eval1 | topology=real | <topology tags> …
```

**A re-bake changes none of those.** Re-quantize a pack (MXFP4 → MXFP8, a fresh JANG bake, any weight edit) and install it over the old one under the same name: the layer count, head dims, KV mode and serializer version are all unchanged, so the key is **byte-identical across the swap**. The new weights then restore the **old** weights' KV and keep generating from activations that never came from them.

Silent — and it looks exactly like a bad quant. That's the worst part: re-baking under a stable name is routine here, and *"the re-quant is incoherent"* is precisely the conclusion this bug invites.

## The fix

Fold the weights' identity into the key:

```
modelName | weights=<fnv1a> | kv=<mode> | cachefmt=2 | …
```

- **`stat` per shard, not a content hash.** Digesting 94 GB on every load isn't affordable, and `(size, mtime)` over the shard set already changes on any real re-bake. This is a cache *invalidation* key, not a security boundary.
- **`config.json` and the tokenizer files are in the set.** A rope/quant-metadata or token-id edit invalidates a stored KV just as surely as a weight edit does.
- **An unreadable bundle fingerprints to a fresh UUID** → cold prefill rather than a wrong-weights hit. A false miss costs one slow request; a false hit costs a wrong answer.
- **FNV-1a, not `hashValue`.** Swift seeds `Hasher` per process, so a `hashValue`-derived key would differ on **every launch** and the prefix cache would never hit again — trading a correctness bug for a performance one. Pinned by a test.

## Tests

- `cacheCoordinatorModelKey_isolatesWeightsRebakedUnderTheSameName` — same name + same topology + different weights ⇒ **different key**; and unchanged weights ⇒ **same key** (so the cache still warms).
- `weightsFingerprint_isStableAndDeterministic` — identical across calls, changes when a shard changes.
- `weightsFingerprint_unreadableBundleNeverMatches` — never yields a reusable key.

6/6 green in `MLXBatchAdapterTests`.

Found by an adversarial audit of the spawn/delegation model lifecycle, not by a live repro; the namespace collision is confirmed from the code.