### PR TITLE
Repin vmlx-swift: tool-call delimiter leak + batch prose cut

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e6c32c5a24407607c15879fd0a9094340de69499"
+        "revision" : "8f731c2388daeab1c257303bf653a00218ee51dd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e6c32c5a24407607c15879fd0a9094340de69499"
+        "revision" : "8f731c2388daeab1c257303bf653a00218ee51dd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "e6c32c5a24407607c15879fd0a9094340de69499"
+            revision: "8f731c2388daeab1c257303bf653a00218ee51dd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "e6c32c5a24407607c15879fd0a9094340de69499""#))
-        #expect(packageResolved.contains(#""revision" : "e6c32c5a24407607c15879fd0a9094340de69499""#))
-        #expect(workspaceResolved.contains(#""revision" : "e6c32c5a24407607c15879fd0a9094340de69499""#))
-        #expect(appResolved.contains(#""revision" : "e6c32c5a24407607c15879fd0a9094340de69499""#))
+        #expect(packageSwift.contains(#"revision: "8f731c2388daeab1c257303bf653a00218ee51dd""#))
+        #expect(packageResolved.contains(#""revision" : "8f731c2388daeab1c257303bf653a00218ee51dd""#))
+        #expect(workspaceResolved.contains(#""revision" : "8f731c2388daeab1c257303bf653a00218ee51dd""#))
+        #expect(appResolved.contains(#""revision" : "8f731c2388daeab1c257303bf653a00218ee51dd""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -700,7 +700,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "e6c32c5a24407607c15879fd0a9094340de69499"
+        let expectedRuntimeHardenedRevision = "8f731c2388daeab1c257303bf653a00218ee51dd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e6c32c5a24407607c15879fd0a9094340de69499"
+        "revision" : "8f731c2388daeab1c257303bf653a00218ee51dd"
       }
     },
     {


### PR DESCRIPTION
Picks up [vmlx-swift#147](https://github.com/osaurus-ai/vmlx-swift/pull/147) (`8f731c23`).

## 1. Gemma's `<|"|>` delimiter was leaking into tool arguments

`<|"|>` is the string-quote delimiter of gemma's bare-call wire format
(`call:name{key:<|"|>value<|"|>}`) — structure, never data. The parser terminated raw scalars only
on `,` `]` `}`, so a stray delimiter got swallowed verbatim into the value.

Caught in the live harness, verbatim: Gemma-4-12B-MXFP8 delegating an image edit to Qwen-Image-Edit
sent a `source_path` with the delimiter still attached, and `ImageGenerationService` rejected a
**real, freshly generated image** as a non-existent file:

```
{"ok":false,"kind":"invalid_args","field":"source_paths",
 "message":"unsupported source image extension: \"output/elephant_image.png<|\"|>\"","tool":"image"}
```

The same function also returned nil on an unterminated string, which breaks the caller's key/value
loop — dropping that argument **and every argument after it** (reproduced with an empty argument map).

## 2. BatchEngine cut prose before a tool call

`StopStringMatcher` withholds up to `maxStopLen - 1` characters while it disambiguates a possible
stop. That text *precedes* the tool call in the model's output — but `ModelRuntime` stops forwarding
text once a `.toolCall` lands (deliberate post-tool no-leak suppression), so the tail was emitted
afterwards and silently dropped, cutting the answer mid-word.

`Evaluate.swift` already drained the matcher before the event. **BatchEngine never got that fix** —
and BatchEngine is the path we serve with. Any API client that sets `stop` while the model calls a
tool hit this.

## Repin hygiene

All **six** pin sites updated — `Package.swift`, the three `Package.resolved`, and both source
tripwires (`RuntimePolicySourceTests`, `ImageGenerationBridgeContractTests`).

Not just a SHA bump: `swift package resolve` ran, and I verified the **resolved checkout source**
actually contains both fixes (`.build/checkouts/vmlx-swift` at `8f731c23`, both hunks present).
Tripwires green locally, including "vmlx pin uses consolidated package with runtime hardening".