### PR TITLE
Headless runs must not claim to be the user; the stats card must not invent a tok/s

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -666,7 +666,8 @@ public final class BackgroundTaskManager: ObservableObject {
             folderBookmark: request.folderBookmark,
             source: request.source,
             sourcePluginId: request.sourcePluginId,
-            externalSessionKey: request.externalSessionKey
+            externalSessionKey: request.externalSessionKey,
+            loadIntent: request.loadIntent
         )
     }
 

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -41,7 +41,8 @@ public final class ExecutionContext: ObservableObject {
         folderBookmark: Data? = nil,
         source: SessionSource = .chat,
         sourcePluginId: String? = nil,
-        externalSessionKey: String? = nil
+        externalSessionKey: String? = nil,
+        loadIntent: ModelLoadIntent = .interactive
     ) {
         self.id = id
         self.agentId = agentId
@@ -56,6 +57,7 @@ public final class ExecutionContext: ObservableObject {
         // actual saved session.
         session.sessionId = id
         session.source = source
+        session.loadIntent = loadIntent
         session.sourcePluginId = sourcePluginId
         session.externalSessionKey = externalSessionKey
         session.dispatchTaskId = id

--- a/Packages/OsaurusCore/Managers/NextRunScheduler.swift
+++ b/Packages/OsaurusCore/Managers/NextRunScheduler.swift
@@ -266,7 +266,8 @@ public final class NextRunScheduler {
             return
         }
 
-        let request = await Self.makeDispatchRequest(for: entry)
+        // The agent woke itself on a timer. Nobody is waiting.
+        let request = await Self.makeDispatchRequest(for: entry, loadIntent: .background)
         guard let handle = await TaskDispatcher.shared.dispatch(request) else {
             print(
                 "[NextRunScheduler] dispatch failed for agent \(entry.agentId.uuidString.prefix(8))"
@@ -299,14 +300,23 @@ public final class NextRunScheduler {
 
     /// Build the dispatch request for a wake, including the previous-run
     /// pointer looked up from `agent_runs`.
-    public static func makeDispatchRequest(for entry: NextRunEntry) async -> DispatchRequest {
+    /// - Parameter loadIntent: `.background` for the automatic wake (nobody is
+    ///   waiting on it, so it must not evict the user's model), `.interactive`
+    ///   for the "Run now" button in the Next Run panel, which shares this
+    ///   builder but has a human watching it. Defaults to `.interactive` so a
+    ///   new caller fails safe -- toward loading, not toward refusing.
+    public static func makeDispatchRequest(
+        for entry: NextRunEntry,
+        loadIntent: ModelLoadIntent = .interactive
+    ) async -> DispatchRequest {
         let previousRun = await latestCompletedRun(for: entry.agentId)
         return DispatchRequest(
             prompt: composeDispatchPrompt(entry: entry, previousRun: previousRun),
             agentId: entry.agentId,
             title: sessionTitle(for: entry),
             source: .selfSchedule,
-            externalSessionKey: nil
+            externalSessionKey: nil,
+            loadIntent: loadIntent
         )
     }
 

--- a/Packages/OsaurusCore/Managers/ScheduleManager.swift
+++ b/Packages/OsaurusCore/Managers/ScheduleManager.swift
@@ -203,7 +203,11 @@ public final class ScheduleManager {
     /// Manually trigger a schedule to run now
     public func runNow(_ scheduleId: UUID) {
         guard let schedule = schedules.first(where: { $0.id == scheduleId }) else { return }
-        executeSchedule(schedule)
+        // A hand-pressed button. The user is watching this run, so it keeps the
+        // normal right to load its model -- even though it arrives with the same
+        // `source: .schedule` as the 3am cron fire below. That is exactly why the
+        // intent is passed explicitly instead of inferred from `source`.
+        executeSchedule(schedule, loadIntent: .interactive)
     }
 
     // MARK: - Plugin Grouping
@@ -328,9 +332,10 @@ public final class ScheduleManager {
             return schedule.shouldRunNow(asOf: now)
         }
 
-        // Execute all due schedules
+        // Timer fired on its own. Nobody is waiting on this, so it must not
+        // evict the model the user is actually chatting with.
         for schedule in schedulesToRun {
-            executeSchedule(schedule)
+            executeSchedule(schedule, loadIntent: .background)
         }
 
         // Schedule the next timer
@@ -350,7 +355,7 @@ public final class ScheduleManager {
                 // If the once date is in the past but hasn't run yet
                 if date <= now && schedule.executionAnchor == nil {
                     print("[Osaurus] Found missed once schedule: \(schedule.name)")
-                    executeSchedule(schedule)
+                    executeSchedule(schedule, loadIntent: .background)
                 }
             } else {
                 // For recurring schedules, check if we missed the last run
@@ -360,7 +365,7 @@ public final class ScheduleManager {
                         nextAfterAnchor <= now
                     {
                         print("[Osaurus] Found missed recurring schedule: \(schedule.name)")
-                        executeSchedule(schedule)
+                        executeSchedule(schedule, loadIntent: .background)
                     }
                 }
             }
@@ -370,7 +375,7 @@ public final class ScheduleManager {
     // MARK: - Execution
 
     /// Execute a schedule by dispatching to TaskDispatcher
-    private func executeSchedule(_ schedule: Schedule) {
+    private func executeSchedule(_ schedule: Schedule, loadIntent: ModelLoadIntent) {
         // Schedules MUST target an explicit custom agent. nil or built-in
         // agentIds were previously coerced to `Agent.defaultId`, silently
         // running anonymous schedules under the Default agent. Refuse the
@@ -397,7 +402,8 @@ public final class ScheduleManager {
             folderPath: triggeredSchedule.folderPath,
             folderBookmark: triggeredSchedule.folderBookmark,
             source: .schedule,
-            externalSessionKey: triggeredSchedule.id.uuidString
+            externalSessionKey: triggeredSchedule.id.uuidString,
+            loadIntent: loadIntent
         )
 
         print("[Osaurus] Executing schedule: \(triggeredSchedule.name)")

--- a/Packages/OsaurusCore/Managers/WatcherManager.swift
+++ b/Packages/OsaurusCore/Managers/WatcherManager.swift
@@ -613,7 +613,11 @@ public final class WatcherManager {
                     folderPath: watcher.watchPath,
                     folderBookmark: watcher.watchBookmark,
                     source: .watcher,
-                    externalSessionKey: watcher.id.uuidString
+                    externalSessionKey: watcher.id.uuidString,
+                    // A file changed on disk and we reacted. The user did not ask
+                    // for this right now and is not waiting on it, so it must not
+                    // evict the model they are chatting with.
+                    loadIntent: .background
                 )
 
                 guard let handle = await TaskDispatcher.shared.dispatch(request) else {

--- a/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
+++ b/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
@@ -48,6 +48,19 @@ public struct DispatchRequest: Sendable {
     /// task-local binding at the HTTP layer were lost across the dispatch
     /// pipeline. Never used to relax an inherited external-surface context.
     public let externalSurface: Bool
+    /// Whether this run's model load may evict a model someone else is using.
+    ///
+    /// Deliberately NOT derived from `source`. `source` records *where* a run
+    /// came from; this records whether anyone is *waiting on it*, and the two
+    /// genuinely differ: a cron-fired schedule and the user pressing "Run Now"
+    /// on that same schedule both arrive as `.schedule`, but only one of them
+    /// has a human watching a spinner. Inferring intent from `source` would
+    /// make the button refuse to load its own model.
+    ///
+    /// So it is set at the trigger boundary — the one place that knows. Timer
+    /// fires, watcher fires and agent self-wakes pass `.background`; every
+    /// hand-pressed button and every waiting API client keeps the default.
+    public let loadIntent: ModelLoadIntent
 
     public init(
         id: UUID = UUID(),
@@ -62,7 +75,8 @@ public struct DispatchRequest: Sendable {
         source: SessionSource = .chat,
         externalSessionKey: String? = nil,
         requestedToolNames: [String] = [],
-        externalSurface: Bool = false
+        externalSurface: Bool = false,
+        loadIntent: ModelLoadIntent = .interactive
     ) {
         self.id = id
         self.prompt = prompt
@@ -77,6 +91,7 @@ public struct DispatchRequest: Sendable {
         self.externalSessionKey = externalSessionKey
         self.requestedToolNames = requestedToolNames
         self.externalSurface = externalSurface
+        self.loadIntent = loadIntent
     }
 }
 

--- a/Packages/OsaurusCore/Models/Chat/RequestLog.swift
+++ b/Packages/OsaurusCore/Models/Chat/RequestLog.swift
@@ -82,6 +82,16 @@ enum RequestSource: String, Sendable, CaseIterable {
     /// Inbound traffic from another Osaurus peer over the Secure Channel
     /// (remote chat completions and remote agent runs).
     case p2p = "P2P"
+    /// Autonomous, headless runs that nobody is waiting on: cron schedules,
+    /// file-system watchers, agent self-wakes.
+    ///
+    /// These used to be flattened into `.chatUI` on the way to the model,
+    /// because `ChatSession` built its engine as `ChatEngine(source: .chatUI)`
+    /// unconditionally and dropped its own `SessionSource`. That mislabel had
+    /// teeth: `accelerateIdleUnloadAfterChatClose` only shortens residency for
+    /// `.chatUI`-sourced models, so closing an unrelated chat window could
+    /// accelerate the unload of the model a scheduled job was mid-run with.
+    case scheduled = "Scheduled"
 
     var displayName: String {
         switch self {
@@ -89,6 +99,7 @@ enum RequestSource: String, Sendable, CaseIterable {
         case .httpAPI: return L("HTTP API")
         case .plugin: return L("Plugin")
         case .p2p: return L("P2P")
+        case .scheduled: return L("Scheduled")
         }
     }
 }

--- a/Packages/OsaurusCore/Models/Chat/SessionSource.swift
+++ b/Packages/OsaurusCore/Models/Chat/SessionSource.swift
@@ -110,3 +110,25 @@ public enum PluginDisplayNameResolver {
         return pluginId
     }
 }
+
+// MARK: - Inference provenance
+
+extension SessionSource {
+    /// How the inference layer should label requests from this session.
+    ///
+    /// `ChatSession` used to hand every engine `.chatUI` regardless of where the
+    /// session actually came from, so a cron fire, a file-watcher trigger and an
+    /// agent self-wake all reached `ModelRuntime` claiming to be the user typing
+    /// in the chat window. Two things depended on that lie being true, and both
+    /// were wrong for headless runs: which loads are allowed to evict a resident
+    /// model, and which models get their idle-unload accelerated when a chat
+    /// window closes.
+    var inferenceSource: RequestSource {
+        switch self {
+        case .chat: return .chatUI
+        case .http: return .httpAPI
+        case .plugin: return .plugin
+        case .schedule, .watcher, .selfSchedule: return .scheduled
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension ChatSession: ChatWarmupSessionContext {
     func makeWarmupEngine() -> ChatEngineProtocol {
-        chatEngineFactory()
+        chatEngineFactory(source.inferenceSource)
     }
 
     func makeWarmupPayload() async -> ChatWarmupPayload? {

--- a/Packages/OsaurusCore/Services/FeatureTelemetry.swift
+++ b/Packages/OsaurusCore/Services/FeatureTelemetry.swift
@@ -316,6 +316,7 @@ enum FeatureTelemetry {
         case .httpAPI: return "http_api"
         case .plugin: return "plugin"
         case .p2p: return "p2p"
+        case .scheduled: return "scheduled"
         }
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/RollingTokenRate.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RollingTokenRate.swift
@@ -166,17 +166,26 @@ struct RollingTokenRate: Sendable {
     }
 
     /// Final steady-state rate at the end of stream — same as `currentRate`
-    /// at the moment of `lastAt`. Caller stamps this on `ChatTurn` once
-    /// the stream finishes. Falls back to `totalTokens / wallTime` ONLY
-    /// if the warm-up never elapsed (response was too short to converge).
+    /// at the moment of `lastAt`. Caller stamps this on `ChatTurn` once the
+    /// stream finishes.
+    ///
+    /// Returns `nil` when the response was too short for the warm-up to elapse.
+    /// It does NOT invent a number for that case, and the previous fallback --
+    /// `totalTokens / (lastAt - firstAt)` -- is exactly why: `firstAt` is when
+    /// the first token *arrived*, not when decoding began, so the span omits all
+    /// the decode time that produced it. When a short reply is delivered in one
+    /// coalesced burst, first and last observation land ~3ms apart and the
+    /// "average" reads as thousands of tok/s. That is the `2397.3 tok/s • 7
+    /// tokens` in the chat stats card, and it is the same burst artifact
+    /// `currentRate` already documents and floors against just above.
+    ///
+    /// There is no honest denominator to reach for here: this type only sees
+    /// arrival timestamps. The caller has the engine's real decode wall-clock
+    /// (`GenerateCompletionInfo.generateTime`, measured from the end of prefill)
+    /// and should prefer that when this returns `nil`.
     func finalRate() -> Double? {
-        guard let firstAt, let lastAt else { return nil }
-        if let rolling = currentRate(at: lastAt) { return rolling }
-        // Fallback: full-generation average. Better than no number at all
-        // for ultra-short responses — same as the pre-rolling behavior.
-        let wall = lastAt.timeIntervalSince(firstAt)
-        guard wall > 0, totalTokens > 0 else { return nil }
-        return Double(totalTokens) / wall
+        guard lastAt != nil else { return nil }
+        return currentRate(at: lastAt!)
     }
 
     // MARK: - Internal

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionAgentSettingsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionAgentSettingsTests.swift
@@ -33,7 +33,7 @@ struct ChatSessionAgentSettingsTests {
             let engine = AgentSettingsCaptureEngine()
             let session = ChatSession()
             session.agentId = agent.id
-            session.chatEngineFactory = { engine }
+            session.chatEngineFactory = { _ in engine }
 
             session.send("Use the configured sampling values.")
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -103,7 +103,7 @@ struct ChatSessionQueuedSendTests {
     func naturalCompletion_autoFlushesQueuedSend() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 60) }
+            session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 60) }
 
             session.send("first")
             // Wait for the streaming flag to flip so the queued send
@@ -129,7 +129,7 @@ struct ChatSessionQueuedSendTests {
     func stop_doesNotAutoFlushAndLeavesQueueIntact() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+            session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("first")
             try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
@@ -155,7 +155,7 @@ struct ChatSessionQueuedSendTests {
     func sendNowInterrupting_stopsAndDispatchesAsNewUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+            session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("first")
             try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
@@ -194,7 +194,7 @@ struct ChatSessionQueuedSendTests {
     func send_attachmentOnlyTurnPersistsBeforeAssistantCompletes() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+            session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
             let attachment = Attachment.document(
                 filename: "assessment.txt",
                 content: "rubric details",
@@ -221,7 +221,7 @@ struct ChatSessionQueuedSendTests {
     func send_plainTextPersistsBeforeAssistantCompletes() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+            session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("persist while streaming")
             try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
@@ -241,7 +241,7 @@ struct ChatSessionQueuedSendTests {
     func privacyCancelRemovesPersistedTransientUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
 
             session.send("review will cancel")
 
@@ -262,7 +262,7 @@ struct ChatSessionQueuedSendTests {
             let session = ChatSession()
             let premintedId = UUID()
             session.sessionId = premintedId
-            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
 
             session.send("review will cancel")
 
@@ -289,7 +289,7 @@ struct ChatSessionQueuedSendTests {
 
             let session = ChatSession()
             session.load(from: existing)
-            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
 
             session.send("review will cancel")
 
@@ -308,7 +308,7 @@ struct ChatSessionQueuedSendTests {
     func privacyCancelLeavesQueuedSendPending() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { DelayedCancellingBeforeDeltaChatEngine(delayMs: 120) }
+            session.chatEngineFactory = { _ in DelayedCancellingBeforeDeltaChatEngine(delayMs: 120) }
 
             session.send("review will cancel")
             try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
@@ -338,7 +338,7 @@ struct ChatSessionQueuedSendTests {
     func stopBeforeFirstDeltaKeepsPersistedUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+            session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("keep this after stop")
             try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
@@ -370,7 +370,7 @@ struct ChatSessionQueuedSendTests {
 
             let session = ChatSession()
             session.load(from: existing)
-            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
             let assistantId = try #require(session.turns.last?.id)
 
             session.regenerate(turnId: assistantId)
@@ -401,7 +401,7 @@ struct ChatSessionQueuedSendTests {
 
             let session = ChatSession()
             session.load(from: existing)
-            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
             let userId = try #require(session.turns.first?.id)
 
             session.editAndRegenerate(turnId: userId, newContent: "edited question")
@@ -440,7 +440,7 @@ struct ChatSessionQueuedSendTests {
 
             #expect(session.turns.map(\.content) == ["original question", "original answer"])
 
-            session.chatEngineFactory = { CancellingBeforeDeltaChatEngine() }
+            session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
             session.send("later normal message")
 
             try await waitUntil(timeout: .seconds(2)) {

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -28,7 +28,7 @@ struct ChatSessionStopTests {
     func stop_ignoresLateResultsWhenEngineSetupIgnoresCancellation() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { IgnoringCancellationChatEngine() }
+            session.chatEngineFactory = { _ in IgnoringCancellationChatEngine() }
 
             session.send("Hello")
             try await Task.sleep(for: .milliseconds(20))
@@ -49,7 +49,7 @@ struct ChatSessionStopTests {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
             let engine = CancellationObservingChatEngine()
-            session.chatEngineFactory = { engine }
+            session.chatEngineFactory = { _ in engine }
 
             session.send("Hello")
             try await waitUntilAsync(timeout: Self.asyncTimeout) {
@@ -71,7 +71,7 @@ struct ChatSessionStopTests {
     func send_ignoresReentrantSendBeforeStreamingFlagFlips() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { IgnoringCancellationChatEngine() }
+            session.chatEngineFactory = { _ in IgnoringCancellationChatEngine() }
 
             session.send("first")
             session.send("second")
@@ -87,7 +87,7 @@ struct ChatSessionStopTests {
     func send_finishesReasoningOnlyLocalStream() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { ReasoningOnlyChatEngine() }
+            session.chatEngineFactory = { _ in ReasoningOnlyChatEngine() }
 
             session.send("Hello")
 

--- a/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskInterruptTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskInterruptTests.swift
@@ -20,7 +20,7 @@ struct BackgroundTaskInterruptTests {
 
     private func makeRunningState() -> (state: BackgroundTaskState, mgr: BackgroundTaskManager) {
         let context = ExecutionContext(agentId: Agent.defaultId)
-        context.chatSession.chatEngineFactory = { MockChatEngine() }
+        context.chatSession.chatEngineFactory = { _ in MockChatEngine() }
         let state = BackgroundTaskState(
             id: UUID(),
             taskTitle: "interrupt-test",

--- a/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskStreamingObserverTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskStreamingObserverTests.swift
@@ -27,7 +27,7 @@ struct BackgroundTaskStreamingObserverTests {
         let context = ExecutionContext(agentId: Agent.defaultId)
         // Mock engine yields nothing — guarantees `isStreaming` only changes
         // when the test sets it explicitly, so we control the timeline.
-        context.chatSession.chatEngineFactory = { MockChatEngine() }
+        context.chatSession.chatEngineFactory = { _ in MockChatEngine() }
 
         let state = BackgroundTaskState(
             id: UUID(),

--- a/Packages/OsaurusCore/Tests/Plugin/PluginClarifyEventTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginClarifyEventTests.swift
@@ -85,7 +85,7 @@ struct BackgroundTaskClarifyObserverTests {
         let context = ExecutionContext(agentId: Agent.defaultId)
         // Mock engine yields nothing so isStreaming only flips when the
         // test sets it explicitly. Mirrors `BackgroundTaskStreamingObserverTests`.
-        context.chatSession.chatEngineFactory = { MockChatEngine() }
+        context.chatSession.chatEngineFactory = { _ in MockChatEngine() }
 
         let state = BackgroundTaskState(
             id: UUID(),
@@ -260,7 +260,7 @@ struct PluginClarifyEmissionTests {
         pluginId: String
     ) -> (state: BackgroundTaskState, mgr: BackgroundTaskManager) {
         let context = ExecutionContext(agentId: Agent.defaultId)
-        context.chatSession.chatEngineFactory = { MockChatEngine() }
+        context.chatSession.chatEngineFactory = { _ in MockChatEngine() }
         let state = BackgroundTaskState(
             id: UUID(),
             taskTitle: "clarify-emit-test",

--- a/Packages/OsaurusCore/Tests/Service/HeadlessLoadIntentTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/HeadlessLoadIntentTests.swift
@@ -1,0 +1,127 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Autonomous runs — a cron schedule firing, a file watcher tripping, an agent
+/// waking itself — must not evict the model the user is chatting with. Runs a
+/// human is waiting on must still load freely.
+///
+/// The trap this suite exists to hold shut: **`source` and intent are different
+/// questions.** A cron fire and the user pressing "Run Now" on that same schedule
+/// both arrive as `source: .schedule`. Deriving intent from `source` would make
+/// the button refuse to load its own model — a "fix" that breaks the feature it
+/// was meant to protect. So intent is set at the trigger boundary, which is the
+/// only place that knows whether anyone is waiting.
+@Suite("Headless load intent")
+struct HeadlessLoadIntentTests {
+    private static func packageRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        var cursor = here.deletingLastPathComponent()  // Service/
+        cursor.deleteLastPathComponent()  // Tests/
+        return cursor.deletingLastPathComponent()  // OsaurusCore/
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        try String(contentsOf: packageRoot().appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    // MARK: - Defaults fail safe (toward loading, never toward refusing)
+
+    @Test("A dispatch is interactive unless its trigger says otherwise")
+    func dispatchDefaultsToInteractive() {
+        let request = DispatchRequest(prompt: "hi")
+        // The dangerous default would be `.background`: a real user-facing run
+        // that forgot the flag would silently decline to load its model.
+        #expect(request.loadIntent == .interactive)
+    }
+
+    @Test("An autonomous trigger carries background intent end to end")
+    @MainActor
+    func backgroundDispatchCarriesIntent() {
+        let cron = DispatchRequest(prompt: "daily digest", source: .schedule, loadIntent: .background)
+        #expect(cron.loadIntent == .background)
+
+        let context = ExecutionContext(
+            agentId: UUID(),
+            source: .schedule,
+            loadIntent: cron.loadIntent
+        )
+        // The session is what ultimately builds the request the model sees; if the
+        // intent dies here, everything downstream is interactive again.
+        #expect(context.chatSession.loadIntent == .background)
+        #expect(context.chatSession.source.inferenceSource == .scheduled)
+    }
+
+    // MARK: - The trap
+
+    @Test("Run Now stays interactive even though it is a schedule")
+    func runNowIsNotBackground() throws {
+        let src = try Self.source("Managers/ScheduleManager.swift")
+
+        // `runNow` and the cron fire call the SAME `executeSchedule` with the SAME
+        // `source: .schedule`. Only the explicit intent tells them apart. If someone
+        // "simplifies" this by inferring intent from `source`, the Run Now button
+        // silently stops being able to load its model whenever another model is
+        // resident — and it will look like a hang, not a refusal.
+        #expect(src.contains("executeSchedule(schedule, loadIntent: .interactive)"))
+        #expect(src.contains("executeSchedule(schedule, loadIntent: .background)"))
+        #expect(
+            !src.contains("executeSchedule(schedule)\n"),
+            "every executeSchedule call must state its intent explicitly"
+        )
+
+        // Same shared-builder trap in the Next Run panel: the automatic wake and the
+        // panel's own "Run now" button both go through `makeDispatchRequest`.
+        let scheduler = try Self.source("Managers/NextRunScheduler.swift")
+        #expect(scheduler.contains("makeDispatchRequest(for: entry, loadIntent: .background)"))
+        let panel = try Self.source("Views/Agent/NextRunPanelView.swift")
+        #expect(
+            !panel.contains("loadIntent: .background"),
+            "the Next Run panel button is a human pressing it — it must not be background"
+        )
+    }
+
+    @Test("Every autonomous trigger is background")
+    func autonomousTriggersAreBackground() throws {
+        let watcher = try Self.source("Managers/WatcherManager.swift")
+        #expect(watcher.contains("loadIntent: .background"))
+    }
+
+    // MARK: - The session's provenance must survive to the engine
+
+    @Test("Headless sessions no longer masquerade as the chat UI")
+    func headlessSessionsAreNotChatUI() throws {
+        let chatView = try Self.source("Views/Chat/ChatView.swift")
+
+        // The engine factory used to hardcode `ChatEngine(source: .chatUI)` and ignore
+        // the session's own `source`, flattening cron/watcher/self-wake runs into
+        // "the user is typing". That mislabel had teeth beyond eviction:
+        // `accelerateIdleUnloadAfterChatClose` only shortens residency for `.chatUI`
+        // models, so closing an unrelated chat window could accelerate the unload of
+        // the model a scheduled job was mid-run with.
+        #expect(
+            !chatView.contains("ChatEngine(source: .chatUI)"),
+            "the engine must take the session's real source, not a hardcoded .chatUI"
+        )
+        #expect(chatView.contains("chatEngineFactory(source.inferenceSource)"))
+    }
+
+    @Test("Autonomous sources map to a provenance that is not chatUI")
+    func autonomousSourcesMapAwayFromChatUI() {
+        #expect(SessionSource.schedule.inferenceSource == .scheduled)
+        #expect(SessionSource.watcher.inferenceSource == .scheduled)
+        #expect(SessionSource.selfSchedule.inferenceSource == .scheduled)
+
+        // …and the ones a human drives keep theirs.
+        #expect(SessionSource.chat.inferenceSource == .chatUI)
+        #expect(SessionSource.http.inferenceSource == .httpAPI)
+        #expect(SessionSource.plugin.inferenceSource == .plugin)
+
+        // The chat-close accelerated unload keys on exactly this: anything that is
+        // not `.chatUI` is left alone.
+        #expect(SessionSource.schedule.inferenceSource != .chatUI)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RollingTokenRateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RollingTokenRateTests.swift
@@ -11,8 +11,10 @@
 //     rate (immune to first-token amortization)
 //   - Reasoning + content + tool-arg tokens count uniformly so thinking
 //     ON and thinking OFF on the same model show the same number
-//   - `finalRate()` falls back to full-generation average ONLY when
-//     warm-up never elapsed (response too short to converge)
+//   - `finalRate()` returns nil when warm-up never elapsed (response too
+//     short to converge) — it does NOT invent an average over the delivery
+//     span, which reads as thousands of tok/s on a burst-delivered reply.
+//     The caller falls back to the engine's real decode wall-clock rate.
 //
 // If any of these flip, expect user-visible regressions in the chat
 // stats card. The rationale for each numeric default is in
@@ -133,22 +135,42 @@ struct RollingTokenRateTests {
 
     // MARK: - Final rate fallback
 
-    @Test("finalRate: falls back to full-gen average when warm-up never elapsed")
-    func finalRate_shortResponse_fallsBackToAverage() {
+    @Test("finalRate: reports nothing rather than inventing a rate for a short reply")
+    func finalRate_shortResponse_reportsNothing() {
         var r = RollingTokenRate()
         let t0 = Date()
         // 3 tokens in 0.2s — never passes either warm-up gate.
         r.observe(tokens: 1, at: t0.addingTimeInterval(0.0))
         r.observe(tokens: 1, at: t0.addingTimeInterval(0.1))
         r.observe(tokens: 1, at: t0.addingTimeInterval(0.2))
-        // currentRate is nil — warm-up not satisfied.
         #expect(r.currentRate(at: t0.addingTimeInterval(0.2)) == nil)
-        // finalRate returns the full-gen average (3 tokens / 0.2s = 15).
-        guard let final = r.finalRate() else {
-            Issue.record("finalRate should fall back even when currentRate is nil")
-            return
+
+        // This used to return `totalTokens / (lastAt - firstAt)` = ~15 tok/s, which
+        // LOOKS reasonable — and that plausibility is exactly why the bug survived:
+        // the same expression is a lie whenever delivery is bursty (below). This type
+        // only sees arrival timestamps and has no honest denominator for a reply that
+        // never converged, so it says so. The caller substitutes the engine's real
+        // decode wall-clock rate.
+        #expect(r.finalRate() == nil)
+    }
+
+    @Test("finalRate: a short reply delivered in one burst never reports thousands of tok/s")
+    func finalRate_burstDelivery_isNotPhysicallyImpossible() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // The real shape of the bug: a 7-token answer arrives coalesced, so first and
+        // last observation land ~3ms apart. `totalTokens / (lastAt - firstAt)` is then
+        // 7 / 0.003 ≈ 2333 tok/s — the `2397.3 tok/s • 7 tokens` seen in the chat card.
+        // No local model decodes at 2000+ tok/s; the number was an artifact of when the
+        // bytes were *delivered*, not of how fast anything was generated.
+        r.observe(tokens: 4, at: t0)
+        r.observe(tokens: 3, at: t0.addingTimeInterval(0.003))
+
+        let rate = r.finalRate()
+        #expect(rate == nil, "got \(String(describing: rate)) — a delivery burst is not a decode speed")
+        if let rate {
+            #expect(rate < 1000, "a rate this high is not physically achievable and must never be shown")
         }
-        #expect(final >= 14 && final <= 16, "expected ~15 tok/s, got \(final)")
     }
 
     @Test("finalRate: prefers rolling steady-state when warmed up")

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2922,6 +2922,10 @@ final class ChatSession: ObservableObject {
         // invariant across {thinking on/off, tools yes/no, local/remote}.
         // See `RollingTokenRate` doc for the window-choice rationale.
         var rollingRate = RollingTokenRate()
+        // The engine's own decode rate: generated tokens over the real decode
+        // wall-clock, measured from the end of prefill. Used when the rolling
+        // window never converges (short replies) — see the final stamp below.
+        var engineTokensPerSecond: Double? = nil
         // Throttle UI updates of the live rolling rate. The stream may
         // produce 100+ deltas/sec; clamping rate refreshes to ~5Hz keeps
         // SwiftUI repaints cheap without losing visible smoothness.
@@ -3111,14 +3115,18 @@ final class ChatSession: ObservableObject {
                     }
                 } else if let stats = StreamingStatsHint.decode(delta) {
                     uiStatsHintCount += 1
-                    // Final stats from vmlx — captured for the post-loop
-                    // stamp. We DELIBERATELY do NOT overwrite the rolling
-                    // rate here: vmlx's `tokensPerSecond` is the full-
-                    // generation average, which has the same first-token-
-                    // amortisation problem the rolling rate was added to
-                    // fix. The rolling rate's steady-state value is used
-                    // for the visible bubble after the stream ends; vmlx's
-                    // tokenCount is preserved as the authoritative count.
+                    // Final stats from vmlx — captured for the post-loop stamp.
+                    // We do NOT overwrite the live rolling rate here: while the
+                    // window has converged it is the better steady-state read.
+                    // But we no longer THROW THIS AWAY either. It is a real
+                    // measurement (tokens over the decode wall-clock, timed from
+                    // the end of prefill), and it is the only honest number
+                    // available for replies too short for the window to converge
+                    // — the case that used to be filled in with an average over
+                    // the delivery burst and render as `2397.3 tok/s • 7 tokens`.
+                    if stats.tokensPerSecond.isFinite, stats.tokensPerSecond > 0 {
+                        engineTokensPerSecond = stats.tokensPerSecond
+                    }
                     currentTurn.generationTokenCount = stats.tokenCount
                     // Vmlx tells us the model never closed `</think>` before
                     // EOS / max_tokens. Persist on the turn so the bubble
@@ -3222,12 +3230,23 @@ final class ChatSession: ObservableObject {
         if let first = firstDeltaTime {
             currentTurn.timeToFirstToken = first.timeIntervalSince(streamStartTime)
             // Stamp the steady-state tok/s. Single source of truth across
-            // local-MLX, remote-API, with-tools, and thinking-on/off paths
-            // — the rolling rate observed every text-bearing delta during
-            // the loop above. Falls back to full-generation average if the
-            // response was too short for the warm-up to elapse (see
-            // `RollingTokenRate.finalRate`).
-            currentTurn.generationTokensPerSecond = rollingRate.finalRate()
+            // local-MLX, remote-API, with-tools, and thinking-on/off paths.
+            //
+            // Order matters, and every rung is a real measurement:
+            //   1. the converged rolling window — best steady-state read, and
+            //      immune to first-token amortisation;
+            //   2. the engine's decode rate — a true tokens-over-decode-wall
+            //      figure for replies too short for the window to converge;
+            //   3. nothing.
+            //
+            // Rung 3 is the point. There is no fourth rung that guesses. The old
+            // fallback divided the token count by the span between the first and
+            // last *arrival*, which for a short reply delivered in one coalesced
+            // burst is a few milliseconds — hence the impossible thousands of
+            // tok/s on a 7-token answer. A blank cell is honest; that number was
+            // not.
+            currentTurn.generationTokensPerSecond =
+                rollingRate.finalRate() ?? engineTokensPerSecond
             // Token count: prefer vmlx's authoritative count (already
             // assigned in the stats sentinel branch above) — only fall back
             // to our chars/4 estimate if the stats sentinel never fired

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -203,6 +203,19 @@ final class ChatSession: ObservableObject {
     /// (plugin / HTTP / scheduler / watcher) runs, defaults to `.chat` for
     /// user-driven UI sessions.
     var source: SessionSource = .chat
+    /// Whether this session's model loads may evict a model someone else is using.
+    ///
+    /// Set from `DispatchRequest.loadIntent` at the trigger boundary. Headless
+    /// autonomous runs (cron fire, watcher, agent self-wake) arrive `.background`
+    /// and will decline rather than take the GPU from an active chat; everything
+    /// a human is waiting on -- including the "Run Now" buttons that share those
+    /// same code paths -- stays `.interactive`.
+    ///
+    /// This exists because the engine's own `RequestSource` has only four cases
+    /// (chatUI / httpAPI / plugin / p2p) and every headless session was being
+    /// flattened into `.chatUI` on its way to the model, losing the distinction
+    /// entirely.
+    var loadIntent: ModelLoadIntent = .interactive
     var sourcePluginId: String?
     var externalSessionKey: String?
     var dispatchTaskId: UUID?
@@ -368,8 +381,12 @@ final class ChatSession: ObservableObject {
     /// run was cancelled by the user (or by `sendNowInterrupting`) and must
     /// not auto-flush a queued send. Reset to false at the top of `send(...)`.
     private var stopRequested: Bool = false
-    var chatEngineFactory: @MainActor () -> ChatEngineProtocol = {
-        ChatEngine(source: .chatUI)
+    /// Takes the session's own inference provenance. It used to hardcode
+    /// `.chatUI` and ignore `source` entirely, so every headless run -- cron
+    /// schedule, file watcher, agent self-wake -- reached the model claiming to
+    /// be the user typing in the chat window.
+    var chatEngineFactory: @MainActor (InferenceSource) -> ChatEngineProtocol = {
+        ChatEngine(source: $0)
     }
     // nonisolated(unsafe) allows deinit to access these for cleanup
     nonisolated(unsafe) private var remoteModelsObserver: NSObjectProtocol?
@@ -3754,7 +3771,7 @@ final class ChatSession: ObservableObject {
                     let ttftTrace: TTFTTrace? = nil
                 #endif
                 do {
-                    let engine = chatEngineFactory()
+                    let engine = chatEngineFactory(source.inferenceSource)
                     let chatCfg = ChatConfigurationStore.load()
 
                     // MARK: - Capability Setup
@@ -4694,6 +4711,7 @@ final class ChatSession: ObservableObject {
                                 ? self.windowState?.pinnedRemoteAgentEffectiveModel : nil
                             req.modelOptions =
                                 self.activeModelOptions.isEmpty ? nil : self.activeModelOptions
+                            req.backgroundModelLoad = (self.loadIntent == .background)
                             req.ttftTrace = ttftTrace
                             // Correlate the Insights log this send produces back to the
                             // assistant turn, so the per-message "Insights" button can
@@ -4968,6 +4986,7 @@ final class ChatSession: ObservableObject {
                                 isRemoteAgentTarget
                                 ? windowState?.pinnedRemoteAgentEffectiveModel : nil
                             finalReq.modelOptions = activeModelOptions.isEmpty ? nil : activeModelOptions
+                            finalReq.backgroundModelLoad = (loadIntent == .background)
                             finalReq.turnId = assistantTurn.id
                             // Distinct logical step (the post-cap summarizing
                             // call) so it bills once and dedupes on its own

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1461,7 +1461,7 @@ final class NativeStatsView: NSView {
             parts.append(String(format: L("%.1f tok/s"), tps))
         }
         if let count = tokenCount {
-            parts.append(L("\(count) tokens"))
+            parts.append(count == 1 ? L("1 token") : L("\(count) tokens"))
         }
         // Trailing diagnostic chip — vmlx tells us the model never emitted
         // `</think>` (or the family's close tag) before EOS / max_tokens.

--- a/Packages/OsaurusCore/Views/Insights/InsightsDetailPane.swift
+++ b/Packages/OsaurusCore/Views/Insights/InsightsDetailPane.swift
@@ -243,6 +243,7 @@ struct InsightsDetailPane: View {
         case .httpAPI: return "network"
         case .plugin: return "puzzlepiece.extension.fill"
         case .p2p: return "antenna.radiowaves.left.and.right"
+        case .scheduled: return "clock.arrow.circlepath"
         }
     }
 

--- a/Packages/OsaurusCore/Views/Insights/InsightsView.swift
+++ b/Packages/OsaurusCore/Views/Insights/InsightsView.swift
@@ -630,6 +630,7 @@ private struct SourceBadge: View {
         case .httpAPI: return .blue
         case .plugin: return .teal
         case .p2p: return .purple
+        case .scheduled: return .orange
         }
     }
 }
@@ -641,6 +642,7 @@ extension RequestSource {
         case .httpAPI: return "HTTP"
         case .plugin: return "Plugin"
         case .p2p: return "P2P"
+        case .scheduled: return "Scheduled"
         }
     }
 }


### PR DESCRIPTION
Stacked on #1994 (needs `ModelLoadIntent` from it). Two independent fixes; both live-gated on a dev build via computer-use.

---

## 1. Headless runs claimed to be the user

A cron schedule firing, a file watcher tripping, an agent waking itself — nobody is waiting on any of these, so none of them should be able to evict the model someone is actively chatting with. All three could.

**The information was never missing — it was thrown away.** Every trigger already tags its `DispatchRequest` with a truthful `source` (`.schedule`, `.watcher`, `.selfSchedule`), and `ExecutionContext` copies it onto the `ChatSession`. Then `ChatSession` built its engine as `ChatEngine(source: .chatUI)`, unconditionally, ignoring its own `source` — so every headless run reached the model claiming to be the user typing in the chat window.

That mislabel had two teeth:
- **Load intent.** A headless run got the same right to evict a resident model as a human pressing send.
- **Residency.** `accelerateIdleUnloadAfterChatClose` only shortens residency for `.chatUI`-sourced models — so closing an unrelated chat window could accelerate the unload of the model a scheduled job was mid-run with.

### The subtlety, and why intent is NOT derived from `source`

A cron fire and the user pressing **Run Now** on that same schedule both arrive as `.schedule`. They call the same `executeSchedule`. Inferring intent from `source` would make the Run Now button refuse to load its own model whenever another model happened to be resident — breaking the feature in the name of protecting it. Same trap in the Next Run panel, where the automatic wake and the panel's own button share `makeDispatchRequest`.

So `loadIntent` is set at the **trigger boundary**, the one place that knows whether anyone is waiting. Timer fires, missed-schedule catch-up, watcher fires and agent self-wakes pass `.background`; every hand-pressed button and every waiting API client keeps the default `.interactive`. A caller who forgets fails safe — toward loading, not toward refusing.

`RequestSource` gains a `.scheduled` case rather than being made to lie with `.chatUI` or `.httpAPI`; the Insights log now says "Scheduled", which is what actually happened.

Tests pin the **trap itself**: Run Now must stay interactive, the Next Run panel button must not be background, and no engine may be constructed with a hardcoded `.chatUI` again.

---

## 2. The chat stats card invented a tok/s it never measured

It showed **`2397.3 tok/s • 7 tokens`**. No local model decodes at 2000+ tok/s. That number was not a measurement of anything.

`RollingTokenRate.finalRate()` fell back to `totalTokens / (lastAt - firstAt)` when the rolling window never converged. But `firstAt` is when the first token **arrived**, not when decoding began — so the span omits all the decode time that produced it. When a short reply is delivered in one coalesced burst, first and last arrival land ~3 ms apart: `7 / 0.003` = 2333 tok/s. **It measured the delivery, not the decode.**

`currentRate` already documents this exact hazard and floors its denominator against it ("would collapse an oldest-to-now span toward zero and report a physically impossible rate"). The fallback did the very thing that comment warns about. The existing test missed it because it only exercised the benign case — 3 tokens spread evenly over 0.2 s reads as a plausible 15 tok/s — and never a burst. **That plausibility is why the bug survived.**

There is no honest denominator available to that type: it only sees arrival timestamps. So it no longer guesses. `finalRate()` returns `nil` when the window never converged, and the caller falls back to the **engine's real decode rate** — tokens over the decode wall-clock, timed from the end of prefill — which the UI was already receiving in the stats sentinel and deliberately discarding.

Every rung of the ladder is a real measurement, and the last rung is *nothing*. A blank cell is honest; `2397.3 tok/s` was not.

(Engine-side companion, for the `NaN`/`+inf` the accessors could also emit: osaurus-ai/vmlx-swift#143.)

---

## Live proof (dev build, GUI only, computer-use)

**Stats card** — the exact case that used to fabricate thousands:

| reply | stats line (verbatim) |
|---|---|
| `yes` | `TTFT 0.21s • 25.5 tok/s • 1 tokens` |
| `Hello.` | `TTFT 0.23s • 24.7 tok/s • 2 tokens` |
| 200-word paragraph | `TTFT 0.57s • 38.0 tok/s • 183 tokens` |

A 1-token reply — the worst case for the old divide — now reports a rate in the same neighbourhood as the long-form one on the same binary, instead of 60× higher. **No value above 1000.** (These are Debug-build magnitudes and say nothing about actual decode speed; the point is the *shape*.)

That pass also surfaced `1 tokens`, fixed in the last commit.

**Interactive loading unaffected:**
- Explicit picker switch `Gemma 4 e2b it 4bit` → `Qwen3 0.6B 8bit` still evicts and loads — `Warming up…` → `Model warm — ready for a fast first response`.
- 3-turn context held (Paris → Seine/Aube/Marne → Seine). No mojibake, looping, truncation, unclosed reasoning, or stray template tags.
- No chat hung. **No error banner, no `Skipped background load`, no `would evict`.**

## Found, but NOT from this change

Schedule **"Run Now" never produces output** — sometimes stuck at `Running`, sometimes "Completed" with an empty result. **Reproduced identically on unmodified `main`** (baseline dev build), so it is pre-existing. App stdout shows the generation runs and finishes but emits nothing:

```
[Osaurus][Stream] Starting stream wrapper for model: mlx-community/gemma-4-e2b-it-4bit
[Osaurus][Stream] Stream completed: 0 content/reasoning deltas in 0.85s
                  classification=sentinel-only reasoning=0 stats=1 toolHints=0
```

Filed separately; it is the reason Run Now could not itself serve as the live gate here.
