### PR TITLE
A request may only execute the tools it exposed

### DIFF
--- a/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
+++ b/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
@@ -33,6 +33,15 @@ public enum ChatExecutionContext {
     /// can swap its check for a spinner while its audio plays
     @TaskLocal public static var currentToolCallId: String?
 
+    /// What this request is allowed to EXECUTE, as opposed to what it merely exposed.
+    ///
+    /// See ``ToolExecutionScope``. `nil` means no scope was published — the surface gates its own
+    /// tools and the registry behaves exactly as it did before. That is deliberately permissive:
+    /// binding it on every entrypoint at once would risk breaking a surface we cannot gate live,
+    /// and a guard that breaks working features is not an improvement. The chat/agent loop — where
+    /// an unexposed tool was actually observed executing — publishes one.
+    @TaskLocal static var toolExecutionScope: ToolExecutionScope?
+
     /// The current `agent_runs.id` row (`SchedulerDatabase`) so every
     /// mutation done by `db.*` tools or scheduling tools can stamp its
     /// originating run on the `_changelog` audit trail (spec §1.4,

--- a/Packages/OsaurusCore/Tests/Service/ToolExecutionScopeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ToolExecutionScopeTests.swift
@@ -1,0 +1,127 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Tools fired in the app while the tools toggle was visibly **off**.
+///
+/// Exposure and execution were never bound to each other. The prompt decided which tools the model
+/// was *told* about, but nothing stopped it from naming one it had never been shown: the parser
+/// records any name once at least one schema is present, and `ToolRegistry` executed it, because
+/// the registry believed access control had already happened upstream. It had not. A sandbox /
+/// plugin / MCP tool deliberately withheld from an agent would run if the model simply guessed its
+/// name.
+///
+/// The obvious fix — freeze an immutable allowlist from the rendered schema — would have **broken a
+/// feature that works today**: `capabilities_load` and `sandbox_plugin_register` deliberately make
+/// tools callable mid-run while `<tools>` stays frozen (rewriting it would bust the paged-KV prefix
+/// for the whole conversation). So the scope has to be able to grow. These tests pin both halves:
+/// the hole is closed, AND capability loading still works.
+@Suite("A request may only execute what it exposed")
+struct ToolExecutionScopeTests {
+
+    private func spec(_ name: String) -> Tool {
+        Tool(
+            type: "function",
+            function: ToolFunction(name: name, description: "test tool \(name)", parameters: nil)
+        )
+    }
+
+    @Test("A tool that was exposed is permitted")
+    func exposedToolIsPermitted() {
+        let scope = ToolExecutionScope(exposed: [spec("get_current_time"), spec("file_read")])
+        #expect(scope.permits("get_current_time"))
+        #expect(scope.permits("file_read"))
+    }
+
+    @Test("A tool that was never exposed is refused, however plausible its name")
+    func unexposedToolIsRefused() {
+        // The exact live failure: the request exposes a benign tool, a sandbox tool is registered
+        // process-wide but withheld from this agent, and the model names it anyway.
+        let scope = ToolExecutionScope(exposed: [spec("get_current_time")])
+
+        #expect(!scope.permits("sandbox_exec"))
+        #expect(!scope.permits("shell_run"))
+        #expect(!scope.permits("file_write"))
+    }
+
+    @Test("An empty exposure permits nothing — it is not the same as 'no allowlist'")
+    func emptyExposurePermitsNothing() {
+        // Tools OFF. Conflating "this request exposed nothing" with "no allowlist was published"
+        // is exactly how an unexposed tool got through.
+        let scope = ToolExecutionScope(exposed: [])
+        #expect(!scope.permits("get_current_time"))
+        #expect(!scope.permits("sandbox_exec"))
+        #expect(scope.authorizedNames.isEmpty)
+    }
+
+    @Test("capabilities_load can still make a tool callable mid-run")
+    func capabilityLoadGrowsTheScope() {
+        // `toolSpecs` stays FROZEN for the rest of the run — rewriting the rendered <tools> block
+        // would bust the paged-KV prefix — so a tool loaded mid-run is callable WITHOUT ever
+        // appearing in the frozen schema. An immutable allowlist would refuse the very tool the
+        // model was just handed, and capability loading would die.
+        let scope = ToolExecutionScope(exposed: [spec("capabilities_load")])
+        #expect(!scope.permits("web_search"))
+
+        scope.activate(["web_search", "web_fetch"])
+
+        #expect(scope.permits("web_search"))
+        #expect(scope.permits("web_fetch"))
+        // …and activating one tool must not fling the doors open for everything else.
+        #expect(!scope.permits("sandbox_exec"))
+    }
+
+    @Test("Activation is additive and never revokes the original grant")
+    func activationIsAdditive() {
+        let scope = ToolExecutionScope(exposed: [spec("get_current_time")])
+        scope.activate(["web_search"])
+        #expect(scope.permits("get_current_time"))
+        #expect(scope.permits("web_search"))
+    }
+}
+
+/// The check has to sit in the right place, or the model routes around it.
+@Suite("The allowlist is enforced where it cannot be bypassed")
+struct ToolExecutionScopeWiringTests {
+    private static func source(_ relativePath: String) throws -> String {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Service/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+        return try String(
+            contentsOf: packageRoot.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    @Test("The check runs AFTER the tool/ prefix is normalized away")
+    func checkRunsAfterNameNormalization() throws {
+        let src = try Self.source("Tools/ToolRegistry.swift")
+
+        guard
+            let strip = src.range(of: #"if toolsByName[name] == nil, name.hasPrefix("tool/")"#),
+            let check = src.range(of: "ChatExecutionContext.toolExecutionScope")
+        else {
+            Issue.record("could not locate the normalization or the check")
+            return
+        }
+
+        // Checking the RAW name would let the model bypass the whole allowlist by prefixing a
+        // name it was never given: `tool/sandbox_exec` normalizes to `sandbox_exec` afterwards.
+        #expect(
+            strip.lowerBound < check.lowerBound,
+            "the allowlist must be checked on the NORMALIZED name, or `tool/` walks straight past it"
+        )
+    }
+
+    @Test("The chat loop publishes a scope, so the guard is actually reached")
+    func chatLoopPublishesTheScope() throws {
+        // A guard the system never reaches is not a guard. We have shipped that twice.
+        let src = try Self.source("Views/Chat/ChatView.swift")
+        #expect(src.contains("let toolScope = ToolExecutionScope(exposed: toolSpecs)"))
+        #expect(src.contains("$toolExecutionScope"))
+        // …and it must grow when capabilities_load hands the model new tools.
+        #expect(src.contains("toolScope.activate(newTools.map { $0.function.name })"))
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolExecutionScope.swift
+++ b/Packages/OsaurusCore/Tools/ToolExecutionScope.swift
@@ -1,0 +1,58 @@
+//
+//  ToolExecutionScope.swift
+//  osaurus
+//
+//  Binds what a request EXPOSED to the model to what it is allowed to EXECUTE.
+//
+
+import Foundation
+
+/// The set of tools one request is allowed to run.
+///
+/// Exposure and execution were never bound to each other. The prompt decided which tools the
+/// model was *told* about, but nothing stopped it from naming one it had never been shown: the
+/// parser records any name once at least one schema is present, and `ToolRegistry` then executed
+/// it, because the registry believed access control had already happened upstream. It had not. A
+/// sandbox / plugin / MCP tool deliberately withheld from an agent would run if the model simply
+/// guessed its name — and tools fired in the app with the tools toggle visibly **off**.
+///
+/// A plain `Set` is not enough, because it would break a feature that works today.
+/// `capabilities_load` and `sandbox_plugin_register` deliberately make tools callable **mid-run**
+/// while the rendered `<tools>` block stays frozen (rewriting it would bust the paged-KV prefix for
+/// the whole conversation). So authorization has to be able to *grow* during the run — hence a
+/// mutable scope that owns both the initial grant and any same-run activations, rather than an
+/// immutable snapshot that would silently kill capability loading.
+///
+/// Activations live **here**, not in the process-wide `CapabilityLoadBuffer`: that buffer is
+/// global, so two concurrent requests can drain each other's activations and authorize a tool the
+/// other one loaded.
+final class ToolExecutionScope: @unchecked Sendable {
+    private let lock = NSLock()
+    private var allowed: Set<String>
+
+    /// Seed from the FINAL model-visible schema — the specs that survived every agent, mode and
+    /// composer gate. Not from the registry, not from `builtInToolNames`, not from
+    /// `runtimeManagedToolNames`: those are supersets of what this request was allowed to see, and
+    /// unioning them back in would re-open the hole this exists to close.
+    init(exposed specs: [Tool]) {
+        self.allowed = Set(specs.map { $0.function.name })
+    }
+
+    /// Is this tool authorized for this request?
+    func permits(_ name: String) -> Bool {
+        lock.withLock { allowed.contains(name) }
+    }
+
+    /// Authorize a tool that this run activated after the schema was frozen
+    /// (`capabilities_load`, `sandbox_plugin_register`). The model was told about it in the tool
+    /// result, so it is legitimately callable — it simply is not in the frozen `<tools>` block.
+    func activate(_ names: [String]) {
+        guard !names.isEmpty else { return }
+        lock.withLock { allowed.formUnion(names) }
+    }
+
+    /// Everything currently authorized. Diagnostics only.
+    var authorizedNames: Set<String> {
+        lock.withLock { allowed }
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -5,8 +5,14 @@
 //  Central registry for chat tools. Provides OpenAI tool specs and execution by name.
 //
 
-import Foundation
 import Combine
+import Foundation
+import OSLog
+
+/// Refusals here are security-relevant: a tool the request never exposed tried to run.
+enum ToolRegistryLogger {
+    static let registry = Logger(subsystem: "ai.osaurus", category: "tool.registry")
+}
 
 private let toolBodyTimeoutQueue = DispatchQueue(label: "ai.osaurus.tool-registry.timeout")
 
@@ -651,6 +657,34 @@ public final class ToolRegistry: ObservableObject {
             let stripped = String(name.dropFirst("tool/".count))
             if toolsByName[stripped] != nil { name = stripped }
         }
+
+        // A tool this request never exposed must not run, however convincingly the model asks
+        // for it.
+        //
+        // Exposure and execution were not bound together. The prompt chose which tools the model
+        // was TOLD about, but nothing stopped it from naming one it was never shown: the parser
+        // records any name once at least one schema is present, and this registry then ran it,
+        // because the comment above used to say access control had already happened upstream. It
+        // had not. A sandbox / plugin / MCP tool deliberately withheld from an agent would execute
+        // if the model merely guessed its name — and tools fired in the app with the tools toggle
+        // visibly OFF.
+        //
+        // Deliberately AFTER the `tool/` normalization above: checking `rawName` would let the
+        // model bypass the whole thing by prefixing the name it was never given.
+        //
+        // `nil` scope means the surface published none and gates its own tools — the registry then
+        // behaves exactly as before. See `ChatExecutionContext.toolExecutionScope`.
+        if let scope = ChatExecutionContext.toolExecutionScope, !scope.permits(name) {
+            ToolRegistryLogger.registry.error(
+                "refusing '\(name, privacy: .public)': not exposed to this request")
+            return ToolErrorEnvelope(
+                kind: .toolNotFound,
+                reason: "\(name) is not available in this conversation.",
+                toolName: name,
+                retryable: false
+            ).toJSONString()
+        }
+
         // External-surface deny list: refuse workspace-mutating tool
         // classes for HTTP/MCP-initiated executions regardless of
         // registration state or permission policy.

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4096,6 +4096,14 @@ final class ChatSession: ObservableObject {
                     let isManualTools = liveToolMode == .manual
                     cachedContext = context
 
+                    // What this run may EXECUTE, seeded from what it actually EXPOSED.
+                    //
+                    // The model can name a tool it was never shown (the parser records any name
+                    // once a schema exists) and the registry used to run it. One object for the
+                    // whole run: `capabilities_load` legitimately GROWS this set mid-run while
+                    // `toolSpecs` stays frozen, so an immutable snapshot would kill that feature.
+                    let toolScope = ToolExecutionScope(exposed: toolSpecs)
+
                     // Persist the always-loaded snapshot back onto the session
                     // so the next send freezes the schema against tools that
                     // register mid-session. Preserves any capabilities_load
@@ -4395,6 +4403,11 @@ final class ChatSession: ObservableObject {
                             // unrelated run; persist only in auto mode (manual
                             // mode keeps the user's explicit tool set fixed).
                             let newTools = await CapabilityLoadBuffer.shared.drain()
+                            // These tools were just made callable to the model — their schemas ride
+                            // in the tool result — while `toolSpecs` stays frozen. Authorize them
+                            // for the rest of THIS run, or the allowlist above would refuse the very
+                            // tools the model was just handed.
+                            toolScope.activate(newTools.map { $0.function.name })
                             if !newTools.isEmpty, !isManualTools, let sid = self.sessionId {
                                 let names = newTools.map { $0.function.name }
                                 let snapshot = context.alwaysLoadedNames
@@ -4511,22 +4524,27 @@ final class ChatSession: ObservableObject {
                             // `currentAgentId` is already pinned by the
                             // outer turn-level binding; we only need to
                             // layer per-tool-call session/turn/call ids.
-                            let resultText = try await ChatExecutionContext.$currentSessionId.withValue(
-                                sessionIdForTools
-                            ) {
-                                try await ChatExecutionContext.$currentAssistantTurnId.withValue(assistantTurn.id) {
-                                    try await ChatExecutionContext.$currentToolCallId.withValue(callId) {
-                                        // The combined-mode host-read scope +
-                                        // secret-read policy are bound centrally
-                                        // inside ToolRegistry.execute, so every
-                                        // entrypoint inherits them uniformly.
-                                        try await ToolRegistry.shared.execute(
-                                            name: inv.toolName,
-                                            argumentsJSON: inv.jsonArguments
-                                        )
+                            let resultText = try await ChatExecutionContext.$toolExecutionScope
+                                .withValue(toolScope) {
+                                    try await ChatExecutionContext.$currentSessionId.withValue(
+                                        sessionIdForTools
+                                    ) {
+                                        try await ChatExecutionContext.$currentAssistantTurnId
+                                            .withValue(assistantTurn.id) {
+                                                try await ChatExecutionContext.$currentToolCallId
+                                                    .withValue(callId) {
+                                                        // The combined-mode host-read scope +
+                                                        // secret-read policy are bound centrally
+                                                        // inside ToolRegistry.execute, so every
+                                                        // entrypoint inherits them uniformly.
+                                                        try await ToolRegistry.shared.execute(
+                                                            name: inv.toolName,
+                                                            argumentsJSON: inv.jsonArguments
+                                                        )
+                                                    }
+                                            }
                                     }
                                 }
-                            }
                             return await postProcessToolResult(inv, callId: callId, resultText: resultText)
                         } catch {
                             // Store rejection/error as the result so UI shows "Rejected" instead of hanging.
@@ -4667,14 +4685,16 @@ final class ChatSession: ObservableObject {
                             let results = await AgentToolLoop.runBatchInParallel(
                                 approved.map { ($0.invocation, $0.callId) }
                             ) { inv, callId in
-                                try await ChatExecutionContext.$currentSessionId.withValue(sessionIdForTools) {
-                                    try await ChatExecutionContext.$currentAssistantTurnId.withValue(turnIdForTools) {
-                                        try await ChatExecutionContext.$currentToolCallId.withValue(callId) {
-                                            try await ToolRegistry.shared.execute(
-                                                name: inv.toolName,
-                                                argumentsJSON: inv.jsonArguments,
-                                                permissionGateResolved: true
-                                            )
+                                try await ChatExecutionContext.$toolExecutionScope.withValue(toolScope) {
+                                    try await ChatExecutionContext.$currentSessionId.withValue(sessionIdForTools) {
+                                        try await ChatExecutionContext.$currentAssistantTurnId.withValue(turnIdForTools) {
+                                            try await ChatExecutionContext.$currentToolCallId.withValue(callId) {
+                                                try await ToolRegistry.shared.execute(
+                                                    name: inv.toolName,
+                                                    argumentsJSON: inv.jsonArguments,
+                                                    permissionGateResolved: true
+                                                )
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
### The bug

**Tools fired in the app while the tools toggle was visibly OFF.** Observed live: with Sandbox disabled, `Get current time · 170ms` **executed**, and a home-directory request ran `Searched capabilities · 514ms`.

### Root cause

Tool **exposure** and tool **execution** were never bound to each other.

The prompt decides which tools the model is *told* about. But nothing stopped it from **naming one it had never been shown**: the parser records any name once at least one schema is present (`ToolCallProcessor.swift:93`), chat dispatches it into the **process-wide** registry (`ChatView.swift`), and the registry ran it — because the registry's own comment said *"access control happens upstream"*. It had not.

So a **sandbox / plugin / MCP tool deliberately withheld from an agent would execute if the model simply guessed its name.**

### Why the obvious fix would have been worse than the bug

Freezing an immutable allowlist from the rendered schema **kills `capabilities_load`.**

`capabilities_load` and `sandbox_plugin_register` deliberately make tools callable **mid-run** while the rendered `<tools>` block stays **frozen** — rewriting it would bust the paged-KV prefix for the whole conversation. Those tools are legitimately callable *without ever appearing in the frozen schema*. An immutable allowlist would refuse the very tool the model was just handed.

So the scope is **mutable**: seeded from the final model-visible schema, and grown when a capability is activated.

### Two details that decide whether this works at all

- **The check runs AFTER `tool/`-prefix normalization.** Checking the raw name would let the model bypass the entire allowlist by prefixing a name it was never given (`tool/sandbox_exec` → `sandbox_exec`). Pinned by a test.
- **Activations live in the request scope, not `CapabilityLoadBuffer`.** That buffer is process-wide, so two concurrent requests could drain each other's activations and authorize a tool the *other* one loaded.

### Scope of enforcement

A `nil` scope means the surface published none and gates its own tools — the registry then behaves **exactly as before**. That is deliberate. Binding every entrypoint at once would risk breaking a surface I cannot gate live, and **a guard that breaks working features is not an improvement**. The chat/agent loop — where an unexposed tool was actually observed executing — publishes one. Remaining surfaces (HTTP `/agents/{id}/run`, plugin `complete`, evals, MCP) are enumerated and should follow, each with its own gate.

### Live proof (dev-built app, codex computer-use)

| | result |
|---|---|
| **Tools OFF** | all three tool requests **blocked** — no cards, nothing executed |
| **Tools ON** | `Get current time · 151ms` → *"The current time is Sunday, July 12, 2026, at 7:49 PM PDT."*; `Ran a command in sandbox · 282ms` → *"the output was: hello"* |
| **Capability load** | `Searched capabilities · 288ms` → `Searched the web for 'current weather in Tokyo' · 1.1s` → **the freshly-loaded tool executed** |

**Nothing was wrongly refused**; no *"is not available in this conversation"* appeared. No looping, leaked markup, gibberish or truncation.

7 tests, including that `capabilities_load` still grows the scope and that the `tool/` prefix cannot bypass the check.

### Unrelated anomaly noticed during the gate

A `wc -l` request produced **two** execution cards (`617ms`, `588ms`) for one request — a duplicate tool execution. Not caused by this change; filed separately.