### PR TITLE
Add local model verification workbench

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import os
 
 /// Represents an MLX-compatible LLM that can be downloaded and used
-struct MLXModel: Identifiable, Codable {
+struct MLXModel: Identifiable, Codable, Sendable {
     let id: String
     let name: String
     let description: String

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -173084,6 +173084,14 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "模型包摘要" } }
       }
     },
+    "Auto tool choice" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Automatische Werkzeugwahl" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "자동 도구 선택" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Автоматический выбор инструмента" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "自动工具选择" } }
+      }
+    },
     "Decode speed" : {
       "localizations" : {
         "de" : { "stringUnit" : { "state" : "translated", "value" : "Dekodiergeschwindigkeit" } },

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -173067,6 +173067,158 @@
           }
         }
       }
+    },
+    "%@ evidence bound to this exact bundle." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "%@-Nachweis, der genau an dieses Modellpaket gebunden ist." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이 정확한 모델 번들에 연결된 %@ 증거입니다." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Результат «%@» привязан именно к этому пакету модели." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "%@ 证据已绑定到此确切模型包。" } }
+      }
+    },
+    "Bundle digest" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Paketprüfsumme" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "번들 다이제스트" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Дайджест пакета" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "模型包摘要" } }
+      }
+    },
+    "Decode speed" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Dekodiergeschwindigkeit" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "디코딩 속도" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Скорость декодирования" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "解码速度" } }
+      }
+    },
+    "Download the model before running live verification." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Laden Sie das Modell herunter, bevor Sie die Live-Prüfung ausführen." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "실시간 검증을 실행하기 전에 모델을 다운로드하세요." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Перед запуском проверки скачайте модель." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "请先下载模型，然后再运行实时验证。" } }
+      }
+    },
+    "Non-passing evidence" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Nicht bestandene Nachweise" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "통과하지 못한 증거" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Непройденные проверки" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未通过的证据" } }
+      }
+    },
+    "Hashing the exact bundle and running bounded generation, tool, continuation, and cancellation probes." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Das genaue Paket wird gehasht; begrenzte Generierungs-, Werkzeug-, Fortsetzungs- und Abbruchprüfungen werden ausgeführt." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "정확한 번들을 해시하고 제한된 생성, 도구, 연속 생성 및 취소 검사를 실행하고 있습니다." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Вычисляется хеш точного пакета и выполняются ограниченные проверки генерации, инструментов, продолжения и отмены." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "正在对确切模型包进行哈希，并运行有界的生成、工具、续写和取消探测。" } }
+      }
+    },
+    "Local model verification" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Lokale Modellprüfung" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "로컬 모델 검증" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Проверка локальной модели" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "本地模型验证" } }
+      }
+    },
+    "Not declared" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Nicht deklariert" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선언되지 않음" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Не объявлен" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未声明" } }
+      }
+    },
+    "Not recorded" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Nicht erfasst" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "기록되지 않음" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Не записано" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未记录" } }
+      }
+    },
+    "Result" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Ergebnis" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "결과" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Результат" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "结果" } }
+      }
+    },
+    "Reveal report" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Bericht anzeigen" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "보고서 보기" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Показать отчёт" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "显示报告" } }
+      }
+    },
+    "Run live probes before relying on tool use, continuation, or runtime behavior." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Führen Sie Live-Prüfungen aus, bevor Sie sich auf Werkzeugnutzung, Fortsetzung oder Laufzeitverhalten verlassen." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "도구 사용, 연속 생성 또는 런타임 동작을 신뢰하기 전에 실시간 검사를 실행하세요." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Перед использованием инструментов, продолжения или поведения среды выполните проверку в реальном времени." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在依赖工具使用、续写或运行时行为之前，请先运行实时探测。" } }
+      }
+    },
+    "The model bundle changed after this report. Verify it again before relying on the result." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Das Modellpaket wurde nach diesem Bericht geändert. Prüfen Sie es erneut, bevor Sie sich auf das Ergebnis verlassen." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이 보고서 이후 모델 번들이 변경되었습니다. 결과를 신뢰하기 전에 다시 검증하세요." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "После создания отчёта пакет модели изменился. Повторите проверку, прежде чем полагаться на результат." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "生成此报告后模型包已更改。请重新验证后再依赖该结果。" } }
+      }
+    },
+    "The saved result is stale because the model bundle changed." : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Das gespeicherte Ergebnis ist veraltet, da sich das Modellpaket geändert hat." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "모델 번들이 변경되어 저장된 결과가 오래되었습니다." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Сохранённый результат устарел, так как пакет модели изменился." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "模型包已更改，保存的结果已过期。" } }
+      }
+    },
+    "Tool parser" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Werkzeugparser" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "도구 파서" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Парсер инструментов" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "工具解析器" } }
+      }
+    },
+    "Verify this model" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Dieses Modell prüfen" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이 모델 검증" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Проверить эту модель" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "验证此模型" } }
+      }
+    },
+    "Unproven (stale evidence)" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Unbewiesen (veralteter Nachweis)" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "미검증 (오래된 증거)" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Не доказано (устаревшие данные)" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未验证（证据已过期）" } }
+      }
+    },
+    "Unverified" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Nicht verifiziert" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "미검증" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Не проверено" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未验证" } }
+      }
+    },
+    "vMLX revision" : {
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "vMLX-Revision" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "vMLX 리비전" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Ревизия vMLX" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "vMLX 修订版本" } }
+      }
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
@@ -7,14 +7,17 @@
 
 import Foundation
 
-public final class EvidenceReportRegistryService {
+public final class EvidenceReportRegistryService: @unchecked Sendable {
+    public static let shared = EvidenceReportRegistryService()
+
     private var summariesByID: [String: EvidenceReportSummary] = [:]
+    private let lock = NSLock()
     private let fileManager: FileManager
-    private let now: () -> Date
+    private let now: @Sendable () -> Date
 
     public init(
         fileManager: FileManager = .default,
-        now: @escaping () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.fileManager = fileManager
         self.now = now
@@ -33,6 +36,8 @@ public final class EvidenceReportRegistryService {
         _ descriptor: EvidenceReportDescriptor,
         relativeTo baseURL: URL? = nil
     ) -> EvidenceReportSummary {
+        lock.lock()
+        defer { lock.unlock() }
         let summary = makeSummary(from: descriptor, relativeTo: baseURL)
         if let existing = summariesByID[summary.id] {
             summariesByID[summary.id] = preferredSummary(existing, summary)
@@ -43,16 +48,26 @@ public final class EvidenceReportRegistryService {
     }
 
     public func list(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> [EvidenceReportSummary] {
-        summariesByID.values
+        lock.lock()
+        defer { lock.unlock() }
+        return summariesByID.values
             .filter { filter.includes($0) }
             .sorted(by: Self.sortSummaries)
     }
 
     public func snapshot(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> EvidenceReportRegistrySnapshot {
-        EvidenceReportRegistrySnapshot(reports: list(filter))
+        lock.lock()
+        defer { lock.unlock() }
+        return EvidenceReportRegistrySnapshot(
+            reports: summariesByID.values
+                .filter { filter.includes($0) }
+                .sorted(by: Self.sortSummaries)
+        )
     }
 
     public func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
         summariesByID.removeAll()
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
@@ -561,7 +561,11 @@ enum LocalModelBundleInspector {
         let config = contentByRelativePath["config.json"].flatMap(jsonObject(at:))
         let generation = contentByRelativePath["generation_config.json"].flatMap(jsonObject(at:))
         let jang = contentByRelativePath["jang_config.json"].flatMap(jsonObject(at:))
-        let hasTokenizerTemplate = tokenizer?["chat_template"] != nil
+        let tokenizerTemplateEnabled = firstBool(
+            keys: ["has_tokenizer_chat_template"], in: [jang], default: true
+        )
+        let hasTokenizerTemplate = tokenizerTemplateEnabled
+            && tokenizer?["chat_template"] != nil
         let hasStandaloneTemplate = contentByRelativePath["chat_template.jinja"] != nil
         let templateSource: String
         let templateFallback: String?
@@ -576,8 +580,9 @@ enum LocalModelBundleInspector {
             templateSource = "bundle:config.json"
             templateFallback = nil
         } else if let declaredTemplateSource {
-            templateSource = "bundle:\(declaredTemplateSource)"
-            templateFallback = nil
+            templateSource = "runtime:\(declaredTemplateSource)"
+            templateFallback =
+                "The runtime declares a non-file chat-template source that is not digest-bound or authoritatively pinned."
         } else {
             templateSource = "runtime fallback"
             templateFallback = "The bundle does not declare a chat template; the runtime-selected fallback is unproven."
@@ -590,7 +595,9 @@ enum LocalModelBundleInspector {
         let standaloneTemplate = contentByRelativePath["chat_template.jinja"]
             .flatMap { try? Data(contentsOf: $0) }
             .flatMap { String(data: $0, encoding: .utf8) }
-        let tokenizerTemplate = tokenizer?["chat_template"] as? String
+        let tokenizerTemplate = tokenizerTemplateEnabled
+            ? tokenizer?["chat_template"] as? String
+            : nil
         let jangCapability = contentByRelativePath["jang_config.json"]
             .flatMap { try? Data(contentsOf: $0) }
             .flatMap(LocalReasoningCapability.analyzeJangConfig(data:))
@@ -668,6 +675,17 @@ enum LocalModelBundleInspector {
             if let found = recursiveFirstString(keys: Set(keys), object: root) { return found }
         }
         return nil
+    }
+
+    private static func firstBool(
+        keys: [String], in roots: [[String: Any]?], default defaultValue: Bool
+    ) -> Bool {
+        for root in roots.compactMap({ $0 }) {
+            for key in keys {
+                if let value = root[key] as? Bool { return value }
+            }
+        }
+        return defaultValue
     }
 
     private static func recursiveFirstString(keys: Set<String>, object: Any) -> String? {

--- a/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
@@ -20,6 +20,7 @@ enum LocalModelVerificationClassification: String, Codable, CaseIterable, Sendab
 enum LocalModelVerificationProbe: String, Codable, CaseIterable, Sendable {
     case generation
     case reasoning
+    case autoToolChoice = "auto_tool_choice"
     case schemaValidToolCall = "schema_valid_tool_call"
     case toolResultContinuation = "tool_result_continuation"
     case secondToolCall = "second_tool_call"
@@ -44,44 +45,139 @@ enum LocalModelCancellationProbeOutcome: Equatable, Sendable {
 }
 
 enum LocalModelCancellationHandshake {
+    private final class Observation: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cancelled = false
+        private var observedDelta = false
+        private var postCancelDeltas = 0
+
+        func recordDelta() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if cancelled { postCancelDeltas += 1 }
+            let isFirst = !observedDelta
+            observedDelta = true
+            return isFirst
+        }
+
+        func markCancelled() {
+            lock.lock()
+            cancelled = true
+            lock.unlock()
+        }
+
+        var observedPostCancelDelta: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return postCancelDeltas > 0
+        }
+
+        var wasCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+    }
+
+    private enum Event: Sendable {
+        case started
+        case completed(ResultKind)
+    }
+
+    private enum ResultKind: Sendable {
+        case terminatedAfterCancellation
+        case completedBeforeCancellation
+        case cancelled
+        case failed(String)
+    }
+
     static func run(
-        timeout: Duration = .seconds(30),
+        startTimeout: Duration = .seconds(30),
+        terminationTimeout: Duration = .seconds(5),
+        teardown: @escaping @Sendable () async -> Void = {},
         operation: @escaping @Sendable (@escaping @Sendable () -> Void) async throws -> Void
     ) async -> LocalModelCancellationProbeOutcome {
-        let started = AsyncStream<Void>.makeStream()
+        let events = AsyncStream<Event>.makeStream()
+        let observation = Observation()
         let task = Task {
-            defer { started.continuation.finish() }
-            try await operation {
-                started.continuation.yield()
+            do {
+                try await operation {
+                    if observation.recordDelta() {
+                        events.continuation.yield(.started)
+                    }
+                }
+                events.continuation.yield(.completed(
+                    observation.wasCancelled
+                        ? .terminatedAfterCancellation
+                        : .completedBeforeCancellation
+                ))
+            } catch is CancellationError {
+                events.continuation.yield(.completed(.cancelled))
+            } catch {
+                let code = (error as NSError).code
+                events.continuation.yield(.completed(.failed("runtime_stream_error_\(code)")))
             }
+            events.continuation.finish()
         }
-        let observedStart = await withTaskGroup(of: Bool.self) { group in
+
+        let firstEvent: Event? = await withTaskGroup(of: Event?.self) { group in
             group.addTask {
-                for await _ in started.stream { return true }
-                return false
+                for await event in events.stream { return event }
+                return nil
             }
             group.addTask {
-                try? await Task.sleep(for: timeout)
-                return false
+                try? await Task.sleep(for: startTimeout)
+                return nil
             }
-            let result = await group.next() ?? false
+            guard let result = await group.next() else { return nil }
             group.cancelAll()
             return result
         }
-        guard observedStart else {
+        guard case .started = firstEvent else {
             task.cancel()
-            _ = await task.result
+            if case .completed(.failed(let code)) = firstEvent {
+                return .failed("cancellation_stream_start_\(code)")
+            }
+            if case .completed(.completedBeforeCancellation) = firstEvent {
+                return .blocked("The generation stream completed before an in-flight event was observed.")
+            }
             return .blocked("No generation event was observed before the bounded cancellation deadline.")
         }
 
+        observation.markCancelled()
         task.cancel()
-        switch await task.result {
-        case .failure(let error) where error is CancellationError:
+        let teardownTask = Task { await teardown() }
+        let completion: ResultKind? = await withTaskGroup(of: ResultKind?.self) { group in
+            group.addTask {
+                for await event in events.stream {
+                    if case .completed(let result) = event { return result }
+                }
+                return nil
+            }
+            group.addTask {
+                try? await Task.sleep(for: terminationTimeout)
+                return nil
+            }
+            guard let result = await group.next() else { return nil }
+            group.cancelAll()
+            return result
+        }
+        guard let completion else {
+            task.cancel()
+            teardownTask.cancel()
+            return .failed("cancellation_stream_termination_timeout")
+        }
+        teardownTask.cancel()
+        if observation.observedPostCancelDelta {
+            return .failed("cancellation_stream_emitted_after_cancel")
+        }
+        switch completion {
+        case .terminatedAfterCancellation, .cancelled:
             return .passed
-        case .failure(let error):
-            return .failed("The in-flight generation failed during cancellation: \(error)")
-        case .success:
-            return .failed("The in-flight generation completed without acknowledging cancellation.")
+        case .completedBeforeCancellation:
+            return .blocked("The generation stream completed before cancellation could be exercised.")
+        case .failed(let code):
+            return .failed("cancellation_stream_teardown_\(code)")
         }
     }
 }
@@ -113,6 +209,7 @@ struct LocalModelVerificationProbeResult: Codable, Equatable, Sendable, Identifi
     let probe: LocalModelVerificationProbe
     let status: LocalModelVerificationProbeStatus
     let detail: String
+    let errorCode: String?
     let tokenCount: Int?
     let tokensPerSecond: Double?
     let stopReason: String?
@@ -133,7 +230,7 @@ struct LocalModelBundleEvidence: Codable, Equatable, Sendable {
 }
 
 struct LocalModelVerificationArtifact: Codable, Equatable, Sendable {
-    static let currentSchemaVersion = 2
+    static let currentSchemaVersion = 3
 
     let schemaVersion: Int
     let modelId: String
@@ -144,8 +241,8 @@ struct LocalModelVerificationArtifact: Codable, Equatable, Sendable {
     let completedAt: Date
     let probes: [LocalModelVerificationProbeResult]
 
-    var failedOrBlocked: [LocalModelVerificationProbeResult] {
-        probes.filter { $0.status != .passed }
+    var nonPassingEvidence: [LocalModelVerificationProbeResult] {
+        probes.filter { $0.status == .failed || $0.status == .error || $0.status == .blocked }
     }
 
     func isStale(currentDigest: String?) -> Bool {
@@ -161,7 +258,7 @@ struct LocalModelVerificationArtifact: Codable, Equatable, Sendable {
 
 enum LocalModelVerificationAuthority {
     static let requiredProbes: Set<LocalModelVerificationProbe> = [
-        .generation, .schemaValidToolCall, .toolResultContinuation, .secondToolCall,
+        .generation, .autoToolChoice, .schemaValidToolCall, .toolResultContinuation, .secondToolCall,
         .markerLeakage, .stopAndEOS, .throughput, .cancellation,
     ]
 
@@ -170,9 +267,10 @@ enum LocalModelVerificationAuthority {
     ) -> LocalModelVerificationClassification {
         let grouped = Dictionary(grouping: rows, by: \.probe)
         let requiredRows = requiredProbes.compactMap { grouped[$0]?.first }
+        let allRequiredRows = rows.filter { requiredProbes.contains($0.probe) }
         let hasDuplicateRequiredProbe = requiredProbes.contains { (grouped[$0]?.count ?? 0) != 1 }
 
-        if requiredRows.contains(where: { $0.status == .error || $0.status == .failed }) {
+        if allRequiredRows.contains(where: { $0.status == .error || $0.status == .failed }) {
             return .failed
         }
         if let throughput = grouped[.throughput]?.first, throughput.status == .passed {
@@ -184,7 +282,8 @@ enum LocalModelVerificationAuthority {
             return requiredRows.contains(where: { $0.status == .passed }) ? .partial : .unproven
         }
         if requiredRows.allSatisfy({ $0.status == .passed }) {
-            return rows.first(where: { $0.probe == .reasoning })?.status == .failed
+            let reasoningStatus = rows.first(where: { $0.probe == .reasoning })?.status
+            return reasoningStatus == .failed || reasoningStatus == .error
                 ? .partial
                 : .proven
         }
@@ -194,7 +293,13 @@ enum LocalModelVerificationAuthority {
     }
 
     static func validates(_ artifact: LocalModelVerificationArtifact) -> Bool {
-        classify(artifact.probes) == artifact.classification
+        validDigest(artifact.bundle.digest)
+            && classify(artifact.probes) == artifact.classification
+    }
+
+    static func validDigest(_ digest: String) -> Bool {
+        guard digest.count == 71, digest.hasPrefix("sha256:") else { return false }
+        return digest.dropFirst(7).allSatisfy { $0.isHexDigit }
     }
 }
 
@@ -316,36 +421,33 @@ actor MLXLocalModelVerificationEngine: LocalModelVerificationEngine {
     }
 
     func probeCancellation(modelId: String, modelName: String) async -> LocalModelCancellationProbeOutcome {
-        await LocalModelCancellationHandshake.run { observedStart in
-            let parameters = GenerationParameters(
-                temperature: nil,
-                maxTokens: 2_048,
-                maxTokensExplicit: true,
-                suppressProgressUI: true,
-                requestSource: .httpAPI
-            )
-            let stream = try await ModelRuntime.shared.streamWithTools(
-                messages: [ChatMessage(
-                    role: "user",
-                    content: "Count upward indefinitely, one number per line."
-                )],
-                parameters: parameters,
-                stopSequences: [],
-                tools: [],
-                toolChoice: nil,
-                modelId: modelId,
-                modelName: modelName
-            )
-            var observedEvent = false
-            for try await _ in stream {
-                if !observedEvent {
-                    observedEvent = true
-                    observedStart()
+        await LocalModelCancellationHandshake.run(
+            teardown: { await ModelRuntime.shared.cancelGeneration(name: modelName) },
+            operation: { observedDelta in
+                let parameters = GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 2_048,
+                    maxTokensExplicit: true,
+                    suppressProgressUI: true,
+                    requestSource: .httpAPI
+                )
+                let stream = try await ModelRuntime.shared.streamWithTools(
+                    messages: [ChatMessage(
+                        role: "user",
+                        content: "Count upward indefinitely, one number per line."
+                    )],
+                    parameters: parameters,
+                    stopSequences: [],
+                    tools: [],
+                    toolChoice: nil,
+                    modelId: modelId,
+                    modelName: modelName
+                )
+                for try await _ in stream {
+                    observedDelta()
                 }
-                try Task.checkCancellation()
             }
-            try Task.checkCancellation()
-        }
+        )
     }
 }
 
@@ -364,6 +466,11 @@ enum LocalModelBundleInspector {
                 return "The model bundle contains a symbolic link or non-regular entry: \(path)"
             }
         }
+    }
+
+    private struct BundleFile {
+        let logicalURL: URL
+        let contentURL: URL
     }
 
     static func inspect(
@@ -389,7 +496,7 @@ enum LocalModelBundleInspector {
         }
 
         let huggingFaceRepositoryRoot = huggingFaceRepositoryRoot(for: directory)
-        var files: [URL] = []
+        var files: [BundleFile] = []
         for case let url as URL in enumerator {
             try cancellationCheck()
             let values = try url.resourceValues(forKeys: keys)
@@ -401,28 +508,35 @@ enum LocalModelBundleInspector {
                 else {
                     throw InspectionError.unsafeEntry(url.path)
                 }
-                files.append(url)
+                files.append(BundleFile(logicalURL: url, contentURL: resolved))
                 continue
             }
             if values.isDirectory == true { continue }
             guard values.isRegularFile == true else {
                 throw InspectionError.unsafeEntry(url.path)
             }
-            files.append(url)
+            files.append(BundleFile(logicalURL: url, contentURL: url))
         }
-        files.sort { relativePath($0, under: directory) < relativePath($1, under: directory) }
+        files.sort {
+            relativePath($0.logicalURL, under: directory)
+                < relativePath($1.logicalURL, under: directory)
+        }
 
         var rootHasher = SHA256()
         var stateHasher = SHA256()
         var totalBytes: Int64 = 0
         for file in files {
             try cancellationCheck()
-            let relative = relativePath(file, under: directory)
-            let values = try file.resourceValues(forKeys: keys)
-            stateHasher.update(data: Data(relative.utf8))
-            stateHasher.update(data: Data("\(values.fileSize ?? 0)".utf8))
-            stateHasher.update(data: Data("\(values.contentModificationDate?.timeIntervalSince1970 ?? 0)".utf8))
-            let handle = try FileHandle(forReadingFrom: file)
+            let relative = relativePath(file.logicalURL, under: directory)
+            let values = try file.contentURL.resourceValues(forKeys: keys)
+            update(&stateHasher, domain: "path", value: relative)
+            update(&stateHasher, domain: "size", value: "\(values.fileSize ?? 0)")
+            update(
+                &stateHasher,
+                domain: "mtime",
+                value: "\(values.contentModificationDate?.timeIntervalSince1970 ?? 0)"
+            )
+            let handle = try FileHandle(forReadingFrom: file.contentURL)
             defer { try? handle.close() }
             var fileHasher = SHA256()
             var fileBytes: Int64 = 0
@@ -440,13 +554,15 @@ enum LocalModelBundleInspector {
             withUnsafeBytes(of: fileBytes.bigEndian) { rootHasher.update(bufferPointer: $0) }
         }
 
-        let tokenizer = jsonObject(at: directory.appendingPathComponent("tokenizer_config.json"))
-        let config = jsonObject(at: directory.appendingPathComponent("config.json"))
-        let generation = jsonObject(at: directory.appendingPathComponent("generation_config.json"))
-        let jang = jsonObject(at: directory.appendingPathComponent("jang_config.json"))
+        let contentByRelativePath = Dictionary(uniqueKeysWithValues: files.map {
+            (relativePath($0.logicalURL, under: directory), $0.contentURL)
+        })
+        let tokenizer = contentByRelativePath["tokenizer_config.json"].flatMap(jsonObject(at:))
+        let config = contentByRelativePath["config.json"].flatMap(jsonObject(at:))
+        let generation = contentByRelativePath["generation_config.json"].flatMap(jsonObject(at:))
+        let jang = contentByRelativePath["jang_config.json"].flatMap(jsonObject(at:))
         let hasTokenizerTemplate = tokenizer?["chat_template"] != nil
-        let hasStandaloneTemplate = fm.fileExists(
-            atPath: directory.appendingPathComponent("chat_template.jinja").path)
+        let hasStandaloneTemplate = contentByRelativePath["chat_template.jinja"] != nil
         let templateSource: String
         let templateFallback: String?
         let declaredTemplateSource = firstString(keys: ["chat_template_source"], in: [jang])
@@ -471,9 +587,16 @@ enum LocalModelBundleInspector {
             keys: ["parser", "format", "tool_call_parser", "tool_calling"],
             in: [jang, tokenizer, config]
         )
-        let reasoningCapability = LocalReasoningCapability.readChatTemplate(at: directory)
+        let standaloneTemplate = contentByRelativePath["chat_template.jinja"]
+            .flatMap { try? Data(contentsOf: $0) }
+            .flatMap { String(data: $0, encoding: .utf8) }
+        let tokenizerTemplate = tokenizer?["chat_template"] as? String
+        let jangCapability = contentByRelativePath["jang_config.json"]
+            .flatMap { try? Data(contentsOf: $0) }
+            .flatMap(LocalReasoningCapability.analyzeJangConfig(data:))
+        let reasoningCapability = (standaloneTemplate ?? tokenizerTemplate)
             .map(LocalReasoningCapability.analyze(template:))
-            ?? LocalReasoningCapability.readJangConfigReasoning(at: directory)
+            ?? jangCapability
         let reasoningDeclared = reasoningCapability?.supportsThinking == true
         let defaults = (generation ?? [:]).reduce(into: [String: String]()) { output, entry in
             guard let rendered = scalarString(entry.value) else { return }
@@ -496,36 +619,7 @@ enum LocalModelBundleInspector {
     }
 
     static func currentStateFingerprint(directory: URL) throws -> String {
-        let fm = FileManager.default
-        let keys: Set<URLResourceKey> = [
-            .isRegularFileKey, .isSymbolicLinkKey, .isDirectoryKey, .fileSizeKey,
-            .contentModificationDateKey,
-        ]
-        guard let enumerator = fm.enumerator(
-            at: directory,
-            includingPropertiesForKeys: Array(keys),
-            options: [.skipsHiddenFiles]
-        ) else { throw InspectionError.missingBundle }
-        var entries: [(String, Int, TimeInterval)] = []
-        for case let url as URL in enumerator {
-            let values = try url.resourceValues(forKeys: keys)
-            if values.isSymbolicLink == true { throw InspectionError.unsafeEntry(url.path) }
-            if values.isDirectory == true { continue }
-            guard values.isRegularFile == true else { throw InspectionError.unsafeEntry(url.path) }
-            entries.append((
-                relativePath(url, under: directory),
-                values.fileSize ?? 0,
-                values.contentModificationDate?.timeIntervalSince1970 ?? 0
-            ))
-        }
-        entries.sort { $0.0 < $1.0 }
-        var hasher = SHA256()
-        for entry in entries {
-            hasher.update(data: Data(entry.0.utf8))
-            hasher.update(data: Data("\(entry.1)".utf8))
-            hasher.update(data: Data("\(entry.2)".utf8))
-        }
-        return "sha256:" + hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        try inspect(directory: directory).stateFingerprint
     }
 
     private static func relativePath(_ url: URL, under root: URL) -> String {
@@ -547,6 +641,15 @@ enum LocalModelBundleInspector {
         let path = url.standardizedFileURL.path
         let rootPath = root.standardizedFileURL.path
         return path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    private static func update(_ hasher: inout SHA256, domain: String, value: String) {
+        let domainData = Data(domain.utf8)
+        let valueData = Data(value.utf8)
+        withUnsafeBytes(of: UInt64(domainData.count).bigEndian) { hasher.update(bufferPointer: $0) }
+        hasher.update(data: domainData)
+        withUnsafeBytes(of: UInt64(valueData.count).bigEndian) { hasher.update(bufferPointer: $0) }
+        hasher.update(data: valueData)
     }
 
     private static func jsonObject(at url: URL) -> [String: Any]? {
@@ -671,6 +774,10 @@ actor LocalModelVerificationArtifactStore {
         try fileManager.removeItem(at: url)
     }
 
+    func relativeArtifactPath(at url: URL) -> String {
+        "model-verification/\(url.deletingLastPathComponent().lastPathComponent)/\(url.lastPathComponent)"
+    }
+
     private static func modelStorageKey(_ modelId: String) -> String {
         SHA256.hash(data: Data(modelId.utf8))
             .map { String(format: "%02x", $0) }
@@ -718,20 +825,25 @@ actor LocalModelVerificationService {
     }
 
     func latest(modelId: String) async -> (LocalModelVerificationArtifact, URL)? {
-        await store.latest(modelId: modelId)
+        guard let latest = await store.latest(modelId: modelId) else { return nil }
+        register(artifact: latest.artifact, at: latest.url)
+        return latest
     }
 
     func verify(model: MLXModel) async throws -> (LocalModelVerificationArtifact, URL) {
         try await store.begin(modelId: model.id)
         var savedArtifactURL: URL?
+        var ledgerProjected = false
         do {
             let startedAt = now()
             let bundle = try LocalModelBundleInspector.inspect(directory: model.localDirectory)
             let probes = try await runProbes(model: model, bundle: bundle)
+            try Task.checkCancellation()
             let completedBundle = try LocalModelBundleInspector.inspect(directory: model.localDirectory)
             guard completedBundle.digest == bundle.digest else {
                 throw VerificationError.bundleChangedDuringVerification
             }
+            try Task.checkCancellation()
             let artifact = LocalModelVerificationArtifact(
                 schemaVersion: LocalModelVerificationArtifact.currentSchemaVersion,
                 modelId: model.id,
@@ -742,21 +854,29 @@ actor LocalModelVerificationService {
                 completedAt: now(),
                 probes: probes
             )
+            try Task.checkCancellation()
             let url = try await store.save(artifact)
             savedArtifactURL = url
+            try Task.checkCancellation()
+            let relativeArtifactPath = await store.relativeArtifactPath(at: url)
             try ModelCapabilityLedger.saveVerification(
                 classification: artifact.classification,
                 digest: artifact.bundle.digest,
-                artifactPath: url.path,
+                artifactPath: relativeArtifactPath,
                 measuredAt: ISO8601DateFormatter().string(from: artifact.completedAt),
                 for: model.id
             )
+            ledgerProjected = true
+            try Task.checkCancellation()
             register(artifact: artifact, at: url)
             await store.end(modelId: model.id)
             return (artifact, url)
         } catch {
             if let savedArtifactURL {
                 try? await store.removeArtifact(at: savedArtifactURL)
+            }
+            if ledgerProjected {
+                try? ModelCapabilityLedger.removeVerification(for: model.id)
             }
             await store.end(modelId: model.id)
             throw error
@@ -768,7 +888,7 @@ actor LocalModelVerificationService {
         bundle: LocalModelBundleEvidence
     ) async throws -> [LocalModelVerificationProbeResult] {
         var rows: [LocalModelVerificationProbeResult] = []
-        let plain = await attempt(
+        let plain = try await attempt(
             model: model,
             request: LocalModelLiveProbeRequest(
                 messages: [ChatMessage(role: "user", content: "Reply with exactly READY.")],
@@ -781,11 +901,13 @@ actor LocalModelVerificationService {
             passed: plain.transcript?.visibleText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
             passDetail: "The model produced visible text through the native MLX chat path.",
             failure: plain.error ?? "The model produced no visible final answer.",
+            errorCode: plain.errorCode,
             transcript: plain.transcript
         ))
 
+        var reasoningTranscript: LocalModelLiveProbeTranscript?
         if bundle.reasoningDeclared {
-            let reasoningProbe = await attempt(
+            let reasoningProbe = try await attempt(
                 model: model,
                 request: LocalModelLiveProbeRequest(
                     messages: [ChatMessage(
@@ -796,6 +918,7 @@ actor LocalModelVerificationService {
                     modelOptions: ["reasoningEffort": .string("high")]
                 )
             )
+            reasoningTranscript = reasoningProbe.transcript
             try Task.checkCancellation()
             rows.append(result(
                 .reasoning,
@@ -804,86 +927,125 @@ actor LocalModelVerificationService {
                     && reasoningProbe.transcript?.unclosedReasoning == false,
                 passDetail: "The runtime emitted a dedicated, closed reasoning channel.",
                 failure: reasoningProbe.error ?? "The bundle declares reasoning, but this run emitted no clean reasoning channel plus visible answer.",
+                errorCode: reasoningProbe.errorCode,
                 transcript: reasoningProbe.transcript
             ))
         } else {
             rows.append(row(.reasoning, .unsupported, "The bundle does not declare a reasoning mode; no reasoning pass is claimed."))
         }
 
-        let tool = fixtureTool()
-        let first = await attempt(
-            model: model,
-            request: LocalModelLiveProbeRequest(
-                messages: [ChatMessage(role: "user", content: "Use city_temperature for Paris. Do not guess.")],
-                tools: [tool], toolChoice: .required, maxTokens: 128, stopSequences: []
-            )
-        )
-        try Task.checkCancellation()
-        let firstArgsValid = validCityArguments(first.transcript?.toolArguments, expected: "Paris")
-        rows.append(result(
-            .schemaValidToolCall,
-            passed: first.transcript?.toolName == "city_temperature" && firstArgsValid,
-            passDetail: "The model emitted city_temperature with schema-valid JSON arguments.",
-            failure: first.error ?? "The first tool call was missing, named incorrectly, or had invalid arguments.",
-            transcript: first.transcript
-        ))
-
-        var continuation: (transcript: LocalModelLiveProbeTranscript?, error: String?) = (nil, nil)
-        var second: (transcript: LocalModelLiveProbeTranscript?, error: String?) = (nil, nil)
-        if first.transcript?.toolName == "city_temperature", firstArgsValid {
-            let callId = "verification_call_1"
-            let history = [
-                ChatMessage(role: "user", content: "Use city_temperature for Paris. Do not guess."),
-                ChatMessage(
-                    role: "assistant", content: nil,
-                    tool_calls: [ToolCall(
-                        id: callId, type: "function",
-                        function: ToolCallFunction(name: "city_temperature", arguments: first.transcript?.toolArguments ?? "{}")
-                    )],
-                    tool_call_id: nil
-                ),
-                ChatMessage(role: "tool", content: #"{"city":"Paris","celsius":21}"#, tool_calls: nil, tool_call_id: callId),
-            ]
-            continuation = await attempt(
-                model: model,
-                request: LocalModelLiveProbeRequest(
-                    messages: history + [ChatMessage(role: "user", content: "State the returned Paris temperature in one sentence.")],
-                    tools: [tool], toolChoice: .auto, maxTokens: 96, stopSequences: []
-                )
-            )
-            try Task.checkCancellation()
-            let grounded = continuation.transcript?.visibleText.contains("21") == true
-            rows.append(result(
-                .toolResultContinuation,
-                passed: grounded,
-                passDetail: "The continuation consumed the executed fixture result and returned 21.",
-                failure: continuation.error ?? "The continuation did not ground its answer in the injected tool result.",
-                transcript: continuation.transcript
-            ))
-            second = await attempt(
-                model: model,
-                request: LocalModelLiveProbeRequest(
-                    messages: history + [ChatMessage(role: "user", content: "Now use city_temperature for Berlin. Do not guess.")],
-                    tools: [tool], toolChoice: .required, maxTokens: 128, stopSequences: []
-                )
-            )
-            try Task.checkCancellation()
-            rows.append(result(
-                .secondToolCall,
-                passed: second.transcript?.toolName == "city_temperature"
-                    && validCityArguments(second.transcript?.toolArguments, expected: "Berlin"),
-                passDetail: "The model emitted a second schema-valid tool call after tool history.",
-                failure: second.error ?? "The model failed the second tool call after result history.",
-                transcript: second.transcript
-            ))
+        var first: (
+            transcript: LocalModelLiveProbeTranscript?, error: String?, errorCode: String?
+        ) = (nil, nil, nil)
+        var continuation: (
+            transcript: LocalModelLiveProbeTranscript?, error: String?, errorCode: String?
+        ) = (nil, nil, nil)
+        var second: (
+            transcript: LocalModelLiveProbeTranscript?, error: String?, errorCode: String?
+        ) = (nil, nil, nil)
+        if bundle.templateFallback != nil {
+            for probe in [
+                LocalModelVerificationProbe.autoToolChoice, .schemaValidToolCall,
+                .toolResultContinuation, .secondToolCall,
+            ] {
+                rows.append(row(
+                    probe,
+                    .blocked,
+                    "The bundle has no declared chat template; dependent tool evidence remains unproven."
+                ))
+            }
         } else {
-            rows.append(row(.toolResultContinuation, .blocked, "Blocked because the first tool call did not validate."))
-            rows.append(row(.secondToolCall, .blocked, "Blocked because the first tool call did not validate."))
+            let tool = fixtureTool()
+            first = try await attempt(
+                model: model,
+                request: LocalModelLiveProbeRequest(
+                    messages: [ChatMessage(role: "user", content: "Use city_temperature for Paris. Do not guess.")],
+                    tools: [tool], toolChoice: .auto, maxTokens: 128, stopSequences: []
+                )
+            )
+            try Task.checkCancellation()
+            rows.append(result(
+                .autoToolChoice,
+                passed: first.transcript?.toolName == "city_temperature"
+                    && validCityArguments(first.transcript?.toolArguments, expected: "Paris"),
+                passDetail: "The model selected a schema-valid tool through production auto choice.",
+                failure: first.error ?? "The model did not select the fixture tool through auto choice.",
+                errorCode: first.errorCode,
+                transcript: first.transcript
+            ))
+            rows.append(result(
+                .schemaValidToolCall,
+                passed: first.transcript?.toolName == "city_temperature"
+                    && validCityArguments(first.transcript?.toolArguments, expected: "Paris"),
+                passDetail: "The model emitted city_temperature with schema-valid JSON arguments.",
+                failure: first.error ?? "The first tool call was missing, named incorrectly, or had invalid arguments.",
+                errorCode: first.errorCode,
+                transcript: first.transcript
+            ))
+            let firstArgsValid = validCityArguments(first.transcript?.toolArguments, expected: "Paris")
+            if first.transcript?.toolName == "city_temperature", firstArgsValid {
+                let callId = "verification_call_1"
+                let history = [
+                    ChatMessage(role: "user", content: "Use city_temperature for Paris. Do not guess."),
+                    ChatMessage(
+                        role: "assistant", content: nil,
+                        tool_calls: [ToolCall(
+                            id: callId, type: "function",
+                            function: ToolCallFunction(name: "city_temperature", arguments: first.transcript?.toolArguments ?? "{}")
+                        )],
+                        tool_call_id: nil
+                    ),
+                    ChatMessage(role: "tool", content: #"{"city":"Paris","celsius":21}"#, tool_calls: nil, tool_call_id: callId),
+                ]
+                continuation = try await attempt(
+                    model: model,
+                    request: LocalModelLiveProbeRequest(
+                        messages: history + [ChatMessage(role: "user", content: "State the returned Paris temperature in one sentence.")],
+                        tools: [tool], toolChoice: .auto, maxTokens: 96, stopSequences: []
+                    )
+                )
+                try Task.checkCancellation()
+                rows.append(result(
+                    .toolResultContinuation,
+                    passed: continuation.transcript.map {
+                        groundedTemperatureAnswer($0.visibleText, city: "Paris", celsius: 21)
+                    } == true,
+                    passDetail: "The continuation consumed the executed fixture result and returned 21 C.",
+                    failure: continuation.error ?? "The continuation did not ground its answer in the injected tool result.",
+                    errorCode: continuation.errorCode,
+                    transcript: continuation.transcript
+                ))
+                second = try await attempt(
+                    model: model,
+                    request: LocalModelLiveProbeRequest(
+                        messages: history + [ChatMessage(role: "user", content: "Now use city_temperature for Berlin. Do not guess.")],
+                        tools: [tool], toolChoice: .required, maxTokens: 128, stopSequences: []
+                    )
+                )
+                try Task.checkCancellation()
+                rows.append(result(
+                    .secondToolCall,
+                    passed: second.transcript?.toolName == "city_temperature"
+                        && validCityArguments(second.transcript?.toolArguments, expected: "Berlin"),
+                    passDetail: "The model emitted a second schema-valid tool call after tool history.",
+                    failure: second.error ?? "The model failed the second tool call after result history.",
+                    errorCode: second.errorCode,
+                    transcript: second.transcript
+                ))
+            } else {
+                rows.append(row(.toolResultContinuation, .blocked, "Blocked because the first tool call did not validate."))
+                rows.append(row(.secondToolCall, .blocked, "Blocked because the first tool call did not validate."))
+            }
         }
 
-        let transcripts = [plain.transcript, first.transcript, continuation.transcript, second.transcript]
+        let transcripts = [
+            plain.transcript, reasoningTranscript, first.transcript,
+            continuation.transcript, second.transcript,
+        ]
             .compactMap { $0 }
-        let leaked = transcripts.flatMap { markerLeaks(in: $0.visibleText) }
+        let leaked = transcripts.flatMap {
+            markerLeaks(in: $0.visibleText) + markerLeaks(in: $0.reasoningText)
+        }
         if transcripts.isEmpty {
             rows.append(row(
                 .markerLeakage,
@@ -915,6 +1077,7 @@ actor LocalModelVerificationService {
             probe: .throughput,
             status: rates.isEmpty ? .failed : .passed,
             detail: rates.isEmpty ? "No positive decode token/s evidence was emitted." : "Recorded positive decode throughput.",
+            errorCode: rates.isEmpty ? "throughput_missing" : nil,
             tokenCount: transcripts.compactMap(\.tokenCount).max(),
             tokensPerSecond: rates.max(),
             stopReason: nil
@@ -929,15 +1092,16 @@ actor LocalModelVerificationService {
                 "A generation event was observed before the in-flight request acknowledged cancellation."
             ))
         case .blocked(let detail):
-            rows.append(row(.cancellation, .blocked, detail))
-        case .failed(let detail):
-            rows.append(row(.cancellation, .failed, detail))
-        }
-        if bundle.templateFallback != nil {
             rows.append(row(
-                .schemaValidToolCall,
-                .blocked,
-                "The bundle has no declared chat template; runtime fallback use remains unproven even if output parsed."
+                .cancellation, .blocked, detail,
+                errorCode: "cancellation_stream_not_started"
+            ))
+        case .failed(let code):
+            rows.append(row(
+                .cancellation,
+                .failed,
+                "The runtime stream did not terminate cleanly after cancellation.",
+                errorCode: code
             ))
         }
         return deduplicate(rows)
@@ -946,14 +1110,33 @@ actor LocalModelVerificationService {
     private func attempt(
         model: MLXModel,
         request: LocalModelLiveProbeRequest
-    ) async -> (transcript: LocalModelLiveProbeTranscript?, error: String?) {
+    ) async throws -> (
+        transcript: LocalModelLiveProbeTranscript?,
+        error: String?,
+        errorCode: String?
+    ) {
         do {
-            return (try await engine.generate(modelId: model.id, modelName: model.name, request: request), nil)
+            return (
+                try await engine.generate(modelId: model.id, modelName: model.name, request: request),
+                nil,
+                nil
+            )
         } catch is CancellationError {
-            return (nil, "Probe was cancelled.")
+            throw CancellationError()
         } catch {
-            return (nil, String(describing: error))
+            return (nil, "The runtime probe failed.", "runtime_probe_failed")
         }
+    }
+
+    private func groundedTemperatureAnswer(_ text: String, city: String, celsius: Int) -> Bool {
+        let lowered = text.lowercased()
+        guard lowered.contains(city.lowercased()) else { return false }
+        let escaped = NSRegularExpression.escapedPattern(for: String(celsius))
+        return lowered.range(
+            of: #"(?<![0-9.])"# + escaped
+                + #"(?:\.0+)?\s*(?:°\s*c|celsius|c\b|degrees?\s*c(?:elsius)?)(?![0-9])"#,
+            options: .regularExpression
+        ) != nil
     }
 
     private func fixtureTool() -> Tool {
@@ -985,7 +1168,9 @@ actor LocalModelVerificationService {
     private func markerLeaks(in text: String) -> [String] {
         let markers = [
             "<think>", "</think>", "<tool_call>", "</tool_call>",
-            "<|tool_call|>", "<|channel|>", "<|analysis|>", "\u{FFFE}",
+            "<|tool_call|>", "<|channel|>", "<|analysis|>", "<|recipient|>",
+            "<|start|>", "<|end|>", "<|im_start|>", "<|im_end|>",
+            "<|python_tag|>", "assistant to=", "\u{FFFE}",
         ]
         return markers.filter { text.localizedCaseInsensitiveContains($0) }
     }
@@ -995,12 +1180,14 @@ actor LocalModelVerificationService {
         passed: Bool,
         passDetail: String,
         failure: String,
+        errorCode: String?,
         transcript: LocalModelLiveProbeTranscript?
     ) -> LocalModelVerificationProbeResult {
         LocalModelVerificationProbeResult(
             probe: probe,
             status: passed ? .passed : (transcript == nil ? .error : .failed),
             detail: passed ? passDetail : failure,
+            errorCode: passed ? nil : errorCode,
             tokenCount: transcript?.tokenCount,
             tokensPerSecond: transcript?.tokensPerSecond,
             stopReason: transcript?.stopReason
@@ -1010,10 +1197,12 @@ actor LocalModelVerificationService {
     private func row(
         _ probe: LocalModelVerificationProbe,
         _ status: LocalModelVerificationProbeStatus,
-        _ detail: String
+        _ detail: String,
+        errorCode: String? = nil
     ) -> LocalModelVerificationProbeResult {
         LocalModelVerificationProbeResult(
             probe: probe, status: status, detail: detail,
+            errorCode: errorCode,
             tokenCount: nil, tokensPerSecond: nil, stopReason: nil
         )
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
@@ -1,0 +1,1081 @@
+//
+//  LocalModelVerificationWorkbench.swift
+//  osaurus
+//
+//  On-demand, digest-bound proof that a local bundle works through Osaurus's
+//  real MLX generation and tool-continuation path.
+//
+
+import CryptoKit
+import Foundation
+
+enum LocalModelVerificationClassification: String, Codable, CaseIterable, Sendable {
+    case proven
+    case partial
+    case unsupported
+    case failed
+    case unproven
+}
+
+enum LocalModelVerificationProbe: String, Codable, CaseIterable, Sendable {
+    case generation
+    case reasoning
+    case schemaValidToolCall = "schema_valid_tool_call"
+    case toolResultContinuation = "tool_result_continuation"
+    case secondToolCall = "second_tool_call"
+    case markerLeakage = "marker_leakage"
+    case stopAndEOS = "stop_and_eos"
+    case throughput
+    case cancellation
+}
+
+enum LocalModelVerificationProbeStatus: String, Codable, Sendable {
+    case passed
+    case failed
+    case blocked
+    case unsupported
+    case error
+}
+
+enum LocalModelCancellationProbeOutcome: Equatable, Sendable {
+    case passed
+    case blocked(String)
+    case failed(String)
+}
+
+enum LocalModelCancellationHandshake {
+    static func run(
+        timeout: Duration = .seconds(30),
+        operation: @escaping @Sendable (@escaping @Sendable () -> Void) async throws -> Void
+    ) async -> LocalModelCancellationProbeOutcome {
+        let started = AsyncStream<Void>.makeStream()
+        let task = Task {
+            defer { started.continuation.finish() }
+            try await operation {
+                started.continuation.yield()
+            }
+        }
+        let observedStart = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await _ in started.stream { return true }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+        guard observedStart else {
+            task.cancel()
+            _ = await task.result
+            return .blocked("No generation event was observed before the bounded cancellation deadline.")
+        }
+
+        task.cancel()
+        switch await task.result {
+        case .failure(let error) where error is CancellationError:
+            return .passed
+        case .failure(let error):
+            return .failed("The in-flight generation failed during cancellation: \(error)")
+        case .success:
+            return .failed("The in-flight generation completed without acknowledging cancellation.")
+        }
+    }
+}
+
+struct LocalModelVerificationPublicationGuard: Sendable {
+    struct Token: Equatable, Sendable {
+        fileprivate let generation: UInt64
+        fileprivate let modelId: String
+    }
+
+    private var generation: UInt64 = 0
+
+    mutating func begin(modelId: String) -> Token {
+        generation &+= 1
+        return Token(generation: generation, modelId: modelId)
+    }
+
+    mutating func invalidate() {
+        generation &+= 1
+    }
+
+    func permits(_ token: Token, currentModelId: String) -> Bool {
+        token.generation == generation && token.modelId == currentModelId
+    }
+}
+
+struct LocalModelVerificationProbeResult: Codable, Equatable, Sendable, Identifiable {
+    var id: String { probe.rawValue }
+    let probe: LocalModelVerificationProbe
+    let status: LocalModelVerificationProbeStatus
+    let detail: String
+    let tokenCount: Int?
+    let tokensPerSecond: Double?
+    let stopReason: String?
+}
+
+struct LocalModelBundleEvidence: Codable, Equatable, Sendable {
+    let digest: String
+    let stateFingerprint: String
+    let fileCount: Int
+    let byteCount: Int64
+    let templateSource: String
+    let templateFallback: String?
+    let parserFormat: String?
+    let generationDefaults: [String: String]
+    let reasoningDeclared: Bool
+    let vmlxRevision: String?
+    let vmlxRevisionSource: String
+}
+
+struct LocalModelVerificationArtifact: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 2
+
+    let schemaVersion: Int
+    let modelId: String
+    let modelName: String
+    let bundle: LocalModelBundleEvidence
+    let classification: LocalModelVerificationClassification
+    let startedAt: Date
+    let completedAt: Date
+    let probes: [LocalModelVerificationProbeResult]
+
+    var failedOrBlocked: [LocalModelVerificationProbeResult] {
+        probes.filter { $0.status != .passed }
+    }
+
+    func isStale(currentDigest: String?) -> Bool {
+        guard let currentDigest else { return true }
+        return currentDigest != bundle.digest
+    }
+
+    func isStale(currentStateFingerprint: String?) -> Bool {
+        guard let currentStateFingerprint else { return true }
+        return currentStateFingerprint != bundle.stateFingerprint
+    }
+}
+
+enum LocalModelVerificationAuthority {
+    static let requiredProbes: Set<LocalModelVerificationProbe> = [
+        .generation, .schemaValidToolCall, .toolResultContinuation, .secondToolCall,
+        .markerLeakage, .stopAndEOS, .throughput, .cancellation,
+    ]
+
+    static func classify(
+        _ rows: [LocalModelVerificationProbeResult]
+    ) -> LocalModelVerificationClassification {
+        let grouped = Dictionary(grouping: rows, by: \.probe)
+        let requiredRows = requiredProbes.compactMap { grouped[$0]?.first }
+        let hasDuplicateRequiredProbe = requiredProbes.contains { (grouped[$0]?.count ?? 0) != 1 }
+
+        if requiredRows.contains(where: { $0.status == .error || $0.status == .failed }) {
+            return .failed
+        }
+        if let throughput = grouped[.throughput]?.first, throughput.status == .passed {
+            guard let rate = throughput.tokensPerSecond, rate.isFinite, rate > 0 else {
+                return .failed
+            }
+        }
+        guard !hasDuplicateRequiredProbe, requiredRows.count == requiredProbes.count else {
+            return requiredRows.contains(where: { $0.status == .passed }) ? .partial : .unproven
+        }
+        if requiredRows.allSatisfy({ $0.status == .passed }) {
+            return rows.first(where: { $0.probe == .reasoning })?.status == .failed
+                ? .partial
+                : .proven
+        }
+        if requiredRows.allSatisfy({ $0.status == .unsupported }) { return .unsupported }
+        if requiredRows.contains(where: { $0.status == .passed }) { return .partial }
+        return .unproven
+    }
+
+    static func validates(_ artifact: LocalModelVerificationArtifact) -> Bool {
+        classify(artifact.probes) == artifact.classification
+    }
+}
+
+struct LocalModelLiveProbeRequest: Sendable {
+    let messages: [ChatMessage]
+    let tools: [Tool]
+    let toolChoice: ToolChoiceOption?
+    let maxTokens: Int
+    let stopSequences: [String]
+    let modelOptions: [String: ModelOptionValue]
+
+    init(
+        messages: [ChatMessage],
+        tools: [Tool],
+        toolChoice: ToolChoiceOption?,
+        maxTokens: Int,
+        stopSequences: [String],
+        modelOptions: [String: ModelOptionValue] = [:]
+    ) {
+        self.messages = messages
+        self.tools = tools
+        self.toolChoice = toolChoice
+        self.maxTokens = maxTokens
+        self.stopSequences = stopSequences
+        self.modelOptions = modelOptions
+    }
+}
+
+struct LocalModelLiveProbeTranscript: Equatable, Sendable {
+    let visibleText: String
+    let reasoningText: String
+    let toolName: String?
+    let toolArguments: String?
+    let tokenCount: Int?
+    let tokensPerSecond: Double?
+    let stopReason: String?
+    let unclosedReasoning: Bool
+}
+
+protocol LocalModelVerificationEngine: Sendable {
+    func generate(
+        modelId: String,
+        modelName: String,
+        request: LocalModelLiveProbeRequest
+    ) async throws -> LocalModelLiveProbeTranscript
+
+    func probeCancellation(modelId: String, modelName: String) async -> LocalModelCancellationProbeOutcome
+}
+
+/// The production adapter deliberately uses the same streaming path as native
+/// chat. No template, parser, sampler, or stop behavior is replaced here.
+actor MLXLocalModelVerificationEngine: LocalModelVerificationEngine {
+    func generate(
+        modelId: String,
+        modelName: String,
+        request: LocalModelLiveProbeRequest
+    ) async throws -> LocalModelLiveProbeTranscript {
+        let parameters = GenerationParameters(
+            temperature: nil,
+            maxTokens: request.maxTokens,
+            maxTokensExplicit: true,
+            modelOptions: request.modelOptions,
+            suppressProgressUI: true,
+            requestSource: .httpAPI
+        )
+        let stream = try await ModelRuntime.shared.streamWithTools(
+            messages: request.messages,
+            parameters: parameters,
+            stopSequences: request.stopSequences,
+            tools: request.tools,
+            toolChoice: request.toolChoice,
+            modelId: modelId,
+            modelName: modelName
+        )
+
+        var visible = ""
+        var reasoning = ""
+        var toolName: String?
+        var toolArguments: String?
+        var tokenCount: Int?
+        var tokensPerSecond: Double?
+        var stopReason: String?
+        var unclosedReasoning = false
+
+        do {
+            for try await delta in stream {
+                try Task.checkCancellation()
+                if let decoded = StreamingReasoningHint.decode(delta) {
+                    reasoning += decoded
+                } else if let decoded = StreamingToolHint.decode(delta) {
+                    toolName = decoded
+                } else if let decoded = StreamingToolHint.decodeArgs(delta) {
+                    toolArguments = decoded
+                } else if let stats = StreamingStatsHint.decode(delta) {
+                    tokenCount = stats.tokenCount
+                    tokensPerSecond = stats.tokensPerSecond
+                    stopReason = stats.stopReason
+                    unclosedReasoning = stats.unclosedReasoning
+                } else if !StreamingToolHint.isSentinel(delta) {
+                    visible += delta
+                }
+            }
+        } catch let invocation as ServiceToolInvocation {
+            toolName = invocation.toolName
+            toolArguments = invocation.jsonArguments
+        }
+
+        try Task.checkCancellation()
+        return LocalModelLiveProbeTranscript(
+            visibleText: visible,
+            reasoningText: reasoning,
+            toolName: toolName,
+            toolArguments: toolArguments,
+            tokenCount: tokenCount,
+            tokensPerSecond: tokensPerSecond,
+            stopReason: stopReason,
+            unclosedReasoning: unclosedReasoning
+        )
+    }
+
+    func probeCancellation(modelId: String, modelName: String) async -> LocalModelCancellationProbeOutcome {
+        await LocalModelCancellationHandshake.run { observedStart in
+            let parameters = GenerationParameters(
+                temperature: nil,
+                maxTokens: 2_048,
+                maxTokensExplicit: true,
+                suppressProgressUI: true,
+                requestSource: .httpAPI
+            )
+            let stream = try await ModelRuntime.shared.streamWithTools(
+                messages: [ChatMessage(
+                    role: "user",
+                    content: "Count upward indefinitely, one number per line."
+                )],
+                parameters: parameters,
+                stopSequences: [],
+                tools: [],
+                toolChoice: nil,
+                modelId: modelId,
+                modelName: modelName
+            )
+            var observedEvent = false
+            for try await _ in stream {
+                if !observedEvent {
+                    observedEvent = true
+                    observedStart()
+                }
+                try Task.checkCancellation()
+            }
+            try Task.checkCancellation()
+        }
+    }
+}
+
+enum LocalModelBundleInspector {
+    static let vmlxRevisionSource = "unverified: linked runtime exposes no source revision"
+
+    enum InspectionError: LocalizedError {
+        case missingBundle
+        case unsafeEntry(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingBundle:
+                return "The local model bundle is missing."
+            case .unsafeEntry(let path):
+                return "The model bundle contains a symbolic link or non-regular entry: \(path)"
+            }
+        }
+    }
+
+    static func inspect(
+        directory: URL,
+        cancellationCheck: () throws -> Void = { try Task.checkCancellation() }
+    ) throws -> LocalModelBundleEvidence {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw InspectionError.missingBundle
+        }
+
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey, .isSymbolicLinkKey, .isDirectoryKey, .fileSizeKey,
+            .contentModificationDateKey,
+        ]
+        guard let enumerator = fm.enumerator(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw InspectionError.missingBundle
+        }
+
+        let huggingFaceRepositoryRoot = huggingFaceRepositoryRoot(for: directory)
+        var files: [URL] = []
+        for case let url as URL in enumerator {
+            try cancellationCheck()
+            let values = try url.resourceValues(forKeys: keys)
+            if values.isSymbolicLink == true {
+                let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+                guard let huggingFaceRepositoryRoot,
+                    isContained(resolved, in: huggingFaceRepositoryRoot),
+                    (try resolved.resourceValues(forKeys: [.isRegularFileKey])).isRegularFile == true
+                else {
+                    throw InspectionError.unsafeEntry(url.path)
+                }
+                files.append(url)
+                continue
+            }
+            if values.isDirectory == true { continue }
+            guard values.isRegularFile == true else {
+                throw InspectionError.unsafeEntry(url.path)
+            }
+            files.append(url)
+        }
+        files.sort { relativePath($0, under: directory) < relativePath($1, under: directory) }
+
+        var rootHasher = SHA256()
+        var stateHasher = SHA256()
+        var totalBytes: Int64 = 0
+        for file in files {
+            try cancellationCheck()
+            let relative = relativePath(file, under: directory)
+            let values = try file.resourceValues(forKeys: keys)
+            stateHasher.update(data: Data(relative.utf8))
+            stateHasher.update(data: Data("\(values.fileSize ?? 0)".utf8))
+            stateHasher.update(data: Data("\(values.contentModificationDate?.timeIntervalSince1970 ?? 0)".utf8))
+            let handle = try FileHandle(forReadingFrom: file)
+            defer { try? handle.close() }
+            var fileHasher = SHA256()
+            var fileBytes: Int64 = 0
+            while true {
+                try cancellationCheck()
+                let data = try handle.read(upToCount: 4 * 1_024 * 1_024) ?? Data()
+                if data.isEmpty { break }
+                fileHasher.update(data: data)
+                fileBytes += Int64(data.count)
+            }
+            totalBytes += fileBytes
+            rootHasher.update(data: Data(relative.utf8))
+            rootHasher.update(data: Data([0]))
+            rootHasher.update(data: Data(fileHasher.finalize()))
+            withUnsafeBytes(of: fileBytes.bigEndian) { rootHasher.update(bufferPointer: $0) }
+        }
+
+        let tokenizer = jsonObject(at: directory.appendingPathComponent("tokenizer_config.json"))
+        let config = jsonObject(at: directory.appendingPathComponent("config.json"))
+        let generation = jsonObject(at: directory.appendingPathComponent("generation_config.json"))
+        let jang = jsonObject(at: directory.appendingPathComponent("jang_config.json"))
+        let hasTokenizerTemplate = tokenizer?["chat_template"] != nil
+        let hasStandaloneTemplate = fm.fileExists(
+            atPath: directory.appendingPathComponent("chat_template.jinja").path)
+        let templateSource: String
+        let templateFallback: String?
+        let declaredTemplateSource = firstString(keys: ["chat_template_source"], in: [jang])
+        if hasTokenizerTemplate {
+            templateSource = "bundle:tokenizer_config.json"
+            templateFallback = nil
+        } else if hasStandaloneTemplate {
+            templateSource = "bundle:chat_template.jinja"
+            templateFallback = nil
+        } else if config?["chat_template"] != nil {
+            templateSource = "bundle:config.json"
+            templateFallback = nil
+        } else if let declaredTemplateSource {
+            templateSource = "bundle:\(declaredTemplateSource)"
+            templateFallback = nil
+        } else {
+            templateSource = "runtime fallback"
+            templateFallback = "The bundle does not declare a chat template; the runtime-selected fallback is unproven."
+        }
+
+        let parser = firstString(
+            keys: ["parser", "format", "tool_call_parser", "tool_calling"],
+            in: [jang, tokenizer, config]
+        )
+        let reasoningCapability = LocalReasoningCapability.readChatTemplate(at: directory)
+            .map(LocalReasoningCapability.analyze(template:))
+            ?? LocalReasoningCapability.readJangConfigReasoning(at: directory)
+        let reasoningDeclared = reasoningCapability?.supportsThinking == true
+        let defaults = (generation ?? [:]).reduce(into: [String: String]()) { output, entry in
+            guard let rendered = scalarString(entry.value) else { return }
+            output[entry.key] = rendered
+        }
+
+        return LocalModelBundleEvidence(
+            digest: "sha256:" + rootHasher.finalize().map { String(format: "%02x", $0) }.joined(),
+            stateFingerprint: "sha256:" + stateHasher.finalize().map { String(format: "%02x", $0) }.joined(),
+            fileCount: files.count,
+            byteCount: totalBytes,
+            templateSource: templateSource,
+            templateFallback: templateFallback,
+            parserFormat: parser,
+            generationDefaults: defaults,
+            reasoningDeclared: reasoningDeclared,
+            vmlxRevision: nil,
+            vmlxRevisionSource: vmlxRevisionSource
+        )
+    }
+
+    static func currentStateFingerprint(directory: URL) throws -> String {
+        let fm = FileManager.default
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey, .isSymbolicLinkKey, .isDirectoryKey, .fileSizeKey,
+            .contentModificationDateKey,
+        ]
+        guard let enumerator = fm.enumerator(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        ) else { throw InspectionError.missingBundle }
+        var entries: [(String, Int, TimeInterval)] = []
+        for case let url as URL in enumerator {
+            let values = try url.resourceValues(forKeys: keys)
+            if values.isSymbolicLink == true { throw InspectionError.unsafeEntry(url.path) }
+            if values.isDirectory == true { continue }
+            guard values.isRegularFile == true else { throw InspectionError.unsafeEntry(url.path) }
+            entries.append((
+                relativePath(url, under: directory),
+                values.fileSize ?? 0,
+                values.contentModificationDate?.timeIntervalSince1970 ?? 0
+            ))
+        }
+        entries.sort { $0.0 < $1.0 }
+        var hasher = SHA256()
+        for entry in entries {
+            hasher.update(data: Data(entry.0.utf8))
+            hasher.update(data: Data("\(entry.1)".utf8))
+            hasher.update(data: Data("\(entry.2)".utf8))
+        }
+        return "sha256:" + hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func relativePath(_ url: URL, under root: URL) -> String {
+        String(url.standardizedFileURL.path.dropFirst(root.standardizedFileURL.path.count + 1))
+    }
+
+    private static func huggingFaceRepositoryRoot(for directory: URL) -> URL? {
+        var candidate = directory.standardizedFileURL
+        while candidate.path != "/" {
+            if candidate.lastPathComponent.hasPrefix("models--") {
+                return candidate
+            }
+            candidate.deleteLastPathComponent()
+        }
+        return nil
+    }
+
+    private static func isContained(_ url: URL, in root: URL) -> Bool {
+        let path = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    private static func jsonObject(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func scalarString(_ value: Any) -> String? {
+        if let string = value as? String { return string }
+        if let number = value as? NSNumber { return number.stringValue }
+        return nil
+    }
+
+    private static func firstString(keys: [String], in roots: [[String: Any]?]) -> String? {
+        for root in roots.compactMap({ $0 }) {
+            if let found = recursiveFirstString(keys: Set(keys), object: root) { return found }
+        }
+        return nil
+    }
+
+    private static func recursiveFirstString(keys: Set<String>, object: Any) -> String? {
+        if let dictionary = object as? [String: Any] {
+            for key in dictionary.keys.sorted() {
+                guard let value = dictionary[key] else { continue }
+                if keys.contains(key), let rendered = scalarString(value) {
+                    return rendered
+                }
+                if let found = recursiveFirstString(keys: keys, object: value) {
+                    return found
+                }
+            }
+        } else if let array = object as? [Any] {
+            for value in array {
+                if let found = recursiveFirstString(keys: keys, object: value) { return found }
+            }
+        }
+        return nil
+    }
+
+}
+
+actor LocalModelVerificationArtifactStore {
+    @TaskLocal static var directoryOverrideForTests: URL?
+
+    private var inFlightModels: Set<String> = []
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func begin(modelId: String) throws {
+        guard inFlightModels.insert(modelId).inserted else {
+            throw CocoaError(.fileWriteFileExists, userInfo: [
+                NSLocalizedDescriptionKey: "Verification is already running for this model."
+            ])
+        }
+    }
+
+    func end(modelId: String) {
+        inFlightModels.remove(modelId)
+    }
+
+    func save(_ artifact: LocalModelVerificationArtifact) throws -> URL {
+        let directory = Self.directoryOverrideForTests
+            ?? OsaurusPaths.config().appendingPathComponent("model-verification", isDirectory: true)
+        let modelKey = Self.modelStorageKey(artifact.modelId)
+        let modelDirectory = directory.appendingPathComponent(modelKey, isDirectory: true)
+        try fileManager.createDirectory(
+            at: modelDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let destination = modelDirectory.appendingPathComponent(
+            Self.artifactFileName(digest: artifact.bundle.digest)
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(artifact)
+        try data.write(to: destination, options: [.atomic])
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
+        return destination
+    }
+
+    func latest(modelId: String) -> (artifact: LocalModelVerificationArtifact, url: URL)? {
+        let directory = Self.directoryOverrideForTests
+            ?? OsaurusPaths.config().appendingPathComponent("model-verification", isDirectory: true)
+        let modelKey = Self.modelStorageKey(modelId)
+        let modelDirectory = directory.appendingPathComponent(modelKey, isDirectory: true)
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: modelDirectory,
+            includingPropertiesForKeys: [
+                .contentModificationDateKey, .isRegularFileKey, .isSymbolicLinkKey,
+            ],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return files.compactMap { url -> (LocalModelVerificationArtifact, URL, Date)? in
+            let values = try? url.resourceValues(forKeys: [
+                .contentModificationDateKey, .isRegularFileKey, .isSymbolicLinkKey,
+            ])
+            guard values?.isRegularFile == true, values?.isSymbolicLink != true,
+                url.pathExtension == "json",
+                let data = try? Data(contentsOf: url),
+                let artifact = try? decoder.decode(LocalModelVerificationArtifact.self, from: data),
+                artifact.schemaVersion == LocalModelVerificationArtifact.currentSchemaVersion,
+                artifact.modelId == modelId,
+                url.lastPathComponent == Self.artifactFileName(digest: artifact.bundle.digest),
+                LocalModelVerificationAuthority.validates(artifact)
+            else { return nil }
+            let date = values?.contentModificationDate ?? artifact.completedAt
+            return (artifact, url, date)
+        }
+        .max { $0.2 < $1.2 }
+        .map { ($0.0, $0.1) }
+    }
+
+    func removeArtifact(at url: URL) throws {
+        guard url.pathExtension == "json" else { return }
+        try fileManager.removeItem(at: url)
+    }
+
+    private static func modelStorageKey(_ modelId: String) -> String {
+        SHA256.hash(data: Data(modelId.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private static func artifactFileName(digest: String) -> String {
+        digest.replacingOccurrences(of: ":", with: "-") + ".json"
+    }
+}
+
+actor LocalModelVerificationService {
+    enum VerificationError: LocalizedError {
+        case bundleChangedDuringVerification
+
+        var errorDescription: String? {
+            switch self {
+            case .bundleChangedDuringVerification:
+                return "The model bundle changed during verification. Run verification again."
+            }
+        }
+    }
+
+    static let shared = LocalModelVerificationService(
+        engine: MLXLocalModelVerificationEngine(),
+        store: LocalModelVerificationArtifactStore(),
+        registry: .shared
+    )
+
+    private let engine: any LocalModelVerificationEngine
+    private let store: LocalModelVerificationArtifactStore
+    private let registry: EvidenceReportRegistryService
+    private let now: @Sendable () -> Date
+
+    init(
+        engine: any LocalModelVerificationEngine,
+        store: LocalModelVerificationArtifactStore,
+        registry: EvidenceReportRegistryService,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.engine = engine
+        self.store = store
+        self.registry = registry
+        self.now = now
+    }
+
+    func latest(modelId: String) async -> (LocalModelVerificationArtifact, URL)? {
+        await store.latest(modelId: modelId)
+    }
+
+    func verify(model: MLXModel) async throws -> (LocalModelVerificationArtifact, URL) {
+        try await store.begin(modelId: model.id)
+        var savedArtifactURL: URL?
+        do {
+            let startedAt = now()
+            let bundle = try LocalModelBundleInspector.inspect(directory: model.localDirectory)
+            let probes = try await runProbes(model: model, bundle: bundle)
+            let completedBundle = try LocalModelBundleInspector.inspect(directory: model.localDirectory)
+            guard completedBundle.digest == bundle.digest else {
+                throw VerificationError.bundleChangedDuringVerification
+            }
+            let artifact = LocalModelVerificationArtifact(
+                schemaVersion: LocalModelVerificationArtifact.currentSchemaVersion,
+                modelId: model.id,
+                modelName: model.name,
+                bundle: bundle,
+                classification: LocalModelVerificationAuthority.classify(probes),
+                startedAt: startedAt,
+                completedAt: now(),
+                probes: probes
+            )
+            let url = try await store.save(artifact)
+            savedArtifactURL = url
+            try ModelCapabilityLedger.saveVerification(
+                classification: artifact.classification,
+                digest: artifact.bundle.digest,
+                artifactPath: url.path,
+                measuredAt: ISO8601DateFormatter().string(from: artifact.completedAt),
+                for: model.id
+            )
+            register(artifact: artifact, at: url)
+            await store.end(modelId: model.id)
+            return (artifact, url)
+        } catch {
+            if let savedArtifactURL {
+                try? await store.removeArtifact(at: savedArtifactURL)
+            }
+            await store.end(modelId: model.id)
+            throw error
+        }
+    }
+
+    private func runProbes(
+        model: MLXModel,
+        bundle: LocalModelBundleEvidence
+    ) async throws -> [LocalModelVerificationProbeResult] {
+        var rows: [LocalModelVerificationProbeResult] = []
+        let plain = await attempt(
+            model: model,
+            request: LocalModelLiveProbeRequest(
+                messages: [ChatMessage(role: "user", content: "Reply with exactly READY.")],
+                tools: [], toolChoice: nil, maxTokens: 32, stopSequences: []
+            )
+        )
+        try Task.checkCancellation()
+        rows.append(result(
+            .generation,
+            passed: plain.transcript?.visibleText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
+            passDetail: "The model produced visible text through the native MLX chat path.",
+            failure: plain.error ?? "The model produced no visible final answer.",
+            transcript: plain.transcript
+        ))
+
+        if bundle.reasoningDeclared {
+            let reasoningProbe = await attempt(
+                model: model,
+                request: LocalModelLiveProbeRequest(
+                    messages: [ChatMessage(
+                        role: "user",
+                        content: "Reason briefly, then answer with exactly 4: what is 2 + 2?"
+                    )],
+                    tools: [], toolChoice: nil, maxTokens: 128, stopSequences: [],
+                    modelOptions: ["reasoningEffort": .string("high")]
+                )
+            )
+            try Task.checkCancellation()
+            rows.append(result(
+                .reasoning,
+                passed: reasoningProbe.transcript?.reasoningText.isEmpty == false
+                    && reasoningProbe.transcript?.visibleText.isEmpty == false
+                    && reasoningProbe.transcript?.unclosedReasoning == false,
+                passDetail: "The runtime emitted a dedicated, closed reasoning channel.",
+                failure: reasoningProbe.error ?? "The bundle declares reasoning, but this run emitted no clean reasoning channel plus visible answer.",
+                transcript: reasoningProbe.transcript
+            ))
+        } else {
+            rows.append(row(.reasoning, .unsupported, "The bundle does not declare a reasoning mode; no reasoning pass is claimed."))
+        }
+
+        let tool = fixtureTool()
+        let first = await attempt(
+            model: model,
+            request: LocalModelLiveProbeRequest(
+                messages: [ChatMessage(role: "user", content: "Use city_temperature for Paris. Do not guess.")],
+                tools: [tool], toolChoice: .required, maxTokens: 128, stopSequences: []
+            )
+        )
+        try Task.checkCancellation()
+        let firstArgsValid = validCityArguments(first.transcript?.toolArguments, expected: "Paris")
+        rows.append(result(
+            .schemaValidToolCall,
+            passed: first.transcript?.toolName == "city_temperature" && firstArgsValid,
+            passDetail: "The model emitted city_temperature with schema-valid JSON arguments.",
+            failure: first.error ?? "The first tool call was missing, named incorrectly, or had invalid arguments.",
+            transcript: first.transcript
+        ))
+
+        var continuation: (transcript: LocalModelLiveProbeTranscript?, error: String?) = (nil, nil)
+        var second: (transcript: LocalModelLiveProbeTranscript?, error: String?) = (nil, nil)
+        if first.transcript?.toolName == "city_temperature", firstArgsValid {
+            let callId = "verification_call_1"
+            let history = [
+                ChatMessage(role: "user", content: "Use city_temperature for Paris. Do not guess."),
+                ChatMessage(
+                    role: "assistant", content: nil,
+                    tool_calls: [ToolCall(
+                        id: callId, type: "function",
+                        function: ToolCallFunction(name: "city_temperature", arguments: first.transcript?.toolArguments ?? "{}")
+                    )],
+                    tool_call_id: nil
+                ),
+                ChatMessage(role: "tool", content: #"{"city":"Paris","celsius":21}"#, tool_calls: nil, tool_call_id: callId),
+            ]
+            continuation = await attempt(
+                model: model,
+                request: LocalModelLiveProbeRequest(
+                    messages: history + [ChatMessage(role: "user", content: "State the returned Paris temperature in one sentence.")],
+                    tools: [tool], toolChoice: .auto, maxTokens: 96, stopSequences: []
+                )
+            )
+            try Task.checkCancellation()
+            let grounded = continuation.transcript?.visibleText.contains("21") == true
+            rows.append(result(
+                .toolResultContinuation,
+                passed: grounded,
+                passDetail: "The continuation consumed the executed fixture result and returned 21.",
+                failure: continuation.error ?? "The continuation did not ground its answer in the injected tool result.",
+                transcript: continuation.transcript
+            ))
+            second = await attempt(
+                model: model,
+                request: LocalModelLiveProbeRequest(
+                    messages: history + [ChatMessage(role: "user", content: "Now use city_temperature for Berlin. Do not guess.")],
+                    tools: [tool], toolChoice: .required, maxTokens: 128, stopSequences: []
+                )
+            )
+            try Task.checkCancellation()
+            rows.append(result(
+                .secondToolCall,
+                passed: second.transcript?.toolName == "city_temperature"
+                    && validCityArguments(second.transcript?.toolArguments, expected: "Berlin"),
+                passDetail: "The model emitted a second schema-valid tool call after tool history.",
+                failure: second.error ?? "The model failed the second tool call after result history.",
+                transcript: second.transcript
+            ))
+        } else {
+            rows.append(row(.toolResultContinuation, .blocked, "Blocked because the first tool call did not validate."))
+            rows.append(row(.secondToolCall, .blocked, "Blocked because the first tool call did not validate."))
+        }
+
+        let transcripts = [plain.transcript, first.transcript, continuation.transcript, second.transcript]
+            .compactMap { $0 }
+        let leaked = transcripts.flatMap { markerLeaks(in: $0.visibleText) }
+        if transcripts.isEmpty {
+            rows.append(row(
+                .markerLeakage,
+                .blocked,
+                "No successful transcript was available to inspect for marker leakage."
+            ))
+        } else {
+            rows.append(row(
+                .markerLeakage,
+                leaked.isEmpty ? .passed : .failed,
+                leaked.isEmpty
+                    ? "No reasoning, tool, or parser markers leaked into visible output."
+                    : "Visible output leaked protocol markers: \(leaked.sorted().joined(separator: ", "))."
+            ))
+        }
+        let stopEvidence = transcripts.contains { transcript in
+            guard let stop = transcript.stopReason?.lowercased() else { return false }
+            return stop == "stop" || stop == "eos" || stop == "end_of_sequence"
+        }
+        rows.append(row(
+            .stopAndEOS,
+            stopEvidence ? .passed : .failed,
+            stopEvidence
+                ? "The runtime reported a natural stop/EOS reason."
+                : "No natural stop/EOS reason was reported by any completed probe."
+        ))
+        let rates = transcripts.compactMap(\.tokensPerSecond).filter { $0.isFinite && $0 > 0 }
+        rows.append(LocalModelVerificationProbeResult(
+            probe: .throughput,
+            status: rates.isEmpty ? .failed : .passed,
+            detail: rates.isEmpty ? "No positive decode token/s evidence was emitted." : "Recorded positive decode throughput.",
+            tokenCount: transcripts.compactMap(\.tokenCount).max(),
+            tokensPerSecond: rates.max(),
+            stopReason: nil
+        ))
+        let cancellation = await engine.probeCancellation(modelId: model.id, modelName: model.name)
+        try Task.checkCancellation()
+        switch cancellation {
+        case .passed:
+            rows.append(row(
+                .cancellation,
+                .passed,
+                "A generation event was observed before the in-flight request acknowledged cancellation."
+            ))
+        case .blocked(let detail):
+            rows.append(row(.cancellation, .blocked, detail))
+        case .failed(let detail):
+            rows.append(row(.cancellation, .failed, detail))
+        }
+        if bundle.templateFallback != nil {
+            rows.append(row(
+                .schemaValidToolCall,
+                .blocked,
+                "The bundle has no declared chat template; runtime fallback use remains unproven even if output parsed."
+            ))
+        }
+        return deduplicate(rows)
+    }
+
+    private func attempt(
+        model: MLXModel,
+        request: LocalModelLiveProbeRequest
+    ) async -> (transcript: LocalModelLiveProbeTranscript?, error: String?) {
+        do {
+            return (try await engine.generate(modelId: model.id, modelName: model.name, request: request), nil)
+        } catch is CancellationError {
+            return (nil, "Probe was cancelled.")
+        } catch {
+            return (nil, String(describing: error))
+        }
+    }
+
+    private func fixtureTool() -> Tool {
+        Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "city_temperature",
+                description: "Return a deterministic fixture temperature for a city.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "city": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("city")]),
+                    "additionalProperties": .bool(false),
+                ])
+            )
+        )
+    }
+
+    private func validCityArguments(_ json: String?, expected: String) -> Bool {
+        guard let json, let data = json.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            object.count == 1, let city = object["city"] as? String
+        else { return false }
+        return city.caseInsensitiveCompare(expected) == .orderedSame
+    }
+
+    private func markerLeaks(in text: String) -> [String] {
+        let markers = [
+            "<think>", "</think>", "<tool_call>", "</tool_call>",
+            "<|tool_call|>", "<|channel|>", "<|analysis|>", "\u{FFFE}",
+        ]
+        return markers.filter { text.localizedCaseInsensitiveContains($0) }
+    }
+
+    private func result(
+        _ probe: LocalModelVerificationProbe,
+        passed: Bool,
+        passDetail: String,
+        failure: String,
+        transcript: LocalModelLiveProbeTranscript?
+    ) -> LocalModelVerificationProbeResult {
+        LocalModelVerificationProbeResult(
+            probe: probe,
+            status: passed ? .passed : (transcript == nil ? .error : .failed),
+            detail: passed ? passDetail : failure,
+            tokenCount: transcript?.tokenCount,
+            tokensPerSecond: transcript?.tokensPerSecond,
+            stopReason: transcript?.stopReason
+        )
+    }
+
+    private func row(
+        _ probe: LocalModelVerificationProbe,
+        _ status: LocalModelVerificationProbeStatus,
+        _ detail: String
+    ) -> LocalModelVerificationProbeResult {
+        LocalModelVerificationProbeResult(
+            probe: probe, status: status, detail: detail,
+            tokenCount: nil, tokensPerSecond: nil, stopReason: nil
+        )
+    }
+
+    private func deduplicate(
+        _ rows: [LocalModelVerificationProbeResult]
+    ) -> [LocalModelVerificationProbeResult] {
+        var byProbe: [LocalModelVerificationProbe: LocalModelVerificationProbeResult] = [:]
+        for row in rows {
+            guard let existing = byProbe[row.probe] else {
+                byProbe[row.probe] = row
+                continue
+            }
+            if statusSeverity(row.status) > statusSeverity(existing.status) {
+                byProbe[row.probe] = row
+            }
+        }
+        return LocalModelVerificationProbe.allCases.compactMap { byProbe[$0] }
+    }
+
+    private func statusSeverity(_ status: LocalModelVerificationProbeStatus) -> Int {
+        switch status {
+        case .passed: 0
+        case .unsupported: 1
+        case .blocked: 2
+        case .failed: 3
+        case .error: 4
+        }
+    }
+
+    private func register(artifact: LocalModelVerificationArtifact, at url: URL) {
+        let counts = EvidenceReportCounts(
+            total: artifact.probes.count,
+            passed: artifact.probes.count { $0.status == .passed },
+            failed: artifact.probes.count { $0.status == .failed },
+            errored: artifact.probes.count { $0.status == .error },
+            skipped: artifact.probes.count { $0.status == .unsupported },
+            blocked: artifact.probes.count { $0.status == .blocked }
+        )
+        let status: EvidenceReportStatus = switch artifact.classification {
+        case .proven: .passed
+        case .partial: .partial
+        case .unsupported: .blocked
+        case .failed: .failed
+        case .unproven: .unknown
+        }
+        registry.register(EvidenceReportDescriptor(
+            id: "model-verification|\(artifact.modelId)|\(artifact.bundle.digest)",
+            kind: .liveProof,
+            source: "local-model-verification",
+            artifactURL: url,
+            status: status,
+            counts: counts,
+            startedAt: artifact.startedAt,
+            completedAt: artifact.completedAt,
+            metadata: [
+                "model_id": artifact.modelId,
+                "bundle_digest": artifact.bundle.digest,
+                "classification": artifact.classification.rawValue,
+                "vmlx_revision": artifact.bundle.vmlxRevision ?? "unverified",
+                "vmlx_revision_source": artifact.bundle.vmlxRevisionSource,
+            ]
+        ))
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/LocalModelVerificationWorkbench.swift
@@ -473,6 +473,11 @@ enum LocalModelBundleInspector {
         let contentURL: URL
     }
 
+    private enum BooleanLookup {
+        case missing
+        case value(Bool)
+    }
+
     static func inspect(
         directory: URL,
         cancellationCheck: () throws -> Void = { try Task.checkCancellation() }
@@ -681,11 +686,32 @@ enum LocalModelBundleInspector {
         keys: [String], in roots: [[String: Any]?], default defaultValue: Bool
     ) -> Bool {
         for root in roots.compactMap({ $0 }) {
-            for key in keys {
-                if let value = root[key] as? Bool { return value }
+            if case .value(let value) = recursiveFirstBool(
+                keys: Set(keys), object: root
+            ) {
+                return value
             }
         }
         return defaultValue
+    }
+
+    private static func recursiveFirstBool(
+        keys: Set<String>, object: Any
+    ) -> BooleanLookup {
+        if let dictionary = object as? [String: Any] {
+            for key in dictionary.keys.sorted() {
+                guard let value = dictionary[key] else { continue }
+                if keys.contains(key), let boolean = value as? Bool { return .value(boolean) }
+                let nested = recursiveFirstBool(keys: keys, object: value)
+                if case .value = nested { return nested }
+            }
+        } else if let array = object as? [Any] {
+            for value in array {
+                let nested = recursiveFirstBool(keys: keys, object: value)
+                if case .value = nested { return nested }
+            }
+        }
+        return .missing
     }
 
     private static func recursiveFirstString(keys: Set<String>, object: Any) -> String? {
@@ -962,15 +988,14 @@ actor LocalModelVerificationService {
             transcript: LocalModelLiveProbeTranscript?, error: String?, errorCode: String?
         ) = (nil, nil, nil)
         if bundle.templateFallback != nil {
+            let detail = bundle.templateSource.hasPrefix("runtime:")
+                ? "The runtime-only chat-template source is not digest-bound or authoritatively pinned; dependent tool evidence remains unproven."
+                : "The bundle contains no chat-template content; dependent tool evidence remains unproven."
             for probe in [
                 LocalModelVerificationProbe.autoToolChoice, .schemaValidToolCall,
                 .toolResultContinuation, .secondToolCall,
             ] {
-                rows.append(row(
-                    probe,
-                    .blocked,
-                    "The bundle has no declared chat template; dependent tool evidence remains unproven."
-                ))
+                rows.append(row(probe, .blocked, detail))
             }
         } else {
             let tool = fixtureTool()

--- a/Packages/OsaurusCore/Services/ModelRuntime/ModelCapabilityLedger.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ModelCapabilityLedger.swift
@@ -182,12 +182,16 @@ enum ModelCapabilityLedger {
             return cache.records
         }
         var records: [String: Record] = [:]
-        if mtime != nil,
-            let data = try? Data(contentsOf: url),
-            let decoded = try? JSONDecoder().decode([String: Record].self, from: data) {
-            records = decoded
-            ledgerLog.info(
-                "loaded \(records.count, privacy: .public) capability record(s)")
+        if mtime != nil {
+            do {
+                let data = try Data(contentsOf: url)
+                records = try JSONDecoder().decode([String: Record].self, from: data)
+                ledgerLog.info(
+                    "loaded \(records.count, privacy: .public) capability record(s)")
+            } catch {
+                ledgerLog.error("capability ledger is unreadable or corrupt; preserving prior cache")
+                return cache.checkedURL == url ? cache.records : [:]
+            }
         }
         cache = CacheBox(records: records, mtime: mtime, checkedURL: url)
         return records
@@ -198,17 +202,13 @@ enum ModelCapabilityLedger {
     /// target key is overlaid, so every other record survives verbatim,
     /// including fields this build does not know about (the gauntlet-written
     /// `probes`/`evidence` maps; a `[String: Record]` decode/re-encode round
-    /// trip would strip them from EVERY record). The residual race is
-    /// whole-file last-write-wins: a writer working from a stale snapshot
-    /// can lose the OTHER writer's key, but never an unrelated record or
-    /// field it merely carried along.
+    /// trip would strip them from every record). All writers share the same
+    /// lock, so each merge observes the prior completed write.
     static func save(record: Record, for modelName: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
         let url = fileURL
-        var records: [String: Any] = [:]
-        if let data = try? Data(contentsOf: url),
-            let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            records = existing
-        }
+        var records = try rawRecordsForWrite(at: url)
         let encoded = try JSONEncoder().encode(record)
         records[normalize(modelName)] = try JSONSerialization.jsonObject(with: encoded)
         try FileManager.default.createDirectory(
@@ -228,17 +228,15 @@ enum ModelCapabilityLedger {
         if failVerificationWriteForTests {
             throw CocoaError(.fileWriteUnknown)
         }
-        guard digest.hasPrefix("sha256:"), digest.count == 71 else {
+        guard LocalModelVerificationAuthority.validDigest(digest) else {
             throw CocoaError(.fileWriteInvalidFileName, userInfo: [
                 NSLocalizedDescriptionKey: "Verification evidence requires a full SHA-256 bundle digest."
             ])
         }
+        lock.lock()
+        defer { lock.unlock() }
         let url = fileURL
-        var records: [String: Any] = [:]
-        if let data = try? Data(contentsOf: url),
-            let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            records = existing
-        }
+        var records = try rawRecordsForWrite(at: url)
         let key = verificationStorageKey(modelName)
         var target = records[key] as? [String: Any] ?? [:]
         target["verificationClassification"] = classification.rawValue
@@ -249,6 +247,17 @@ enum ModelCapabilityLedger {
         records[key] = target
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: records, options: [.prettyPrinted, .sortedKeys])
+        try writePrivateLedger(data, to: url)
+    }
+
+    static func removeVerification(for modelName: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let url = fileURL
+        var records = try rawRecordsForWrite(at: url)
+        records.removeValue(forKey: verificationStorageKey(modelName))
         let data = try JSONSerialization.data(
             withJSONObject: records, options: [.prettyPrinted, .sortedKeys])
         try writePrivateLedger(data, to: url)
@@ -285,5 +294,14 @@ enum ModelCapabilityLedger {
         } else {
             try fileManager.moveItem(at: temporaryURL, to: url)
         }
+    }
+
+    private static func rawRecordsForWrite(at url: URL) throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
+        let data = try Data(contentsOf: url)
+        guard let records = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return records
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/ModelCapabilityLedger.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ModelCapabilityLedger.swift
@@ -27,12 +27,14 @@
 //  invalidation once the gauntlet computes it.
 //
 
+import CryptoKit
 import Foundation
 import os.log
 
 private let ledgerLog = Logger(subsystem: "com.dinoki.osaurus", category: "CapabilityLedger")
 
 enum ModelCapabilityLedger {
+    @TaskLocal static var failVerificationWriteForTests = false
 
     enum Verdict: String, Codable, Sendable {
         case pass
@@ -54,6 +56,41 @@ enum ModelCapabilityLedger {
         var digest: String?
         var chip: String?
         var measuredAt: String?
+
+        /// Digest-bound verification projection. The full evidence remains in
+        /// the registered JSON artifact; the ledger only points at it and never
+        /// promotes a model by name or load success.
+        var verificationClassification: String?
+        var verificationModelId: String?
+        var verificationDigest: String?
+        var verificationMeasuredAt: String?
+        var verificationArtifactPath: String?
+
+        init(
+            productionServing: Verdict? = nil,
+            blockReason: String? = nil,
+            source: String? = nil,
+            digest: String? = nil,
+            chip: String? = nil,
+            measuredAt: String? = nil,
+            verificationClassification: String? = nil,
+            verificationModelId: String? = nil,
+            verificationDigest: String? = nil,
+            verificationMeasuredAt: String? = nil,
+            verificationArtifactPath: String? = nil
+        ) {
+            self.productionServing = productionServing
+            self.blockReason = blockReason
+            self.source = source
+            self.digest = digest
+            self.chip = chip
+            self.measuredAt = measuredAt
+            self.verificationClassification = verificationClassification
+            self.verificationModelId = verificationModelId
+            self.verificationDigest = verificationDigest
+            self.verificationMeasuredAt = verificationMeasuredAt
+            self.verificationArtifactPath = verificationArtifactPath
+        }
     }
 
     // MARK: - Seed rules (compiled-in; reproduce today's hardcoded behavior)
@@ -178,6 +215,75 @@ enum ModelCapabilityLedger {
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         let data = try JSONSerialization.data(
             withJSONObject: records, options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: url, options: .atomic)
+        try writePrivateLedger(data, to: url)
+    }
+
+    static func saveVerification(
+        classification: LocalModelVerificationClassification,
+        digest: String,
+        artifactPath: String,
+        measuredAt: String,
+        for modelName: String
+    ) throws {
+        if failVerificationWriteForTests {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        guard digest.hasPrefix("sha256:"), digest.count == 71 else {
+            throw CocoaError(.fileWriteInvalidFileName, userInfo: [
+                NSLocalizedDescriptionKey: "Verification evidence requires a full SHA-256 bundle digest."
+            ])
+        }
+        let url = fileURL
+        var records: [String: Any] = [:]
+        if let data = try? Data(contentsOf: url),
+            let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            records = existing
+        }
+        let key = verificationStorageKey(modelName)
+        var target = records[key] as? [String: Any] ?? [:]
+        target["verificationClassification"] = classification.rawValue
+        target["verificationModelId"] = modelName
+        target["verificationDigest"] = digest
+        target["verificationMeasuredAt"] = measuredAt
+        target["verificationArtifactPath"] = artifactPath
+        records[key] = target
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: records, options: [.prettyPrinted, .sortedKeys])
+        try writePrivateLedger(data, to: url)
+    }
+
+    static func verificationStorageKey(_ modelId: String) -> String {
+        let digest = SHA256.hash(data: Data(modelId.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "verification:\(digest)"
+    }
+
+    private static func writePrivateLedger(_ data: Data, to url: URL) throws {
+        let fileManager = FileManager.default
+        let temporaryURL = url.deletingLastPathComponent().appendingPathComponent(
+            ".\(url.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        defer { try? fileManager.removeItem(at: temporaryURL) }
+        guard fileManager.createFile(
+            atPath: temporaryURL.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        if fileManager.fileExists(atPath: url.path) {
+            let values = try url.resourceValues(forKeys: [
+                .isRegularFileKey, .isSymbolicLinkKey,
+            ])
+            guard values.isRegularFile == true, values.isSymbolicLink != true else {
+                throw CocoaError(.fileWriteInvalidFileName)
+            }
+            _ = try fileManager.replaceItemAt(url, withItemAt: temporaryURL)
+        } else {
+            try fileManager.moveItem(at: temporaryURL, to: url)
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
@@ -338,24 +338,30 @@ struct LocalModelVerificationWorkbenchTests {
         #expect(configEvidence.templateFallback == nil)
     }
 
-    @Test func runtimeOnlyJangTemplateSourceBlocksAllToolProof() async throws {
-        let engine = ScriptedVerificationEngine(transcripts: [transcript()])
-        try await withEnvironment(engine: engine, template: false) { service, model, _, _ in
-            try Data(
-                #"{"chat_template_source":"builtin_encoding_module","has_tokenizer_chat_template":false}"#.utf8
-            ).write(to: model.localDirectory.appendingPathComponent("jang_config.json"))
+    @Test func nestedRuntimeOnlyJangTemplateSourceBlocksAllToolProof() async throws {
+        for hasStaleTokenizerTemplate in [false, true] {
+            let engine = ScriptedVerificationEngine(transcripts: [transcript()])
+            try await withEnvironment(
+                engine: engine, template: hasStaleTokenizerTemplate
+            ) { service, model, _, _ in
+                try Data(
+                    #"{"chat":{"chat_template_source":"builtin_encoding_module","has_tokenizer_chat_template":false}}"#.utf8
+                ).write(to: model.localDirectory.appendingPathComponent("jang_config.json"))
 
-            let (artifact, _) = try await service.verify(model: model)
-            #expect(artifact.bundle.templateSource == "runtime:builtin_encoding_module")
-            #expect(artifact.bundle.templateFallback != nil)
-            for probe in [
-                LocalModelVerificationProbe.autoToolChoice, .schemaValidToolCall,
-                .toolResultContinuation, .secondToolCall,
-            ] {
-                #expect(artifact.probes.first { $0.probe == probe }?.status == .blocked)
+                let (artifact, _) = try await service.verify(model: model)
+                #expect(artifact.bundle.templateSource == "runtime:builtin_encoding_module")
+                #expect(artifact.bundle.templateFallback != nil)
+                for probe in [
+                    LocalModelVerificationProbe.autoToolChoice, .schemaValidToolCall,
+                    .toolResultContinuation, .secondToolCall,
+                ] {
+                    let row = artifact.probes.first { $0.probe == probe }
+                    #expect(row?.status == .blocked)
+                    #expect(row?.detail.contains("runtime-only chat-template source") == true)
+                }
+                #expect(artifact.classification != .proven)
+                #expect(await engine.capturedRequests().count == 1)
             }
-            #expect(artifact.classification != .proven)
-            #expect(await engine.capturedRequests().count == 1)
         }
     }
 
@@ -458,6 +464,10 @@ struct LocalModelVerificationWorkbenchTests {
             #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .blocked)
             #expect(artifact.probes.first { $0.probe == .toolResultContinuation }?.status == .blocked)
             #expect(artifact.probes.first { $0.probe == .secondToolCall }?.status == .blocked)
+            #expect(
+                artifact.probes.first { $0.probe == .autoToolChoice }?.detail
+                    .contains("contains no chat-template content") == true
+            )
             #expect(artifact.classification == .failed)
         }
     }

--- a/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
@@ -7,17 +7,20 @@ private actor ScriptedVerificationEngine: LocalModelVerificationEngine {
     private var transcripts: [LocalModelLiveProbeTranscript]
     private let cancellationOutcome: LocalModelCancellationProbeOutcome
     private let onFirstGenerate: (@Sendable () -> Void)?
+    private let throwCancellationAtRequest: Int?
     private var didRunFirstGenerate = false
     private(set) var requests: [LocalModelLiveProbeRequest] = []
 
     init(
         transcripts: [LocalModelLiveProbeTranscript],
         cancellationOutcome: LocalModelCancellationProbeOutcome = .passed,
-        onFirstGenerate: (@Sendable () -> Void)? = nil
+        onFirstGenerate: (@Sendable () -> Void)? = nil,
+        throwCancellationAtRequest: Int? = nil
     ) {
         self.transcripts = transcripts
         self.cancellationOutcome = cancellationOutcome
         self.onFirstGenerate = onFirstGenerate
+        self.throwCancellationAtRequest = throwCancellationAtRequest
     }
 
     func generate(
@@ -26,6 +29,9 @@ private actor ScriptedVerificationEngine: LocalModelVerificationEngine {
         request: LocalModelLiveProbeRequest
     ) async throws -> LocalModelLiveProbeTranscript {
         requests.append(request)
+        if requests.count == throwCancellationAtRequest {
+            throw CancellationError()
+        }
         if !didRunFirstGenerate {
             didRunFirstGenerate = true
             onFirstGenerate?()
@@ -75,6 +81,7 @@ struct LocalModelVerificationWorkbenchTests {
             probe: probe,
             status: status,
             detail: "fixture",
+            errorCode: nil,
             tokenCount: probe == .throughput ? 8 : nil,
             tokensPerSecond: tokensPerSecond,
             stopReason: probe == .stopAndEOS ? "eos" : nil
@@ -294,6 +301,41 @@ struct LocalModelVerificationWorkbenchTests {
         }
     }
 
+    @Test func inspectorPinsResolvedHuggingFaceContentAgainstSymlinkRetarget() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hf-retarget-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let repository = root.appendingPathComponent("models--org--repo", isDirectory: true)
+        let blobs = repository.appendingPathComponent("blobs", isDirectory: true)
+        let snapshot = repository.appendingPathComponent("snapshots/revision", isDirectory: true)
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        let firstBlob = blobs.appendingPathComponent("first")
+        let secondBlob = blobs.appendingPathComponent("second")
+        try Data("first".utf8).write(to: firstBlob)
+        try Data("other".utf8).write(to: secondBlob)
+        let weight = snapshot.appendingPathComponent("model.safetensors")
+        try FileManager.default.createSymbolicLink(
+            atPath: weight.path, withDestinationPath: "../../blobs/first"
+        )
+        let expected = try LocalModelBundleInspector.inspect(directory: snapshot)
+
+        var checks = 0
+        let pinned = try LocalModelBundleInspector.inspect(directory: snapshot) {
+            checks += 1
+            if checks == 2 {
+                try FileManager.default.removeItem(at: weight)
+                try FileManager.default.createSymbolicLink(
+                    atPath: weight.path, withDestinationPath: "../../blobs/second"
+                )
+            }
+        }
+        #expect(pinned.digest == expected.digest)
+        #expect(pinned.stateFingerprint == expected.stateFingerprint)
+        #expect(try LocalModelBundleInspector.currentStateFingerprint(directory: snapshot)
+            != expected.stateFingerprint)
+    }
+
     @Test func completeToolSequenceProducesProvenArtifactAndIntegratesRegistryAndLedger() async throws {
         let engine = ScriptedVerificationEngine(transcripts: [
             transcript(),
@@ -321,10 +363,14 @@ struct LocalModelVerificationWorkbenchTests {
             )
             #expect(record["verificationClassification"] as? String == "proven")
             #expect((record["verificationDigest"] as? String)?.hasPrefix("sha256:") == true)
-            #expect(record["verificationArtifactPath"] as? String == url.path)
+            let recordedPath = try #require(record["verificationArtifactPath"] as? String)
+            #expect(recordedPath.hasPrefix("model-verification/"))
+            #expect(!recordedPath.hasPrefix("/"))
+            #expect(!recordedPath.contains(NSHomeDirectory()))
 
             let requests = await engine.capturedRequests()
             #expect(requests.count == 4)
+            #expect(requests[1].toolChoice == .auto)
             #expect(requests[2].messages.contains { $0.role == "tool" && $0.content?.contains("21") == true })
             #expect(requests[3].messages.contains { $0.role == "tool" })
         }
@@ -339,7 +385,9 @@ struct LocalModelVerificationWorkbenchTests {
             #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .error)
             #expect(artifact.probes.first { $0.probe == .toolResultContinuation }?.status == .blocked)
             #expect(artifact.probes.first { $0.probe == .markerLeakage }?.status == .blocked)
-            #expect(registry.list().first?.counts.errored == 2)
+            #expect(artifact.probes.first { $0.probe == .generation }?.errorCode == "runtime_probe_failed")
+            #expect(!artifact.probes.contains { $0.detail.contains(NSHomeDirectory()) })
+            #expect(registry.list().first?.counts.errored == 3)
         }
     }
 
@@ -348,7 +396,10 @@ struct LocalModelVerificationWorkbenchTests {
         try await withEnvironment(engine: engine, template: false) { service, model, _, _ in
             let (artifact, _) = try await service.verify(model: model)
             #expect(artifact.bundle.templateFallback != nil)
-            #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .error)
+            #expect(artifact.probes.first { $0.probe == .autoToolChoice }?.status == .blocked)
+            #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .blocked)
+            #expect(artifact.probes.first { $0.probe == .toolResultContinuation }?.status == .blocked)
+            #expect(artifact.probes.first { $0.probe == .secondToolCall }?.status == .blocked)
             #expect(artifact.classification == .failed)
         }
     }
@@ -392,25 +443,71 @@ struct LocalModelVerificationWorkbenchTests {
     }
 
     @Test func cancellationHandshakeRequiresObservedInFlightGeneration() async {
-        let passed = await LocalModelCancellationHandshake.run(timeout: .seconds(1)) { started in
+        let passed = await LocalModelCancellationHandshake.run(
+            startTimeout: .seconds(1), terminationTimeout: .seconds(1)
+        ) { started in
             started()
             try await Task.sleep(for: .seconds(30))
         }
         #expect(passed == .passed)
 
-        let blocked = await LocalModelCancellationHandshake.run(timeout: .milliseconds(20)) { _ in }
+        let blocked = await LocalModelCancellationHandshake.run(
+            startTimeout: .milliseconds(20)
+        ) { _ in }
         guard case .blocked = blocked else {
             Issue.record("A request that never starts must remain blocked")
             return
         }
 
-        let completed = await LocalModelCancellationHandshake.run(timeout: .seconds(1)) { started in
+        let completed = await LocalModelCancellationHandshake.run(
+            startTimeout: .seconds(1)
+        ) { started in
             started()
         }
-        guard case .failed = completed else {
+        guard case .blocked = completed else {
+            Issue.record("Completion before a generated delta must remain blocked")
+            return
+        }
+    }
+
+    @Test func cancellationHandshakeRejectsNonCooperativeAndPostCancelStreams() async {
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let nonCooperative = await LocalModelCancellationHandshake.run(
+            startTimeout: .seconds(1), terminationTimeout: .milliseconds(25)
+        ) { observed in
+            observed()
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                    continuation.resume()
+                }
+            }
+        }
+        #expect(nonCooperative == .failed("cancellation_stream_termination_timeout"))
+        #expect(startedAt.duration(to: clock.now) < .milliseconds(250))
+
+        let postCancel = await LocalModelCancellationHandshake.run(
+            startTimeout: .seconds(1), terminationTimeout: .seconds(1)
+        ) { observed in
+            observed()
+            do {
+                try await Task.sleep(for: .seconds(30))
+            } catch is CancellationError {
+                observed()
+            }
+        }
+        #expect(postCancel == .failed("cancellation_stream_emitted_after_cancel"))
+
+        let preYieldFailure = await LocalModelCancellationHandshake.run(
+            startTimeout: .seconds(1)
+        ) { _ in
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        guard case .failed(let code) = preYieldFailure else {
             Issue.record("Completion without cancellation acknowledgement must fail")
             return
         }
+        #expect(code.hasPrefix("cancellation_stream_start_runtime_stream_error_"))
     }
 
     @Test func publicationGuardRejectsCancelledAndReplacedRuns() {
@@ -487,6 +584,59 @@ struct LocalModelVerificationWorkbenchTests {
             let (artifact, _) = try await service.verify(model: model)
             #expect(artifact.probes.first { $0.probe == .reasoning }?.status == .unsupported)
             #expect(artifact.classification == .proven)
+            #expect(!artifact.nonPassingEvidence.contains { $0.probe == .reasoning })
+        }
+    }
+
+    @Test func reasoningErrorAndReasoningMarkerLeakCannotBeProven() async throws {
+        let errorEngine = ScriptedVerificationEngine(transcripts: [transcript()])
+        try await withEnvironment(engine: errorEngine, reasoning: true) { service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.probes.first { $0.probe == .reasoning }?.status == .error)
+            #expect(artifact.classification != .proven)
+        }
+
+        let markerEngine = ScriptedVerificationEngine(transcripts: [
+            transcript(),
+            transcript(visible: "4", reasoning: "<|recipient|> hidden"),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+            transcript(visible: "Paris is 21 C."),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+        ])
+        try await withEnvironment(engine: markerEngine, reasoning: true) { service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.probes.first { $0.probe == .markerLeakage }?.status == .failed)
+            #expect(artifact.classification == .failed)
+        }
+    }
+
+    @Test func continuationGroundingRejectsUnrelatedAndEmbeddedNumbers() async throws {
+        for answer in ["Paris temperature is 2100 C.", "Paris has 21 people; temperature unavailable."] {
+            let engine = ScriptedVerificationEngine(transcripts: [
+                transcript(),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+                transcript(visible: answer),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+            ])
+            try await withEnvironment(engine: engine) { service, model, _, _ in
+                let (artifact, _) = try await service.verify(model: model)
+                #expect(artifact.probes.first { $0.probe == .toolResultContinuation }?.status == .failed)
+                #expect(artifact.classification == .failed)
+            }
+        }
+    }
+
+    @Test func cancellationNeverPublishesPartialEvidence() async throws {
+        let engine = ScriptedVerificationEngine(
+            transcripts: [transcript()], throwCancellationAtRequest: 1
+        )
+        try await withEnvironment(engine: engine) { service, model, registry, ledgerURL in
+            await #expect(throws: CancellationError.self) {
+                try await service.verify(model: model)
+            }
+            #expect(await service.latest(modelId: model.id) == nil)
+            #expect(registry.list().isEmpty)
+            #expect(!FileManager.default.fileExists(atPath: ledgerURL.path))
         }
     }
 
@@ -607,6 +757,14 @@ struct LocalModelVerificationWorkbenchTests {
                     measuredAt: "now", for: "org/model"
                 )
             }
+            #expect(throws: (any Error).self) {
+                try ModelCapabilityLedger.saveVerification(
+                    classification: .proven,
+                    digest: "sha256:" + String(repeating: "z", count: 64),
+                    artifactPath: "model-verification/a.json",
+                    measuredAt: "now", for: "org/model"
+                )
+            }
             try ModelCapabilityLedger.saveVerification(
                 classification: .partial,
                 digest: "sha256:" + String(repeating: "b", count: 64),
@@ -637,6 +795,89 @@ struct LocalModelVerificationWorkbenchTests {
                     as? NSNumber
             ).intValue
             #expect(permissions & 0o777 == 0o600)
+        }
+    }
+
+    @Test func corruptLedgerIsNotSilentlyReplaced() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ledger-corrupt-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("ledger.json")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let corrupt = Data("{not-json".utf8)
+        try corrupt.write(to: url)
+        ModelCapabilityLedger.$fileURLOverrideForTests.withValue(url) {
+            #expect(throws: (any Error).self) {
+                try ModelCapabilityLedger.save(
+                    record: .init(source: "fixture"), for: "org/model"
+                )
+            }
+            #expect(throws: (any Error).self) {
+                try ModelCapabilityLedger.saveVerification(
+                    classification: .partial,
+                    digest: "sha256:" + String(repeating: "a", count: 64),
+                    artifactPath: "model-verification/a.json",
+                    measuredAt: "now", for: "org/model"
+                )
+            }
+            #expect((try? Data(contentsOf: url)) == corrupt)
+        }
+    }
+
+    @Test func concurrentLedgerWritersPreserveServingAndVerificationRecords() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ledger-concurrent-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("ledger.json")
+        try await ModelCapabilityLedger.$fileURLOverrideForTests.withValue(url) {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for index in 0..<12 {
+                    group.addTask {
+                        try ModelCapabilityLedger.save(
+                            record: .init(source: "serving-\(index)"),
+                            for: "org/serving-\(index)"
+                        )
+                    }
+                    group.addTask {
+                        try ModelCapabilityLedger.saveVerification(
+                            classification: .partial,
+                            digest: "sha256:" + String(repeating: "a", count: 64),
+                            artifactPath: "model-verification/\(index).json",
+                            measuredAt: "now", for: "org/verification-\(index)"
+                        )
+                    }
+                }
+                try await group.waitForAll()
+            }
+            let raw = try #require(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+            )
+            for index in 0..<12 {
+                #expect(raw["org/serving_\(index)"] != nil)
+                #expect(raw[ModelCapabilityLedger.verificationStorageKey(
+                    "org/verification-\(index)"
+                )] != nil)
+            }
+        }
+    }
+
+    @Test func loadingValidatedArtifactReRegistersRestartEvidence() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [
+            transcript(),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+            transcript(visible: "Paris is 21 C."),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+        ])
+        try await withEnvironment(engine: engine) { service, model, _, _ in
+            _ = try await service.verify(model: model)
+            let restartedRegistry = EvidenceReportRegistryService()
+            let restarted = LocalModelVerificationService(
+                engine: ScriptedVerificationEngine(transcripts: []),
+                store: LocalModelVerificationArtifactStore(),
+                registry: restartedRegistry
+            )
+            #expect(await restarted.latest(modelId: model.id) != nil)
+            #expect(restartedRegistry.list().count == 1)
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
@@ -1,0 +1,810 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+private actor ScriptedVerificationEngine: LocalModelVerificationEngine {
+    private var transcripts: [LocalModelLiveProbeTranscript]
+    private let cancellationOutcome: LocalModelCancellationProbeOutcome
+    private let onFirstGenerate: (@Sendable () -> Void)?
+    private var didRunFirstGenerate = false
+    private(set) var requests: [LocalModelLiveProbeRequest] = []
+
+    init(
+        transcripts: [LocalModelLiveProbeTranscript],
+        cancellationOutcome: LocalModelCancellationProbeOutcome = .passed,
+        onFirstGenerate: (@Sendable () -> Void)? = nil
+    ) {
+        self.transcripts = transcripts
+        self.cancellationOutcome = cancellationOutcome
+        self.onFirstGenerate = onFirstGenerate
+    }
+
+    func generate(
+        modelId: String,
+        modelName: String,
+        request: LocalModelLiveProbeRequest
+    ) async throws -> LocalModelLiveProbeTranscript {
+        requests.append(request)
+        if !didRunFirstGenerate {
+            didRunFirstGenerate = true
+            onFirstGenerate?()
+        }
+        guard !transcripts.isEmpty else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return transcripts.removeFirst()
+    }
+
+    func probeCancellation(modelId: String, modelName: String) async -> LocalModelCancellationProbeOutcome {
+        cancellationOutcome
+    }
+
+    func capturedRequests() -> [LocalModelLiveProbeRequest] { requests }
+}
+
+struct LocalModelVerificationWorkbenchTests {
+    private let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func transcript(
+        visible: String = "READY",
+        reasoning: String = "",
+        tool: String? = nil,
+        arguments: String? = nil,
+        tps: Double = 12,
+        stop: String = "eos"
+    ) -> LocalModelLiveProbeTranscript {
+        LocalModelLiveProbeTranscript(
+            visibleText: visible,
+            reasoningText: reasoning,
+            toolName: tool,
+            toolArguments: arguments,
+            tokenCount: 8,
+            tokensPerSecond: tps,
+            stopReason: stop,
+            unclosedReasoning: false
+        )
+    }
+
+    private func evidenceRow(
+        _ probe: LocalModelVerificationProbe,
+        status: LocalModelVerificationProbeStatus = .passed,
+        tokensPerSecond: Double? = nil
+    ) -> LocalModelVerificationProbeResult {
+        LocalModelVerificationProbeResult(
+            probe: probe,
+            status: status,
+            detail: "fixture",
+            tokenCount: probe == .throughput ? 8 : nil,
+            tokensPerSecond: tokensPerSecond,
+            stopReason: probe == .stopAndEOS ? "eos" : nil
+        )
+    }
+
+    private func completeEvidenceRows(tokensPerSecond: Double = 12) -> [LocalModelVerificationProbeResult] {
+        LocalModelVerificationAuthority.requiredProbes.map { probe in
+            evidenceRow(
+                probe,
+                tokensPerSecond: probe == .throughput ? tokensPerSecond : nil
+            )
+        }
+    }
+
+    private func storedArtifact(
+        modelId: String,
+        digestCharacter: Character,
+        classification: LocalModelVerificationClassification = .proven
+    ) -> LocalModelVerificationArtifact {
+        LocalModelVerificationArtifact(
+            schemaVersion: LocalModelVerificationArtifact.currentSchemaVersion,
+            modelId: modelId,
+            modelName: modelId,
+            bundle: LocalModelBundleEvidence(
+                digest: "sha256:" + String(repeating: digestCharacter, count: 64),
+                stateFingerprint: "sha256:" + String(repeating: digestCharacter, count: 64),
+                fileCount: 1,
+                byteCount: 1,
+                templateSource: "bundle:test",
+                templateFallback: nil,
+                parserFormat: "fixture",
+                generationDefaults: [:],
+                reasoningDeclared: false,
+                vmlxRevision: nil,
+                vmlxRevisionSource: LocalModelBundleInspector.vmlxRevisionSource
+            ),
+            classification: classification,
+            startedAt: fixedDate,
+            completedAt: fixedDate,
+            probes: classification == .proven ? completeEvidenceRows() : []
+        )
+    }
+
+    private func makeBundle(
+        root: URL,
+        reasoning: Bool = false,
+        template: Bool = true
+    ) throws -> MLXModel {
+        let bundle = root.appendingPathComponent("fixture", isDirectory: true)
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        try Data(#"{"model_type":"fixture"}"#.utf8).write(
+            to: bundle.appendingPathComponent("config.json"))
+        let tokenizer = template
+            ? (reasoning
+                ? #"{"chat_template":"{% if enable_thinking %}<think>{% endif %}{{ messages }}","tool_call_parser":"fixture"}"#
+                : #"{"chat_template":"{{ messages }}","tool_call_parser":"fixture"}"#)
+            : #"{"tokenizer_class":"FixtureTokenizer"}"#
+        try Data(tokenizer.utf8).write(to: bundle.appendingPathComponent("tokenizer_config.json"))
+        let generation = reasoning
+            ? #"{"top_k":20,"enable_thinking":true}"#
+            : #"{"top_k":20}"#
+        try Data(generation.utf8).write(to: bundle.appendingPathComponent("generation_config.json"))
+        if reasoning && !template {
+            try Data(#"{"chat":{"reasoning":{"supported":true}}}"#.utf8).write(
+                to: bundle.appendingPathComponent("jang_config.json")
+            )
+        }
+        try Data("weights".utf8).write(to: bundle.appendingPathComponent("model.safetensors"))
+        return MLXModel(
+            id: "org/fixture", name: "Fixture", description: "", downloadURL: "",
+            bundleDirectory: bundle
+        )
+    }
+
+    private func withEnvironment<T>(
+        engine: ScriptedVerificationEngine,
+        reasoning: Bool = false,
+        template: Bool = true,
+        _ body: (LocalModelVerificationService, MLXModel, EvidenceReportRegistryService, URL) async throws -> T
+    ) async throws -> T {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("verification-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = try makeBundle(root: root, reasoning: reasoning, template: template)
+        let artifactDirectory = root.appendingPathComponent("artifacts", isDirectory: true)
+        let ledgerURL = root.appendingPathComponent("model-ledger.json")
+        let store = LocalModelVerificationArtifactStore()
+        let registry = EvidenceReportRegistryService(now: { self.fixedDate })
+        let service = LocalModelVerificationService(
+            engine: engine, store: store, registry: registry, now: { self.fixedDate }
+        )
+        return try await LocalModelVerificationArtifactStore.$directoryOverrideForTests
+            .withValue(artifactDirectory) {
+                try await ModelCapabilityLedger.$fileURLOverrideForTests.withValue(ledgerURL) {
+                    try await body(service, model, registry, ledgerURL)
+                }
+            }
+    }
+
+    @Test func artifactSchemaRoundTripsAndDigestStalenessIsExact() throws {
+        let bundle = LocalModelBundleEvidence(
+            digest: "sha256:" + String(repeating: "a", count: 64),
+            stateFingerprint: "sha256:" + String(repeating: "c", count: 64),
+            fileCount: 2, byteCount: 4,
+            templateSource: "bundle:tokenizer_config.json", templateFallback: nil,
+            parserFormat: "fixture", generationDefaults: ["top_k": "20"],
+            reasoningDeclared: false,
+            vmlxRevision: nil,
+            vmlxRevisionSource: LocalModelBundleInspector.vmlxRevisionSource
+        )
+        let artifact = LocalModelVerificationArtifact(
+            schemaVersion: LocalModelVerificationArtifact.currentSchemaVersion,
+            modelId: "org/model", modelName: "Model", bundle: bundle,
+            classification: .unproven, startedAt: fixedDate, completedAt: fixedDate,
+            probes: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            LocalModelVerificationArtifact.self,
+            from: encoder.encode(artifact)
+        )
+        #expect(decoded == artifact)
+        #expect(!decoded.isStale(currentDigest: bundle.digest))
+        #expect(decoded.isStale(currentDigest: "sha256:" + String(repeating: "b", count: 64)))
+        #expect(decoded.isStale(currentDigest: nil))
+        #expect(!decoded.isStale(currentStateFingerprint: bundle.stateFingerprint))
+        #expect(decoded.isStale(currentStateFingerprint: nil))
+    }
+
+    @Test func evidenceAuthorityRejectsEmptyIncompleteDuplicateAndZeroThroughputRows() {
+        #expect(LocalModelVerificationAuthority.classify([]) == .unproven)
+
+        let incomplete = [evidenceRow(.generation)]
+        #expect(LocalModelVerificationAuthority.classify(incomplete) == .partial)
+
+        var duplicate = completeEvidenceRows()
+        duplicate.append(evidenceRow(.generation))
+        #expect(LocalModelVerificationAuthority.classify(duplicate) != .proven)
+
+        let zeroThroughput = completeEvidenceRows(tokensPerSecond: 0)
+        #expect(LocalModelVerificationAuthority.classify(zeroThroughput) == .failed)
+
+        let missingThroughput = completeEvidenceRows().filter { $0.probe != .throughput }
+        #expect(LocalModelVerificationAuthority.classify(missingThroughput) != .proven)
+        #expect(LocalModelVerificationAuthority.classify(completeEvidenceRows()) == .proven)
+    }
+
+    @Test func exactDigestChangesWithFileContentAndRejectsSymlinks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bundle-inspector-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let file = root.appendingPathComponent("weights.safetensors")
+        try Data("one".utf8).write(to: file)
+        let first = try LocalModelBundleInspector.inspect(directory: root)
+        let originalDate = try #require(
+            try file.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        )
+        try Data("two".utf8).write(to: file)
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: file.path
+        )
+        let second = try LocalModelBundleInspector.inspect(directory: root)
+        let changedValues = try file.resourceValues(forKeys: [
+            .fileSizeKey, .contentModificationDateKey,
+        ])
+        #expect(first.digest != second.digest)
+        #expect(changedValues.fileSize == 3)
+        let restoredDate = changedValues.contentModificationDate ?? .distantPast
+        #expect(abs(restoredDate.timeIntervalSince(originalDate)) < 0.001)
+        let artifact = LocalModelVerificationArtifact(
+            schemaVersion: LocalModelVerificationArtifact.currentSchemaVersion,
+            modelId: "org/model", modelName: "Model", bundle: first,
+            classification: .proven, startedAt: fixedDate, completedAt: fixedDate, probes: []
+        )
+        #expect(artifact.isStale(currentDigest: second.digest))
+        #expect(first.templateFallback != nil)
+
+        let link = root.appendingPathComponent("unsafe-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
+        #expect(throws: LocalModelBundleInspector.InspectionError.self) {
+            try LocalModelBundleInspector.inspect(directory: root)
+        }
+    }
+
+    @Test func inspectorAllowsOnlyContainedHuggingFaceBlobSymlinks() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hf-symlink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let repository = root.appendingPathComponent("models--org--repo", isDirectory: true)
+        let blobs = repository.appendingPathComponent("blobs", isDirectory: true)
+        let snapshot = repository.appendingPathComponent("snapshots/revision", isDirectory: true)
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        let blob = blobs.appendingPathComponent("config-blob")
+        try Data(#"{"model_type":"fixture"}"#.utf8).write(to: blob)
+        let config = snapshot.appendingPathComponent("config.json")
+        try FileManager.default.createSymbolicLink(
+            atPath: config.path,
+            withDestinationPath: "../../blobs/config-blob"
+        )
+        let accepted = try LocalModelBundleInspector.inspect(directory: snapshot)
+        #expect(accepted.fileCount == 1)
+        #expect(accepted.byteCount > 0)
+
+        let outside = root.appendingPathComponent("outside")
+        try Data("outside".utf8).write(to: outside)
+        let escaping = snapshot.appendingPathComponent("escaping")
+        try FileManager.default.createSymbolicLink(at: escaping, withDestinationURL: outside)
+        #expect(throws: LocalModelBundleInspector.InspectionError.self) {
+            try LocalModelBundleInspector.inspect(directory: snapshot)
+        }
+    }
+
+    @Test func completeToolSequenceProducesProvenArtifactAndIntegratesRegistryAndLedger() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [
+            transcript(),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+            transcript(visible: "Paris is 21 C."),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+        ])
+        try await withEnvironment(engine: engine) { service, model, registry, ledgerURL in
+            let (artifact, url) = try await service.verify(model: model)
+            #expect(artifact.classification == .proven)
+            #expect(artifact.schemaVersion == LocalModelVerificationArtifact.currentSchemaVersion)
+            #expect(FileManager.default.fileExists(atPath: url.path))
+            let permissions = try #require(
+                try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+            ).intValue
+            #expect(permissions & 0o777 == 0o600)
+            #expect(Set(artifact.probes.map(\.probe)) == Set(LocalModelVerificationProbe.allCases))
+            #expect(registry.list().count == 1)
+            #expect(registry.list().first?.status == .passed)
+
+            let raw = try #require(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: ledgerURL)) as? [String: Any])
+            let record = try #require(
+                raw[ModelCapabilityLedger.verificationStorageKey("org/fixture")] as? [String: Any]
+            )
+            #expect(record["verificationClassification"] as? String == "proven")
+            #expect((record["verificationDigest"] as? String)?.hasPrefix("sha256:") == true)
+            #expect(record["verificationArtifactPath"] as? String == url.path)
+
+            let requests = await engine.capturedRequests()
+            #expect(requests.count == 4)
+            #expect(requests[2].messages.contains { $0.role == "tool" && $0.content?.contains("21") == true })
+            #expect(requests[3].messages.contains { $0.role == "tool" })
+        }
+    }
+
+    @Test func engineErrorsRemainExplicitAndClassifyFailed() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [])
+        try await withEnvironment(engine: engine) { service, model, registry, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.classification == .failed)
+            #expect(artifact.probes.first { $0.probe == .generation }?.status == .error)
+            #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .error)
+            #expect(artifact.probes.first { $0.probe == .toolResultContinuation }?.status == .blocked)
+            #expect(artifact.probes.first { $0.probe == .markerLeakage }?.status == .blocked)
+            #expect(registry.list().first?.counts.errored == 2)
+        }
+    }
+
+    @Test func templateFallbackCannotHideToolFailure() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [])
+        try await withEnvironment(engine: engine, template: false) { service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.bundle.templateFallback != nil)
+            #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .error)
+            #expect(artifact.classification == .failed)
+        }
+    }
+
+    @Test func cancelledStopReasonDoesNotCountAsNaturalEOS() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [
+            transcript(stop: "cancelled"),
+            transcript(
+                visible: "", tool: "city_temperature",
+                arguments: #"{"city":"Paris"}"#, stop: "cancelled"
+            ),
+            transcript(visible: "Paris is 21 C.", stop: "cancelled"),
+            transcript(
+                visible: "", tool: "city_temperature",
+                arguments: #"{"city":"Berlin"}"#, stop: "cancelled"
+            ),
+        ])
+        try await withEnvironment(engine: engine) { service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.probes.first { $0.probe == .stopAndEOS }?.status == .failed)
+            #expect(artifact.classification == .failed)
+        }
+    }
+
+    @Test func markerLeakAndCancellationFailureCannotBePromoted() async throws {
+        let engine = ScriptedVerificationEngine(
+            transcripts: [
+                transcript(visible: "READY <tool_call>"),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+                transcript(visible: "Paris is 21 C."),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+            ],
+            cancellationOutcome: .failed("fixture rejected cancellation")
+        )
+        try await withEnvironment(engine: engine) { service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.classification == .failed)
+            #expect(artifact.probes.first { $0.probe == .markerLeakage }?.status == .failed)
+            #expect(artifact.probes.first { $0.probe == .cancellation }?.status == .failed)
+        }
+    }
+
+    @Test func cancellationHandshakeRequiresObservedInFlightGeneration() async {
+        let passed = await LocalModelCancellationHandshake.run(timeout: .seconds(1)) { started in
+            started()
+            try await Task.sleep(for: .seconds(30))
+        }
+        #expect(passed == .passed)
+
+        let blocked = await LocalModelCancellationHandshake.run(timeout: .milliseconds(20)) { _ in }
+        guard case .blocked = blocked else {
+            Issue.record("A request that never starts must remain blocked")
+            return
+        }
+
+        let completed = await LocalModelCancellationHandshake.run(timeout: .seconds(1)) { started in
+            started()
+        }
+        guard case .failed = completed else {
+            Issue.record("Completion without cancellation acknowledgement must fail")
+            return
+        }
+    }
+
+    @Test func publicationGuardRejectsCancelledAndReplacedRuns() {
+        var guardState = LocalModelVerificationPublicationGuard()
+        let first = guardState.begin(modelId: "org/first")
+        #expect(guardState.permits(first, currentModelId: "org/first"))
+        guardState.invalidate()
+        #expect(!guardState.permits(first, currentModelId: "org/first"))
+
+        let second = guardState.begin(modelId: "org/second")
+        #expect(!guardState.permits(second, currentModelId: "org/first"))
+        #expect(guardState.permits(second, currentModelId: "org/second"))
+    }
+
+    @Test func bundleMutationDuringVerificationCannotPublishEvidence() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("verification-mutation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = try makeBundle(root: root)
+        let weightURL = model.localDirectory.appendingPathComponent("model.safetensors")
+        let engine = ScriptedVerificationEngine(
+            transcripts: [
+                transcript(),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+                transcript(visible: "Paris is 21 C."),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+            ],
+            onFirstGenerate: {
+                try? Data("changed".utf8).write(to: weightURL)
+            }
+        )
+        let artifactDirectory = root.appendingPathComponent("artifacts", isDirectory: true)
+        let service = LocalModelVerificationService(
+            engine: engine,
+            store: LocalModelVerificationArtifactStore(),
+            registry: EvidenceReportRegistryService(),
+            now: { self.fixedDate }
+        )
+        await LocalModelVerificationArtifactStore.$directoryOverrideForTests
+            .withValue(artifactDirectory) {
+                await #expect(throws: LocalModelVerificationService.VerificationError.self) {
+                    try await service.verify(model: model)
+                }
+                #expect(await service.latest(modelId: model.id) == nil)
+            }
+    }
+
+    @Test func reasoningAndTemplateFallbackAreHonestEvidenceRows() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [
+            transcript(),
+            transcript(visible: "4", reasoning: "bounded thought"),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+            transcript(visible: "Paris is 21 C."),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+        ])
+        try await withEnvironment(engine: engine, reasoning: true, template: false) {
+            service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.bundle.templateFallback != nil)
+            #expect(artifact.probes.first { $0.probe == .reasoning }?.status == .passed)
+            #expect(artifact.probes.first { $0.probe == .schemaValidToolCall }?.status == .blocked)
+            #expect(artifact.classification == .partial)
+        }
+    }
+
+    @Test func unsupportedReasoningIsSeparateFromFailure() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [
+            transcript(),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+            transcript(visible: "Paris is 21 C."),
+            transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+        ])
+        try await withEnvironment(engine: engine) { service, model, _, _ in
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.probes.first { $0.probe == .reasoning }?.status == .unsupported)
+            #expect(artifact.classification == .proven)
+        }
+    }
+
+    @Test func storeRejectsConcurrentVerificationAndUsesAtomicPrivateArtifact() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("artifact-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = LocalModelVerificationArtifactStore()
+        try await LocalModelVerificationArtifactStore.$directoryOverrideForTests.withValue(root) {
+            try await store.begin(modelId: "org/model")
+            await #expect(throws: (any Error).self) {
+                try await store.begin(modelId: "org/model")
+            }
+            await store.end(modelId: "org/model")
+            try await store.begin(modelId: "org/model")
+            await store.end(modelId: "org/model")
+        }
+    }
+
+    @Test func artifactStorageSeparatesCollidingNormalizedIdsAndRejectsCrossBoundContent() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("artifact-collision-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = LocalModelVerificationArtifactStore()
+        let hyphen = storedArtifact(modelId: "org/foo-bar", digestCharacter: "a")
+        let underscore = storedArtifact(modelId: "org/foo_bar", digestCharacter: "b")
+
+        try await LocalModelVerificationArtifactStore.$directoryOverrideForTests.withValue(root) {
+            let hyphenURL = try await store.save(hyphen)
+            let underscoreURL = try await store.save(underscore)
+            #expect(hyphenURL.deletingLastPathComponent() != underscoreURL.deletingLastPathComponent())
+            #expect(await store.latest(modelId: hyphen.modelId)?.artifact.modelId == hyphen.modelId)
+            #expect(await store.latest(modelId: underscore.modelId)?.artifact.modelId == underscore.modelId)
+
+            try Data(contentsOf: hyphenURL).write(to: underscoreURL, options: .atomic)
+            #expect(await store.latest(modelId: underscore.modelId) == nil)
+            #expect(await store.latest(modelId: hyphen.modelId)?.artifact.bundle.digest == hyphen.bundle.digest)
+        }
+    }
+
+    @Test func ledgerFailureRollsBackArtifactAndRegistryPublication() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("artifact-rollback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = try makeBundle(root: root)
+        let artifactDirectory = root.appendingPathComponent("artifacts", isDirectory: true)
+        let ledgerURL = root.appendingPathComponent("model-ledger.json")
+        let registry = EvidenceReportRegistryService()
+        let service = LocalModelVerificationService(
+            engine: ScriptedVerificationEngine(transcripts: [
+                transcript(),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Paris"}"#),
+                transcript(visible: "Paris is 21 C."),
+                transcript(visible: "", tool: "city_temperature", arguments: #"{"city":"Berlin"}"#),
+            ]),
+            store: LocalModelVerificationArtifactStore(),
+            registry: registry,
+            now: { self.fixedDate }
+        )
+
+        await LocalModelVerificationArtifactStore.$directoryOverrideForTests
+            .withValue(artifactDirectory) {
+                await ModelCapabilityLedger.$fileURLOverrideForTests.withValue(ledgerURL) {
+                    await ModelCapabilityLedger.$failVerificationWriteForTests.withValue(true) {
+                        await #expect(throws: (any Error).self) {
+                            try await service.verify(model: model)
+                        }
+                        #expect(await service.latest(modelId: model.id) == nil)
+                        #expect(registry.list().isEmpty)
+                    }
+                }
+            }
+    }
+
+    @Test func artifactStoreIgnoresUnknownSchemaVersions() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("verification-schema-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = LocalModelVerificationArtifactStore()
+        let artifact = LocalModelVerificationArtifact(
+            schemaVersion: LocalModelVerificationArtifact.currentSchemaVersion + 1,
+            modelId: "org/model", modelName: "Model",
+            bundle: LocalModelBundleEvidence(
+                digest: "sha256:" + String(repeating: "a", count: 64),
+                stateFingerprint: "sha256:" + String(repeating: "b", count: 64),
+                fileCount: 1, byteCount: 1, templateSource: "bundle:test",
+                templateFallback: nil, parserFormat: nil, generationDefaults: [:],
+                reasoningDeclared: false,
+                vmlxRevision: nil,
+                vmlxRevisionSource: LocalModelBundleInspector.vmlxRevisionSource
+            ),
+            classification: .unproven, startedAt: fixedDate, completedAt: fixedDate,
+            probes: []
+        )
+        try await LocalModelVerificationArtifactStore.$directoryOverrideForTests.withValue(root) {
+            _ = try await store.save(artifact)
+            let latest = await store.latest(modelId: artifact.modelId)
+            #expect(latest == nil)
+        }
+    }
+
+    @Test func ledgerRejectsEvidenceWithoutFullDigestAndPreservesExistingFields() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ledger-verification-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("ledger.json")
+        try ModelCapabilityLedger.$fileURLOverrideForTests.withValue(url) {
+            try ModelCapabilityLedger.save(
+                record: .init(
+                    productionServing: .fail, blockReason: "existing", source: "gauntlet",
+                    digest: "sha256:" + String(repeating: "a", count: 64)
+                ),
+                for: "org/model"
+            )
+            #expect(throws: (any Error).self) {
+                try ModelCapabilityLedger.saveVerification(
+                    classification: .proven, digest: "model-name", artifactPath: "/tmp/a",
+                    measuredAt: "now", for: "org/model"
+                )
+            }
+            try ModelCapabilityLedger.saveVerification(
+                classification: .partial,
+                digest: "sha256:" + String(repeating: "b", count: 64),
+                artifactPath: "/tmp/evidence.json", measuredAt: "now", for: "org/model"
+            )
+            let raw = try #require(
+                try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+            let servingRecord = try #require(raw["org/model"] as? [String: Any])
+            let verificationRecord = try #require(
+                raw[ModelCapabilityLedger.verificationStorageKey("org/model")] as? [String: Any]
+            )
+            #expect(servingRecord["productionServing"] as? String == "fail")
+            #expect(servingRecord["blockReason"] as? String == "existing")
+            #expect(servingRecord["source"] as? String == "gauntlet")
+            #expect(
+                servingRecord["digest"] as? String
+                    == "sha256:" + String(repeating: "a", count: 64)
+            )
+            #expect(verificationRecord["verificationModelId"] as? String == "org/model")
+            #expect(verificationRecord["verificationClassification"] as? String == "partial")
+            #expect(
+                verificationRecord["verificationDigest"] as? String
+                    == "sha256:" + String(repeating: "b", count: 64)
+            )
+            #expect(verificationRecord["verificationMeasuredAt"] as? String == "now")
+            let permissions = try #require(
+                try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions]
+                    as? NSNumber
+            ).intValue
+            #expect(permissions & 0o777 == 0o600)
+        }
+    }
+}
+
+@Suite(
+    "Live local model verification",
+    .enabled(if: ProcessInfo.processInfo.environment["OSAURUS_LIVE_MODEL_VERIFICATION_PATH"] != nil),
+    .serialized
+)
+struct LiveLocalModelVerificationTests {
+    @Test func productionEngineProducesDigestBoundTruthfulEvidence() async throws {
+        try Self.prepareMLXMetallib()
+        let environment = ProcessInfo.processInfo.environment
+        let path = try #require(environment["OSAURUS_LIVE_MODEL_VERIFICATION_PATH"])
+        let modelId = environment["OSAURUS_LIVE_MODEL_VERIFICATION_ID"]
+            ?? "mlx-community/Qwen3.5-9B-MLX-4bit"
+        let bundleURL = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("live-model-verification-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let previousPathRoot = OsaurusPaths.overrideRoot
+        let previousExternalRoots = ExternalModelLocator.testRootsOverride
+        OsaurusPaths.overrideRoot = root.appendingPathComponent("app-root", isDirectory: true)
+        let huggingFaceRoot = bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        ExternalModelLocator.testRootsOverride = [
+            (root: huggingFaceRoot, source: .huggingFaceCache)
+        ]
+        ExternalModelLocator.invalidateInMemory()
+        _ = ExternalModelLocator.rescan()
+        defer {
+            ExternalModelLocator.testRootsOverride = previousExternalRoots
+            ExternalModelLocator.invalidateInMemory()
+            OsaurusPaths.overrideRoot = previousPathRoot
+        }
+        #expect(
+            ExternalModelLocator.path(forId: modelId)?.standardizedFileURL == bundleURL
+        )
+
+        let model = MLXModel(
+            id: modelId,
+            name: modelId.split(separator: "/").last.map(String.init) ?? modelId,
+            description: "Live verification fixture",
+            downloadURL: "",
+            bundleDirectory: bundleURL,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+        let artifactRoot = root.appendingPathComponent("artifacts", isDirectory: true)
+        let ledgerURL = root.appendingPathComponent("model-ledger.json")
+        let registry = EvidenceReportRegistryService()
+        let service = LocalModelVerificationService(
+            engine: MLXLocalModelVerificationEngine(),
+            store: LocalModelVerificationArtifactStore(),
+            registry: registry
+        )
+
+        let result = try await LocalModelVerificationArtifactStore.$directoryOverrideForTests
+            .withValue(artifactRoot) {
+                try await ModelCapabilityLedger.$fileURLOverrideForTests.withValue(ledgerURL) {
+                    try await service.verify(model: model)
+                }
+            }
+        let artifact = result.0
+        let currentBundle = try LocalModelBundleInspector.inspect(directory: bundleURL)
+        #expect(artifact.schemaVersion == LocalModelVerificationArtifact.currentSchemaVersion)
+        #expect(artifact.modelId == modelId)
+        #expect(artifact.bundle.digest == currentBundle.digest)
+        #expect(LocalModelVerificationAuthority.validates(artifact))
+        #expect(Set(artifact.probes.map(\.probe)).isSuperset(of: LocalModelVerificationAuthority.requiredProbes))
+        for probe in LocalModelVerificationAuthority.requiredProbes {
+            #expect(artifact.probes.count { $0.probe == probe } == 1)
+        }
+        if artifact.classification == .proven {
+            #expect(
+                artifact.probes
+                    .filter { LocalModelVerificationAuthority.requiredProbes.contains($0.probe) }
+                    .allSatisfy { $0.status == .passed }
+            )
+            let throughput = try #require(
+                artifact.probes.first { $0.probe == .throughput }?.tokensPerSecond
+            )
+            #expect(throughput.isFinite && throughput > 0)
+        }
+        let loaded = await LocalModelVerificationArtifactStore.$directoryOverrideForTests
+            .withValue(artifactRoot) {
+                await service.latest(modelId: modelId)
+            }
+        let loadedArtifact = try #require(loaded?.0)
+        #expect(loadedArtifact.modelId == artifact.modelId)
+        #expect(loadedArtifact.bundle.digest == artifact.bundle.digest)
+        #expect(loadedArtifact.classification == artifact.classification)
+        #expect(loadedArtifact.probes == artifact.probes)
+        #expect(registry.list().first?.status != .passed || artifact.classification == .proven)
+
+        let probeSummary = artifact.probes.map {
+            "\($0.probe.rawValue)=\($0.status.rawValue)"
+        }.joined(separator: ",")
+        let rates = artifact.probes.compactMap(\.tokensPerSecond)
+        print("LIVE_MODEL_VERIFICATION classification=\(artifact.classification.rawValue)")
+        print("LIVE_MODEL_VERIFICATION probes=\(probeSummary)")
+        print("LIVE_MODEL_VERIFICATION token_s=\(rates.map(String.init(describing:)).joined(separator: ","))")
+
+        await ModelRuntime.shared.unloadModelsNotIn([])
+    }
+
+    private static func prepareMLXMetallib() throws {
+        let fileManager = FileManager.default
+        let environment = ProcessInfo.processInfo.environment
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let candidates = [
+            environment["OSAURUS_MLX_METALLIB"].map { URL(fileURLWithPath: $0) },
+            repositoryRoot.appendingPathComponent(
+                "build/DerivedData/Build/Products/Release/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
+            ),
+            repositoryRoot.appendingPathComponent(
+                "build/DerivedData/Build/Products/Release/osaurus.app/Contents/Resources/default.metallib"
+            ),
+        ].compactMap { $0 }
+        guard let source = candidates.first(where: { fileManager.fileExists(atPath: $0.path) }) else {
+            throw CocoaError(.fileNoSuchFile, userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Build the app or set OSAURUS_MLX_METALLIB before running live model verification."
+            ])
+        }
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let destinations = [
+            packageRoot.appendingPathComponent(".build/arm64-apple-macosx/debug"),
+            packageRoot.appendingPathComponent(
+                ".build/arm64-apple-macosx/debug/OsaurusCorePackageTests.xctest/Contents/MacOS"
+            ),
+            packageRoot.appendingPathComponent(
+                ".build/arm64-apple-macosx/debug/OsaurusCorePackageTests.xctest/Contents/Resources"
+            ),
+            packageRoot.appendingPathComponent(".build/debug"),
+            packageRoot.appendingPathComponent(
+                ".build/debug/OsaurusCorePackageTests.xctest/Contents/MacOS"
+            ),
+            packageRoot.appendingPathComponent(
+                ".build/debug/OsaurusCorePackageTests.xctest/Contents/Resources"
+            ),
+        ]
+        var installed = false
+        for directory in destinations {
+            do {
+                try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+                for name in ["default.metallib", "mlx.metallib"] {
+                    let destination = directory.appendingPathComponent(name)
+                    if !fileManager.fileExists(atPath: destination.path) {
+                        try fileManager.copyItem(at: source, to: destination)
+                    }
+                }
+                installed = true
+            } catch {
+                continue
+            }
+        }
+        guard installed else { throw CocoaError(.fileWriteNoPermission) }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalModelVerificationWorkbenchTests.swift
@@ -301,6 +301,64 @@ struct LocalModelVerificationWorkbenchTests {
         }
     }
 
+    @Test func onlyOnDiskTemplateContentIsDigestBoundProvenance() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("template-provenance-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let tokenizerModel = try makeBundle(root: root.appendingPathComponent("tokenizer"))
+        let tokenizerEvidence = try LocalModelBundleInspector.inspect(
+            directory: tokenizerModel.localDirectory
+        )
+        #expect(tokenizerEvidence.templateSource == "bundle:tokenizer_config.json")
+        #expect(tokenizerEvidence.templateFallback == nil)
+
+        let standaloneModel = try makeBundle(
+            root: root.appendingPathComponent("standalone"), template: false
+        )
+        try Data("{{ messages }}".utf8).write(
+            to: standaloneModel.localDirectory.appendingPathComponent("chat_template.jinja")
+        )
+        let standaloneEvidence = try LocalModelBundleInspector.inspect(
+            directory: standaloneModel.localDirectory
+        )
+        #expect(standaloneEvidence.templateSource == "bundle:chat_template.jinja")
+        #expect(standaloneEvidence.templateFallback == nil)
+
+        let configModel = try makeBundle(
+            root: root.appendingPathComponent("config"), template: false
+        )
+        try Data(#"{"model_type":"fixture","chat_template":"{{ messages }}"}"#.utf8).write(
+            to: configModel.localDirectory.appendingPathComponent("config.json")
+        )
+        let configEvidence = try LocalModelBundleInspector.inspect(
+            directory: configModel.localDirectory
+        )
+        #expect(configEvidence.templateSource == "bundle:config.json")
+        #expect(configEvidence.templateFallback == nil)
+    }
+
+    @Test func runtimeOnlyJangTemplateSourceBlocksAllToolProof() async throws {
+        let engine = ScriptedVerificationEngine(transcripts: [transcript()])
+        try await withEnvironment(engine: engine, template: false) { service, model, _, _ in
+            try Data(
+                #"{"chat_template_source":"builtin_encoding_module","has_tokenizer_chat_template":false}"#.utf8
+            ).write(to: model.localDirectory.appendingPathComponent("jang_config.json"))
+
+            let (artifact, _) = try await service.verify(model: model)
+            #expect(artifact.bundle.templateSource == "runtime:builtin_encoding_module")
+            #expect(artifact.bundle.templateFallback != nil)
+            for probe in [
+                LocalModelVerificationProbe.autoToolChoice, .schemaValidToolCall,
+                .toolResultContinuation, .secondToolCall,
+            ] {
+                #expect(artifact.probes.first { $0.probe == probe }?.status == .blocked)
+            }
+            #expect(artifact.classification != .proven)
+            #expect(await engine.capturedRequests().count == 1)
+        }
+    }
+
     @Test func inspectorPinsResolvedHuggingFaceContentAgainstSymlinkRetarget() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("hf-retarget-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -100,6 +100,16 @@ struct ModelDetailView: View, Identifiable {
     /// shared cache in `init` so a warm cache shows the checkmark immediately.
     @State private var resolvedIsDownloaded: Bool
 
+    /// Digest-bound live verification is separate from static compatibility
+    /// diagnostics. It only appears after a user explicitly runs the probes.
+    @State private var verificationArtifact: LocalModelVerificationArtifact?
+    @State private var verificationArtifactURL: URL?
+    @State private var verificationIsStale = false
+    @State private var isVerifyingModel = false
+    @State private var verificationError: String?
+    @State private var verificationTask: Task<Void, Never>?
+    @State private var verificationPublicationGuard = LocalModelVerificationPublicationGuard()
+
     init(model: MLXModel, variants: [MLXModel] = []) {
         self._selectedModel = State(initialValue: model)
         self.variants = variants
@@ -134,6 +144,8 @@ struct ModelDetailView: View, Identifiable {
 
                     runtimeDiagnosticsCard
 
+                    modelVerificationCard
+
                     modelCardSection
 
                     detailsCard
@@ -167,6 +179,8 @@ struct ModelDetailView: View, Identifiable {
                 await loadDownloadState()
             }
 
+            Task { await loadVerification() }
+
             Task {
                 await estimateIfNeeded()
                 await loadHFDetails()
@@ -176,7 +190,14 @@ struct ModelDetailView: View, Identifiable {
         .onReceive(NotificationCenter.default.publisher(for: .localModelsChanged)) { _ in
             // The shared cache is invalidated on this notification; re-resolve
             // off-main so the checkmark stays in sync after a download or delete.
-            Task { await loadDownloadState() }
+            cancelModelVerification()
+            Task {
+                await loadDownloadState()
+                await loadVerification()
+            }
+        }
+        .onDisappear {
+            cancelModelVerification()
         }
     }
 
@@ -186,6 +207,7 @@ struct ModelDetailView: View, Identifiable {
     /// loading placeholders until the new repo's data lands.
     private func selectVariant(_ variant: MLXModel) {
         guard variant.id != selectedModel.id else { return }
+        cancelModelVerification()
         selectedModel = variant
 
         estimatedSize = nil
@@ -202,9 +224,14 @@ struct ModelDetailView: View, Identifiable {
         didCopyPath = false
         diagnostics = nil
         resolvedIsDownloaded = MLXModelDownloadCache.value(for: variant.id) ?? false
+        verificationArtifact = nil
+        verificationArtifactURL = nil
+        verificationIsStale = false
+        verificationError = nil
 
         Task { await loadDiagnostics() }
         Task { await loadDownloadState() }
+        Task { await loadVerification() }
         Task {
             await estimateIfNeeded()
             await loadHFDetails()
@@ -556,6 +583,312 @@ struct ModelDetailView: View, Identifiable {
         case .partial: return "exclamationmark.triangle.fill"
         case .needsDownload: return "arrow.down.circle.fill"
         case .unproven: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    @ViewBuilder
+    private var modelVerificationCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: verificationIcon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(verificationTint)
+                    .frame(width: 18, height: 18)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Local model verification", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(verificationSummary)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+
+                Button(action: startModelVerification) {
+                    HStack(spacing: 5) {
+                        if isVerifyingModel {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Image(systemName: "checkmark.shield")
+                                .font(.system(size: 11, weight: .semibold))
+                        }
+                        Text(isVerifyingModel ? "Verifying…" : "Verify this model", bundle: .module)
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(!resolvedIsDownloaded || isVerifyingModel)
+            }
+
+            if let artifact = verificationArtifact {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 14, alignment: .topLeading),
+                        GridItem(.flexible(), spacing: 14, alignment: .topLeading),
+                    ],
+                    alignment: .leading,
+                    spacing: 10
+                ) {
+                    DiagnosticFact(
+                        label: L("Result"),
+                        value: verificationIsStale
+                            ? L("Unproven (stale evidence)")
+                            : artifact.classification.rawValue.capitalized
+                    )
+                    DiagnosticFact(
+                        label: L("Bundle digest"),
+                        value: String(artifact.bundle.digest.suffix(12))
+                    )
+                    DiagnosticFact(
+                        label: L("Template"),
+                        value: artifact.bundle.templateSource
+                    )
+                    DiagnosticFact(
+                        label: L("Tool parser"),
+                        value: artifact.bundle.parserFormat ?? L("Not declared")
+                    )
+                    DiagnosticFact(
+                        label: L("vMLX revision"),
+                        value: artifact.bundle.vmlxRevision.map { String($0.prefix(12)) }
+                            ?? L("Unverified")
+                    )
+                    DiagnosticFact(
+                        label: L("Decode speed"),
+                        value: verificationRate(artifact)
+                    )
+                }
+
+                if verificationIsStale {
+                    verificationNotice(
+                        icon: "arrow.triangle.2.circlepath",
+                        text: L("The model bundle changed after this report. Verify it again before relying on the result."),
+                        color: theme.warningColor
+                    )
+                }
+
+                if let fallback = artifact.bundle.templateFallback {
+                    verificationNotice(
+                        icon: "exclamationmark.triangle.fill",
+                        text: fallback,
+                        color: theme.warningColor
+                    )
+                }
+
+                if !artifact.failedOrBlocked.isEmpty {
+                    Divider().background(theme.cardBorder)
+                    VStack(alignment: .leading, spacing: 7) {
+                        Text("Non-passing evidence", bundle: .module)
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(theme.tertiaryText)
+                            .textCase(.uppercase)
+                        ForEach(artifact.failedOrBlocked) { probe in
+                            HStack(alignment: .top, spacing: 7) {
+                                Image(systemName: verificationProbeIcon(probe.status))
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundColor(verificationProbeTint(probe.status))
+                                    .frame(width: 12)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(probe.probe.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
+                                        .font(.system(size: 11, weight: .semibold))
+                                        .foregroundColor(theme.secondaryText)
+                                    Text(probe.detail)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(theme.tertiaryText)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let verificationArtifactURL {
+                    Button(
+                        action: {
+                            NSWorkspace.shared.activateFileViewerSelecting([verificationArtifactURL])
+                        },
+                        label: {
+                            Label(
+                                title: { Text("Reveal report", bundle: .module) },
+                                icon: { Image(systemName: "doc.text.magnifyingglass") }
+                            )
+                            .font(.system(size: 11, weight: .medium))
+                        }
+                    )
+                    .buttonStyle(.plain)
+                    .foregroundColor(theme.accentColor)
+                }
+            }
+
+            if let verificationError {
+                verificationNotice(
+                    icon: "xmark.octagon.fill",
+                    text: verificationError,
+                    color: theme.errorColor
+                )
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .detailCardSurface()
+    }
+
+    private var verificationSummary: String {
+        if isVerifyingModel {
+            return L("Hashing the exact bundle and running bounded generation, tool, continuation, and cancellation probes.")
+        }
+        if verificationIsStale {
+            return L("The saved result is stale because the model bundle changed.")
+        }
+        if let artifact = verificationArtifact {
+            return String(
+                format: L("%@ evidence bound to this exact bundle."),
+                artifact.classification.rawValue.capitalized
+            )
+        }
+        if !resolvedIsDownloaded {
+            return L("Download the model before running live verification.")
+        }
+        return L("Run live probes before relying on tool use, continuation, or runtime behavior.")
+    }
+
+    private var verificationTint: Color {
+        if verificationIsStale { return theme.warningColor }
+        guard let classification = verificationArtifact?.classification else {
+            return theme.tertiaryText
+        }
+        switch classification {
+        case .proven: return theme.successColor
+        case .partial, .unsupported, .unproven: return theme.warningColor
+        case .failed: return theme.errorColor
+        }
+    }
+
+    private var verificationIcon: String {
+        if verificationIsStale { return "arrow.triangle.2.circlepath" }
+        switch verificationArtifact?.classification {
+        case .proven: return "checkmark.shield.fill"
+        case .failed: return "xmark.octagon.fill"
+        case .partial, .unsupported, .unproven: return "exclamationmark.triangle.fill"
+        case nil: return "checkmark.shield"
+        }
+    }
+
+    private func verificationNotice(icon: String, text: String, color: Color) -> some View {
+        HStack(alignment: .top, spacing: 7) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(color)
+            Text(text)
+                .font(.system(size: 10))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func verificationProbeIcon(_ status: LocalModelVerificationProbeStatus) -> String {
+        switch status {
+        case .passed: return "checkmark.circle.fill"
+        case .failed, .error: return "xmark.octagon.fill"
+        case .blocked, .unsupported: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func verificationProbeTint(_ status: LocalModelVerificationProbeStatus) -> Color {
+        switch status {
+        case .passed: return theme.successColor
+        case .failed, .error: return theme.errorColor
+        case .blocked, .unsupported: return theme.warningColor
+        }
+    }
+
+    private func verificationRate(_ artifact: LocalModelVerificationArtifact) -> String {
+        guard let rate = artifact.probes.compactMap(\.tokensPerSecond).max() else {
+            return L("Not recorded")
+        }
+        return String(format: "%.1f tok/s", rate)
+    }
+
+    private func loadVerification() async {
+        let target = model
+        let latest = await LocalModelVerificationService.shared.latest(modelId: target.id)
+        let digest: String? = if latest == nil {
+            nil
+        } else {
+            await exactBundleDigest(directory: target.localDirectory)
+        }
+        await MainActor.run {
+            guard isCurrent(target.id) else { return }
+            verificationArtifact = latest?.0
+            verificationArtifactURL = latest?.1
+            verificationIsStale = latest?.0.isStale(currentDigest: digest) ?? false
+        }
+    }
+
+    private func exactBundleDigest(directory: URL) async -> String? {
+        let digestTask = Task.detached(priority: .utility) {
+            try? LocalModelBundleInspector.inspect(directory: directory).digest
+        }
+        return await withTaskCancellationHandler {
+            await digestTask.value
+        } onCancel: {
+            digestTask.cancel()
+        }
+    }
+
+    private func cancelModelVerification() {
+        verificationPublicationGuard.invalidate()
+        verificationTask?.cancel()
+        verificationTask = nil
+        isVerifyingModel = false
+    }
+
+    private func startModelVerification() {
+        guard resolvedIsDownloaded, !isVerifyingModel else { return }
+        verificationTask?.cancel()
+        verificationError = nil
+        isVerifyingModel = true
+        let target = model
+        let publicationToken = verificationPublicationGuard.begin(modelId: target.id)
+        verificationTask = Task {
+            do {
+                let result = try await LocalModelVerificationService.shared.verify(model: target)
+                try Task.checkCancellation()
+                await MainActor.run {
+                    guard verificationPublicationGuard.permits(
+                        publicationToken,
+                        currentModelId: model.id
+                    ) else { return }
+                    verificationArtifact = result.0
+                    verificationArtifactURL = result.1
+                    verificationIsStale = false
+                    verificationError = nil
+                    isVerifyingModel = false
+                    verificationTask = nil
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    guard verificationPublicationGuard.permits(
+                        publicationToken,
+                        currentModelId: model.id
+                    ) else { return }
+                    isVerifyingModel = false
+                    verificationTask = nil
+                }
+            } catch {
+                await MainActor.run {
+                    guard verificationPublicationGuard.permits(
+                        publicationToken,
+                        currentModelId: model.id
+                    ) else { return }
+                    verificationError = error.localizedDescription
+                    isVerifyingModel = false
+                    verificationTask = nil
+                }
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -105,10 +105,14 @@ struct ModelDetailView: View, Identifiable {
     @State private var verificationArtifact: LocalModelVerificationArtifact?
     @State private var verificationArtifactURL: URL?
     @State private var verificationIsStale = false
+    @State private var verificationTerminalInvalidated = false
     @State private var isVerifyingModel = false
     @State private var verificationError: String?
     @State private var verificationTask: Task<Void, Never>?
+    @State private var activeVerificationModelId: String?
     @State private var verificationPublicationGuard = LocalModelVerificationPublicationGuard()
+    @State private var verificationLoadTask: Task<Void, Never>?
+    @State private var verificationLoadGuard = LocalModelVerificationPublicationGuard()
 
     init(model: MLXModel, variants: [MLXModel] = []) {
         self._selectedModel = State(initialValue: model)
@@ -179,7 +183,7 @@ struct ModelDetailView: View, Identifiable {
                 await loadDownloadState()
             }
 
-            Task { await loadVerification() }
+            startVerificationLoad()
 
             Task {
                 await estimateIfNeeded()
@@ -190,14 +194,17 @@ struct ModelDetailView: View, Identifiable {
         .onReceive(NotificationCenter.default.publisher(for: .localModelsChanged)) { _ in
             // The shared cache is invalidated on this notification; re-resolve
             // off-main so the checkmark stays in sync after a download or delete.
-            cancelModelVerification()
             Task {
                 await loadDownloadState()
-                await loadVerification()
             }
+            if let activeVerificationModelId, activeVerificationModelId != model.id {
+                cancelModelVerification()
+            }
+            startVerificationLoad()
         }
         .onDisappear {
             cancelModelVerification()
+            cancelVerificationLoad()
         }
     }
 
@@ -208,6 +215,7 @@ struct ModelDetailView: View, Identifiable {
     private func selectVariant(_ variant: MLXModel) {
         guard variant.id != selectedModel.id else { return }
         cancelModelVerification()
+        cancelVerificationLoad()
         selectedModel = variant
 
         estimatedSize = nil
@@ -227,11 +235,12 @@ struct ModelDetailView: View, Identifiable {
         verificationArtifact = nil
         verificationArtifactURL = nil
         verificationIsStale = false
+        verificationTerminalInvalidated = false
         verificationError = nil
 
         Task { await loadDiagnostics() }
         Task { await loadDownloadState() }
-        Task { await loadVerification() }
+        startVerificationLoad()
         Task {
             await estimateIfNeeded()
             await loadHFDetails()
@@ -624,7 +633,7 @@ struct ModelDetailView: View, Identifiable {
                 .disabled(!resolvedIsDownloaded || isVerifyingModel)
             }
 
-            if let artifact = verificationArtifact {
+            if !isVerifyingModel, let artifact = verificationArtifact {
                 LazyVGrid(
                     columns: [
                         GridItem(.flexible(), spacing: 14, alignment: .topLeading),
@@ -678,27 +687,32 @@ struct ModelDetailView: View, Identifiable {
                     )
                 }
 
-                if !artifact.failedOrBlocked.isEmpty {
+                if !artifact.nonPassingEvidence.isEmpty {
                     Divider().background(theme.cardBorder)
                     VStack(alignment: .leading, spacing: 7) {
                         Text("Non-passing evidence", bundle: .module)
                             .font(.system(size: 10, weight: .bold))
                             .foregroundColor(theme.tertiaryText)
                             .textCase(.uppercase)
-                        ForEach(artifact.failedOrBlocked) { probe in
+                        ForEach(artifact.nonPassingEvidence) { probe in
                             HStack(alignment: .top, spacing: 7) {
                                 Image(systemName: verificationProbeIcon(probe.status))
                                     .font(.system(size: 10, weight: .semibold))
                                     .foregroundColor(verificationProbeTint(probe.status))
                                     .frame(width: 12)
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text(probe.probe.rawValue.replacingOccurrences(of: "_", with: " ").capitalized)
+                                    Text(verificationProbeLabel(probe.probe))
                                         .font(.system(size: 11, weight: .semibold))
                                         .foregroundColor(theme.secondaryText)
                                     Text(probe.detail)
                                         .font(.system(size: 10))
                                         .foregroundColor(theme.tertiaryText)
                                         .fixedSize(horizontal: false, vertical: true)
+                                    if let errorCode = probe.errorCode {
+                                        Text(errorCode)
+                                            .font(.system(size: 9, design: .monospaced))
+                                            .foregroundColor(theme.tertiaryText)
+                                    }
                                 }
                             }
                         }
@@ -756,6 +770,7 @@ struct ModelDetailView: View, Identifiable {
     }
 
     private var verificationTint: Color {
+        if isVerifyingModel { return theme.accentColor }
         if verificationIsStale { return theme.warningColor }
         guard let classification = verificationArtifact?.classification else {
             return theme.tertiaryText
@@ -768,6 +783,7 @@ struct ModelDetailView: View, Identifiable {
     }
 
     private var verificationIcon: String {
+        if isVerifyingModel { return "hourglass" }
         if verificationIsStale { return "arrow.triangle.2.circlepath" }
         switch verificationArtifact?.classification {
         case .proven: return "checkmark.shield.fill"
@@ -797,6 +813,11 @@ struct ModelDetailView: View, Identifiable {
         }
     }
 
+    private func verificationProbeLabel(_ probe: LocalModelVerificationProbe) -> String {
+        if probe == .autoToolChoice { return L("Auto tool choice") }
+        return probe.rawValue.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
     private func verificationProbeTint(_ status: LocalModelVerificationProbeStatus) -> Color {
         switch status {
         case .passed: return theme.successColor
@@ -806,14 +827,25 @@ struct ModelDetailView: View, Identifiable {
     }
 
     private func verificationRate(_ artifact: LocalModelVerificationArtifact) -> String {
-        guard let rate = artifact.probes.compactMap(\.tokensPerSecond).max() else {
+        guard let rate = artifact.probes.first(where: { $0.probe == .throughput })?
+            .tokensPerSecond, rate.isFinite, rate > 0
+        else {
             return L("Not recorded")
         }
         return String(format: "%.1f tok/s", rate)
     }
 
-    private func loadVerification() async {
+    private func startVerificationLoad() {
+        verificationLoadTask?.cancel()
         let target = model
+        let token = verificationLoadGuard.begin(modelId: target.id)
+        verificationLoadTask = Task { await loadVerification(target: target, token: token) }
+    }
+
+    private func loadVerification(
+        target: MLXModel,
+        token: LocalModelVerificationPublicationGuard.Token
+    ) async {
         let latest = await LocalModelVerificationService.shared.latest(modelId: target.id)
         let digest: String? = if latest == nil {
             nil
@@ -821,11 +853,18 @@ struct ModelDetailView: View, Identifiable {
             await exactBundleDigest(directory: target.localDirectory)
         }
         await MainActor.run {
-            guard isCurrent(target.id) else { return }
+            guard verificationLoadGuard.permits(token, currentModelId: model.id) else { return }
             verificationArtifact = latest?.0
             verificationArtifactURL = latest?.1
-            verificationIsStale = latest?.0.isStale(currentDigest: digest) ?? false
+            verificationIsStale = verificationTerminalInvalidated
+                || (latest?.0.isStale(currentDigest: digest) ?? false)
         }
+    }
+
+    private func cancelVerificationLoad() {
+        verificationLoadGuard.invalidate()
+        verificationLoadTask?.cancel()
+        verificationLoadTask = nil
     }
 
     private func exactBundleDigest(directory: URL) async -> String? {
@@ -843,6 +882,7 @@ struct ModelDetailView: View, Identifiable {
         verificationPublicationGuard.invalidate()
         verificationTask?.cancel()
         verificationTask = nil
+        activeVerificationModelId = nil
         isVerifyingModel = false
     }
 
@@ -852,6 +892,7 @@ struct ModelDetailView: View, Identifiable {
         verificationError = nil
         isVerifyingModel = true
         let target = model
+        activeVerificationModelId = target.id
         let publicationToken = verificationPublicationGuard.begin(modelId: target.id)
         verificationTask = Task {
             do {
@@ -865,9 +906,12 @@ struct ModelDetailView: View, Identifiable {
                     verificationArtifact = result.0
                     verificationArtifactURL = result.1
                     verificationIsStale = false
+                    verificationTerminalInvalidated = false
                     verificationError = nil
                     isVerifyingModel = false
+                    activeVerificationModelId = nil
                     verificationTask = nil
+                    startVerificationLoad()
                 }
             } catch is CancellationError {
                 await MainActor.run {
@@ -876,7 +920,10 @@ struct ModelDetailView: View, Identifiable {
                         currentModelId: model.id
                     ) else { return }
                     isVerifyingModel = false
+                    verificationTerminalInvalidated = true
+                    activeVerificationModelId = nil
                     verificationTask = nil
+                    startVerificationLoad()
                 }
             } catch {
                 await MainActor.run {
@@ -886,7 +933,10 @@ struct ModelDetailView: View, Identifiable {
                     ) else { return }
                     verificationError = error.localizedDescription
                     isVerifyingModel = false
+                    verificationTerminalInvalidated = true
+                    activeVerificationModelId = nil
                     verificationTask = nil
+                    startVerificationLoad()
                 }
             }
         }

--- a/docs/LOCAL_MODEL_VERIFICATION.md
+++ b/docs/LOCAL_MODEL_VERIFICATION.md
@@ -8,8 +8,10 @@ an Osaurus tool workflow.
 ## Evidence contract
 
 Each run hashes every regular file in the selected bundle and binds the report
-to that exact SHA-256 digest. Symbolic links and non-regular entries fail the
-inspection. The report also records:
+to that exact SHA-256 digest. Non-regular entries fail inspection. Hugging Face
+snapshot symlinks are accepted only when their once-resolved target is a
+regular file contained by the same repository; other symlinks fail. The report
+also records:
 
 - the bundle chat-template source and any runtime fallback;
 - the declared tool parser or format;
@@ -18,10 +20,12 @@ inspection. The report also records:
   otherwise an explicit `unverified` source rather than an asserted pin;
 - per-probe stop reason, token count, and decode token/s when emitted.
 
-Reports are stored as versioned JSON under
+Reports are stored as private, versioned JSON under
 `~/.osaurus/config/model-verification/`, registered as `live_proof` evidence,
-and projected into `model-ledger.json` with their exact bundle digest. The
-ledger projection does not change the production-serving decision.
+and projected into `model-ledger.json` with their exact bundle digest and a
+configuration-relative artifact path. Loading a validated saved report
+re-registers it after restart. The ledger projection does not change the
+production-serving decision.
 
 ## Live probes
 
@@ -31,13 +35,15 @@ checks:
 
 1. visible generation;
 2. a dedicated, closed reasoning channel when the bundle declares one;
-3. a schema-valid fixture tool call;
-4. continuation grounded in the executed fixture result;
-5. a second schema-valid tool call after tool history;
-6. no visible reasoning, parser, or tool markers;
-7. a reported natural stop/EOS reason;
-8. positive decode token/s;
-9. cooperative cancellation after the live stream emits its first event.
+3. production-default `auto` tool selection;
+4. a schema-valid fixture tool call and arguments;
+5. continuation grounded in the executed fixture result;
+6. a second schema-valid tool call after tool history;
+7. no visible reasoning, parser, or tool markers in visible or reasoning text;
+8. a reported natural stop/EOS reason;
+9. positive decode token/s;
+10. stream termination within a bounded deadline after cancellation, with no
+    post-cancel deltas.
 
 Reasoning is `unsupported`, rather than failed, when the bundle declares no
 reasoning mode. A missing chat template blocks tool-call proof even if a runtime

--- a/docs/LOCAL_MODEL_VERIFICATION.md
+++ b/docs/LOCAL_MODEL_VERIFICATION.md
@@ -1,0 +1,60 @@
+# Local Model Verification
+
+The Local Model Verification Workbench is an on-demand live proof surface in
+the downloaded model detail view. Static compatibility metadata remains useful
+for preflight diagnostics, but it does not establish that a model can complete
+an Osaurus tool workflow.
+
+## Evidence contract
+
+Each run hashes every regular file in the selected bundle and binds the report
+to that exact SHA-256 digest. Symbolic links and non-regular entries fail the
+inspection. The report also records:
+
+- the bundle chat-template source and any runtime fallback;
+- the declared tool parser or format;
+- scalar values from `generation_config.json`;
+- the linked vMLX revision when the runtime exposes authoritative provenance,
+  otherwise an explicit `unverified` source rather than an asserted pin;
+- per-probe stop reason, token count, and decode token/s when emitted.
+
+Reports are stored as versioned JSON under
+`~/.osaurus/config/model-verification/`, registered as `live_proof` evidence,
+and projected into `model-ledger.json` with their exact bundle digest. The
+ledger projection does not change the production-serving decision.
+
+## Live probes
+
+The workbench uses the normal Osaurus MLX chat/template/parser path. It does not
+replace model-native generation defaults or repair model output. A complete run
+checks:
+
+1. visible generation;
+2. a dedicated, closed reasoning channel when the bundle declares one;
+3. a schema-valid fixture tool call;
+4. continuation grounded in the executed fixture result;
+5. a second schema-valid tool call after tool history;
+6. no visible reasoning, parser, or tool markers;
+7. a reported natural stop/EOS reason;
+8. positive decode token/s;
+9. cooperative cancellation after the live stream emits its first event.
+
+Reasoning is `unsupported`, rather than failed, when the bundle declares no
+reasoning mode. A missing chat template blocks tool-call proof even if a runtime
+fallback happens to parse one run. The workbench recomputes the exact bundle
+digest off the main actor before presenting saved evidence and again before
+publishing a completed run. Any digest change makes the report visibly stale or
+aborts publication and requires re-verification.
+
+## Classifications
+
+- `proven`: every required live probe passed for the exact digest.
+- `partial`: some required evidence passed, but a probe is blocked or a
+  declared optional capability failed.
+- `unsupported`: the runtime contract explicitly does not support the tested
+  capability.
+- `failed`: a required live probe failed or errored.
+- `unproven`: no sufficient live evidence exists.
+
+Fixture-driven tests exercise the protocol deterministically. They are not a
+substitute for the on-demand live row for a real local model.


### PR DESCRIPTION
## Summary
- adds a model-detail workbench that verifies a local MLX bundle through the production streaming engine
- records exact bundle digest, template provenance, generation, automatic tool choice, schema-valid arguments, tool-result continuation, a second tool call, marker boundaries, natural stop/EOS, token/s, and cancellation behavior
- classifies evidence as exactly `proven`, `partial`, `unsupported`, `failed`, or `unproven`
- stores private JSON evidence, projects the result into the canonical model capability ledger, and registers validated artifacts in the evidence index
- marks evidence stale when the exact bundle changes and prevents stale or cancelled runs from publishing

## Evidence integrity
- `proven` requires the exact complete required-probe set, positive throughput, and no failed/blocked/error rows
- artifact keys bind the exact model ID and bundle digest; collisions and mismatched loads fail closed
- Hugging Face symlinks are accepted only when they resolve to regular files within the same repository root
- runtime-only template sources are labeled unverified and cannot produce tool-use proof
- nested JANG `has_tokenizer_chat_template: false` overrides stale tokenizer template content
- cancellation must terminate the underlying stream within a bound; wrapper cancellation alone does not count
- ledger writes are serialized, atomic, private, and preserve existing data on corrupt or unreadable input

## Live local proof
Model: `mlx-community/Qwen3.5-9B-MLX-4bit`

Result: `partial`

Passed:
- generation
- automatic tool choice
- schema-valid tool call
- tool-result continuation
- second tool call
- marker boundaries
- natural stop/EOS
- positive throughput
- in-flight cancellation

Not proven:
- declared reasoning behavior

Observed throughput: `28.54–32.99 tok/s`

## Validation
- 30 deterministic workbench/adversarial tests passed
- 12 evidence registry and ledger tests passed
- opt-in production-engine Qwen integration test passed
- unsigned Release CLI and app builds passed; embedded CLI verified
- localization, scoped strict SwiftLint, and `git diff --check` passed
- final evidence-integrity ship-gate review found no remaining actionable issue

## Review state
This PR is draft while GitHub checks run and a native model-detail UI screenshot/walkthrough is captured. It does not change model prompts, generation defaults, parsers, or serving behavior.