### PR TITLE
evals: hermetic run storage — eval runs can never touch the user's real contexts

### DIFF
--- a/COMMUNITY_EVALS.md
+++ b/COMMUNITY_EVALS.md
@@ -87,6 +87,24 @@ API keys. Failure transcripts stay in the git-ignored `build/` dir on your
 machine. The auto-PR commits exactly one new file and never touches shared
 files, so parallel contributions can't conflict.
 
+## Your Osaurus data is untouched
+
+Every eval process runs against a **disposable storage root** under your
+system temp dir (`osaurus-evals-<uuid>`), never your real `~/.osaurus`. The
+dummy agents, providers, schedules, memories, and chat state the suites seed
+all land in that throwaway root — your chats, agents, memories, and settings
+are exactly as you left them after the run. The run only *reads* a few host
+resources: your installed models/plugins (read-only), plus one-shot copies of
+your chat and sandbox config so model resolution and sandbox detection work.
+The one shared resource is the sandbox VM itself (it takes minutes to boot and
+is shared with the app); per-case cleanup unprovisions the temporary eval
+agents it creates inside the VM.
+
+On normal completion the disposable root is deleted automatically. If a run
+crashes or is killed, the leftover root under `$TMPDIR` is swept by the next
+eval run (or can be removed manually — `rm -rf "$TMPDIR"/osaurus-evals-*`
+while no eval is running).
+
 ## Instructions for coding agents
 
 If you are an AI agent asked to contribute a run, follow these steps exactly:

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -197,9 +197,11 @@ The loop batches each model's suites into ONE process (the model loads and
 warms once, not once per suite), and when `MODELS` mixes local and
 remote-provider ids it runs the remote models in a parallel background lane —
 remote decode is network-bound, so it doesn't contend with local MLX GPU work.
-The remote lane runs config-isolated (it can't race the local lane on
-`~/.osaurus`) and the sandbox-VM suite is serialized across lanes with a lock.
-Set `PARALLEL_REMOTE=0` to restore the fully sequential order.
+Every eval process runs in its own hermetic throwaway storage root (see
+"Hermetic run storage" below), so parallel lanes can never race each other —
+or a live Osaurus app — on `~/.osaurus`; the sandbox-VM suite is serialized
+across lanes with a lock (the VM itself is host-global). Set
+`PARALLEL_REMOTE=0` to restore the fully sequential order.
 
 Each run lands in `build/evals/loop/<timestamp>/` (also symlinked as
 `build/evals/loop/latest`) with:
@@ -309,11 +311,29 @@ requests `stream_options.include_usage` and surfaces the provider's `usage` as
 the same in-band stats hint the local runtime emits (decode tok/s stays nil when
 the provider omits it, rather than being fabricated).
 
+**Hermetic run storage.** Every `osaurus-evals run` (and `agent-loop-lab`)
+process — pure data suites included — runs against a disposable
+`$TMPDIR/osaurus-evals-<uuid>/` storage root
+(`EvalBootstrap.configureIsolatedRunStorage`). Fixture agents, providers,
+schedules, memory rows, methods, skills, chat state, and KV caches an eval
+creates all land in that throwaway root and **can never touch the user's real
+`~/.osaurus` contexts**. The isolated root is seeded with the few host
+resources a run must still see: read-only symlinks for `Tools/` (installed
+plugins, only when the plan loads them), `cache/external-models.json`
+(HF-cache / LM-Studio model resolution), and `container/` (the host-global
+sandbox VM runtime — boot costs minutes and the container is shared with the
+host app, so it is the one deliberate exception); plus **copies** of
+`config/chat.json` (keeps `--model auto` resolvable) and `config/sandbox.json`
+(keeps provisioned-sandbox detection) so any write a run triggers mutates the
+copy, not the user's file. On normal exit the process deletes its root; roots
+leaked by watchdog `_exit` / crashes are collected by the next run's orphan
+sweep (dead `.owner.pid`).
+
 Startup bootstrap is domain-aware. Suites that require installed native plugins
 load them and rebuild search indices so they mirror the host app. `capability_search`
 suites initialize only the selected tool / method / skill index lanes without
-loading native plugins; those index-only runs use isolated temporary storage so
-fixtures never touch the user's real databases. Debug builds also use
+loading native plugins; index fixtures build fresh inside the isolated root so
+they never touch the user's real databases. Debug builds also use
 a deterministic in-process storage key; release builds still use OsaurusCore's
 normal noninteractive storage-key path against the isolated database files
 (used only when a run opts in to encrypted fixtures; plaintext fixtures need no key).

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/AgentLoopRegressionLabCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/AgentLoopRegressionLabCLI.swift
@@ -82,7 +82,7 @@ extension OsaurusEvalsCLI {
             filter: opts.filter,
             preference: opts.pluginBootstrapPreference
         )
-        _ = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(for: bootstrapPlan)
+        _ = EvalBootstrap.configureIsolatedRunStorage(for: bootstrapPlan)
         let startupWatchdog =
             bootstrapPlan.requiresWork
             ? makeAgentLoopLabStartupWatchdog(options: opts, suite: combinedSuite)

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -37,9 +37,9 @@ struct OsaurusEvalsCLI {
         // SecItemCopyMatching → securityd with 0% CPU). `LAContext`/UI-skip flags
         // are ignored on legacy items, so the only correct fix is to run
         // Keychain-free: every wrapper (incl. MasterKey) then no-ops. This
-        // mirrors the existing isolated config/search storage for default-agent
-        // cases. Forced before any OsaurusCore access; the harness never needs
-        // real Keychain (remote providers are ephemeral and env-keyed).
+        // matches the hermetic run storage every eval process gets. Forced
+        // before any OsaurusCore access; the harness never needs real
+        // Keychain (remote providers are ephemeral and env-keyed).
         setenv("OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS", "1", 1)
 
         // The sandbox secrets pipeline (sandbox_secret_set → exec env
@@ -176,23 +176,17 @@ struct OsaurusEvalsCLI {
                 )
             }
         )
-        _ = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(for: bootstrapPlan)
-        // Default-agent cases EXECUTE real configure write tools; isolate the
-        // config root (after the search-isolation call so a mixed suite keeps
-        // its plugin `Tools` symlink) so writes never touch the real
-        // `~/.osaurus`. No-op for suites without `default_agent` cases.
-        // OSAURUS_EVALS_ISOLATE_CONFIG=1 forces isolation regardless: the
-        // optimization loop's parallel remote lane sets it so concurrent
-        // processes can never race each other (or a live app) on the real
-        // config root. Only safe for explicit-model runs (an isolated root
-        // has no chat config for `auto` to resolve against) — which remote
-        // `provider/model` ids always are.
-        let forceConfigIsolation =
-            ProcessInfo.processInfo.environment["OSAURUS_EVALS_ISOLATE_CONFIG"] == "1"
-        _ = EvalBootstrap.configureIsolatedConfigStorageIfNeeded(
-            isolate: forceConfigIsolation
-                || suites.contains { $0.selectedCasesIncludeDefaultAgent(filter: opts.filter) }
-        )
+        // Hermetic run storage, unconditionally: EVERY eval run gets a
+        // throwaway root so fixture seeds and executed tool writes (agents,
+        // schedules, providers, memory, methods, skills, chat state) can
+        // never land in the user's real `~/.osaurus` contexts. Host
+        // resources evals must still see are seeded in: config snapshots
+        // are copies (`chat.json` keeps `--model auto` resolvable,
+        // `sandbox.json` keeps provisioned-sandbox detection), and the
+        // sandbox VM runtime stays host-global via a `container/` symlink.
+        // Concurrent lanes (the optimization loop's parallel remote lane)
+        // are safe by construction — each process owns its own root.
+        _ = EvalBootstrap.configureIsolatedRunStorage(for: bootstrapPlan)
         let startupWatchdog =
             bootstrapPlan.requiresWork
             ? makeStartupWatchdog(options: opts, suite: suites[0])

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
@@ -78,21 +78,6 @@ public struct EvalBootstrapPlan: Sendable, Equatable {
         loadInstalledPlugins || !searchIndexScope.isEmpty
     }
 
-    /// True when the run will open/sync any of the shared search DBs
-    /// (`tool_index`, `methods`, skill index) — i.e. whenever it loads
-    /// installed plugins (`loadInstalledPlugins()` syncs all three) OR
-    /// brings up a non-empty index scope. Those runs must stay hermetic:
-    /// a developer (or CI) with the Osaurus host app running holds the
-    /// real `~/.osaurus` SQLite DBs in WAL mode, so the eval's
-    /// `ToolDatabase.open()` against the same files fails (→ silent
-    /// registry fallback, `index=0`) or its `syncFromRegistry()` write
-    /// deadlocks against the app. Isolating to a temp root sidesteps that;
-    /// the plugin `Tools/` dir is symlinked back in so plugin discovery
-    /// still works (see `configureIsolatedSearchStorageIfNeeded`).
-    public var usesIsolatedSearchStorage: Bool {
-        requiresWork
-    }
-
     /// Union of several per-suite plans — the bootstrap for a multi-suite
     /// (`--suite A --suite B`) run, where ONE process must satisfy every
     /// selected suite: plugins load if ANY suite needs them, and each index
@@ -151,68 +136,38 @@ public struct EvalBootstrapPlan: Sendable, Equatable {
 /// plugin loading.
 @MainActor
 public enum EvalBootstrap {
-    /// Capability-search is an index-only eval lane, so automatic
-    /// no-plugin runs should not touch the developer's real encrypted
-    /// databases or wait on Keychain. The CLI calls this before startup
-    /// bootstrap and keeps the override alive for the whole process.
-    @discardableResult
-    public static func configureIsolatedSearchStorageIfNeeded(
-        for plan: EvalBootstrapPlan
-    ) -> URL? {
-        guard plan.usesIsolatedSearchStorage else { return nil }
-        return isolateRootWithExternalModelsManifest(symlinkTools: plan.loadInstalledPlugins)
-    }
-
-    /// Isolate **configuration** storage for the `default_agent` domain.
+    /// Isolate ALL persistent Osaurus storage for this eval process,
+    /// unconditionally.
     ///
-    /// Default-agent eval cases drive the real multi-turn loop, which
-    /// EXECUTES the consolidated configure write tools (`osaurus_agent`,
-    /// `osaurus_provider`, `osaurus_mcp`, `osaurus_schedule`, …) through the
-    /// live `ToolRegistry`. Run unguarded, an `osaurus_agent create` would
-    /// add a junk agent to the developer's real `~/.osaurus`, an
-    /// `osaurus_schedule create` would register a schedule that later fires,
-    /// and so on. Isolating the root to a fresh temp dir keeps the real
-    /// config pristine — every executed write lands in the throwaway root —
-    /// while the external-models manifest symlink keeps the local MLX run
-    /// model resolvable (Foundation needs no manifest).
+    /// Every eval run — pure data suites included — gets a throwaway
+    /// `osaurus-evals-<uuid>` root under `$TMPDIR`, so nothing an eval case
+    /// seeds or a model executes (fixture agents, schedules, providers,
+    /// memory rows, methods, skills, chat history, KV caches) can ever land
+    /// in the user's real `~/.osaurus` contexts. This replaces the old
+    /// conditional search-/config-isolation pair: partial isolation left
+    /// ad-hoc runs (memory, agent_loop, capability_claims without a
+    /// default_agent case) writing eval fixtures into the live root.
     ///
-    /// Must run AFTER `configureIsolatedSearchStorageIfNeeded` so a mixed
-    /// suite that also loads plugins keeps that path's `Tools` symlink: when
-    /// the root is already isolated this only installs the credential-sheet
-    /// bypass and returns nil (no double-isolation).
+    /// The isolated root is seeded with the few host resources evals must
+    /// still see (see `seedHostSnapshots`):
+    ///   - `Tools/` symlink (installed native plugins, read-only dylib scan)
+    ///     when the plan loads plugins;
+    ///   - `cache/external-models.json` symlink so HF-cache / LM-Studio MLX
+    ///     models stay resolvable (the manifest records absolute paths);
+    ///   - a COPY of `config/chat.json` so `--model auto` resolves against
+    ///     the user's configured default model without exposing the real
+    ///     file to writes;
+    ///   - a COPY of `config/sandbox.json` so sandbox suites still detect a
+    ///     provisioned host (`setupComplete`) — provisioning stamps written
+    ///     during the run land in the throwaway copy;
+    ///   - a `container/` symlink: the sandbox VM (kernel, rootfs, workspace)
+    ///     is host-global BY DESIGN — boot costs minutes and the container is
+    ///     shared with the host app — so it is the one deliberate exception
+    ///     to isolation. Per-case sandbox-agent cleanup still runs.
     ///
-    /// Model compatibility: local MLX and `foundation` resolve through the
-    /// symlinked external-models manifest; remote `provider/model` runs work
-    /// too because the CLI never routes through config-root provider records
-    /// anyway — `EvalRemoteProviderBootstrap` connects ephemeral providers
-    /// from environment API keys. Only `--model auto` needs the real config
-    /// root (an isolated root has no chat config to resolve against). The
-    /// optimization loop's parallel remote lane leans on this: it forces
-    /// isolation (`OSAURUS_EVALS_ISOLATE_CONFIG=1`) for explicit remote ids
-    /// so concurrent processes never share the real `~/.osaurus`.
-    @discardableResult
-    public static func configureIsolatedConfigStorageIfNeeded(isolate: Bool) -> URL? {
-        guard isolate else { return nil }
-
-        // `osaurus_provider` add / set_credentials open an AppKit credential
-        // sheet via `ProviderCredentialPromptService`. A headless eval run
-        // has no UI loop to dismiss it, so resolve every request as
-        // `.cancelled`: the model's tool CALL (what the matrix scores) is
-        // still recorded, and nothing is written to Keychain. Production code
-        // leaves this hook nil; the eval CLI process is torn down after the
-        // run, so the override never leaks into a real session.
-        ProviderCredentialPromptService.bypassUI = { _ in .cancelled }
-
-        return isolateRootWithExternalModelsManifest(symlinkTools: false)
-    }
-
-    /// Shared isolation primitive: create a fresh temp root, symlink the real
-    /// external-models manifest in (so HF-cache / LM-Studio MLX models stay
-    /// resolvable), optionally symlink the real `Tools` dir (plugin
-    /// discovery), point `OsaurusPaths.root` at it, and seed the DEBUG
-    /// storage key. Returns the temp root, or nil when the root is ALREADY
-    /// overridden — the first isolation owns the symlinks; a second caller
-    /// must not clobber them with a fresh (symlink-less) root.
+    /// Returns the temp root, or nil when the root is ALREADY overridden
+    /// (e.g. a test set `OsaurusPaths.overrideRoot`) — the first isolation
+    /// owns the seeds; a second caller must not clobber them.
     ///
     /// Lifecycle: the root is a THROWAWAY, and each one can grow to ~10 GB
     /// (the KV regime override points `cache/kv_v2` inside it). Left behind,
@@ -228,28 +183,17 @@ public enum EvalBootstrap {
     ///      collected when its recorded pid no longer exists. Concurrent
     ///      eval processes (the optimization loop's parallel remote lane)
     ///      are safe: their pids are alive, so their roots are skipped.
-    private static func isolateRootWithExternalModelsManifest(symlinkTools: Bool) -> URL? {
+    @discardableResult
+    public static func configureIsolatedRunStorage(for plan: EvalBootstrapPlan) -> URL? {
         guard OsaurusPaths.overrideRoot == nil else { return nil }
 
         // Collect roots leaked by dead eval processes BEFORE adding our own.
         // Best-effort: a sweep failure must never block bootstrap.
         sweepOrphanedIsolatedRoots()
 
-        // Resolve the REAL plugin install dir before overriding the root —
-        // `OsaurusPaths.tools()` is `root()/Tools`, so we have to capture it
-        // while `root()` still points at `~/.osaurus`.
-        let realToolsDir = symlinkTools ? OsaurusPaths.tools() : nil
-
-        // Same capture-before-override rule for the external-models manifest
-        // (`root()/cache/external-models.json`): the id -> absolute bundle-path
-        // registry that makes HF-cache / LM-Studio models resolvable via
-        // ExternalModelLocator -> discoverLocalModels -> ChatEngine routing. An
-        // eval whose `--model` lives only in `~/.cache/huggingface/hub` (e.g.
-        // `mlx-community/Qwen3-4B-4bit`) is reachable ONLY through this manifest;
-        // under the isolated temp root it is absent, so an LLM run on the
-        // isolated path (CapabilityClaims / default_agent) would route the
-        // model to `.none` and error every case with `modelNotFound`.
-        let realExternalModelsManifest = OsaurusPaths.externalModelsManifestFile()
+        // Resolve the REAL root before overriding it — every seeded path is
+        // derived from it while `root()` still points at `~/.osaurus`.
+        let realRoot = OsaurusPaths.root()
 
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-evals-\(UUID().uuidString)", isDirectory: true)
@@ -273,39 +217,13 @@ public enum EvalBootstrap {
             EvalBootstrap.cleanupIsolatedRootForExit()
         }
 
-        // Plugin discovery scans `root()/Tools`. When this run loads
-        // installed plugins, symlink the real Tools dir into the isolated
-        // root so `PluginManager.loadAll()` still finds (and registers the
-        // tools/skills of) the user's installed plugins, while the derived
-        // search DBs are created fresh in temp. Read-only dylib scan — no
-        // lock contention with a running host app, unlike the DBs.
-        if let realToolsDir,
-            FileManager.default.fileExists(atPath: realToolsDir.path)
-        {
-            let linkedTools = root.appendingPathComponent("Tools", isDirectory: true)
-            try? FileManager.default.createSymbolicLink(
-                at: linkedTools,
-                withDestinationURL: realToolsDir
-            )
-        }
+        seedHostSnapshots(
+            realRoot: realRoot,
+            isolatedRoot: root,
+            symlinkTools: plan.loadInstalledPlugins
+        )
 
         OsaurusPaths.overrideRoot = root
-
-        // Symlink the real external-models manifest into the isolated cache so
-        // HF-cache / LM-Studio MLX models stay resolvable on the isolated path.
-        // The manifest records absolute bundle paths, so reads resolve in
-        // place; read-only — the eval LLM path never rescans or rewrites it.
-        if FileManager.default.fileExists(atPath: realExternalModelsManifest.path) {
-            let isolatedManifest = OsaurusPaths.externalModelsManifestFile()
-            try? FileManager.default.createDirectory(
-                at: isolatedManifest.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try? FileManager.default.createSymbolicLink(
-                at: isolatedManifest,
-                withDestinationURL: realExternalModelsManifest
-            )
-        }
 
         #if DEBUG
             StorageKeyManager.shared._setKeyForTesting(
@@ -314,6 +232,83 @@ public enum EvalBootstrap {
         #endif
 
         return root
+    }
+
+    /// Seed the isolated root with the host resources an eval run must still
+    /// see. Everything else starts empty and is thrown away with the root.
+    /// Read-only shares are SYMLINKS (deleting the root removes the link,
+    /// never the target); config snapshots are COPIES so any write an eval
+    /// triggers mutates the throwaway copy, not the user's file. Internal
+    /// (not private) so the seeding contract is unit-testable against a
+    /// fabricated "real" root without touching `OsaurusPaths.overrideRoot`.
+    static func seedHostSnapshots(realRoot: URL, isolatedRoot: URL, symlinkTools: Bool) {
+        let fm = FileManager.default
+
+        // Plugin discovery scans `root()/Tools`. When this run loads
+        // installed plugins, symlink the real Tools dir into the isolated
+        // root so `PluginManager.loadAll()` still finds (and registers the
+        // tools/skills of) the user's installed plugins, while the derived
+        // search DBs are created fresh in temp. Read-only dylib scan — no
+        // lock contention with a running host app, unlike the DBs.
+        if symlinkTools {
+            let realTools = realRoot.appendingPathComponent("Tools", isDirectory: true)
+            if fm.fileExists(atPath: realTools.path) {
+                try? fm.createSymbolicLink(
+                    at: isolatedRoot.appendingPathComponent("Tools", isDirectory: true),
+                    withDestinationURL: realTools
+                )
+            }
+        }
+
+        // Symlink the real external-models manifest into the isolated cache so
+        // HF-cache / LM-Studio MLX models stay resolvable on the isolated path.
+        // The manifest records absolute bundle paths, so reads resolve in
+        // place; read-only — the eval LLM path never rescans or rewrites it.
+        // Without it, an LLM run whose `--model` lives only in
+        // `~/.cache/huggingface/hub` (e.g. `mlx-community/Qwen3-4B-4bit`)
+        // would route to `.none` and error every case with `modelNotFound`.
+        let realCache = realRoot.appendingPathComponent("cache", isDirectory: true)
+        let realManifest = realCache.appendingPathComponent("external-models.json")
+        if fm.fileExists(atPath: realManifest.path) {
+            let isolatedCache = isolatedRoot.appendingPathComponent("cache", isDirectory: true)
+            try? fm.createDirectory(at: isolatedCache, withIntermediateDirectories: true)
+            try? fm.createSymbolicLink(
+                at: isolatedCache.appendingPathComponent("external-models.json"),
+                withDestinationURL: realManifest
+            )
+        }
+
+        // COPY (never symlink) the config snapshots evals legitimately read:
+        //   - chat.json: `--model auto` resolves the user's configured
+        //     default model through `ChatConfigurationStore`.
+        //   - sandbox.json: sandbox suites gate on `setupComplete`; without
+        //     the snapshot every SandboxFrontier case silently skips with
+        //     "sandbox setup incomplete on this host".
+        // A copy keeps the real files pristine when a run (or an executed
+        // configure tool) writes them back — the write lands in the copy.
+        let realConfig = realRoot.appendingPathComponent("config", isDirectory: true)
+        let isolatedConfig = isolatedRoot.appendingPathComponent("config", isDirectory: true)
+        for fileName in ["chat.json", "sandbox.json"] {
+            let source = realConfig.appendingPathComponent(fileName)
+            guard fm.fileExists(atPath: source.path) else { continue }
+            try? fm.createDirectory(at: isolatedConfig, withIntermediateDirectories: true)
+            try? fm.copyItem(at: source, to: isolatedConfig.appendingPathComponent(fileName))
+        }
+
+        // The sandbox VM runtime (kernel, initfs, persisted rootfs, the
+        // /workspace mount, bridge socket) is host-global BY DESIGN: boot
+        // costs minutes and the container is shared with the host app, so
+        // sandbox suites must reach the REAL container state. This is the
+        // one deliberate isolation exception; user-context records (agents,
+        // schedules, memory, …) stay isolated, and per-case sandbox-agent
+        // cleanup (`cleanupSandboxCase`) still unprovisions VM-side state.
+        let realContainer = realRoot.appendingPathComponent("container", isDirectory: true)
+        if fm.fileExists(atPath: realContainer.path) {
+            try? fm.createSymbolicLink(
+                at: isolatedRoot.appendingPathComponent("container", isDirectory: true),
+                withDestinationURL: realContainer
+            )
+        }
     }
 
     /// Name of the pid marker each isolated root carries so a later process
@@ -604,13 +599,6 @@ public extension EvalSuite {
             methods: needsMethods,
             skills: needsSkills
         )
-    }
-
-    /// True when any selected case targets the `default_agent` domain, which
-    /// executes real configure write tools and therefore needs config-storage
-    /// isolation (see `EvalBootstrap.configureIsolatedConfigStorageIfNeeded`).
-    func selectedCasesIncludeDefaultAgent(filter: String?) -> Bool {
-        selectedCases(filter: filter).contains { $0.domain == "default_agent" }
     }
 
     private func selectedCases(filter: String?) -> [EvalCase] {

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -1191,10 +1191,11 @@ public enum EvalRunner {
         // Per-case fixture setup. Both `seedMethods` and `enableSkills`
         // mutate persistent state (SQLite + on-disk skill files) — the
         // wrap snapshots prior state and restores it after the case
-        // body runs. Crashes mid-case can leak `eval-` prefixed methods
-        // and toggled-on skills into the developer's local state; we
-        // accept this as a cost of running fixtures against the live
-        // DB rather than building an isolated test harness.
+        // body runs. Every eval process now runs against an isolated
+        // throwaway root (`EvalBootstrap.configureIsolatedRunStorage`),
+        // so a crash mid-case at worst leaks `eval-` prefixed methods
+        // into the temp root the orphan sweep later deletes — never
+        // into the developer's real databases.
         let seededMethods = await applySeedMethods(testCase.fixtures.seedMethods)
         let priorSkillState = await applyEnableSkills(testCase.fixtures.enableSkills)
 

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapHostSnapshotTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapHostSnapshotTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+/// Pins the seeding contract of the hermetic run storage
+/// (`EvalBootstrap.seedHostSnapshots`): the isolated root shares only the
+/// host resources an eval must see, and never in a way that lets a run
+/// mutate the user's real files.
+///
+///   - `config/chat.json` and `config/sandbox.json` are COPIES — a write an
+///     eval triggers (provision stamps, executed configure tools) lands in
+///     the throwaway copy, so the user's context files stay pristine.
+///   - `Tools/` (installed plugins) and `cache/external-models.json` are
+///     read-only shares via SYMLINK; deleting the isolated root removes the
+///     link, never the target.
+///   - `container/` is a symlink to the host-global sandbox VM runtime —
+///     the one deliberate isolation exception (VM boot costs minutes and
+///     the container is shared with the host app).
+@MainActor
+struct EvalBootstrapHostSnapshotTests {
+    private func makeRealRoot() throws -> URL {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("host-snapshot-real-\(UUID().uuidString)", isDirectory: true)
+        let config = root.appendingPathComponent("config", isDirectory: true)
+        let cache = root.appendingPathComponent("cache", isDirectory: true)
+        try fm.createDirectory(at: config, withIntermediateDirectories: true)
+        try fm.createDirectory(at: cache, withIntermediateDirectories: true)
+        try fm.createDirectory(
+            at: root.appendingPathComponent("Tools", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try fm.createDirectory(
+            at: root.appendingPathComponent("container", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try #"{"coreModelName":"test-model"}"#.write(
+            to: config.appendingPathComponent("chat.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"setupComplete":true}"#.write(
+            to: config.appendingPathComponent("sandbox.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "{}".write(
+            to: cache.appendingPathComponent("external-models.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        // Live user context that must NEVER be shared into the eval root.
+        try fm.createDirectory(
+            at: root.appendingPathComponent("agents", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try fm.createDirectory(
+            at: root.appendingPathComponent("memory", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    private func makeIsolatedRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("host-snapshot-isolated-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func isSymlink(_ url: URL) -> Bool {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attrs?[.type] as? FileAttributeType) == .typeSymbolicLink
+    }
+
+    private func isRegularFile(_ url: URL) -> Bool {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attrs?[.type] as? FileAttributeType) == .typeRegular
+    }
+
+    @Test func configSnapshotsAreCopiesNotSymlinks() throws {
+        let fm = FileManager.default
+        let real = try makeRealRoot()
+        let isolated = try makeIsolatedRoot()
+        defer {
+            try? fm.removeItem(at: real)
+            try? fm.removeItem(at: isolated)
+        }
+
+        EvalBootstrap.seedHostSnapshots(realRoot: real, isolatedRoot: isolated, symlinkTools: false)
+
+        let chatCopy = isolated.appendingPathComponent("config/chat.json")
+        let sandboxCopy = isolated.appendingPathComponent("config/sandbox.json")
+        #expect(isRegularFile(chatCopy))
+        #expect(isRegularFile(sandboxCopy))
+
+        // Mutating the copy must leave the user's real file untouched.
+        try "MUTATED-BY-EVAL".write(to: sandboxCopy, atomically: true, encoding: .utf8)
+        let realSandbox = try String(
+            contentsOf: real.appendingPathComponent("config/sandbox.json"),
+            encoding: .utf8
+        )
+        #expect(realSandbox == #"{"setupComplete":true}"#)
+    }
+
+    @Test func readOnlySharesAreSymlinks() throws {
+        let fm = FileManager.default
+        let real = try makeRealRoot()
+        let isolated = try makeIsolatedRoot()
+        defer {
+            try? fm.removeItem(at: real)
+            try? fm.removeItem(at: isolated)
+        }
+
+        EvalBootstrap.seedHostSnapshots(realRoot: real, isolatedRoot: isolated, symlinkTools: true)
+
+        let tools = isolated.appendingPathComponent("Tools")
+        let manifest = isolated.appendingPathComponent("cache/external-models.json")
+        let container = isolated.appendingPathComponent("container")
+        #expect(isSymlink(tools))
+        #expect(isSymlink(manifest))
+        #expect(isSymlink(container))
+        #expect(
+            try fm.destinationOfSymbolicLink(atPath: container.path)
+                == real.appendingPathComponent("container", isDirectory: true).path
+        )
+
+        // Deleting the isolated root must remove the links, never the
+        // shared host targets — the cleanup/orphan-sweep safety property.
+        try fm.removeItem(at: isolated)
+        #expect(fm.fileExists(atPath: real.appendingPathComponent("Tools").path))
+        #expect(fm.fileExists(atPath: real.appendingPathComponent("container").path))
+        #expect(fm.fileExists(atPath: real.appendingPathComponent("cache/external-models.json").path))
+    }
+
+    @Test func toolsSymlinkIsGatedOnPluginLoading() throws {
+        let fm = FileManager.default
+        let real = try makeRealRoot()
+        let isolated = try makeIsolatedRoot()
+        defer {
+            try? fm.removeItem(at: real)
+            try? fm.removeItem(at: isolated)
+        }
+
+        EvalBootstrap.seedHostSnapshots(realRoot: real, isolatedRoot: isolated, symlinkTools: false)
+
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("Tools").path))
+    }
+
+    @Test func userContextIsNeverShared() throws {
+        let fm = FileManager.default
+        let real = try makeRealRoot()
+        let isolated = try makeIsolatedRoot()
+        defer {
+            try? fm.removeItem(at: real)
+            try? fm.removeItem(at: isolated)
+        }
+
+        EvalBootstrap.seedHostSnapshots(realRoot: real, isolatedRoot: isolated, symlinkTools: true)
+
+        // Live user-context stores start empty in the isolated root: eval
+        // fixtures write fresh files there, never into the real root.
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("agents").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("memory").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("chat-history").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("methods").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("scheduler.sqlite").path))
+    }
+
+    @Test func missingHostFilesAreSkippedGracefully() throws {
+        let fm = FileManager.default
+        // A bare real root (fresh machine, nothing provisioned yet).
+        let real = fm.temporaryDirectory
+            .appendingPathComponent("host-snapshot-bare-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: real, withIntermediateDirectories: true)
+        let isolated = try makeIsolatedRoot()
+        defer {
+            try? fm.removeItem(at: real)
+            try? fm.removeItem(at: isolated)
+        }
+
+        EvalBootstrap.seedHostSnapshots(realRoot: real, isolatedRoot: isolated, symlinkTools: true)
+
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("Tools").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("container").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("config/chat.json").path))
+        #expect(!fm.fileExists(atPath: isolated.appendingPathComponent("config/sandbox.json").path))
+    }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
@@ -52,7 +52,6 @@ struct EvalBootstrapPlanTests {
                     searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
                 )
         )
-        #expect(plan.usesIsolatedSearchStorage)
     }
 
     @Test func capabilitySearchScopesIndexBootstrapToSelectedLanes() {
@@ -141,7 +140,7 @@ struct EvalBootstrapPlanTests {
     }
 
     @MainActor
-    @Test func isolatedSearchStorageOverridesOsaurusRoot() {
+    @Test func runStorageIsolationOverridesOsaurusRoot() {
         let previousRoot = OsaurusPaths.overrideRoot
         var isolatedRoot: URL?
         defer {
@@ -152,7 +151,7 @@ struct EvalBootstrapPlanTests {
             }
         }
 
-        let root = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(
+        let root = EvalBootstrap.configureIsolatedRunStorage(
             for: EvalBootstrapPlan(
                 loadInstalledPlugins: false,
                 searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
@@ -171,8 +170,34 @@ struct EvalBootstrapPlanTests {
         }
     }
 
+    /// Hermetic-context invariant: EVERY eval run isolates, even a plan with
+    /// no bootstrap work at all (pure data suites). Fixture seeds from any
+    /// domain must never be able to land in the user's real `~/.osaurus`.
     @MainActor
-    @Test func nonIsolatedBootstrapDoesNotReplaceExistingRootOverride() {
+    @Test func runStorageIsolationAppliesToNoWorkPlans() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        var isolatedRoot: URL?
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            StorageKeyManager.shared.wipeCache()
+            if let isolatedRoot {
+                try? FileManager.default.removeItem(at: isolatedRoot)
+            }
+        }
+
+        let plan = EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false)
+        #expect(!plan.requiresWork)
+
+        let root = EvalBootstrap.configureIsolatedRunStorage(for: plan)
+        isolatedRoot = root
+
+        #expect(root != nil)
+        #expect(OsaurusPaths.overrideRoot == root)
+        #expect(root?.lastPathComponent.hasPrefix("osaurus-evals-") == true)
+    }
+
+    @MainActor
+    @Test func isolationDoesNotReplaceExistingRootOverride() {
         let previousRoot = OsaurusPaths.overrideRoot
         let existingRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-evals-existing-\(UUID().uuidString)", isDirectory: true)
@@ -181,7 +206,7 @@ struct EvalBootstrapPlanTests {
             OsaurusPaths.overrideRoot = previousRoot
         }
 
-        let root = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(
+        let root = EvalBootstrap.configureIsolatedRunStorage(
             for: EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false)
         )
 

--- a/scripts/evals/optimization-loop.sh
+++ b/scripts/evals/optimization-loop.sh
@@ -75,15 +75,13 @@ set -uo pipefail
 #   PARALLEL_REMOTE "1" (default) → when MODELS mixes local and remote-provider
 #                  ids, run the remote models' LLM pass in a background lane
 #                  concurrent with the local lane (remote decode is
-#                  network-bound — no GPU contention). The remote lane runs
-#                  with config storage force-isolated so it can never race the
-#                  local lane on the real ~/.osaurus chat config. The
-#                  sandbox-VM suite is the one exception: it is serialized
-#                  across lanes with a lock (Apple Containerization is
-#                  host-global) and runs WITHOUT forced isolation — the host's
-#                  provisioned sandbox.json lives in the real root, and an
-#                  isolated root would read setupComplete=false and skip every
-#                  case. "0" restores the fully sequential order.
+#                  network-bound — no GPU contention). Every eval process runs
+#                  in its own hermetic throwaway storage root (with copied
+#                  chat/sandbox config snapshots), so concurrent lanes can
+#                  never race each other — or the developer's live app — on
+#                  the real ~/.osaurus. The sandbox-VM suite is still
+#                  serialized across lanes with a lock (Apple Containerization
+#                  is host-global). "0" restores the fully sequential order.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -351,16 +349,12 @@ run_model_lane() {
   done
   run_suites_batch "${model}" "llm-${label}" "batch" ${batch_suites[@]+"${batch_suites[@]}"}
   for s in ${vm_suites[@]+"${vm_suites[@]}"}; do
-    # VM suites must NOT inherit forced config isolation (the remote lane
-    # sets OSAURUS_EVALS_ISOLATE_CONFIG=1 for its whole model pass): an
-    # isolated root hides the host's provisioned sandbox.json, so
-    # setupComplete reads false and every case silently skips with
-    # "sandbox setup incomplete on this host". The sandbox VM and its
-    # provisioning config are host-global by design, and cross-lane
-    # contention is already serialized by with_sandbox_lock — the same
-    # real-root regime the local lane always used for this suite.
-    OSAURUS_EVALS_ISOLATE_CONFIG=0 with_sandbox_lock \
-      run_suite "${model}" "llm-${label}" "${s}"
+    # VM suites run hermetically like every other suite: the eval process's
+    # isolated root carries a COPY of the host's provisioned sandbox.json
+    # (so setupComplete reads true) and a `container/` symlink to the real
+    # host-global VM runtime. Cross-lane contention on that shared VM is
+    # serialized by with_sandbox_lock.
+    with_sandbox_lock run_suite "${model}" "llm-${label}" "${s}"
   done
 }
 
@@ -403,15 +397,14 @@ for model in ${MODELS}; do
 done
 
 remote_lane() {
-  # Remote models never need the real ~/.osaurus chat config (the model id is
-  # explicit and the provider is bootstrapped from env keys), so force config
-  # isolation: the lane cannot race the local lane — or the developer's live
-  # app — on shared config state.
+  # Each eval process already runs in its own hermetic storage root, so the
+  # remote lane cannot race the local lane — or the developer's live app —
+  # on shared config state.
   local model label
   for model in ${REMOTE_MODELS[@]+"${REMOTE_MODELS[@]}"}; do
     label="$(label_for "${model}")"
     log "LLM suites for model=${model} (label=${label}) [remote lane]:"
-    OSAURUS_EVALS_ISOLATE_CONFIG=1 run_model_lane "${model}" "${label}"
+    run_model_lane "${model}" "${label}"
   done
 }
 


### PR DESCRIPTION
## Summary

- Every `osaurus-evals run` (and `agent-loop-lab`) process now runs against a **disposable storage root** (`$TMPDIR/osaurus-evals-<uuid>`), unconditionally — previously isolation only kicked in for `default_agent` cases or search-index bootstrap, so ad-hoc runs (memory, agent_loop, capability_claims, …) could leave dummy agents, schedules, memory rows, and `eval-*` methods in the user's real `~/.osaurus`.
- The isolated root is seeded with the few host resources a run must see: **copies** of `config/chat.json` (keeps `--model auto` resolvable) and `config/sandbox.json` (keeps provisioned-sandbox detection — writes land in the throwaway copy), plus read-only **symlinks** for `Tools/` (when the plan loads plugins), `cache/external-models.json`, and `container/` (the host-global sandbox VM, the one deliberate exception since boot costs minutes and it's shared with the app).
- Removes the `OSAURUS_EVALS_ISOLATE_CONFIG` force/disable branching from `scripts/evals/optimization-loop.sh` — the sandbox lane and the parallel remote lane are hermetic by construction now. PID-owner exit cleanup and the orphan sweep are unchanged; no backup/restore of `~/.osaurus` (the real root is simply never written).
- New `EvalBootstrapHostSnapshotTests` pin the seeding contract (copies vs symlinks, no user-context sharing, links never delete host targets, bare hosts seed gracefully); `EvalBootstrapPlanTests` gains coverage that even no-bootstrap pure suites isolate. Docs updated (`COMMUNITY_EVALS.md` "Your Osaurus data is untouched", evals README "Hermetic run storage").

Note: sandbox provisioning stamps (`setupComplete`, boot durations, image digest) written *during* an eval now land in the throwaway `sandbox.json` copy — the host app remains the source of truth for provisioning, matching the suite's existing requirement that the host be set up beforehand.

## Test plan

- [x] `swift build --package-path Packages/OsaurusEvals`
- [x] `swift test --package-path Packages/OsaurusEvals` (185 tests, 25 suites, incl. new `EvalBootstrapHostSnapshotTests`)
- [x] `bash -n` on edited eval scripts; `swift format lint` clean on new/changed code
- [ ] CI (`test-core`, `test-evals`)
- [ ] Post-merge smoke: a suite run against a provisioned host confirms SandboxFrontier still detects setup + `$TMPDIR/osaurus-evals-*` is deleted on exit