### PR TITLE
Fix spawn_model target contract

### DIFF
--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
@@ -207,14 +207,11 @@ enum AgentSubagentRunner {
                         + TokenEstimator.estimate(outcome.reasoning)
                 }
                 usage.completionTokens += stepCompletion
-                if let tps = outcome.tokensPerSecond {
-                    usage.tokensPerSecond = tps
-                } else if stepCompletion > 0 {
-                    let elapsed = Date().timeIntervalSince(stepStarted)
-                    if elapsed > 0.5 {
-                        usage.tokensPerSecond = Double(stepCompletion) / elapsed
-                    }
-                }
+                usage.tokensPerSecond = resolvedTokensPerSecond(
+                    reported: outcome.tokensPerSecond,
+                    completionTokens: stepCompletion,
+                    elapsed: Date().timeIntervalSince(stepStarted)
+                ) ?? usage.tokensPerSecond
 
                 if !outcome.toolCalls.isEmpty {
                     // Frame the assistant tool_calls message exactly as the
@@ -338,6 +335,26 @@ enum AgentSubagentRunner {
                 usage: usage
             )
         }
+    }
+
+    /// Prefer a provider/runtime decode rate when it is genuinely populated.
+    /// Remote providers that report token counts but omit throughput currently
+    /// encode `0` in the terminal stats hint; treat that sentinel value as
+    /// unavailable and fall back to measured end-to-end model-step throughput.
+    /// This is deliberately conservative (the elapsed interval includes TTFT)
+    /// but remains real telemetry rather than a synthetic sampler default.
+    static func resolvedTokensPerSecond(
+        reported: Double?,
+        completionTokens: Int,
+        elapsed: TimeInterval
+    ) -> Double? {
+        if let reported, reported.isFinite, reported > 0 {
+            return reported
+        }
+        guard completionTokens > 0, elapsed.isFinite, elapsed > 0 else {
+            return nil
+        }
+        return Double(completionTokens) / elapsed
     }
 
     // MARK: - Stream consumption

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2255,6 +2255,26 @@ public struct SystemPromptComposer: Sendable {
             byName = byName.filter { allowed.contains($0.key) }
         }
 
+        // `spawn_model` is agent-scoped, so its request-local schema should be
+        // agent-scoped too. Publish the exact legal ids as a nested enum. Remote
+        // providers can validate/select them directly, local tool parsers receive
+        // the same contract, and a blank/guessed id is corrected before the
+        // provider-routing gate. Execution still re-checks the allow-list.
+        if let spawnModel = byName[SubagentCapabilityRegistry.spawnModelToolName] {
+            let config = SubagentConfigurationStore.snapshot()
+            let allowedModelIds = SubagentToolVisibility.effectiveSpawnableModels(
+                isDefault: snapshot.agentId == Agent.defaultId,
+                config: config,
+                perAgentEnabled: snapshot.spawnDelegationEnabled,
+                perAgentModelTargets: snapshot.spawnableModelNames
+            )
+            byName[SubagentCapabilityRegistry.spawnModelToolName] =
+                SpawnModelTool.constrainedSpec(
+                    spawnModel,
+                    allowedModelIds: allowedModelIds
+                )
+        }
+
         // Generation-only image schema: when `image` survived the gates but no
         // ready edit model is installed, swap it to the edit-free variant (no
         // `source_paths` / `strength`, generation-only description) so the model

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -262,16 +262,27 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
         settings: AgentSettings?
     ) async throws -> ResolvedModel {
         let perAgentModelTargets = settings?.spawnableModelNames ?? []
+        let allowedModelTargets = SubagentToolVisibility.effectiveSpawnableModels(
+            isDefault: isDefault,
+            config: config,
+            perAgentEnabled: settings?.spawnDelegationEnabled ?? false,
+            perAgentModelTargets: perAgentModelTargets
+        )
         guard
             SubagentToolVisibility.spawnModelAllowed(
                 modelId,
                 isDefault: isDefault,
                 config: config,
-                perAgentModelTargets: perAgentModelTargets
+                perAgentModelTargets: allowedModelTargets
             )
         else {
             throw SubagentError.denied(
-                Self.notSpawnableMessage(kind: "Model", name: modelId, isDefault: isDefault)
+                Self.notSpawnableMessage(
+                    kind: "Model",
+                    name: modelId,
+                    isDefault: isDefault,
+                    allowedNames: allowedModelTargets
+                )
             )
         }
 
@@ -580,10 +591,18 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
     /// Shared "not spawnable" denial copy for both targets, so the agent and
     /// model messages can't drift. `kind` is the capitalized noun ("Agent" /
     /// "Model"); the tab pointer differs for the main chat vs a custom agent.
-    private static func notSpawnableMessage(kind: String, name: String, isDefault: Bool) -> String {
-        isDefault
+    private static func notSpawnableMessage(
+        kind: String,
+        name: String,
+        isDefault: Bool,
+        allowedNames: [String] = []
+    ) -> String {
+        let base = isDefault
             ? "\(kind) '\(name)' is not spawnable. Add it in the main chat's Subagents tab."
             : "\(kind) '\(name)' is not spawnable from this agent. Add it in the agent's Subagents tab."
+        guard !allowedNames.isEmpty else { return base }
+        let exact = allowedNames.map { "'\($0)'" }.joined(separator: ", ")
+        return base + " Use exactly one configured id: \(exact)."
     }
 
     private func seedMessages(systemPrompt: String, input: String) -> [ChatMessage] {

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -147,6 +147,20 @@ struct SystemPromptComposerToolResolutionTests {
         return Set(props.keys)
     }
 
+    /// Exact ids published in the request-local `spawn_model.model` enum.
+    private func spawnModelEnum(_ tools: [Tool]) -> [String] {
+        guard let spawn = tools.first(where: { $0.function.name == "spawn_model" }),
+            case .object(let root)? = spawn.function.parameters,
+            case .object(let properties)? = root["properties"],
+            case .object(let model)? = properties["model"],
+            case .array(let values)? = model["enum"]
+        else { return [] }
+        return values.compactMap {
+            if case .string(let value) = $0 { return value }
+            return nil
+        }
+    }
+
     // MARK: - Auto mode
 
     @Test
@@ -776,17 +790,21 @@ struct SystemPromptComposerToolResolutionTests {
             #expect(!withAgents.contains("image"))
 
             // Model pool only → spawn_model, not spawn_agent.
-            let withModels = Set(
-                SystemPromptComposer.resolveTools(
-                    snapshot: makeSnapshot(
-                        spawnDelegationEnabled: true,
-                        spawnableModelNames: ["qwen3-4b-4bit"]
-                    ),
-                    executionMode: .none
-                ).map { $0.function.name }
+            let remoteModelIds = [
+                "openai-chatgpt/gpt-5.6-sol",
+                "anthropic/claude-opus-4-8",
+            ]
+            let modelTools = SystemPromptComposer.resolveTools(
+                snapshot: makeSnapshot(
+                    spawnDelegationEnabled: true,
+                    spawnableModelNames: remoteModelIds
+                ),
+                executionMode: .none
             )
+            let withModels = Set(modelTools.map { $0.function.name })
             #expect(withModels.contains("spawn_model"))
             #expect(!withModels.contains("spawn_agent"))
+            #expect(spawnModelEnum(modelTools) == remoteModelIds)
 
             // Toggle on but BOTH lists empty → nothing to spawn → both hidden.
             let noTargets = Set(

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnToolTests.swift
@@ -64,6 +64,15 @@ struct SpawnToolTests {
         #expect(ToolEnvelope.isError(malformed))
     }
 
+    @Test func spawnModelRejectsWhitespaceModelBeforeSpawnabilityGate() async throws {
+        let result = try await SpawnModelTool().execute(
+            argumentsJSON: #"{"input":"do a thing","model":"   \n\t"}"#
+        )
+        #expect(ToolEnvelope.isError(result))
+        #expect(ToolEnvelope.failureMessage(result).contains("cannot be blank"))
+        #expect(!ToolEnvelope.failureMessage(result).contains("Model '' is not spawnable"))
+    }
+
     @Test func bypassesRegistryTimeout() {
         // The nested loop outlives the registry's per-tool wall clock; both spawn
         // tools must opt out so the host owns the deadline.

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnToolTests.swift
@@ -108,6 +108,41 @@ struct SpawnToolTests {
         #expect(kind.feedTitle.contains("qwen3-4b-4bit"))
     }
 
+    @Test func spawnModelUsagePrefersPositiveProviderThroughput() {
+        let resolved = AgentSubagentRunner.resolvedTokensPerSecond(
+            reported: 73.5,
+            completionTokens: 42,
+            elapsed: 2.0
+        )
+        #expect(resolved == 73.5)
+    }
+
+    @Test func spawnModelUsageMeasuresThroughputWhenProviderReportsZero() {
+        let resolved = AgentSubagentRunner.resolvedTokensPerSecond(
+            reported: 0,
+            completionTokens: 5,
+            elapsed: 0.25
+        )
+        #expect(resolved == 20)
+    }
+
+    @Test func spawnModelUsageDoesNotInventThroughputWithoutMeasurement() {
+        #expect(
+            AgentSubagentRunner.resolvedTokensPerSecond(
+                reported: nil,
+                completionTokens: 5,
+                elapsed: 0
+            ) == nil
+        )
+        #expect(
+            AgentSubagentRunner.resolvedTokensPerSecond(
+                reported: .nan,
+                completionTokens: 0,
+                elapsed: 1
+            ) == nil
+        )
+    }
+
     /// Per-agent spawnable enforcement (agents): a CUSTOM launching agent may
     /// only spawn agents in its OWN `spawnableAgentNames` list — the global
     /// pool does NOT apply to it. Here the main chat's pool lists "Helper", but

--- a/Packages/OsaurusCore/Tools/SpawnModelTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnModelTool.swift
@@ -44,13 +44,52 @@ public final class SpawnModelTool: OsaurusTool, @unchecked Sendable {
 
     public init() {}
 
+    /// Narrow the request-local schema to the launching agent's actual model
+    /// pool. The base registry spec must stay agent-neutral, but the schema sent
+    /// to a model has the agent snapshot available and should not advertise an
+    /// unconstrained string that can only fail later at the execution gate.
+    ///
+    /// The executor still enforces the allow-list independently. This enum is
+    /// guidance + provider-side validation, not the security boundary.
+    static func constrainedSpec(_ tool: Tool, allowedModelIds: [String]) -> Tool {
+        let normalized = SubagentConfiguration.normalizedSpawnableModelNames(allowedModelIds)
+        guard !normalized.isEmpty,
+            case .object(var root)? = tool.function.parameters,
+            case .object(var properties)? = root["properties"],
+            case .object(var model)? = properties["model"]
+        else { return tool }
+
+        model["enum"] = .array(normalized.map(JSONValue.string))
+        properties["model"] = .object(model)
+        root["properties"] = .object(properties)
+        return Tool(
+            type: tool.type,
+            function: ToolFunction(
+                name: tool.function.name,
+                description: tool.function.description,
+                parameters: .object(root)
+            )
+        )
+    }
+
     public func execute(argumentsJSON: String) async throws -> String {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
         let inputReq = requireString(args, "input", expected: "the task for the subagent", tool: name)
         guard case .value(let input) = inputReq else { return inputReq.failureEnvelope ?? "" }
         let modelReq = requireString(args, "model", expected: "a spawnable model id", tool: name)
-        guard case .value(let model) = modelReq else { return modelReq.failureEnvelope ?? "" }
+        guard case .value(let rawModel) = modelReq else { return modelReq.failureEnvelope ?? "" }
+        let model = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Argument 'model' cannot be blank.",
+                field: "model",
+                expected: "one exact model id from this agent's spawn_model schema",
+                tool: name,
+                retryable: true
+            )
+        }
 
         // The shared host owns the recursion guard, live feed, permission
         // verdict, residency handoff, compact-result normalization, and


### PR DESCRIPTION
## Summary

- constrain the request-local `spawn_model` model schema to the launching agent exact allowed model IDs
- reject blank and whitespace-only model arguments as invalid arguments before the spawnability/provider-routing gate
- include configured IDs in nonblank denial errors while retaining the execution-time allowlist check
- preserve positive provider/runtime throughput, but measure conservative end-to-end model-step throughput when a remote provider reports completion tokens with the `0 tok/s` sentinel
- add executor, request-schema, and spawn throughput regressions

This addresses the 0.22.x failure that surfaced as `Model empty is not spawnable` before any provider was contacted. It does not invent aliases, defaults, fallback models, or sampler/prompt masking.

Computer Use foreground launching is already fixed independently by #2032; this branch is based on the main commit containing that merged fix. The vmlx-swift pin remains unchanged at `a9b10f60`.

## Verification

- `SpawnToolTests`: 14 passed
- `SystemPromptComposerToolResolutionTests`: 33 passed
- expanded settings/residency/delegation matrix: 135 tests in 10 suites passed
- `ComputerUseEvidencePackTests/testOpenVerbLaunchesForegroundSoTheWindowIsVisibleAndVerifiable`: passed
- release app build: succeeded
- PR CI on `00051cc7c`: `test-core`, `test-evals`, `test-cli`, SwiftLint, shellcheck, and release-draft all passed
- `git diff --check`

## Live proof

Run against the installed Developer-ID-signed app built from `00051cc7c`:

- TextEdit: Computer Use returned `ok: true` after one step with `Opened TextEdit and confirmed it is in the foreground.`; 12.3s tool duration, 31.9 parent tok/s
- Calculator: Computer Use returned `ok: true` after one step with `Successfully opened the Calculator application and verified it is in the foreground.`; 12.3s tool duration, 31.3 parent tok/s
- the app remained responsive after both GUI actions; no beachball or forced restart
- local `spawn_model` target `mlx-community/Qwen3-0.6B-8bit` completed through `handoff=true`, with unload/restore phase order, 374.4 child tok/s, and a restored 30.8 tok/s parent continuation
- connected-provider `spawn_model` target `dsv4/deepseek-v4-flash` returned exactly `REMOTE-TPS-PONG`; 1.49s tool duration, 0.403s child model step, 17.4 measured child tok/s, 7 completion tokens, and a coherent 31.2 tok/s parent final
- the temporary remote model allowlist entry used for proof was removed afterward; the agent original two entries remain
- the live Subagents settings surface showed Spawn enabled, default model set to `Use the agent model`, and both allowed-model entries present
- exact AppleScript rows: volume `0`, date `2026-7-14`, Finder desktop count `18`, and frontmost app `Screen Sharing`; all succeeded with emitted token/s