### PR TITLE
Computer Use AX bounding + AccessibilityBoundedElement test fix + vmlx repin (SpecDec tail flush #148)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8f731c2388daeab1c257303bf653a00218ee51dd"
+        "revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
       }
     },
     {

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
@@ -316,7 +316,15 @@ final class AccessibilityManager: @unchecked Sendable {
         preparedPids.insert(pid)
         lock.unlock()
 
-        let app = AXUIElementCreateApplication(pid)
+        // `axApp` (NOT a raw app element): the messaging timeout does not
+        // propagate from the system-wide element, so a raw element makes the
+        // two sets below UNBOUNDED. They are the most
+        // dangerous AX calls we make — flipping `AXEnhancedUserInterface` /
+        // `AXManualAccessibility` forces the target to build its entire
+        // accessibility tree synchronously, and an app that is still launching
+        // can sit on the reply indefinitely. This is the open-app path, so an
+        // unbounded block here wedges the driver queue for the whole session.
+        let app = Self.axApp(pid)
         AXUIElementSetAttributeValue(app, "AXManualAccessibility" as CFString, true as CFTypeRef)
         AXUIElementSetAttributeValue(
             app,
@@ -1378,7 +1386,12 @@ private func waitUntilReady(
         // can stay hidden, occluded, or behind another Space.
         let frontmostOK = !requireFrontmost || app.isActive
 
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        // Bounded app element (see `AccessibilityManager.axApp`). A raw app
+        // element inherits no messaging timeout, so this poll — which by
+        // construction runs against an app that is still coming up — could
+        // block forever on a single read instead of failing and retrying
+        // within the 5s budget above.
+        let axApp = AccessibilityManager.axApp(app.processIdentifier)
         var windowValue: CFTypeRef?
         let windowResult = AXUIElementCopyAttributeValue(
             axApp,

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8f731c2388daeab1c257303bf653a00218ee51dd"
+        "revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         // a Swift bounds check. Contains the previous ff714f1 pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8f731c2388daeab1c257303bf653a00218ee51dd"
+            revision: "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/ComputerUse/Driver/AccessibilityBoundedElementSourceTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Driver/AccessibilityBoundedElementSourceTests.swift
@@ -1,0 +1,97 @@
+//
+//  AccessibilityBoundedElementSourceTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  EVERY AX application element must carry a messaging timeout.
+//
+//  `AXUIElementSetMessagingTimeout` on the system-wide element does NOT
+//  propagate to per-application elements, so an element built with a raw
+//  `AXUIElementCreateApplication(pid)` has NO timeout at all: a single read or
+//  write against a slow, launching, or wedged target app can block the calling
+//  thread forever. `AccessibilityManager.axApp(pid)` exists precisely to stamp
+//  the timeout on, and its doc comment says every app-element site must go
+//  through it.
+//
+//  That contract was stated and then broken. The "Fix Computer Use main-thread
+//  hangs" change applied the timeout "at every app-element site" — and missed
+//  two, BOTH of them on the open-app path:
+//
+//    - `prepareForAccessibility(pid:)`, which flips `AXManualAccessibility` /
+//      `AXEnhancedUserInterface`. Those are the most dangerous AX calls we make:
+//      they force the target to build its entire accessibility tree, and an app
+//      that is still launching can sit on the reply indefinitely.
+//    - `waitUntilReady(app:)`, whose poll runs — by construction — against an
+//      app that is still coming up.
+//
+//  So the one driver path that opens an application was also the only one whose
+//  AX calls were unbounded, while every other path was capped at 1.5s. A prose
+//  comment did not stop that from being reintroduced once, so this is a source
+//  guard instead: the ONLY place allowed to call `AXUIElementCreateApplication`
+//  is `axApp` itself.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class AccessibilityBoundedElementSourceTests: XCTestCase {
+
+    /// `Accessibility.swift`, read from the source tree next to this test.
+    private func accessibilitySource() throws -> String {
+        // Tests/ComputerUse/Driver/<this file> → Packages/OsaurusCore/…
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Driver
+            .deletingLastPathComponent()  // ComputerUse
+            .deletingLastPathComponent()  // Tests
+        let source = packageRoot
+            .appendingPathComponent("ComputerUse/Driver/Mac/Accessibility.swift")
+        return try String(contentsOf: source, encoding: .utf8)
+    }
+
+    /// Every `AXUIElementCreateApplication` must live inside `axApp`, which is
+    /// the only function that follows it with `AXUIElementSetMessagingTimeout`.
+    func testOnlyAxAppConstructsAnApplicationElement() throws {
+        let source = try accessibilitySource()
+
+        let creations = source.components(separatedBy: "AXUIElementCreateApplication").count - 1
+        XCTAssertGreaterThan(creations, 0, "sanity: the symbol should appear at all")
+        XCTAssertEqual(
+            creations,
+            1,
+            """
+            Found \(creations) uses of AXUIElementCreateApplication in Accessibility.swift. \
+            Exactly ONE is allowed — the one inside `axApp(_:)`, which stamps the \
+            per-app messaging timeout on. Any other site produces an AX element with NO \
+            timeout, and a single call against a launching or wedged app can then block \
+            the driver forever. Route it through `AccessibilityManager.axApp(pid)`.
+            """)
+    }
+
+    /// …and that single use must be the one immediately bounded by a timeout.
+    func testTheSoleApplicationElementIsGivenAMessagingTimeout() throws {
+        let source = try accessibilitySource()
+
+        guard let axAppRange = source.range(of: "static func axApp(") else {
+            return XCTFail("axApp(_:) is gone — the bounded-element contract has no home")
+        }
+        guard let creationRange = source.range(of: "AXUIElementCreateApplication") else {
+            return XCTFail("no AX application element is constructed at all")
+        }
+        XCTAssertTrue(
+            creationRange.lowerBound > axAppRange.lowerBound,
+            "the only AXUIElementCreateApplication must be the one inside axApp(_:)")
+
+        // The timeout must be applied to that element, not merely to the
+        // system-wide one (which does not propagate).
+        let tail = source[creationRange.upperBound...]
+        let boundedSoon = tail.prefix(200).contains("AXUIElementSetMessagingTimeout")
+        XCTAssertTrue(
+            boundedSoon,
+            """
+            axApp(_:) built an application element without immediately calling \
+            AXUIElementSetMessagingTimeout on it. Without that, the element is unbounded: \
+            the system-wide timeout does not propagate to per-application elements.
+            """)
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Driver/AccessibilityBoundedElementSourceTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Driver/AccessibilityBoundedElementSourceTests.swift
@@ -44,6 +44,7 @@ final class AccessibilityBoundedElementSourceTests: XCTestCase {
             .deletingLastPathComponent()  // Driver
             .deletingLastPathComponent()  // ComputerUse
             .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // OsaurusCore (source lives outside Tests/)
         let source = packageRoot
             .appendingPathComponent("ComputerUse/Driver/Mac/Accessibility.swift")
         return try String(contentsOf: source, encoding: .utf8)

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "8f731c2388daeab1c257303bf653a00218ee51dd""#))
-        #expect(packageResolved.contains(#""revision" : "8f731c2388daeab1c257303bf653a00218ee51dd""#))
-        #expect(workspaceResolved.contains(#""revision" : "8f731c2388daeab1c257303bf653a00218ee51dd""#))
-        #expect(appResolved.contains(#""revision" : "8f731c2388daeab1c257303bf653a00218ee51dd""#))
+        #expect(packageSwift.contains(#"revision: "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
+        #expect(packageResolved.contains(#""revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
+        #expect(workspaceResolved.contains(#""revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
+        #expect(appResolved.contains(#""revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -700,7 +700,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "8f731c2388daeab1c257303bf653a00218ee51dd"
+        let expectedRuntimeHardenedRevision = "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8f731c2388daeab1c257303bf653a00218ee51dd"
+        "revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
       }
     },
     {


### PR DESCRIPTION
Consolidated PR.

## Changes
1. **Computer Use: bound the two AX calls on the open-app path** — fixes the first-GUI-action beachball (unbounded `AXUIElementCopyAttributeValue`/messaging on the open-app path). Live-proven via Computer Use (TextEdit opens, no beachball).
2. **Fix AccessibilityBoundedElementSource test path** — the AX source-guard tests resolved `packageRoot` to `Packages/OsaurusCore/Tests` (three `deletingLastPathComponent`) and appended `ComputerUse/Driver/Mac/Accessibility.swift`, producing a nonexistent `Tests/ComputerUse/...` path → both tests errored "no such file". One more deletion reaches `Packages/OsaurusCore`, where the source actually lives. This was the sole `test-core` failure.
3. **Repin vmlx-swift → a9b10f60 (#148)** — picks up the SpecDec fix that flushes the detokenizer's held-back tail at end of stream, so the last ≤24 characters of speculative-decode answers are no longer dropped. Updates Package.swift, all three Package.resolved, and the two revision tripwire tests.

## Verification
- vmlx@a9b10f60 resolves cleanly (`swift package resolve` OK).
- test-core previously failed ONLY on the two AX path tests (now fixed); test-cli / test-evals / swiftlint / shellcheck were green.
- AX bounding live-proven on the dev app.