### PR TITLE
Add runtime installation doctor

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
@@ -12,6 +12,7 @@ import OsaurusCLICore
 struct OsaurusCLI {
     private enum CommandType {
         case status
+        case doctor([String])
         case serve([String])
         case stop
         case list
@@ -34,6 +35,7 @@ struct OsaurusCLI {
         let rest = Array(args.dropFirst())
         switch command {
         case "status": return .status
+        case "doctor": return .doctor(rest)
         case "serve": return .serve(rest)
         case "stop": return .stop
         case "list": return .list
@@ -70,6 +72,8 @@ struct OsaurusCLI {
         switch cmd {
         case .status:
             await StatusCommand.execute(args: [])
+        case .doctor(let args):
+            await DoctorCommand.execute(args: args)
         case .serve(let args):
             await ServeCommand.execute(args: args)
         case .stop:
@@ -123,6 +127,9 @@ struct OsaurusCLI {
                                       access key here or via OSAURUS_MCP_ACCESS_KEY.
               osaurus version         Show version (also: --version or -v)
               osaurus status          Check if the Osaurus server is running
+              osaurus doctor [--port N] [--json] [--redact]
+                                      Diagnose CLI/app version skew, duplicate app
+                                      bundles, server startup, and model storage
               osaurus list            List available model IDs
               osaurus show <model_id> Show metadata for a model
               osaurus pull <model_id> Download a model from Hugging Face

--- a/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
@@ -127,9 +127,11 @@ struct OsaurusCLI {
                                       access key here or via OSAURUS_MCP_ACCESS_KEY.
               osaurus version         Show version (also: --version or -v)
               osaurus status          Check if the Osaurus server is running
-              osaurus doctor [--port N] [--json] [--redact]
+              osaurus doctor [--port N] [--json] [--redact] [--verify-signatures]
                                       Diagnose CLI/app version skew, duplicate app
-                                      bundles, server startup, and model storage
+                                      bundles, server startup, and model storage.
+                                      Signature checks are explicit because they can
+                                      be slow when many app bundles are installed.
               osaurus list            List available model IDs
               osaurus show <model_id> Show metadata for a model
               osaurus pull <model_id> Download a model from Hugging Face

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Doctor.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Doctor.swift
@@ -1,0 +1,128 @@
+//
+//  Doctor.swift
+//  OsaurusCLI
+//
+//  Read-only installation and server-start diagnostics.
+//
+
+import Foundation
+
+public struct DoctorCommand: Command {
+    public static let name = "doctor"
+
+    struct Options: Equatable {
+        let port: Int?
+        let json: Bool
+        let redact: Bool
+    }
+
+    enum ArgumentError: Error, Equatable {
+        case invalid(String)
+    }
+
+    public static func execute(args: [String]) async {
+        let options: Options
+        do {
+            options = try parseOptions(args)
+        } catch let error as ArgumentError {
+            let detail: String
+            switch error { case .invalid(let message): detail = message }
+            fputs("osaurus doctor: \(detail)\n", stderr)
+            fputs("Usage: osaurus doctor [--port 1...65535] [--json] [--redact]\n", stderr)
+            exit(EXIT_FAILURE)
+        } catch {
+            fputs("osaurus doctor: invalid arguments\n", stderr)
+            exit(EXIT_FAILURE)
+        }
+
+        let report = await InstallationDiagnostics.collect(requestedPort: options.port)
+        let output = options.redact ? report.redacted() : report
+        if options.json {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            do {
+                let data = try encoder.encode(output)
+                guard let text = String(data: data, encoding: .utf8) else {
+                    throw EncodingError.invalidValue(
+                        data,
+                        .init(codingPath: [], debugDescription: "JSON output was not UTF-8")
+                    )
+                }
+                print(text)
+            } catch {
+                fputs("osaurus doctor: could not encode diagnostic JSON\n", stderr)
+                exit(EXIT_FAILURE)
+            }
+        } else {
+            print(render(output))
+        }
+        let usable = report.diagnosis == .healthy || report.diagnosis == .serverNotRunning
+        exit(usable ? EXIT_SUCCESS : EXIT_FAILURE)
+    }
+
+    static func parseOptions(_ args: [String]) throws -> Options {
+        var port: Int?
+        var json = false
+        var redact = false
+        var index = 0
+        while index < args.count {
+            switch args[index] {
+            case "--port" where index + 1 < args.count:
+                guard let value = Int(args[index + 1]), (1 ... 65_535).contains(value) else {
+                    throw ArgumentError.invalid("--port must be an integer from 1 through 65535")
+                }
+                port = value
+                index += 2
+            case "--port":
+                throw ArgumentError.invalid("--port requires a value")
+            case "--json":
+                json = true
+                index += 1
+            case "--redact":
+                redact = true
+                index += 1
+            default:
+                throw ArgumentError.invalid("unknown argument `\(args[index])`")
+            }
+        }
+        return Options(port: port, json: json, redact: redact)
+    }
+
+    public static func render(_ report: InstallationDiagnosticReport) -> String {
+        var lines = [
+            "Osaurus installation doctor",
+            "Diagnosis: \(report.diagnosis.rawValue)",
+            "CLI: \(report.cliPath) (\(versionLabel(report.cliVersion, build: report.cliBuild)))",
+            "Server: http://127.0.0.1:\(report.requestedPort) — \(report.serverHealthy ? "healthy" : "unavailable")",
+        ]
+        if let owner = report.portOwner { lines.append("Port owner: \(owner)") }
+        if report.apps.isEmpty {
+            lines.append("Apps: none discovered")
+        } else {
+            lines.append("Apps:")
+            for app in report.apps {
+                let markers = [app.isCompanion ? "companion" : nil, app.isRunning ? "running" : nil]
+                    .compactMap { $0 }.joined(separator: ", ")
+                lines.append(
+                    "- \(app.path) (\(versionLabel(app.version, build: app.build)))"
+                        + (markers.isEmpty ? "" : " [\(markers)]")
+                        + " signature=\(app.signature.rawValue) notarization=\(app.notarization.rawValue)"
+                )
+            }
+        }
+        lines.append(
+            "Models: \(report.modelCountComplete ? "" : "at least ")\(report.modelCount) at \(report.modelRoot)"
+                + " [\(report.modelRootSource)]"
+                + (report.modelRootReadable ? "" : " (not readable)")
+        )
+        lines.append("Next step: \(report.recommendation)")
+        return lines.joined(separator: "\n")
+    }
+
+    private static func versionLabel(_ version: String?, build: String?) -> String {
+        let version = version ?? "development/unproven"
+        guard let build, !build.isEmpty else { return version }
+        return "\(version), build \(build)"
+    }
+}

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Doctor.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Doctor.swift
@@ -27,7 +27,10 @@ public struct DoctorCommand: Command {
             options = try parseOptions(args)
         } catch let error as ArgumentError {
             let detail: String
-            switch error { case .invalid(let message): detail = message }
+            switch error {
+            case .invalid(let message):
+                detail = message
+            }
             fputs("osaurus doctor: \(detail)\n", stderr)
             fputs(
                 "Usage: osaurus doctor [--port 1...65535] [--json] [--redact] [--verify-signatures]\n",

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Doctor.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Doctor.swift
@@ -14,6 +14,7 @@ public struct DoctorCommand: Command {
         let port: Int?
         let json: Bool
         let redact: Bool
+        let verifySignatures: Bool
     }
 
     enum ArgumentError: Error, Equatable {
@@ -28,14 +29,20 @@ public struct DoctorCommand: Command {
             let detail: String
             switch error { case .invalid(let message): detail = message }
             fputs("osaurus doctor: \(detail)\n", stderr)
-            fputs("Usage: osaurus doctor [--port 1...65535] [--json] [--redact]\n", stderr)
+            fputs(
+                "Usage: osaurus doctor [--port 1...65535] [--json] [--redact] [--verify-signatures]\n",
+                stderr
+            )
             exit(EXIT_FAILURE)
         } catch {
             fputs("osaurus doctor: invalid arguments\n", stderr)
             exit(EXIT_FAILURE)
         }
 
-        let report = await InstallationDiagnostics.collect(requestedPort: options.port)
+        let report = await InstallationDiagnostics.collect(
+            requestedPort: options.port,
+            includeSignatureChecks: options.verifySignatures
+        )
         let output = options.redact ? report.redacted() : report
         if options.json {
             let encoder = JSONEncoder()
@@ -65,6 +72,7 @@ public struct DoctorCommand: Command {
         var port: Int?
         var json = false
         var redact = false
+        var verifySignatures = false
         var index = 0
         while index < args.count {
             switch args[index] {
@@ -82,11 +90,19 @@ public struct DoctorCommand: Command {
             case "--redact":
                 redact = true
                 index += 1
+            case "--verify-signatures":
+                verifySignatures = true
+                index += 1
             default:
                 throw ArgumentError.invalid("unknown argument `\(args[index])`")
             }
         }
-        return Options(port: port, json: json, redact: redact)
+        return Options(
+            port: port,
+            json: json,
+            redact: redact,
+            verifySignatures: verifySignatures
+        )
     }
 
     public static func render(_ report: InstallationDiagnosticReport) -> String {

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
@@ -134,7 +134,8 @@ public struct ServeCommand: Command {
             requestedPort: portToCheck,
             includeSignatureChecks: false,
             startupAttempted: true,
-            includeModelInventory: false
+            includeModelInventory: false,
+            includeComprehensiveAppSearch: false
         )
         if diagnostic.serverHealthy {
             print("listening on http://127.0.0.1:\(portToCheck)")

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
@@ -133,7 +133,8 @@ public struct ServeCommand: Command {
         let diagnostic = await InstallationDiagnostics.collect(
             requestedPort: portToCheck,
             includeSignatureChecks: false,
-            startupAttempted: true
+            startupAttempted: true,
+            includeModelInventory: false
         )
         if diagnostic.serverHealthy {
             print("listening on http://127.0.0.1:\(portToCheck)")

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Serve.swift
@@ -130,17 +130,21 @@ public struct ServeCommand: Command {
             }
             try? await Task.sleep(nanoseconds: 200_000_000)  // 200ms
         }
-        // Improved guidance on failure
-        let altPort = min(max(portToCheck + 1, 1), 65535)
+        let diagnostic = await InstallationDiagnostics.collect(
+            requestedPort: portToCheck,
+            includeSignatureChecks: false,
+            startupAttempted: true
+        )
+        if diagnostic.serverHealthy {
+            print("listening on http://127.0.0.1:\(portToCheck)")
+            exit(EXIT_SUCCESS)
+        }
         fputs(
             """
             Failed to start server on port \(portToCheck)
-            Hints:
-              - The port may be busy. Try: osaurus serve --port \(altPort)
-              - Ensure Osaurus.app is installed: brew install --cask osaurus
-              - Try launching the app first, then serve:
-                open -a /Applications/Osaurus.app && osaurus serve
-              - You can also open the UI: osaurus ui
+            Diagnosis: \(diagnostic.diagnosis.rawValue)
+            Next step: \(diagnostic.recommendation)
+            Run `osaurus doctor --redact` for a shareable installation report.
             """.appending("\n"),
             stderr
         )

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Version.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Version.swift
@@ -2,7 +2,8 @@
 //  Version.swift
 //  osaurus
 //
-//  Command to display the Osaurus version and build number from environment variables.
+//  Command to display release metadata from the build environment or the
+//  companion application bundle.
 //
 
 import Foundation
@@ -11,21 +12,22 @@ public struct VersionCommand: Command {
     public static let name = "version"
 
     public static func execute(args: [String]) async {
-        var versionString: String?
-        var buildString: String?
-
-        if let v = ProcessInfo.processInfo.environment["OSAURUS_VERSION"] { versionString = v }
-        if let b = ProcessInfo.processInfo.environment["OSAURUS_BUILD_NUMBER"] { buildString = b }
-
-        let output: String
-        if let v = versionString, let b = buildString, !b.isEmpty {
-            output = "Osaurus \(v) (\(b))"
-        } else if let v = versionString {
-            output = "Osaurus \(v)"
-        } else {
-            output = "Osaurus dev"
-        }
-        print(output)
+        print(output())
         exit(EXIT_SUCCESS)
+    }
+
+    public static func output(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        executablePath: String = CommandLine.arguments.first ?? ""
+    ) -> String {
+        let resolved = CLIVersionResolver.resolve(
+            environment: environment,
+            executablePath: executablePath
+        )
+        if let version = resolved.version, let build = resolved.build {
+            return "Osaurus \(version) (\(build))"
+        }
+        if let version = resolved.version { return "Osaurus \(version)" }
+        return "Osaurus dev"
     }
 }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
@@ -20,6 +20,7 @@ public struct AppControl {
         )
     }
 
+    @MainActor
     public static func launchAppIfNeeded() async {
         // Try to detect if server responds; if yes, nothing to do
         let port = Configuration.resolveConfiguredPort() ?? 1337
@@ -60,6 +61,7 @@ public struct AppControl {
     }
 
     /// Attempts to locate the installed Osaurus.app bundle path using common locations and Spotlight.
+    @MainActor
     public static func findAppBundlePath() -> String? {
         let fm = FileManager.default
         for path in commonAppBundlePaths() where fm.fileExists(atPath: path) {
@@ -71,7 +73,8 @@ public struct AppControl {
     /// Returns every known bundle for the Osaurus identifier. Multiple rows
     /// are significant because LaunchServices can otherwise launch a stale
     /// registration even when the CLI belongs to a newer app bundle.
-    public static func findAppBundlePaths() -> [String] {
+    @MainActor
+    public static func findAppBundlePaths(includeSpotlightSearch: Bool = true) -> [String] {
         let fm = FileManager.default
         let home = NSHomeDirectory()
         let candidates = commonAppBundlePaths()
@@ -81,9 +84,14 @@ public struct AppControl {
         ) {
             paths.append(launchServicesSelection.path)
         }
-        let query = "kMDItemCFBundleIdentifier == 'com.dinoki.osaurus'"
-        paths.append(contentsOf: spotlightFindAll(queryArgs: ["-onlyin", "/Applications", query]))
-        paths.append(contentsOf: spotlightFindAll(queryArgs: ["-onlyin", "\(home)/Applications", query]))
+        if includeSpotlightSearch {
+            let query = "kMDItemCFBundleIdentifier == 'com.dinoki.osaurus'"
+            paths.append(contentsOf: spotlightFindAll(queryArgs: ["-onlyin", "/Applications", query]))
+            paths.append(contentsOf: spotlightFindAll(queryArgs: ["-onlyin", "\(home)/Applications", query]))
+            // Preserve discovery of side-loaded and development bundles that
+            // are indexed but not currently registered with LaunchServices.
+            paths.append(contentsOf: spotlightFindAll(queryArgs: [query]))
+        }
         return deduplicatedBundlePaths(paths.filter {
             fm.fileExists(atPath: $0) && URL(fileURLWithPath: $0).pathExtension.lowercased() == "app"
         })
@@ -93,6 +101,8 @@ public struct AppControl {
         [
             "/Applications/Osaurus.app",
             "\(NSHomeDirectory())/Applications/Osaurus.app",
+            "/Applications/osaurus.app",
+            "\(NSHomeDirectory())/Applications/osaurus.app",
         ]
     }
 
@@ -109,6 +119,7 @@ public struct AppControl {
         }
     }
 
+    @MainActor
     public static func runningAppBundlePath() -> String? {
         NSRunningApplication.runningApplications(withBundleIdentifier: "com.dinoki.osaurus")
             .first?.bundleURL?.path

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AppKit
+import Darwin
 
 public struct AppControl {
     public static func postDistributedNotification(name: String, userInfo: [AnyHashable: Any]) {
@@ -59,56 +60,90 @@ public struct AppControl {
     }
 
     /// Attempts to locate the installed Osaurus.app bundle path using common locations and Spotlight.
-    private static func findAppBundlePath() -> String? {
+    public static func findAppBundlePath() -> String? {
         let fm = FileManager.default
-        let home = NSHomeDirectory()
-        let candidates = [
-            "/Applications/Osaurus.app",
-            "\(home)/Applications/Osaurus.app",
-            "/Applications/osaurus.app",
-            "\(home)/Applications/osaurus.app",
-        ]
-        for c in candidates {
-            if fm.fileExists(atPath: c) { return c }
+        for path in commonAppBundlePaths() where fm.fileExists(atPath: path) {
+            return path
         }
-        // Try Spotlight via mdfind, restricted to Applications folders first
-        if let path = spotlightFind(queryArgs: [
-            "-onlyin", "/Applications",
-            "-onlyin", "\(home)/Applications",
-            "kMDItemCFBundleIdentifier == 'com.dinoki.osaurus'",
-        ]) {
-            if fm.fileExists(atPath: path) { return path }
-        }
-        // Unrestricted Spotlight fallback (search entire metadata index)
-        if let path = spotlightFind(queryArgs: [
-            "kMDItemCFBundleIdentifier == 'com.dinoki.osaurus'"
-        ]) {
-            if fm.fileExists(atPath: path) { return path }
-        }
-        return nil
+        return findAppBundlePaths().first
     }
 
-    /// Runs mdfind with the provided arguments and returns the first non-empty line.
-    private static func spotlightFind(queryArgs: [String]) -> String? {
+    /// Returns every known bundle for the Osaurus identifier. Multiple rows
+    /// are significant because LaunchServices can otherwise launch a stale
+    /// registration even when the CLI belongs to a newer app bundle.
+    public static func findAppBundlePaths() -> [String] {
+        let fm = FileManager.default
+        let home = NSHomeDirectory()
+        let candidates = commonAppBundlePaths()
+        var paths = candidates.filter { fm.fileExists(atPath: $0) }
+        if let launchServicesSelection = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.dinoki.osaurus"
+        ) {
+            paths.append(launchServicesSelection.path)
+        }
+        let query = "kMDItemCFBundleIdentifier == 'com.dinoki.osaurus'"
+        paths.append(contentsOf: spotlightFindAll(queryArgs: ["-onlyin", "/Applications", query]))
+        paths.append(contentsOf: spotlightFindAll(queryArgs: ["-onlyin", "\(home)/Applications", query]))
+        return deduplicatedBundlePaths(paths.filter {
+            fm.fileExists(atPath: $0) && URL(fileURLWithPath: $0).pathExtension.lowercased() == "app"
+        })
+    }
+
+    private static func commonAppBundlePaths() -> [String] {
+        [
+            "/Applications/Osaurus.app",
+            "\(NSHomeDirectory())/Applications/Osaurus.app",
+        ]
+    }
+
+    static func deduplicatedBundlePaths(_ paths: [String]) -> [String] {
+        var seen = Set<String>()
+        return paths.compactMap { path in
+            let canonical = URL(fileURLWithPath: path)
+                .resolvingSymlinksInPath()
+                .standardizedFileURL.path
+            // macOS application volumes are normally case-insensitive. Treat
+            // spelling-only variants as one registration even on a test volume.
+            guard seen.insert(canonical.lowercased()).inserted else { return nil }
+            return canonical
+        }
+    }
+
+    public static func runningAppBundlePath() -> String? {
+        NSRunningApplication.runningApplications(withBundleIdentifier: "com.dinoki.osaurus")
+            .first?.bundleURL?.path
+    }
+
+    /// Runs mdfind with the provided arguments and returns existing result paths.
+    private static func spotlightFindAll(queryArgs: [String]) -> [String] {
         let mdfind = Process()
         let outPipe = Pipe()
+        let finished = DispatchSemaphore(value: 0)
         mdfind.executableURL = URL(fileURLWithPath: "/usr/bin/mdfind")
         mdfind.standardOutput = outPipe
+        mdfind.standardError = FileHandle.nullDevice
         mdfind.arguments = queryArgs
+        mdfind.terminationHandler = { _ in finished.signal() }
         do {
             try mdfind.run()
-            mdfind.waitUntilExit()
+            guard finished.wait(timeout: .now() + 2) == .success else {
+                mdfind.terminate()
+                if finished.wait(timeout: .now() + 0.5) == .timedOut {
+                    Darwin.kill(mdfind.processIdentifier, SIGKILL)
+                    _ = finished.wait(timeout: .now() + 1)
+                }
+                mdfind.waitUntilExit()
+                return []
+            }
             if mdfind.terminationStatus == 0 {
                 let data = try outPipe.fileHandleForReading.readToEnd() ?? Data()
                 if let s = String(data: data, encoding: .utf8) {
-                    if let first = s.split(separator: "\n").first, !first.isEmpty {
-                        return String(first)
-                    }
+                    return s.split(separator: "\n").map(String.init)
                 }
             }
         } catch {
             // ignore failures; fallback will be nil
         }
-        return nil
+        return []
     }
 }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/Configuration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/Configuration.swift
@@ -83,4 +83,81 @@ public struct Configuration {
     public static func toolsRootDirectory() -> URL {
         ToolsPaths.toolsRootDirectory()
     }
+
+    struct ModelsDirectoryResolution: Equatable, Sendable {
+        let url: URL
+        let source: String
+    }
+
+    public static func resolveModelsDirectory() -> URL {
+        resolveModelsDirectoryWithSource().url
+    }
+
+    static func resolveModelsDirectoryWithSource(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        appDefaults: UserDefaults? = UserDefaults(suiteName: "com.dinoki.osaurus"),
+        sharedDefaults: UserDefaults? = UserDefaults(suiteName: "group.com.osaurus.shared"),
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> ModelsDirectoryResolution {
+        if let raw = environment["OSU_MODELS_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
+            return .init(
+                url: URL(fileURLWithPath: (raw as NSString).expandingTildeInPath, isDirectory: true),
+                source: "environment"
+            )
+        }
+        if let bookmarkData = appDefaults?.data(forKey: "ModelDirectoryBookmark"),
+            let bookmarked = resolveModelDirectoryBookmark(bookmarkData)
+        {
+            return .init(url: bookmarked, source: "app_bookmark")
+        }
+        if let stored = sharedDefaults?.string(forKey: "modelsDirectoryPath"), !stored.isEmpty {
+            return .init(
+                url: URL(fileURLWithPath: (stored as NSString).expandingTildeInPath, isDirectory: true),
+                source: "shared_cli_setting"
+            )
+        }
+
+        let fm = FileManager.default
+        let current = home.appendingPathComponent("MLXModels", isDirectory: true)
+        let legacy = home.appendingPathComponent("Documents/MLXModels", isDirectory: true)
+        let cliFallback = home.appendingPathComponent(".osaurus/models", isDirectory: true)
+        if directoryHasVisibleContents(current, fileManager: fm) { return .init(url: current, source: "app_default") }
+        if directoryHasVisibleContents(legacy, fileManager: fm) { return .init(url: legacy, source: "legacy_app_default") }
+        if directoryHasVisibleContents(cliFallback, fileManager: fm) {
+            return .init(url: cliFallback, source: "cli_default")
+        }
+        if fm.fileExists(atPath: current.path) { return .init(url: current, source: "app_default") }
+        if fm.fileExists(atPath: legacy.path) { return .init(url: legacy, source: "legacy_app_default") }
+        if fm.fileExists(atPath: cliFallback.path) { return .init(url: cliFallback, source: "cli_default") }
+        return .init(url: current, source: "app_default")
+    }
+
+    private static func resolveModelDirectoryBookmark(_ data: Data) -> URL? {
+        var stale = false
+        if let url = try? URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &stale
+        ), !stale {
+            return url
+        }
+        stale = false
+        return try? URL(
+            resolvingBookmarkData: data,
+            options: [],
+            relativeTo: nil,
+            bookmarkDataIsStale: &stale
+        )
+    }
+
+    private static func directoryHasVisibleContents(_ url: URL, fileManager: FileManager) -> Bool {
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return false }
+        return !contents.isEmpty
+    }
 }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
@@ -1,0 +1,438 @@
+//
+//  InstallationDiagnostics.swift
+//  OsaurusCLI
+//
+//  Read-only diagnostics for the CLI/app installation boundary. The CLI and
+//  app communicate through a distributed notification, so version skew or a
+//  duplicate LaunchServices registration can otherwise look like a generic
+//  server timeout.
+//
+
+import Foundation
+import Darwin
+
+public enum StartupDiagnosticKind: String, Codable, Sendable {
+    case healthy
+    case appAbsent = "app_absent"
+    case appStale = "app_stale_incompatible"
+    case appNewer = "app_newer_than_cli"
+    case duplicateBundles = "duplicate_bundles"
+    case portBusy = "port_busy"
+    case serverUnhealthy = "server_unhealthy"
+    case serverNotRunning = "server_not_running"
+    case startupTimeout = "startup_timeout"
+}
+
+public enum SignatureDiagnosticState: String, Codable, Sendable {
+    case valid
+    case invalid
+    case timedOut = "timed_out"
+    case unchecked
+}
+
+public struct AppBundleDiagnostic: Codable, Equatable, Sendable {
+    public let path: String
+    public let version: String?
+    public let build: String?
+    public let isRunning: Bool
+    public let isCompanion: Bool
+    public let signature: SignatureDiagnosticState
+    public let notarization: SignatureDiagnosticState
+
+    public init(
+        path: String,
+        version: String?,
+        build: String?,
+        isRunning: Bool,
+        isCompanion: Bool,
+        signature: SignatureDiagnosticState = .unchecked,
+        notarization: SignatureDiagnosticState = .unchecked
+    ) {
+        self.path = path
+        self.version = version
+        self.build = build
+        self.isRunning = isRunning
+        self.isCompanion = isCompanion
+        self.signature = signature
+        self.notarization = notarization
+    }
+}
+
+public struct InstallationDiagnosticReport: Codable, Equatable, Sendable {
+    public let generatedAt: Date
+    public let cliPath: String
+    public let cliVersion: String?
+    public let cliBuild: String?
+    public let requestedPort: Int
+    public let configuredPort: Int?
+    public let serverHealthy: Bool
+    public let portOwner: String?
+    public let modelRoot: String
+    public let modelRootSource: String
+    public let modelRootReadable: Bool
+    public let modelCount: Int
+    public let modelCountComplete: Bool
+    public let apps: [AppBundleDiagnostic]
+    public let diagnosis: StartupDiagnosticKind
+    public let recommendation: String
+
+    public func redacted(homeDirectory: String = NSHomeDirectory()) -> Self {
+        func scrub(_ value: String) -> String {
+            var output = value
+            let patterns = [#"/System/Volumes/Data/Users/[^/\s]+"#, #"/Users/[^/\s]+"#]
+            for pattern in patterns {
+                output = output.replacingOccurrences(
+                    of: pattern,
+                    with: "~",
+                    options: .regularExpression
+                )
+            }
+            let homes = [
+                homeDirectory,
+                URL(fileURLWithPath: homeDirectory).resolvingSymlinksInPath().path,
+                FileManager.default.homeDirectoryForCurrentUser.path,
+                FileManager.default.homeDirectoryForCurrentUser.resolvingSymlinksInPath().path,
+            ]
+            for home in Set(homes) where !home.isEmpty && home != "/" {
+                output = output.replacingOccurrences(of: home, with: "~")
+            }
+            return output
+        }
+        return Self(
+            generatedAt: generatedAt,
+            cliPath: scrub(cliPath),
+            cliVersion: cliVersion,
+            cliBuild: cliBuild,
+            requestedPort: requestedPort,
+            configuredPort: configuredPort,
+            serverHealthy: serverHealthy,
+            portOwner: portOwner,
+            modelRoot: scrub(modelRoot),
+            modelRootSource: modelRootSource,
+            modelRootReadable: modelRootReadable,
+            modelCount: modelCount,
+            modelCountComplete: modelCountComplete,
+            apps: apps.map {
+                AppBundleDiagnostic(
+                    path: scrub($0.path),
+                    version: $0.version,
+                    build: $0.build,
+                    isRunning: $0.isRunning,
+                    isCompanion: $0.isCompanion,
+                    signature: $0.signature,
+                    notarization: $0.notarization
+                )
+            },
+            diagnosis: diagnosis,
+            recommendation: scrub(recommendation)
+        )
+    }
+}
+
+public struct ResolvedCLIVersion: Equatable, Sendable {
+    public let version: String?
+    public let build: String?
+    public let companionAppPath: String?
+}
+
+public enum CLIVersionResolver {
+    public static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        executablePath: String = CommandLine.arguments.first ?? ""
+    ) -> ResolvedCLIVersion {
+        if let version = nonempty(environment["OSAURUS_VERSION"]) {
+            return ResolvedCLIVersion(
+                version: version,
+                build: nonempty(environment["OSAURUS_BUILD_NUMBER"]),
+                companionAppPath: companionAppPath(for: executablePath)
+            )
+        }
+
+        let companion = companionAppPath(for: executablePath)
+        if let companion,
+            let metadata = bundleMetadata(at: companion),
+            let version = metadata.version {
+            return ResolvedCLIVersion(
+                version: version,
+                build: metadata.build,
+                companionAppPath: companion
+            )
+        }
+        return ResolvedCLIVersion(version: nil, build: nil, companionAppPath: companion)
+    }
+
+    public static func companionAppPath(for executablePath: String) -> String? {
+        guard !executablePath.isEmpty else { return nil }
+        let resolved = URL(fileURLWithPath: executablePath).resolvingSymlinksInPath().path
+        guard let range = resolved.range(of: ".app/Contents/") else { return nil }
+        return String(resolved[..<range.lowerBound]) + ".app"
+    }
+
+    public static func bundleMetadata(at appPath: String) -> (version: String?, build: String?)? {
+        let plist = URL(fileURLWithPath: appPath)
+            .appendingPathComponent("Contents/Info.plist")
+        guard let data = try? Data(contentsOf: plist),
+            let object = try? PropertyListSerialization.propertyList(from: data, format: nil),
+            let dictionary = object as? [String: Any]
+        else { return nil }
+        return (
+            nonempty(dictionary["CFBundleShortVersionString"] as? String),
+            nonempty(dictionary["CFBundleVersion"] as? String)
+        )
+    }
+
+    private static func nonempty(_ value: String?) -> String? {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
+    }
+}
+
+public enum InstallationDiagnostics {
+    @MainActor
+    public static func collect(
+        requestedPort: Int? = nil,
+        includeSignatureChecks: Bool = true,
+        startupAttempted: Bool = false
+    ) async -> InstallationDiagnosticReport {
+        let configuredPort = Configuration.resolveConfiguredPort()
+        let port = requestedPort ?? configuredPort ?? 1337
+        let runningPath = AppControl.runningAppBundlePath()
+        let cliPath = URL(fileURLWithPath: CommandLine.arguments.first ?? "")
+            .resolvingSymlinksInPath().path
+        let cli = CLIVersionResolver.resolve(
+            executablePath: cliPath
+        )
+        let discoveredPaths = await Task.detached(priority: .utility) {
+            AppControl.findAppBundlePaths()
+        }.value
+        let appPaths = await Task.detached(priority: .utility) {
+            AppControl.deduplicatedBundlePaths(
+                discoveredPaths + [runningPath, cli.companionAppPath].compactMap { $0 }
+            ).filter { FileManager.default.fileExists(atPath: $0) }
+        }.value
+        let healthy = await ServerControl.checkHealth(port: port)
+        let owner = await Task.detached(priority: .utility) { portOwner(port: port) }.value
+
+        let apps = await Task.detached(priority: .utility) {
+            appPaths.map { path -> AppBundleDiagnostic in
+                let metadata = CLIVersionResolver.bundleMetadata(at: path)
+                let signature = includeSignatureChecks
+                    ? assess(executable: "/usr/bin/codesign", arguments: ["--verify", "--deep", "--strict", path])
+                    : .unchecked
+                let notarization = includeSignatureChecks
+                    ? assess(executable: "/usr/sbin/spctl", arguments: ["-a", "-t", "execute", path])
+                    : .unchecked
+                return AppBundleDiagnostic(
+                    path: path,
+                    version: metadata?.version,
+                    build: metadata?.build,
+                    isRunning: normalized(path) == runningPath.map(normalized),
+                    isCompanion: normalized(path) == cli.companionAppPath.map(normalized),
+                    signature: signature,
+                    notarization: notarization
+                )
+            }
+        }.value
+
+        let diagnosis = classify(
+            apps: apps,
+            cliVersion: cli.version,
+            cliBuild: cli.build,
+            healthy: healthy,
+            portOwner: owner,
+            startupAttempted: startupAttempted
+        )
+        let modelResolution = Configuration.resolveModelsDirectoryWithSource()
+        let modelSnapshot = await Task.detached(priority: .utility) {
+            let readable = FileManager.default.isReadableFile(atPath: modelResolution.url.path)
+            let count = countModelBundles(in: modelResolution.url)
+            return (readable, count)
+        }.value
+
+        return InstallationDiagnosticReport(
+            generatedAt: Date(),
+            cliPath: cliPath,
+            cliVersion: cli.version,
+            cliBuild: cli.build,
+            requestedPort: port,
+            configuredPort: configuredPort,
+            serverHealthy: healthy,
+            portOwner: owner,
+            modelRoot: modelResolution.url.path,
+            modelRootSource: modelResolution.source,
+            modelRootReadable: modelSnapshot.0,
+            modelCount: modelSnapshot.1.count,
+            modelCountComplete: modelSnapshot.1.complete,
+            apps: apps,
+            diagnosis: diagnosis,
+            recommendation: recommendation(for: diagnosis, port: port)
+        )
+    }
+
+    nonisolated public static func classify(
+        apps: [AppBundleDiagnostic],
+        cliVersion: String?,
+        cliBuild: String? = nil,
+        healthy: Bool,
+        portOwner: String?,
+        startupAttempted: Bool = false
+    ) -> StartupDiagnosticKind {
+        if apps.count > 1 { return .duplicateBundles }
+        if let app = apps.first,
+            let appVersion = app.version,
+            let cliVersion,
+            compareVersions(appVersion, cliVersion) != .orderedSame {
+            return compareVersions(appVersion, cliVersion) == .orderedAscending
+                ? .appStale
+                : .appNewer
+        }
+        if let appBuild = apps.first?.build, let cliBuild,
+            compareVersions(appBuild, cliBuild) != .orderedSame {
+            return compareVersions(appBuild, cliBuild) == .orderedAscending ? .appStale : .appNewer
+        }
+        if healthy { return .healthy }
+        if apps.isEmpty { return .appAbsent }
+        if let portOwner {
+            return isOsaurusPortOwner(portOwner) ? .serverUnhealthy : .portBusy
+        }
+        return startupAttempted ? .startupTimeout : .serverNotRunning
+    }
+
+    nonisolated public static func recommendation(
+        for diagnosis: StartupDiagnosticKind,
+        port: Int
+    ) -> String {
+        switch diagnosis {
+        case .healthy:
+            return "No installation problem detected."
+        case .appAbsent:
+            return "Install Osaurus.app, then run `osaurus serve --port \(port)` again."
+        case .appStale:
+            return "Update the installed Osaurus app so it matches the CLI, then retry."
+        case .appNewer:
+            return "Update the CLI or invoke the helper bundled with the installed Osaurus app."
+        case .duplicateBundles:
+            return "Quit Osaurus and remove or archive duplicate registered app bundles, then launch the intended app explicitly."
+        case .portBusy:
+            return "Choose another port or stop the non-Osaurus process using port \(port)."
+        case .serverUnhealthy:
+            return "The Osaurus process owns port \(port) but is unhealthy. Quit it, relaunch the intended app, and inspect `osaurus doctor`."
+        case .serverNotRunning:
+            return "The installation looks usable, but the server is not running. Launch Osaurus or run `osaurus serve --port \(port)`."
+        case .startupTimeout:
+            return "Launch the intended Osaurus app explicitly, then retry `osaurus serve --port \(port)`."
+        }
+    }
+
+    nonisolated private static func portOwner(port: Int) -> String? {
+        let result = run(
+            executable: "/usr/sbin/lsof",
+            arguments: ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-Fpc"],
+            timeout: 1.0,
+            captureOutput: true
+        )
+        guard result.state == .valid, !result.output.isEmpty else { return nil }
+        let fields = result.output.split(separator: "\n").map(String.init)
+        let pid = fields.first { $0.hasPrefix("p") }.map { String($0.dropFirst()) }
+        let command = fields.first { $0.hasPrefix("c") }.map { String($0.dropFirst()) }
+        return [command, pid.map { "pid \($0)" }].compactMap { $0 }.joined(separator: " ")
+    }
+
+    nonisolated private static func assess(executable: String, arguments: [String]) -> SignatureDiagnosticState {
+        run(executable: executable, arguments: arguments, timeout: 2.0).state
+    }
+
+    nonisolated private static func run(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval,
+        captureOutput: Bool = false
+    ) -> (state: SignatureDiagnosticState, output: String) {
+        let process = Process()
+        let finished = DispatchSemaphore(value: 0)
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = captureOutput ? pipe : FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        process.terminationHandler = { _ in finished.signal() }
+        do {
+            try process.run()
+        } catch {
+            return (.unchecked, "")
+        }
+        if finished.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            if finished.wait(timeout: .now() + 0.5) == .timedOut {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                _ = finished.wait(timeout: .now() + 1)
+            }
+            process.waitUntilExit()
+            return (.timedOut, "")
+        }
+        let output: String
+        if captureOutput,
+            let data = try? pipe.fileHandleForReading.readToEnd(),
+            let decoded = String(data: data, encoding: .utf8) {
+            output = decoded
+        } else {
+            output = ""
+        }
+        return (process.terminationStatus == 0 ? .valid : .invalid, output)
+    }
+
+    nonisolated private static func normalized(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    nonisolated private static func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let left = normalizedVersionComponents(lhs)
+        let right = normalizedVersionComponents(rhs)
+        let count = max(left.count, right.count)
+        for index in 0..<count {
+            let l = index < left.count ? left[index] : 0
+            let r = index < right.count ? right[index] : 0
+            if l < r { return .orderedAscending }
+            if l > r { return .orderedDescending }
+        }
+        return .orderedSame
+    }
+
+    nonisolated private static func normalizedVersionComponents(_ value: String) -> [Int] {
+        value.split(separator: ".").map { component in
+            Int(component.prefix { $0.isNumber }) ?? 0
+        }
+    }
+
+    nonisolated private static func isOsaurusPortOwner(_ owner: String) -> Bool {
+        let command = owner.split(separator: " ").first.map(String.init)?.lowercased()
+        return command == "osaurus"
+    }
+
+    nonisolated static func countModelBundles(
+        in root: URL,
+        maximumEntries: Int = 100_000
+    ) -> (count: Int, complete: Bool) {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else { return (0, false) }
+        var modelDirectories = Set<String>()
+        var visited = 0
+        for case let url as URL in enumerator {
+            visited += 1
+            if visited > maximumEntries { return (modelDirectories.count, false) }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            guard values?.isRegularFile == true, values?.isSymbolicLink != true else { continue }
+            let name = url.lastPathComponent.lowercased()
+            if name == "config.json" || name == "tokenizer_config.json" || name.hasSuffix(".safetensors") {
+                modelDirectories.insert(url.deletingLastPathComponent().standardizedFileURL.path)
+            }
+        }
+        return (modelDirectories.count, true)
+    }
+}

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
@@ -194,7 +194,8 @@ public enum InstallationDiagnostics {
     public static func collect(
         requestedPort: Int? = nil,
         includeSignatureChecks: Bool = true,
-        startupAttempted: Bool = false
+        startupAttempted: Bool = false,
+        includeModelInventory: Bool = true
     ) async -> InstallationDiagnosticReport {
         let configuredPort = Configuration.resolveConfiguredPort()
         let port = requestedPort ?? configuredPort ?? 1337
@@ -204,9 +205,9 @@ public enum InstallationDiagnostics {
         let cli = CLIVersionResolver.resolve(
             executablePath: cliPath
         )
-        let discoveredPaths = await Task.detached(priority: .utility) {
-            AppControl.findAppBundlePaths()
-        }.value
+        // NSWorkspace is main-thread-bound. Keep discovery on this MainActor
+        // entry point, then move filesystem-only work off actor below.
+        let discoveredPaths = AppControl.findAppBundlePaths()
         let appPaths = await Task.detached(priority: .utility) {
             AppControl.deduplicatedBundlePaths(
                 discoveredPaths + [runningPath, cli.companionAppPath].compactMap { $0 }
@@ -247,6 +248,9 @@ public enum InstallationDiagnostics {
         let modelResolution = Configuration.resolveModelsDirectoryWithSource()
         let modelSnapshot = await Task.detached(priority: .utility) {
             let readable = FileManager.default.isReadableFile(atPath: modelResolution.url.path)
+            guard includeModelInventory else {
+                return (readable, (count: 0, complete: false))
+            }
             let count = countModelBundles(in: modelResolution.url)
             return (readable, count)
         }.value
@@ -292,11 +296,12 @@ public enum InstallationDiagnostics {
             compareVersions(appBuild, cliBuild) != .orderedSame {
             return compareVersions(appBuild, cliBuild) == .orderedAscending ? .appStale : .appNewer
         }
+        if let portOwner {
+            if !isOsaurusPortOwner(portOwner) { return .portBusy }
+            if !healthy { return .serverUnhealthy }
+        }
         if healthy { return .healthy }
         if apps.isEmpty { return .appAbsent }
-        if let portOwner {
-            return isOsaurusPortOwner(portOwner) ? .serverUnhealthy : .portBusy
-        }
         return startupAttempted ? .startupTimeout : .serverNotRunning
     }
 

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
@@ -193,7 +193,7 @@ public enum InstallationDiagnostics {
     @MainActor
     public static func collect(
         requestedPort: Int? = nil,
-        includeSignatureChecks: Bool = true,
+        includeSignatureChecks: Bool = false,
         startupAttempted: Bool = false,
         includeModelInventory: Bool = true,
         includeComprehensiveAppSearch: Bool = true

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/InstallationDiagnostics.swift
@@ -195,7 +195,8 @@ public enum InstallationDiagnostics {
         requestedPort: Int? = nil,
         includeSignatureChecks: Bool = true,
         startupAttempted: Bool = false,
-        includeModelInventory: Bool = true
+        includeModelInventory: Bool = true,
+        includeComprehensiveAppSearch: Bool = true
     ) async -> InstallationDiagnosticReport {
         let configuredPort = Configuration.resolveConfiguredPort()
         let port = requestedPort ?? configuredPort ?? 1337
@@ -207,7 +208,9 @@ public enum InstallationDiagnostics {
         )
         // NSWorkspace is main-thread-bound. Keep discovery on this MainActor
         // entry point, then move filesystem-only work off actor below.
-        let discoveredPaths = AppControl.findAppBundlePaths()
+        let discoveredPaths = AppControl.findAppBundlePaths(
+            includeSpotlightSearch: includeComprehensiveAppSearch
+        )
         let appPaths = await Task.detached(priority: .utility) {
             AppControl.deduplicatedBundlePaths(
                 discoveredPaths + [runningPath, cli.companionAppPath].compactMap { $0 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/InstallationDiagnosticsTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/InstallationDiagnosticsTests.swift
@@ -1,0 +1,385 @@
+//
+//  InstallationDiagnosticsTests.swift
+//  OsaurusCLITests
+//
+//  Regression coverage for stale and duplicate app installations that used to
+//  collapse into ServeCommand's generic timeout message.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCLICore
+
+@Suite
+struct InstallationDiagnosticsTests {
+    @Test
+    func explicitBuildMetadataPrecedesCompanionBundle() throws {
+        let app = try makeApp(version: "0.22.3", build: "223")
+        defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+        let output = VersionCommand.output(
+            environment: ["OSAURUS_VERSION": "9.1.0", "OSAURUS_BUILD_NUMBER": "42"],
+            executablePath: app.appendingPathComponent("Contents/Helpers/osaurus").path
+        )
+
+        #expect(output == "Osaurus 9.1.0 (42)")
+    }
+
+    @Test
+    func packagedHelperReadsCompanionBundleVersion() throws {
+        let app = try makeApp(version: "0.22.3", build: "223")
+        defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+        let output = VersionCommand.output(
+            environment: [:],
+            executablePath: app.appendingPathComponent("Contents/Helpers/osaurus").path
+        )
+
+        #expect(output == "Osaurus 0.22.3 (223)")
+    }
+
+    @Test
+    func genuineDevelopmentBuildStillReportsDev() {
+        let output = VersionCommand.output(
+            environment: [:],
+            executablePath: "/tmp/osaurus"
+        )
+        #expect(output == "Osaurus dev")
+    }
+
+    @Test
+    func standaloneCLIDoesNotBorrowDiscoveredAppVersion() throws {
+        let app = try makeApp(version: "0.22.3", build: "223")
+        defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+
+        let resolved = CLIVersionResolver.resolve(
+            environment: [:],
+            executablePath: "/tmp/osaurus"
+        )
+
+        #expect(resolved.version == nil)
+        #expect(resolved.companionAppPath == nil)
+    }
+
+    @Test
+    func bundlePathDeduplicationIgnoresCaseAndSymlinkAliases() throws {
+        let app = try makeApp(version: "0.22.3", build: "223")
+        let alias = app.deletingLastPathComponent().appendingPathComponent("Alias.app")
+        defer { try? FileManager.default.removeItem(at: app.deletingLastPathComponent()) }
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: app)
+
+        let paths = AppControl.deduplicatedBundlePaths([
+            app.path,
+            app.path.replacingOccurrences(of: "Osaurus.app", with: "osaurus.app"),
+            alias.path,
+        ])
+
+        #expect(paths.count == 1)
+        #expect(paths[0] == app.path)
+    }
+
+    @Test(arguments: [
+        (apps: [], cli: "0.22.3", healthy: false, owner: nil, expected: StartupDiagnosticKind.appAbsent),
+        (
+            apps: [app(version: "0.18.4")], cli: "0.22.3", healthy: false, owner: nil,
+            expected: StartupDiagnosticKind.appStale
+        ),
+        (
+            apps: [app(version: "0.23.0")], cli: "0.22.3", healthy: false, owner: nil,
+            expected: StartupDiagnosticKind.appNewer
+        ),
+        (
+            apps: [app(version: "0.22.3"), app(path: "/Users/test/Osaurus.app", version: "0.18.4")],
+            cli: "0.22.3", healthy: false, owner: nil,
+            expected: StartupDiagnosticKind.duplicateBundles
+        ),
+        (
+            apps: [app(version: "0.22.3"), app(path: "/Users/test/Osaurus.app", version: "0.18.4")],
+            cli: "0.22.3", healthy: false, owner: "python pid 7",
+            expected: StartupDiagnosticKind.duplicateBundles
+        ),
+        (
+            apps: [app(version: "0.22.3")], cli: "0.22.3", healthy: false,
+            owner: "python pid 7", expected: StartupDiagnosticKind.portBusy
+        ),
+        (
+            apps: [app(version: "0.22.3")], cli: "0.22.3", healthy: false,
+            owner: "osaurus pid 8", expected: StartupDiagnosticKind.serverUnhealthy
+        ),
+        (
+            apps: [app(version: "0.22.3")], cli: "0.22.3", healthy: false, owner: nil,
+            expected: StartupDiagnosticKind.serverNotRunning
+        ),
+        (
+            apps: [app(version: "0.18.4")], cli: "0.22.3", healthy: true, owner: "osaurus pid 8",
+            expected: StartupDiagnosticKind.appStale
+        ),
+    ])
+    func classifiesStartupFailures(
+        apps: [AppBundleDiagnostic],
+        cli: String,
+        healthy: Bool,
+        owner: String?,
+        expected: StartupDiagnosticKind
+    ) {
+        #expect(
+            InstallationDiagnostics.classify(
+                apps: apps,
+                cliVersion: cli,
+                healthy: healthy,
+                portOwner: owner
+            ) == expected
+        )
+    }
+
+    @Test func sameVersionDifferentBuildDetectsSkew() {
+        let stale = AppBundleDiagnostic(
+            path: "/Applications/Osaurus.app",
+            version: "0.22.3",
+            build: "9",
+            isRunning: false,
+            isCompanion: true
+        )
+        #expect(
+            InstallationDiagnostics.classify(
+                apps: [stale],
+                cliVersion: "0.22.3",
+                cliBuild: "10",
+                healthy: false,
+                portOwner: nil
+            ) == .appStale
+        )
+    }
+
+    @Test func numericVersionComparisonDoesNotUseLexicographicOrdering() {
+        #expect(
+            InstallationDiagnostics.classify(
+                apps: [Self.app(version: "0.10")],
+                cliVersion: "0.9",
+                healthy: false,
+                portOwner: nil
+            ) == .appNewer
+        )
+    }
+
+    @Test func equivalentVersionComponentCountsDoNotReportSkew() {
+        #expect(
+            InstallationDiagnostics.classify(
+                apps: [Self.app(version: "1.0")],
+                cliVersion: "1.0.0",
+                healthy: false,
+                portOwner: nil
+            ) == .serverNotRunning
+        )
+    }
+
+    @Test func attemptedStartupWithoutListenerReportsTimeout() {
+        #expect(
+            InstallationDiagnostics.classify(
+                apps: [Self.app(version: "0.22.3")],
+                cliVersion: "0.22.3",
+                healthy: false,
+                portOwner: nil,
+                startupAttempted: true
+            ) == .startupTimeout
+        )
+    }
+
+    @Test func ownerNameMustExactlyIdentifyOsaurus() {
+        #expect(
+            InstallationDiagnostics.classify(
+                apps: [Self.app(version: "0.22.3")],
+                cliVersion: "0.22.3",
+                healthy: false,
+                portOwner: "myosaurushelper pid 8"
+            ) == .portBusy
+        )
+    }
+
+    @Test func modelCountCountsBundlesInsteadOfOrganizationFolders() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let first = root.appendingPathComponent("mlx-community/first", isDirectory: true)
+        let second = root.appendingPathComponent("mlx-community/second", isDirectory: true)
+        try FileManager.default.createDirectory(at: first, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: second, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: first.appendingPathComponent("config.json"))
+        try Data().write(to: second.appendingPathComponent("model.safetensors"))
+
+        #expect(InstallationDiagnostics.countModelBundles(in: root) == (2, true))
+        #expect(InstallationDiagnostics.countModelBundles(in: root, maximumEntries: 1).complete == false)
+    }
+
+    @Test func modelDirectoryEnvironmentOverrideIsExplicitlyAttributed() {
+        let resolution = Configuration.resolveModelsDirectoryWithSource(
+            environment: ["OSU_MODELS_DIR": "/Volumes/Models"],
+            appDefaults: nil,
+            sharedDefaults: nil,
+            home: URL(fileURLWithPath: "/Users/test")
+        )
+        #expect(resolution.url.path == "/Volumes/Models")
+        #expect(resolution.source == "environment")
+    }
+
+    @Test
+    func redactedReportScrubsHomePathsButKeepsUsefulStructure() {
+        let home = "/Users/alice"
+        let report = InstallationDiagnosticReport(
+            generatedAt: Date(timeIntervalSince1970: 0),
+            cliPath: "\(home)/bin/osaurus",
+            cliVersion: "0.22.3",
+            cliBuild: "223",
+            requestedPort: 1337,
+            configuredPort: 4242,
+            serverHealthy: false,
+            portOwner: "osaurus pid 42",
+            modelRoot: "\(home)/.osaurus/models",
+            modelRootSource: "cli_default",
+            modelRootReadable: true,
+            modelCount: 2,
+            modelCountComplete: true,
+            apps: [Self.app(path: "\(home)/Applications/Osaurus.app", version: "0.22.3")],
+            diagnosis: .serverNotRunning,
+            recommendation: "Inspect \(home)/Applications/Osaurus.app"
+        ).redacted(homeDirectory: home)
+        let serialized = String(data: try! JSONEncoder().encode(report), encoding: .utf8)!
+
+        #expect(!serialized.contains(home))
+        #expect(report.cliPath == "~/bin/osaurus")
+        #expect(report.modelRoot == "~/.osaurus/models")
+        #expect(report.portOwner == "osaurus pid 42")
+    }
+
+    @Test
+    func redactedReportScrubsResolvedDataVolumeHome() {
+        let report = InstallationDiagnosticReport(
+            generatedAt: Date(timeIntervalSince1970: 0),
+            cliPath: "/System/Volumes/Data/Users/alice/bin/osaurus",
+            cliVersion: nil,
+            cliBuild: nil,
+            requestedPort: 1337,
+            configuredPort: nil,
+            serverHealthy: false,
+            portOwner: nil,
+            modelRoot: "/System/Volumes/Data/Users/alice/.osaurus/models",
+            modelRootSource: "cli_default",
+            modelRootReadable: true,
+            modelCount: 0,
+            modelCountComplete: true,
+            apps: [],
+            diagnosis: .appAbsent,
+            recommendation: "Inspect /System/Volumes/Data/Users/alice/Applications"
+        ).redacted(homeDirectory: "/Users/alice")
+
+        let rendered = DoctorCommand.render(report)
+        #expect(!rendered.contains("alice"))
+        #expect(report.cliPath == "~/bin/osaurus")
+    }
+
+    @Test
+    func doctorOptionsValidatePortsAndUnknownArguments() throws {
+        #expect(try DoctorCommand.parseOptions(["--port", "4242", "--json", "--redact"])
+            == .init(port: 4242, json: true, redact: true))
+        #expect(throws: DoctorCommand.ArgumentError.self) {
+            _ = try DoctorCommand.parseOptions(["--port", "0"])
+        }
+        #expect(throws: DoctorCommand.ArgumentError.self) {
+            _ = try DoctorCommand.parseOptions(["--port", "70000"])
+        }
+        #expect(throws: DoctorCommand.ArgumentError.self) {
+            _ = try DoctorCommand.parseOptions(["--unknown"])
+        }
+    }
+
+    @Test
+    func diagnosticReportAlwaysEncodesToNonemptyJSON() throws {
+        let report = InstallationDiagnosticReport(
+            generatedAt: Date(timeIntervalSince1970: 0),
+            cliPath: "/usr/local/bin/osaurus",
+            cliVersion: nil,
+            cliBuild: nil,
+            requestedPort: 1337,
+            configuredPort: nil,
+            serverHealthy: false,
+            portOwner: nil,
+            modelRoot: "~/.osaurus/models",
+            modelRootSource: "cli_default",
+            modelRootReadable: true,
+            modelCount: 0,
+            modelCountComplete: true,
+            apps: [],
+            diagnosis: .appAbsent,
+            recommendation: "Install Osaurus.app."
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(report)
+        #expect(!data.isEmpty)
+    }
+
+    @Test
+    func reportRenderingDoesNotIncludeEnvironmentValues() {
+        let canary = "SECRET_TOKEN_CANARY"
+        let report = InstallationDiagnosticReport(
+            generatedAt: Date(),
+            cliPath: "/Applications/Osaurus.app/Contents/Helpers/osaurus",
+            cliVersion: "0.22.3",
+            cliBuild: "223",
+            requestedPort: 1337,
+            configuredPort: 1337,
+            serverHealthy: false,
+            portOwner: nil,
+            modelRoot: "~/.osaurus/models",
+            modelRootSource: "cli_default",
+            modelRootReadable: true,
+            modelCount: 1,
+            modelCountComplete: true,
+            apps: [Self.app(version: "0.22.3")],
+            diagnosis: .serverNotRunning,
+            recommendation: "Launch the intended app."
+        )
+
+        let rendered = DoctorCommand.render(report)
+        #expect(!rendered.contains(canary))
+        #expect(rendered.contains("server_not_running"))
+        #expect(rendered.contains("0.22.3"))
+        #expect(rendered.contains("build 223"))
+    }
+
+    private static func app(
+        path: String = "/Applications/Osaurus.app",
+        version: String
+    ) -> AppBundleDiagnostic {
+        AppBundleDiagnostic(
+            path: path,
+            version: version,
+            build: nil,
+            isRunning: false,
+            isCompanion: true
+        )
+    }
+
+    private func makeApp(version: String, build: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-version-test-\(UUID().uuidString)")
+        let app = root.appendingPathComponent("Osaurus.app")
+        let contents = app.appendingPathComponent("Contents")
+        try FileManager.default.createDirectory(
+            at: contents.appendingPathComponent("Helpers"),
+            withIntermediateDirectories: true
+        )
+        let plist: [String: Any] = [
+            "CFBundleIdentifier": "com.dinoki.osaurus",
+            "CFBundleShortVersionString": version,
+            "CFBundleVersion": build,
+        ]
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: contents.appendingPathComponent("Info.plist"), options: .atomic)
+        return app
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/InstallationDiagnosticsTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/InstallationDiagnosticsTests.swift
@@ -82,6 +82,18 @@ struct InstallationDiagnosticsTests {
     @Test(arguments: [
         (apps: [], cli: "0.22.3", healthy: false, owner: nil, expected: StartupDiagnosticKind.appAbsent),
         (
+            apps: [], cli: "0.22.3", healthy: false, owner: "python pid 7",
+            expected: StartupDiagnosticKind.portBusy
+        ),
+        (
+            apps: [], cli: "0.22.3", healthy: false, owner: "osaurus pid 8",
+            expected: StartupDiagnosticKind.serverUnhealthy
+        ),
+        (
+            apps: [], cli: "0.22.3", healthy: true, owner: "python pid 7",
+            expected: StartupDiagnosticKind.portBusy
+        ),
+        (
             apps: [app(version: "0.18.4")], cli: "0.22.3", healthy: false, owner: nil,
             expected: StartupDiagnosticKind.appStale
         ),

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/InstallationDiagnosticsTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/InstallationDiagnosticsTests.swift
@@ -291,8 +291,11 @@ struct InstallationDiagnosticsTests {
 
     @Test
     func doctorOptionsValidatePortsAndUnknownArguments() throws {
-        #expect(try DoctorCommand.parseOptions(["--port", "4242", "--json", "--redact"])
-            == .init(port: 4242, json: true, redact: true))
+        #expect(try DoctorCommand.parseOptions([
+            "--port", "4242", "--json", "--redact", "--verify-signatures",
+        ]) == .init(port: 4242, json: true, redact: true, verifySignatures: true))
+        #expect(try DoctorCommand.parseOptions([])
+            == .init(port: nil, json: false, redact: false, verifySignatures: false))
         #expect(throws: DoctorCommand.ArgumentError.self) {
             _ = try DoctorCommand.parseOptions(["--port", "0"])
         }


### PR DESCRIPTION
## Summary

- Add `osaurus doctor` with human-readable and JSON diagnostics for CLI/app version skew, duplicate bundles, model paths, server health, and port ownership.
- Replace generic serve timeouts with a typed diagnosis and a specific recovery step.
- Keep app discovery main-thread safe, preserve side-loaded bundle discovery, and use a lean failure path during `serve`.
- Make deep signature and notarization checks explicit through `--verify-signatures` so the default diagnostic remains responsive on machines with many indexed app bundles.

## Validation

- all 117 CLI tests passed
- 18 installation diagnostic tests passed
- focused strict SwiftLint passed
- unsigned Release CLI build passed
- `git diff --check` passed
- live `osaurus doctor --json --redact` smoke completed in 0.97 seconds while discovering 21 app bundles; signature states remained explicitly `unchecked`

## Security and privacy

- `--redact` removes user home paths from shareable reports
- diagnostics never include credentials or model contents
- process probes are bounded and fully reaped
- signature verification is read-only and opt-in; timeouts remain distinct from invalid signatures
