### PR TITLE
fixed find bar crash when scrolling to a match in a partially rendered message

### DIFF
--- a/Packages/OsaurusCore/Tests/Views/SearchOccurrenceIndexTests.swift
+++ b/Packages/OsaurusCore/Tests/Views/SearchOccurrenceIndexTests.swift
@@ -65,7 +65,13 @@ struct SearchOccurrenceIndexTests {
             Issue.record("rectOfSearchOccurrence not found")
             return
         }
-        let body = String(src[start.lowerBound...].prefix(1600))
+        // Slice to the end of the function (the next member declaration) rather
+        // than a fixed-length prefix — comment growth inside the function must
+        // not silently shrink what this test inspects.
+        let tail = src[start.lowerBound...]
+        let body =
+            tail.range(of: "\n    var searchOccurrenceTotal").map { String(tail[..<$0.lowerBound]) }
+            ?? String(tail)
 
         // The shipped producer of the negative index: when `index - consumed`
         // fell inside a child's range but that child returned nil for the rect,

--- a/Packages/OsaurusCore/Tests/Views/SearchOccurrenceIndexTests.swift
+++ b/Packages/OsaurusCore/Tests/Views/SearchOccurrenceIndexTests.swift
@@ -56,4 +56,29 @@ struct SearchOccurrenceIndexTests {
             "surface the producer in debug rather than quietly returning nil forever"
         )
     }
+
+    @Test("The owning child's answer is final — no fall-through to later siblings")
+    func owningChildDoesNotFallThrough() throws {
+        let src = try Self.source("Views/Chat/NativeMarkdownView.swift")
+
+        guard let start = src.range(of: "func rectOfSearchOccurrence(") else {
+            Issue.record("rectOfSearchOccurrence not found")
+            return
+        }
+        let body = String(src[start.lowerBound...].prefix(1600))
+
+        // The shipped producer of the negative index: when `index - consumed`
+        // fell inside a child's range but that child returned nil for the rect,
+        // the loop continued and bumped `consumed` past `index`, so the next
+        // sibling received a negative index. Once a child owns the index, its
+        // result — rect or nil — must be returned, never skipped.
+        #expect(
+            !body.contains("if index - consumed < childCount,"),
+            "combining ownership and rect availability in one condition recreates the fall-through that produced the negative index (Sentry APPLE-MACOS-10V)"
+        )
+        #expect(
+            body.contains("if index - consumed < childCount {"),
+            "ownership must be decided before asking the child for a rect"
+        )
+    }
 }

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -301,9 +301,16 @@ final class NativeMarkdownView: NSView {
         for entry in segmentViews {
             guard let child = entry.view as? NativeMarkdownView else { continue }
             let childCount = child.searchOccurrenceTotal
-            if index - consumed < childCount,
-                let rect = child.rectOfSearchOccurrence(index - consumed)
-            {
+            if index - consumed < childCount {
+                // This child owns the occurrence: return its answer, even when
+                // that answer is nil (text view not in a window yet, zero-height
+                // rect). Falling through here handed later siblings an
+                // already-consumed index — negative after the next `consumed`
+                // bump — which passed their upper-bound-only check and trapped
+                // in Array.subscript (Sentry APPLE-MACOS-10V).
+                guard let rect = child.rectOfSearchOccurrence(index - consumed) else {
+                    return nil
+                }
                 return child.convert(rect, to: self)
             }
             consumed += childCount


### PR DESCRIPTION
## Summary

  fixes #1964 follow-up crash (Sentry APPLE-MACOS-10V, EXC_BREAKPOINT in Array._checkSubscript on 0.22.0)

  - searching a conversation could kill the app when the find bar scrolled to the current match
  - in rectOfSearchOccurrence, when the child owning the occurrence returned nil for its rect (text view not in a window yet, zero height rect) the loop fell through to later siblings
  - after the consumed count was bumped past the index, the next sibling received a negative index that passed the upper-bound-only check and trapped in Array.subscript
  - once a child owns the index its answer is now final, a nil rect degrades to the caller's scroll-to-turn fallback instead of continuing the loop
  - this identifies the producer of the negative index that PR #2015 guarded against but left unknown
  - adds a regression test pinning that ownership is decided before the rect lookup

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
