### PR TITLE
Align plugin capability status with runtime registry

### DIFF
--- a/Packages/OsaurusCore/Services/Plugin/PluginCapabilityProjection.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginCapabilityProjection.swift
@@ -1,0 +1,197 @@
+//
+//  PluginCapabilityProjection.swift
+//  osaurus
+//
+//  One read-only projection for every plugin surface shown in the Plugins UI.
+//  Native plugins and imported Claude plugins have different execution models;
+//  keeping that distinction prevents an imported skill package from being
+//  misreported as a loadable native plugin.
+//
+
+import Foundation
+
+enum PluginCapabilityKind: String, Sendable {
+    case native
+    case claude
+}
+
+enum PluginCapabilityStatus: String, Sendable {
+    case available
+    case installed
+    case needsAttention = "needs_attention"
+    case failed
+}
+
+struct PluginCapabilityProjectionRow: Equatable, Sendable {
+    let pluginId: String
+    let name: String
+    let kind: PluginCapabilityKind
+    let status: PluginCapabilityStatus
+    let installed: Bool
+    let installationHealthy: Bool
+    let enabledArtifactCount: Int
+    let version: String?
+    let latestVersion: String?
+    let nativeLoadFailed: Bool
+    let artifactCounts: ClaudePluginArtifactCounts?
+    let attentionReason: String?
+    let attentionClass: String?
+
+    var needsAttention: Bool { status == .needsAttention }
+    var failed: Bool { status == .failed }
+
+    var dictionary: [String: Any] {
+        var result: [String: Any] = [
+            "plugin_id": pluginId,
+            "name": name,
+            "kind": kind.rawValue,
+            "status": status.rawValue,
+            "installed": installed,
+            "installation_healthy": installationHealthy,
+            "enabled_artifact_count": enabledArtifactCount,
+            // Compatibility aliases retained for existing agent workflows.
+            "has_load_error": nativeLoadFailed,
+            "installed_version": version ?? "",
+            "load_error": nativeLoadFailed ? "The native plugin failed to load." : "",
+        ]
+        if let version { result["version"] = version }
+        if let latestVersion { result["latest_version"] = latestVersion }
+        if nativeLoadFailed {
+            result["failure_reason"] = "The native plugin failed to load."
+            result["failure_class"] = "native_load_failed"
+        }
+        if let artifactCounts {
+            result["artifacts"] = [
+                "skills": artifactCounts.skill,
+                "schedules": artifactCounts.schedule,
+                "commands": artifactCounts.command,
+                "mcp": artifactCounts.mcp,
+            ]
+        }
+        if let attentionReason {
+            result["attention_reason"] = attentionReason
+        }
+        if let attentionClass {
+            result["attention_class"] = attentionClass
+        }
+        return result
+    }
+}
+
+@MainActor
+enum PluginCapabilityProjection {
+    static func current() -> [PluginCapabilityProjectionRow] {
+        let claudePlugins = InstalledClaudePluginsAggregator.buildPlugins(
+            snapshots: ClaudePluginManifestStore.all(),
+            skills: SkillManager.shared.skills,
+            schedules: ScheduleManager.shared.schedules,
+            commands: SlashCommandRegistry.shared.customCommands,
+            providers: MCPProviderManager.shared.configuration.providers
+        )
+        return build(
+            nativePlugins: PluginRepositoryService.shared.plugins,
+            claudePlugins: claudePlugins
+        )
+    }
+
+    static func build(
+        nativePlugins: [PluginState],
+        claudePlugins: [ClaudePluginInstalled]
+    ) -> [PluginCapabilityProjectionRow] {
+        let nativeRows = nativePlugins.map { plugin in
+            let installed = plugin.installedVersion != nil
+            let loadFailed = installed && plugin.loadError != nil
+            return PluginCapabilityProjectionRow(
+                pluginId: plugin.pluginId,
+                name: plugin.displayName,
+                kind: .native,
+                status: loadFailed ? .failed : (installed ? .installed : .available),
+                installed: installed,
+                installationHealthy: installed && !loadFailed,
+                enabledArtifactCount: 0,
+                version: plugin.installedVersion?.description,
+                latestVersion: plugin.latestVersion?.description,
+                nativeLoadFailed: loadFailed,
+                artifactCounts: nil,
+                attentionReason: nil,
+                attentionClass: nil
+            )
+        }
+
+        let claudeRows = claudePlugins.map { plugin in
+            let needsAttention = plugin.needsPostInstallAttention || plugin.totalCount == 0
+            let enabledArtifactCount = plugin.skills.filter(\.enabled).count
+                + plugin.mcps.filter(\.enabled).count
+                + plugin.schedules.filter(\.isEnabled).count
+                + plugin.commands.count
+            return PluginCapabilityProjectionRow(
+                pluginId: plugin.pluginId,
+                name: plugin.displayName,
+                kind: .claude,
+                status: needsAttention ? .needsAttention : .installed,
+                installed: true,
+                installationHealthy: !needsAttention,
+                enabledArtifactCount: enabledArtifactCount,
+                version: plugin.version,
+                latestVersion: plugin.availableVersion,
+                nativeLoadFailed: false,
+                artifactCounts: plugin.counts,
+                attentionReason: attentionReason(for: plugin),
+                attentionClass: attentionClass(for: plugin)
+            )
+        }
+
+        return (nativeRows + claudeRows).sorted {
+            if $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedSame {
+                return $0.pluginId < $1.pluginId
+            }
+            return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    private static func attentionReason(for plugin: ClaudePluginInstalled) -> String? {
+        if plugin.totalCount == 0 {
+            return "No plugin artifacts are currently installed."
+        }
+        if plugin.hasPartialImport {
+            return "Some declared plugin components were not imported."
+        }
+        guard let outcome = plugin.snapshot?.installOutcome else { return nil }
+        if !outcome.errors.isEmpty {
+            return "The plugin import reported errors."
+        }
+        if !outcome.oauthProvidersNeedingSignIn.isEmpty {
+            return "An imported MCP provider requires sign-in."
+        }
+        if !outcome.placeholderTokensSkipped.isEmpty
+            || !outcome.stdioProvidersNeedingConfiguration.isEmpty
+        {
+            return "An imported MCP provider requires credential or environment configuration."
+        }
+        if !outcome.stdioProvidersBlockedNoSandbox.isEmpty {
+            return "An imported stdio MCP provider requires the sandbox."
+        }
+        if !outcome.skippedStdioMCPServers.isEmpty {
+            return "An imported stdio MCP provider was skipped."
+        }
+        if !outcome.schedulesNeedingCron.isEmpty {
+            return "An imported schedule requires review."
+        }
+        return nil
+    }
+
+    private static func attentionClass(for plugin: ClaudePluginInstalled) -> String? {
+        if plugin.totalCount == 0 { return "empty_import" }
+        if plugin.hasPartialImport { return "partial_import" }
+        guard let outcome = plugin.snapshot?.installOutcome else { return nil }
+        if !outcome.errors.isEmpty { return "import_error" }
+        if !outcome.oauthProvidersNeedingSignIn.isEmpty { return "oauth_required" }
+        if !outcome.placeholderTokensSkipped.isEmpty
+            || !outcome.stdioProvidersNeedingConfiguration.isEmpty
+        { return "credential_configuration_required" }
+        if !outcome.stdioProvidersBlockedNoSandbox.isEmpty { return "sandbox_required" }
+        if !outcome.skippedStdioMCPServers.isEmpty { return "stdio_provider_skipped" }
+        if !outcome.schedulesNeedingCron.isEmpty { return "schedule_review_required" }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Tests/Plugin/PluginCapabilityProjectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginCapabilityProjectionTests.swift
@@ -1,0 +1,286 @@
+//
+//  PluginCapabilityProjectionTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for #2039: the Plugins UI shows both native and
+//  imported Claude plugins, so agent-readable configuration tools must use the
+//  same combined projection while preserving each plugin's execution kind.
+//
+
+import Foundation
+import OsaurusRepository
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+@MainActor
+struct PluginCapabilityProjectionTests {
+    @Test
+    func combinesNativeAndClaudePluginsWithoutChangingTheirExecutionKind() {
+        let native = PluginState(
+            pluginId: "xlsx",
+            name: "XLSX",
+            pluginDescription: nil,
+            authors: nil,
+            license: nil,
+            capabilities: nil,
+            installedVersion: SemanticVersion.parse("1.2.3"),
+            latestVersion: SemanticVersion.parse("1.3.0")
+        )
+        let claude = makeClaudePlugin(
+            id: "github:business/plugins/bm-prd-creator",
+            name: "BM PRD Creator",
+            declaredSkills: 1,
+            skills: [InstalledClaudeSkill(name: "Create PRD", enabled: true)]
+        )
+
+        let rows = PluginCapabilityProjection.build(
+            nativePlugins: [native],
+            claudePlugins: [claude]
+        )
+
+        #expect(rows.count == 2)
+        #expect(rows.map(\.pluginId).contains("xlsx"))
+        #expect(rows.map(\.pluginId).contains("github:business/plugins/bm-prd-creator"))
+
+        let nativeRow = rows.first { $0.pluginId == "xlsx" }
+        #expect(nativeRow?.kind == .native)
+        #expect(nativeRow?.installed == true)
+        #expect(nativeRow?.installationHealthy == true)
+        #expect(nativeRow?.enabledArtifactCount == 0)
+        #expect(nativeRow?.dictionary["installed_version"] as? String == "1.2.3")
+        #expect(nativeRow?.dictionary["latest_version"] as? String == "1.3.0")
+        #expect(nativeRow?.dictionary["has_load_error"] as? Bool == false)
+
+        let claudeRow = rows.first { $0.pluginId.contains("bm-prd-creator") }
+        #expect(claudeRow?.kind == .claude)
+        #expect(claudeRow?.installed == true)
+        #expect(claudeRow?.installationHealthy == true)
+        #expect(claudeRow?.enabledArtifactCount == 1)
+        #expect(claudeRow?.artifactCounts?.skill == 1)
+    }
+
+    @Test
+    func reportsIncompleteClaudeImportAsInstalledButNeedingAttention() {
+        let plugin = makeClaudePlugin(
+            id: "github:business/plugins/partial",
+            name: "Partial",
+            declaredSkills: 2,
+            skills: [InstalledClaudeSkill(name: "Only Skill", enabled: false)]
+        )
+
+        let row = PluginCapabilityProjection.build(
+            nativePlugins: [],
+            claudePlugins: [plugin]
+        ).first
+
+        #expect(row?.installed == true)
+        #expect(row?.status == .needsAttention)
+        #expect(row?.installationHealthy == false)
+        #expect(row?.dictionary["attention_class"] as? String == "partial_import")
+        #expect(row?.dictionary["failure_class"] == nil)
+        #expect(row?.dictionary["attention_reason"] as? String != nil)
+    }
+
+    @Test
+    func doesNotExposeNativeLoadErrorDetails() {
+        let tokenCanary = "ghp_DO_NOT_EXPOSE"
+        let native = PluginState(
+            pluginId: "broken",
+            name: "Broken",
+            pluginDescription: nil,
+            authors: nil,
+            license: nil,
+            capabilities: nil,
+            installedVersion: SemanticVersion.parse("1.0.0"),
+            loadError: "dlopen /Users/alice/private/plugin.dylib failed with \(tokenCanary)"
+        )
+
+        let row = PluginCapabilityProjection.build(
+            nativePlugins: [native],
+            claudePlugins: []
+        )[0]
+        let serialized = String(describing: row.dictionary)
+
+        #expect(row.status == .failed)
+        #expect(!serialized.contains(tokenCanary))
+        #expect(!serialized.contains("/Users/alice"))
+        #expect(serialized.contains("failed to load"))
+        #expect(row.dictionary["has_load_error"] as? Bool == true)
+        #expect(row.dictionary["load_error"] as? String == "The native plugin failed to load.")
+    }
+
+    @Test
+    func includesManifestOnlyClaudePluginWithoutClaimingAgentAvailability() {
+        let plugin = makeClaudePlugin(
+            id: "github:business/plugins/manifest-only",
+            name: "Manifest Only",
+            declaredSkills: 0,
+            skills: []
+        )
+
+        let row = PluginCapabilityProjection.build(
+            nativePlugins: [],
+            claudePlugins: [plugin]
+        )[0]
+
+        #expect(row.installed)
+        #expect(!row.installationHealthy)
+        #expect(row.status == .needsAttention)
+        #expect(row.artifactCounts?.total == 0)
+        #expect(row.dictionary["attention_reason"] as? String == "No plugin artifacts are currently installed.")
+    }
+
+    @Test
+    func scheduleAndCommandArtifactsAreCountedWithoutClaimingAgentAvailability() {
+        let id = "github:business/plugins/automation"
+        let snapshot = makeSnapshot(id: id, name: "Automation", declaredSkills: 0)
+        let plugin = ClaudePluginInstalled(
+            pluginId: id,
+            snapshot: snapshot,
+            counts: .init(schedule: 1, command: 1),
+            schedules: [
+                InstalledClaudeSchedule(
+                    id: UUID(),
+                    name: "Daily brief",
+                    frequencyText: "daily",
+                    nextRunText: nil,
+                    isEnabled: true
+                ),
+            ],
+            commands: [
+                InstalledClaudeCommand(
+                    id: UUID(),
+                    name: "brief",
+                    icon: "doc.text",
+                    description: "",
+                    templatePreview: nil
+                ),
+            ]
+        )
+
+        let row = PluginCapabilityProjection.build(nativePlugins: [], claudePlugins: [plugin])[0]
+
+        #expect(row.installationHealthy)
+        #expect(row.enabledArtifactCount == 2)
+        #expect(row.dictionary["available_to_agent"] == nil)
+        #expect(row.status == .installed)
+    }
+
+    @Test
+    func reportsSafePostInstallAttentionCategory() {
+        let id = "github:business/plugins/oauth"
+        let snapshot = ClaudePluginManifestSnapshot(
+            pluginId: id,
+            name: "oauth",
+            displayName: "OAuth",
+            description: nil,
+            version: "1.0.0",
+            sourceOwner: "business",
+            sourceRepo: "plugins",
+            installedAt: Date(),
+            declaredCounts: .init(skills: 1, agents: 0, commands: 0, mcp: 1),
+            installOutcome: .init(oauthProvidersNeedingSignIn: ["private-provider-name"])
+        )
+        let plugin = ClaudePluginInstalled(
+            pluginId: id,
+            snapshot: snapshot,
+            counts: .init(skill: 1, mcp: 1),
+            skills: [InstalledClaudeSkill(name: "OAuth helper", enabled: true)]
+        )
+
+        let row = PluginCapabilityProjection.build(nativePlugins: [], claudePlugins: [plugin])[0]
+        let reason = row.dictionary["attention_reason"] as? String
+
+        #expect(reason == "An imported MCP provider requires sign-in.")
+        #expect(!(reason ?? "").contains("private-provider-name"))
+        #expect(row.dictionary["attention_class"] as? String == "oauth_required")
+        #expect(row.dictionary["failure_class"] == nil)
+        #expect(row.dictionary["latest_version"] == nil)
+    }
+
+    @Test
+    func configurationToolPluginSummaryAndFiltersUseTheCombinedTruthfulProjection() {
+        let native = PluginState(
+            pluginId: "broken",
+            name: "Broken",
+            pluginDescription: nil,
+            authors: nil,
+            license: nil,
+            capabilities: nil,
+            installedVersion: SemanticVersion.parse("1.0.0"),
+            loadError: "private loader detail"
+        )
+        let claude = makeClaudePlugin(
+            id: "github:business/plugins/partial",
+            name: "Partial",
+            declaredSkills: 2,
+            skills: [InstalledClaudeSkill(name: "One", enabled: true)]
+        )
+        let rows = PluginCapabilityProjection.build(nativePlugins: [native], claudePlugins: [claude])
+
+        let summary = OsaurusStatusTool.pluginSummary(rows)
+        #expect(summary["installed"] as? Int == 2)
+        #expect(summary["failed"] as? Int == 1)
+        #expect(summary["needs_attention"] as? Int == 1)
+        #expect(summary["installation_healthy"] as? Int == 0)
+
+        let failed = OsaurusListTool.filteredPluginItems(rows, filter: "failed")
+        let attention = OsaurusListTool.filteredPluginItems(rows, filter: "needs_attention")
+        #expect(failed.count == 1)
+        #expect(failed.first?["plugin_id"] as? String == "broken")
+        #expect(attention.count == 1)
+        #expect(attention.first?["kind"] as? String == "claude")
+        #expect(attention.first?["available_to_agent"] == nil)
+    }
+
+    private func makeClaudePlugin(
+        id: String,
+        name: String,
+        declaredSkills: Int,
+        skills: [InstalledClaudeSkill]
+    ) -> ClaudePluginInstalled {
+        ClaudePluginInstalled(
+            pluginId: id,
+            snapshot: makeSnapshot(id: id, name: name, declaredSkills: declaredSkills),
+            counts: .init(skill: skills.count),
+            skills: skills
+        )
+    }
+
+    private func makeSnapshot(
+        id: String,
+        name: String,
+        declaredSkills: Int
+    ) -> ClaudePluginManifestSnapshot {
+        ClaudePluginManifestSnapshot(
+            pluginId: id,
+            name: name.lowercased(),
+            displayName: name,
+            description: nil,
+            version: "1.0.0",
+            sourceOwner: "business",
+            sourceRepo: "plugins",
+            installedAt: Date(),
+            declaredCounts: .init(
+                skills: declaredSkills,
+                agents: 0,
+                commands: 0,
+                mcp: 0
+            )
+        )
+    }
+}
+
+private extension InstalledClaudeSkill {
+    init(name: String, enabled: Bool) {
+        self.init(
+            id: UUID(),
+            name: name,
+            description: "",
+            category: nil,
+            enabled: enabled
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tools/ConfigurationTools.swift
+++ b/Packages/OsaurusCore/Tools/ConfigurationTools.swift
@@ -125,6 +125,19 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
 
     public init() {}
 
+    static func pluginSummary(_ plugins: [PluginCapabilityProjectionRow]) -> [String: Any] {
+        let installed = plugins.filter(\.installed)
+        return [
+            "installed": installed.count,
+            "failed": installed.filter(\.failed).count,
+            "needs_attention": installed.filter(\.needsAttention).count,
+            "installation_healthy": installed.filter(\.installationHealthy).count,
+            "enabled_artifacts": installed.reduce(0) { $0 + $1.enabledArtifactCount },
+            "native": installed.filter { $0.kind == .native }.count,
+            "claude": installed.filter { $0.kind == .claude }.count,
+        ]
+    }
+
     public func execute(argumentsJSON: String) async throws -> String {
         if let gate = ConfigurationToolBase.defaultAgentGateFailure(tool: name) {
             return gate
@@ -145,9 +158,10 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
             let mcpConnected = MCPProviderManager.shared.providerStates.values
                 .filter { $0.isConnected }.count
 
-            let plugins = PluginRepositoryService.shared.plugins
-            let installedPlugins = plugins.filter { $0.installedVersion != nil }
-            let failedPlugins = installedPlugins.filter { $0.loadError != nil }
+            let plugins = PluginCapabilityProjection.current()
+            let installedPlugins = plugins.filter(\.installed)
+            let failedPlugins = installedPlugins.filter(\.failed)
+            let pluginsNeedingAttention = installedPlugins.filter(\.needsAttention)
             let pluginRepositoryDiagnostic = PluginRepositoryDiagnosticProjection.dictionary(
                 PluginRepositoryService.shared.lastRefreshResult
             )
@@ -182,8 +196,12 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
                 }
             }
             if !failedPlugins.isEmpty {
-                let names = failedPlugins.prefix(3).map { $0.displayName }.joined(separator: ", ")
+                let names = failedPlugins.prefix(3).map(\.name).joined(separator: ", ")
                 suggestions.append("Plugins failed to load: \(names). Check their manifest / consent state.")
+            }
+            if !pluginsNeedingAttention.isEmpty {
+                let names = pluginsNeedingAttention.prefix(3).map(\.name).joined(separator: ", ")
+                suggestions.append("Plugins need attention: \(names). Inspect their plugin diagnostics.")
             }
             if !downloadingModels.isEmpty {
                 suggestions.append("\(downloadingModels.count) model(s) downloading — poll osaurus_status again.")
@@ -212,11 +230,9 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
                     "configured": mcpProviders.count,
                     "connected": mcpConnected,
                 ],
-                "plugins": [
-                    "installed": installedPlugins.count,
-                    "failed": failedPlugins.count,
+                "plugins": Self.pluginSummary(plugins).merging([
                     "repository": pluginRepositoryDiagnostic ?? [:],
-                ],
+                ]) { _, new in new },
                 "schedules": [
                     "total": schedules.count,
                     "enabled": enabledSchedules.count,
@@ -237,8 +253,12 @@ public final class OsaurusListTool: OsaurusTool, @unchecked Sendable {
         "List items in a configuration scope. `scope` ∈ "
         + "{agents, models, providers, mcp, plugins, schedules}. "
         + "Optional `filter` is scope-specific: models: installed|downloading|recommended|all; "
-        + "providers/mcp: enabled|disabled|connected|all; plugins: installed|available|failed; "
-        + "schedules: enabled|disabled."
+        + "providers/mcp: enabled|disabled|connected|all; "
+        + "plugins: installed|available|failed|needs_attention; "
+        + "schedules: enabled|disabled. Plugin rows include `kind` (`native` or `claude`); "
+        + "Claude rows describe imported skill/MCP packages, not native loadable plugins. "
+        + "Use `status`, `installation_healthy`, and `attention_class`/`failure_class` "
+        + "rather than treating `installed` alone as proof that a plugin is ready."
     public let parameters: JSONValue? = .object([
         "type": .string("object"),
         "additionalProperties": .bool(false),
@@ -272,6 +292,24 @@ public final class OsaurusListTool: OsaurusTool, @unchecked Sendable {
         case "enabled": return items.filter { ($0["enabled"] as? Bool) == true }
         case "disabled": return items.filter { ($0["enabled"] as? Bool) == false }
         case "connected": return items.filter { ($0["connected"] as? Bool) == true }
+        default: return items
+        }
+    }
+
+    static func filteredPluginItems(
+        _ plugins: [PluginCapabilityProjectionRow],
+        filter: String
+    ) -> [[String: Any]] {
+        let items = plugins.map(\.dictionary)
+        switch filter {
+        case "installed": return items.filter { ($0["installed"] as? Bool) == true }
+        case "available": return items.filter { ($0["installed"] as? Bool) == false }
+        case "failed":
+            return items.filter { ($0["status"] as? String) == PluginCapabilityStatus.failed.rawValue }
+        case "needs_attention":
+            return items.filter {
+                ($0["status"] as? String) == PluginCapabilityStatus.needsAttention.rawValue
+            }
         default: return items
         }
     }
@@ -366,33 +404,14 @@ public final class OsaurusListTool: OsaurusTool, @unchecked Sendable {
                     "items": Self.filterByEnabledConnected(items, filter: filter),
                 ]
             case "plugins":
-                let plugins = PluginRepositoryService.shared.plugins
-                let items = plugins.map { state -> [String: Any] in
-                    return [
-                        "plugin_id": state.pluginId,
-                        "name": state.displayName,
-                        "installed": state.installedVersion != nil,
-                        "has_load_error": state.loadError != nil,
-                    ]
-                }
-                let filtered: [[String: Any]]
-                switch filter {
-                case "installed":
-                    filtered = items.filter { ($0["installed"] as? Bool) == true }
-                case "available":
-                    filtered = items.filter { ($0["installed"] as? Bool) == false }
-                case "failed":
-                    filtered = items.filter { ($0["has_load_error"] as? Bool) == true }
-                default:
-                    filtered = items
-                }
+                let plugins = PluginCapabilityProjection.current()
                 payload = [
                     "scope": "plugins",
                     "filter": filter,
                     "repository": PluginRepositoryDiagnosticProjection.dictionary(
                         PluginRepositoryService.shared.lastRefreshResult
                     ) ?? [:],
-                    "items": filtered,
+                    "items": Self.filteredPluginItems(plugins, filter: filter),
                 ]
             case "schedules":
                 let schedules = ScheduleManager.shared.schedules.map { s -> [String: Any] in
@@ -543,17 +562,10 @@ public final class OsaurusDescribeTool: OsaurusTool, @unchecked Sendable {
                     payload = nil
                 }
             case "plugins":
-                if let plugin = PluginRepositoryService.shared.plugins
+                if let plugin = PluginCapabilityProjection.current()
                     .first(where: { $0.pluginId == idStr })
                 {
-                    payload = [
-                        "plugin_id": plugin.pluginId,
-                        "name": plugin.displayName,
-                        "installed": plugin.installedVersion != nil,
-                        "installed_version": plugin.installedVersion?.description ?? "",
-                        "latest_version": plugin.latestVersion?.description ?? "",
-                        "load_error": plugin.loadError ?? "",
-                    ]
+                    payload = plugin.dictionary
                 } else {
                     payload = nil
                 }


### PR DESCRIPTION
## Summary
- derive plugin capability status from the same runtime registry used by plugin execution
- keep list and status responses consistent when a plugin is installed, disabled, unavailable, or missing
- preserve explicit diagnostics instead of reporting contradictory availability

Fixes #2039

## Validation
- 7 focused plugin capability projection tests passed
- `git diff --check`
- scoped lint validation

## Eval evidence
- Local model: `foundation`
- Suite: `CapabilityClaims`
- Result: 11 total, 8 passed, 0 failed, 0 errored, 3 skipped because `osaurus.browser` was not installed
- Floors: all listed floors met
- Artifact: `build/evals/pr2042-foundation-capability-claims.json`
- Limitation: no independent judge or frontier-provider credential was available, so this is local evidence only

## Risk
The change is limited to capability projection and status reporting. It does not install, enable, or execute plugins.

## Ready gate
This remains draft until frontier capability-claim evidence is attached. The implementation, focused tests, and local evidence are complete.