### PR TITLE
Refuse background model loads inside the actor, not before it

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -791,6 +791,15 @@ struct ChatCompletionRequest: Codable, Sendable {
     /// required for sliding-window models whose caches cannot be trimmed to
     /// a boundary at store time.
     var warmupPrefill: Bool = false
+    /// Local-only: when true, this request's model load must not disturb a model
+    /// that is already resident or already loading — the runtime refuses the load
+    /// instead of evicting. Set by housekeeping that nobody is waiting on
+    /// (speculative warm-up, greeting generation, transcript cleanup, memory
+    /// distillation). Never set for a request a human is waiting on: those are
+    /// entitled to the GPU.
+    ///
+    /// Not decoded from OpenAI JSON, not sent to providers.
+    var backgroundModelLoad: Bool = false
 
     /// Resolved max tokens, preferring max_tokens then max_completion_tokens.
     var resolvedMaxTokens: Int? { max_tokens ?? max_completion_tokens }

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -849,6 +849,10 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.remoteAgentProviderId = remoteAgentProviderId
         copy.suppressProgressUI = suppressProgressUI
         copy.warmupPrefill = warmupPrefill
+        // Must be copied with the other local-only flags. Dropping it silently
+        // promotes a background request back to interactive — and an interactive
+        // request is allowed to evict the model someone is using.
+        copy.backgroundModelLoad = backgroundModelLoad
         copy.logprobs = logprobs
         copy.top_logprobs = top_logprobs
         return copy
@@ -893,6 +897,10 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.remoteAgentProviderId = remoteAgentProviderId
         copy.suppressProgressUI = suppressProgressUI
         copy.warmupPrefill = warmupPrefill
+        // Must be copied with the other local-only flags. Dropping it silently
+        // promotes a background request back to interactive — and an interactive
+        // request is allowed to evict the model someone is using.
+        copy.backgroundModelLoad = backgroundModelLoad
         copy.logprobs = logprobs
         copy.top_logprobs = top_logprobs
         return copy

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -181,7 +181,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             runAsRemoteAgent: request.runAsRemoteAgent,
             suppressProgressUI: request.suppressProgressUI,
             warmupPrefill: request.warmupPrefill,
-            requestSource: inferenceSource
+            requestSource: inferenceSource,
+            loadIntent: request.backgroundModelLoad ? .background : .interactive
         )
 
         // Mode 2 (remote agent run): route to the *selected agent's provider*,

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -160,12 +160,13 @@ extension ChatSession: ChatWarmupSessionContext {
     /// previous local model should not stay resident just because the user
     /// moved off local models entirely.
     func performModelResidencySwitch(evictOthers: Bool) async {
-        // Background housekeeping must not preempt a load already in flight
-        // (an API request or another window's explicit switch): under the
-        // strict single-model policy the preload below cancels whatever is
-        // loading, and the eviction races its teardown — observed live as a
-        // 94 GB HY3 load dying to a stale-selection warm-up. The next real
-        // send re-runs this switch anyway.
+        // Guards the *eviction* below, which is an explicit unload and so isn't
+        // covered by the runtime's load-intent refusal. Still a best-effort
+        // check-then-act — it narrows the window rather than closing it — but
+        // tearing down residency while another window's or an API client's load
+        // is materializing is exactly the 94 GB HY3 death we saw live. The
+        // preload further down needs no probe: it passes `.background` and the
+        // runtime refuses atomically.
         if await ModelRuntime.shared.hasLoadInFlight() { return }
         if evictOthers {
             let active = ChatWindowManager.shared.activeLocalModelNames()
@@ -184,7 +185,10 @@ extension ChatSession: ChatWarmupSessionContext {
         {
             return
         }
-        try? await ModelRuntime.shared.preload(name: model)
+        // Speculative: it only exists to hide the load cost of a selection the
+        // user has not sent to yet. It must never be the reason someone else's
+        // model gets evicted, so it declines rather than disturb residency.
+        try? await ModelRuntime.shared.preload(name: model, intent: .background)
     }
 
     func notifySessionBecameActive() {

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -160,17 +160,16 @@ extension ChatSession: ChatWarmupSessionContext {
     /// previous local model should not stay resident just because the user
     /// moved off local models entirely.
     func performModelResidencySwitch(evictOthers: Bool) async {
-        // Guards the *eviction* below, which is an explicit unload and so isn't
-        // covered by the runtime's load-intent refusal. Still a best-effort
-        // check-then-act — it narrows the window rather than closing it — but
-        // tearing down residency while another window's or an API client's load
-        // is materializing is exactly the 94 GB HY3 death we saw live. The
-        // preload further down needs no probe: it passes `.background` and the
-        // runtime refuses atomically.
-        if await ModelRuntime.shared.hasLoadInFlight() { return }
+        // The GC below is an explicit unload, not a load, so the runtime's
+        // load-intent refusal can't cover it — but the decision still has to be
+        // made *inside* the actor. `skipIfLoadInFlight` does that: a model that
+        // is mid-load is in `loadingTasks`, not `modelCache`, and holds no lease,
+        // so it is invisible to both the window snapshot and the lease check, and
+        // a sweep would tear the runtime down around it. That is the 94 GB HY3
+        // load we watched die to a stale-selection warm-up.
         if evictOthers {
             let active = ChatWindowManager.shared.activeLocalModelNames()
-            await ModelRuntime.shared.unloadModelsNotIn(active)
+            await ModelRuntime.shared.unloadModelsNotIn(active, skipIfLoadInFlight: true)
         }
 
         guard !ChatConfigurationStore.load().warmModelsOnLoad else { return }

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -407,6 +407,13 @@ final class ChatWarmupController: ObservableObject {
         // sliding-window models like Gemma 4, whose caches cannot be
         // trimmed back to a boundary at store time).
         request.warmupPrefill = true
+        // A warm-up that follows the user's own model pick carries their intent
+        // and may displace a resident model. A speculative one (launch-time
+        // restore of the last UI selection, an idle re-warm) may not — that is
+        // the warm-up that was observed unloading a 94 GB model an API client
+        // had just finished loading. The runtime enforces this atomically, at
+        // the eviction itself; the early-outs above are only a fast path.
+        request.backgroundModelLoad = (payload.model != userIntentWarmupModel)
 
         let startedAt = Date()
         let engine = session.makeWarmupEngine()

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -189,6 +189,13 @@ final class ChatWarmupController: ObservableObject {
         // allowed to displace whatever is resident. Speculative warm-ups
         // (session became active, post-run re-warm) are not; see
         // `performWarmup`'s resident-model guard.
+        //
+        // This is a ONE-SHOT grant, consumed by the warm-up it authorizes (see
+        // `consumeUserIntent(for:)`). It used to be set here and never cleared,
+        // which quietly turned "the user just picked A" into "any warm-up of A,
+        // forever, may evict" — so a re-warm of A minutes later, triggered by
+        // nothing the user did, could still unload the model an API client was
+        // using. The privilege has to expire with the intent that created it.
         userIntentWarmupModel = newModel
 
         let policy =
@@ -348,8 +355,14 @@ final class ChatWarmupController: ObservableObject {
         // observed live as a launch-time warm-up for the restored UI
         // selection unloading the 94 GB model an API client had just
         // loaded. Only the warm-up that follows the user's own model pick
-        // (`userIntentWarmupModel`) may displace a resident model.
-        if payload.model != userIntentWarmupModel,
+        // may displace a resident model.
+        //
+        // Resolved ONCE here and threaded down, so the early gate below and the
+        // load intent in `runWarmupGeneration` can never disagree about whether
+        // this warm-up carries the user's intent.
+        let userIntent = consumeUserIntent(for: payload.model)
+
+        if !userIntent,
             await ModelRuntime.shared.hasResidentModelOther(than: payload.model)
         {
             state = .cold
@@ -362,7 +375,8 @@ final class ChatWarmupController: ObservableObject {
         state = .warming
         let id = UUID()
         let task = Task { @MainActor in
-            await runWarmupGeneration(session: session, payload: payload, id: id)
+            await runWarmupGeneration(
+                session: session, payload: payload, id: id, userIntent: userIntent)
         }
         inFlightWarmup = task
         inFlightWarmupID = id
@@ -373,10 +387,25 @@ final class ChatWarmupController: ObservableObject {
         }
     }
 
+    /// Claim the one-shot "the user picked this model by hand" grant, if this
+    /// warm-up is the one it was issued for. Returns `true` at most once per
+    /// pick: the grant authorizes a single warm-up to displace a resident model,
+    /// and every later re-warm of the same model is speculative again.
+    ///
+    /// Only consumed on the path that actually proceeds to warm up. A warm-up
+    /// refused for lacking intent never had the grant, so there is nothing to
+    /// consume and nothing is lost.
+    private func consumeUserIntent(for model: String) -> Bool {
+        guard userIntentWarmupModel == model else { return false }
+        userIntentWarmupModel = nil
+        return true
+    }
+
     private func runWarmupGeneration(
         session: ChatWarmupSessionContext,
         payload: ChatWarmupPayload,
-        id: UUID
+        id: UUID,
+        userIntent: Bool
     ) async {
         // `.auto` renders the same tokenizer tool specs as a real send's
         // resolved tool choice (`.auto`/`.required` are byte-identical in
@@ -413,7 +442,7 @@ final class ChatWarmupController: ObservableObject {
         // the warm-up that was observed unloading a 94 GB model an API client
         // had just finished loading. The runtime enforces this atomically, at
         // the eviction itself; the early-outs above are only a fast path.
-        request.backgroundModelLoad = (payload.model != userIntentWarmupModel)
+        request.backgroundModelLoad = !userIntent
 
         let startedAt = Date()
         let engine = session.makeWarmupEngine()

--- a/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
@@ -159,7 +159,13 @@ public actor CoreModelService {
         let params = GenerationParameters(
             temperature: Float(temperature),
             maxTokens: maxTokens,
-            modelOptions: modelOptions
+            modelOptions: modelOptions,
+            // Carried all the way into `ModelRuntime.loadContainer`, which refuses
+            // a background load *at the moment it would evict* — atomically, inside
+            // the actor. Probing residency from out here and then loading on a
+            // later actor hop is a check-then-act race: whatever the probe saw can
+            // change before the load runs.
+            loadIntent: intent == .background ? .background : .interactive
         )
 
         do {
@@ -481,40 +487,25 @@ public actor CoreModelService {
 
         switch route {
         case .service(let service, let effectiveModel):
-            if intent == .background, service.id == MLXService.shared.id {
-                try await Self.declineIfItWouldDisturbTheUsersModel(effectiveModel)
-            }
             let promptLen = messages.last?.content?.count ?? 0
             logger.debug(
                 "Routing to \(service.id) (model: \(effectiveModel), prompt: \(promptLen) chars)"
             )
-            return try await service.generateOneShot(
-                messages: messages,
-                parameters: params,
-                requestedModel: model
-            )
+            do {
+                return try await service.generateOneShot(
+                    messages: messages,
+                    parameters: params,
+                    requestedModel: model
+                )
+            } catch let refusal as ModelRuntime.ResidencyRefusedError {
+                // `params.loadIntent == .background` and the load would have
+                // disturbed the user's model. Not a backend fault — surface it as
+                // the existing skip error so the breaker stays out of it.
+                logger.info("\(refusal.errorDescription ?? "background load refused")")
+                throw CoreModelError.backgroundWouldEvictUserModel(effectiveModel)
+            }
         case .none:
             throw CoreModelError.modelUnavailable(model)
-        }
-    }
-
-    /// The MLX runtime is strictly single-model: loading `model` evicts whoever
-    /// is resident, and starting a load cancels one already in flight. Neither is
-    /// acceptable on behalf of a background caller — memory distillation must not
-    /// throw away the model the user is mid-conversation with, and voice-transcript
-    /// cleanup must not cancel the load the user is watching a spinner for.
-    ///
-    /// Same rule the warm-up and greeting paths already follow: filling an *empty*
-    /// slot is fine, disturbing an occupied one is not. Remote and Foundation
-    /// routes don't touch GPU residency, so this only gates the local MLX route.
-    private static func declineIfItWouldDisturbTheUsersModel(_ model: String) async throws {
-        if await ModelRuntime.shared.hasLoadInFlight() {
-            logger.info("Declining background call for '\(model)': a model load is in flight")
-            throw CoreModelError.backgroundWouldEvictUserModel(model)
-        }
-        if await ModelRuntime.shared.hasResidentModelOther(than: model) {
-            logger.info("Declining background call for '\(model)': another model is resident")
-            throw CoreModelError.backgroundWouldEvictUserModel(model)
         }
     }
 

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -80,6 +80,18 @@ struct GenerationParameters: Sendable {
     /// kept warm by API clients. Defaults to `.httpAPI` — the conservative
     /// choice (never accelerated) for paths that don't set it explicitly.
     let requestSource: RequestSource
+    /// Whether this generation's model load may disturb a model someone else is
+    /// using. `.interactive` (the default) keeps today's behaviour: a human is
+    /// waiting, so the load may evict a resident model or cancel an in-flight
+    /// one. Housekeeping generations — memory distillation, greetings,
+    /// voice-transcript cleanup, speculative warm-up — must pass `.background`,
+    /// which makes `ModelRuntime` refuse the load rather than take the GPU out
+    /// from under an active chat.
+    ///
+    /// This rides on `GenerationParameters` rather than being a separate
+    /// argument so it survives the whole ChatEngine → MLXService → ModelRuntime
+    /// path without every layer having to re-plumb it.
+    let loadIntent: ModelLoadIntent
 
     init(
         temperature: Float?,
@@ -101,7 +113,8 @@ struct GenerationParameters: Sendable {
         runAsRemoteAgent: Bool = false,
         suppressProgressUI: Bool = false,
         warmupPrefill: Bool = false,
-        requestSource: RequestSource = .httpAPI
+        requestSource: RequestSource = .httpAPI,
+        loadIntent: ModelLoadIntent = .interactive
     ) {
         self.temperature = temperature
         self.maxTokens = maxTokens
@@ -123,6 +136,7 @@ struct GenerationParameters: Sendable {
         self.suppressProgressUI = suppressProgressUI
         self.warmupPrefill = warmupPrefill
         self.requestSource = requestSource
+        self.loadIntent = loadIntent
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -29,8 +29,56 @@ private let genLog = Logger(subsystem: "com.dinoki.osaurus", category: "Generati
 private let _vlmFactory = MLXVLM.VLMModelFactory.shared
 private let _llmFactory = MLXLLM.LLMModelFactory.shared
 
+/// Whether a load may disturb the model someone is already using.
+///
+/// The runtime is strictly single-model by default: loading B evicts resident A
+/// and cancels an in-flight load of A. That is fine when a human is waiting on
+/// B — they asked for it. It is never fine on behalf of housekeeping (memory
+/// distillation, greeting generation, voice-transcript cleanup, speculative
+/// warm-up, a cron-fired agent), which must fill an *empty* slot or step aside.
+///
+/// This has to be enforced inside the actor, at the moment of eviction. Callers
+/// used to probe `hasLoadInFlight()` / `hasResidentModelOther(than:)` and then
+/// load on a later actor hop — a check-then-act race that loses whatever arrived
+/// in between. `ModelRuntime` is reentrant across every `await`, so the only
+/// atomic place to refuse is the same synchronous segment that observed the
+/// conflict.
+public enum ModelLoadIntent: Sendable, Equatable {
+    /// A human is waiting on this load. May evict and cancel as needed.
+    case interactive
+    /// Housekeeping. Reuses a resident model or fills an empty slot; refuses
+    /// rather than disturb a model that is resident or already loading.
+    case background
+}
+
 public actor ModelRuntime {
     // MARK: - Types
+
+    /// Thrown when a `.background` load would have evicted a resident model or
+    /// cancelled an in-flight one. Callers are expected to treat this as "not
+    /// now" — skip the housekeeping, or retry later — never as a hard failure.
+    public struct ResidencyRefusedError: Error, LocalizedError, Sendable, Equatable {
+        public enum Conflict: Sendable, Equatable {
+            /// A different model is resident and would have been evicted.
+            case wouldEvictResident(String)
+            /// A different model is mid-load and would have been cancelled.
+            case wouldCancelLoadInFlight(String)
+        }
+
+        public let requestedModel: String
+        public let conflict: Conflict
+
+        public var errorDescription: String? {
+            switch conflict {
+            case .wouldEvictResident(let resident):
+                return
+                    "Skipped background load of '\(requestedModel)': it would evict '\(resident)', which is in use"
+            case .wouldCancelLoadInFlight(let loading):
+                return
+                    "Skipped background load of '\(requestedModel)': it would cancel the in-flight load of '\(loading)'"
+            }
+        }
+    }
 
     struct LoadRefusedError: Error, LocalizedError, Sendable {
         let modelName: String
@@ -221,7 +269,7 @@ public actor ModelRuntime {
     /// Warm-load an installed local model without starting generation. Used by
     /// delegated jobs that temporarily evict chat models for unified-memory
     /// headroom, then restore the prior resident set after the helper job.
-    func preload(name: String) async throws {
+    func preload(name: String, intent: ModelLoadIntent = .interactive) async throws {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw NSError(
@@ -239,7 +287,7 @@ public actor ModelRuntime {
             )
         }
         if modelCache[found.name] != nil { return }
-        _ = try await loadContainer(id: found.id, name: found.name)
+        _ = try await loadContainer(id: found.id, name: found.name, intent: intent)
         // A preload never acquires a generation lease, so without arming the
         // idle timer here the model would stay resident FOREVER if no
         // generation ever follows (the timer is otherwise only scheduled on
@@ -1551,12 +1599,37 @@ public actor ModelRuntime {
         }
     }
 
+    /// Refuse a `.background` load that is about to disturb someone else's model.
+    ///
+    /// This is deliberately **synchronous**. `ModelRuntime` is an actor, so an
+    /// actor-isolated segment with no `await` in it runs to completion without
+    /// interleaving. Callers must therefore observe the conflict (read
+    /// `loadingTasks` / `modelCache`) and call this in the *same* segment — no
+    /// suspension in between. That is what makes the refusal atomic with the
+    /// eviction it is preventing.
+    ///
+    /// Checking-then-awaiting from outside the actor (the old
+    /// `hasLoadInFlight()` + `preload()` shape) cannot work: whatever the probe
+    /// saw is already stale by the time the load runs.
+    private func refuseBackgroundLoadIfItWouldDisturb(
+        intent: ModelLoadIntent,
+        requested: String,
+        conflict: @autoclosure () -> ResidencyRefusedError.Conflict
+    ) throws {
+        guard intent == .background else { return }
+        let refusal = ResidencyRefusedError(requestedModel: requested, conflict: conflict())
+        genLog.info(
+            "loadContainer: refusing background load model=\(requested, privacy: .public) reason=\(refusal.errorDescription ?? "", privacy: .public)"
+        )
+        throw refusal
+    }
+
     /// True while any model load is registered or holds the cold-load slot.
-    /// Background housekeeping (chat warm-up, residency-switch preload/GC)
-    /// checks this before acting: under the strict single-model policy a
-    /// late-arriving background load cancels whatever is already loading, so
-    /// a stale-selection warm-up firing during an explicit API load evicts
-    /// the user's model mid-materialization.
+    ///
+    /// Diagnostics only. Do **not** gate a load on this: the answer is stale the
+    /// moment it returns, because the load you would then start runs on a later
+    /// actor hop. Pass `intent: .background` down into the load instead and let
+    /// `refuseBackgroundLoadIfItWouldDisturb` decide atomically.
     func hasLoadInFlight() -> Bool {
         !loadingTasks.isEmpty || coldLoadActive
     }
@@ -1581,8 +1654,9 @@ public actor ModelRuntime {
     /// Hy3-sized residents do not collide with the next load.
     private func unloadForFlexibleResidentBudget(
         targetName: String,
-        incomingWeightsSizeBytes: Int64
-    ) async {
+        incomingWeightsSizeBytes: Int64,
+        intent: ModelLoadIntent = .interactive
+    ) async throws {
         let limit = Self.flexibleResidentBudgetBytes()
         guard limit > 0 else { return }
 
@@ -1596,6 +1670,15 @@ public actor ModelRuntime {
                 return
             }
 
+            // Flexible mode evicts too, just for a different reason (RAM budget
+            // rather than strict single-model). Without this the "background
+            // never disturbs a resident model" contract would hold only under
+            // the default policy — a silent hole for anyone on manualMultiModel.
+            try refuseBackgroundLoadIfItWouldDisturb(
+                intent: intent,
+                requested: targetName,
+                conflict: .wouldEvictResident(candidate.key)
+            )
             genLog.info(
                 "loadContainer: flexible budget eviction of \(candidate.key, privacy: .public) before loading \(targetName, privacy: .public) residentBytes=\(self.residentWeightBytes(excluding: targetName), privacy: .public) incomingBytes=\(incomingWeightsSizeBytes, privacy: .public) limitBytes=\(limit, privacy: .public)"
             )
@@ -1603,7 +1686,11 @@ public actor ModelRuntime {
         }
     }
 
-    private func loadContainer(id: String, name: String) async throws -> SessionHolder {
+    private func loadContainer(
+        id: String,
+        name: String,
+        intent: ModelLoadIntent = .interactive
+    ) async throws -> SessionHolder {
         try Task.checkCancellation()
         let policy = await ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
         let loadStartedAt = CFAbsoluteTimeGetCurrent()
@@ -1651,6 +1738,13 @@ public actor ModelRuntime {
                 let otherName = otherLoading.key
                 let otherRecord = otherLoading.value
                 if policy == .strictSingleModel {
+                    // Same actor segment as the `loadingTasks` read above — no
+                    // `await` between observing the conflict and refusing.
+                    try refuseBackgroundLoadIfItWouldDisturb(
+                        intent: intent,
+                        requested: name,
+                        conflict: .wouldCancelLoadInFlight(otherName)
+                    )
                     genLog.info(
                         "loadContainer: strict drain of in-flight load \(otherName, privacy: .public)"
                     )
@@ -1676,6 +1770,15 @@ public actor ModelRuntime {
             if policy == .strictSingleModel,
                 let other = modelCache.keys.first(where: { $0 != name })
             {
+                // `strictEvict` suspends (it waits on the `ModelLease` actor)
+                // before it unloads, so a check placed *inside* it would not be
+                // atomic with the eviction. Refuse here, in the same segment
+                // that read `modelCache`.
+                try refuseBackgroundLoadIfItWouldDisturb(
+                    intent: intent,
+                    requested: name,
+                    conflict: .wouldEvictResident(other)
+                )
                 await strictEvict(other)
                 continue
             }
@@ -1723,6 +1826,14 @@ public actor ModelRuntime {
                 let otherName = otherLoading.key
                 let otherRecord = otherLoading.value
                 if policy == .strictSingleModel {
+                    // Re-checked after `acquireColdLoadSlot()`, which suspends —
+                    // the actor is reentrant across it, so the pre-slot check
+                    // above proves nothing about the state we see now.
+                    try refuseBackgroundLoadIfItWouldDisturb(
+                        intent: intent,
+                        requested: name,
+                        conflict: .wouldCancelLoadInFlight(otherName)
+                    )
                     genLog.info(
                         "loadContainer: strict drain of in-flight load \(otherName, privacy: .public) after cold-load wait"
                     )
@@ -1748,6 +1859,15 @@ public actor ModelRuntime {
             if policy == .strictSingleModel,
                 let other = modelCache.keys.first(where: { $0 != name })
             {
+                // `strictEvict` suspends (it waits on the `ModelLease` actor)
+                // before it unloads, so a check placed *inside* it would not be
+                // atomic with the eviction. Refuse here, in the same segment
+                // that read `modelCache`.
+                try refuseBackgroundLoadIfItWouldDisturb(
+                    intent: intent,
+                    requested: name,
+                    conflict: .wouldEvictResident(other)
+                )
                 await strictEvict(other)
                 continue
             }
@@ -1875,9 +1995,10 @@ public actor ModelRuntime {
         try Task.checkCancellation()
 
         if policy == .manualMultiModel {
-            await unloadForFlexibleResidentBudget(
+            try await unloadForFlexibleResidentBudget(
                 targetName: name,
-                incomingWeightsSizeBytes: loadFootprintBytes
+                incomingWeightsSizeBytes: loadFootprintBytes,
+                intent: intent
             )
         }
         try Task.checkCancellation()
@@ -2675,7 +2796,11 @@ public actor ModelRuntime {
         }
         let holder: SessionHolder
         do {
-            holder = try await loadContainer(id: modelId, name: modelName)
+            holder = try await loadContainer(
+                id: modelId,
+                name: modelName,
+                intent: parameters.loadIntent
+            )
         } catch {
             await ModelResidencyManager.shared.cancel(modelName: modelName)
             if shouldReportModelLoad {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -842,7 +842,24 @@ public actor ModelRuntime {
     /// per-model `unload` call internally waits for the lease to drop before
     /// freeing buffers, so this method is safe to call with a stale `activeNames`
     /// snapshot — at worst the unload is briefly deferred, never a crash.
-    func unloadModelsNotIn(_ activeNames: Set<String>) async {
+    ///
+    /// - Parameter skipIfLoadInFlight: for housekeeping callers (residency-switch
+    ///   GC). A model that is *loading* is in `loadingTasks`, not yet in
+    ///   `modelCache`, and holds no lease — so it is invisible to both the
+    ///   `activeNames` snapshot and the lease check, and GC will happily tear
+    ///   down the runtime around it. Callers used to guard this by probing
+    ///   `hasLoadInFlight()` first, which is check-then-act: the probe returns,
+    ///   the actor yields, a load registers, and the GC proceeds anyway.
+    ///   Passing `true` moves that decision inside the actor, into the same
+    ///   synchronous segment as the `modelCache` read below.
+    func unloadModelsNotIn(
+        _ activeNames: Set<String>,
+        skipIfLoadInFlight: Bool = false
+    ) async {
+        if skipIfLoadInFlight, hasLoadInFlight() {
+            genLog.info("GC: skipping residency sweep — a model load is in flight")
+            return
+        }
         let leaseHeld = await ModelLease.shared.activeNames()
         let keep = activeNames.union(leaseHeld)
         let toUnload = modelCache.keys.filter { !keep.contains($0) }

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionCleanupService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionCleanupService.swift
@@ -129,9 +129,16 @@ public final class TranscriptionCleanupService {
             ChatMessage(role: "system", content: Self.systemPrompt),
             ChatMessage(role: "user", content: userPrompt),
         ]
+        // This fallback bypasses `CoreModelService` and calls `MLXService`
+        // directly, so it has to declare its own intent: tidying a voice
+        // transcript is never worth evicting the model someone is chatting with.
+        // `backgroundSafeModel` above still picks well (prefer resident, accept
+        // an idle runtime), but it is a heuristic on a stale snapshot — this is
+        // the guard the runtime actually enforces, at the eviction itself.
         let params = GenerationParameters(
             temperature: 0.1,
             maxTokens: max(256, trimmed.count),
+            loadIntent: .background
         )
 
         let start = Date()

--- a/Packages/OsaurusCore/Tests/Service/ResidencyIntentTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ResidencyIntentTests.swift
@@ -178,6 +178,60 @@ struct ResidencyIntentTests {
         #expect(params.loadIntent == .background)
     }
 
+    // MARK: - The intent must survive the trip, and must expire
+
+    @Test("Copying a request keeps its background flag")
+    func copyHelpersPreserveBackgroundIntent() throws {
+        let src = try Self.source("Models/API/OpenAIAPI.swift")
+
+        // `withModel` and `withContext` rebuild the request field by field. Both
+        // already carry the other local-only flags. Omitting this one silently
+        // PROMOTES a background request to interactive — and interactive requests
+        // are the ones allowed to evict a model someone is using. A dropped flag
+        // here undoes the entire guard, quietly, with no failing test anywhere.
+        let copies = src.components(separatedBy: "copy.backgroundModelLoad = backgroundModelLoad")
+            .count - 1
+        let helpers = src.components(separatedBy: "copy.warmupPrefill = warmupPrefill").count - 1
+        #expect(helpers == 2, "expected withModel + withContext to copy local-only flags")
+        #expect(
+            copies == helpers,
+            """
+            \(helpers) request-copy helpers but only \(copies) copy \
+            `backgroundModelLoad`. A helper that drops it turns background \
+            housekeeping back into an eviction-entitled interactive request.
+            """
+        )
+    }
+
+    @Test("The user's warm-up privilege is one-shot, not permanent")
+    func userIntentGrantIsConsumed() throws {
+        let src = try Self.source("Services/Chat/ChatWarmupController.swift")
+
+        // `userIntentWarmupModel` records "the user just picked this by hand", which
+        // entitles the follow-up warm-up to displace a resident model. It used to be
+        // set and never cleared — so "the user picked A once" silently became "any
+        // warm-up of A, forever, may evict", and a re-warm minutes later, triggered
+        // by nothing the user did, could still unload an API client's model. The
+        // grant has to expire with the intent that created it.
+        #expect(
+            src.contains("private func consumeUserIntent(for model: String) -> Bool"),
+            "the user-intent grant must be consumed, not merely compared against"
+        )
+        #expect(
+            src.contains("userIntentWarmupModel = nil"),
+            "consuming the grant must clear it"
+        )
+
+        // And it must be resolved once and threaded, not re-derived at each use —
+        // two independent comparisons against a mutable field can disagree.
+        #expect(src.contains("let userIntent = consumeUserIntent(for: payload.model)"))
+        #expect(src.contains("request.backgroundModelLoad = !userIntent"))
+        #expect(
+            !src.contains("payload.model != userIntentWarmupModel"),
+            "no site may re-derive user intent by comparing the raw field"
+        )
+    }
+
     // MARK: - The refusal is legible
 
     @Test("A refusal says which model it protected and why")

--- a/Packages/OsaurusCore/Tests/Service/ResidencyIntentTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ResidencyIntentTests.swift
@@ -1,0 +1,200 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// The runtime is strictly single-model: loading B evicts resident A and cancels
+/// an in-flight load of A. `ModelLoadIntent` decides who is allowed to do that.
+///
+/// The whole guarantee rests on one property that is easy to break by accident and
+/// impossible to see in a passing behavioural test: **the refusal must happen in
+/// the same actor segment that observed the conflict.** `ModelRuntime` is an actor,
+/// so it is reentrant across every `await`. A guard that suspends — even once,
+/// even "briefly" — lets another task register a load or finish one in the gap,
+/// and the eviction it was supposed to prevent happens anyway.
+///
+/// That is precisely the bug these tests exist to stop from coming back: the
+/// previous fix probed `hasLoadInFlight()` / `hasResidentModelOther(than:)` from
+/// *outside* the actor and then loaded on a later hop. Check-then-act. It read as
+/// correct and shipped.
+@Suite("Model residency intent")
+struct ResidencyIntentTests {
+    private static func packageRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        var cursor = here.deletingLastPathComponent()  // Service/
+        cursor.deleteLastPathComponent()  // Tests/
+        return cursor.deletingLastPathComponent()  // OsaurusCore/
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = packageRoot().appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static var modelRuntimeSource: String {
+        get throws { try source("Services/ModelRuntime.swift") }
+    }
+
+    /// The body of `loadContainer`, where every strict-policy eviction lives.
+    private static func loadContainerBody() throws -> String {
+        let src = try modelRuntimeSource
+        let start = try #require(src.range(of: "private func loadContainer("))
+        // `loadContainer` is followed by the next `private func` at the same depth.
+        let end = try #require(
+            src.range(of: "\n    private func ", range: start.upperBound ..< src.endIndex)
+        )
+        return String(src[start.lowerBound ..< end.lowerBound])
+    }
+
+    // MARK: - The atomicity invariant
+
+    @Test("The refusal is synchronous, so it cannot be interleaved")
+    func refusalIsSynchronous() throws {
+        let src = try Self.modelRuntimeSource
+        let signature = try #require(
+            src.range(of: "private func refuseBackgroundLoadIfItWouldDisturb(")
+        )
+        // Everything up to the opening brace of the body.
+        let header = String(src[signature.lowerBound ..< src.endIndex].prefix(400))
+        let bodyStart = try #require(header.range(of: ") throws {"))
+        let declaration = String(header[header.startIndex ..< bodyStart.upperBound])
+
+        // If this ever becomes `async`, the guard can suspend between observing the
+        // conflicting state and throwing — and the actor will happily run another
+        // load in that window. The refusal would still "work" in every test and
+        // still lose the user's model in production.
+        #expect(
+            !declaration.contains("async"),
+            """
+            refuseBackgroundLoadIfItWouldDisturb must stay synchronous. An actor \
+            only guarantees mutual exclusion within a segment that contains no \
+            `await`; making this async reopens the check-then-act race it exists \
+            to close.
+            """
+        )
+    }
+
+    @Test("Every strict-policy eviction is guarded, in both loops")
+    func everyEvictionIsGuarded() throws {
+        let body = try Self.loadContainerBody()
+
+        // `loadContainer` runs its residency loop twice: once before
+        // `acquireColdLoadSlot()` and once after. The second pass is not
+        // redundant — acquiring the slot suspends, the actor is reentrant across
+        // it, so state observed before the wait proves nothing after it. Both
+        // passes evict, so both passes must guard.
+        let evictions = body.components(separatedBy: "await strictEvict(").count - 1
+        let cancels = body.components(separatedBy: "await cancelAndDrainLoadingTasks(").count - 1
+        let guards =
+            body.components(separatedBy: "try refuseBackgroundLoadIfItWouldDisturb(").count - 1
+
+        #expect(evictions == 2, "expected the resident-eviction branch in both residency loops")
+        #expect(cancels == 2, "expected the in-flight-cancel branch in both residency loops")
+        #expect(
+            guards >= evictions + cancels,
+            """
+            Found \(evictions) evictions + \(cancels) in-flight cancels but only \
+            \(guards) guards in loadContainer. Every destructive branch needs its \
+            own refusal, in the same actor segment that observed the conflict.
+            """
+        )
+    }
+
+    @Test("The guard precedes the eviction it protects, with no await in between")
+    func guardPrecedesEvictionWithoutSuspending() throws {
+        let body = try Self.loadContainerBody()
+
+        // For each destructive call, walk back to the nearest guard and assert
+        // nothing suspends in the gap. An `await` between them would hand the actor
+        // to another task after we decided it was safe to evict.
+        for destructive in ["await strictEvict(", "await cancelAndDrainLoadingTasks("] {
+            var cursor = body.startIndex
+            while let call = body.range(of: destructive, range: cursor ..< body.endIndex) {
+                let preceding = String(body[body.startIndex ..< call.lowerBound])
+                let lastGuard = try #require(
+                    preceding.range(of: "try refuseBackgroundLoadIfItWouldDisturb(", options: .backwards),
+                    "\(destructive) is not preceded by a residency guard"
+                )
+                let between = String(preceding[lastGuard.upperBound ..< preceding.endIndex])
+                #expect(
+                    !between.contains("await "),
+                    """
+                    An `await` sits between the residency guard and \(destructive). \
+                    The actor can reschedule there, so the state the guard approved \
+                    is not the state being evicted.
+                    """
+                )
+                cursor = call.upperBound
+            }
+        }
+    }
+
+    @Test("Flexible (manualMultiModel) residency is guarded too")
+    func flexibleBudgetEvictionIsGuarded() throws {
+        let src = try Self.modelRuntimeSource
+        let start = try #require(src.range(of: "private func unloadForFlexibleResidentBudget("))
+        let end = try #require(
+            src.range(of: "\n    private func ", range: start.upperBound ..< src.endIndex)
+        )
+        let body = String(src[start.lowerBound ..< end.lowerBound])
+
+        // Without this the contract "background never disturbs a resident model"
+        // would silently hold only under the default eviction policy — anyone on
+        // manualMultiModel would keep the original bug.
+        #expect(body.contains("try refuseBackgroundLoadIfItWouldDisturb("))
+        #expect(body.contains("intent: ModelLoadIntent"))
+    }
+
+    // MARK: - Defaults: the safe direction
+
+    @Test("Loads are interactive unless a caller opts into background")
+    func loadIntentDefaultsToInteractive() throws {
+        let params = GenerationParameters(temperature: 0.0, maxTokens: 16)
+        // Defaulting to `.background` would be the dangerous direction: a real user
+        // request that forgot to set the flag would silently refuse to load.
+        #expect(params.loadIntent == .interactive)
+
+        // Decoding an ordinary API request must not be able to turn the flag on:
+        // it is local-only. A remote client that could set it would be able to make
+        // its own requests refuse to load — or, worse, if the sense were ever
+        // inverted, evict on demand.
+        let wire = #"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#
+        let request = try JSONDecoder().decode(
+            ChatCompletionRequest.self,
+            from: Data(wire.utf8)
+        )
+        #expect(request.backgroundModelLoad == false)
+    }
+
+    @Test("Background housekeeping actually reaches the runtime as background")
+    func backgroundRequestCarriesTheIntent() {
+        let params = GenerationParameters(
+            temperature: 0.1,
+            maxTokens: 64,
+            loadIntent: .background
+        )
+        #expect(params.loadIntent == .background)
+    }
+
+    // MARK: - The refusal is legible
+
+    @Test("A refusal says which model it protected and why")
+    func refusalDescribesTheConflict() {
+        let evict = ModelRuntime.ResidencyRefusedError(
+            requestedModel: "tiny-helper",
+            conflict: .wouldEvictResident("hy3-94gb")
+        )
+        let description = try! #require(evict.errorDescription)
+        #expect(description.contains("tiny-helper"))
+        #expect(description.contains("hy3-94gb"))
+
+        let cancel = ModelRuntime.ResidencyRefusedError(
+            requestedModel: "tiny-helper",
+            conflict: .wouldCancelLoadInFlight("hy3-94gb")
+        )
+        #expect(cancel != evict)
+        #expect(try! #require(cancel.errorDescription).contains("in-flight"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2078,7 +2078,11 @@ struct RuntimePolicySourceTests {
             "Weight-size preflight must count known numbered shards and fall back to a shallow safetensors sum so unknown layouts cannot report 0 bytes."
         )
 
-        let loadStart = try #require(runtime.range(of: "func loadContainer(id: String, name: String)"))
+        // Anchor on the name only — the parameter list grows (it gained
+        // `intent:` for residency safety) and pinning the full signature makes
+        // this preflight-ordering test fail for reasons that have nothing to do
+        // with preflight ordering.
+        let loadStart = try #require(runtime.range(of: "func loadContainer("))
         let loadEnd = try #require(
             runtime.range(of: "let loadID = allocateLoadingTaskID()", range: loadStart.upperBound ..< runtime.endIndex)
         )


### PR DESCRIPTION
## The bug

The MLX runtime is strictly single-model: loading B evicts resident A, and starting a load cancels one already in flight. That is fine when a human is waiting on B — they asked for it. It is never fine on behalf of housekeeping: memory distillation, greeting generation, voice-transcript cleanup and speculative warm-up have no business taking the GPU out from under an active chat.

#1986 tried to stop that. It did not, and the reason is instructive.

It probed `hasLoadInFlight()` / `hasResidentModelOther(than:)` from **outside** the actor, then loaded on a **later actor hop**. `ModelRuntime` is an actor, so it is reentrant across every `await`: whatever the probe saw is already stale by the time the load runs. A load can register or finish in the gap and get evicted anyway. Classic check-then-act.

Seven call sites had copies of that same racy shape. All seven confirmed.

## The fix

Thread a `ModelLoadIntent` down into `loadContainer` and refuse in the **same synchronous actor segment that observed the conflict** — the only place where the decision and the eviction cannot be interleaved.

All five destructive branches are covered:

- both strict-policy in-flight cancels,
- both strict-policy resident evictions — the residency loop runs **twice**, because `acquireColdLoadSlot()` suspends and the actor is reentrant across it, so state seen before the wait proves nothing after it,
- the flexible-budget evictor, without which the contract would have silently held only under the *default* eviction policy and left anyone on `manualMultiModel` with the original bug.

A check placed just before `await strictEvict(…)` would **not** have been enough: `strictEvict` suspends on the `ModelLease` actor before it unloads.

Intent rides on `GenerationParameters`, so it survives the whole `ChatEngine → MLXService → ModelRuntime` path. It defaults to `.interactive`: a caller who forgets the flag keeps today's behaviour rather than silently refusing to load. `backgroundModelLoad` is local-only and cannot be set from the wire.

## Three more holes, found by adversarially reviewing the above

The first commit's *system* claim was wrong, and an adversarial pass refuted it. The guard was atomic when reached; the system did not reliably reach it with `.background`.

1. **The user's warm-up privilege never expired.** `userIntentWarmupModel` records "the user just picked this by hand", which entitles the follow-up warm-up to displace a resident model — and it was set once and cleared *nowhere*, not in `reset()`, not in `shutdown()`. So "the user picked A" silently became "any warm-up of A, forever, may evict", and a re-warm minutes later, triggered by nothing the user did, could still unload the model an API client was using. The new guard was powerless here, because the caller mislabelled the request as interactive before it ever reached the runtime. Now one-shot, consumed by the warm-up it authorizes, resolved **once** and threaded so the early gate and the load intent cannot disagree.

2. **Both request-copy helpers dropped the flag.** `withModel` and `withContext` rebuild the request field by field and carry every other local-only flag. Omitting `backgroundModelLoad` silently *promotes* a background request to interactive — the direction that evicts.

3. **The residency-switch GC still probed from outside the actor.** A model that is mid-load sits in `loadingTasks`, not `modelCache`, and holds no lease — invisible to both the window snapshot and the lease check — so the sweep would tear the runtime down around it. `unloadModelsNotIn(_:skipIfLoadInFlight:)` now makes that call inside the actor.

## Tests

The invariant here is one a passing behavioural test cannot see, so the tests are structural on purpose:

- **the guard must stay synchronous** — if it ever becomes `async` it can suspend between observing the conflict and throwing, and the actor will happily run another load in that window. It would still "work" in every test and still lose the user's model in production.
- **every destructive branch must be preceded by it, with no `await` in between.**
- the one-shot grant is consumed; the copy helpers preserve the flag.

Verified red → green, not just green: removing the guard from *one* of the two residency loops turns two tests red with the exact diagnosis (`Found 2 evictions + 2 in-flight cancels but only 3 guards`). Making the guard `async` fails to compile at all four call sites.

296/296 pass in the affected suites (`Residency|RuntimePolicy|MLXBatchAdapter|CoreModel|Warmup|ChatEngine`).

## Live proof (dev-built app, GUI only)

My change's risk is a **regression** — a load that now refuses when it shouldn't. So that is what was tested live, in the dev build, via computer use:

- ✅ **The critical one:** explicit picker switch `Gemma 4 e2b it 4bit` → `Qwen3 0.6B 8bit` still evicts and loads — `Warming up…` → `Model warm — ready for a fast first response`.
- ✅ Four-turn conversation held context (Paris → Seine/Loire/Garonne → Loire). No empty replies, looping, truncation, mojibake, stray template tags, or unclosed reasoning tags.
- ✅ Tool card succeeded green: `Searched the web for "rivers in France" · 1.0s`.
- ✅ No chat hung on loading. **No error banner, no `Skipped background load`, no `would evict` anywhere.**
- ✅ **Zero refusals logged during interactive use** — the guard never wrongly refuses a load a human is waiting on.

Honest about the split: the GUI proves **no interactive regression** (it never created a background-vs-resident conflict, so it cannot show the refusal *firing*). The refusal itself is proven by the sabotage-verified tests above.

One defect observed live, and it is **not** from this change: Gemma-4-E2B answered in one sentence when asked for two. A 2B model's instruction-following, on clean text.

## Not fixed here

The idle-manager, memory-pressure and post-load cancellation paths have their own teardown races. They are **unloads**, not loads, so no load intent can reach them — the common root is that `unload` shuts the BatchEngine down *before* it waits for active leases. Pre-existing, out of scope, filed separately.
