### PR TITLE
Fix Product Hunt launch window to 24 hours

### DIFF
--- a/Packages/OsaurusCore/Services/ProductHuntLaunchCampaign.swift
+++ b/Packages/OsaurusCore/Services/ProductHuntLaunchCampaign.swift
@@ -23,9 +23,10 @@ public final class ProductHuntLaunchCampaign {
     /// local calendar date. Verified against ISO-8601 parses in tests.
     nonisolated public static let windowOpensAt = Date(timeIntervalSince1970: 1_783_926_060)
 
-    /// 2026-07-15T07:01:00Z — exactly 48 hours after open. The interval is
-    /// half-open (`open <= now < close`), so this instant itself is closed.
-    nonisolated public static let windowClosesAt = Date(timeIntervalSince1970: 1_784_098_860)
+    /// 2026-07-14T07:01:00Z — exactly 24 hours after open (Product Hunt
+    /// launches run for one day). The interval is half-open
+    /// (`open <= now < close`), so this instant itself is closed.
+    nonisolated public static let windowClosesAt = Date(timeIntervalSince1970: 1_784_012_460)
 
     /// Product Hunt launch page, opened by the dialog's primary button.
     nonisolated public static let launchURL = URL(string: "https://links.osaurus.ai/ph")!

--- a/Packages/OsaurusCore/Tests/Service/ProductHuntLaunchCampaignTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ProductHuntLaunchCampaignTests.swift
@@ -39,9 +39,9 @@ struct ProductHuntLaunchCampaignTests {
     @Test func windowBounds_match_spec_utc_instants() {
         let iso = ISO8601DateFormatter()
         #expect(iso.date(from: "2026-07-13T07:01:00Z") == open)
-        #expect(iso.date(from: "2026-07-15T07:01:00Z") == close)
-        // 48-hour window.
-        #expect(close.timeIntervalSince(open) == 48 * 3600)
+        #expect(iso.date(from: "2026-07-14T07:01:00Z") == close)
+        // 24-hour window — Product Hunt launches run for one day.
+        #expect(close.timeIntervalSince(open) == 24 * 3600)
     }
 
     // MARK: - Time boundaries (half-open interval)


### PR DESCRIPTION
## Summary
- Follow-up to #1998: Product Hunt launches run for one day, not two. The dialog window now closes at `2026-07-14T07:01:00Z` (24 hours after open) instead of `2026-07-15T07:01:00Z`.
- Updated `ProductHuntLaunchCampaign.windowClosesAt` and the boundary test's ISO-8601/duration expectations to match.

## Test plan
- [ ] `ProductHuntLaunchCampaignTests` pass (boundary tests exercise the exact open/close instants and the ISO-8601 equivalence of the new close bound)