### PR TITLE
Stop TTS from going silent after the output device changes

### DIFF
--- a/Packages/OsaurusCore/Managers/TTSService.swift
+++ b/Packages/OsaurusCore/Managers/TTSService.swift
@@ -8,8 +8,15 @@
 
 import AVFoundation
 import Combine
+import OSLog
 @preconcurrency import FluidAudio
 import Foundation
+
+/// TTS diagnostics. A synthesis failure used to be a bare `print`, which meant a user whose
+/// audio silently died had nothing to send us and nothing to read.
+enum TTSLogger {
+    static let service = Logger(subsystem: "ai.osaurus", category: "tts.service")
+}
 
 /// Errors mapped onto tool error envelopes by the `speak` tool.
 public enum TTSPlaybackError: Error {
@@ -83,6 +90,12 @@ public final class TTSService: ObservableObject {
     private var engineConfigured = false
     private var pendingBufferCount = 0
     private var streamFinished = false
+
+    /// Set when AVAudioEngine tells us its graph was torn down (an output-route change).
+    /// The engine keeps claiming `isRunning` afterwards, so this is the only honest signal
+    /// that the next playback must re-establish the connections.
+    private var engineNeedsRebuild = false
+    private var engineChangeObserver: NSObjectProtocol?
 
     private init() {}
 
@@ -318,7 +331,13 @@ public final class TTSService: ObservableObject {
     }
 
     private func handleStreamError(_ error: Error, for messageId: UUID) {
-        print("[TTSService] synthesis error: \(error)")
+        // A `print` is not a user-facing error. When synthesis fails, playback ends, the
+        // Stop control flips back on its own, and the user is left with silence and no
+        // explanation — indistinguishable from the app simply ignoring them. Say what
+        // happened, in the one place they are already looking at TTS.
+        TTSLogger.service.error(
+            "TTS synthesis failed: \(error.localizedDescription, privacy: .public)")
+        modelState = .failed(error.localizedDescription)
         if playingMessageId == messageId {
             stop()
         }
@@ -344,14 +363,59 @@ public final class TTSService: ObservableObject {
     }
 
     private func configureEngineIfNeeded() throws {
+        // Do NOT trust `isRunning` alone.
+        //
+        // When the output device changes — AirPods connecting, the user switching to the
+        // built-in speakers, the default device changing — AVAudioEngine tears its graph
+        // down and posts `.AVAudioEngineConfigurationChange`, but it keeps reporting
+        // `isRunning == true`. Returning early on that would leave the player node wired to
+        // a device that no longer exists: buffers are still consumed, their completion
+        // handlers still fire, the Stop control still flips back on its own — and not a
+        // single sample is audible, with no error anywhere. That is exactly what a silent
+        // TTS looks like from the outside.
+        //
+        // `engineNeedsRebuild` is set by the configuration-change observer, so the next
+        // playback re-establishes the graph instead of politely doing nothing.
+        if engineNeedsRebuild {
+            if audioEngine.isRunning { audioEngine.stop() }
+            engineConfigured = false
+            engineNeedsRebuild = false
+        }
+
         if engineConfigured, audioEngine.isRunning { return }
         if !engineConfigured {
             audioEngine.attach(playerNode)
             audioEngine.connect(playerNode, to: audioEngine.mainMixerNode, format: sourceFormat)
             engineConfigured = true
+            // Registered against the engine we just built, and only once.
+            observeEngineConfigurationChanges()
         }
         if !audioEngine.isRunning {
             try audioEngine.start()
+        }
+    }
+
+    /// Rebuild the audio graph on the next playback.
+    ///
+    /// Set from `.AVAudioEngineConfigurationChange`, which fires on every output-route
+    /// change. The notification arrives on an arbitrary thread and we only ever flip a
+    /// flag, so the rebuild happens on the main actor inside `configureEngineIfNeeded`,
+    /// where the rest of the engine lives.
+    private func observeEngineConfigurationChanges() {
+        guard engineChangeObserver == nil else { return }
+        engineChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: audioEngine,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.engineNeedsRebuild = true
+                // A route change mid-utterance drops the rest of the audio on the floor.
+                // End the playback honestly rather than leaving a Stop control the user has
+                // to press to silence something they cannot hear.
+                if self.playingMessageId != nil { self.stop() }
+            }
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/TTSEngineRebuildTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/TTSEngineRebuildTests.swift
@@ -1,0 +1,80 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// TTS went silent for a user who was switching between AirPods and the built-in speakers.
+/// PocketTTS Preview kept working; the chat speaker button and Auto Speak produced nothing —
+/// the Stop control appeared and then flipped back on its own, with no error anywhere.
+///
+/// The cause is an AVAudioEngine contract that is easy to get wrong: on an output-route change
+/// the engine tears its graph down and posts `.AVAudioEngineConfigurationChange`, but it goes on
+/// reporting `isRunning == true`. `configureEngineIfNeeded` returned early on exactly that
+/// condition, so the player node stayed wired to a device that no longer existed. Buffers were
+/// still consumed, their completion handlers still fired, playback still "finished" — and not one
+/// sample was audible. From the outside that is indistinguishable from the app ignoring the user.
+///
+/// Exercising a real route change needs real hardware, so this pins the two properties that make
+/// the silent path impossible: the engine is not trusted on `isRunning` alone, and a synthesis
+/// failure is no longer swallowed by a `print`.
+@Suite("TTS survives an output-device change")
+struct TTSEngineRebuildTests {
+    private static func source() throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Service/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+        return try String(
+            contentsOf: packageRoot.appendingPathComponent("Managers/TTSService.swift"),
+            encoding: .utf8)
+    }
+
+    @Test("A route change forces the audio graph to be rebuilt")
+    func routeChangeRebuildsTheEngine() throws {
+        let src = try Self.source()
+
+        // Without this observer nothing ever learns the graph died, and every later playback
+        // renders into a device that is gone.
+        #expect(
+            src.contains("AVAudioEngineConfigurationChange"),
+            "an output-route change must be observed — the engine will not tell you otherwise"
+        )
+        #expect(src.contains("engineNeedsRebuild"))
+
+        // And the early return must consult it. `isRunning` is true even when the graph is dead,
+        // so trusting it alone is precisely the silent-audio bug.
+        guard let start = src.range(of: "private func configureEngineIfNeeded()") else {
+            Issue.record("configureEngineIfNeeded not found")
+            return
+        }
+        let body = String(src[start.lowerBound...].prefix(1400))
+        #expect(
+            body.contains("if engineNeedsRebuild"),
+            "configureEngineIfNeeded must rebuild after a configuration change, not return early"
+        )
+    }
+
+    @Test("A synthesis failure is reported, not printed into the void")
+    func synthesisFailureIsSurfaced() throws {
+        let src = try Self.source()
+        guard let start = src.range(of: "private func handleStreamError(") else {
+            Issue.record("handleStreamError not found")
+            return
+        }
+        let body = String(src[start.lowerBound...].prefix(600))
+
+        // A `print` leaves the user with silence and nothing to send us. They cannot even tell
+        // whether the app heard the click.
+        #expect(
+            !body.contains("print("),
+            "a failure the user experiences as silence must be logged and surfaced, not printed"
+        )
+        #expect(body.contains("TTSLogger.service.error"))
+        #expect(
+            body.contains("modelState = .failed"),
+            "surface the failure in the state the TTS UI already shows"
+        )
+    }
+}


### PR DESCRIPTION
### The report

Osaurus 0.22.2, M1 MacBook Air, macOS Tahoe 26.5.2.

- ✅ Speech-to-Text works. PocketTTS downloaded. **PocketTTS Preview plays fine** (voice Vera) — through **both AirPods and the MacBook speakers**.
- ❌ **Auto Speak: no audio. Speaker button on a chat response: no audio.**
- The speaker icon changes to Stop while the response generates, then back to the speaker icon when it finishes — **but there is never any sound.**
- Already ruled out by the reporter: different output devices, thinking on/off, smooth streaming on/off, new chats, auto-speak global *and* per-agent, manual speaker button, full app restart.

### What I ruled out

Preview and chat go through the **same `TTSService.shared`** — same engine, same player node — so PocketTTS, synthesis, and audio routing were all exonerated immediately. Then:

- **Voice override**: the chat path passes an agent voice that Preview does not. Dead end — the agent voice is `Default (global)`, so it resolves to the same voice Preview uses. (And an invalid voice already falls back to the default.)
- **`manager` being nil while `isModelReady` is true**: dead end — `ensureModelLoaded` sets both together on the main actor.
- **Synthesis throwing**: dead end — no synthesis error was ever emitted.

### Root cause

`AVAudioEngine` tears its graph down on an **output-route change** and posts `.AVAudioEngineConfigurationChange` — but it **keeps reporting `isRunning == true`**.

```swift
private func configureEngineIfNeeded() throws {
    if engineConfigured, audioEngine.isRunning { return }   // ← returns early on a DEAD graph
```

So after AirPods connect (or the user switches to the speakers), the player node stays wired to a device that no longer exists. Buffers are still consumed, their completion handlers still fire, playback still "finishes" — **and not one sample is audible.** The Stop control appears and flips back on its own. No error. Exactly the report.

`TTSService` had **no observer for that notification at all**.

### The fix

Observe `.AVAudioEngineConfigurationChange` and rebuild the graph on the next playback, instead of trusting `isRunning`. A route change mid-utterance now ends playback honestly rather than leaving a Stop control the user has to press to silence something they cannot hear.

**Also:** a synthesis failure was a bare `print`. Someone whose audio silently died had nothing to read and nothing to send us. It is now logged and surfaced in the state the TTS UI already shows.

### Honest status

**I could not reproduce the silence on this machine.** I drove the real app: PocketTTS downloaded, Preview timed, chat playback timed. Chat playback duration **scales with text length** here (5.9s / 5.9s / 5.1s for three sentences vs **2.0s** for one word), so audio genuinely is being rendered on this hardware.

This fixes a **real latent bug whose failure mode matches the report exactly**, and the reporter's environment — macOS Tahoe, switching between AirPods and speakers — is precisely its trigger. It is not a reproduction-backed cure, and I am not claiming it is.

The reporter offered Console logs. With this change there is finally something in them to read: `ai.osaurus / tts.service`.