### PR TITLE
Agent request lifecycles independent of the chat window

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -58,11 +58,21 @@ public final class BackgroundTaskManager: ObservableObject {
     private var streamingObserved: Set<UUID> = []
 
     /// Background-task id keyed by the chat window currently bound to it.
-    /// Populated by `detachChatWindow` and by `openTaskWindow`; consulted
-    /// by `ChatWindowManager` in `windowWillClose` to decide whether to
-    /// skip `cleanup()` (which would otherwise call `session.stop()` and
-    /// kill the in-flight stream).
+    /// Populated by `detachChatWindow`, `openTaskWindow`, and
+    /// `bindWindow(_:toTask:)`; consulted by `ChatWindowManager` in
+    /// `windowWillClose` to decide whether to skip `cleanup()` (which would
+    /// otherwise call `session.stop()` and kill the in-flight stream).
+    /// Window attachment is pure view state — it never affects execution.
     private var taskIdByWindow: [UUID: UUID] = [:]
+
+    /// FIFO admission queue: task ids accepted while the configured
+    /// concurrency limits were saturated, in submission order. Each id has a
+    /// matching deferred start closure in `pendingStarts`. Promoted by
+    /// `pumpQueue()` whenever a running task stops consuming its slot.
+    private var queuedOrder: [UUID] = []
+
+    /// Deferred start work for queued tasks, keyed by task id.
+    private var pendingStarts: [UUID: @MainActor () async -> Void] = [:]
 
     /// Subject for batching view updates with throttling
     private let viewUpdateSubject = PassthroughSubject<Void, Never>()
@@ -87,13 +97,15 @@ public final class BackgroundTaskManager: ObservableObject {
     // MARK: - Toast Ordering
 
     /// Status ordering for the notch: awaiting input first, then running,
-    /// then terminal states. Lower sorts earlier.
+    /// then queued, then terminal states. Lower sorts earlier.
     private static func statusSortPriority(_ status: BackgroundTaskStatus) -> Int {
         switch status {
-        case .awaitingClarification: return 0
+        case .waitingForInput: return 0
         case .running: return 1
-        case .completed: return 2
-        case .cancelled: return 3
+        case .queued: return 2
+        case .completed: return 3
+        case .failed: return 3
+        case .cancelled: return 4
         }
     }
 
@@ -107,6 +119,11 @@ public final class BackgroundTaskManager: ObservableObject {
             // notch by setting `showToast = false`. The task is still tracked
             // for completion signaling — it just doesn't render.
             .filter { $0.showToast }
+            // A task attached to a live chat window surfaces its state in
+            // that window; the notch/toast only reports detached work so
+            // completion/failure never double-announces (or leaks into) the
+            // chat the user is currently looking at.
+            .filter { !isTaskAttachedToWindow($0.id) }
             .sorted { a, b in
                 let ap = Self.statusSortPriority(a.status), bp = Self.statusSortPriority(b.status)
                 if ap != bp { return ap < bp }
@@ -139,18 +156,87 @@ public final class BackgroundTaskManager: ObservableObject {
         return backgroundTasks[id] != nil
     }
 
-    /// Detach a streaming chat window's session into a background task so
-    /// the user can close the window without killing the in-flight stream.
-    /// The detached task surfaces in `NotchView` and can be re-opened via
-    /// `openTaskWindow(_:)`.
+    /// Whether any live chat window is currently bound to (viewing) this
+    /// task. Attached tasks surface their state in the window instead of
+    /// the notch/toast.
+    func isTaskAttachedToWindow(_ taskId: UUID) -> Bool {
+        taskIdByWindow.contains { windowId, boundTask in
+            boundTask == taskId && ChatWindowManager.shared.windowExists(id: windowId)
+        }
+    }
+
+    /// Bind a window to a task so closing/switching that window is treated
+    /// as detaching the view rather than stopping execution, and so the
+    /// notch/toast stops double-reporting a chat the user can already see.
+    public func bindWindow(_ windowId: UUID, toTask taskId: UUID) {
+        taskIdByWindow[windowId] = taskId
+        recomputeSortedToastTasks()
+        viewUpdateSubject.send()
+    }
+
+    /// Remove a window's task binding (window closed or switched to another
+    /// chat). The task itself is untouched; if it is still active it
+    /// resurfaces in the notch/toast.
+    public func unbindWindow(_ windowId: UUID) {
+        guard taskIdByWindow.removeValue(forKey: windowId) != nil else { return }
+        recomputeSortedToastTasks()
+        viewUpdateSubject.send()
+    }
+
+    /// The live (active) registry task currently driving the given persisted
+    /// session id, if any. Used by chat windows to re-attach the exact
+    /// in-memory `ChatSession` when the user reopens a running chat instead
+    /// of hydrating a stale copy from disk.
+    public func liveTask(forSessionId sessionId: UUID) -> BackgroundTaskState? {
+        backgroundTasks.values.first { state in
+            state.status.isActive && state.chatSession?.sessionId == sessionId
+        }
+    }
+
+    /// Sessions of all still-active registry tasks. Residency GC uses this
+    /// so a detached run's model counts as "still wanted" exactly like a
+    /// model selected in an open window.
+    func activeTaskSessions() -> [ChatSession] {
+        backgroundTasks.values.compactMap { state in
+            guard state.status.isActive else { return nil }
+            return state.chatSession
+        }
+    }
+
+    /// True when any registry-owned session is mid-stream on a local model.
+    /// Feeds the "one local generation at a time" admission check so a run
+    /// detached from its window still blocks a competing local send — the
+    /// shared inference context can only run one, and loading a second
+    /// would evict the first and cancel its stream. Sessions currently
+    /// attached to a window are excluded (the window-scan side of the check
+    /// already counts those).
+    func isAnyDetachedTaskStreamingLocalModel(excludingSession excluded: ChatSession? = nil) -> Bool {
+        backgroundTasks.values.contains { state in
+            guard let session = state.chatSession, session !== excluded else { return false }
+            guard !isTaskAttachedToWindow(state.id) else { return false }
+            return session.isStreamingLocalModel
+        }
+    }
+
+    /// Adopt a live in-flight `ChatSession` into the registry so its
+    /// execution lifecycle is owned here, independent of any window. Reuses
+    /// the existing instance verbatim (no new session, no disk hydration) so
+    /// all publishers keep firing uninterrupted.
     ///
-    /// No-op if the window doesn't exist, isn't streaming, or was already
-    /// detached.
-    public func detachChatWindow(windowId: UUID) {
-        guard taskIdByWindow[windowId] == nil,
-            let session = ChatWindowManager.shared.windowState(id: windowId)?.session,
-            session.isStreaming
-        else { return }
+    /// Returns the task id, or nil if the session isn't streaming. If the
+    /// session is already registry-owned, returns the existing task id.
+    @discardableResult
+    func adoptSession(_ session: ChatSession, windowId: UUID? = nil) -> UUID? {
+        // Already tracked? Just (re)bind the window.
+        if let existing = backgroundTasks.values.first(where: { $0.chatSession === session }) {
+            if let windowId { taskIdByWindow[windowId] = existing.id }
+            return existing.id
+        }
+        // Adoptable while executing OR paused on a clarify prompt — a run
+        // waiting for input is still alive and must survive the view going
+        // away. (The clarify observer installed below immediately replays
+        // the pause into `.waitingForInput`.)
+        guard session.isStreaming || session.awaitingClarify != nil else { return nil }
 
         // Persist before adopting so the sidebar and `openTaskWindow` reload
         // path both see a real saved row for this session.
@@ -172,8 +258,25 @@ public final class BackgroundTaskManager: ObservableObject {
         )
         registerTask(state)
         observeChatTask(state, session: session)
-        taskIdByWindow[windowId] = state.id
-        print("[BackgroundTaskManager] Detached chat window \(windowId) as task \(state.id)")
+        if let windowId { taskIdByWindow[windowId] = state.id }
+        recomputeSortedToastTasks()
+        return state.id
+    }
+
+    /// Detach a streaming chat window's session into a background task so
+    /// the user can close the window without killing the in-flight stream.
+    /// The detached task surfaces in `NotchView` and can be re-opened via
+    /// `openTaskWindow(_:)`.
+    ///
+    /// No-op if the window doesn't exist, isn't streaming, or was already
+    /// detached.
+    public func detachChatWindow(windowId: UUID) {
+        guard taskIdByWindow[windowId] == nil,
+            let session = ChatWindowManager.shared.windowState(id: windowId)?.session
+        else { return }
+        if let taskId = adoptSession(session, windowId: windowId) {
+            print("[BackgroundTaskManager] Detached chat window \(windowId) as task \(taskId)")
+        }
     }
 
     /// Open a window for a background task
@@ -183,8 +286,9 @@ public final class BackgroundTaskManager: ObservableObject {
         if let context = state.executionContext {
             let windowId = ChatWindowManager.shared.createWindowForContext(context, showImmediately: true)
             // Bind window→task so closing this window doesn't kill the
-            // still-running task — gated in `ChatWindowManager.windowWillClose`.
-            taskIdByWindow[windowId] = backgroundId
+            // still-running task — gated in `ChatWindowManager.windowWillClose` —
+            // and so the notch/toast stops reporting a chat that's now visible.
+            bindWindow(windowId, toTask: backgroundId)
         }
 
         if !state.status.isActive {
@@ -231,16 +335,26 @@ public final class BackgroundTaskManager: ObservableObject {
         // Drop any window→task bindings pointing here so a still-open
         // window's close path stops thinking the task is alive.
         taskIdByWindow = taskIdByWindow.filter { $0.value != backgroundId }
+        // Drop any deferred start so a finalized queued task can't launch.
+        queuedOrder.removeAll { $0 == backgroundId }
+        pendingStarts.removeValue(forKey: backgroundId)
 
         state.releaseReferences()
 
         backgroundTasks.removeValue(forKey: backgroundId)
         recomputeSortedToastTasks()
+        pumpQueue()
     }
 
     /// Cancel all active background tasks. Called during app termination.
+    /// Queued requests are cancelled FIRST: cancelling a running task frees
+    /// its slot and pumps the queue, so doing it the other way around would
+    /// briefly promote (and start) queued work mid-shutdown.
     public func cancelAllTasks() {
-        for id in backgroundTasks.keys {
+        for queuedId in queuedOrder {
+            cancelTask(queuedId)
+        }
+        for (id, state) in backgroundTasks where state.status.isActive {
             cancelTask(id)
         }
     }
@@ -270,9 +384,14 @@ public final class BackgroundTaskManager: ObservableObject {
         }
     }
 
-    /// Cancel a background task
+    /// Cancel a background task (queued or running)
     public func cancelTask(_ backgroundId: UUID) {
         guard let state = backgroundTasks[backgroundId] else { return }
+
+        // A queued task never started — drop its deferred start so a later
+        // pump can't resurrect it.
+        queuedOrder.removeAll { $0 == backgroundId }
+        pendingStarts.removeValue(forKey: backgroundId)
 
         state.chatSession?.stop()
         state.status = .cancelled
@@ -309,6 +428,8 @@ public final class BackgroundTaskManager: ObservableObject {
             json: PluginHostContext.serializeCancelledEvent(taskTitle: state.taskTitle)
         )
         scheduleAutoFinalize(backgroundId)
+        recomputeSortedToastTasks()
+        pumpQueue()
     }
 
     /// Soft-stop a running task by cancelling its current stream.
@@ -368,7 +489,7 @@ public final class BackgroundTaskManager: ObservableObject {
             return nil
         }
 
-        guard canDispatchNewTask(source: request.source, agentId: request.agentId) else { return nil }
+        guard isDispatchRequestValid(source: request.source, agentId: request.agentId) else { return nil }
 
         // KPI: an agent run accepted via background dispatch (HTTP dispatch
         // endpoint, plugin, or schedule).
@@ -411,15 +532,20 @@ public final class BackgroundTaskManager: ObservableObject {
             )
         }
 
-        // Register state before starting so awaitCompletion always finds the task
+        // Admission: capacity available → start immediately; saturated →
+        // register as `.queued` and defer the start until `pumpQueue()`
+        // promotes it (FIFO). Either way the request is registered before
+        // execution so `awaitCompletion` always finds the task.
+        let startsImmediately = hasExecutionCapacity(agentId: request.agentId)
+
         let state = BackgroundTaskState(
             id: context.id,
             taskTitle: context.title ?? "Chat",
             agentId: context.agentId,
             chatSession: context.chatSession,
             executionContext: context,
-            status: .running,
-            currentStep: "Running...",
+            status: startsImmediately ? .running : .queued,
+            currentStep: startsImmediately ? "Running..." : "Queued",
             source: request.source,
             sourcePluginId: request.sourcePluginId,
             externalSessionKey: request.externalSessionKey,
@@ -437,76 +563,92 @@ public final class BackgroundTaskManager: ObservableObject {
         registerTask(state)
         observeChatTask(state, session: context.chatSession)
 
-        // Agent DB run logging (spec §1.4 + §8). Only DB-enabled agents
-        // get an `agent_runs` row + a bound `currentRunId`; for the
-        // default agent and any user-created agent that hasn't opted
-        // in, this is a no-op so the existing dispatch surface keeps
-        // the same behavior and the same overhead.
-        let agentMgr = AgentManager.shared
-        let dbEnabled = agentMgr.effectiveDBEnabled(for: context.agentId)
         // Pre-seed the per-run budget caps from `Agent.settings.limits`
         // (spec §11.3). `tokensIn/Out` and `costUSD` start at 0 and are
         // updated mid-stream by `recordUsage(...)`; the dispatcher
         // cancels the task once either threshold is crossed.
-        if let agent = agentMgr.agent(for: context.agentId) {
+        if let agent = AgentManager.shared.agent(for: context.agentId) {
             state.runTokensLimit = agent.settings.limits.runTokensLimit
             state.runCostUSDLimit = agent.settings.limits.runCostUSDLimit
         }
-        var boundRunId: UUID? = nil
-        var boundActor: String = "user"
-        if dbEnabled {
-            let triggerKind = Self.triggerKind(for: request.source)
-            // `triggerPayload` is intentionally minimal: persisting the
-            // full prompt here would duplicate ChatHistoryDatabase data
-            // and inflate the scheduler DB. We surface the dispatch
-            // source + external key so the Activity tab can tag the
-            // row with what woke it.
-            let triggerPayload = Self.triggerPayload(for: request)
-            do {
-                try SchedulerDatabase.shared.open()
-                let runId = try SchedulerDatabase.shared.recordRunStart(
-                    agentId: context.agentId,
-                    triggerKind: triggerKind,
-                    triggerPayload: triggerPayload,
-                    instructions: request.prompt
-                )
-                boundRunId = runId
-                state.agentRunId = runId
-                boundActor = "agent"
-            } catch {
-                print(
-                    "[BackgroundTaskManager] recordRunStart failed for agent "
-                        + "\(context.agentId): \(error)"
-                )
-            }
-        }
 
-        // Bind the run-id + actor + background-task id for the entire
-        // chat task. `chatSession.send` creates an unstructured
-        // `Task { @MainActor in ... }` inside `ExecutionContext.start`
-        // — unstructured Tasks inherit task locals captured at the
-        // moment of creation, so any `db_*` tool call or streaming
-        // producer dispatched from the inference loop picks these up
-        // without needing per-call wiring. `currentBackgroundId` is
-        // the same `BackgroundTaskState.id` we just registered, so
-        // streaming layers can call `recordUsage(backgroundId:)` for
-        // mid-stream budget enforcement (spec §11.3).
-        //
-        // `isExternalSurface` is rebound here from request metadata so the
-        // externally-denied tool policy holds at the dispatcher layer even if
-        // an upstream task-local binding (e.g. the HTTP handler's wrapper)
-        // were lost across the dispatch pipeline. External-ness can only be
-        // widened, never narrowed: an inherited external context stays
-        // external for loopback/plugin/schedule requests too.
-        let externalSurface = Self.resolvedExternalSurface(for: request)
-        await ChatExecutionContext.$isExternalSurface.withValue(externalSurface) {
-            await ChatExecutionContext.$currentRunId.withValue(boundRunId) {
-                await ChatExecutionContext.$currentRunActor.withValue(boundActor) {
-                    await ChatExecutionContext.$currentBackgroundId.withValue(context.id) {
-                        await context.start(prompt: request.prompt)
+        // The actual execution start. Runs immediately when a slot is
+        // available, or later from `pumpQueue()` when queued. Everything
+        // that marks a run as "started" (the `agent_runs` row, the
+        // task-local bindings, `context.start`) lives here so a queued
+        // request has no execution side effects until promoted.
+        let startWork: @MainActor () async -> Void = { [weak state] in
+            guard let state else { return }
+
+            // Agent DB run logging (spec §1.4 + §8). Only DB-enabled agents
+            // get an `agent_runs` row + a bound `currentRunId`; for the
+            // default agent and any user-created agent that hasn't opted
+            // in, this is a no-op so the existing dispatch surface keeps
+            // the same behavior and the same overhead.
+            var boundRunId: UUID? = nil
+            var boundActor: String = "user"
+            if AgentManager.shared.effectiveDBEnabled(for: context.agentId) {
+                let triggerKind = Self.triggerKind(for: request.source)
+                // `triggerPayload` is intentionally minimal: persisting the
+                // full prompt here would duplicate ChatHistoryDatabase data
+                // and inflate the scheduler DB. We surface the dispatch
+                // source + external key so the Activity tab can tag the
+                // row with what woke it.
+                let triggerPayload = Self.triggerPayload(for: request)
+                do {
+                    try SchedulerDatabase.shared.open()
+                    let runId = try SchedulerDatabase.shared.recordRunStart(
+                        agentId: context.agentId,
+                        triggerKind: triggerKind,
+                        triggerPayload: triggerPayload,
+                        instructions: request.prompt
+                    )
+                    boundRunId = runId
+                    state.agentRunId = runId
+                    boundActor = "agent"
+                } catch {
+                    print(
+                        "[BackgroundTaskManager] recordRunStart failed for agent "
+                            + "\(context.agentId): \(error)"
+                    )
+                }
+            }
+            // Bind the run-id + actor + background-task id for the entire
+            // chat task. `chatSession.send` creates an unstructured
+            // `Task { @MainActor in ... }` inside `ExecutionContext.start`
+            // — unstructured Tasks inherit task locals captured at the
+            // moment of creation, so any `db_*` tool call or streaming
+            // producer dispatched from the inference loop picks these up
+            // without needing per-call wiring. `currentBackgroundId` is
+            // the same `BackgroundTaskState.id` we just registered, so
+            // streaming layers can call `recordUsage(backgroundId:)` for
+            // mid-stream budget enforcement (spec §11.3).
+            //
+            // `isExternalSurface` is rebound here from request metadata so the
+            // externally-denied tool policy holds at the dispatcher layer even if
+            // an upstream task-local binding (e.g. the HTTP handler's wrapper)
+            // were lost across the dispatch pipeline. External-ness can only be
+            // widened, never narrowed: an inherited external context stays
+            // external for loopback/plugin/schedule requests too.
+            let externalSurface = Self.resolvedExternalSurface(for: request)
+            await ChatExecutionContext.$isExternalSurface.withValue(externalSurface) {
+                await ChatExecutionContext.$currentRunId.withValue(boundRunId) {
+                    await ChatExecutionContext.$currentRunActor.withValue(boundActor) {
+                        await ChatExecutionContext.$currentBackgroundId.withValue(context.id) {
+                            await context.start(prompt: request.prompt)
+                        }
                     }
                 }
             }
+        }
+
+        if startsImmediately {
+            await startWork()
+        } else {
+            queuedOrder.append(context.id)
+            pendingStarts[context.id] = startWork
+            state.appendActivity(kind: .info, title: "Queued — waiting for a free slot")
+            print("[BackgroundTaskManager] Queued chat task \(context.id) (capacity saturated)")
         }
 
         let reattachNote = reattach == nil ? "" : " (reattached to session \(context.id))"
@@ -594,39 +736,68 @@ public final class BackgroundTaskManager: ObservableObject {
 
     private static let maxTasksPerAgent = 5
 
-    /// Check whether a new task can be dispatched without exceeding the global
-    /// limit or the per-agent limit. The global limit is user-configurable via
-    /// settings; the per-agent limit prevents a single agent from monopolizing
-    /// all slots in multi-agent scenarios.
-    private func canDispatchNewTask(source: SessionSource, agentId: UUID?) -> Bool {
+    /// Structural validity of a dispatch request. Capacity is NOT checked
+    /// here — a valid request that arrives while the limits are saturated is
+    /// accepted and queued rather than rejected.
+    private func isDispatchRequestValid(source: SessionSource, agentId: UUID?) -> Bool {
         // Plugin / sandbox callers must supply an agentId. Without one, the
-        // per-agent cap below would be silently skipped — letting a single
+        // per-agent cap would be silently skipped — letting a single
         // sandboxed plugin saturate every slot. The bridge always provides
         // an id post-fix, so a nil here is a programmer error.
         if source == .plugin, agentId == nil {
             print("[BackgroundTaskManager] Refusing plugin dispatch without agentId")
             return false
         }
+        return true
+    }
 
+    /// Whether an execution slot is free under both the user-configurable
+    /// global limit and the per-agent limit. Only slot-consuming statuses
+    /// count: queued tasks haven't started, and tasks waiting for input
+    /// released their slot.
+    private func hasExecutionCapacity(agentId: UUID?) -> Bool {
         let globalLimit = ToastManager.shared.configuration.maxConcurrentTasks
-        let activeTasks = backgroundTasks.values.filter { $0.status.isActive }
+        let slotted = backgroundTasks.values.filter { $0.status.consumesExecutionSlot }
 
-        guard activeTasks.count < globalLimit else {
-            print("[BackgroundTaskManager] Global task limit reached (\(globalLimit)), rejecting dispatch")
-            return false
-        }
+        guard slotted.count < globalLimit else { return false }
 
         if let agentId {
-            let agentCount = activeTasks.filter { $0.agentId == agentId }.count
-            guard agentCount < Self.maxTasksPerAgent else {
-                print(
-                    "[BackgroundTaskManager] Per-agent task limit reached (\(Self.maxTasksPerAgent)) for agent \(agentId), rejecting dispatch"
-                )
-                return false
-            }
+            let agentCount = slotted.filter { $0.agentId == agentId }.count
+            guard agentCount < Self.maxTasksPerAgent else { return false }
         }
 
         return true
+    }
+
+    /// Promote queued tasks into free execution slots, oldest first. A task
+    /// whose agent is still at its per-agent cap is skipped so it doesn't
+    /// head-of-line block work for other agents; it stays queued in place.
+    private func pumpQueue() {
+        while true {
+            // Drop stale entries (cancelled/finalized while queued).
+            queuedOrder.removeAll { backgroundTasks[$0]?.status != .queued }
+
+            guard
+                let nextId = queuedOrder.first(where: { id in
+                    guard let state = backgroundTasks[id] else { return false }
+                    return hasExecutionCapacity(agentId: state.agentId)
+                }),
+                let state = backgroundTasks[nextId],
+                let startWork = pendingStarts.removeValue(forKey: nextId)
+            else { return }
+
+            queuedOrder.removeAll { $0 == nextId }
+            // Claim the slot synchronously so a second pump in the same
+            // runloop tick can't over-admit past the limit.
+            state.status = .running
+            state.currentStep = "Running..."
+            state.appendActivity(kind: .info, title: "Started")
+            recomputeSortedToastTasks()
+            print("[BackgroundTaskManager] Promoted queued task \(nextId)")
+            Task { @MainActor in
+                await startWork()
+            }
+        }
     }
 
     /// Register a new task state and log an initial activity entry.
@@ -638,12 +809,50 @@ public final class BackgroundTaskManager: ObservableObject {
     }
 
     #if DEBUG
+        /// Test-only: a fully isolated manager instance. Scheduler tests —
+        /// especially ones exercising `cancelAllTasks` (app shutdown) —
+        /// must not run against `.shared`, where they would cancel tasks
+        /// registered by other concurrently-running suites.
+        static func makeForTesting() -> BackgroundTaskManager {
+            BackgroundTaskManager()
+        }
+
         /// Test-only: insert a pre-built `BackgroundTaskState` directly so
         /// regression tests can exercise `observeChatTask` without spinning up
         /// a real `ExecutionContext` + MLX-backed engine.
         func registerTaskForTesting(_ state: BackgroundTaskState) {
             backgroundTasks[state.id] = state
             recomputeSortedToastTasks()
+        }
+
+        /// Test-only: register a task through the same admission gate
+        /// `dispatchChat` uses — it starts immediately when capacity is
+        /// available, or lands in the FIFO queue with its start deferred
+        /// until `pumpQueue()` promotes it. Lets scheduler tests exercise
+        /// queueing, promotion order, and cancellation without a real
+        /// dispatch pipeline.
+        func admitTaskForTesting(
+            _ state: BackgroundTaskState,
+            start: @escaping @MainActor () async -> Void
+        ) {
+            if hasExecutionCapacity(agentId: state.agentId) {
+                state.status = .running
+                backgroundTasks[state.id] = state
+                recomputeSortedToastTasks()
+                Task { @MainActor in await start() }
+            } else {
+                state.status = .queued
+                state.currentStep = "Queued"
+                backgroundTasks[state.id] = state
+                queuedOrder.append(state.id)
+                pendingStarts[state.id] = start
+                recomputeSortedToastTasks()
+            }
+        }
+
+        /// Test-only: run a queue promotion pass.
+        func pumpQueueForTesting() {
+            pumpQueue()
         }
     #endif
 
@@ -677,6 +886,8 @@ public final class BackgroundTaskManager: ObservableObject {
         switch state.status {
         case .completed:
             return .completed(sessionId: state.executionContext?.chatSession.sessionId)
+        case .failed(let summary):
+            return .failed(summary)
         case .cancelled:
             return .cancelled
         default:
@@ -721,7 +932,7 @@ public final class BackgroundTaskManager: ObservableObject {
     /// Mark a task as completed and signal callers.
     /// The toast persists until the user views it or dismisses manually.
     private func markCompleted(_ state: BackgroundTaskState, success: Bool, summary: String) {
-        state.status = .completed(success: success, summary: summary)
+        state.status = success ? .completed(summary: summary) : .failed(summary: summary)
         state.currentStep = nil
         state.executionContext?.chatSession.save()
         // Close out the scheduler `agent_runs` row, if one was opened
@@ -767,6 +978,8 @@ public final class BackgroundTaskManager: ObservableObject {
             outputText: outputText
         )
         emitPluginEvent(state, type: eventType, json: json)
+        recomputeSortedToastTasks()
+        pumpQueue()
     }
 
     // MARK: - Private: Run-Trace Persistence
@@ -952,6 +1165,7 @@ public final class BackgroundTaskManager: ObservableObject {
             state.status = .running
             state.currentStep = "Running..."
         } else if state.status == .running, streamingObserved.contains(taskId) {
+            defer { pumpQueue() }
             // Belt-and-suspenders: if the streaming-end tick somehow
             // races ahead of the clarify sink, inspect the live session
             // before tripping the terminal branch. The `.running` guard
@@ -967,18 +1181,21 @@ public final class BackgroundTaskManager: ObservableObject {
 
     /// Bridge `ChatSession.awaitingClarify` into the per-task plugin event
     /// surface. Setting a payload transitions the task to
-    /// `.awaitingClarification` and emits `OSR_TASK_EVENT_CLARIFICATION`.
+    /// `.waitingForInput` and emits `OSR_TASK_EVENT_CLARIFICATION`.
     /// Clearing it is a no-op here — the next streaming tick is the
     /// single writer for the `.running` transition.
     private func handleChatClarifyChange(taskId: UUID, payload: ClarifyPayload?) {
         guard let state = backgroundTasks[taskId], let payload else { return }
-        state.status = .awaitingClarification
+        state.status = .waitingForInput
         state.currentStep = "Waiting for clarification"
         emitPluginEvent(
             state,
             type: .clarification,
             json: PluginHostContext.serializeClarificationEvent(payload: payload)
         )
+        // Waiting requests stay alive but release their execution slot so
+        // queued work isn't starved by a task idling on the user.
+        pumpQueue()
     }
 
     /// Scan newly added turns for tool calls and record them as activity.

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -118,6 +118,18 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         sessionData: ChatSessionData?,
         showImmediately: Bool
     ) -> UUID {
+        // Reopening a chat the registry is still running: attach the live
+        // in-memory session (same `ChatSession` instance, stream keeps
+        // rendering) instead of hydrating a stale copy from disk.
+        if let sessionId = sessionData?.id,
+            let liveTask = BackgroundTaskManager.shared.liveTask(forSessionId: sessionId),
+            let context = liveTask.executionContext
+        {
+            let windowId = createWindowForContext(context, showImmediately: showImmediately)
+            BackgroundTaskManager.shared.bindWindow(windowId, toTask: liveTask.id)
+            return windowId
+        }
+
         let windowId = UUID()
         let effectiveAgentId = agentId ?? AgentManager.shared.activeAgentId
 
@@ -212,35 +224,17 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         }
     }
 
-    /// Close a chat window by ID
+    /// Close a chat window by ID. Closing never stops execution: a mid-run
+    /// session is auto-detached into the `BackgroundTaskManager` registry by
+    /// `windowWillClose`, so there is no confirmation gate.
     public func closeWindow(id: UUID) {
         guard let window = nsWindows[id] else {
             print("[ChatWindowManager] No window found for ID \(id)")
             return
         }
 
-        // Check if we should allow the close (may show background task dialog)
-        guard shouldAllowClose(id: id) else {
-            return
-        }
-
         // Close will trigger the delegate which handles cleanup
         window.close()
-    }
-
-    /// Gate the close: if the session is mid-stream and not already
-    /// detached to a background task, surface the in-chat confirmation
-    /// overlay and tell AppKit to keep the window open. The user's pick
-    /// (Continue in Background / Stop and Close) re-enters via
-    /// `closeWindow(id:)`, which now passes this gate.
-    private func shouldAllowClose(id: UUID) -> Bool {
-        guard let state = windowStates[id] else { return true }
-        if BackgroundTaskManager.shared.isWindowDetachedToBackground(windowId: id) {
-            return true
-        }
-        guard state.session.isStreaming else { return true }
-        state.showCloseConfirmation = true
-        return false
     }
 
     /// Show/focus a window by ID
@@ -375,9 +369,15 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         windows.values.filter { $0.agentId == agentId }
     }
 
-    /// Find a window by session ID
+    /// Find a window by session ID. Consults the live per-window state
+    /// (sessions are replaceable — a window can switch chats after
+    /// creation), falling back to the creation-time info for windows whose
+    /// state hasn't been registered yet.
     public func findWindow(bySessionId sessionId: UUID) -> ChatWindowInfo? {
-        windows.values.first { $0.sessionId == sessionId }
+        if let (windowId, _) = windowStates.first(where: { $0.value.session.sessionId == sessionId }) {
+            return windows[windowId]
+        }
+        return windows.values.first { $0.sessionId == sessionId }
     }
 
     /// Check if any windows are visible
@@ -385,13 +385,16 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         nsWindows.values.contains { $0.isVisible }
     }
 
-    /// True when any open chat session is currently streaming a model
-    /// response. Read by `GenerativeGreetingPool` to defer background
-    /// refills while an interactive turn is in flight — both calls
-    /// share the same MLX context and unboxing them concurrently
-    /// degrades token-per-second on the user's active conversation.
+    /// True when any open chat session — or any active registry-owned
+    /// background run — is currently streaming a model response. Read by
+    /// `GenerativeGreetingPool` to defer background refills while a turn is
+    /// in flight — both calls share the same MLX context and unboxing them
+    /// concurrently degrades token-per-second on the user's active
+    /// conversation. Detached runs count too: their stream is just as
+    /// sensitive to contention as a windowed one.
     public var isAnySessionStreaming: Bool {
         windowStates.values.contains { $0.session.isStreaming }
+            || BackgroundTaskManager.shared.activeTaskSessions().contains { $0.isStreaming }
     }
 
     /// True while any chat window has a blocking in-chat prompt (secret or
@@ -404,20 +407,26 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     }
 
     /// True when a chat window OTHER than `excluding` is currently streaming a
-    /// local model. Enforces one local generation at a time across windows: the
-    /// shared inference context can only run one, and loading a second would
-    /// evict the first and cancel its in-flight stream.
+    /// local model, or a detached registry task is. Enforces one local
+    /// generation at a time across windows AND background runs: the shared
+    /// inference context can only run one, and loading a second would evict
+    /// the first and cancel its in-flight stream.
     func isOtherWindowStreamingLocalModel(excluding windowId: UUID?) -> Bool {
-        windowStates.contains { id, state in
+        let excludedSession = windowId.flatMap { windowStates[$0]?.session }
+        return windowStates.contains { id, state in
             id != windowId && state.session.isStreamingLocalModel
         }
+            || BackgroundTaskManager.shared.isAnyDetachedTaskStreamingLocalModel(
+                excludingSession: excludedSession
+            )
     }
 
-    /// True when ANY chat window is currently streaming a local model. Used to
-    /// defer local empty-state greeting generation while a user stream is in
-    /// flight.
+    /// True when ANY chat window or detached registry task is currently
+    /// streaming a local model. Used to defer local empty-state greeting
+    /// generation while a user stream is in flight.
     var isAnyWindowStreamingLocalModel: Bool {
         windowStates.values.contains { $0.session.isStreamingLocalModel }
+            || BackgroundTaskManager.shared.isAnyDetachedTaskStreamingLocalModel()
     }
 
     /// Get the count of active windows
@@ -454,16 +463,20 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     }
 
     /// Returns the set of local model names selected by currently-open chat
-    /// windows. Used as a "keep loaded for next interaction" hint for GC.
+    /// windows plus any active registry-owned (detached) background tasks.
+    /// Used as a "keep loaded for next interaction" hint for GC.
     ///
     /// Safety against unloading a model mid-stream is enforced by `ModelLease`
     /// inside `ModelRuntime.unloadModelsNotIn` — this set only needs to cover
-    /// the UX heuristic of "the user still has a window open with this model
-    /// selected, don't pay reload cost on their next keystroke".
+    /// the UX heuristic of "the user still has a window (or live background
+    /// run) with this model selected, don't pay reload cost on their next
+    /// keystroke".
     func activeLocalModelNames() -> Set<String> {
-        Set(
-            windowStates.values.compactMap { state in
-                guard let model = state.session.selectedModel,
+        let windowSessions = windowStates.values.map { $0.session }
+        let detachedSessions = BackgroundTaskManager.shared.activeTaskSessions()
+        return Set(
+            (windowSessions + detachedSessions).compactMap { session in
+                guard let model = session.selectedModel,
                     let found = ModelManager.findInstalledModel(named: model)
                 else { return nil }
                 return found.name
@@ -541,11 +554,9 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         windowId: UUID,
         windowState: ChatWindowState
     ) -> NSWindow {
-        // Create ChatView with the existing window state
-        let chatView = ChatView(windowState: windowState)
-            .environment(\.theme, windowState.theme)
-
-        let hostingController = NSHostingController(rootView: chatView)
+        let hostingController = NSHostingController(
+            rootView: ChatWindowRootView(windowState: windowState)
+        )
 
         let panel = createChatPanel(windowId: windowId, windowState: windowState)
         panel.contentViewController = hostingController
@@ -570,11 +581,9 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         )
         windowStates[windowId] = windowState
 
-        // Create ChatView with window state
-        let chatView = ChatView(windowState: windowState)
-            .environment(\.theme, windowState.theme)
-
-        let hostingController = NSHostingController(rootView: chatView)
+        let hostingController = NSHostingController(
+            rootView: ChatWindowRootView(windowState: windowState)
+        )
 
         let panel = createChatPanel(windowId: windowId, windowState: windowState)
         panel.contentViewController = hostingController
@@ -651,7 +660,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         // items and the traffic-light area.
         toolbar.centeredItemIdentifier = ChatToolbarDelegate.agentItem
 
-        let toolbarDelegate = ChatToolbarDelegate(windowState: windowState, session: windowState.session)
+        let toolbarDelegate = ChatToolbarDelegate(windowState: windowState)
         toolbar.delegate = toolbarDelegate
         panel.chatToolbarDelegate = toolbarDelegate
         panel.toolbar = toolbar
@@ -713,13 +722,21 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     }
 
     // Called by delegate to determine if window should close (for Cmd+W, etc.)
+    // Always true: closing a window only detaches the view — a mid-run
+    // session is handed to the BackgroundTaskManager registry below.
     fileprivate func windowShouldClose(id: UUID) -> Bool {
-        return shouldAllowClose(id: id)
+        return true
     }
 
     // Called by delegate when window will close
     fileprivate func windowWillClose(id: UUID) {
         print("[ChatWindowManager] Window \(id) will close")
+
+        // A window closing over a live run automatically detaches the
+        // session into the registry (execution continues; progress surfaces
+        // in the notch). No-op when idle or when the session is already
+        // registry-owned.
+        BackgroundTaskManager.shared.detachChatWindow(windowId: id)
 
         let isDetachedToBackground = BackgroundTaskManager.shared.isWindowDetachedToBackground(windowId: id)
 
@@ -730,10 +747,18 @@ public final class ChatWindowManager: NSObject, ObservableObject {
                 callback()
             }
             windowStates[id]?.cleanup()
+        } else if let state = windowStates[id] {
+            // The run survives the window: break only the view links so the
+            // detached session can't push alerts or sidebar refreshes into a
+            // dead window state. Execution is untouched.
+            if state.session.windowState === state {
+                state.session.windowState = nil
+            }
+            state.session.onSessionChanged = nil
         }
 
         // Clean up all local references. BackgroundTaskState independently retains
-        // the ChatWindowState it needs, so removing it here is always safe.
+        // the ChatSession/ExecutionContext it needs, so removing it here is always safe.
         sessionCallbacks.removeValue(forKey: id)
         windowDelegates.removeValue(forKey: id)
         windowStates.removeValue(forKey: id)
@@ -798,8 +823,32 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         // Post notification for VAD resume
         NotificationCenter.default.post(name: .chatViewClosed, object: id)
 
+        // Now that no view shows the task, drop the window→task binding so
+        // the still-running work (and its eventual completion/failure)
+        // surfaces in the notch/toast.
+        BackgroundTaskManager.shared.unbindWindow(id)
+
         let msg = isDetachedToBackground ? " (detached to background)" : ""
         print("[ChatWindowManager] Window \(id) cleanup complete\(msg), remaining: \(windows.count)")
+    }
+}
+
+// MARK: - Window Root View
+
+/// Hosting-root wrapper that rebuilds `ChatView` whenever the window's
+/// `session` is swapped out (chat switch while a run keeps executing in the
+/// registry, or re-attaching a live background session). `ChatView` binds
+/// `@ObservedObject` to the session captured at struct construction, so it
+/// must be reconstructed — and `.id` keyed on session identity resets its
+/// per-conversation `@State` (scroll position, editing, find matches) the
+/// same way a fresh window would.
+private struct ChatWindowRootView: View {
+    @ObservedObject var windowState: ChatWindowState
+
+    var body: some View {
+        ChatView(windowState: windowState)
+            .id(ObjectIdentifier(windowState.session))
+            .environment(\.theme, windowState.theme)
     }
 }
 
@@ -836,11 +885,9 @@ private final class ChatToolbarDelegate: NSObject, NSToolbarDelegate {
     ]
 
     private weak var windowState: ChatWindowState?
-    private weak var session: ChatSession?
 
-    init(windowState: ChatWindowState, session: ChatSession) {
+    init(windowState: ChatWindowState) {
         self.windowState = windowState
-        self.session = session
         super.init()
     }
 
@@ -857,7 +904,7 @@ private final class ChatToolbarDelegate: NSObject, NSToolbarDelegate {
         itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
-        guard let windowState, let session else { return nil }
+        guard let windowState else { return nil }
 
         switch itemIdentifier {
         case Self.sidebarItem:
@@ -871,14 +918,14 @@ private final class ChatToolbarDelegate: NSObject, NSToolbarDelegate {
             return makeHostingItem(
                 identifier: itemIdentifier,
                 rootView:
-                    ChatToolbarAgentView(windowState: windowState, session: session)
+                    ChatToolbarAgentView(windowState: windowState)
             )
 
         case Self.actionItem:
             return makeHostingItem(
                 identifier: itemIdentifier,
                 rootView:
-                    ChatToolbarActionView(windowState: windowState, session: session)
+                    ChatToolbarActionView(windowState: windowState)
             )
 
         case Self.pinItem:
@@ -931,7 +978,6 @@ private struct ChatToolbarSidebarView: View {
 /// Agent selector pill that lives in the toolbar's centered slot.
 private struct ChatToolbarAgentView: View {
     @ObservedObject var windowState: ChatWindowState
-    @ObservedObject var session: ChatSession
 
     /// Incremented by the `/agent` slash command notification to pop the
     /// agent picker open from the input card.
@@ -1011,8 +1057,20 @@ extension Notification.Name {
 }
 
 /// Contextual action button: new-chat plus once a conversation exists.
+/// Split into an outer view (observing `windowState`, which republishes when
+/// the window's session is replaced) and an inner content view holding the
+/// `@ObservedObject` session, so the button tracks the CURRENT session's
+/// turns after a chat switch instead of a stale instance.
 private struct ChatToolbarActionView: View {
     @ObservedObject var windowState: ChatWindowState
+
+    var body: some View {
+        ChatToolbarActionContent(windowState: windowState, session: windowState.session)
+    }
+}
+
+private struct ChatToolbarActionContent: View {
+    let windowState: ChatWindowState
     @ObservedObject var session: ChatSession
 
     var body: some View {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -45,18 +45,17 @@ final class ChatWindowState: ObservableObject {
     // MARK: - Identity & Session
 
     let windowId: UUID
-    let session: ChatSession
+    /// The session this window currently displays. Replaceable: switching
+    /// chats while a run is in flight detaches the running session into the
+    /// `BackgroundTaskManager` registry (execution continues) and installs a
+    /// different `ChatSession` here. `@Published` so the window root view can
+    /// rebuild `ChatView` around the new instance.
+    @Published private(set) var session: ChatSession
     let foundationModelAvailable: Bool
 
     // MARK: - View State
 
     @Published var showSidebar: Bool = false
-
-    /// Drives the in-chat "Keep this chat running?" confirmation overlay
-    /// that intercepts a close while `session.isStreaming` is true. Set
-    /// from `ChatWindowManager.shouldAllowClose`; cleared by the alert's
-    /// button actions in `ChatView`.
-    @Published var showCloseConfirmation: Bool = false
 
     /// Drives the "a local model is already running in another window" alert
     /// raised when the user tries to start a second local generation. Only one
@@ -193,6 +192,9 @@ final class ChatWindowState: ObservableObject {
         self.cachedAgentDisplayName = Self.displayName(for: cachedActiveAgent)
         decodeBackgroundImageAsync(themeConfig: theme.customThemeConfig)
 
+        // Re-link the adopted session to this window so busy alerts and
+        // Mode 2 routing reach the view that now displays it.
+        self.session.windowState = self
         self.session.onSessionChanged = { [weak self] in
             self?.refreshSessionsDebounced()
         }
@@ -223,21 +225,6 @@ final class ChatWindowState: ObservableObject {
         session.onSessionChanged = nil
     }
 
-    // MARK: - Close-Confirmation Actions
-
-    /// "Continue in Background" — adopt the live session as a background
-    /// task (visible in the notch) and dismiss the window.
-    func confirmCloseInBackground() {
-        BackgroundTaskManager.shared.detachChatWindow(windowId: windowId)
-        ChatWindowManager.shared.closeWindow(id: windowId)
-    }
-
-    /// "Stop and Close" — cancel the in-flight stream, then dismiss.
-    func confirmCloseAndStop() {
-        session.stop()
-        ChatWindowManager.shared.closeWindow(id: windowId)
-    }
-
     // MARK: - API
 
     var activeAgent: Agent { cachedActiveAgent }
@@ -250,7 +237,11 @@ final class ChatWindowState: ObservableObject {
         TTSService.shared.stop()
         if !session.turns.isEmpty { session.save() }
         adoptAgent(newAgentId)
-        session.reset(for: newAgentId)
+        if detachRunningSessionIfNeeded() {
+            installFreshSession(agentId: newAgentId)
+        } else {
+            session.reset(for: newAgentId)
+        }
         refreshSessions()
     }
 
@@ -258,7 +249,11 @@ final class ChatWindowState: ObservableObject {
         TTSService.shared.stop()
         if !session.turns.isEmpty { session.save() }
         flushCurrentSession()
-        session.reset(for: agentId)
+        if detachRunningSessionIfNeeded() {
+            installFreshSession(agentId: agentId)
+        } else {
+            session.reset(for: agentId)
+        }
         refreshSessions()
         // KPI: user started a new chat conversation. Count only.
         FeatureTelemetry.chatSessionStarted()
@@ -282,8 +277,74 @@ final class ChatWindowState: ObservableObject {
             adoptAgent(targetAgentId)
         }
 
-        session.load(from: resolvedData)
+        // Reopening a chat the registry is still running: attach the live
+        // in-memory session instead of hydrating a stale copy from disk —
+        // the stream keeps rendering into the reopened view, and disk state
+        // lags behind the in-flight turns.
+        if let liveTask = BackgroundTaskManager.shared.liveTask(forSessionId: sessionData.id),
+            let liveSession = liveTask.chatSession
+        {
+            detachRunningSessionIfNeeded()
+            attachSession(liveSession, registryTaskId: liveTask.id)
+        } else if detachRunningSessionIfNeeded() {
+            // The chat we're leaving keeps running in the background; the
+            // target loads into a brand-new session so the two never share
+            // transcript state.
+            installFreshSession(agentId: targetAgentId, loading: resolvedData)
+        } else {
+            session.load(from: resolvedData)
+        }
         refreshSessions()
+    }
+
+    // MARK: - Detach / Attach
+
+    /// Hand a mid-run session over to the `BackgroundTaskManager` registry so
+    /// its execution lifecycle survives this window moving to another chat
+    /// (or closing). Returns true when a handoff happened — the caller must
+    /// then install a replacement session rather than reuse (and thereby
+    /// stop) the detached one.
+    @discardableResult
+    private func detachRunningSessionIfNeeded() -> Bool {
+        guard session.isStreaming || session.awaitingClarify != nil else { return false }
+        guard BackgroundTaskManager.shared.adoptSession(session) != nil else { return false }
+        // The detached run no longer belongs to this window: break the weak
+        // window link so it can't push alerts into a view showing a
+        // different conversation, and stop routing its saves into this
+        // window's sidebar refresh.
+        session.windowState = nil
+        session.onSessionChanged = nil
+        BackgroundTaskManager.shared.unbindWindow(windowId)
+        return true
+    }
+
+    /// Install a brand-new `ChatSession` for this window (optionally loading
+    /// persisted turns), used after the previous one was detached to the
+    /// registry.
+    private func installFreshSession(agentId: UUID, loading data: ChatSessionData? = nil) {
+        let fresh = ChatSession()
+        fresh.windowState = self
+        fresh.agentId = agentId
+        fresh.applyInitialModelSelection()
+        if let data { fresh.load(from: data) }
+        fresh.onSessionChanged = { [weak self] in
+            self?.refreshSessionsDebounced()
+        }
+        session = fresh
+    }
+
+    /// Attach an existing (registry-owned) live session to this window so
+    /// the user sees the in-flight stream. Execution ownership stays with
+    /// the registry; the window is only a view. The window→task binding
+    /// makes close/switch detach instead of stop, and suppresses the
+    /// duplicate notch/toast surface while the chat is visible.
+    private func attachSession(_ liveSession: ChatSession, registryTaskId: UUID) {
+        liveSession.windowState = self
+        liveSession.onSessionChanged = { [weak self] in
+            self?.refreshSessionsDebounced()
+        }
+        session = liveSession
+        BackgroundTaskManager.shared.bindWindow(windowId, toTask: registryTaskId)
     }
 
     /// Switch every per-agent piece of window state (`agentId`,

--- a/Packages/OsaurusCore/Models/BackgroundTaskModels.swift
+++ b/Packages/OsaurusCore/Models/BackgroundTaskModels.swift
@@ -11,36 +11,64 @@ import Foundation
 
 // MARK: - Background Task Status
 
-/// Status of a background task
+/// Lifecycle status of an agent request. Every request moves through an
+/// explicit state machine that is independent of whether any chat window is
+/// currently displaying it:
+///
+///     queued → running → waitingForInput → running → completed / failed
+///     queued / running → cancelled
+///
+/// Only explicit Stop/cancel, app shutdown, budget exhaustion, or terminal
+/// execution ends a request — never a UI context switch.
 public enum BackgroundTaskStatus: Equatable, Sendable {
+    /// Accepted but not yet started: waiting for an execution slot under the
+    /// configured concurrency limits. Promoted FIFO as capacity frees up.
+    case queued
     /// Task is actively executing
     case running
-    /// Task is paused waiting for user clarification
-    case awaitingClarification
-    /// Task has completed (success or failure)
-    case completed(success: Bool, summary: String)
+    /// Task is paused waiting for user input (e.g. a clarify prompt). Alive,
+    /// but not consuming an execution slot.
+    case waitingForInput
+    /// Task finished successfully
+    case completed(summary: String)
+    /// Task finished with an error
+    case failed(summary: String)
     /// Task was cancelled
     case cancelled
 
-    /// Whether the task is still active (running or awaiting input)
+    /// Whether the task is still alive (queued, running, or awaiting input)
     public var isActive: Bool {
         switch self {
-        case .running, .awaitingClarification:
+        case .queued, .running, .waitingForInput:
             return true
-        case .completed, .cancelled:
+        case .completed, .failed, .cancelled:
             return false
         }
     }
 
+    /// Whether the task currently occupies one of the limited execution
+    /// slots. Queued tasks haven't started; waiting tasks released their
+    /// slot so queued work can be promoted while they idle on the user.
+    public var consumesExecutionSlot: Bool {
+        self == .running
+    }
+
+    /// Whether the task ended in a terminal state (success, failure, or cancel)
+    public var isTerminal: Bool { !isActive }
+
     /// Display name for UI
     public var displayName: String {
         switch self {
+        case .queued:
+            return L("Queued")
         case .running:
             return L("Running")
-        case .awaitingClarification:
+        case .waitingForInput:
             return L("Waiting")
-        case .completed(let success, _):
-            return success ? L("Completed") : L("Failed")
+        case .completed:
+            return L("Completed")
+        case .failed:
+            return L("Failed")
         case .cancelled:
             return L("Cancelled")
         }
@@ -49,12 +77,16 @@ public enum BackgroundTaskStatus: Equatable, Sendable {
     /// Icon name for UI
     public var iconName: String {
         switch self {
+        case .queued:
+            return "clock"
         case .running:
             return "arrow.triangle.2.circlepath"
-        case .awaitingClarification:
+        case .waitingForInput:
             return "questionmark.circle.fill"
-        case .completed(let success, _):
-            return success ? "checkmark.circle.fill" : "xmark.circle.fill"
+        case .completed:
+            return "checkmark.circle.fill"
+        case .failed:
+            return "xmark.circle.fill"
         case .cancelled:
             return "stop.circle.fill"
         }

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -3061,9 +3061,13 @@ extension PluginHostContext {
         }
 
         switch state.status {
-        case .running, .awaitingClarification:
+        case .queued:
+            result["status"] = "queued"
+            if let step = state.currentStep { result["current_step"] = step }
+
+        case .running, .waitingForInput:
             // v3: chat tasks always serialize as "running". The
-            // `.awaitingClarification` enum case is still used internally
+            // `.waitingForInput` enum case is still used internally
             // for UI hints (toast, notch) but never exposed via task_status,
             // because clarification is handled inline through the `clarify`
             // agent intercept rather than as an out-of-band state.
@@ -3081,9 +3085,17 @@ extension PluginHostContext {
             }
             if !activity.isEmpty { result["activity"] = activity }
 
-        case .completed(let success, let summary):
-            result["status"] = success ? "completed" : "failed"
-            result["success"] = success
+        case .completed(let summary):
+            result["status"] = "completed"
+            result["success"] = true
+            result["summary"] = summary
+            if let execCtx = state.executionContext {
+                result["session_id"] = execCtx.id.uuidString
+            }
+
+        case .failed(let summary):
+            result["status"] = "failed"
+            result["success"] = false
             result["summary"] = summary
             if let execCtx = state.executionContext {
                 result["session_id"] = execCtx.id.uuidString

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionDetachTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionDetachTests.swift
@@ -1,0 +1,275 @@
+//
+//  ChatWindowSessionDetachTests.swift
+//  osaurusTests
+//
+//  Pins the "UI context switch only detaches the view" contract on
+//  `ChatWindowState` + `BackgroundTaskManager`:
+//
+//  - Starting a new chat / loading another session / switching agent while
+//    a run is streaming hands the running `ChatSession` to the registry
+//    (execution continues) and installs a replacement session — it never
+//    stops the run.
+//  - The detached run's output lands only in its own session; the window's
+//    new session never sees it.
+//  - Reopening a chat the registry is still running re-attaches the SAME
+//    in-memory `ChatSession` instance (subsequent deltas keep landing in
+//    it) instead of hydrating a stale copy from disk.
+//  - Tearing down one window state never stops another window's stream.
+//
+//  Uses `ChatHistoryTestStorage` for isolated persistence; engines are
+//  scripted test doubles, so no real model is loaded.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Engine double
+
+/// Blocks long enough for the test to switch UI context mid-stream, then
+/// yields one delta and finishes cleanly.
+private actor SlowFinishingChatEngine: ChatEngineProtocol {
+    let delayMs: Int
+
+    init(delayMs: Int) {
+        self.delayMs = delayMs
+    }
+
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        let delay = delayMs
+        return AsyncThrowingStream { continuation in
+            Task {
+                try? await Task.sleep(for: .milliseconds(delay))
+                continuation.yield("background answer")
+                continuation.finish()
+            }
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatWindowSessionDetachTests", code: 1)
+    }
+}
+
+// MARK: - Local waitUntil
+
+private func waitUntil(
+    timeout: Duration = .seconds(5),
+    _ predicate: @MainActor @escaping () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await predicate() { return }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    throw NSError(domain: "ChatWindowSessionDetachTests", code: 2)
+}
+
+// MARK: - Tests
+
+@Suite(.serialized)
+@MainActor
+struct ChatWindowSessionDetachTests {
+
+    private var mgr: BackgroundTaskManager { BackgroundTaskManager.shared }
+
+    /// Finalize the registry task (if any) that owns the given session so
+    /// no state leaks into other suites on the shared manager.
+    private func finalizeTask(ownedBy session: ChatSession) {
+        if let sessionId = session.sessionId,
+            let task = mgr.liveTask(forSessionId: sessionId)
+        {
+            mgr.finalizeTask(task.id)
+        }
+    }
+
+    /// Start a stream on the window's current session and wait for it to
+    /// be genuinely in flight.
+    private func startStream(
+        in window: ChatWindowState,
+        prompt: String,
+        delayMs: Int = 500
+    ) async throws -> ChatSession {
+        let session = window.session
+        session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: delayMs) }
+        session.send(prompt)
+        try await waitUntil(timeout: .seconds(2)) { session.isStreaming }
+        return session
+    }
+
+    // MARK: New chat while streaming
+
+    @Test func startNewChat_whileStreaming_detachesRunAndKeepsItStreaming() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let running = try await startStream(in: window, prompt: "long question")
+
+            window.startNewChat()
+
+            // The view detached: the window shows a fresh session while the
+            // run keeps executing, now owned by the registry.
+            #expect(window.session !== running, "window must install a replacement session")
+            #expect(running.isStreaming, "UI context switch must not stop the run")
+            let sessionId = try #require(running.sessionId)
+            let task = try #require(mgr.liveTask(forSessionId: sessionId))
+            #expect(task.status == .running)
+            #expect(task.chatSession === running)
+            // The detached run no longer pushes view state into this window.
+            #expect(running.windowState == nil)
+
+            // The run finishes in the background: its output lands ONLY in
+            // its own session; the window's new chat never sees it.
+            try await waitUntil { !running.isStreaming }
+            #expect(running.turns.contains { $0.role == .assistant && $0.content.contains("background answer") })
+            #expect(window.session.turns.isEmpty, "background output must not leak into the new chat")
+            try await waitUntil { task.status == .completed(summary: "Chat completed") }
+
+            mgr.finalizeTask(task.id)
+            window.cleanup()
+        }
+    }
+
+    @Test func startNewChat_whileIdle_reusesSessionWithoutRegistryTask() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let idle = window.session
+
+            window.startNewChat()
+
+            // No run in flight → plain reset, no detach, no registry entry.
+            #expect(window.session === idle)
+            window.cleanup()
+        }
+    }
+
+    // MARK: Loading another chat while streaming
+
+    @Test func loadSession_whileStreaming_keepsOldRunningAndIsolatesTranscripts() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let running = try await startStream(in: window, prompt: "keep going")
+
+            // The user clicks a different conversation in the sidebar.
+            let targetId = UUID()
+            let target = ChatSessionData(
+                id: targetId,
+                title: "Other conversation",
+                createdAt: Date(),
+                updatedAt: Date(),
+                selectedModel: nil,
+                turns: [
+                    ChatTurnData(role: .user, content: "old question"),
+                    ChatTurnData(role: .assistant, content: "old answer"),
+                ],
+                agentId: Agent.defaultId
+            )
+            window.loadSession(target)
+
+            // The target loaded into a brand-new session; the old run is
+            // registry-owned and still streaming.
+            #expect(window.session !== running)
+            #expect(window.session.sessionId == targetId)
+            #expect(window.session.turns.map(\.content) == ["old question", "old answer"])
+            #expect(running.isStreaming)
+            let runningId = try #require(running.sessionId)
+            #expect(mgr.liveTask(forSessionId: runningId) != nil)
+
+            // Background completion stays out of the loaded conversation.
+            try await waitUntil { !running.isStreaming }
+            #expect(window.session.turns.count == 2)
+            #expect(running.turns.contains { $0.role == .assistant && $0.content.contains("background answer") })
+
+            finalizeTask(ownedBy: running)
+            window.cleanup()
+        }
+    }
+
+    // MARK: Reopening a running chat
+
+    @Test func loadSession_ofLiveRun_reattachesSameSessionInstance() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let running = try await startStream(in: window, prompt: "still working", delayMs: 800)
+
+            // Detach: the window moves to a new chat while the run continues.
+            window.startNewChat()
+            let runningId = try #require(running.sessionId)
+            let task = try #require(mgr.liveTask(forSessionId: runningId))
+            #expect(running.isStreaming)
+
+            // Reopen the running chat from the sidebar: the EXACT live
+            // instance is re-attached — not a stale disk copy — and the
+            // window is bound to the task (view attachment, not ownership).
+            let reopenData = ChatSessionData(
+                id: runningId,
+                title: running.title,
+                createdAt: Date(),
+                updatedAt: Date(),
+                selectedModel: nil,
+                turns: [],
+                agentId: Agent.defaultId
+            )
+            window.loadSession(reopenData)
+
+            #expect(window.session === running, "reopening a live chat must attach the in-memory session")
+            #expect(mgr.taskId(forWindowId: window.windowId) == task.id)
+            #expect(running.windowState === window)
+
+            // Subsequent deltas keep landing in the re-attached session.
+            try await waitUntil { !running.isStreaming }
+            #expect(window.session.turns.contains { $0.role == .assistant && $0.content.contains("background answer") })
+
+            mgr.finalizeTask(task.id)
+            window.cleanup()
+        }
+    }
+
+    // MARK: Agent switch while streaming
+
+    @Test func switchAgent_whileStreaming_detachesInsteadOfResetting() async throws {
+        try await ChatHistoryTestStorage.run {
+            let custom = Agent(
+                name: "DetachSwitch-\(UUID().uuidString.prefix(6))",
+                systemPrompt: "test",
+                agentAddress: "test-detach-\(UUID().uuidString)"
+            )
+            AgentManager.shared.add(custom)
+
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let running = try await startStream(in: window, prompt: "hold on")
+
+            window.switchAgent(to: custom.id)
+
+            #expect(window.session !== running)
+            #expect(window.session.agentId == custom.id)
+            #expect(running.isStreaming, "switching agents must not stop the previous run")
+            let runningId = try #require(running.sessionId)
+            #expect(mgr.liveTask(forSessionId: runningId) != nil)
+
+            try await waitUntil { !running.isStreaming }
+            finalizeTask(ownedBy: running)
+            window.cleanup()
+            _ = await AgentManager.shared.delete(id: custom.id)
+        }
+    }
+
+    // MARK: Two windows
+
+    @Test func tearingDownOneWindow_doesNotStopAnotherWindowsStream() async throws {
+        try await ChatHistoryTestStorage.run {
+            let windowA = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let windowB = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let streamB = try await startStream(in: windowB, prompt: "window B work")
+
+            // Window A closes (idle) — full cleanup path.
+            windowA.cleanup()
+
+            #expect(streamB.isStreaming, "closing window A must not stop window B's run")
+            try await waitUntil { !streamB.isStreaming }
+            #expect(streamB.turns.contains { $0.role == .assistant && $0.content.contains("background answer") })
+
+            windowB.cleanup()
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Plugin/AgentRequestLifecycleTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/AgentRequestLifecycleTests.swift
@@ -1,0 +1,443 @@
+//
+//  AgentRequestLifecycleTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the independent agent-request lifecycle contract on
+//  `BackgroundTaskManager`:
+//
+//  - Admission over capacity QUEUES (FIFO) instead of rejecting; the
+//    deferred start has no execution side effects until promoted.
+//  - Freeing a slot (finalize, completion, cancel) promotes the oldest
+//    eligible queued request; an agent at its per-agent cap is skipped
+//    without head-of-line blocking other agents' work.
+//  - `.waitingForInput` releases the execution slot (queued work is not
+//    starved by a run idling on the user) and resumes to `.running`
+//    without re-queueing.
+//  - Cancelling a queued request drops its deferred start permanently.
+//  - `cancelAllTasks` (app shutdown) cancels running AND queued work.
+//  - Toast surfacing: waiting sorts before running before queued, and a
+//    stale window binding (window gone) never hides a task.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Helpers
+
+/// Records whether a queued task's deferred start closure ever ran.
+@MainActor
+private final class StartProbe {
+    private(set) var started = false
+    func makeStart() -> @MainActor () async -> Void {
+        { self.started = true }
+    }
+}
+
+@MainActor
+private func makeTaskState(
+    agentId: UUID,
+    title: String,
+    status: BackgroundTaskStatus = .running
+) -> BackgroundTaskState {
+    let context = ExecutionContext(agentId: agentId)
+    context.chatSession.chatEngineFactory = { _ in MockChatEngine() }
+    return BackgroundTaskState(
+        id: UUID(),
+        taskTitle: title,
+        agentId: agentId,
+        chatSession: context.chatSession,
+        executionContext: context,
+        status: status,
+        currentStep: status == .running ? "Running..." : nil
+    )
+}
+
+private func waitUntil(
+    timeout: Duration = .seconds(3),
+    _ predicate: @MainActor @escaping () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await predicate() { return }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    throw NSError(domain: "AgentRequestLifecycleTests", code: 1)
+}
+
+// MARK: - Queue scheduling
+
+@Suite(.serialized)
+@MainActor
+struct AgentRequestQueueSchedulingTests {
+
+    /// Isolated manager instance: these tests saturate capacity, zero the
+    /// global limit, and run `cancelAllTasks` — against `.shared` that
+    /// would cancel/stall tasks registered by concurrently-running suites
+    /// (e.g. `ChatWindowSessionDetachTests`' adopted sessions).
+    private let mgr = BackgroundTaskManager.makeForTesting()
+
+    /// Fill the per-agent cap (5) with directly-registered running tasks
+    /// for a unique agent id, isolating capacity math from anything other
+    /// suites may have in flight on the shared manager.
+    private func fillAgentCap(_ agentId: UUID) -> [BackgroundTaskState] {
+        (0..<5).map { i in
+            let state = makeTaskState(agentId: agentId, title: "filler-\(i)")
+            mgr.registerTaskForTesting(state)
+            return state
+        }
+    }
+
+    @Test func saturatedAgent_admissionQueuesInsteadOfRejecting() async throws {
+        let agent = UUID()
+        let fillers = fillAgentCap(agent)
+        defer { fillers.forEach { mgr.finalizeTask($0.id) } }
+
+        let probe = StartProbe()
+        let queued = makeTaskState(agentId: agent, title: "queued-6")
+        mgr.admitTaskForTesting(queued, start: probe.makeStart())
+        defer { mgr.finalizeTask(queued.id) }
+
+        #expect(queued.status == .queued)
+        #expect(mgr.taskState(for: queued.id) != nil, "queued request must be registered, not dropped")
+        #expect(probe.started == false, "queued request must have no execution side effects")
+        // Queued requests surface globally like any other lifecycle state.
+        #expect(mgr.sortedToastTasks.contains { $0.id == queued.id })
+    }
+
+    @Test func slotFree_promotesQueuedInFIFOOrder() async throws {
+        let agent = UUID()
+        let fillers = fillAgentCap(agent)
+
+        let probe6 = StartProbe()
+        let probe7 = StartProbe()
+        let queued6 = makeTaskState(agentId: agent, title: "queued-6")
+        let queued7 = makeTaskState(agentId: agent, title: "queued-7")
+        mgr.admitTaskForTesting(queued6, start: probe6.makeStart())
+        mgr.admitTaskForTesting(queued7, start: probe7.makeStart())
+        defer {
+            fillers.forEach { mgr.finalizeTask($0.id) }
+            mgr.finalizeTask(queued6.id)
+            mgr.finalizeTask(queued7.id)
+        }
+        #expect(queued6.status == .queued)
+        #expect(queued7.status == .queued)
+
+        // First slot frees: the OLDER queued task is promoted, not the newer.
+        mgr.finalizeTask(fillers[0].id)
+        #expect(queued6.status == .running)
+        #expect(queued7.status == .queued)
+        try await waitUntil { probe6.started }
+        #expect(probe7.started == false)
+
+        // Second slot frees: the remaining queued task follows.
+        mgr.finalizeTask(fillers[1].id)
+        #expect(queued7.status == .running)
+        try await waitUntil { probe7.started }
+    }
+
+    @Test func waitingForInput_releasesSlotAndResumesWithoutRequeue() async throws {
+        let agent = UUID()
+        var fillers = (0..<4).map { i in
+            let state = makeTaskState(agentId: agent, title: "filler-\(i)")
+            mgr.registerTaskForTesting(state)
+            return state
+        }
+        // Fifth slot: a task with a live observed session that will pause
+        // on a clarify prompt.
+        let pausing = makeTaskState(agentId: agent, title: "pausing")
+        mgr.registerTaskForTesting(pausing)
+        mgr.observeChatTask(pausing, session: pausing.chatSession!)
+        fillers.append(pausing)
+
+        let probe = StartProbe()
+        let queued = makeTaskState(agentId: agent, title: "queued")
+        mgr.admitTaskForTesting(queued, start: probe.makeStart())
+        defer {
+            fillers.forEach { mgr.finalizeTask($0.id) }
+            mgr.finalizeTask(queued.id)
+        }
+        #expect(queued.status == .queued)
+
+        // The run pauses for user input: it stays alive but releases its
+        // slot, so the queued request is promoted instead of starving.
+        pausing.chatSession?.isStreaming = true
+        try await Task.sleep(for: .milliseconds(10))
+        pausing.chatSession?.awaitingClarify =
+            ClarifyPayload(question: "Which db?", options: [], allowMultiple: false)
+        try await Task.sleep(for: .milliseconds(10))
+
+        #expect(pausing.status == .waitingForInput)
+        #expect(queued.status == .running)
+        try await waitUntil { probe.started }
+
+        // The user answers: the paused run resumes straight to `.running`
+        // — it is never demoted back into the queue.
+        pausing.chatSession?.awaitingClarify = nil
+        pausing.chatSession?.isStreaming = true
+        try await Task.sleep(for: .milliseconds(10))
+        #expect(pausing.status == .running)
+    }
+
+    @Test func naturalCompletion_promotesQueued() async throws {
+        let agent = UUID()
+        var fillers = (0..<4).map { i in
+            let state = makeTaskState(agentId: agent, title: "filler-\(i)")
+            mgr.registerTaskForTesting(state)
+            return state
+        }
+        let finishing = makeTaskState(agentId: agent, title: "finishing")
+        mgr.registerTaskForTesting(finishing)
+        mgr.observeChatTask(finishing, session: finishing.chatSession!)
+        fillers.append(finishing)
+
+        let probe = StartProbe()
+        let queued = makeTaskState(agentId: agent, title: "queued")
+        mgr.admitTaskForTesting(queued, start: probe.makeStart())
+        defer {
+            fillers.forEach { mgr.finalizeTask($0.id) }
+            mgr.finalizeTask(queued.id)
+        }
+        #expect(queued.status == .queued)
+
+        // The running task's stream ends cleanly → terminal `.completed`
+        // → its slot promotes the queued request.
+        finishing.chatSession?.isStreaming = true
+        try await Task.sleep(for: .milliseconds(10))
+        finishing.chatSession?.isStreaming = false
+        try await Task.sleep(for: .milliseconds(10))
+
+        #expect(finishing.status == .completed(summary: "Chat completed"))
+        #expect(queued.status == .running)
+        try await waitUntil { probe.started }
+    }
+
+    @Test func cancelQueuedTask_dropsDeferredStartPermanently() async throws {
+        let agent = UUID()
+        let fillers = fillAgentCap(agent)
+
+        let probe = StartProbe()
+        let queued = makeTaskState(agentId: agent, title: "queued-cancel")
+        mgr.admitTaskForTesting(queued, start: probe.makeStart())
+        #expect(queued.status == .queued)
+
+        mgr.cancelTask(queued.id)
+        #expect(queued.status == .cancelled)
+
+        // Free every slot: the cancelled request must never be resurrected
+        // by the promotion pass.
+        fillers.forEach { mgr.finalizeTask($0.id) }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(probe.started == false)
+        #expect(queued.status == .cancelled)
+
+        mgr.finalizeTask(queued.id)
+    }
+
+    @Test func promotion_skipsAgentAtCapWithoutBlockingOtherAgents() async throws {
+        let agentX = UUID()
+        let agentY = UUID()
+        let fillers = fillAgentCap(agentX)
+
+        // Force BOTH follow-ups into the queue by zeroing the global limit,
+        // then restore it: agent X's request stays capacity-blocked by the
+        // per-agent cap while agent Y's is not.
+        let originalConfig = ToastManager.shared.configuration
+        var zeroed = originalConfig
+        zeroed.maxConcurrentTasks = 0
+        ToastManager.shared.updateConfiguration(zeroed)
+
+        let probeX = StartProbe()
+        let probeY = StartProbe()
+        let queuedX = makeTaskState(agentId: agentX, title: "queued-x")
+        let queuedY = makeTaskState(agentId: agentY, title: "queued-y")
+        mgr.admitTaskForTesting(queuedX, start: probeX.makeStart())
+        mgr.admitTaskForTesting(queuedY, start: probeY.makeStart())
+        defer {
+            fillers.forEach { mgr.finalizeTask($0.id) }
+            mgr.finalizeTask(queuedX.id)
+            mgr.finalizeTask(queuedY.id)
+        }
+        #expect(queuedX.status == .queued)
+        #expect(queuedY.status == .queued)
+
+        ToastManager.shared.updateConfiguration(originalConfig)
+        mgr.pumpQueueForTesting()
+
+        // Y jumps past the capacity-blocked X (no head-of-line blocking);
+        // X stays queued in place.
+        #expect(queuedY.status == .running)
+        #expect(queuedX.status == .queued)
+        try await waitUntil { probeY.started }
+        #expect(probeX.started == false)
+
+        // Once agent X frees a slot, its queued request follows.
+        mgr.finalizeTask(fillers[0].id)
+        #expect(queuedX.status == .running)
+        try await waitUntil { probeX.started }
+    }
+
+    @Test func cancelAllTasks_cancelsRunningAndQueued() async throws {
+        let agent = UUID()
+        let running = makeTaskState(agentId: agent, title: "running")
+        mgr.registerTaskForTesting(running)
+        // Saturate the agent so the second request queues.
+        let fillers = (0..<4).map { i in
+            let state = makeTaskState(agentId: agent, title: "filler-\(i)")
+            mgr.registerTaskForTesting(state)
+            return state
+        }
+
+        let probe = StartProbe()
+        let queued = makeTaskState(agentId: agent, title: "queued")
+        mgr.admitTaskForTesting(queued, start: probe.makeStart())
+        #expect(queued.status == .queued)
+
+        mgr.cancelAllTasks()
+
+        #expect(running.status == .cancelled)
+        #expect(queued.status == .cancelled)
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(probe.started == false)
+
+        ([running, queued] + fillers).forEach { mgr.finalizeTask($0.id) }
+    }
+
+    @Test func toastOrdering_waitingBeforeRunningBeforeQueued() async throws {
+        let agent = UUID()
+        let running = makeTaskState(agentId: agent, title: "t-running", status: .running)
+        let waiting = makeTaskState(agentId: agent, title: "t-waiting", status: .waitingForInput)
+        let queued = makeTaskState(agentId: agent, title: "t-queued", status: .queued)
+        // Register in the "wrong" order to prove the sort is by status.
+        mgr.registerTaskForTesting(queued)
+        mgr.registerTaskForTesting(running)
+        mgr.registerTaskForTesting(waiting)
+        defer {
+            [running, waiting, queued].forEach { mgr.finalizeTask($0.id) }
+        }
+
+        let ourIds: Set<UUID> = [running.id, waiting.id, queued.id]
+        let ours = mgr.sortedToastTasks.filter { ourIds.contains($0.id) }
+        #expect(ours.map(\.id) == [waiting.id, running.id, queued.id])
+    }
+
+    /// A window binding whose window no longer exists must not suppress a
+    /// task from the global toast surface — otherwise a crashed / torn-down
+    /// window would permanently hide a still-running request.
+    @Test func staleWindowBinding_doesNotHideTaskFromToasts() async throws {
+        let agent = UUID()
+        let state = makeTaskState(agentId: agent, title: "stale-bind")
+        mgr.registerTaskForTesting(state)
+        defer { mgr.finalizeTask(state.id) }
+
+        let ghostWindowId = UUID()
+        mgr.bindWindow(ghostWindowId, toTask: state.id)
+        defer { mgr.unbindWindow(ghostWindowId) }
+
+        #expect(mgr.isTaskAttachedToWindow(state.id) == false)
+        #expect(mgr.sortedToastTasks.contains { $0.id == state.id })
+    }
+}
+
+// MARK: - Concurrent tool-batch ownership
+
+/// Minimal scripted loop surface for concurrency tests: records executed
+/// calls and completed batches, with an artificial per-tool delay so two
+/// concurrent runs genuinely interleave on the main actor.
+@MainActor
+private final class ConcurrentLoopSurface {
+    var steps: [AgentLoopModelStep]
+    let toolDelayMs: Int
+    var executedCalls: [(name: String, callId: String)] = []
+    var batchOutcomes: [[AgentLoopToolOutcome]] = []
+
+    init(steps: [AgentLoopModelStep], toolDelayMs: Int) {
+        self.steps = steps
+        self.toolDelayMs = toolDelayMs
+    }
+
+    func makeHooks() -> AgentLoopHooks {
+        AgentLoopHooks(
+            isCancelled: { false },
+            buildMessages: { _ in
+                AgentLoopIterationInput(messages: [ChatMessage(role: "user", content: "task")])
+            },
+            modelStep: { _, _ in
+                guard !self.steps.isEmpty else { return .finalResponse }
+                return self.steps.removeFirst()
+            },
+            willProcessCall: { _, _ in },
+            onDedupedResult: { _, _, _ in },
+            executeTool: { inv, callId in
+                // Yield across the actor so the two concurrent runs interleave.
+                try? await Task.sleep(for: .milliseconds(self.toolDelayMs))
+                self.executedCalls.append((inv.toolName, callId))
+                return AgentLoopToolExecution(result: ToolEnvelope.success(tool: inv.toolName, text: "ok"))
+            },
+            onBatchComplete: { outcomes in
+                self.batchOutcomes.append(outcomes)
+            },
+            pendingTodoCount: nil
+        )
+    }
+}
+
+@MainActor
+struct ConcurrentToolBatchIsolationTests {
+
+    private func invocation(_ name: String) -> ServiceToolInvocation {
+        ServiceToolInvocation(toolName: name, jsonArguments: "{}", toolCallId: nil)
+    }
+
+    /// Two requests run their multi-call tool batches at the same time.
+    /// Each batch stays owned by its own request: executions and ordered
+    /// outcomes land only in the surface that issued them, both runs stay
+    /// live until their full batch settles, and neither run's results leak
+    /// into the other.
+    @Test func simultaneousBatches_stayOwnedByTheirRequest() async throws {
+        let surfaceA = ConcurrentLoopSurface(
+            steps: [.toolCalls([invocation("a_first"), invocation("a_second"), invocation("a_third")])],
+            toolDelayMs: 15
+        )
+        let surfaceB = ConcurrentLoopSurface(
+            steps: [.toolCalls([invocation("b_first"), invocation("b_second")])],
+            toolDelayMs: 25
+        )
+
+        let hooksA = surfaceA.makeHooks()
+        let hooksB = surfaceB.makeHooks()
+        let runA = Task { @MainActor in
+            try await AgentToolLoop.run(
+                policy: AgentLoopPolicy(maxIterations: 5, stopOnToolRejection: true, dedupeNoticeEnabled: true),
+                state: AgentTaskState(),
+                hooks: hooksA
+            )
+        }
+        let runB = Task { @MainActor in
+            try await AgentToolLoop.run(
+                policy: AgentLoopPolicy(maxIterations: 5, stopOnToolRejection: true, dedupeNoticeEnabled: true),
+                state: AgentTaskState(),
+                hooks: hooksB
+            )
+        }
+        let resultA = try await runA.value
+        let resultB = try await runB.value
+
+        // Both requests ran to completion, staying alive until their whole
+        // batch settled.
+        #expect(resultA.exit == .finalResponse)
+        #expect(resultB.exit == .finalResponse)
+
+        // Every execution landed in the surface that issued it, in model
+        // order — no cross-request leakage despite interleaving.
+        #expect(surfaceA.executedCalls.map(\.name) == ["a_first", "a_second", "a_third"])
+        #expect(surfaceB.executedCalls.map(\.name) == ["b_first", "b_second"])
+
+        // Ordered batch outcomes are per-request as well.
+        #expect(surfaceA.batchOutcomes.count == 1)
+        #expect(surfaceA.batchOutcomes[0].map { $0.invocation.toolName } == ["a_first", "a_second", "a_third"])
+        #expect(surfaceB.batchOutcomes.count == 1)
+        #expect(surfaceB.batchOutcomes[0].map { $0.invocation.toolName } == ["b_first", "b_second"])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskStreamingObserverTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskStreamingObserverTests.swift
@@ -71,11 +71,11 @@ struct BackgroundTaskStreamingObserverTests {
         state.chatSession?.isStreaming = false
         try await Task.sleep(for: .milliseconds(10))
 
-        #expect(state.status == .completed(success: true, summary: "Chat completed"))
+        #expect(state.status == .completed(summary: "Chat completed"))
     }
 
     /// A stream error before completion must transition the task to
-    /// `.completed(success: false, summary: <error>)`.
+    /// `.failed(summary: <error>)`.
     @Test
     func observeChatTask_marksFailedWhenStreamErrorPresent() async throws {
         let (state, mgr) = makeObservedState()
@@ -87,6 +87,6 @@ struct BackgroundTaskStreamingObserverTests {
         state.chatSession?.isStreaming = false
         try await Task.sleep(for: .milliseconds(10))
 
-        #expect(state.status == .completed(success: false, summary: "boom"))
+        #expect(state.status == .failed(summary: "boom"))
     }
 }

--- a/Packages/OsaurusCore/Tests/Plugin/PluginClarifyEventTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginClarifyEventTests.swift
@@ -7,7 +7,7 @@
 //   1. `serializeClarificationEvent` (pure) — payload shape, options-key
 //      omission for free-form questions, allow_multiple round-trip.
 //   2. `BackgroundTaskManager` bridge — `ChatSession.awaitingClarify`
-//      transitions the task to `.awaitingClarification` and SUPPRESSES
+//      transitions the task to `.waitingForInput` and SUPPRESSES
 //      the spurious COMPLETED event that previously fired the moment
 //      the chat-layer intercept yielded the iteration loop.
 //   3. End-to-end emission through a fake `LoadedPlugin` — the plugin
@@ -103,7 +103,7 @@ struct BackgroundTaskClarifyObserverTests {
     }
 
     /// Setting `awaitingClarify` while streaming flips the task to
-    /// `.awaitingClarification`. The status carries through to the
+    /// `.waitingForInput`. The status carries through to the
     /// streaming-end branch so `markCompleted` is skipped.
     @Test
     func awaitingClarifySet_transitionsStatus() async throws {
@@ -116,10 +116,10 @@ struct BackgroundTaskClarifyObserverTests {
             ClarifyPayload(question: "Use Postgres or SQLite?", options: [], allowMultiple: false)
         try await Task.sleep(for: .milliseconds(10))
 
-        #expect(state.status == .awaitingClarification)
+        #expect(state.status == .waitingForInput)
     }
 
-    /// Streaming-end while `state.status == .awaitingClarification` MUST
+    /// Streaming-end while `state.status == .waitingForInput` MUST
     /// NOT mark the task completed. This is the regression guard for the
     /// Telegram-bot bug where COMPLETED was firing with the clarify
     /// envelope as `output`.
@@ -137,14 +137,14 @@ struct BackgroundTaskClarifyObserverTests {
         state.chatSession?.isStreaming = false
         try await Task.sleep(for: .milliseconds(10))
 
-        #expect(state.status == .awaitingClarification)
+        #expect(state.status == .waitingForInput)
     }
 
     /// After the user answers (clearing `awaitingClarify`) the loop
     /// resumes, isStreaming flips back to true, and a subsequent
     /// streaming-end DOES mark the task completed normally. Guards
     /// against an over-broad fix that would leave the task stuck in
-    /// `.awaitingClarification` forever.
+    /// `.waitingForInput` forever.
     @Test
     func resumeAfterClarify_thenStreamingEnd_marksCompleted() async throws {
         let (state, mgr) = makeObservedState()
@@ -162,7 +162,7 @@ struct BackgroundTaskClarifyObserverTests {
         state.chatSession?.isStreaming = false
         try await Task.sleep(for: .milliseconds(10))
 
-        #expect(state.status == .completed(success: true, summary: "Chat completed"))
+        #expect(state.status == .completed(summary: "Chat completed"))
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Plugin/PluginHostAPITests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginHostAPITests.swift
@@ -220,21 +220,35 @@ struct BackgroundTaskStatusTests {
         #expect(status.displayName == L("Running"))
     }
 
-    @Test func awaitingClarificationIsActive() {
-        let status = BackgroundTaskStatus.awaitingClarification
+    @Test func queuedIsActiveButNotSlotConsuming() {
+        let status = BackgroundTaskStatus.queued
         #expect(status.isActive == true)
+        #expect(status.consumesExecutionSlot == false)
+        #expect(status.displayName == L("Queued"))
+    }
+
+    @Test func waitingForInputIsActiveButNotSlotConsuming() {
+        let status = BackgroundTaskStatus.waitingForInput
+        #expect(status.isActive == true)
+        #expect(status.consumesExecutionSlot == false)
         #expect(status.displayName == L("Waiting"))
     }
 
-    @Test func completedSuccessIsNotActive() {
-        let status = BackgroundTaskStatus.completed(success: true, summary: "Done")
+    @Test func runningConsumesExecutionSlot() {
+        #expect(BackgroundTaskStatus.running.consumesExecutionSlot == true)
+    }
+
+    @Test func completedIsNotActive() {
+        let status = BackgroundTaskStatus.completed(summary: "Done")
         #expect(status.isActive == false)
+        #expect(status.consumesExecutionSlot == false)
         #expect(status.displayName == L("Completed"))
     }
 
-    @Test func completedFailureIsNotActive() {
-        let status = BackgroundTaskStatus.completed(success: false, summary: "Error")
+    @Test func failedIsNotActive() {
+        let status = BackgroundTaskStatus.failed(summary: "Error")
         #expect(status.isActive == false)
+        #expect(status.consumesExecutionSlot == false)
         #expect(status.displayName == L("Failed"))
     }
 
@@ -245,10 +259,11 @@ struct BackgroundTaskStatusTests {
     }
 
     @Test func iconNames() {
+        #expect(BackgroundTaskStatus.queued.iconName == "clock")
         #expect(BackgroundTaskStatus.running.iconName == "arrow.triangle.2.circlepath")
-        #expect(BackgroundTaskStatus.awaitingClarification.iconName == "questionmark.circle.fill")
-        #expect(BackgroundTaskStatus.completed(success: true, summary: "").iconName == "checkmark.circle.fill")
-        #expect(BackgroundTaskStatus.completed(success: false, summary: "").iconName == "xmark.circle.fill")
+        #expect(BackgroundTaskStatus.waitingForInput.iconName == "questionmark.circle.fill")
+        #expect(BackgroundTaskStatus.completed(summary: "").iconName == "checkmark.circle.fill")
+        #expect(BackgroundTaskStatus.failed(summary: "").iconName == "xmark.circle.fill")
         #expect(BackgroundTaskStatus.cancelled.iconName == "stop.circle.fill")
     }
 
@@ -256,12 +271,12 @@ struct BackgroundTaskStatusTests {
         #expect(BackgroundTaskStatus.running == BackgroundTaskStatus.running)
         #expect(BackgroundTaskStatus.cancelled == BackgroundTaskStatus.cancelled)
         #expect(
-            BackgroundTaskStatus.completed(success: true, summary: "ok")
-                == BackgroundTaskStatus.completed(success: true, summary: "ok")
+            BackgroundTaskStatus.completed(summary: "ok")
+                == BackgroundTaskStatus.completed(summary: "ok")
         )
         #expect(
-            BackgroundTaskStatus.completed(success: true, summary: "ok")
-                != BackgroundTaskStatus.completed(success: false, summary: "ok")
+            BackgroundTaskStatus.completed(summary: "ok")
+                != BackgroundTaskStatus.failed(summary: "ok")
         )
     }
 }
@@ -647,7 +662,7 @@ struct TaskStateDictTests {
             agentId: Agent.defaultId,
             chatSession: context.chatSession,
             executionContext: context,
-            status: .completed(success: true, summary: "All done")
+            status: .completed(summary: "All done")
         )
         let dict = PluginHostContext.taskStateDict(id: state.id, state: state)
         #expect(dict["title"] as? String == "Deploy app")

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -140,7 +140,7 @@ final class ChatSession: ObservableObject {
     /// for a clarify question. Cleared by `send(...)` before the next
     /// user turn so the loop can resume cleanly. Observed by
     /// `BackgroundTaskManager.observeChatTask` to flip the task status to
-    /// `.awaitingClarification`, emit the type-3 CLARIFICATION event with
+    /// `.waitingForInput`, emit the type-3 CLARIFICATION event with
     /// the parsed payload to the source plugin, and suppress the spurious
     /// COMPLETED that would otherwise fire when `isStreaming` goes false
     /// on the intercept.
@@ -3833,7 +3833,7 @@ final class ChatSession: ObservableObject {
             promptQueue.drainAll()
         }
         // Resume from any prior clarify pause BEFORE the new run starts so
-        // the BTM streaming-state sink sees `.awaitingClarification`
+        // the BTM streaming-state sink sees `.waitingForInput`
         // cleared and the next streaming tick transitions the task back
         // to `.running` cleanly. Redundant nil → nil writes are
         // collapsed downstream by `removeDuplicates`.
@@ -5721,19 +5721,6 @@ struct ChatView: View {
                 secondaryButton: .cancel(L("No"))
             )
             .themedAlert(
-                L("Keep this chat running?"),
-                isPresented: $windowState.showCloseConfirmation,
-                message:
-                    L(
-                        "The model is still generating a reply. Continue in the background and track progress in the menu-bar notch, or stop now."
-                    ),
-                buttons: [
-                    .primary(L("Continue in Background")) { windowState.confirmCloseInBackground() },
-                    .destructive(L("Stop and Close")) { windowState.confirmCloseAndStop() },
-                    .cancel(L("Cancel")),
-                ]
-            )
-            .themedAlert(
                 L("A local model is already running"),
                 isPresented: $windowState.showLocalModelBusyAlert,
                 message:
@@ -5853,6 +5840,13 @@ struct ChatView: View {
                                 windowState.startNewChat()
                             },
                             onDelete: { id in
+                                // Deleting a chat is an explicit destructive
+                                // action: cancel any registry-owned run still
+                                // driving it so a background completion can't
+                                // resurrect the deleted row on save.
+                                if let liveTask = BackgroundTaskManager.shared.liveTask(forSessionId: id) {
+                                    BackgroundTaskManager.shared.cancelTask(liveTask.id)
+                                }
                                 if session.sessionId == id {
                                     session.reset()
                                 }

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -141,9 +141,11 @@ struct NotchView: View {
     private var accentColor: Color {
         guard let task = activeTask else { return theme.accentColorLight }
         switch task.status {
+        case .queued: return notchTertiaryText
         case .running: return theme.accentColorLight
-        case .awaitingClarification: return theme.warningColor
-        case .completed(let success, _): return success ? theme.successColor : theme.errorColor
+        case .waitingForInput: return theme.warningColor
+        case .completed: return theme.successColor
+        case .failed: return theme.errorColor
         case .cancelled: return notchTertiaryText
         }
     }
@@ -403,16 +405,23 @@ struct NotchView: View {
     private var compactTrailing: some View {
         if let task = activeTask {
             switch task.status {
-            case .running, .awaitingClarification:
+            case .queued, .running, .waitingForInput:
                 // Chat tasks don't expose structured progress — show
                 // indeterminate ring (passing -1 makes NotchProgressRing
                 // animate continuously).
                 NotchProgressRing(progress: -1, color: accentColor, size: 14, lineWidth: 1.5)
                     .transition(.opacity.combined(with: .scale(scale: 0.5)))
-            case .completed(let success, _):
+            case .completed:
                 MorphingStatusIcon(
-                    state: success ? .completed : .failed,
-                    accentColor: success ? theme.successColor : theme.errorColor,
+                    state: .completed,
+                    accentColor: theme.successColor,
+                    size: 14
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.5)))
+            case .failed:
+                MorphingStatusIcon(
+                    state: .failed,
+                    accentColor: theme.errorColor,
                     size: 14
                 )
                 .transition(.opacity.combined(with: .scale(scale: 0.5)))
@@ -435,9 +444,9 @@ struct NotchView: View {
 
                 if let task = activeTask {
                     switch task.status {
-                    case .running, .awaitingClarification:
+                    case .queued, .running, .waitingForInput:
                         expandedRunningBody(task: task)
-                    case .completed(_, let summary):
+                    case .completed(let summary), .failed(let summary):
                         expandedCompletedBody(summary: summary, task: task)
                     case .cancelled:
                         expandedCancelledBody(task: task)

--- a/Packages/OsaurusCore/Views/Toast/BackgroundTaskToastView.swift
+++ b/Packages/OsaurusCore/Views/Toast/BackgroundTaskToastView.swift
@@ -92,9 +92,11 @@ struct BackgroundTaskToastView: View {
 
     private var statusIconState: StatusIconState {
         switch taskState.status {
+        case .queued: return .pending
         case .running: return .active
-        case .awaitingClarification: return .pending
-        case .completed(let success, _): return success ? .completed : .failed
+        case .waitingForInput: return .pending
+        case .completed: return .completed
+        case .failed: return .failed
         case .cancelled: return .failed
         }
     }
@@ -104,13 +106,13 @@ struct BackgroundTaskToastView: View {
     @ViewBuilder
     private var contentSection: some View {
         switch taskState.status {
-        case .running, .awaitingClarification:
-            // Chat tasks never enter `awaitingClarification` from the manager —
-            // chat clarifications surface inline via the `clarify` agent
-            // intercept rendered in the chat window. Treat the case as a
-            // running task here for back-compat with any legacy state.
+        case .queued, .running, .waitingForInput:
+            // `.waitingForInput` for chat tasks surfaces inline via the
+            // `clarify` agent intercept rendered in the chat window; here it
+            // renders as a running task with a "Waiting..." step. Queued
+            // tasks show their "Queued" step over the same layout.
             runningContent
-        case .completed(_, let summary):
+        case .completed(let summary), .failed(let summary):
             completedContent(summary: summary)
         case .cancelled:
             cancelledContent
@@ -306,9 +308,11 @@ struct BackgroundTaskToastView: View {
 
     private var accentColor: Color {
         switch taskState.status {
+        case .queued: return theme.tertiaryText
         case .running: return theme.accentColorLight
-        case .awaitingClarification: return theme.warningColor
-        case .completed(let success, _): return success ? theme.successColor : theme.errorColor
+        case .waitingForInput: return theme.warningColor
+        case .completed: return theme.successColor
+        case .failed: return theme.errorColor
         case .cancelled: return theme.tertiaryText
         }
     }


### PR DESCRIPTION
## Summary

Switching to another chat/agent (or closing a window) no longer stops the current run. Each agent request now has an explicit lifecycle owned by `BackgroundTaskManager`, independent of which window — if any — is displaying it.

- **Six-state lifecycle**: `BackgroundTaskStatus` is now `queued / running / waitingForInput / completed / failed / cancelled`, with separate `isActive` and `consumesExecutionSlot` semantics. A run paused on a clarify prompt stays alive but releases its execution slot.
- **FIFO queueing instead of rejection**: when the configured global or per-agent concurrency limit is saturated, `dispatchChat` registers the request as `.queued` with a deferred start; `pumpQueue()` promotes the oldest eligible request whenever a slot frees (completion, failure, cancel, waiting-for-input). An agent at its per-agent cap is skipped without head-of-line blocking other agents. Structurally invalid requests still fail immediately; app shutdown cancels queued and running work.
- **Windows are attachable views**: switching chats/agents or starting a new chat while streaming detaches the live `ChatSession` into the registry and installs a replacement session; closing a window auto-detaches with no "keep running?" confirmation gate. Reopening a running chat re-attaches the exact in-memory `ChatSession` instance (not a stale disk copy), so subsequent deltas keep rendering. `ChatWindowState.session` is now replaceable and the hosting root rebuilds `ChatView` keyed on session identity.
- **Session-scoped surfacing**: the notch/toast reports only detached work — a task attached to a live window never double-announces, and background completion/failure never writes into the currently selected chat. Local-model exclusivity, greeting deferral, and residency GC now consult registry-owned runs too.
- **Only explicit termination ends a request**: Stop, background-task cancel, app shutdown (`cancelAllTasks`), or budget exhaustion.

## Test plan

- [x] New `AgentRequestLifecycleTests`: FIFO promotion, waiting-for-input slot release/resume, queued-cancel permanence, per-agent cap skip without head-of-line blocking, shutdown cancelling running + queued, toast ordering, stale window bindings, and concurrent tool-batch ownership isolation.
- [x] New `ChatWindowSessionDetachTests`: new chat / load session / switch agent mid-stream detach without stopping, reopen re-attaches the same `ChatSession` instance, background output never leaks into the newly selected chat, closing one window never stops another window's stream.
- [x] Updated suites for the new status enum: `BackgroundTaskStreamingObserverTests`, `PluginClarifyEventTests`, `PluginHostAPITests`.
- [x] Existing affected suites pass: `ChatSessionStopTests`, `ChatSessionQueuedSendTests`, `BackgroundTaskInterruptTests`, `AgentToolLoopParallelBatchTests`, `ChatWindowStateAgentSyncTests`, `ChatWindowStateIdentityTests`, `RuntimePolicySourceTests`, `LifecycleConcurrencyTests`, `PluginDispatchToolSelectionTests`.
- [x] Full `make test` run: 5635 tests. Remaining failures are pre-existing environment-dependent issues unrelated to this change (keychain-gated `PluginAgentScopingTests` under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, MCP stdio probe timeouts, and load-induced wall-clock assertions) — each implicated suite passes in isolation.