### PR TITLE
Pin vmlx for native 1-bit JANG support

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
+        "revision" : "1ca402953bf941341889bb00b186e46bf0c18d6f"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -2045,7 +2045,12 @@ extension ModelManager {
                         id: id,
                         name: ModelMetadataParser.friendlyName(from: id),
                         description: L("Local model (detected)"),
-                        downloadURL: "https://huggingface.co/\(id)"
+                        downloadURL: "https://huggingface.co/\(id)",
+                        // The scan already runs off-main. Preserve the bundle's
+                        // architecture tag here so hot UI paths can distinguish
+                        // image-only from video-capable local VLMs without
+                        // re-reading config.json during SwiftUI layout.
+                        modelType: VLMDetection.readModelType(at: resolved)
                     )
                     models.append(model)
                 }

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -261,7 +261,8 @@ public enum ModelMediaCapabilities {
     /// granting audio or video.
     public static func composerCapabilities(
         modelId: String?,
-        fallbackSupportsImages: Bool
+        fallbackSupportsImages: Bool,
+        localModelType: String? = nil
     ) -> Capabilities {
         guard let modelId,
             !modelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -275,6 +276,24 @@ public enum ModelMediaCapabilities {
             !ModelFamilyNames.isNemotronOmniFamily(modelId)
         {
             return .textOnly
+        }
+        // A locally installed bundle may have a product name that does not
+        // advertise its architecture (for example Bonsai-27b-1bit-JANG).
+        // The background model scan records config.json's model_type, while
+        // fallbackSupportsImages proves this particular bundle has a vision
+        // path. Combine those two facts so video-capable Qwen/SmolVLM bundles
+        // do not get downgraded to image-only by their display name. Never use
+        // model_type alone: text-only Qwen 3.5 bundles share the same outer
+        // type and must not acquire media support without the vision bit.
+        if fallbackSupportsImages,
+            let localModelType,
+            videoCapableModelTypes.contains(localModelType.lowercased())
+        {
+            return Capabilities(
+                supportsImage: true,
+                supportsVideo: true,
+                supportsAudio: detected.supportsAudio
+            )
         }
         guard fallbackSupportsImages, !detected.supportsImage else {
             return detected
@@ -296,19 +315,23 @@ public enum ModelMediaCapabilities {
 
     public static func composerDescriptor(
         modelId: String?,
-        fallbackSupportsImages: Bool
+        fallbackSupportsImages: Bool,
+        localModelType: String? = nil
     ) -> Descriptor {
         let normalized = modelId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let displayId = normalized.isEmpty ? "unspecified model" : normalized
         let capabilities = composerCapabilities(
             modelId: modelId,
-            fallbackSupportsImages: fallbackSupportsImages
+            fallbackSupportsImages: fallbackSupportsImages,
+            localModelType: localModelType
         )
         let detected = normalized.isEmpty ? Capabilities.textOnly : from(modelId: normalized)
         let source =
-            fallbackSupportsImages && capabilities.supportsImage && !detected.supportsImage
-            ? "composer fallback"
-            : "model id"
+            capabilities.supportsVideo && !detected.supportsVideo && localModelType != nil
+            ? "local bundle model_type"
+            : fallbackSupportsImages && capabilities.supportsImage && !detected.supportsImage
+                ? "composer fallback"
+                : "model id"
         return buildDescriptor(
             modelId: displayId,
             capabilities: capabilities,
@@ -380,14 +403,6 @@ public enum ModelMediaCapabilities {
 
         // Cross-check the family-by-model_type for video support.
         // model_types known to support video at the engine level:
-        let videoCapableModelTypes: Set<String> = [
-            "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
-            "qwen3_5", "qwen3_5_moe",
-            "qwen3_6", "qwen3_6_moe",
-            "smolvlm",
-            "nemotron_h_omni",
-            "NemotronH_Nano_Omni_Reasoning_V3".lowercased(),
-        ]
         if videoCapableModelTypes.contains(modelType) {
             // Audio belongs only to omni — already returned above.
             return .imageVideo
@@ -432,6 +447,15 @@ public enum ModelMediaCapabilities {
     }
 
     // MARK: - Helpers
+
+    private static let videoCapableModelTypes: Set<String> = [
+        "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
+        "qwen3_5", "qwen3_5_moe",
+        "qwen3_6", "qwen3_6_moe",
+        "smolvlm",
+        "nemotron_h_omni",
+        "NemotronH_Nano_Omni_Reasoning_V3".lowercased(),
+    ]
 
     private static func buildDescriptor(
         modelId: String,

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
+        "revision" : "1ca402953bf941341889bb00b186e46bf0c18d6f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -58,10 +58,12 @@ let package = Package(
         // scope; the compile() overloads and innerCall degrade to empty
         // results instead of trapping on a failed closure evaluation — so a
         // recorded MLX error reaches the error-scope exit instead of dying in
-        // a Swift bounds check. Contains the previous ff714f1 pin.
+        // a Swift bounds check. Contains the previous ff714f1 pin. Now also
+        // carries #149: native schema-2 affine1 JANG loading and Metal kernels,
+        // Qwen3-VL tool-schema preservation, and bounded media-cache cleanup.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
+            revision: "1ca402953bf941341889bb00b186e46bf0c18d6f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -218,6 +218,24 @@ struct ModelManagerTests {
         #expect(detected.count == 4)
     }
 
+    @Test func scanLocalModels_preservesModelTypeForComposerMediaGating() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("osu-media-type-\(UUID().uuidString)")
+        let bundle = root.appendingPathComponent("Bonsai-27b-1bit-JANG")
+        try fm.createDirectory(at: bundle, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        try Data(#"{"model_type":"qwen3_5","vision_config":{}}"#.utf8)
+            .write(to: bundle.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: bundle.appendingPathComponent("tokenizer.json"))
+        try Data().write(to: bundle.appendingPathComponent("model.safetensors"))
+
+        let detected = ModelManager.scanLocalModels(at: root)
+        let model = try #require(detected.first)
+        #expect(model.id == "Bonsai-27b-1bit-JANG")
+        #expect(model.modelType == "qwen3_5")
+    }
+
     @Test func scanLocalModels_detectsFlatAndNestedLayouts() async throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("osu-scan-\(UUID().uuidString)")

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -380,4 +380,33 @@ struct ModelMediaCapabilitiesMCDCTests {
             ) == .omni
         )
     }
+
+    @Test("Composer upgrades an opaque local Qwen 3.5 VLM name to image plus video")
+    func composerCapabilities_usesScannedLocalModelTypeForVideo() {
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "bonsai-27b-1bit-jang",
+                fallbackSupportsImages: true,
+                localModelType: "qwen3_5"
+            ) == .imageVideo
+        )
+        #expect(
+            ModelMediaCapabilities.composerDescriptor(
+                modelId: "bonsai-27b-1bit-jang",
+                fallbackSupportsImages: true,
+                localModelType: "QWEN3_5"
+            ).video.reason.contains("local bundle model_type")
+        )
+    }
+
+    @Test("Local Qwen model_type alone never grants media to a text-only bundle")
+    func composerCapabilities_localModelTypeNeedsVisionProof() {
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "opaque-qwen-checkpoint",
+                fallbackSupportsImages: false,
+                localModelType: "qwen3_5"
+            ) == .textOnly
+        )
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
-        #expect(packageResolved.contains(#""revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
-        #expect(workspaceResolved.contains(#""revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
-        #expect(appResolved.contains(#""revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4""#))
+        #expect(packageSwift.contains(#"revision: "1ca402953bf941341889bb00b186e46bf0c18d6f""#))
+        #expect(packageResolved.contains(#""revision" : "1ca402953bf941341889bb00b186e46bf0c18d6f""#))
+        #expect(workspaceResolved.contains(#""revision" : "1ca402953bf941341889bb00b186e46bf0c18d6f""#))
+        #expect(appResolved.contains(#""revision" : "1ca402953bf941341889bb00b186e46bf0c18d6f""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -693,6 +693,10 @@ struct RuntimePolicySourceTests {
         // store (#141) -- the "Safety Level" slider used to be a stored field no
         // resolver read, so it moved nothing.
         //
+        // Now also carries native schema-2 affine1 JANG loading and Metal
+        // execution, Qwen3-VL tool-schema preservation, and bounded media-cache
+        // cleanup (vmlx-swift#149).
+        //
         // This assertion is a repin tripwire, and it earned its keep: PR #1986
         // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
         // gate run against that build proved only the osaurus-side change while
@@ -700,7 +704,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
+        let expectedRuntimeHardenedRevision = "1ca402953bf941341889bb00b186e46bf0c18d6f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -708,7 +712,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift revision proven for this Gemma QAT correctness checkpoint: Gemma 4 QAT loader/parser fixes, paged-cache default policy, prefill progress wiring, Model2Vec static embedding APIs, and the post-merge pin/readiness proof. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift revision proven for the native affine1 JANG, Qwen3-VL tool-schema, and bounded media-cache checkpoint. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4196,9 +4196,17 @@ extension FloatingInputCard {
     /// substring/regex matcher; tests pin the boundary at
     /// `ModelMediaCapabilitiesMCDCTests`.
     private var mediaCapabilityDescriptor: ModelMediaCapabilities.Descriptor {
-        ModelMediaCapabilities.composerDescriptor(
+        // The local-model scan runs off-main and records config.json's
+        // model_type. Read only its non-blocking snapshot here: this getter is
+        // evaluated from SwiftUI body/layout and must never trigger a disk
+        // scan or synchronously parse a model bundle.
+        let localModelType = selectedModel.flatMap {
+            ModelManager.findInstalledMLXModelFromCache(named: $0)?.modelType
+        }
+        return ModelMediaCapabilities.composerDescriptor(
             modelId: selectedModel,
-            fallbackSupportsImages: supportsImages
+            fallbackSupportsImages: supportsImages,
+            localModelType: localModelType
         )
     }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a9b10f60e330337a9de2d8ebe3ca74a7370525e4"
+        "revision" : "1ca402953bf941341889bb00b186e46bf0c18d6f"
       }
     },
     {


### PR DESCRIPTION
## Summary

- pin `osaurus-ai/vmlx-swift` to merged commit `1ca402953bf941341889bb00b186e46bf0c18d6f` (vmlx-swift #149)
- bring native schema-2 affine1 JANG loading and Metal execution into Osaurus
- include Qwen3-VL tool-schema preservation and bounded media-cache cleanup
- preserve scanned local `model_type` so opaque local Qwen3.5 VLM names expose video only when the bundle also proves vision support
- keep all three resolved-package locks aligned with the manifest pin

## Dependency chain

- MLX PR osaurus-ai/mlx#2 merged at `9e01acd573a18540468160ccaffeb6fb566e891e`
- vmlx-swift PR osaurus-ai/vmlx-swift#149 merged at `1ca402953bf941341889bb00b186e46bf0c18d6f`

## Current source verification

- `ModelMediaCapabilitiesMCDCTests` plus the local-model scanner regression: 41 tests passed
- `RuntimePolicySourceTests`, `ImageGenerationBridgeContractTests`, the required-tool dispatch test, and required-tool template-context test: 93 tests passed
- `git diff --check` passed
- isolated Release app resolved the exact vmlx revision above

The complete local Osaurus suite is not claimed green: an untouched `ChatWindowSessionDetachTests` row failed in an earlier full run and that run later stalled. The focused changed-path suites above were rerun from this commit and passed.

## Live Release verification

Exact merged vmlx code against `/Users/eric/models/Bonsai-27b-1bit-JANG`:

- coherent two-turn text at 44.52 and 44.35 tok/s; peak physical-footprint delta about 1.55 GiB
- grounded image multi-turn and real-video multi-turn
- structured same-media cache hit and different-media miss
- structured tool call with no raw protocol leakage
- naturally closed reasoning with visible final answer and no marker leakage
- audio is not declared by the bundle and is not an applicable row

Isolated signed Osaurus Release app, without replacing or stopping `/Applications/osaurus.app`:

- model discovered as Bonsai 27b 1bit JANG with 27B / 128k metadata
- text callback returned ORCHID at 48.8 and 50.0 tok/s across two turns
- image attachment grounded the blue-circle/orange-square fixture at 45.3 tok/s
- rebuilt picker visibly advertised image + video support and accepted a real `.mov`
- video turn returned exactly `triangle` at 50.7 tok/s; dependent follow-up returned exactly `The video showed a triangle.` at 42.7 tok/s
- reasoning remained in the collapsed thought rail with no visible protocol markers
- two repeated seeded `auto` and two repeated seeded `required` API rows returned identical structured `multiply({"a":6,"b":7})` semantics at 29.9–35.6 tok/s
- Server settings visibly showed Prefix Cache on, GPU paged cache off, legacy disk cache off, and SSM re-derive on
- Live Activity showed one cache-enabled hybrid/paged-incompatible model and real disk-L2/SSM hit, miss, and store activity
- current app footprint after the combined text/image/video/tool session was 4,556 MB; observed process peak was 5,697 MB. The lower 1.55 GiB figure above is the vmlx text-row incremental peak and is intentionally reported separately.

The isolated proof app is separate from the installed/running Osaurus app.
