### PR TITLE
Vision is not an image job; ground a spawned child's two file surfaces

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -686,10 +686,18 @@ public enum SystemPromptTemplates {
     /// edit model is installed. Counters the persona-led refusal ("I'm
     /// text-only / I can't make images") and keeps the edit-continuation
     /// CONDITIONAL (never a forced "now edit it").
+    ///
+    /// The anti-refusal rule is deliberately blunt, which gave it a blast
+    /// radius: an image the USER attached, plus a question about it, reads to
+    /// the model as "an existing image + a prompt" — the exact edit shape — and
+    /// nothing here said otherwise. Live: a VL question ("how many circles?")
+    /// was answered by calling `image` instead of by looking. Vision is not an
+    /// image job, so the boundary is stated explicitly.
     public static let imageGenerationGuidance = """
         ## Image generation
 
         - You CAN create and edit images with the `image` tool. To create, call `image` with a `prompt`. To edit an existing image, call `image` with a `prompt` PLUS `source_paths` set to the image path(s) — `source_paths` is what switches it into edit mode.
+        - Only call `image` when the user wants a picture CREATED or CHANGED. If the user attached an image and is asking ABOUT it — what it shows, what it says, counting or describing something in it — look at the image and answer directly. That is vision, not an image job.
         - NEVER claim you can't make images or are "text-only", and don't redirect the user to another app or settings — you have this tool, so use it.
         - The result renders inline in the chat automatically; do not call `share_artifact` for it. If the user asked for a follow-up edit of that image, call `image` again with `source_paths` set to the saved result path; otherwise confirm briefly in one sentence.
         - The job runs locally and may briefly swap models; that is expected.
@@ -697,10 +705,12 @@ public enum SystemPromptTemplates {
 
     /// Compact generate + edit directive for small local models: same behavior
     /// at a fraction of the tokens (anti-refusal, edit-mode switch, inline
-    /// render / no `share_artifact`, conditional edit-continuation).
+    /// render / no `share_artifact`, conditional edit-continuation, and the
+    /// same vision-vs-image-job boundary).
     public static let imageGenerationGuidanceCompact = """
         ## Image generation
         - You CAN create/edit images with the `image` tool: call it with a `prompt`; add `source_paths` (existing image path[s]) to edit instead of create.
+        - Only call `image` to CREATE or CHANGE a picture. If the user attached an image and is asking about what it shows or says, look at it and answer directly — that is vision, not an image job.
         - NEVER say you can't make images or are "text-only", and don't redirect to another app or settings — use the tool.
         - The result renders inline automatically; don't call `share_artifact`. For a requested follow-up edit, call `image` again with `source_paths` set to the saved path; otherwise confirm briefly.
         """
@@ -713,6 +723,7 @@ public enum SystemPromptTemplates {
         ## Image generation
 
         - You CAN create images with the `image` tool: call `image` with a `prompt`. Editing existing images is not available, so do not offer or attempt it.
+        - Only call `image` when the user wants a picture CREATED. If the user attached an image and is asking ABOUT it — what it shows, what it says, counting or describing something in it — look at the image and answer directly. That is vision, not an image job.
         - NEVER claim you can't make images or are "text-only", and don't redirect the user to another app or settings — you have this tool, so use it.
         - The result renders inline in the chat automatically; do not call `share_artifact` for it. Confirm briefly in one sentence.
         - The job runs locally and may briefly swap models; that is expected.
@@ -722,6 +733,7 @@ public enum SystemPromptTemplates {
     public static let imageGenerationOnlyGuidanceCompact = """
         ## Image generation
         - You CAN create images with the `image` tool: call it with a `prompt`. Editing existing images is not available — don't offer or attempt it.
+        - Only call `image` to CREATE a picture. If the user attached an image and is asking about what it shows or says, look at it and answer directly — that is vision, not an image job.
         - NEVER say you can't make images or are "text-only", and don't redirect to another app or settings — use the tool.
         - The result renders inline automatically; don't call `share_artifact`. Confirm briefly.
         """

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -322,13 +322,19 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         let budgets = self.budgets.normalized
         let deadline = Date().addingTimeInterval(TimeInterval(budgets.maxElapsedSeconds))
         let started = Date()
-        let seed = seedMessages(systemPrompt: systemPrompt, input: input)
         let sessionId = "spawn-\((resolvedAgentId ?? UUID()).uuidString)-\(UUID().uuidString)"
         let toolset = await Self.makeToolset(
             access: toolAccess,
             maxToolCalls: budgets.maxToolCalls,
             feed: feed,
             agentSpecs: agentToolSpecs
+        )
+        // Seed AFTER the toolset so the grounding can name only the tools the
+        // child actually received.
+        let seed = seedMessages(
+            systemPrompt: systemPrompt,
+            input: input,
+            toolNames: toolset.map { $0.specs.map(\.function.name) } ?? []
         )
 
         let result = try await AgentSubagentRunner.run(
@@ -586,12 +592,63 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
             : "\(kind) '\(name)' is not spawnable from this agent. Add it in the agent's Subagents tab."
     }
 
-    private func seedMessages(systemPrompt: String, input: String) -> [ChatMessage] {
+    private func seedMessages(
+        systemPrompt: String,
+        input: String,
+        toolNames: [String]
+    ) -> [ChatMessage] {
         var msgs: [ChatMessage] = []
+        var sections: [String] = []
+
         let sys = systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !sys.isEmpty { msgs.append(ChatMessage(role: "system", content: sys)) }
+        if !sys.isEmpty { sections.append(sys) }
+        if let surfaces = Self.fileSurfaceGrounding(toolNames: toolNames) {
+            sections.append(surfaces)
+        }
+
+        if !sections.isEmpty {
+            msgs.append(ChatMessage(role: "system", content: sections.joined(separator: "\n\n")))
+        }
         msgs.append(ChatMessage(role: "user", content: input))
         return msgs
+    }
+
+    /// Tell the child which filesystem each of its read tools actually reads.
+    ///
+    /// The curated child toolset can carry BOTH surfaces at once — `file_read` /
+    /// `file_search` read the user's open folder on the host, `sandbox_read_file`
+    /// / `sandbox_search_files` read inside the Linux sandbox — and `spawn_model`
+    /// runs the child with an EMPTY system prompt, so nothing said which was
+    /// which. With two similarly-named tools and no grounding the choice is a
+    /// coin flip: live, a child told "use the file_read tool to read AGENTS.md
+    /// from the current working folder" called `sandbox_read_file` instead, got a
+    /// failure, and only succeeded on an identical retry.
+    ///
+    /// This states a fact about the tools (the same thing their descriptions do);
+    /// it does not tell the model what to conclude or how to answer.
+    static func fileSurfaceGrounding(toolNames: [String]) -> String? {
+        let names = Set(toolNames)
+        let hasHost = names.contains("file_read") || names.contains("file_search")
+        let hasSandbox =
+            names.contains("sandbox_read_file") || names.contains("sandbox_search_files")
+
+        switch (hasHost, hasSandbox) {
+        case (true, true):
+            return """
+                Your read tools cover two different filesystems:
+                - `file_read` / `file_search` read the user's open folder on the host Mac.
+                - `sandbox_read_file` / `sandbox_search_files` read inside the Linux sandbox.
+                They are separate: a file in the open folder is NOT reachable with the sandbox \
+                tools, and vice versa. Pick the pair that matches where the task's files live.
+                """
+        case (true, false):
+            return "`file_read` / `file_search` read the user's open folder on the host Mac."
+        case (false, true):
+            return
+                "`sandbox_read_file` / `sandbox_search_files` read inside the Linux sandbox."
+        case (false, false):
+            return nil
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Tests/AgentDelegation/SpawnChildFileSurfaceGroundingTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/SpawnChildFileSurfaceGroundingTests.swift
@@ -1,0 +1,67 @@
+//
+//  SpawnChildFileSurfaceGroundingTests.swift
+//  OsaurusCore
+//
+//  A spawned child can hold BOTH filesystem surfaces at once — `file_read` /
+//  `file_search` (the user's open folder on the host) and `sandbox_read_file` /
+//  `sandbox_search_files` (inside the Linux sandbox) — while `spawn_model` runs
+//  it with an EMPTY system prompt. Nothing told it which was which.
+//
+//  Live: a child told "use the file_read tool to read 'AGENTS.md' from the
+//  current working folder" called `sandbox_read_file` instead. That failed; an
+//  identical retry succeeded. Two similarly-named tools plus zero grounding is a
+//  coin flip, not a race.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("A spawned child is told which filesystem each read tool reads")
+struct SpawnChildFileSurfaceGroundingTests {
+
+    /// The live failure shape: both surfaces in one toolset.
+    @Test("both surfaces present: the child is told they are separate filesystems")
+    func bothSurfacesAreDisambiguated() throws {
+        let grounding = try #require(
+            TextSubagentKind.fileSurfaceGrounding(toolNames: [
+                "file_read", "file_search", "sandbox_read_file", "sandbox_search_files",
+            ]))
+
+        #expect(grounding.contains("file_read"))
+        #expect(grounding.contains("sandbox_read_file"))
+        // The load-bearing fact: they are NOT the same filesystem.
+        #expect(grounding.contains("open folder"))
+        #expect(grounding.contains("sandbox"))
+        #expect(grounding.contains("NOT reachable"))
+    }
+
+    @Test("host tools only: no sandbox tool is ever mentioned")
+    func hostOnlyDoesNotMentionSandbox() throws {
+        let grounding = try #require(
+            TextSubagentKind.fileSurfaceGrounding(toolNames: ["file_read", "file_search"]))
+
+        #expect(grounding.contains("file_read"))
+        // Never name a tool the child does not have.
+        #expect(grounding.contains("sandbox_read_file") == false)
+    }
+
+    @Test("sandbox tools only: no host tool is ever mentioned")
+    func sandboxOnlyDoesNotMentionHost() throws {
+        let grounding = try #require(
+            TextSubagentKind.fileSurfaceGrounding(toolNames: [
+                "sandbox_read_file", "sandbox_search_files",
+            ]))
+
+        #expect(grounding.contains("sandbox_read_file"))
+        #expect(grounding.contains("file_read") == false)
+    }
+
+    /// A text-only child (no tool access) must stay text-only: no file section,
+    /// no wasted tokens, and nothing that implies tools it cannot call.
+    @Test("no file tools: no grounding is injected at all")
+    func noFileToolsInjectsNothing() {
+        #expect(TextSubagentKind.fileSurfaceGrounding(toolNames: []) == nil)
+        #expect(TextSubagentKind.fileSurfaceGrounding(toolNames: ["web_search"]) == nil)
+    }
+}


### PR DESCRIPTION
> **Do not merge yet.** Neither fix has been proven on the live dev-built app. Opening for review; live visual multiturn proof still owed.

Two independent prompt-level defects. Both are root causes, not symptoms — in each case the model behaved correctly given information that was wrong or missing.

## 1. VL questions were answered by generating a picture

The image guidance told the model to call `image` whenever it saw an existing image plus a prompt — which is exactly the shape of an edit request — and nothing carved out the case where the user attaches an image and asks a question **about** it. The anti-refusal wording is deliberately blunt, and that gave it a blast radius: *"how many circles are in this?"* reads as "an existing image + a prompt" and got routed into an image job instead of being looked at.

Fixed by stating the boundary in all four guidance variants: `image` is for **creating or changing** a picture; looking at an attached image and answering is **vision, not an image job**.

## 2. A spawned child coin-flipped between two filesystem surfaces

`spawn_model` sets `systemPrompt = ""` and `seedMessages` emitted no system message — while the child was handed **both** file surfaces at once: `file_read` (the host folder) and `sandbox_read_file` (the sandbox container). Nothing told it which was which, so the choice was a coin flip and `sandbox_read_file` failed intermittently.

**This was never a race**, which is what the intermittency made it look like. It was an ungrounded child.

Adds `fileSurfaceGrounding(toolNames:)` and seeds it into the child. `seedMessages` now runs **after** `makeToolset` and takes the resolved tool names, so the grounding names only the surfaces the child actually got — a child that never received a tool is never told about it.

## Tests
`SpawnChildFileSurfaceGroundingTests` (4).

## Not included
No vmlx repin — the companion engine fix (osaurus-ai/vmlx-swift#148, SpecDec detokenizer tail) is still open.