### PR TITLE
fix scheduled runs never completing by evicting finished headless tasks

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -854,6 +854,16 @@ public final class BackgroundTaskManager: ObservableObject {
         func pumpQueueForTesting() {
             pumpQueue()
         }
+
+        /// Test-only: whether a terminal-state auto-finalize timer is pending
+        /// for this task. Locks in that `markCompleted` schedules its own
+        /// eviction the same way `cancelTask` does — without it a finished
+        /// headless run (schedule / plugin / HTTP) lingers in the registry and
+        /// the next dispatch reattaching by `externalSessionKey` collides with
+        /// the stale `.completed` state.
+        func hasPendingAutoFinalizeForTesting(_ id: UUID) -> Bool {
+            autoFinalizeTasks[id] != nil
+        }
     #endif
 
     private func createContext(for request: DispatchRequest) -> ExecutionContext {
@@ -978,6 +988,20 @@ public final class BackgroundTaskManager: ObservableObject {
             outputText: outputText
         )
         emitPluginEvent(state, type: eventType, json: json)
+        // Evict the finished task the same way the cancel path does
+        // (`cancelTask` -> `scheduleAutoFinalize`). Without this a completed
+        // *headless* run (schedule / plugin / HTTP — no window) is never
+        // removed from `backgroundTasks`, its observers are never cancelled,
+        // and its id lingers in `streamingObserved`. The next dispatch that
+        // reattaches by `externalSessionKey` (schedules reuse `schedule.id`)
+        // then collides with the zombie state: `awaitCompletion` short-
+        // circuits on the stale `.completed`, stacked observers double-fire
+        // streaming transitions, and leaked runs eventually saturate the
+        // execution slots so later fires queue and never start. Interactive
+        // runs avoid the leak via `openTaskWindow` -> `finalizeTask`; the
+        // 15s auto-finalize is the headless equivalent (and is cancelled by
+        // `finalizeTask` if a window opens the chat first).
+        scheduleAutoFinalize(state.id)
         recomputeSortedToastTasks()
         pumpQueue()
     }

--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -978,6 +978,20 @@ public final class BackgroundTaskManager: ObservableObject {
             outputText: outputText
         )
         emitPluginEvent(state, type: eventType, json: json)
+        // Evict the finished task the same way the cancel path does
+        // (`cancelTask` -> `scheduleAutoFinalize`). Without this a completed
+        // *headless* run (schedule / plugin / HTTP — no window) is never
+        // removed from `backgroundTasks`, its observers are never cancelled,
+        // and its id lingers in `streamingObserved`. The next dispatch that
+        // reattaches by `externalSessionKey` (schedules reuse `schedule.id`)
+        // then collides with the zombie state: `awaitCompletion` short-
+        // circuits on the stale `.completed`, stacked observers double-fire
+        // streaming transitions, and leaked runs eventually saturate the
+        // execution slots so later fires queue and never start. Interactive
+        // runs avoid the leak via `openTaskWindow` -> `finalizeTask`; the
+        // 15s auto-finalize is the headless equivalent (and is cancelled by
+        // `finalizeTask` if a window opens the chat first).
+        scheduleAutoFinalize(state.id)
         recomputeSortedToastTasks()
         pumpQueue()
     }

--- a/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskStreamingObserverTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/BackgroundTaskStreamingObserverTests.swift
@@ -74,6 +74,26 @@ struct BackgroundTaskStreamingObserverTests {
         #expect(state.status == .completed(summary: "Chat completed"))
     }
 
+    /// A completed headless task must schedule its own eviction (mirroring
+    /// the cancel path) so it doesn't linger in the registry. Without this a
+    /// later schedule reattaching by `externalSessionKey` collides with the
+    /// stale `.completed` state: `awaitCompletion` short-circuits on old data
+    /// and leaked runs eventually saturate the execution slots — the "runs
+    /// forever" bug.
+    @Test
+    func observeChatTask_schedulesAutoFinalizeAfterCompletion() async throws {
+        let (state, mgr) = makeObservedState()
+        defer { mgr.finalizeTask(state.id) }
+
+        state.chatSession?.isStreaming = true
+        try await Task.sleep(for: .milliseconds(10))
+        state.chatSession?.isStreaming = false
+        try await Task.sleep(for: .milliseconds(10))
+
+        #expect(state.status == .completed(summary: "Chat completed"))
+        #expect(mgr.hasPendingAutoFinalizeForTesting(state.id))
+    }
+
     /// A stream error before completion must transition the task to
     /// `.failed(summary: <error>)`.
     @Test


### PR DESCRIPTION
## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
