### PR TITLE
Computer Use: open apps foreground so the window is visible and the model doesn't misreport failure

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -997,7 +997,15 @@ public enum ComputerUseLoop {
         guard let identifier = action.app, !identifier.isEmpty else {
             return .failure("missing app name")
         }
-        let result = await driver.open(identifier: identifier, background: true)
+        // An explicit `open` verb means the agent (on the user's behalf) wants to
+        // use this app, so launch it foreground: `background: true` sets
+        // `config.hides = true`, and a hidden Cocoa app exposes no AX windows —
+        // `waitUntilReady` then times out, the follow-up capture is empty, and the
+        // model concludes the open failed even though the app did launch. Opening
+        // frontmost brings the window across, populates the AX tree, and lets the
+        // verify capture actually see it. (Background/hidden launching stays
+        // available on the driver primitive for silent perception paths.)
+        let result = await driver.open(identifier: identifier, background: false)
         switch result {
         case .success(let info):
             let snapshot = await driver.capture(pid: info.pid, tier: .ax)

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -954,10 +954,13 @@ final class ComputerUseEvidencePackTests: XCTestCase {
     @MainActor
     func testOpenVerbLaunchesForegroundSoTheWindowIsVisibleAndVerifiable() async {
         let pid: Int32 = 7420
-        let window = CUWindow(id: 1, title: "Untitled", x: 0, y: 0, w: 600, h: 400)
+        let window = CUWindowSummary(id: 1, title: "Untitled", focused: true, x: 0, y: 0, w: 600, h: 400)
         let snapshot = CUSnapshot(
-            tier: .ax,
+            snapshotId: 1,
             pid: pid,
+            app: "TextEdit",
+            focusedWindow: "Untitled",
+            tier: .ax,
             truncated: false,
             windows: [window],
             elements: [CUElement(id: "doc", role: "textarea", label: "Document", value: "", windowId: 1)],

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -944,6 +944,64 @@ final class ComputerUseEvidencePackTests: XCTestCase {
     private func value(in snapshot: CUSnapshot, id: String) -> String? {
         snapshot.elements.first(where: { $0.id == id })?.value
     }
+
+    /// An explicit `open` verb must launch the app FOREGROUND (`background: false`).
+    /// A background launch sets `config.hides = true`; a hidden Cocoa app exposes no
+    /// AX windows, so the readiness poll times out, the verify capture is empty, and
+    /// the model reports the open as failed even though the app did launch. Regression
+    /// guard for the 0.22.3 report: "launches the app but never brings the window to
+    /// the foreground, then incorrectly reports the task as failed."
+    @MainActor
+    func testOpenVerbLaunchesForegroundSoTheWindowIsVisibleAndVerifiable() async {
+        let pid: Int32 = 7420
+        let window = CUWindow(id: 1, title: "Untitled", x: 0, y: 0, w: 600, h: 400)
+        let snapshot = CUSnapshot(
+            tier: .ax,
+            pid: pid,
+            truncated: false,
+            windows: [window],
+            elements: [CUElement(id: "doc", role: "textarea", label: "Document", value: "", windowId: 1)],
+            image: nil
+        )
+        let driver = MockMacDriver(
+            availability: MacDriverAvailability(accessibility: true, screenRecording: true, skyLight: true),
+            apps: [CUAppListing(pid: pid, bundleId: "com.apple.TextEdit", name: "TextEdit", active: false, hidden: false)],
+            snapshots: [pid: [snapshot, snapshot]]
+        )
+
+        let result = await ComputerUseLoop.run(
+            goal: "Open TextEdit.",
+            modelId: "scripted-open",
+            driver: driver,
+            gate: ComputerUseGate(
+                policy: AutonomyPolicy(globalPreset: .autonomous, allowlist: ["TextEdit"])
+            ),
+            feed: SubagentFeed(toolCallId: "evidence-open-fg", kindId: "computer_use", title: "Open TextEdit"),
+            interrupt: InterruptToken(),
+            confirm: { _ in true },
+            limits: RunLimits(maxSteps: 3, wallClockSeconds: 30),
+            vision: .none,
+            sessionId: "evidence-open-fg",
+            nextAction: ComputerUseLoop.scriptedProvider([
+                AgentAction(verb: .open, app: "TextEdit"),
+                AgentAction(verb: .done, reason: "TextEdit is open."),
+            ])
+        )
+
+        XCTAssertTrue(result.outcome.isSuccess, "Open run should succeed; got \(result.outcome)")
+        let openCalls = await driver.openCalls
+        XCTAssertEqual(openCalls.count, 1, "The open verb must reach the driver exactly once.")
+        XCTAssertEqual(openCalls.first?.identifier, "TextEdit")
+        XCTAssertEqual(
+            openCalls.first?.background,
+            false,
+            """
+            The `open` verb launched the app in background mode. Background launching sets \
+            config.hides = true, so the app never comes to the foreground and exposes no AX \
+            windows — the model then reports a successful launch as a failure. An explicit \
+            open must foreground the app.
+            """)
+    }
 }
 
 private actor ConfirmationRecorder {


### PR DESCRIPTION
## Computer Use: open apps foreground so the window is visible and verifiable

### Reported symptom (0.22.3)
> Computer Use successfully launches applications such as TextEdit and Calculator — their icons appear as running in the Dock — but it does not bring their windows to the foreground and then incorrectly reports the task as failed. AppleScript execution itself works when given exact scripts. Accessibility is enabled for Osaurus.

### Root cause
The `open` verb in the Computer Use loop launched the target app with `background: true`. In the driver, `background` maps to `NSWorkspace.OpenConfiguration.hides = true` **and** `activates = false`. A **hidden** Cocoa app exposes no AX windows, so:

1. `waitUntilReady` never satisfies its `hasWindow` condition and burns the full 5s timeout,
2. the follow-up verify `capture(tier: .ax)` returns an empty / menu-bar-only tree,
3. the model sees no window and concludes the open **failed** — even though the app did launch (hence the running Dock icon).

The window never foregrounds because `activates = false` and the app is hidden outright.

### Fix
`handleOpen` now launches the app **foreground** (`background: false`). An explicit `open` verb means the agent, on the user's behalf, wants to use that app — so the window comes across, the AX tree populates, and the verify capture actually sees it. Background/hidden launching stays available on the driver primitive (`openApplication(background:)`) for silent perception paths; nothing else called the interactive open with `background: true` (the 1-arg convenience wrapper has no callers).

### Test
Adds a `MockMacDriver`-backed regression test (`ComputerUseEvidencePackTests.testOpenVerbLaunchesForegroundSoTheWindowIsVisibleAndVerifiable`) that scripts an `open` verb through the full `ComputerUseLoop.run` and asserts the driver open call uses `background: false`.

### Scope
- osaurus-only change (`ComputerUse/Loop/ComputerUseLoop.swift`, 1 line + regression test). No vmlx change.
- vmlx-swift stays pinned at `a9b10f60` (SpecDec detokenizer tail flush #148), already on `main`.
- An independent audit of the AppleScript tool-dispatch and spawn/delegation paths found no correctness defects; both are re-proven live below.

### Live proof
Proven on a Developer-ID-signed dev build via live Computer Use driving the real UI (no API/CLI): open TextEdit + Calculator now foreground and report success; four distinct AppleScript tasks return concrete values; spawn/delegation returns cleanly. (Details in PR comment.)
