### PR TITLE
fixed mcp tool discovery dropping paginated tools/list results

### DIFF
--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -571,8 +571,8 @@ public final class MCPProviderManager: ObservableObject {
             try await withTimeout(seconds: 10) {
                 _ = try await client.connect(transport: transport)
             }
-            let (tools, _) = try await withTimeout(seconds: 10) {
-                try await client.listTools()
+            let tools = try await withTimeout(seconds: 10) {
+                try await client.listAllTools()
             }
             stopStdioRunners(for: provider.id)
             return tools.count
@@ -626,7 +626,7 @@ public final class MCPProviderManager: ObservableObject {
             _ = try await client.connect(transport: transport)
 
             // List tools to verify connection
-            let (tools, _) = try await client.listTools()
+            let tools = try await client.listAllTools()
 
             await client.disconnect()
             return tools.count
@@ -986,9 +986,11 @@ public final class MCPProviderManager: ObservableObject {
     }
 
     private func discoverTools(for providerId: UUID, client: MCP.Client, provider: MCPProvider) async throws {
-        // List tools with timeout
-        let (mcpTools, _) = try await withTimeout(seconds: provider.discoveryTimeout) {
-            try await client.listTools()
+        // List tools with timeout, following pagination cursors so servers
+        // that split tools/list across pages (e.g. Baserow, #1999) aren't
+        // truncated to their first page.
+        let mcpTools = try await withTimeout(seconds: provider.discoveryTimeout) {
+            try await client.listAllTools()
         }
 
         // Store discovered tools

--- a/Packages/OsaurusCore/Services/MCP/MCPClientToolPagination.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPClientToolPagination.swift
@@ -1,0 +1,42 @@
+//
+//  MCPClientToolPagination.swift
+//  OsaurusCore
+//
+//  Cursor-following wrapper around `MCP.Client.listTools`. The MCP spec
+//  allows servers to paginate `tools/list`; a single call only returns the
+//  first page, so callers that treat it as the full tool set silently drop
+//  every tool past page one (osaurus-ai/osaurus#1999 — Baserow returns a
+//  paginated list and Osaurus discovered zero tools).
+//
+
+import Foundation
+import MCP
+
+extension MCP.Client {
+    /// Fetch every page of `tools/list`, following `nextCursor` until the
+    /// server stops returning one.
+    ///
+    /// `maxPages` is a guard against a misbehaving server that returns a
+    /// cursor forever (or cycles cursors); on hitting the cap the tools
+    /// collected so far are returned rather than throwing, since a partial
+    /// list is strictly more useful than none.
+    public func listAllTools(maxPages: Int = 100) async throws -> [MCP.Tool] {
+        var allTools: [MCP.Tool] = []
+        var cursor: String? = nil
+        var seenCursors = Set<String>()
+        for _ in 0..<maxPages {
+            let (tools, nextCursor) = try await listTools(cursor: cursor)
+            allTools.append(contentsOf: tools)
+            guard let next = nextCursor, !next.isEmpty else {
+                return allTools
+            }
+            // A repeated cursor would loop forever without the page cap;
+            // bail out early instead of burning the remaining pages.
+            guard seenCursors.insert(next).inserted else {
+                return allTools
+            }
+            cursor = next
+        }
+        return allTools
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -126,7 +126,8 @@ public struct MCPProviderProbeResult: Codable, Identifiable, Sendable, Equatable
             stage: .listTools,
             reasonCode: .succeeded,
             toolCount: tools.count,
-            toolNames: tools.map(\.name).sorted(),
+            // Server order, which for a paginated tools/list is page order.
+            toolNames: tools.map(\.name),
             message: L("Probe completed initialize/listTools and found \(tools.count) tool(s)."),
             action: nil
         )

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -299,8 +299,8 @@ public enum MCPProviderProbeService {
             try await withTimeout(seconds: provider.discoveryTimeout) {
                 _ = try await client.connect(transport: transport)
             }
-            let (tools, _) = try await withTimeout(seconds: provider.discoveryTimeout) {
-                try await client.listTools()
+            let tools = try await withTimeout(seconds: provider.discoveryTimeout) {
+                try await client.listAllTools()
             }
             // Probes are short-lived by contract: disconnect the client so
             // HTTP transports invalidate their URLSession (and stop any SSE

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPClientToolPaginationTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPClientToolPaginationTests.swift
@@ -1,0 +1,181 @@
+//
+//  MCPClientToolPaginationTests.swift
+//  osaurusTests
+//
+//  Regression coverage for cursor-following tools/list discovery
+//  (osaurus-ai/osaurus#1999 — servers that paginate tools/list were
+//  truncated to their first page).
+//
+
+import Foundation
+import Logging
+import MCP
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("MCP tools/list pagination")
+struct MCPClientToolPaginationTests {
+    @Test func listAllToolsFollowsNextCursorAcrossPages() async throws {
+        let transport = PaginatedFakeMCPTransport(pages: [
+            (tools: ["alpha", "beta"], nextCursor: "cursor-2"),
+            (tools: ["gamma"], nextCursor: "cursor-3"),
+            (tools: ["delta"], nextCursor: nil),
+        ])
+        let client = MCP.Client(name: "Osaurus", version: "1.0.0")
+        _ = try await client.connect(transport: transport)
+        defer { Task { await client.disconnect() } }
+
+        let tools = try await client.listAllTools()
+
+        #expect(tools.map(\.name) == ["alpha", "beta", "gamma", "delta"])
+        #expect(await transport.receivedCursors == [nil, "cursor-2", "cursor-3"])
+    }
+
+    @Test func listAllToolsStopsOnRepeatedCursorInsteadOfLooping() async throws {
+        let transport = PaginatedFakeMCPTransport(
+            pages: [(tools: ["alpha"], nextCursor: "stuck")],
+            stuckCursor: "stuck"
+        )
+        let client = MCP.Client(name: "Osaurus", version: "1.0.0")
+        _ = try await client.connect(transport: transport)
+        defer { Task { await client.disconnect() } }
+
+        let tools = try await client.listAllTools()
+
+        // The stuck page's tools are collected once; the repeated cursor
+        // terminates the loop rather than re-fetching forever.
+        #expect(tools.map(\.name) == ["alpha", "stuck-tool"])
+    }
+
+    @Test func probeDiscoversToolsFromPaginatedServer() async throws {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Paginated MCP",
+            url: "",
+            discoveryTimeout: 5,
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "fake-mcp"
+        )
+
+        let result = await MCPProviderProbeService.probeForTesting(
+            provider: provider,
+            transport: PaginatedFakeMCPTransport(pages: [
+                (tools: ["list_tables"], nextCursor: "cursor-2"),
+                (tools: ["list_table_rows"], nextCursor: nil),
+            ])
+        )
+
+        #expect(result.succeeded)
+        #expect(result.toolCount == 2)
+        #expect(result.toolNames == ["list_tables", "list_table_rows"])
+    }
+}
+
+/// Fake transport whose tools/list handler serves a fixed sequence of pages
+/// keyed by the request's `cursor` param. An optional `stuckCursor` always
+/// responds with the same `nextCursor` it was asked for, to exercise the
+/// cycle guard.
+private actor PaginatedFakeMCPTransport: MCP.Transport {
+    nonisolated let logger = Logger(
+        label: "osaurus.tests.paginated-fake-mcp-transport",
+        factory: { _ in SwiftLogNoOpLogHandler() }
+    )
+
+    private let stream: AsyncThrowingStream<Data, Error>
+    private let continuation: AsyncThrowingStream<Data, Error>.Continuation
+    private let pages: [(tools: [String], nextCursor: String?)]
+    private let stuckCursor: String?
+    private(set) var receivedCursors: [String?] = []
+
+    init(pages: [(tools: [String], nextCursor: String?)], stuckCursor: String? = nil) {
+        var continuation: AsyncThrowingStream<Data, Error>.Continuation!
+        self.stream = AsyncThrowingStream { continuation = $0 }
+        self.continuation = continuation
+        self.pages = pages
+        self.stuckCursor = stuckCursor
+    }
+
+    func connect() async throws {}
+
+    func disconnect() async {
+        continuation.finish()
+    }
+
+    func send(_ data: Data) async throws {
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let object, let method = object["method"] as? String else { return }
+        let id = object["id"] ?? 0
+
+        switch method {
+        case "initialize":
+            continuation.yield(
+                responseData(
+                    id: id,
+                    result: [
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": ["tools": [:]],
+                        "serverInfo": ["name": "fake", "version": "1.0.0"],
+                    ]
+                )
+            )
+        case "tools/list":
+            let params = object["params"] as? [String: Any]
+            let cursor = params?["cursor"] as? String
+            receivedCursors.append(cursor)
+            continuation.yield(responseData(id: id, result: toolsPage(for: cursor)))
+        default:
+            break
+        }
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Error> {
+        stream
+    }
+
+    private func toolsPage(for cursor: String?) -> [String: Any] {
+        if let stuckCursor, cursor == stuckCursor {
+            var page = toolsResult(names: ["stuck-tool"])
+            page["nextCursor"] = stuckCursor
+            return page
+        }
+        // Resolve the page: nil cursor is page 0; otherwise the page after
+        // the one that emitted this cursor.
+        let pageIndex: Int
+        if let cursor {
+            pageIndex = (pages.firstIndex(where: { $0.nextCursor == cursor }) ?? -1) + 1
+        } else {
+            pageIndex = 0
+        }
+        guard pageIndex < pages.count else { return toolsResult(names: []) }
+        let page = pages[pageIndex]
+        var result = toolsResult(names: page.tools)
+        if let next = page.nextCursor {
+            result["nextCursor"] = next
+        }
+        return result
+    }
+
+    private func toolsResult(names: [String]) -> [String: Any] {
+        [
+            "tools": names.map {
+                [
+                    "name": $0,
+                    "description": "Fixture tool \($0)",
+                    "inputSchema": ["type": "object", "properties": [:]],
+                ]
+            }
+        ]
+    }
+
+    private func responseData(id: Any, result: [String: Any]) -> Data {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        ]
+        return try! JSONSerialization.data(withJSONObject: response)
+    }
+}


### PR DESCRIPTION
## Summary

fixes #1999

  ## Problem

  - servers that paginate `tools/list` (like the official Baserow MCP server with its dynamically generated per table tools) connected successfully but showed zero tools
  - `client.listTools()` was called once and the returned `nextCursor` was discarded, so only the first page was ever fetched
  - the same endpoint worked in Claude Desktop because its client follows the pagination cursor

  ## Changes
  
  - add `MCP.Client.listAllTools()` in `MCPClientToolPagination.swift` that follows `nextCursor` until exhausted, with a 100 page cap and a repeated cursor guard so a misbehaving server cannot loop forever (partial results are returned instead of throwing)
  - switch all four single page call sites to the new helper: tool discovery in `MCPProviderManager.discoverTools()`, the stdio and http connection tests in the same file, and the probe in `MCPProviderProbeService.runProbe()`
  - the existing per provider discovery timeout now wraps the full pagination loop
  - add regression tests with a fake paginated transport covering cursor following across pages, stuck cursor termination, and a probe against a two page server

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
