### PR TITLE
Add opt-in materialized weight loading override

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3175,12 +3175,18 @@ public actor ModelRuntime {
             inspectBundleFacts
             ? LoadBundleFacts.inspect(bundleURL: modelDirectory)
             : nil
-        let plan = settings.resolvedMemorySafetyPlan(
+        var plan = settings.resolvedMemorySafetyPlan(
             baseLoadConfiguration: baseLoadConfiguration,
             bundleFacts: bundleFacts,
             host: MemoryStatus.snapshot(),
             request: nil
         )
+        if forceMaterializedWeights {
+            plan.loadConfiguration.useMmapSafetensors = false
+            genLog.warning(
+                "loadContainer: OSAURUS_MATERIALIZE_WEIGHTS enabled; forcing materialized weight loading for \(modelName, privacy: .public)"
+            )
+        }
         if !plan.blockingIssues.isEmpty {
             let issueSummary = plan.blockingIssues
                 .map { "\($0.field): \($0.message)" }
@@ -3190,6 +3196,13 @@ public actor ModelRuntime {
             )
         }
         return plan
+    }
+
+    private nonisolated static var forceMaterializedWeights: Bool {
+        let value = ProcessInfo.processInfo.environment["OSAURUS_MATERIALIZE_WEIGHTS"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return value == "1" || value == "true" || value == "yes"
     }
 
     private nonisolated static func describeDraftStrategy(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2030,6 +2030,26 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("ModelRuntime applies the materialized-weights override through memory safety resolution")
+    func modelRuntimeAppliesMaterializedWeightsOverrideCentrally() throws {
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+        let start = try #require(runtime.range(of: "private nonisolated static func resolveMemorySafetyLoadPlan("))
+        let end = try #require(
+            runtime.range(
+                of: "private nonisolated static func describeDraftStrategy(",
+                range: start.upperBound ..< runtime.endIndex
+            )
+        )
+        let body = String(runtime[start.lowerBound ..< end.lowerBound])
+
+        #expect(body.contains("var plan = settings.resolvedMemorySafetyPlan("))
+        #expect(body.contains("if forceMaterializedWeights {"))
+        #expect(body.contains("plan.loadConfiguration.useMmapSafetensors = false"))
+        #expect(body.contains("OSAURUS_MATERIALIZE_WEIGHTS enabled"))
+        #expect(body.contains("environment[\"OSAURUS_MATERIALIZE_WEIGHTS\"]"))
+        #expect(body.contains("value == \"1\" || value == \"true\" || value == \"yes\""))
+    }
+
     @Test("ModelRuntime keeps weight-size directory scans out of the default load path")
     func modelRuntimeWeightSizePreflightIsManualMultiModelOnly() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")


### PR DESCRIPTION
## Summary

Add an opt-in `OSAURUS_MATERIALIZE_WEIGHTS` environment variable that forces safetensor weights to be materialized instead of memory-mapped.

This is useful on systems where memory-mapped model weights can be evicted or cause unstable performance under memory pressure. Materializing the weights keeps them resident in allocated memory and provides a workaround without changing the default loading behavior for other users.

When `OSAURUS_MATERIALIZE_WEIGHTS=1` is set, Osaurus uses:

```swift
useMmapSafetensors = false
```

When the variable is not set, the existing memory-mapped loading behavior remains unchanged.

## Test Plan

Model used: `minimax-m2.7-jangtq`

1. Build and launch Osaurus without the environment variable.

2. Load the model and verify that the existing memory-mapped safetensor path is used.

3. Quit Osaurus.

4. Launch it with the environment variable enabled:

   ```bash
   OSAURUS_MATERIALIZE_WEIGHTS=1 \
     /Applications/Osaurus.app/Contents/MacOS/Osaurus
   ```

   Alternatively, add `OSAURUS_MATERIALIZE_WEIGHTS=1` to the environment variables in the Xcode scheme.

5. Load the same model.

6. Verify that `useMmapSafetensors` is set to `false` and the safetensor weights are materialized.

7. Run an inference request and confirm that model loading and generation complete successfully.

8. Remove the environment variable and confirm that the default memory-mapped behavior is restored.

## Screenshots

Not applicable. No UI changes.
