### PR TITLE
Add hardware-safe automatic on-device routing

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -756,9 +756,11 @@ extension AgentManager {
         return agent.systemPrompt
     }
 
-    /// Get the effective model for an agent
-    /// For custom agents without a model set, falls back to global "new agent" default
-    public func effectiveModel(for agentId: UUID) -> String? {
+    /// Get the persisted model choice after applying agent inheritance, without
+    /// resolving synthetic choices such as Automatic. Settings and chat use
+    /// this to distinguish an explicitly automatic agent from one pinned to a
+    /// concrete model.
+    func configuredModel(for agentId: UUID) -> String? {
         let defaultAgentModel = DefaultAgentConfigurationStore.load().defaultModel
         guard let agent = agent(for: agentId) else {
             return defaultAgentModel ?? ChatConfigurationStore.load().defaultModel
@@ -775,6 +777,33 @@ extension AgentManager {
         return agent.defaultModel
             ?? ChatConfigurationStore.load().defaultModel
             ?? defaultAgentModel
+    }
+
+    /// Get the concrete effective model for an agent. An explicit Automatic
+    /// choice resolves only to an installed, compatible on-device chat model;
+    /// it never falls through to a connected cloud provider. Callers that need
+    /// media-aware routing should use `automaticModelDecision` with the turn's
+    /// requirements before dispatch.
+    public func effectiveModel(for agentId: UUID) -> String? {
+        let configured = configuredModel(for: agentId)
+        guard AutomaticModelRoutingPolicy.isAutomatic(configured) else { return configured }
+        return automaticModelDecision(for: agentId)?.modelId
+    }
+
+    func automaticModelDecision(
+        for agentId: UUID,
+        requirements: AutomaticModelRoutingPolicy.Requirements = .text,
+        currentModelId: String? = nil,
+        items: [ModelPickerItem]? = nil
+    ) -> AutomaticModelRoutingPolicy.Decision? {
+        guard AutomaticModelRoutingPolicy.isAutomatic(configuredModel(for: agentId)) else {
+            return nil
+        }
+        return AutomaticModelRoutingPolicy.resolve(
+            items: items ?? ModelPickerItemCache.shared.items,
+            requirements: requirements,
+            currentModelId: currentModelId
+        )
     }
 
     /// Get the effective temperature for an agent

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1991,6 +1991,37 @@ extension ModelManager {
                 || exists(dir, "video_config.json")
         }
 
+        /// Read the weight total from bounded bundle metadata while the local
+        /// discovery scan is already off-main. Hugging Face sharded exports
+        /// publish the exact logical byte count in
+        /// `model.safetensors.index.json`; single-file exports can be sized
+        /// with one stat call. This avoids recursively walking every shard of
+        /// 100+ GB bundles while still giving RAM guidance an authoritative
+        /// local size even when the repo was copied in manually and has no HF
+        /// `ModelSizeCache` entry.
+        func localWeightSizeBytes(_ dir: URL) -> Int64? {
+            let index = dir.appendingPathComponent("model.safetensors.index.json")
+            if exists(dir, "model.safetensors.index.json"),
+                let data = try? Data(contentsOf: index, options: [.mappedIfSafe]),
+                let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let metadata = object["metadata"] as? [String: Any],
+                let number = metadata["total_size"] as? NSNumber
+            {
+                let bytes = number.int64Value
+                if bytes > 0 { return bytes }
+            }
+
+            let single = dir.appendingPathComponent("model.safetensors")
+            if exists(dir, "model.safetensors"),
+                let attributes = try? fm.attributesOfItem(atPath: single.path),
+                let number = attributes[.size] as? NSNumber
+            {
+                let bytes = number.int64Value
+                if bytes > 0 { return bytes }
+            }
+            return nil
+        }
+
         func shouldDescendIntoLocalModelCandidate(_ entry: URL) -> Bool {
             let name = entry.lastPathComponent.lowercased()
             let skippedInfrastructureDirectories: Set<String> = [
@@ -2072,6 +2103,7 @@ extension ModelManager {
                         name: ModelMetadataParser.friendlyName(from: id),
                         description: L("Local model (detected)"),
                         downloadURL: "https://huggingface.co/\(id)",
+                        downloadSizeBytes: localWeightSizeBytes(resolved),
                         // The scan already runs off-main. Preserve the bundle's
                         // architecture tag here so hot UI paths can distinguish
                         // image-only from video-capable local VLMs without

--- a/Packages/OsaurusCore/Models/Configuration/AutomaticModelRoutingPolicy.swift
+++ b/Packages/OsaurusCore/Models/Configuration/AutomaticModelRoutingPolicy.swift
@@ -1,0 +1,202 @@
+//
+//  AutomaticModelRoutingPolicy.swift
+//  OsaurusCore
+//
+//  Explicit, hardware-safe automatic routing for agent chat.
+//
+
+import Foundation
+
+/// Resolves an agent's explicit "Automatic" model setting to a concrete
+/// on-device chat model. Cloud providers are deliberately excluded: choosing
+/// Automatic must not silently change privacy or incur usage charges.
+enum AutomaticModelRoutingPolicy {
+    /// Persisted in the existing default-model field. The value is namespaced
+    /// so it cannot collide with a provider's ordinary `auto` model slug.
+    static let modelId = "osaurus-internal/automatic-on-device"
+
+    struct Requirements: OptionSet, Hashable, Sendable {
+        let rawValue: UInt8
+
+        static let image = Requirements(rawValue: 1 << 0)
+        static let video = Requirements(rawValue: 1 << 1)
+        static let audio = Requirements(rawValue: 1 << 2)
+
+        static let text: Requirements = []
+
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+
+        init(attachments: [Attachment]) {
+            var value: Requirements = .text
+            if attachments.hasImages { value.insert(.image) }
+            if attachments.hasVideos { value.insert(.video) }
+            if attachments.hasAudios { value.insert(.audio) }
+            self = value
+        }
+
+        var label: String {
+            var labels: [String] = []
+            if contains(.image) { labels.append("image") }
+            if contains(.video) { labels.append("video") }
+            if contains(.audio) { labels.append("audio") }
+            return labels.isEmpty ? "text" : labels.joined(separator: " + ")
+        }
+    }
+
+    struct Decision: Equatable, Sendable {
+        let modelId: String
+        let displayName: String
+        let requirements: Requirements
+        let explanation: String
+    }
+
+    static func isAutomatic(_ model: String?) -> Bool {
+        model?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .caseInsensitiveCompare(modelId) == .orderedSame
+    }
+
+    /// Pick the strongest safely fitting installed model. A currently selected
+    /// safe model wins when it still satisfies the turn, preventing gratuitous
+    /// model churn (and preserving multi-turn cache locality). A vision turn may
+    /// upgrade a text-only route to a local VLM. Tight/too-large models never
+    /// route automatically; users can still choose them explicitly.
+    static func resolve(
+        items: [ModelPickerItem],
+        requirements: Requirements = .text,
+        currentModelId: String? = nil,
+        physicalMemoryGB: Double = GPUMemoryBudget.hostPhysicalMemoryGB
+    ) -> Decision? {
+        let localCandidates = items.filter { item in
+            guard item.id != modelId else { return false }
+            guard case .local = item.source else { return false }
+            guard item.isLikelyChatCapable else { return false }
+            guard item.hardwareCompatibility == .compatible else { return false }
+            return item.supports(requirements)
+        }
+
+        if let currentModelId,
+            let current = localCandidates.first(where: { $0.id == currentModelId })
+        {
+            return decision(
+                for: current,
+                requirements: requirements,
+                physicalMemoryGB: physicalMemoryGB
+            )
+        }
+
+        if let selected = strongest(in: localCandidates) {
+            return decision(
+                for: selected,
+                requirements: requirements,
+                physicalMemoryGB: physicalMemoryGB
+            )
+        }
+
+        // Apple's Foundation model is on-device and safe, but text-only. It is
+        // the honest last resort when no installed MLX model has a safe route.
+        if requirements.isEmpty,
+            let foundation = items.first(where: {
+                if case .foundation = $0.source {
+                    return $0.id != modelId && $0.isLikelyChatCapable
+                }
+                return false
+            })
+        {
+            return Decision(
+                modelId: foundation.id,
+                displayName: foundation.displayName,
+                requirements: requirements,
+                explanation: "On-device fallback · no installed local model has a safe measured fit"
+            )
+        }
+        return nil
+    }
+
+    /// Media the Automatic composer may advertise. Each flag is granted only
+    /// when the policy can name a concrete compatible on-device route for that
+    /// modality; a text route never causes unsupported media controls to appear.
+    static func availableMediaCapabilities(
+        items: [ModelPickerItem],
+        physicalMemoryGB: Double = GPUMemoryBudget.hostPhysicalMemoryGB
+    ) -> ModelMediaCapabilities.Capabilities {
+        ModelMediaCapabilities.Capabilities(
+            supportsImage: resolve(
+                items: items,
+                requirements: .image,
+                physicalMemoryGB: physicalMemoryGB
+            ) != nil,
+            supportsVideo: resolve(
+                items: items,
+                requirements: .video,
+                physicalMemoryGB: physicalMemoryGB
+            ) != nil,
+            supportsAudio: resolve(
+                items: items,
+                requirements: .audio,
+                physicalMemoryGB: physicalMemoryGB
+            ) != nil
+        )
+    }
+
+    static func failureExplanation(for requirements: Requirements) -> String {
+        if requirements.isEmpty {
+            return "No installed on-device chat model fits this Mac's recommended local-model budget."
+        }
+        return
+            "No installed on-device model supports \(requirements.label) input and fits this Mac's recommended local-model budget."
+    }
+
+    private static func strongest(in candidates: [ModelPickerItem]) -> ModelPickerItem? {
+        candidates.max { lhs, rhs in
+            let leftParameters = parameterBillions(lhs.parameterCount) ?? 0
+            let rightParameters = parameterBillions(rhs.parameterCount) ?? 0
+            if leftParameters != rightParameters { return leftParameters < rightParameters }
+            let left = lhs.estimatedMemoryGB ?? 0
+            let right = rhs.estimatedMemoryGB ?? 0
+            if left != right { return left < right }
+            if lhs.defaultChatSelectionRank != rhs.defaultChatSelectionRank {
+                return lhs.defaultChatSelectionRank > rhs.defaultChatSelectionRank
+            }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedDescending
+        }
+    }
+
+    /// Catalog parameter strings are display metadata (for example `27B`,
+    /// `1.7B`, or `350M`). Prefer the larger capable model before using working
+    /// set as a tiebreak, which avoids treating a better 1-bit model as weaker
+    /// merely because its quantization is smaller on disk/in memory.
+    private static func parameterBillions(_ value: String?) -> Double? {
+        guard let value else { return nil }
+        let normalized = value.uppercased()
+        let number = normalized.prefix { $0.isNumber || $0 == "." }
+        guard let parsed = Double(number) else { return nil }
+        if normalized.contains("B") { return parsed }
+        if normalized.contains("M") { return parsed / 1_000 }
+        return nil
+    }
+
+    private static func decision(
+        for item: ModelPickerItem,
+        requirements: Requirements,
+        physicalMemoryGB: Double
+    ) -> Decision {
+        let fit =
+            ModelHardwareGuidance.fitSummary(
+                estimatedMemoryGB: item.estimatedMemoryGB,
+                compatibility: item.hardwareCompatibility,
+                physicalMemoryGB: physicalMemoryGB
+            ) ?? "On-device model"
+        let capability =
+            requirements.isEmpty
+            ? "Private on-device route"
+            : "On-device \(requirements.label) route"
+        return Decision(
+            modelId: item.id,
+            displayName: item.displayName,
+            requirements: requirements,
+            explanation: "\(capability) · \(fit)"
+        )
+    }
+}

--- a/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
+++ b/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
@@ -28,15 +28,21 @@ enum GPUMemoryBudget {
 
     /// Apple's default split between the GPU working set and everything else.
     /// Machines at or below 36 GB hold back proportionally more for the OS.
+    /// The 128 GB-and-up tier follows the 84% working-set ceiling Metal
+    /// advertises on current high-memory Apple silicon, leaving roughly 20 GB
+    /// for macOS and app/runtime overhead while still allowing explicit
+    /// 105–109 GB-class loads. Mid-memory machines retain the conservative 75%
+    /// split that prevents the proven 48 GB paging regression.
     ///
-    /// This is deliberately the long-standing documented split rather than the
-    /// (larger) figure recent macOS releases advertise — an M5 Max on macOS 26
-    /// reports 84% of RAM. Pinning the catalog verdict to the conservative
-    /// number keeps it stable across OS releases and never optimistic, and the
-    /// `.tight` band below absorbs the difference.
+    /// The tier boundary is deliberate: current 128 GB hardware advertises an
+    /// 84% Metal working set, while the smaller-machine paging regression was
+    /// reproduced under the older 75% split. Host calculations are still
+    /// capped by Metal's live advertised value below.
     static func defaultBudgetGB(physicalMemoryGB: Double) -> Double {
         guard physicalMemoryGB > 0 else { return 0 }
-        return physicalMemoryGB * (physicalMemoryGB <= 36.5 ? (2.0 / 3.0) : 0.75)
+        if physicalMemoryGB <= 36.5 { return physicalMemoryGB * (2.0 / 3.0) }
+        if physicalMemoryGB >= 127.5 { return physicalMemoryGB * 0.84 }
+        return physicalMemoryGB * 0.75
     }
 
     /// Physical memory of the machine we're running on, in GB.
@@ -74,5 +80,103 @@ enum GPUMemoryBudget {
             let advertised = hostAdvertisedBudgetGB
         else { return base }
         return min(base, advertised)
+    }
+}
+
+/// User-facing wording for the exact budget that powers model compatibility
+/// and automatic routing. Keeping this beside `GPUMemoryBudget` prevents UI
+/// copy from drifting back to raw physical RAM while the policy uses the
+/// smaller GPU working-set ceiling.
+enum ModelHardwareGuidance {
+    /// Native image jobs use a separate MLX graph with denoise/VAE buffers.
+    /// Keep their catalog estimate identical to the existing execution-time
+    /// RAM preflight (`ChatResidencyHandoff.memoryPreflight`) so Automatic and
+    /// the visible fit label never approve a graph the final gate estimates
+    /// differently.
+    private static let delegatedModelRuntimeInflation = 1.3
+    private static let delegatedModelRuntimeHeadroomGB = 3.0
+
+    /// The same fit bands used by chat-model cards, image-model defaults, and
+    /// Automatic routing. Explicit tight-fit choices remain selectable; only
+    /// `.compatible` is eligible for an unattended automatic route.
+    static func compatibility(
+        estimatedMemoryGB: Double?,
+        physicalMemoryGB: Double
+    ) -> ModelCompatibility {
+        guard let required = estimatedMemoryGB, required > 0, physicalMemoryGB > 0 else {
+            return .unknown
+        }
+        let budget = GPUMemoryBudget.budgetGB(physicalMemoryGB: physicalMemoryGB)
+        guard budget > 0 else { return .unknown }
+        let ratio = required / budget
+        if ratio <= 0.85 { return .compatible }
+        if ratio <= 1.10 { return .tight }
+        return .tooLarge
+    }
+
+    static func formattedGB(_ value: Double) -> String {
+        guard value.isFinite, value > 0 else { return "0 GB" }
+        if abs(value.rounded() - value) < 0.05 {
+            return String(format: "%.0f GB", value)
+        }
+        return String(format: "%.1f GB", value)
+    }
+
+    static func estimatedImageWorkingSetGB(onDiskBytes: UInt64) -> Double? {
+        guard onDiskBytes > 0 else { return nil }
+        let onDiskGB = Double(onDiskBytes) / (1024 * 1024 * 1024)
+        return onDiskGB * delegatedModelRuntimeInflation
+            + delegatedModelRuntimeHeadroomGB
+    }
+
+    static func delegatedModelPreflightRequiredBytes(onDiskBytes: Int64) -> Int64 {
+        guard onDiskBytes > 0 else { return 0 }
+        let headroomBytes = Int64(
+            delegatedModelRuntimeHeadroomGB * 1024 * 1024 * 1024
+        )
+        return Int64(Double(onDiskBytes) * delegatedModelRuntimeInflation)
+            + headroomBytes
+    }
+
+    static func budgetSummary(physicalMemoryGB: Double) -> String? {
+        guard physicalMemoryGB > 0 else { return nil }
+        let budget = GPUMemoryBudget.budgetGB(physicalMemoryGB: physicalMemoryGB)
+        guard budget > 0 else { return nil }
+        return "\(formattedGB(physicalMemoryGB)) unified memory · \(formattedGB(budget)) recommended local-model budget"
+    }
+
+    static func fitSummary(
+        estimatedMemoryGB: Double?,
+        compatibility: ModelCompatibility?,
+        physicalMemoryGB: Double
+    ) -> String? {
+        guard let compatibility else { return nil }
+        let verdict: String
+        switch compatibility {
+        case .compatible: verdict = "Comfortable fit"
+        case .tight: verdict = "Tight fit"
+        case .tooLarge: verdict = "Too large"
+        case .unknown: verdict = "Fit unknown"
+        }
+
+        guard
+            let workingSet = workingSetSummary(
+                estimatedMemoryGB: estimatedMemoryGB,
+                physicalMemoryGB: physicalMemoryGB
+            )
+        else { return verdict }
+        return "\(verdict) · \(workingSet)"
+    }
+
+    static func workingSetSummary(
+        estimatedMemoryGB: Double?,
+        physicalMemoryGB: Double
+    ) -> String? {
+        guard let estimatedMemoryGB, estimatedMemoryGB > 0 else { return nil }
+        let budget = GPUMemoryBudget.budgetGB(physicalMemoryGB: physicalMemoryGB)
+        guard budget > 0 else {
+            return "~\(formattedGB(estimatedMemoryGB)) working set"
+        }
+        return "~\(formattedGB(estimatedMemoryGB)) working set · \(formattedGB(budget)) budget"
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -539,22 +539,41 @@ struct MLXModel: Identifiable, Codable {
         }
     }
 
-    /// Estimated memory required to run this model (in GB), including overhead
-    /// for KV cache, activations, and runtime buffers.
+    /// Estimated memory required to load this model (in GB), including runtime
+    /// headroom.
     ///
     /// Prefers the **measured** on-disk size (folded in from `ModelSizeCache`
     /// via `withDownloadSize`) when known — weights dominate the footprint, so
     /// the real byte count plus the headroom multiplier is more honest than
     /// the `params × bytesPerParameter` constant heuristic. The heuristic is
     /// only the fallback for entries we haven't sized yet.
-    var estimatedMemoryGB: Double? {
+    /// Near-RAM-scale loads on 128 GB-and-up Macs are materialized by the real
+    /// vMLX memory-safety plan (rather than mmap-streamed) when the weights fit.
+    /// For that lane the runtime's authoritative preflight is weights plus a
+    /// fixed 4 GiB working margin; multiplying a 98 GiB bundle by the generic
+    /// 1.25 factor falsely reports 122.5 GiB and blocks the 105–109 GB-class
+    /// bundles these machines can load. Smaller models and smaller Macs keep
+    /// the conservative percentage headroom that caught the 48 GB paging
+    /// regression.
+    func estimatedMemoryGB(totalMemoryGB: Double) -> Double? {
         if let dlBytes = downloadSizeBytes, dlBytes > 0 {
-            return Double(dlBytes) * Self.overheadMultiplier / Self.bytesPerGB
+            let weightsGB = Double(dlBytes) / Self.bytesPerGB
+            if totalMemoryGB >= 127.5 {
+                let fraction = weightsGB / totalMemoryGB
+                if fraction > 0.55, fraction <= 0.86 {
+                    return weightsGB + 4.0
+                }
+            }
+            return weightsGB * Self.overheadMultiplier
         }
         if let params = parameterCountBillions {
             return params * bytesPerParameter * 1e9 * Self.overheadMultiplier / Self.bytesPerGB
         }
         return nil
+    }
+
+    var estimatedMemoryGB: Double? {
+        estimatedMemoryGB(totalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB)
     }
 
     /// Formatted estimated memory string (e.g. "~3.5 GB")
@@ -564,17 +583,6 @@ struct MLXModel: Identifiable, Codable {
             ? String(format: "~%.0f MB", gb * 1024)
             : String(format: "~%.1f GB", gb)
     }
-
-    /// Comfortably inside the GPU working set, with room for a long-context KV
-    /// cache to grow.
-    private static let comfortableBudgetRatio: Double = 0.85
-    /// The most a working set may overshoot the budget and still be offered.
-    /// `GPUMemoryBudget.defaultBudgetGB` is the conservative split rather than
-    /// the larger one modern macOS advertises, and the recommended working set
-    /// is a recommendation rather than a cliff, so a small overshoot is
-    /// survivable — it just leaves nothing for other apps. Past this the
-    /// weights get paged.
-    private static let maxBudgetRatio: Double = 1.10
 
     /// Assess whether this model can run on a Mac with `totalMemoryGB` of
     /// unified memory.
@@ -587,13 +595,10 @@ struct MLXModel: Identifiable, Codable {
     /// 48 GB Mac budgets only ~36 GB to the GPU: 89% of RAM, but 119% of what
     /// it can actually hold.
     func compatibility(totalMemoryGB: Double) -> ModelCompatibility {
-        guard let required = estimatedMemoryGB, totalMemoryGB > 0 else { return .unknown }
-        let budget = GPUMemoryBudget.budgetGB(physicalMemoryGB: totalMemoryGB)
-        guard budget > 0 else { return .unknown }
-        let ratio = required / budget
-        if ratio <= Self.comfortableBudgetRatio { return .compatible }
-        if ratio <= Self.maxBudgetRatio { return .tight }
-        return .tooLarge
+        ModelHardwareGuidance.compatibility(
+            estimatedMemoryGB: estimatedMemoryGB(totalMemoryGB: totalMemoryGB),
+            physicalMemoryGB: totalMemoryGB
+        )
     }
 
     /// Compact "MMM yyyy" form of `releasedAt`, e.g. "Apr 2026". Locale
@@ -613,7 +618,7 @@ struct MLXModel: Identifiable, Codable {
 }
 
 /// Hardware compatibility assessment for a model.
-enum ModelCompatibility {
+enum ModelCompatibility: Hashable, Sendable {
     case compatible
     case tight
     case tooLarge

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -142,6 +142,32 @@ public enum ModelMediaCapabilities {
         }
     }
 
+    /// Composer descriptor for Automatic routing. A modality is offered only
+    /// when the routing policy already found a compatible installed on-device
+    /// model for it, so accepting a file can never imply a cloud fallback.
+    static func automaticDescriptor(capabilities: Capabilities) -> Descriptor {
+        func modality(
+            _ value: Modality,
+            supported: Bool
+        ) -> ModalityDescriptor {
+            ModalityDescriptor(
+                modality: value,
+                status: supported ? .supported : .unsupported,
+                reason: supported
+                    ? "Automatic can switch to a compatible on-device \(value.label) model."
+                    : "Automatic found no compatible installed on-device model for \(value.label) input."
+            )
+        }
+
+        return Descriptor(
+            modelId: AutomaticModelRoutingPolicy.modelId,
+            capabilities: capabilities,
+            image: modality(.image, supported: capabilities.supportsImage),
+            video: modality(.video, supported: capabilities.supportsVideo),
+            audio: modality(.audio, supported: capabilities.supportsAudio)
+        )
+    }
+
     // MARK: - Detection by model_id (substring + regex)
     //
     // Fast path used by the UI before / without the model being

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -78,6 +78,13 @@ struct ModelPickerItem: Identifiable, Hashable {
     /// Whether this is a Vision Language Model
     let isVLM: Bool
 
+    /// Per-modality media support used by Automatic routing. These are
+    /// concrete bundle/provider facts, not an inference from the generic VLM
+    /// bit, so video/audio upgrades never target an image-only model.
+    let supportsImageInput: Bool
+    let supportsVideoInput: Bool
+    let supportsAudioInput: Bool
+
     /// Whether the local bundle is in MLX format and therefore loadable by the
     /// local engine. Set from `MLXModel.isMLXFormat` for local items so the
     /// picker can grey out (and refuse to select) co-mingled non-MLX bundles
@@ -92,6 +99,16 @@ struct ModelPickerItem: Identifiable, Hashable {
 
     /// Description of the model (optional)
     let description: String?
+
+    /// Estimated local working set, including runtime overhead. Populated for
+    /// installed MLX models so automatic routing and the picker use the same
+    /// hardware facts as the catalog instead of guessing from parameter names.
+    let estimatedMemoryGB: Double?
+
+    /// Host-specific fit verdict for an installed local model. Nil for cloud,
+    /// Foundation, image-generation, and legacy/test items without a measured
+    /// local working set.
+    let hardwareCompatibility: ModelCompatibility?
 
     /// Input price in micro-USD per million tokens, parsed from the Osaurus
     /// router metadata. Used only to sort the Osaurus tab by price; `nil` for
@@ -125,6 +142,10 @@ struct ModelPickerItem: Identifiable, Hashable {
     let imageDefaultGuidance: Float?
     let imageReady: Bool
 
+    /// Synthetic settings choices such as Automatic are not real models and
+    /// therefore should not appear in the user's favourites list.
+    let isFavoriteEligible: Bool
+
     init(
         id: String,
         displayName: String,
@@ -132,9 +153,14 @@ struct ModelPickerItem: Identifiable, Hashable {
         parameterCount: String? = nil,
         quantization: String? = nil,
         isVLM: Bool = false,
+        supportsImageInput: Bool = false,
+        supportsVideoInput: Bool = false,
+        supportsAudioInput: Bool = false,
         isMLXFormat: Bool = true,
         isEmbedding: Bool = false,
         description: String? = nil,
+        estimatedMemoryGB: Double? = nil,
+        hardwareCompatibility: ModelCompatibility? = nil,
         inputPriceMicroPerMTok: Int64? = nil,
         outputPriceMicroPerMTok: Int64? = nil,
         contextLength: Int? = nil,
@@ -144,7 +170,8 @@ struct ModelPickerItem: Identifiable, Hashable {
         imageCapabilities: ImageModelCapabilities? = nil,
         imageDefaultSteps: Int? = nil,
         imageDefaultGuidance: Float? = nil,
-        imageReady: Bool = false
+        imageReady: Bool = false,
+        isFavoriteEligible: Bool = true
     ) {
         self.id = id
         self.displayName = displayName
@@ -152,9 +179,14 @@ struct ModelPickerItem: Identifiable, Hashable {
         self.parameterCount = parameterCount
         self.quantization = quantization
         self.isVLM = isVLM
+        self.supportsImageInput = supportsImageInput
+        self.supportsVideoInput = supportsVideoInput
+        self.supportsAudioInput = supportsAudioInput
         self.isMLXFormat = isMLXFormat
         self.isEmbedding = isEmbedding
         self.description = description
+        self.estimatedMemoryGB = estimatedMemoryGB
+        self.hardwareCompatibility = hardwareCompatibility
         self.inputPriceMicroPerMTok = inputPriceMicroPerMTok
         self.outputPriceMicroPerMTok = outputPriceMicroPerMTok
         self.contextLength = contextLength
@@ -165,6 +197,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         self.imageDefaultSteps = imageDefaultSteps
         self.imageDefaultGuidance = imageDefaultGuidance
         self.imageReady = imageReady
+        self.isFavoriteEligible = isFavoriteEligible
     }
 
     /// Check if model matches search query using fuzzy matching.
@@ -186,7 +219,7 @@ struct ModelPickerItem: Identifiable, Hashable {
 extension ModelPickerItem {
     /// Create a Foundation model picker item
     static func foundation() -> ModelPickerItem {
-        ModelPickerItem(
+        return ModelPickerItem(
             id: "foundation",
             displayName: "Foundation",
             source: .foundation,
@@ -194,29 +227,63 @@ extension ModelPickerItem {
         )
     }
 
+    /// Synthetic agent-settings choice. It is injected only into model
+    /// settings pickers; the shared runtime cache continues to contain only
+    /// concrete models, so API listings and subagent allow-lists never expose
+    /// this internal routing sentinel as if it were loadable.
+    static func automaticOnDevice() -> ModelPickerItem {
+        return ModelPickerItem(
+            id: AutomaticModelRoutingPolicy.modelId,
+            displayName: "Automatic",
+            source: .foundation,
+            description: "Chooses the strongest compatible model on this Mac and stays on device",
+            isFavoriteEligible: false
+        )
+    }
+
     /// Create a local MLX model picker item from an MLXModel.
     static func fromMLXModel(_ model: MLXModel) -> ModelPickerItem {
-        ModelPickerItem(
+        let media = ModelMediaCapabilities.composerCapabilities(
+            modelId: model.id,
+            fallbackSupportsImages: model.isVLM,
+            localModelType: model.modelType
+        )
+        return ModelPickerItem(
             id: model.id,
             displayName: model.name,
             source: .local,
             parameterCount: model.parameterCount,
             quantization: model.quantization,
             isVLM: model.isVLM,
+            supportsImageInput: media.supportsImage,
+            supportsVideoInput: media.supportsVideo,
+            supportsAudioInput: media.supportsAudio,
             isMLXFormat: model.isMLXFormat,
             isEmbedding: model.isEmbedding,
-            description: model.description
+            description: model.description,
+            estimatedMemoryGB: model.estimatedMemoryGB,
+            hardwareCompatibility: model.compatibility(
+                totalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
+            )
         )
     }
 
     /// Create an on-device image-generation model picker item.
     static func fromImageModel(_ model: ImageModelInfo) -> ModelPickerItem {
-        ModelPickerItem(
+        let estimatedMemoryGB = ModelHardwareGuidance.estimatedImageWorkingSetGB(
+            onDiskBytes: model.totalBytes
+        )
+        return ModelPickerItem(
             id: model.id,
             displayName: model.displayName,
             source: .imageGeneration,
             quantization: model.quantizationBits.map { "\($0)-bit" },
             description: model.ready ? nil : model.blockedReasons.first,
+            estimatedMemoryGB: estimatedMemoryGB,
+            hardwareCompatibility: ModelHardwareGuidance.compatibility(
+                estimatedMemoryGB: estimatedMemoryGB,
+                physicalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
+            ),
             imageKind: model.kind,
             imageCapabilities: model.capabilities,
             imageDefaultSteps: model.defaultSteps,
@@ -235,6 +302,21 @@ extension ModelPickerItem {
             id: modelId,
             displayName: displayName(fromModelId: modelId),
             source: .remote(providerName: providerName, providerId: providerId)
+        )
+    }
+
+    func supports(_ requirements: AutomaticModelRoutingPolicy.Requirements) -> Bool {
+        if requirements.contains(.image), !supportsImageInput { return false }
+        if requirements.contains(.video), !supportsVideoInput { return false }
+        if requirements.contains(.audio), !supportsAudioInput { return false }
+        return true
+    }
+
+    var hardwareGuidance: String? {
+        ModelHardwareGuidance.fitSummary(
+            estimatedMemoryGB: estimatedMemoryGB,
+            compatibility: hardwareCompatibility,
+            physicalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
         )
     }
 
@@ -575,6 +657,12 @@ enum ModelPickerVisionFilter: CaseIterable, Identifiable, Hashable {
 }
 
 extension Array where Element == ModelPickerItem {
+    /// Agent settings include an explicit Automatic choice without polluting
+    /// the shared runtime/catalog list with a non-loadable sentinel.
+    var withAutomaticOnDeviceChoice: [ModelPickerItem] {
+        [.automaticOnDevice()] + filter { $0.id != AutomaticModelRoutingPolicy.modelId }
+    }
+
     /// Keep only models whose context window meets the filter's minimum. Items
     /// with unknown context are dropped when a minimum is set; `.any` is a
     /// no-op that returns the receiver unchanged.

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -55,6 +55,8 @@ public enum ServerRuntimeSettingsStore {
         ".server-runtime-cache-defaults-v2-migrated"
     private static let pagedCacheDefaultOffMigrationMarkerName =
         ".server-runtime-paged-cache-default-off-v3-migrated"
+    private static let memorySafetyOwnedCacheDefaultsMigrationMarkerName =
+        ".server-runtime-memory-safety-cache-defaults-v4-migrated"
 
     // MARK: - Load / Save
 
@@ -160,12 +162,102 @@ public enum ServerRuntimeSettingsStore {
         cachedSnapshot = settings
     }
 
-    public nonisolated static func modelLoadRAMThresholds() -> (soft: Double, hard: Double) {
+    /// Whether the user explicitly selected the dangerous profile with no
+    /// replacement physical-memory ceiling. This is the shared switch for
+    /// Osaurus-owned load refusal/send/eviction gates; keeping it here prevents
+    /// the settings UI and runtime from assigning different meanings to the
+    /// final slider position.
+    public nonisolated static func automaticMemoryLimitsDisabled(
+        for settings: VMLXServerRuntimeSettings? = nil
+    ) -> Bool {
+        let settings = settings ?? snapshot()
+        return settings.memorySafety.mode == .diagnosticDangerous
+            && settings.memorySafety.customPhysicalMemoryFraction == nil
+    }
+
+    public nonisolated static func modelLoadRAMThresholds(
+        for settings: VMLXServerRuntimeSettings? = nil
+    ) -> (soft: Double, hard: Double) {
+        // These thresholds remain useful telemetry in dangerous mode, but
+        // must not retain the legacy 80%/95% assumptions after the user has
+        // explicitly removed automatic memory limits.
+        if automaticMemoryLimitsDisabled(for: settings) {
+            return (soft: 1.0, hard: 1.0)
+        }
         let configuration = diskBackedServerConfiguration() ?? .default
         return ServerConfiguration.normalizedModelLoadRAMThresholds(
             soft: configuration.modelLoadRAMSoftThreshold,
             hard: configuration.modelLoadRAMHardThreshold
         )
+    }
+
+    /// The one Osaurus-owned memory-plan resolver used by the settings UI,
+    /// diagnostics, cache construction, and every model load. vMLX's
+    /// `diagnostic_dangerous` profile deliberately removes allocator/KV caps,
+    /// but its generic resolver still expresses the load ceiling as 100% of
+    /// physical memory and supplies a single-sequence fallback. In Osaurus the
+    /// final slider position is the explicit "no automatic limits" choice:
+    /// when its advanced fields are blank, do not silently retain those two
+    /// host assumptions. Explicit cache/concurrency/custom-fraction overrides
+    /// remain authoritative. Detected physical/Metal working-set sizes remain
+    /// visible as guidance, but Osaurus does not turn them into a refusal in
+    /// this explicitly dangerous mode; engine/platform allocation failures can
+    /// still occur.
+    public nonisolated static func resolvedMemorySafetyPlan(
+        for settings: VMLXServerRuntimeSettings,
+        baseLoadConfiguration: LoadConfiguration = .default,
+        bundleFacts: LoadBundleFacts? = nil,
+        host: MemoryStatus? = nil,
+        request: VMLXMemoryRequestEstimate? = nil
+    ) -> VMLXResolvedMemorySafetyPlan {
+        var plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: baseLoadConfiguration,
+            bundleFacts: bundleFacts,
+            host: host,
+            request: request
+        )
+        guard settings.memorySafety.mode == .diagnosticDangerous else {
+            return plan
+        }
+
+        if settings.memorySafety.customPhysicalMemoryFraction == nil {
+            plan.loadConfiguration.memoryLimit = .unlimited
+            plan.resolvedLoadBudgetBytes = nil
+        }
+        if settings.memorySafety.customMaxConcurrentSequences == nil,
+            settings.concurrency.maxConcurrentSequences == nil
+        {
+            plan.concurrency.maxConcurrentSequences = nil
+        }
+
+        plan.warnings.append(
+            "No automatic Osaurus memory caps, load refusals, or percentage-based evictions are applied. Explicit advanced/cache/concurrency overrides remain in force; physical and Metal working-set guidance stays visible, and engine/platform allocations can still fail."
+        )
+        plan.displaySummary = memorySafetyDisplaySummary(
+            settings: settings,
+            plan: plan
+        )
+        return plan
+    }
+
+    private nonisolated static func memorySafetyDisplaySummary(
+        settings: VMLXServerRuntimeSettings,
+        plan: VMLXResolvedMemorySafetyPlan
+    ) -> String {
+        let concurrency = plan.concurrency.maxConcurrentSequences.map(String.init) ?? "default"
+        let kv = plan.cache.defaultMaxKVSize.map(String.init) ?? "unlimited"
+        return "mode=\(settings.memorySafety.mode.rawValue) slider=\(settings.memorySafety.slider) load_cap=\(residentCapSummary(plan.loadConfiguration.memoryLimit)) allocator_cap=\(residentCapSummary(plan.loadConfiguration.maxResidentBytes)) max_concurrent=\(concurrency) kv_cap=\(kv)"
+    }
+
+    private nonisolated static func residentCapSummary(_ cap: ResidentCap) -> String {
+        switch cap {
+        case .unlimited:
+            return "unlimited"
+        case .fraction(let fraction):
+            return String(format: "%.2f", fraction)
+        case .absolute(let bytes):
+            return String(bytes)
+        }
     }
 
     private nonisolated static func normalizeLoadedSettings(
@@ -225,6 +317,15 @@ public enum ServerRuntimeSettingsStore {
         if shouldRepairPagedCacheDefault(normalized.cache) {
             normalized.cache.pagedKV.enabled = false
             writePagedCacheDefaultOffMigrationMarker()
+        }
+        if shouldRepairMemorySafetyOwnedCacheDefaults(normalized.cache) {
+            // The persisted 15% prefix-cache value was an old product default,
+            // not a user-selected override. Leaving it non-nil makes every
+            // Memory Safety mode inherit 15%, so Performance/Strict cannot
+            // apply 20%/10% and No Automatic Limits cannot remove the cap.
+            // A non-default percentage or an explicit MiB cap is preserved.
+            normalized.cache.prefix.memoryPercent = nil
+            writeMemorySafetyOwnedCacheDefaultsMigrationMarker()
         }
         return normalized
     }
@@ -293,6 +394,36 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func writePagedCacheDefaultOffMigrationMarker() {
         let url = pagedCacheDefaultOffMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
+    }
+
+    private nonisolated static func shouldRepairMemorySafetyOwnedCacheDefaults(
+        _ cache: VMLXServerCacheSettings
+    ) -> Bool {
+        guard
+            !FileManager.default.fileExists(
+                atPath: memorySafetyOwnedCacheDefaultsMigrationMarkerURL().path
+            )
+        else { return false }
+        return cache.prefix.enabled
+            && cache.prefix.legacyEntryCountCache == false
+            && cache.prefix.memoryLimitMB == nil
+            && cache.prefix.memoryPercent == 15.0
+            && cache.prefix.ttlMinutes == nil
+            && cache.pagedKV.enabled == false
+            && (cache.liveKVCodec == .engineSelected || cache.liveKVCodec == .none)
+            && cache.turboQuantKeyBits == nil
+            && cache.turboQuantValueBits == nil
+            && (cache.defaultMaxKVSize == nil || cache.defaultMaxKVSize == 65536)
+            && cache.longPromptMultiplier == 2.0
+            && cache.legacyDisk.enabled == false
+            && cache.blockDisk.enabled
+            && cache.enableSSMReDerive
+    }
+
+    private nonisolated static func writeMemorySafetyOwnedCacheDefaultsMigrationMarker() {
+        let url = memorySafetyOwnedCacheDefaultsMigrationMarkerURL()
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         try? Data().write(to: url, options: [.atomic])
     }
@@ -368,7 +499,11 @@ public enum ServerRuntimeSettingsStore {
                 enabled: true,
                 legacyEntryCountCache: false,
                 memoryLimitMB: nil,
-                memoryPercent: 15,
+                // nil lets the selected Memory Safety profile own this default
+                // (Performance 20%, Safe Auto/Balanced 15%, Strict 10%, and
+                // No Automatic Limits uncapped). An explicit Cache-setting
+                // value remains non-nil and therefore wins in the resolver.
+                memoryPercent: nil,
                 ttlMinutes: nil
             ),
             pagedKV: VMLXPagedKVCacheSettings(
@@ -497,6 +632,10 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func pagedCacheDefaultOffMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(pagedCacheDefaultOffMigrationMarkerName)
+    }
+
+    private nonisolated static func memorySafetyOwnedCacheDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(memorySafetyOwnedCacheDefaultsMigrationMarkerName)
     }
 
     private nonisolated static func legacyConfigurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
+++ b/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
@@ -138,6 +138,17 @@ public enum SettingsSearchIndex {
 
         // MARK: Chat (generation knobs now live in the dedicated Chat tab)
         .init(
+            id: "settings.chat.defaultModel",
+            tab: .chat,
+            section: "Chat",
+            title: "Default Model",
+            keywords: [
+                "automatic", "automatic model", "automatic routing",
+                "on device", "local model", "model routing",
+                "hardware", "hardware guidance", "memory budget",
+            ]
+        ),
+        .init(
             id: "settings.chat.systemPrompt",
             tab: .chat,
             section: "Chat",

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1027,7 +1027,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let runtimeSettings = ServerRuntimeSettingsStore.snapshot()
             let memoryStatus = MemoryStatus.snapshot()
-            let memorySafetyPlan = runtimeSettings.resolvedMemorySafetyPlan(
+            let memorySafetyPlan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+                for: runtimeSettings,
                 baseLoadConfiguration: .osaurusProduction,
                 host: memoryStatus
             )
@@ -1471,6 +1472,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         return [
             "mode": memorySafety.mode.rawValue,
             "slider": memorySafety.slider,
+            "automatic_memory_limits_disabled":
+                ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings),
             "allowed": plan.blockingIssues.isEmpty,
             "display_summary": plan.displaySummary,
             "resolved_physical_memory_bytes": plan.resolvedPhysicalMemoryBytes,
@@ -9094,6 +9097,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         "required_available_bytes": f.requiredAvailableBytes,
                         "soft_limit_bytes": f.softLimitBytes,
                         "hard_limit_bytes": f.hardLimitBytes,
+                        "automatic_memory_limits_disabled":
+                            f.automaticMemoryLimitsDisabled,
                         // What Metal actually keeps resident. A load past this
                         // is paged by macOS rather than refused, so support
                         // needs to see it to explain a "fits but crawls" model.

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4809,10 +4809,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // and older clients send the "default" sentinel. Both resolve to
             // the agent's effective model server-side.
             let model: String
+            var automaticRouteUnavailable = false
             if req.model.isEmpty || req.model == "default" {
-                let agentModel = await MainActor.run { AgentManager.shared.effectiveModel(for: agentId) }
+                let (configuredModel, agentModel) = await MainActor.run {
+                    (
+                        AgentManager.shared.configuredModel(for: agentId),
+                        AgentManager.shared.effectiveModel(for: agentId)
+                    )
+                }
                 if let agentModel {
                     model = agentModel
+                } else if AutomaticModelRoutingPolicy.isAutomatic(configuredModel) {
+                    // Automatic is an explicit on-device privacy boundary. If
+                    // there is no safely fitting local route, never reuse an
+                    // already-loaded cloud model as the generic fallback.
+                    automaticRouteUnavailable = true
+                    model = ""
                 } else {
                     // No configured default model for this agent (e.g. a fresh
                     // install where the user hasn't pinned one). Fall back to the
@@ -4839,8 +4851,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // canonical "agent has no model configured" signal. ("default" is
             // left intact — it resolves to the host's local Foundation model.)
             if model.isEmpty {
-                let msg =
-                    "This agent has no model configured. Set the agent's default model on the host and try again."
+                let msg = automaticRouteUnavailable
+                    ? AutomaticModelRoutingPolicy.failureExplanation(for: .text)
+                    : "This agent has no model configured. Set the agent's default model on the host and try again."
                 RemoteAgentRunLog.serverError(
                     "run agent=\(agentId.uuidString) FAILED reqModel=\(req.model.isEmpty ? "<omitted>" : req.model) error=no_model_resolved"
                 )

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -176553,6 +176553,346 @@
           }
         }
       }
+    },
+    "Automatic (on device)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatisch (auf dem Gerät)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동(온디바이스)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически (на устройстве)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动（设备端）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動（裝置端）"
+          }
+        }
+      }
+    },
+    "Automatic model routing unavailable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatische Modellweiterleitung nicht verfügbar"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 모델 라우팅을 사용할 수 없음"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматическая маршрутизация модели недоступна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动模型路由不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動模型路由無法使用"
+          }
+        }
+      }
+    },
+    "Choose a model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell auswählen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모델 선택"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите модель"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇模型"
+          }
+        }
+      }
+    },
+    "Comfortable fit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passt bequem"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여유 있게 적합"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Комфортно помещается"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻松适配"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輕鬆適配"
+          }
+        }
+      }
+    },
+    "Exceeds this Mac's recommended model budget" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überschreitet das empfohlene Modellbudget dieses Macs"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 Mac의 권장 모델 예산을 초과함"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Превышает рекомендуемый бюджет модели для этого Mac"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超出此 Mac 的建议模型预算"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超出此 Mac 的建議模型預算"
+          }
+        }
+      }
+    },
+    "Fits this Mac's recommended model budget" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passt in das empfohlene Modellbudget dieses Macs"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 Mac의 권장 모델 예산에 맞음"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Укладывается в рекомендуемый бюджет модели для этого Mac"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合此 Mac 的建议模型预算"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合此 Mac 的建議模型預算"
+          }
+        }
+      }
+    },
+    "Local-model budget unavailable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Budget für lokale Modelle nicht verfügbar"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬 모델 예산을 사용할 수 없음"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бюджет локальной модели недоступен"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地模型预算不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機模型預算無法使用"
+          }
+        }
+      }
+    },
+    "No Automatic Limits (Dangerous)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine automatischen Limits (Gefährlich)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 제한 없음(위험)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Без автоматических ограничений (опасно)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无自动限制（危险）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無自動限制（危險）"
+          }
+        }
+      }
+    },
+    "Tight against this Mac's recommended model budget" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Knapp am empfohlenen Modellbudget dieses Macs"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 Mac의 권장 모델 예산에 빠듯함"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Почти достигает рекомендуемого бюджета модели для этого Mac"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接近此 Mac 的建议模型预算上限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接近此 Mac 的建議模型預算上限"
+          }
+        }
+      }
+    },
+    "Too large" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zu groß"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "너무 큼"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Слишком большой"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "过大"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過大"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
@@ -108,10 +108,11 @@ enum ChatResidencyHandoff {
     ) async throws {
         guard enabled, requiredBytes > 0 else { return }
         // Models occupy more resident RAM than their on-disk weights (KV +
-        // activations + framework overhead); inflate the on-disk estimate.
-        let inflation = 1.3
-        let headroom: Int64 = 3 * 1024 * 1024 * 1024  // keep 3 GB for the OS/app
-        let needed = Int64(Double(requiredBytes) * inflation) + headroom
+        // activations + framework overhead). This shared estimate also powers
+        // image-model guidance and Automatic eligibility.
+        let needed = ModelHardwareGuidance.delegatedModelPreflightRequiredBytes(
+            onDiskBytes: requiredBytes
+        )
         let residentChatBytes = await ModelRuntime.shared.cachedModelSummaries()
             .reduce(Int64(0)) { $0 + $1.bytes }
         let projected = availableMemoryBytes() + residentChatBytes

--- a/Packages/OsaurusCore/Services/AgentDelegation/NativeImageJobCoordinator.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/NativeImageJobCoordinator.swift
@@ -247,6 +247,7 @@ struct NativeImageJobResult: Sendable, Equatable {
 
 enum NativeImageJobCoordinatorError: Error, CustomStringConvertible {
     case noReadyModel(kind: SubagentModelKind)
+    case noSafeAutomaticModel(kind: SubagentModelKind)
     case selectedModelUnavailable(model: String, kind: SubagentModelKind)
     case selectedModelIncomplete(model: String, reasons: [String])
     case selectedModelWrongKind(model: String, expected: SubagentModelKind)
@@ -257,6 +258,8 @@ enum NativeImageJobCoordinatorError: Error, CustomStringConvertible {
         switch self {
         case .noReadyModel(let kind):
             return "no ready local model configured or installed for \(kind.rawValue)"
+        case .noSafeAutomaticModel(let kind):
+            return "no ready local model comfortably fits this Mac for automatic \(kind.rawValue); choose a tight-fit model explicitly if you want to try it"
         case .selectedModelUnavailable(let model, let kind):
             return "selected local image model '\(model)' is not installed for \(kind.rawValue)"
         case .selectedModelIncomplete(let model, let reasons):
@@ -277,7 +280,8 @@ enum NativeImageJobModelResolver {
         requested: String?,
         configured: String?,
         available: [ImageModelInfo],
-        kind: SubagentModelKind
+        kind: SubagentModelKind,
+        physicalMemoryGB: Double = GPUMemoryBudget.hostPhysicalMemoryGB
     ) throws -> String {
         if let requested = normalizedID(requested) {
             return try requireReadyModel(requested, available: available, kind: kind)
@@ -285,10 +289,42 @@ enum NativeImageJobModelResolver {
         if let configured = normalizedID(configured) {
             return try requireReadyModel(configured, available: available, kind: kind)
         }
-        if let candidate = available.first(where: { isReady($0, for: kind) }) {
+        let ready = available.filter { isReady($0, for: kind) }
+        guard !ready.isEmpty else {
+            throw NativeImageJobCoordinatorError.noReadyModel(kind: kind)
+        }
+
+        // A nil model means Automatic. Filesystem scan order is not a routing
+        // policy: it changed with installs/deletes and could silently pick the
+        // largest image graph. Choose the smallest ready model that comfortably
+        // fits the same hardware budget used by the UI. Unknown-size legacy
+        // rows remain a deterministic fallback, but tight/oversized rows must
+        // be selected explicitly so the user sees and accepts the RAM warning.
+        let candidates = ready.filter { model in
+            guard model.totalBytes > 0 else { return true }
+            let estimated = ModelHardwareGuidance.estimatedImageWorkingSetGB(
+                onDiskBytes: model.totalBytes
+            )
+            return ModelHardwareGuidance.compatibility(
+                estimatedMemoryGB: estimated,
+                physicalMemoryGB: physicalMemoryGB
+            ) == .compatible
+        }
+        if let candidate = candidates.min(by: automaticImageOrder) {
             return candidate.id
         }
-        throw NativeImageJobCoordinatorError.noReadyModel(kind: kind)
+        throw NativeImageJobCoordinatorError.noSafeAutomaticModel(kind: kind)
+    }
+
+    private static func automaticImageOrder(_ lhs: ImageModelInfo, _ rhs: ImageModelInfo) -> Bool {
+        // Known measured sizes outrank unknown legacy rows; then prefer the
+        // lower-footprint graph. Names/ids make the result stable across scan
+        // order and app restarts.
+        if (lhs.totalBytes > 0) != (rhs.totalBytes > 0) { return lhs.totalBytes > 0 }
+        if lhs.totalBytes != rhs.totalBytes { return lhs.totalBytes < rhs.totalBytes }
+        let byName = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+        if byName != .orderedSame { return byName == .orderedAscending }
+        return lhs.id.localizedCaseInsensitiveCompare(rhs.id) == .orderedAscending
     }
 
     private static func normalizedID(_ value: String?) -> String? {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -188,6 +188,22 @@ final class ChatWarmupController: ObservableObject {
         }
     }
 
+    /// Automatic routing changes `selectedModel` under an explicit
+    /// `isLoadingModel` guard, after the published property has settled. Start
+    /// that switch synchronously so `needsPreSendHandshake` is already true
+    /// before the same send call decides whether it may dispatch immediately.
+    func handleSettledModelSelectionChange(
+        session: ChatWarmupSessionContext,
+        to newModel: String?,
+        performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
+    ) {
+        performModelSelectionChange(
+            session: session,
+            to: newModel,
+            performSwitch: performSwitch
+        )
+    }
+
     private func performModelSelectionChange(
         session: ChatWarmupSessionContext,
         to newModel: String?,

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1050,9 +1050,16 @@ public actor ModelRuntime {
     /// `SubagentResidency`'s coexistence gate, which must stay under it —
     /// loading past this triggers `unloadForFlexibleResidentBudget`'s own
     /// eviction, which would evict the orchestrator with no restore lease.
-    static func flexibleResidentBudgetBytes() -> Int64 {
+    static func flexibleResidentBudgetBytes(
+        physicalMemoryBytes: Int64 = Int64(ProcessInfo.processInfo.physicalMemory),
+        automaticMemoryLimitsDisabled: Bool =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled()
+    ) -> Int64 {
+        if automaticMemoryLimitsDisabled {
+            return .max
+        }
         let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
-        return Int64(Double(ProcessInfo.processInfo.physicalMemory) * thresholds.soft)
+        return Int64(Double(physicalMemoryBytes) * thresholds.soft)
     }
 
     /// Snapshot of the most recent pre-load RAM feasibility assessment.
@@ -1079,6 +1086,10 @@ public actor ModelRuntime {
         public let requiredAvailableBytes: Int64
         public let softLimitBytes: Int64
         public let hardLimitBytes: Int64
+        /// The user explicitly selected the dangerous setting that turns the
+        /// physical/Metal projections into guidance instead of an Osaurus
+        /// send/load refusal.
+        public let automaticMemoryLimitsDisabled: Bool
         /// What Metal will actually keep resident on this machine. Zero when
         /// it can't be determined.
         public let gpuBudgetBytes: Int64
@@ -1129,7 +1140,7 @@ public actor ModelRuntime {
             if residentProjection > hardLimitBytes
                 || incomingLoadFootprintBytes > physicalMemoryBytes
             {
-                return .block
+                return automaticMemoryLimitsDisabled ? .warn : .block
             }
             // A working set past the GPU budget gets paged even on an
             // otherwise idle Mac, so it warns no matter how much RAM happens
@@ -1358,7 +1369,9 @@ public actor ModelRuntime {
         inflightOther: Int64,
         kvHeadroom: Int64,
         physical: Int64,
-        available: Int64
+        available: Int64,
+        automaticMemoryLimitsDisabled: Bool =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled()
     ) -> RAMFeasibility {
         let requiredAvailable = incomingLoadFootprintBytes + kvHeadroom
         let projected = resident + inflightOther + incomingLoadFootprintBytes + kvHeadroom
@@ -1393,6 +1406,7 @@ public actor ModelRuntime {
             requiredAvailableBytes: requiredAvailable,
             softLimitBytes: softLimit,
             hardLimitBytes: hardLimit,
+            automaticMemoryLimitsDisabled: automaticMemoryLimitsDisabled,
             gpuBudgetBytes: Self.gpuBudgetBytes(physicalMemoryBytes: physical),
             timestamp: Date()
         )
@@ -1423,7 +1437,9 @@ public actor ModelRuntime {
         incomingLoadFootprintBytes: Int64,
         excludingResident excludedName: String?,
         modelDirectory: URL? = nil,
-        refuseOnShortfall: Bool = false
+        refuseOnShortfall: Bool = false,
+        automaticMemoryLimitsDisabled: Bool =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled()
     ) throws {
         let physical = Int64(ProcessInfo.processInfo.physicalMemory)
         guard physical > 0, incomingWeightsBytes > 0 else { return }
@@ -1446,7 +1462,8 @@ public actor ModelRuntime {
             inflightOther: inflightOther,
             kvHeadroom: kvHeadroom,
             physical: physical,
-            available: Self.availableMemoryBytes()
+            available: Self.availableMemoryBytes(),
+            automaticMemoryLimitsDisabled: automaticMemoryLimitsDisabled
         )
 
         lastRAMFeasibility = assessment
@@ -2023,11 +2040,16 @@ public actor ModelRuntime {
         // reclaims file cache, so proceeding into a shortfall dies as a
         // Metal command-buffer abort mid-load, not graceful pressure
         // (observed live: available 101 GB loaded clean, 89 GB crashed).
+        let preloadServerSettings = ServerRuntimeSettingsStore.snapshot()
+        let automaticMemoryLimitsDisabled =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(
+                for: preloadServerSettings
+            )
         let willMaterialize =
             !Self.resolveMemorySafetyLoadPlan(
                 modelName: name,
                 modelDirectory: localURL,
-                settings: ServerRuntimeSettingsStore.snapshot(),
+                settings: preloadServerSettings,
                 baseLoadConfiguration: .osaurusProduction,
                 inspectBundleFacts: true
             ).loadConfiguration.useMmapSafetensors
@@ -2068,15 +2090,17 @@ public actor ModelRuntime {
         // eviction / flexible budget trimming above, `resident` reflects what
         // will still be alive when this load lands. Pressure is reported via
         // health/logs; for mmap loads RAM fullness is not a user-requested
-        // load block, but a materialized load short on free memory is
-        // refused outright — see `willMaterialize` above.
+        // load block. A materialized load short on free memory is normally
+        // refused outright, but the explicit No Automatic Limits setting
+        // turns that Osaurus-owned refusal into guidance as advertised.
         try checkRAMFeasibility(
             modelName: name,
             incomingWeightsBytes: weightsBytes,
             incomingLoadFootprintBytes: loadFootprintBytes,
             excludingResident: name,
             modelDirectory: localURL,
-            refuseOnShortfall: willMaterialize
+            refuseOnShortfall: willMaterialize && !automaticMemoryLimitsDisabled,
+            automaticMemoryLimitsDisabled: automaticMemoryLimitsDisabled
         )
 
         // Tool-call format + reasoning parser are stamped automatically by
@@ -2279,7 +2303,8 @@ public actor ModelRuntime {
         // the two diverged and the slider never reached the coordinator.
         var resolvedSettings = settings
         resolvedSettings.cache =
-            settings.resolvedMemorySafetyPlan(
+            ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+                for: settings,
                 host: MemoryStatus.snapshot()
             ).cache
         let diskCacheDir = Self.cacheDiskDirectoryOverride(for: resolvedSettings.cache)
@@ -3325,7 +3350,23 @@ public actor ModelRuntime {
         } else {
             unsetenv("VMLX_ENABLE_UNSAFE_COMPILE")
         }
-        CacheStoreBudget.policy = settings.memorySafety.mode.cacheStorePolicy
+        CacheStoreBudget.policy = cacheStorePolicy(for: settings)
+    }
+
+    /// The engine's diagnostic profile still reserves 45% of remaining RAM
+    /// before storing a prefix snapshot. That is a sensible dangerous-mode
+    /// default for generic hosts, but it is still an automatic percentage cap.
+    /// Osaurus's explicitly named No Automatic Limits choice therefore allows
+    /// a store to use all *measured* remaining physical headroom; the engine's
+    /// final physical-fit check remains intact so a cache optimization cannot
+    /// knowingly allocate beyond the machine.
+    nonisolated static func cacheStorePolicy(
+        for settings: VMLXServerRuntimeSettings
+    ) -> CacheStorePolicy {
+        if ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings) {
+            return CacheStorePolicy(headroomFraction: 1.0)
+        }
+        return settings.memorySafety.mode.cacheStorePolicy
     }
 
     nonisolated static func makeGenerateParameters(
@@ -3484,7 +3525,8 @@ public actor ModelRuntime {
             inspectBundleFacts
             ? LoadBundleFacts.inspect(bundleURL: modelDirectory)
             : nil
-        let plan = settings.resolvedMemorySafetyPlan(
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+            for: settings,
             baseLoadConfiguration: baseLoadConfiguration,
             bundleFacts: bundleFacts,
             host: MemoryStatus.snapshot(),

--- a/Packages/OsaurusCore/Tests/Agent/DefaultAgentConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/DefaultAgentConfigurationStoreTests.swift
@@ -86,4 +86,37 @@ struct DefaultAgentConfigurationStoreTests {
         #expect(decoded.manualToolNames == nil)
         #expect(decoded.manualSkillNames == nil)
     }
+
+    @Test("Automatic persists as a setting but effectiveModel returns a concrete local route")
+    @MainActor
+    func automaticSettingResolvesConcreteLocalModel() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await Self.withTempOverride {
+                var config = DefaultAgentConfigurationStore.load()
+                config.defaultModel = AutomaticModelRoutingPolicy.modelId
+                DefaultAgentConfigurationStore.save(config)
+
+                let local = ModelPickerItem(
+                    id: "local/compatible",
+                    displayName: "Compatible",
+                    source: .local,
+                    estimatedMemoryGB: 4,
+                    hardwareCompatibility: .compatible
+                )
+                let remote = ModelPickerItem.fromRemoteModel(
+                    modelId: "cloud/frontier",
+                    providerName: "Cloud",
+                    providerId: UUID()
+                )
+                let previous = ModelPickerItemCache.shared._setItemsForTesting([remote, local])
+                defer { ModelPickerItemCache.shared._setItemsForTesting(previous) }
+
+                #expect(
+                    AgentManager.shared.configuredModel(for: Agent.defaultId)
+                        == AutomaticModelRoutingPolicy.modelId
+                )
+                #expect(AgentManager.shared.effectiveModel(for: Agent.defaultId) == local.id)
+            }
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/AgentDelegation/NativeImageJobCoordinatorTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/NativeImageJobCoordinatorTests.swift
@@ -136,6 +136,76 @@ struct NativeImageJobCoordinatorTests {
         #expect(resolved == "ready-edit")
     }
 
+    @Test func automaticResolverIsRAMSafeAndIndependentOfScanOrder() throws {
+        let gb: UInt64 = 1024 * 1024 * 1024
+        let large = imageModel(
+            id: "large",
+            ready: true,
+            textToImage: true,
+            totalBytes: 20 * gb
+        )
+        let small = imageModel(
+            id: "small",
+            ready: true,
+            textToImage: true,
+            totalBytes: 4 * gb
+        )
+        let tooLarge = imageModel(
+            id: "too-large",
+            ready: true,
+            textToImage: true,
+            totalBytes: 15 * gb
+        )
+
+        #expect(
+            try NativeImageJobModelResolver.resolve(
+                requested: nil,
+                configured: nil,
+                available: [large, tooLarge, small],
+                kind: .imageGeneration,
+                physicalMemoryGB: 16
+            ) == "small"
+        )
+        #expect(
+            try NativeImageJobModelResolver.resolve(
+                requested: nil,
+                configured: nil,
+                available: [small, large, tooLarge],
+                kind: .imageGeneration,
+                physicalMemoryGB: 16
+            ) == "small"
+        )
+    }
+
+    @Test func automaticResolverRejectsOnlyTightImageModelsButExplicitSelectionRemainsAvailable() throws {
+        let gb: UInt64 = 1024 * 1024 * 1024
+        let tight = imageModel(
+            id: "tight-explicit",
+            ready: true,
+            textToImage: true,
+            totalBytes: 5 * gb
+        )
+
+        #expect(throws: NativeImageJobCoordinatorError.self) {
+            _ = try NativeImageJobModelResolver.resolve(
+                requested: nil,
+                configured: nil,
+                available: [tight],
+                kind: .imageGeneration,
+                physicalMemoryGB: 16
+            )
+        }
+        #expect(
+            try NativeImageJobModelResolver.resolve(
+                requested: tight.id,
+                configured: nil,
+                available: [tight],
+                kind: .imageGeneration,
+                physicalMemoryGB: 16
+            ) == tight.id
+        )
+    }
+
     @Test func chatResidencyPolicyOnlyEvictsForAgentSingleResidency() {
         // The image-job residency decision now lives on the config as the single
         // source consumed by the shared `ChatResidencyHandoff` dedup.
@@ -218,7 +288,8 @@ struct NativeImageJobCoordinatorTests {
         id: String,
         ready: Bool,
         textToImage: Bool,
-        imageEdit: Bool = false
+        imageEdit: Bool = false,
+        totalBytes: UInt64 = 0
     ) -> ImageModelInfo {
         ImageModelInfo(
             id: id,
@@ -231,7 +302,7 @@ struct NativeImageJobCoordinatorTests {
             defaultGuidance: nil,
             capabilities: ImageModelCapabilities(textToImage: textToImage, imageEdit: imageEdit),
             blockedReasons: ready ? [] : ["missing weights"],
-            totalBytes: 0
+            totalBytes: totalBytes
         )
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionAutomaticRoutingTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionAutomaticRoutingTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Chat session automatic model routing", .serialized)
+@MainActor
+struct ChatSessionAutomaticRoutingTests {
+    @Test("session selects a concrete safe local route without replacing Automatic setting")
+    func initialAutomaticRoutePreservesSetting() async {
+        await StoragePathsTestLock.shared.run {
+            let agentId = await MainActor.run {
+                let agent = Agent(name: "Automatic Route Test \(UUID().uuidString)")
+                AgentManager.shared.add(agent)
+                AgentManager.shared.updateDefaultModel(
+                    for: agent.id,
+                    model: AutomaticModelRoutingPolicy.modelId
+                )
+                let small = ModelPickerItem(
+                    id: "local/small",
+                    displayName: "Small",
+                    source: .local,
+                    estimatedMemoryGB: 3,
+                    hardwareCompatibility: .compatible
+                )
+                let strong = ModelPickerItem(
+                    id: "local/strong",
+                    displayName: "Strong",
+                    source: .local,
+                    estimatedMemoryGB: 8,
+                    hardwareCompatibility: .compatible
+                )
+                let cloud = ModelPickerItem.fromRemoteModel(
+                    modelId: "cloud/frontier",
+                    providerName: "Cloud",
+                    providerId: UUID()
+                )
+
+                let session = ChatSession()
+                session.agentId = agent.id
+                session.applyPickerItems([cloud, small, strong])
+
+                #expect(session.selectedModel == strong.id)
+                #expect(session.automaticRoutingDecision?.modelId == strong.id)
+                #expect(session.usesAutomaticModelRouting)
+                #expect(
+                    AgentManager.shared.configuredModel(for: agent.id)
+                        == AutomaticModelRoutingPolicy.modelId
+                )
+
+                // Clicking the row Automatic already resolved to is a same-value
+                // binding write. It must still be treated as an intentional manual
+                // selection and replace the persisted sentinel.
+                session.selectModelFromPicker(strong.id)
+                #expect(AgentManager.shared.configuredModel(for: agent.id) == strong.id)
+                #expect(!session.usesAutomaticModelRouting)
+                return agent.id
+            }
+            _ = await AgentManager.shared.delete(id: agentId)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -177,6 +177,7 @@ struct ChatWarmupControllerRAMGateTests {
             requiredAvailableBytes: requiredAvailable,
             softLimitBytes: soft,
             hardLimitBytes: hard,
+            automaticMemoryLimitsDisabled: false,
             // Budget unknown, so it never influences these warmup assertions.
             gpuBudgetBytes: 0,
             timestamp: Date()

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -37,6 +37,23 @@ struct ChatConfigurationWarmModelsOnLoadTests {
 @MainActor
 struct ChatWarmupControllerModelSwitchTests {
 
+    @Test("settled automatic route exposes pre-send handshake immediately")
+    func settledAutomaticRouteGatesSameSend() async {
+        let session = WarmupTestSession()
+        session.isStreaming = true  // suppress the post-switch speculative warm-up
+        let controller = ChatWarmupController()
+
+        controller.handleSettledModelSelectionChange(
+            session: session,
+            to: "vision-model",
+            performSwitch: { _ in }
+        )
+
+        #expect(controller.needsPreSendHandshake)
+        await controller.awaitActiveModelSwitch()
+        #expect(!controller.needsPreSendHandshake)
+    }
+
     @Test("selection change performs the residency switch immediately")
     func selectionChangeSwitchesImmediately() async {
         var evictionCount = 0

--- a/Packages/OsaurusCore/Tests/Configuration/SettingsSearchIndexTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/SettingsSearchIndexTests.swift
@@ -112,4 +112,14 @@ struct SettingsSearchIndexTests {
         let killSwitchHits = SettingsSearchIndex.search("kill switch")
         #expect(killSwitchHits.contains { $0.id == "agentChannels.globalWrites" && $0.tab == .agentChannels })
     }
+
+    @Test func searchFindsAutomaticRoutingAndHardwareGuidance() {
+        for query in ["automatic model", "automatic routing", "hardware guidance", "memory budget"] {
+            let hits = SettingsSearchIndex.search(query)
+            #expect(
+                hits.contains { $0.id == "settings.chat.defaultModel" && $0.tab == .chat },
+                "Default Model should be reachable for query: \(query)"
+            )
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/AutomaticModelRoutingPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/AutomaticModelRoutingPolicyTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Automatic on-device model routing")
+struct AutomaticModelRoutingPolicyTests {
+    private let providerId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+
+    private func local(
+        _ id: String,
+        memory: Double,
+        parameters: String? = nil,
+        compatibility: ModelCompatibility = .compatible,
+        image: Bool = false,
+        video: Bool = false,
+        audio: Bool = false
+    ) -> ModelPickerItem {
+        ModelPickerItem(
+            id: id,
+            displayName: id,
+            source: .local,
+            parameterCount: parameters,
+            supportsImageInput: image,
+            supportsVideoInput: video,
+            supportsAudioInput: audio,
+            estimatedMemoryGB: memory,
+            hardwareCompatibility: compatibility
+        )
+    }
+
+    @Test("model capability rank beats quantized working-set size")
+    func parameterCountOutranksWorkingSet() {
+        let decision = AutomaticModelRoutingPolicy.resolve(
+            items: [
+                local("local/12b-4bit", memory: 8, parameters: "12B"),
+                local("local/27b-1bit", memory: 4.5, parameters: "27B"),
+            ]
+        )
+
+        #expect(decision?.modelId == "local/27b-1bit")
+    }
+
+    @Test("chooses strongest compatible local model and never cloud")
+    func strongestSafeLocalOnly() {
+        let decision = AutomaticModelRoutingPolicy.resolve(
+            items: [
+                .fromRemoteModel(
+                    modelId: "cloud/frontier",
+                    providerName: "Cloud",
+                    providerId: providerId
+                ),
+                local("local/small", memory: 3),
+                local("local/strong", memory: 9),
+                local("local/tight", memory: 12, compatibility: .tight),
+                local("local/unknown", memory: 20, compatibility: .unknown),
+            ],
+            physicalMemoryGB: 24
+        )
+
+        #expect(decision?.modelId == "local/strong")
+        #expect(decision?.explanation.contains("Private on-device route") == true)
+    }
+
+    @Test("keeps current safe route for multi-turn cache locality")
+    func currentSafeRouteWins() {
+        let decision = AutomaticModelRoutingPolicy.resolve(
+            items: [
+                local("local/small", memory: 3),
+                local("local/strong", memory: 9),
+            ],
+            currentModelId: "local/small"
+        )
+
+        #expect(decision?.modelId == "local/small")
+    }
+
+    @Test("upgrades to compatible media model before a media turn")
+    func mediaUpgrade() {
+        let items = [
+            local("local/text", memory: 8),
+            local("local/vision", memory: 6, image: true, video: true),
+            local("local/omni-tight", memory: 11, compatibility: .tight, image: true, audio: true),
+        ]
+
+        let image = AutomaticModelRoutingPolicy.resolve(
+            items: items,
+            requirements: .image,
+            currentModelId: "local/text"
+        )
+        let video = AutomaticModelRoutingPolicy.resolve(
+            items: items,
+            requirements: .video,
+            currentModelId: "local/text"
+        )
+        let audio = AutomaticModelRoutingPolicy.resolve(
+            items: items,
+            requirements: .audio,
+            currentModelId: "local/text"
+        )
+
+        #expect(image?.modelId == "local/vision")
+        #expect(video?.modelId == "local/vision")
+        #expect(audio == nil)
+    }
+
+    @Test("media controls advertise only routes that can really resolve")
+    func advertisedMediaMatchesRoutes() {
+        let capabilities = AutomaticModelRoutingPolicy.availableMediaCapabilities(
+            items: [
+                .foundation(),
+                local("local/text", memory: 3),
+                local("local/vision", memory: 5, image: true, video: true),
+            ]
+        )
+
+        #expect(capabilities.supportsImage)
+        #expect(capabilities.supportsVideo)
+        #expect(!capabilities.supportsAudio)
+    }
+
+    @Test("Foundation is an on-device text fallback, never a media fallback")
+    func foundationFallbackIsTextOnly() {
+        let items: [ModelPickerItem] = [
+            .foundation(),
+            .fromRemoteModel(
+                modelId: "cloud/vision",
+                providerName: "Cloud",
+                providerId: providerId
+            ),
+        ]
+
+        #expect(AutomaticModelRoutingPolicy.resolve(items: items)?.modelId == "foundation")
+        #expect(
+            AutomaticModelRoutingPolicy.resolve(items: items, requirements: .image) == nil
+        )
+    }
+
+    @Test("synthetic Automatic choice is settings-only")
+    func settingsChoice() {
+        let base = [local("local/text", memory: 3)]
+        let choices = base.withAutomaticOnDeviceChoice
+
+        #expect(choices.first?.id == AutomaticModelRoutingPolicy.modelId)
+        #expect(choices.first?.isFavoriteEligible == false)
+        #expect(choices.dropFirst().map(\.id) == base.map(\.id))
+        #expect(AutomaticModelRoutingPolicy.isAutomatic(choices.first?.id))
+    }
+}
+
+@Suite("Model hardware guidance")
+struct ModelHardwareGuidanceTests {
+    @Test("budget summary distinguishes unified memory from model budget")
+    func budgetSummary() {
+        #expect(
+            ModelHardwareGuidance.budgetSummary(physicalMemoryGB: 24)
+                == "24 GB unified memory · 16 GB recommended local-model budget"
+        )
+    }
+
+    @Test("fit summary reports working set against recommended budget")
+    func fitSummary() {
+        #expect(
+            ModelHardwareGuidance.fitSummary(
+                estimatedMemoryGB: 10,
+                compatibility: .compatible,
+                physicalMemoryGB: 24
+            ) == "Comfortable fit · ~10 GB working set · 16 GB budget"
+        )
+    }
+
+    @Test("128 GB Macs expose the Metal-scale local-model budget")
+    func highMemoryBudgetSummary() {
+        #expect(
+            ModelHardwareGuidance.budgetSummary(physicalMemoryGB: 128)
+                == "128 GB unified memory · 107.5 GB recommended local-model budget"
+        )
+    }
+
+    @Test("image guidance matches the execution-time RAM preflight")
+    func imageWorkingSetMatchesPreflight() throws {
+        let gib: UInt64 = 1024 * 1024 * 1024
+        let estimate = try #require(
+            ModelHardwareGuidance.estimatedImageWorkingSetGB(onDiskBytes: 20 * gib)
+        )
+        #expect(abs(estimate - 29) < 0.001)
+        #expect(
+            ModelHardwareGuidance.delegatedModelPreflightRequiredBytes(
+                onDiskBytes: Int64(20 * gib)
+            ) == Int64(29 * gib)
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
@@ -31,7 +31,8 @@ struct GPUMemoryBudgetTests {
         #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 16) == 16 * (2.0 / 3.0))
         #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 36) == 36 * (2.0 / 3.0))
         #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 48) == 36.0)
-        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 128) == 96.0)
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 96) == 72.0)
+        #expect(GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 128) == 107.52)
     }
 
     @Test("No physical memory yields no budget")
@@ -83,6 +84,17 @@ struct GPUMemoryBudgetTests {
         #expect(ornith.compatibility(totalMemoryGB: 64) == .tight)
         #expect(ornith.compatibility(totalMemoryGB: 96) == .compatible)
         #expect(ornith.compatibility(totalMemoryGB: 128) == .compatible)
+    }
+
+    @Test("A 105 GB-class bundle is offered as a tight explicit load on a 128 GB Mac")
+    func nearRAMScaleModelFits128GBWithWarning() throws {
+        // 105 GB decimal is about 97.8 GiB. The near-RAM load plan uses the
+        // materialized weights plus a 4 GiB working margin, not a fake 25%
+        // expansion that would classify it as impossible.
+        let nearRAM = Self.model("hy3-105gb", gbOnDisk: 97.8)
+        let estimate = try #require(nearRAM.estimatedMemoryGB(totalMemoryGB: 128))
+        #expect(abs(estimate - 101.8) < 0.001)
+        #expect(nearRAM.compatibility(totalMemoryGB: 128) == .tight)
     }
 
     @Test("Small bundles stay comfortable on base-RAM Macs")

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -306,6 +306,27 @@ struct ModelManagerTests {
         #expect(detected.map(\.id).contains("JANGQ-AI/Step-3.7-Flash-JANGTQ_K"))
     }
 
+    @Test func scanLocalModels_readsShardedWeightTotalForNearRAMGuidance() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("osu-sharded-size-\(UUID().uuidString)")
+        let repo = root.appendingPathComponent("JANGQ-AI").appendingPathComponent("Hy3-JANG_2K-MTP")
+        try fm.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        try Data("{}".utf8).write(to: repo.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: repo.appendingPathComponent("tokenizer.json"))
+        let weightBytes: Int64 = 105_275_271_344
+        let index = #"{"metadata":{"total_size":105275271344},"weight_map":{}}"#
+        try Data(index.utf8).write(to: repo.appendingPathComponent("model.safetensors.index.json"))
+
+        let detected = ModelManager.scanLocalModels(at: root)
+        let model = try #require(detected.first)
+        #expect(model.id == "JANGQ-AI/Hy3-JANG_2K-MTP")
+        #expect(model.downloadSizeBytes == weightBytes)
+        #expect(abs((model.estimatedMemoryGB(totalMemoryGB: 128) ?? 0) - 102.04) < 0.02)
+        #expect(model.compatibility(totalMemoryGB: 128) == .tight)
+    }
+
     @Test func scanLocalModels_detectsHighShardCountWithoutFixedMissLoop() async throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("osu-high-shard-scan-\(UUID().uuidString)")

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -40,6 +40,9 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(migrated.cache.blockDisk.enabled == true)
             #expect(migrated.cache.legacyDisk.enabled == false)
             #expect(migrated.cache.liveKVCodec == .engineSelected)
+            // nil: the selected Memory Safety profile owns the effective
+            // prefix-cache percentage (Safe Auto resolves to 15%).
+            #expect(migrated.cache.prefix.memoryPercent == nil)
             // nil: the seed leaves the default KV cap to the RAM-safety slider
             // (safe_auto resolves to 65536 in vmlx, so the effective out-of-box
             // cap is unchanged, but the slider now governs it).
@@ -72,6 +75,7 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(snapshot.cache.blockDisk.enabled == true)
             #expect(snapshot.cache.legacyDisk.enabled == false)
             #expect(snapshot.cache.liveKVCodec == .engineSelected)
+            #expect(snapshot.cache.prefix.memoryPercent == nil)
             // nil: slider governs the default KV cap (see migrate test above).
             #expect(snapshot.cache.defaultMaxKVSize == nil)
             #expect(snapshot.cache.longPromptMultiplier == 2.0)
@@ -80,6 +84,114 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(snapshot.memorySafety.mode == .safeAuto)
             #expect(snapshot.memorySafety.slider == 2)
             #expect(snapshot.memorySafety.allowExperimentalMLXPress == false)
+        }
+    }
+
+    @Test func noAutomaticLimitsRemovesOnlyImplicitCaps() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.cache.prefix.memoryPercent = nil
+        settings.cache.defaultMaxKVSize = nil
+        settings.concurrency.maxConcurrentSequences = nil
+
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(for: settings)
+
+        #expect(plan.loadConfiguration.memoryLimit == .unlimited)
+        #expect(plan.loadConfiguration.maxResidentBytes == .unlimited)
+        #expect(plan.resolvedLoadBudgetBytes == nil)
+        #expect(plan.cache.prefix.memoryPercent == nil)
+        #expect(plan.cache.defaultMaxKVSize == nil)
+        #expect(plan.concurrency.maxConcurrentSequences == nil)
+        #expect(plan.displaySummary.contains("load_cap=unlimited"))
+        #expect(plan.displaySummary.contains("allocator_cap=unlimited"))
+        #expect(plan.displaySummary.contains("max_concurrent=default"))
+        #expect(plan.displaySummary.contains("kv_cap=unlimited"))
+    }
+
+    @Test func noAutomaticLimitsDisablesOsaurusOwnedPercentageGates() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.memorySafety.customPhysicalMemoryFraction = nil
+
+        #expect(ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings))
+        #expect(ServerRuntimeSettingsStore.modelLoadRAMThresholds(for: settings).soft == 1.0)
+        #expect(ServerRuntimeSettingsStore.modelLoadRAMThresholds(for: settings).hard == 1.0)
+        #expect(
+            ModelRuntime.flexibleResidentBudgetBytes(
+                physicalMemoryBytes: 128 << 30,
+                automaticMemoryLimitsDisabled: true
+            ) == .max
+        )
+        #expect(ModelRuntime.cacheStorePolicy(for: settings).headroomFraction == 1.0)
+    }
+
+    @Test func explicitPhysicalFractionKeepsAUserSelectedLimit() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.memorySafety.customPhysicalMemoryFraction = 0.82
+
+        #expect(
+            !ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings)
+        )
+    }
+
+    @Test func noAutomaticLimitsPreservesExplicitOverrides() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.memorySafety.customPhysicalMemoryFraction = 0.82
+        settings.memorySafety.customAllocatorCacheBytes = 256 << 20
+        settings.memorySafety.customDefaultMaxKVSize = 32_768
+        settings.memorySafety.customMaxConcurrentSequences = 3
+        settings.cache.prefix.memoryPercent = 12
+
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(for: settings)
+
+        #expect(plan.loadConfiguration.memoryLimit == .fraction(0.82))
+        #expect(plan.loadConfiguration.maxResidentBytes == .absolute(256 << 20))
+        #expect(plan.resolvedLoadBudgetBytes != nil)
+        #expect(plan.cache.prefix.memoryPercent == 12)
+        #expect(plan.cache.defaultMaxKVSize == 32_768)
+        #expect(plan.concurrency.maxConcurrentSequences == 3)
+    }
+
+    @Test @MainActor func load_movesLegacyImplicitPrefixCapUnderMemorySafety() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var oldDefault = ServerRuntimeSettingsStore.migratedFromLegacy(
+                serverConfiguration: .default,
+                userDefaults: throwawayDefaults()
+            )
+            oldDefault.cache.prefix.memoryPercent = 15
+            try writeSettings(oldDefault, to: dir)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+
+            #expect(loaded.cache.prefix.memoryPercent == nil)
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: dir.appendingPathComponent(
+                        ".server-runtime-memory-safety-cache-defaults-v4-migrated"
+                    ).path
+                )
+            )
+        }
+    }
+
+    @Test @MainActor func load_preservesExplicitPrefixCap() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var explicit = ServerRuntimeSettingsStore.migratedFromLegacy(
+                serverConfiguration: .default,
+                userDefaults: throwawayDefaults()
+            )
+            explicit.cache.prefix.memoryPercent = 12
+            try writeSettings(explicit, to: dir)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+
+            #expect(loaded.cache.prefix.memoryPercent == 12)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -72,7 +72,8 @@ struct ModelRuntimeRAMFeasibilityTests {
             inflightOther: inflightOther,
             kvHeadroom: kvHeadroom,
             physical: physical,
-            available: available
+            available: available,
+            automaticMemoryLimitsDisabled: false
         )
     }
 
@@ -237,6 +238,7 @@ struct ModelRuntimeRAMFeasibilityTests {
             requiredAvailableBytes: 95 * gb,
             softLimitBytes: 70 * gb,
             hardLimitBytes: 90 * gb,
+            automaticMemoryLimitsDisabled: false,
             // Isolate the byte math: no budget, so `exceedsGPUBudget` is false.
             gpuBudgetBytes: 0,
             timestamp: Date()
@@ -259,10 +261,29 @@ struct ModelRuntimeRAMFeasibilityTests {
             requiredAvailableBytes: 10 * gb,
             softLimitBytes: 70 * gb,
             hardLimitBytes: 90 * gb,
+            automaticMemoryLimitsDisabled: false,
             gpuBudgetBytes: 75 * gb,
             timestamp: Date()
         )
         #expect(lowAvailableOnly.loadPressureSeverity == .none)
+    }
+
+    @Test("No Automatic Limits downgrades the send block to visible guidance")
+    func noAutomaticLimitsDoesNotBlockSend() {
+        let f = ModelRuntime.buildRAMFeasibility(
+            modelName: "dangerous-test-model",
+            incomingWeightsBytes: 110 * gb,
+            incomingLoadFootprintBytes: 110 * gb,
+            resident: 0,
+            inflightOther: 0,
+            kvHeadroom: 0,
+            physical: 100 * gb,
+            available: 20 * gb,
+            automaticMemoryLimitsDisabled: true
+        )
+
+        #expect(f.automaticMemoryLimitsDisabled)
+        #expect(f.loadPressureSeverity == .warn)
     }
 
     // MARK: - GPU working-set budget
@@ -286,7 +307,8 @@ struct ModelRuntimeRAMFeasibilityTests {
             kvHeadroom: required - weights,
             physical: physical,
             // 77% "used" — an ordinary idle macOS desktop.
-            available: Int64(0.23 * Double(physical))
+            available: Int64(0.23 * Double(physical)),
+            automaticMemoryLimitsDisabled: false
         )
         #expect(f.requiredAvailableBytes == required)
         #expect(!f.exceedsGPUBudget)
@@ -309,7 +331,8 @@ struct ModelRuntimeRAMFeasibilityTests {
             inflightOther: 0,
             kvHeadroom: 0,
             physical: physical,
-            available: physical
+            available: physical,
+            automaticMemoryLimitsDisabled: false
         )
         #expect(f.exceedsGPUBudget)
         #expect(f.loadPressureSeverity == .warn)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1151,7 +1151,7 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("flexibleResidentBudgetBytes"))
         #expect(serverConfig.contains("defaultModelLoadRAMSoftThreshold"))
         #expect(serverConfig.contains("defaultModelLoadRAMHardThreshold"))
-        #expect(runtimeSettings.contains("modelLoadRAMThresholds()"))
+        #expect(runtimeSettings.contains("modelLoadRAMThresholds("))
         #expect(runtime.contains("unloadForFlexibleResidentBudget"))
         #expect(runtime.contains("policy == .manualMultiModel"))
         #expect(runtime.contains("flexible budget eviction"))
@@ -2031,7 +2031,7 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("loadConfiguration: mtpPlan.loadConfiguration"))
         #expect(runtime.contains("resolvedLoadConfiguration("))
         #expect(runtime.contains("resolveMemorySafetyLoadPlan("))
-        #expect(runtime.contains("settings.resolvedMemorySafetyPlan("))
+        #expect(runtime.contains("ServerRuntimeSettingsStore.resolvedMemorySafetyPlan("))
         #expect(runtime.contains("baseLoadConfiguration: loadConfiguration"))
         #expect(runtime.contains("request: nil"))
         #expect(runtime.contains("memorySafetySummary: memorySafetyPlan.displaySummary"))
@@ -2107,8 +2107,13 @@ struct RuntimePolicySourceTests {
         )
         #expect(
             loadPreflight.contains("!Self.resolveMemorySafetyLoadPlan(")
-                && loadPreflight.contains("refuseOnShortfall: willMaterialize"),
-            "Whether a load materializes must come from the resolved memory-safety plan (single source of truth with vmlx), and materialized loads must make the RAM verdict authoritative — proceeding into a shortfall aborts in a Metal completion handler instead of degrading."
+                && loadPreflight.contains(
+                    "refuseOnShortfall: willMaterialize && !automaticMemoryLimitsDisabled"
+                )
+                && loadPreflight.contains(
+                    "ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled("
+                ),
+            "Whether a load materializes must come from the resolved memory-safety plan, and the materialized-load refusal must follow the same explicit No Automatic Limits setting as the settings UI."
         )
         // Feasibility gate + concurrent-load reservation must run before the
         // load task is allocated, so a cold load can't bypass RAM accounting.
@@ -2129,7 +2134,7 @@ struct RuntimePolicySourceTests {
             "All policies must record the pre-load RAM feasibility assessment before vmlx starts loading."
         )
         #expect(
-            runtime.contains("ServerRuntimeSettingsStore.modelLoadRAMThresholds()")
+            runtime.contains("ServerRuntimeSettingsStore.modelLoadRAMThresholds(")
                 && !runtime.contains("ramHardThreshold = 0.90")
                 && !runtime.contains("ramSoftThreshold = 0.70")
                 && !runtime.contains("* 0.70"),
@@ -2173,6 +2178,10 @@ struct RuntimePolicySourceTests {
         #expect(health.contains("\"available_memory_bytes\": f.availableMemoryBytes"))
         #expect(health.contains("\"required_available_bytes\": f.requiredAvailableBytes"))
         #expect(health.contains("\"incoming_load_footprint_bytes\": f.incomingLoadFootprintBytes"))
+        #expect(
+            health.contains("\"automatic_memory_limits_disabled\":")
+                && health.contains("f.automaticMemoryLimitsDisabled")
+        )
     }
 
     @Test("MiMo and N2 text runtime metadata avoids VLM bundle reads")
@@ -2302,7 +2311,7 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains("@preconcurrency import MLXLMCommon"))
         #expect(httpHandler.contains("let runtimeSettings = ServerRuntimeSettingsStore.snapshot()"))
         #expect(httpHandler.contains("let memoryStatus = MemoryStatus.snapshot()"))
-        #expect(httpHandler.contains("resolvedMemorySafetyPlan("))
+        #expect(httpHandler.contains("ServerRuntimeSettingsStore.resolvedMemorySafetyPlan("))
         #expect(httpHandler.contains("\"memory_safety\""))
         #expect(httpHandler.contains("\"mode\": memorySafety.mode.rawValue"))
         #expect(httpHandler.contains("\"slider\": memorySafety.slider"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1112,6 +1112,16 @@ struct RuntimePolicySourceTests {
         #expect(concurrency.contains("Concurrent Sessions"))
         #expect(concurrency.contains("Continuous Batching"))
         #expect(concurrency.contains("Prompt Prefill Chunk Size"))
+        #expect(
+            concurrency.contains(
+                #"draft.concurrency.maxConcurrentSequences.map(String.init) ?? """#
+            )
+        )
+        #expect(
+            !concurrency.contains(
+                #"draft.concurrency.maxConcurrentSequences.map(String.init) ?? "1""#
+            )
+        )
     }
 
     @Test("Tools settings panel separates wired parser overrides from planned host bridges")

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -11,6 +11,9 @@ func agentColorFor(_ name: String) -> Color {
 }
 
 private func formatModelName(_ model: String) -> String {
+    if AutomaticModelRoutingPolicy.isAutomatic(model) {
+        return L("Automatic (on device)")
+    }
     if let last = model.split(separator: "/").last {
         return String(last)
     }
@@ -2390,6 +2393,13 @@ struct AgentDetailView: View {
                                 .font(.system(size: 13, weight: .medium))
                                 .foregroundColor(theme.primaryText)
                                 .lineLimit(1)
+                        } else if agent.id != Agent.defaultId,
+                            let inherited = agentManager.configuredModel(for: agent.id)
+                        {
+                            Text("Default → \(formatModelName(inherited))")
+                                .font(.system(size: 13))
+                                .foregroundColor(theme.placeholderText)
+                                .lineLimit(1)
                         } else {
                             Text("Default (from global settings)", bundle: .module)
                                 .font(.system(size: 13))
@@ -2414,7 +2424,7 @@ struct AgentDetailView: View {
                 .buttonStyle(PlainButtonStyle())
                 .popover(isPresented: $showModelPicker, arrowEdge: .bottom) {
                     ModelPickerView(
-                        options: pickerItems,
+                        options: pickerItems.withAutomaticOnDeviceChoice,
                         selectedModel: Binding(
                             get: { selectedModel },
                             set: { newModel in
@@ -2427,6 +2437,14 @@ struct AgentDetailView: View {
                         onDismiss: { showModelPicker = false }
                     )
                 }
+
+                agentModelGuidance(
+                    selectedModel: selectedModel
+                        ?? (agent.id == Agent.defaultId
+                            ? nil : agentManager.configuredModel(for: agent.id)),
+                    pickerItems: pickerItems,
+                    inherited: selectedModel == nil && agent.id != Agent.defaultId
+                )
 
                 if selectedModel != nil {
                     Button {
@@ -2445,6 +2463,48 @@ struct AgentDetailView: View {
                     .buttonStyle(PlainButtonStyle())
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func agentModelGuidance(
+        selectedModel: String?,
+        pickerItems: [ModelPickerItem],
+        inherited: Bool
+    ) -> some View {
+        if AutomaticModelRoutingPolicy.isAutomatic(selectedModel) {
+            if let route = AutomaticModelRoutingPolicy.resolve(items: pickerItems) {
+                Label {
+                    Text(
+                        "\(inherited ? "Inherited Automatic" : "Automatic") currently selects \(route.displayName). \(route.explanation)"
+                    )
+                } icon: {
+                    Image(systemName: "sparkles")
+                }
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+            } else {
+                Label(
+                    AutomaticModelRoutingPolicy.failureExplanation(for: .text),
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.warningColor)
+            }
+        } else if let selectedModel,
+            let guidance = pickerItems.first(where: { $0.id == selectedModel })?.hardwareGuidance
+        {
+            Text(inherited ? "Inherited model · \(guidance)" : guidance)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+        }
+
+        if let budget = ModelHardwareGuidance.budgetSummary(
+            physicalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
+        ) {
+            Text("\(budget). Current free memory is checked again before loading.")
+                .font(.system(size: 10))
+                .foregroundColor(theme.tertiaryText)
         }
     }
 
@@ -7413,12 +7473,35 @@ private struct AgentEditorSheet: View {
             .buttonStyle(PlainButtonStyle())
             .popover(isPresented: $showModelPicker, arrowEdge: .bottom) {
                 ModelPickerView(
-                    options: pickerItems,
+                    options: pickerItems.withAutomaticOnDeviceChoice,
                     selectedModel: $selectedModel,
                     agentId: nil,
                     onDismiss: { showModelPicker = false }
                 )
             }
+
+            editorModelGuidance
+        }
+    }
+
+    @ViewBuilder
+    private var editorModelGuidance: some View {
+        if AutomaticModelRoutingPolicy.isAutomatic(selectedModel) {
+            if let route = AutomaticModelRoutingPolicy.resolve(items: pickerItems) {
+                Text("Automatic currently selects \(route.displayName). \(route.explanation)")
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.secondaryText)
+            } else {
+                Text(AutomaticModelRoutingPolicy.failureExplanation(for: .text))
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.warningColor)
+            }
+        } else if let selectedModel,
+            let guidance = pickerItems.first(where: { $0.id == selectedModel })?.hardwareGuidance
+        {
+            Text(guidance)
+                .font(.system(size: 10))
+                .foregroundColor(theme.secondaryText)
         }
     }
 

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -2396,7 +2396,7 @@ struct AgentDetailView: View {
                         } else if agent.id != Agent.defaultId,
                             let inherited = agentManager.configuredModel(for: agent.id)
                         {
-                            Text("Default → \(formatModelName(inherited))")
+                            Text(verbatim: "Default → \(formatModelName(inherited))")
                                 .font(.system(size: 13))
                                 .foregroundColor(theme.placeholderText)
                                 .lineLimit(1)
@@ -7488,7 +7488,7 @@ private struct AgentEditorSheet: View {
     private var editorModelGuidance: some View {
         if AutomaticModelRoutingPolicy.isAutomatic(selectedModel) {
             if let route = AutomaticModelRoutingPolicy.resolve(items: pickerItems) {
-                Text("Automatic currently selects \(route.displayName). \(route.explanation)")
+                Text(verbatim: "Automatic currently selects \(route.displayName). \(route.explanation)")
                     .font(.system(size: 10))
                     .foregroundColor(theme.secondaryText)
             } else {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -241,6 +241,9 @@ final class ChatSession: ObservableObject {
     @Published var input: String = ""
     @Published var pendingAttachments: [Attachment] = []
     @Published var selectedModel: String? = nil
+    /// Concrete route currently chosen for an agent whose persisted model is
+    /// Automatic. The sentinel itself is never sent to a provider or engine.
+    @Published private(set) var automaticRoutingDecision: AutomaticModelRoutingPolicy.Decision?
     /// Proactive model + KV-cache warm-up for faster first-token latency.
     let warmupController = ChatWarmupController()
     @Published var pickerItems: [ModelPickerItem] = []
@@ -480,6 +483,7 @@ final class ChatSession: ObservableObject {
     /// plugins, subagents, other chats). Observe them so a model evicted behind
     /// the window's back cannot keep a stale green warm indicator.
     nonisolated(unsafe) private var runtimeResidencyObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var modelConfigurationCancellable: AnyCancellable?
     /// Flag to prevent auto-persist during initial load or programmatic resets
     private var isLoadingModel: Bool = false
     /// The model the user last picked by hand this session. Picker-list
@@ -613,6 +617,17 @@ final class ChatSession: ObservableObject {
             }
         }
 
+        modelConfigurationCancellable = NotificationCenter.default.publisher(for: .agentUpdated)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] note in
+                guard let self, !self.isStreaming else { return }
+                let sessionAgentId = self.agentId ?? Agent.defaultId
+                if let updatedAgentId = note.object as? UUID, updatedAgentId != sessionAgentId {
+                    return
+                }
+                self.applyEffectiveModel(for: self.agentId)
+            }
+
         // Mirror AgentTodoStore -> currentTodo so the inline UI block
         // updates whenever the agent calls `todo`. Filter by this window's
         // current sessionId so cross-window writes don't leak across.
@@ -697,6 +712,7 @@ final class ChatSession: ObservableObject {
             .sink { [weak self] newModel in
                 guard let self = self, !self.isLoadingModel else { return }
                 guard let model = newModel else { return }
+                self.automaticRoutingDecision = nil
                 self.lastManualModelSelection = model
                 let pid = self.agentId ?? Agent.defaultId
                 // Mode 2 (remote agent run): the model is pinned to the remote
@@ -846,6 +862,7 @@ final class ChatSession: ObservableObject {
         promptQueueCancellable = nil
         contextEstimateCancellable = nil
         modelCacheCancellable = nil
+        modelConfigurationCancellable = nil
         screenContextCancellable = nil
     }
 
@@ -901,8 +918,21 @@ final class ChatSession: ObservableObject {
     /// user had manually changed it.
     private func applyEffectiveModel(for agentId: UUID?) {
         isLoadingModel = true
-        let effectiveModel = AgentManager.shared.effectiveModel(for: agentId ?? Agent.defaultId)
-        if let model = effectiveModel, pickerItems.contains(where: { $0.id == model }) {
+        let resolvedAgentId = agentId ?? Agent.defaultId
+        if AutomaticModelRoutingPolicy.isAutomatic(
+            AgentManager.shared.configuredModel(for: resolvedAgentId)
+        ) {
+            let decision = AgentManager.shared.automaticModelDecision(
+                for: resolvedAgentId,
+                currentModelId: selectedModel,
+                items: pickerItems
+            )
+            automaticRoutingDecision = decision
+            selectedModel = decision?.modelId
+        } else if let model = AgentManager.shared.effectiveModel(for: resolvedAgentId),
+            pickerItems.contains(where: { $0.id == model })
+        {
+            automaticRoutingDecision = nil
             selectedModel = model
         } else if Self.pendingLocalDefaultModelId(for: agentId, in: pickerItems.map(\.id)) != nil {
             // First-run local setup includes temporary Osaurus Cloud access:
@@ -912,6 +942,7 @@ final class ChatSession: ObservableObject {
             // switches over as soon as that bundle lands.
             selectedModel = Self.osaurusRouterValueCandidate(in: pickerItems)?.id
         } else {
+            automaticRoutingDecision = nil
             selectedModel = pickerItems.firstChatCapable?.id
         }
         loadActiveModelOptions(for: selectedModel)
@@ -1088,6 +1119,21 @@ final class ChatSession: ObservableObject {
             // wire, without disturbing the model selection.
             if pickerItems != newOptions {
                 pickerItems = newOptions
+                if AutomaticModelRoutingPolicy.isAutomatic(
+                    AgentManager.shared.configuredModel(for: agentId ?? Agent.defaultId)
+                ) {
+                    let decision = AgentManager.shared.automaticModelDecision(
+                        for: agentId ?? Agent.defaultId,
+                        currentModelId: selectedModel,
+                        items: newOptions
+                    )
+                    automaticRoutingDecision = decision
+                    if selectedModel != decision?.modelId {
+                        isLoadingModel = true
+                        selectedModel = decision?.modelId
+                        isLoadingModel = false
+                    }
+                }
                 loadActiveModelOptions(for: selectedModel)
             }
             return
@@ -1099,16 +1145,29 @@ final class ChatSession: ObservableObject {
         // rebuilds fire on runtime state changes (including the load that the
         // pick itself started), and letting the default win here snapped the
         // chip back to the old model and warm-loaded it over the user's pick.
-        let effectiveModel = AgentManager.shared.effectiveModel(for: agentId ?? Agent.defaultId)
+        let resolvedAgentId = agentId ?? Agent.defaultId
+        let configuredModel = AgentManager.shared.configuredModel(for: resolvedAgentId)
+        let effectiveModel = AgentManager.shared.effectiveModel(for: resolvedAgentId)
         let newSelected: String?
 
-        if let manual = lastManualModelSelection, selectedModel == manual,
+        if AutomaticModelRoutingPolicy.isAutomatic(configuredModel) {
+            let decision = AgentManager.shared.automaticModelDecision(
+                for: resolvedAgentId,
+                currentModelId: selectedModel,
+                items: newOptions
+            )
+            automaticRoutingDecision = decision
+            newSelected = decision?.modelId
+        } else if let manual = lastManualModelSelection, selectedModel == manual,
             newOptionIds.contains(manual)
         {
+            automaticRoutingDecision = nil
             newSelected = manual
         } else if let model = effectiveModel, newOptionIds.contains(model) {
+            automaticRoutingDecision = nil
             newSelected = model
         } else if let prev = selectedModel, newOptionIds.contains(prev) {
+            automaticRoutingDecision = nil
             newSelected = prev
         } else if Self.pendingLocalDefaultModelId(for: agentId, in: newOptionIds) != nil {
             // Pinned local default still downloading: first-run includes
@@ -1116,6 +1175,7 @@ final class ChatSession: ObservableObject {
             // lower-cost capable Router model as soon as it appears.
             newSelected = Self.osaurusRouterValueCandidate(in: newOptions)?.id
         } else {
+            automaticRoutingDecision = nil
             newSelected = newOptions.firstChatCapable?.id
         }
 
@@ -1162,6 +1222,69 @@ final class ChatSession: ObservableObject {
     var selectedModelSupportsVideo: Bool {
         guard let model = selectedModel else { return false }
         return ModelMediaCapabilities.from(modelId: model).supportsVideo
+    }
+
+    var usesAutomaticModelRouting: Bool {
+        AutomaticModelRoutingPolicy.isAutomatic(
+            AgentManager.shared.configuredModel(for: agentId ?? Agent.defaultId)
+        )
+    }
+
+    /// Route model-picker writes through an explicit command rather than only
+    /// observing `$selectedModel`. When Automatic already resolved to the row
+    /// the user clicks, assigning the same concrete id does not publish a new
+    /// value; persist that click anyway so an intentional manual choice always
+    /// exits Automatic.
+    func selectModelFromPicker(_ model: String?) {
+        if usesAutomaticModelRouting, let model {
+            automaticRoutingDecision = nil
+            lastManualModelSelection = model
+            AgentManager.shared.updateDefaultModel(
+                for: agentId ?? Agent.defaultId,
+                model: model
+            )
+        }
+        selectedModel = model
+    }
+
+    /// Resolve Automatic against the actual turn payload. A route change is a
+    /// normal model switch and therefore participates in the existing warm-up
+    /// handshake; the persisted Automatic setting is left untouched.
+    @discardableResult
+    private func resolveAutomaticRoute(for attachments: [Attachment]) -> Bool {
+        guard usesAutomaticModelRouting else { return true }
+        let requirements = AutomaticModelRoutingPolicy.Requirements(attachments: attachments)
+        guard
+            let decision = AgentManager.shared.automaticModelDecision(
+                for: agentId ?? Agent.defaultId,
+                requirements: requirements,
+                currentModelId: selectedModel,
+                items: pickerItems
+            )
+        else {
+            automaticRoutingDecision = nil
+            ToastManager.shared.error(
+                L("Automatic model routing unavailable"),
+                message: AutomaticModelRoutingPolicy.failureExplanation(for: requirements)
+            )
+            return false
+        }
+
+        automaticRoutingDecision = decision
+        guard selectedModel != decision.modelId else { return true }
+        isLoadingModel = true
+        selectedModel = decision.modelId
+        loadActiveModelOptions(for: decision.modelId)
+        applyImageModelDefaults(for: decision.modelId)
+        isLoadingModel = false
+        warmupController.handleSettledModelSelectionChange(
+            session: self,
+            to: decision.modelId,
+            performSwitch: { [weak self] evictOthers in
+                await self?.performModelResidencySwitch(evictOthers: evictOthers)
+            }
+        )
+        return true
     }
 
     /// Get the currently selected ModelPickerItem
@@ -2300,6 +2423,18 @@ final class ChatSession: ObservableObject {
         {
             isLoadingModel = true
             selectedModel = savedModel
+            if AutomaticModelRoutingPolicy.isAutomatic(
+                AgentManager.shared.configuredModel(for: data.agentId ?? Agent.defaultId)
+            ) {
+                automaticRoutingDecision = AgentManager.shared.automaticModelDecision(
+                    for: data.agentId ?? Agent.defaultId,
+                    currentModelId: savedModel,
+                    items: pickerItems
+                )
+                selectedModel = automaticRoutingDecision?.modelId
+            } else {
+                automaticRoutingDecision = nil
+            }
             loadActiveModelOptions(for: selectedModel)
             isLoadingModel = false
         } else {
@@ -3828,6 +3963,11 @@ final class ChatSession: ObservableObject {
         let isRegeneration = !hasContent && !turns.isEmpty
         guard hasContent || isRegeneration else { return }
         guard activeRunId == nil, !isStreaming else {
+            restoreTurnsRollbackAfterAbortedRegeneration()
+            return
+        }
+
+        guard resolveAutomaticRoute(for: attachments) else {
             restoreTurnsRollbackAfterAbortedRegeneration()
             return
         }
@@ -6055,7 +6195,10 @@ struct ChatView: View {
                             // prompt resolution.
                             FloatingInputCard(
                                 text: $observedSession.input,
-                                selectedModel: $observedSession.selectedModel,
+                                selectedModel: Binding(
+                                    get: { observedSession.selectedModel },
+                                    set: { observedSession.selectModelFromPicker($0) }
+                                ),
                                 pendingAttachments: $observedSession.pendingAttachments,
                                 isContinuousVoiceMode: $observedSession.isContinuousVoiceMode,
                                 voiceInputState: $observedSession.voiceInputState,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2756,6 +2756,21 @@ extension FloatingInputCard {
         return pickerItems.first { $0.id == id }
     }
 
+    private var usesAutomaticModelRouting: Bool {
+        guard !isRemoteAgentRun else { return false }
+        return AutomaticModelRoutingPolicy.isAutomatic(
+            agentManager.configuredModel(for: agentId ?? Agent.defaultId)
+        )
+    }
+
+    private var automaticRoutingDecision: AutomaticModelRoutingPolicy.Decision? {
+        guard usesAutomaticModelRouting else { return nil }
+        return AutomaticModelRoutingPolicy.resolve(
+            items: pickerItems,
+            currentModelId: selectedModel
+        )
+    }
+
     private var selectedImagePickerItem: ModelPickerItem? {
         guard selectedPickerItem?.source.isImageGeneration == true else { return nil }
         return selectedPickerItem
@@ -2861,7 +2876,11 @@ extension FloatingInputCard {
             showModelPicker.toggle()
         } content: {
             HStack(spacing: 6) {
-                if isSelectedModelDeprecated {
+                if usesAutomaticModelRouting, automaticRoutingDecision == nil {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(theme.font(size: CGFloat(theme.captionSize) - 2))
+                        .foregroundColor(theme.warningColor)
+                } else if isSelectedModelDeprecated {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(theme.font(size: CGFloat(theme.captionSize) - 2))
                         .foregroundColor(.orange)
@@ -2877,10 +2896,14 @@ extension FloatingInputCard {
                 // Model name with metadata badges
                 if let option = selectedPickerItem {
                     HStack(spacing: 4) {
-                        Text(option.displayName)
-                            .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
-                            .foregroundColor(isSelectedModelDeprecated ? .orange : theme.secondaryText)
-                            .lineLimit(1)
+                        Text(
+                            usesAutomaticModelRouting
+                                ? "Auto → \(option.displayName)"
+                                : option.displayName
+                        )
+                        .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+                        .foregroundColor(isSelectedModelDeprecated ? .orange : theme.secondaryText)
+                        .lineLimit(1)
 
                         // Effective reasoning effort/mode for models with a
                         // segmented reasoning option (Codex catalog, official
@@ -2915,9 +2938,15 @@ extension FloatingInputCard {
                         }
                     }
                 } else {
-                    Text("Select Model", bundle: .module)
-                        .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
-                        .foregroundColor(theme.secondaryText)
+                    Group {
+                        if usesAutomaticModelRouting {
+                            Text("Automatic unavailable", bundle: .module)
+                        } else {
+                            Text("Select Model", bundle: .module)
+                        }
+                    }
+                    .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+                    .foregroundColor(theme.secondaryText)
                 }
 
                 Image(systemName: "chevron.up.chevron.down")
@@ -2927,9 +2956,12 @@ extension FloatingInputCard {
         }
         // Chip-wide hover target: the 6px dot alone is too small to hover.
         .help(
-            isSelectedModelDeprecated
-                ? String(localized: "This model is outdated. Click to switch to a newer version.", bundle: .module)
-                : modelWarmupDotHelp
+            usesAutomaticModelRouting
+                ? (automaticRoutingDecision?.explanation
+                    ?? AutomaticModelRoutingPolicy.failureExplanation(for: .text))
+                : isSelectedModelDeprecated
+                    ? String(localized: "This model is outdated. Click to switch to a newer version.", bundle: .module)
+                    : modelWarmupDotHelp
         )
         .popover(isPresented: $showModelPicker, arrowEdge: .top) {
             ModelPickerView(
@@ -4358,6 +4390,13 @@ extension FloatingInputCard {
     /// substring/regex matcher; tests pin the boundary at
     /// `ModelMediaCapabilitiesMCDCTests`.
     private var mediaCapabilityDescriptor: ModelMediaCapabilities.Descriptor {
+        if usesAutomaticModelRouting {
+            return ModelMediaCapabilities.automaticDescriptor(
+                capabilities: AutomaticModelRoutingPolicy.availableMediaCapabilities(
+                    items: pickerItems
+                )
+            )
+        }
         // The local-model scan runs off-main and records config.json's
         // model_type. Read only its non-blocking snapshot here: this getter is
         // evaluated from SwiftUI body/layout and must never trigger a disk

--- a/Packages/OsaurusCore/Views/ImageGeneration/ImageGenerationView.swift
+++ b/Packages/OsaurusCore/Views/ImageGeneration/ImageGenerationView.swift
@@ -169,18 +169,34 @@ private struct ImageGenerationSettingsTab: View {
                             "The models image jobs fall back to. Each agent can override these in its own Subagents settings."
                         )
 
+                        if let budget = ModelHardwareGuidance.budgetSummary(
+                            physicalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
+                        ) {
+                            sectionBlurb(
+                                "\(budget). Automatic uses the smallest ready image model that comfortably fits; tight-fit models require an explicit choice."
+                            )
+                        }
+
                         controlRow("Generation model") {
                             modelDropdown(
                                 \.defaultImageGenerationModelId,
                                 candidates: pickerItems.imageGenerationDelegateCandidates
                             )
                         }
+                        imageModelGuidance(
+                            currentId: configuration.defaultImageGenerationModelId,
+                            candidates: pickerItems.imageGenerationDelegateCandidates
+                        )
                         controlRow("Edit model") {
                             modelDropdown(
                                 \.defaultImageEditModelId,
                                 candidates: pickerItems.imageEditDelegateCandidates
                             )
                         }
+                        imageModelGuidance(
+                            currentId: configuration.defaultImageEditModelId,
+                            candidates: pickerItems.imageEditDelegateCandidates
+                        )
                         if pickerItems.imageEditDelegateCandidates.isEmpty {
                             editModelEmptyStateHint
                         }
@@ -342,6 +358,45 @@ private struct ImageGenerationSettingsTab: View {
             options: modelOptions(candidates: candidates, currentId: configuration[keyPath: keyPath]),
             selection: modelBinding(keyPath)
         )
+    }
+
+    @ViewBuilder
+    private func imageModelGuidance(
+        currentId: String?,
+        candidates: [ModelPickerItem]
+    ) -> some View {
+        let selected: ModelPickerItem? = {
+            if let currentId, !currentId.isEmpty {
+                return candidates.first { $0.id == currentId }
+            }
+            return candidates
+                .filter { $0.hardwareCompatibility == .compatible }
+                .min {
+                    let lhs = $0.estimatedMemoryGB ?? .greatestFiniteMagnitude
+                    let rhs = $1.estimatedMemoryGB ?? .greatestFiniteMagnitude
+                    if lhs != rhs { return lhs < rhs }
+                    return $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
+                        == .orderedAscending
+                }
+        }()
+
+        if let selected, let guidance = selected.hardwareGuidance {
+            let prefix = (currentId?.isEmpty == false) ? "Selected" : "Automatic"
+            Text("\(prefix): \(selected.displayName) · \(guidance)", bundle: .module)
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if currentId == nil || currentId?.isEmpty == true {
+            Text(
+                "Automatic has no ready image model that comfortably fits this Mac.",
+                bundle: .module
+            )
+            .font(.system(size: 11))
+            .foregroundColor(theme.warningColor)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     /// The dropdown rows for a model picker: "Choose automatically" first, a

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -684,36 +684,32 @@ struct ModelDetailView: View, Identifiable {
     /// decision.
     private var compatibilityLine: some View {
         let verdict = model.compatibility(totalMemoryGB: systemMonitor.totalMemoryGB)
-        let totalMem = systemMonitor.totalMemoryGB
-
-        // The memory estimate reads the same for every verdict except
-        // `.unknown` (where we have nothing to show), so compute it once.
-        let memoryDetail = String(
-            format: L("~%@ of %.0f GB"),
-            model.formattedEstimatedMemory ?? "—",
-            totalMem
-        )
+        let memoryDetail =
+            ModelHardwareGuidance.workingSetSummary(
+                estimatedMemoryGB: model.estimatedMemoryGB,
+                physicalMemoryGB: systemMonitor.totalMemoryGB
+            ) ?? ""
 
         let (icon, title, detail, tint): (String, String, String, Color) = {
             switch verdict {
             case .compatible:
                 return (
                     "checkmark.shield.fill",
-                    L("Should run smoothly on this Mac"),
+                    L("Fits this Mac's recommended model budget"),
                     memoryDetail,
                     theme.successColor
                 )
             case .tight:
                 return (
                     "exclamationmark.triangle.fill",
-                    L("Will be a tight fit"),
+                    L("Tight against this Mac's recommended model budget"),
                     memoryDetail,
                     theme.warningColor
                 )
             case .tooLarge:
                 return (
                     "xmark.octagon.fill",
-                    L("Too large for this Mac"),
+                    L("Exceeds this Mac's recommended model budget"),
                     memoryDetail,
                     theme.errorColor
                 )
@@ -836,11 +832,11 @@ struct ModelDetailView: View, Identifiable {
             let memory = variant.formattedEstimatedMemory
             switch variant.compatibility(totalMemoryGB: totalMemoryGB) {
             case .compatible:
-                return (memory.map { L("Runs Well · needs \($0)") } ?? L("Runs Well"), theme.successColor)
+                return (memory.map { L("Comfortable fit · \($0)") } ?? L("Comfortable fit"), theme.successColor)
             case .tight:
-                return (memory.map { L("Tight Fit · needs \($0)") } ?? L("Tight Fit"), theme.warningColor)
+                return (memory.map { L("Tight fit · \($0)") } ?? L("Tight fit"), theme.warningColor)
             case .tooLarge:
-                return (memory.map { L("Too Large · needs \($0)") } ?? L("Too Large"), theme.errorColor)
+                return (memory.map { L("Too large · \($0)") } ?? L("Too large"), theme.errorColor)
             case .unknown:
                 return (nil, theme.tertiaryText)
             }

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -832,11 +832,11 @@ struct ModelDetailView: View, Identifiable {
             let memory = variant.formattedEstimatedMemory
             switch variant.compatibility(totalMemoryGB: totalMemoryGB) {
             case .compatible:
-                return (memory.map { L("Comfortable fit · \($0)") } ?? L("Comfortable fit"), theme.successColor)
+                return (memory.map { "\(L("Comfortable fit")) · \($0)" } ?? L("Comfortable fit"), theme.successColor)
             case .tight:
-                return (memory.map { L("Tight fit · \($0)") } ?? L("Tight fit"), theme.warningColor)
+                return (memory.map { "\(L("Tight fit")) · \($0)" } ?? L("Tight fit"), theme.warningColor)
             case .tooLarge:
-                return (memory.map { L("Too large · \($0)") } ?? L("Too large"), theme.errorColor)
+                return (memory.map { "\(L("Too large")) · \($0)" } ?? L("Too large"), theme.errorColor)
             case .unknown:
                 return (nil, theme.tertiaryText)
             }

--- a/Packages/OsaurusCore/Views/Model/ModelPickerTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerTableRepresentable.swift
@@ -48,6 +48,7 @@ struct ModelPickerRow: Equatable, Identifiable {
     /// so favourited rows read as favourited everywhere, not only in the
     /// Favourites tab.
     let isFavorite: Bool
+    let isFavoriteEligible: Bool
 
     init(
         modelId: String,
@@ -59,7 +60,8 @@ struct ModelPickerRow: Equatable, Identifiable {
         isVLM: Bool,
         isMLXFormat: Bool = true,
         providerLabel: String? = nil,
-        isFavorite: Bool = false
+        isFavorite: Bool = false,
+        isFavoriteEligible: Bool = true
     ) {
         self.modelId = modelId
         self.sourceKey = sourceKey
@@ -71,6 +73,7 @@ struct ModelPickerRow: Equatable, Identifiable {
         self.isMLXFormat = isMLXFormat
         self.providerLabel = providerLabel
         self.isFavorite = isFavorite
+        self.isFavoriteEligible = isFavoriteEligible
     }
 
     var id: String { "model-\(sourceKey)-\(modelId)" }
@@ -439,6 +442,7 @@ private final class ModelRowCellView: NSTableCellView, NSGestureRecognizerDelega
         isHighlighted: Bool,
         isHovered: Bool,
         isFavorite: Bool,
+        isFavoriteEligible: Bool,
         favoritesMode: Bool,
         colors: ThemeColorCache,
         checkmarkImage: NSImage?,
@@ -582,7 +586,9 @@ private final class ModelRowCellView: NSTableCellView, NSGestureRecognizerDelega
         // against the last value so an unchanged hover/selection pass skips the
         // image swap and the relayout.
         let newAccessoryKind: RowAccessoryKind
-        if favoritesMode {
+        if !isFavoriteEligible {
+            newAccessoryKind = .none
+        } else if favoritesMode {
             newAccessoryKind = .favoritesRemove
         } else if isFavorite {
             newAccessoryKind = .heartFill
@@ -1057,6 +1063,7 @@ extension ModelPickerTableRepresentable {
                 isHighlighted: highlightedRowId == row.id,
                 isHovered: hoveredRowId == row.id,
                 isFavorite: row.isFavorite,
+                isFavoriteEligible: row.isFavoriteEligible,
                 favoritesMode: isFavoritesTab,
                 colors: colors,
                 checkmarkImage: checkmarkImage,
@@ -1073,6 +1080,7 @@ extension ModelPickerTableRepresentable {
                     self?.onSelectModel?(id)
                 },
                 onAccessory: { [weak self] in
+                    guard row.isFavoriteEligible else { return }
                     self?.onToggleFavorite?(row)
                 }
             )

--- a/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
@@ -225,13 +225,14 @@ struct ModelPickerView: View {
             modelId: model.id,
             sourceKey: model.source.uniqueKey,
             displayName: model.displayName,
-            description: model.description,
+            description: model.hardwareGuidance ?? model.description,
             parameterCount: model.parameterCount,
             quantization: model.quantization,
             isVLM: model.isVLM,
             isMLXFormat: model.isMLXFormat,
             providerLabel: providerLabel,
-            isFavorite: favoritesStore.isFavorite(model.favoriteKey)
+            isFavorite: model.isFavoriteEligible && favoritesStore.isFavorite(model.favoriteKey),
+            isFavoriteEligible: model.isFavoriteEligible
         )
     }
 
@@ -324,6 +325,7 @@ struct ModelPickerView: View {
         // with pricing) and not while the cross-provider search is active.
         let activeTab = tabs.first { $0.key == effectiveSelectedTabKey(in: tabs) }
         let showSort = !isSearching && (activeTab?.isOsaurus ?? false)
+        let showHardwareBudget = !isSearching && activeTab?.key == ModelPickerItem.Source.local.uniqueKey
         VStack(spacing: 0) {
             header(showSort: showSort)
             Divider().background(theme.primaryBorder.opacity(0.3))
@@ -333,6 +335,10 @@ struct ModelPickerView: View {
             if !isSearching, tabs.count > 1 {
                 tabBar(tabs: tabs)
                 Divider().background(theme.primaryBorder.opacity(0.3))
+            }
+
+            if showHardwareBudget {
+                hardwareBudgetBanner
             }
 
             if let replacement = selectedModelReplacement {
@@ -358,8 +364,9 @@ struct ModelPickerView: View {
         .frame(
             width: 380,
             height: min(
-                CGFloat(visibleOptions.count * 48 + 160) + optionsSectionHeight,
-                optionsSectionHeight > 0 ? 480 + min(optionsSectionHeight, 200) : 480
+                CGFloat(visibleOptions.count * 48 + 160) + optionsSectionHeight
+                    + (showHardwareBudget ? 46 : 0),
+                optionsSectionHeight > 0 ? 526 + min(optionsSectionHeight, 200) : 526
             )
         )
         .background(popoverBackground)
@@ -387,6 +394,33 @@ struct ModelPickerView: View {
         .onChange(of: options) { _, _ in
             ensureSelectedTabValid()
         }
+    }
+
+    private var hardwareBudgetBanner: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "memorychip")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.accentColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(
+                    ModelHardwareGuidance.budgetSummary(
+                        physicalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
+                    ) ?? L("Local-model budget unavailable")
+                )
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.secondaryText)
+                Text(
+                    "This is a recommended working-set budget; current free memory is checked again at load time.",
+                    bundle: .module
+                )
+                .font(.system(size: 9))
+                .foregroundColor(theme.tertiaryText)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(theme.accentColor.opacity(0.06))
     }
 
     // MARK: - Background & Border

--- a/Packages/OsaurusCore/Views/Model/ModelRowView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelRowView.swift
@@ -427,22 +427,22 @@ struct ModelRowView: View {
         .frame(height: 14)
     }
 
-    /// Plain-language fit verdict. When the RAM estimate is known it reads
-    /// as "Runs Well · needs ~10 GB" so new users get the "will this work on
-    /// my Mac" answer without decoding quant/param jargon.
+    /// Plain-language fit verdict. Keep this wording aligned with the picker
+    /// and detail view so a model never changes from "Comfortable" to "Runs
+    /// Well" merely because the user opened a different surface.
     @ViewBuilder
     private var compatibilityBadge: some View {
         switch content.compatibility {
         case .compatible:
             TintedPill(
                 icon: "checkmark.shield",
-                label: Text(fitText(verdict: L("Runs Well"))),
+                label: Text(fitText(verdict: L("Comfortable fit"))),
                 color: theme.successColor
             )
         case .tight:
             TintedPill(
                 icon: "exclamationmark.triangle",
-                label: Text(fitText(verdict: L("Tight Fit"))),
+                label: Text(fitText(verdict: L("Tight fit"))),
                 color: theme.warningColor
             )
         case .tooLarge:
@@ -458,7 +458,7 @@ struct ModelRowView: View {
 
     private func fitText(verdict: String) -> String {
         guard let memory = content.memoryNeeded else { return verdict }
-        return "\(verdict) · \(L("needs \(memory)"))"
+        return "\(verdict) · \(memory)"
     }
 
     /// Badge showing whether the model is an LLM, VLM, or image generator.

--- a/Packages/OsaurusCore/Views/Model/SystemStatusBar.swift
+++ b/Packages/OsaurusCore/Views/Model/SystemStatusBar.swift
@@ -21,29 +21,37 @@ struct SystemStatusBar: View {
     let totalStorageGB: Double
 
     var body: some View {
-        HStack(spacing: 20) {
-            ResourceGauge(
-                label: L("RAM"),
-                icon: "memorychip",
-                usedFraction: totalMemoryGB > 0 ? usedMemoryGB / totalMemoryGB : 0,
-                detail: String(
-                    format: L("%.0f GB free / %.0f GB"),
-                    max(0, totalMemoryGB - usedMemoryGB),
-                    totalMemoryGB
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 20) {
+                ResourceGauge(
+                    label: L("RAM"),
+                    icon: "memorychip",
+                    usedFraction: totalMemoryGB > 0 ? usedMemoryGB / totalMemoryGB : 0,
+                    detail: String(
+                        format: L("%.0f GB free / %.0f GB"),
+                        max(0, totalMemoryGB - usedMemoryGB),
+                        totalMemoryGB
+                    )
                 )
-            )
 
-            ResourceGauge(
-                label: L("Storage"),
-                icon: DirectoryPickerService.shared.hasValidDirectory ? "externaldrive" : "internaldrive",
-                usedFraction: totalStorageGB > 0
-                    ? (totalStorageGB - availableStorageGB) / totalStorageGB : 0,
-                detail: String(
-                    format: L("%.0f GB free / %.0f GB"),
-                    availableStorageGB,
-                    totalStorageGB
+                ResourceGauge(
+                    label: L("Storage"),
+                    icon: DirectoryPickerService.shared.hasValidDirectory ? "externaldrive" : "internaldrive",
+                    usedFraction: totalStorageGB > 0
+                        ? (totalStorageGB - availableStorageGB) / totalStorageGB : 0,
+                    detail: String(
+                        format: L("%.0f GB free / %.0f GB"),
+                        availableStorageGB,
+                        totalStorageGB
+                    )
                 )
-            )
+            }
+
+            if let budget = ModelHardwareGuidance.budgetSummary(physicalMemoryGB: totalMemoryGB) {
+                Text("\(budget). Model estimates use this working-set budget; live free RAM is checked before load.")
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+            }
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 10)

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -1756,13 +1756,18 @@ struct ConfigureModelChooserModal: View {
             return L("Bigger models are smarter but use more memory.")
         }
         let memoryGB = Int(totalMemoryGB.rounded())
+        let budgetText = ModelHardwareGuidance.formattedGB(
+            GPUMemoryBudget.budgetGB(physicalMemoryGB: totalMemoryGB)
+        )
         if let free = state.freeDiskBytes {
             let freeText = free.formatted(.byteCount(style: .file, allowedUnits: [.gb, .mb]))
             return L(
-                "Bigger models are smarter but need more memory — your Mac has \(memoryGB) GB memory and \(freeText) free storage."
+                "Bigger models are smarter but need more memory — your Mac has \(memoryGB) GB unified memory, a \(budgetText) recommended local-model budget, and \(freeText) free storage."
             )
         }
-        return L("Bigger models are smarter but need more memory — your Mac has \(memoryGB) GB memory.")
+        return L(
+            "Bigger models are smarter but need more memory — your Mac has \(memoryGB) GB unified memory and a \(budgetText) recommended local-model budget."
+        )
     }
 
     // MARK: Catalog (modal-local)

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -362,7 +362,7 @@ struct ChatSettingsView: View {
 
             if AutomaticModelRoutingPolicy.isAutomatic(tempDefaultModel) {
                 if let route = AutomaticModelRoutingPolicy.resolve(items: pickerItems) {
-                    Text("Automatic currently selects \(route.displayName). \(route.explanation)")
+                    Text(verbatim: "Automatic currently selects \(route.displayName). \(route.explanation)")
                         .font(.system(size: 10))
                         .foregroundColor(theme.secondaryText)
                 } else {

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -31,6 +31,9 @@ struct ChatSettingsView: View {
 
     // Chat settings state
     @State private var tempSystemPrompt: String = ""
+    @State private var tempDefaultModel: String?
+    @State private var pickerItems: [ModelPickerItem] = []
+    @State private var showModelPicker = false
     @State private var tempChatTemperature: String = ""
     @State private var tempChatMaxTokens: String = ""
     @State private var tempChatContextLength: String = ""
@@ -150,6 +153,7 @@ struct ChatSettingsView: View {
         }
         // Persist a pending edit if the user leaves before the debounce fires.
         .onDisappear { flushPendingSave() }
+        .onReceive(ModelPickerItemCache.shared.$items) { pickerItems = $0 }
     }
 
     /// Bridges the string-backed placement preference to the boolean
@@ -250,6 +254,8 @@ struct ChatSettingsView: View {
     @ViewBuilder private var chatSection: some View {
         SettingsSection(title: "Chat", icon: "text.bubble") {
             VStack(alignment: .leading, spacing: 20) {
+                defaultModelControl
+
                 // System Prompt
                 StyledSettingsTextArea(
                     label: "System Prompt",
@@ -311,6 +317,86 @@ struct ChatSettingsView: View {
                 }
             }
         }
+    }
+
+    private var defaultModelControl: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Default Model", bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+
+            Button { showModelPicker.toggle() } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: AutomaticModelRoutingPolicy.isAutomatic(tempDefaultModel) ? "sparkles" : "cube.fill")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.accentColor)
+                    Text(defaultModelDisplayName)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(theme.tertiaryText)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(theme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $showModelPicker, arrowEdge: .bottom) {
+                ModelPickerView(
+                    options: pickerItems.withAutomaticOnDeviceChoice,
+                    selectedModel: $tempDefaultModel,
+                    agentId: Agent.defaultId,
+                    onDismiss: { showModelPicker = false }
+                )
+            }
+
+            if AutomaticModelRoutingPolicy.isAutomatic(tempDefaultModel) {
+                if let route = AutomaticModelRoutingPolicy.resolve(items: pickerItems) {
+                    Text("Automatic currently selects \(route.displayName). \(route.explanation)")
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.secondaryText)
+                } else {
+                    Text(AutomaticModelRoutingPolicy.failureExplanation(for: .text))
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.warningColor)
+                }
+            } else if let tempDefaultModel,
+                let guidance = pickerItems.first(where: { $0.id == tempDefaultModel })?.hardwareGuidance
+            {
+                Text(guidance)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.secondaryText)
+            }
+
+            if let budget = ModelHardwareGuidance.budgetSummary(
+                physicalMemoryGB: GPUMemoryBudget.hostPhysicalMemoryGB
+            ) {
+                Text("\(budget). Current free memory is checked again before loading.")
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+            }
+        }
+        .settingsLandingAnchor("settings.chat.defaultModel")
+    }
+
+    private var defaultModelDisplayName: String {
+        guard let tempDefaultModel else { return L("Choose a model") }
+        if AutomaticModelRoutingPolicy.isAutomatic(tempDefaultModel) {
+            return L("Automatic (on device)")
+        }
+        return pickerItems.first(where: { $0.id == tempDefaultModel })?.displayName
+            ?? tempDefaultModel.split(separator: "/").last.map(String.init)
+            ?? tempDefaultModel
     }
 
     // MARK: - Generation Section
@@ -459,6 +545,7 @@ struct ChatSettingsView: View {
         // agent's tools toggle lives in the Agents tab and the global memory
         // switch lives in the Memory tab.
         tempSystemPrompt = defaultAgent.systemPrompt
+        tempDefaultModel = defaultAgent.defaultModel
         tempChatTemperature = defaultAgent.temperature.map { String($0) } ?? ""
         tempChatMaxTokens = defaultAgent.maxTokens.map(String.init) ?? ""
         tempChatContextLength = chat.contextLength.map(String.init) ?? ""
@@ -487,6 +574,7 @@ struct ChatSettingsView: View {
         let chatDefaults = ChatConfiguration.default
 
         tempSystemPrompt = ""
+        tempDefaultModel = nil
         tempChatTemperature = ""
         tempChatMaxTokens = ""
         tempChatContextLength = ""
@@ -504,6 +592,7 @@ struct ChatSettingsView: View {
     /// Snapshot of exactly the fields that `saveConfiguration` persists.
     private struct SaveableFormState: Equatable {
         var systemPrompt: String
+        var defaultModel: String?
         var temperature: String
         var maxTokens: String
         var contextLength: String
@@ -517,6 +606,7 @@ struct ChatSettingsView: View {
     private var currentFormState: SaveableFormState {
         SaveableFormState(
             systemPrompt: tempSystemPrompt,
+            defaultModel: tempDefaultModel,
             temperature: tempChatTemperature,
             maxTokens: tempChatMaxTokens,
             contextLength: tempChatContextLength,
@@ -612,10 +702,14 @@ struct ChatSettingsView: View {
         // agent's tools toggle lives in the Agents tab, and the global memory
         // switch lives in the Memory tab; this view leaves both untouched.
         var defaultAgentCfg = DefaultAgentConfigurationStore.load()
+        let defaultModelChanged = defaultAgentCfg.defaultModel != tempDefaultModel
         defaultAgentCfg.systemPrompt = tempSystemPrompt
         defaultAgentCfg.temperature = parsedTemp
         defaultAgentCfg.maxTokens = parsedMax
         DefaultAgentConfigurationStore.save(defaultAgentCfg)
+        if defaultModelChanged {
+            AgentManager.shared.updateDefaultModel(for: Agent.defaultId, model: tempDefaultModel)
+        }
 
         // Re-baseline so the dirty check clears now that the live form matches
         // what's persisted.

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift
@@ -100,7 +100,11 @@ struct ConcurrencySection: View {
     }
 
     private func syncFromDraft() {
-        let desired = draft.concurrency.maxConcurrentSequences.map(String.init) ?? "1"
+        // Preserve nil as "engine selected" while merely viewing Settings.
+        // Writing the displayed fallback of 1 back through `onChange` made a
+        // clean profile acquire an Osaurus-owned concurrency cap before the
+        // user touched this control, which also made No Automatic Limits lie.
+        let desired = draft.concurrency.maxConcurrentSequences.map(String.init) ?? ""
         if maxConcurrentText != desired { maxConcurrentText = desired }
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift
@@ -15,7 +15,8 @@ struct MemorySafetySection: View {
     @Binding var draft: VMLXServerRuntimeSettings
 
     private var resolvedPlan: VMLXResolvedMemorySafetyPlan {
-        draft.resolvedMemorySafetyPlan(
+        ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+            for: draft,
             baseLoadConfiguration: .osaurusProduction,
             host: MemoryStatus.snapshot()
         )
@@ -45,7 +46,7 @@ struct MemorySafetySection: View {
             SettingsField(
                 label: "Safety Level",
                 hint:
-                    "0 favors performance, 2 is Safe Auto, 3 is strict, and 4 is diagnostic/custom."
+                    "0 favors performance, 2 is Safe Auto, 3 is strict, and 4 removes automatic Osaurus caps."
             ) {
                 VStack(alignment: .leading, spacing: 8) {
                     Slider(value: sliderBinding, in: 0 ... 4, step: 1)
@@ -164,7 +165,7 @@ struct MemorySafetySection: View {
         case 1: return L("Balanced")
         case 2: return L("Safe Auto")
         case 3: return L("Strict")
-        default: return L("Diagnostic / Custom")
+        default: return L("No Automatic Limits (Dangerous)")
         }
     }
 
@@ -177,7 +178,8 @@ struct MemorySafetySection: View {
     }
 
     private var kvCapSummary: String {
-        resolvedPlan.cache.defaultMaxKVSize.map(String.init) ?? "default"
+        resolvedPlan.cache.defaultMaxKVSize.map(String.init)
+            ?? (draft.memorySafety.mode == .diagnosticDangerous ? "unlimited" : "default")
     }
 
     private var concurrencySummary: String {
@@ -218,7 +220,7 @@ struct MemorySafetySection: View {
         case .balanced: return L("Balanced")
         case .safeAuto: return L("Safe Auto")
         case .strict: return L("Strict")
-        case .diagnosticDangerous: return L("Diagnostic / Dangerous")
+        case .diagnosticDangerous: return L("No Automatic Limits (Dangerous)")
         }
     }
 }

--- a/docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md
+++ b/docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md
@@ -1,8 +1,9 @@
 # Automatic Routing and Hardware Guidance Proof Ledger
 
-Date: 2026-07-14 (America/Los_Angeles)
+Started: 2026-07-14 (America/Los_Angeles)
+Last updated: 2026-07-15 (America/Los_Angeles)
 
-This PR has exactly two product goals. A row becomes `CONFIRMED` only when the
+This PR has two product goals plus one settings-truth requirement. A row becomes `CONFIRMED` only when the
 source trace, automated coverage, and live verification named below all exist.
 Source inspection or unit tests without final-app behavior remain `PARTIAL`.
 
@@ -10,8 +11,20 @@ Source inspection or unit tests without final-app behavior remain `PARTIAL`.
 
 | Goal | Product contract | Current status |
 | --- | --- | --- |
-| Better automatic model routing | Agents can explicitly choose `Automatic (on device)`. The persisted sentinel resolves to a concrete installed on-device chat model that has a compatible hardware verdict. Normal turns keep the current safe route for cache locality; media turns can upgrade before send. Automatic never chooses a cloud provider or a tight, too-large, unknown, embedding, AppleScript-only, image-generation, or non-MLX route. Manual model selection exits Automatic. | PARTIAL — implementation and tests in progress; final app proof pending |
-| Clearer hardware guidance | Model selection surfaces distinguish physical unified memory from the smaller recommended local-model working-set budget. Picker rows, model detail, onboarding, download status, and agent settings use the same `GPUMemoryBudget` verdict as routing, and state that current free RAM is checked again at load time. | PARTIAL — implementation and tests in progress; final app proof pending |
+| Better automatic model routing | Agents can explicitly choose `Automatic (on device)`. The persisted sentinel resolves to a concrete installed on-device chat model that has a compatible hardware verdict. Normal turns keep the current safe route for cache locality; media turns can upgrade before send. Automatic never chooses a cloud provider or a tight, too-large, unknown, embedding, AppleScript-only, image-generation, or non-MLX route. Manual model selection exits Automatic. | PARTIAL — source and focused Xcode tests complete; final app proof pending |
+| Clearer hardware guidance | Model selection surfaces distinguish physical unified memory from the smaller recommended local-model working-set budget. Picker rows, model detail, onboarding, download status, and agent settings use the same `GPUMemoryBudget` verdict as routing, and state that current free RAM is checked again at load time. | PARTIAL — source and focused Xcode tests complete; final app proof pending |
+| Memory Safety settings are truthful | UI preview, `/admin/cache-stats`, cache construction, and actual model loads use one Osaurus resolver. `No Automatic Limits (Dangerous)` removes mode-derived load, allocator, prefix, KV, concurrency, chat-send, materialized-load-refusal, flexible-eviction, and prefix-store percentage caps when the corresponding advanced fields are blank. Explicit user overrides remain in force; physical/Metal guidance remains visible, and engine/platform allocation failures are still possible. | PARTIAL — source and focused Xcode tests complete; live settings/load proof pending |
+
+## Scope guard
+
+- No model-family parser, template, sampler, generation-config, content-delta,
+  or tool-JSON behavior changes belong in this PR.
+- MXFP4 is not installed and is not a test target. The only Gemma controls are
+  the installed MXFP8 and JANG_4M bundles. If the reported Gemma behavior does
+  not reproduce in those controls, this PR makes no Gemma behavior change.
+- The PR must not infer a fixed user RAM size. Host UI and routing read current
+  `ProcessInfo.physicalMemory` plus Metal's advertised working-set value; tests
+  use explicit synthetic values only where they are testing pure policy math.
 
 ## Required proof matrix
 
@@ -22,7 +35,40 @@ Source inspection or unit tests without final-app behavior remain `PARTIAL`.
 | Media upgrade | Policy and composer tests prove only modalities with a concrete compatible local route are advertised, and send-time resolution happens before request construction | Attach real supported media in the isolated app; observe the route upgrade and a concrete media-grounded answer. If this Mac has no safe media route, verify the control is honestly absent/rejected instead | NOT YET VERIFIED |
 | No-cloud boundary | Policy tests include connected remote candidates and prove none can win Automatic | With a connected provider visible in the picker, Automatic still names an on-device route and records no remote request | NOT YET VERIFIED |
 | Hardware wording | Formatting tests pin unified-memory, recommended-budget, estimated-working-set, and fit wording to `GPUMemoryBudget` | Visually inspect agent settings, local model picker, model detail/onboarding or download status; displayed numbers must agree across surfaces | NOT YET VERIFIED |
-| Runtime safety | Existing load preflight remains the final current-free-RAM gate; this PR does not change memory limits, sampler defaults, cache topology, or model generation config | Monitor the selected local model load and generation for responsiveness and a bounded physical footprint; no beachball or hidden cloud fallback | NOT YET VERIFIED |
+| Settings persistence | Store tests pin mode/slider round-trip, legacy implicit prefix-cap migration, true unlimited resolution, explicit-override preservation, and the no-limit switch used by Osaurus-owned gates | Change Safe Auto -> No Automatic Limits -> Safe Auto in the isolated app; save/reload each state and compare the visible resolved plan with `/admin/cache-stats.memory_safety` | NOT YET VERIFIED |
+| Runtime setting effect | Source trace must show the same resolver feeding settings preview, diagnostics JSON, cache construction, `loadContainer` configuration, chat send severity, materialized-load refusal, flexible residency, and prefix-store policy | Unload between modes, load an installed control model, and observe the resolved load/allocator/KV/prefix/concurrency values change in diagnostics; no stale next-load-only state | NOT YET VERIFIED |
+| Runtime safety | Existing current-free-RAM/load-pressure telemetry remains visible; this PR does not change sampler defaults, model generation config, parser behavior, or model templates | Monitor the selected local model load and generation for responsiveness and physical footprint; no beachball or hidden cloud fallback | NOT YET VERIFIED |
+
+## Current execution status
+
+- Branch `codex/auto-routing-hardware-guidance` is rebased directly onto merged
+  Osaurus `main` at PR #2041 (`eaba91d05`).
+- The cold SwiftPM command compiled and emitted `OsaurusCore`, then the SwiftPM
+  test target stopped at the known configuration error `no such module
+  'Testing'`. This is compile-only partial evidence, not a test pass.
+- Both focused Xcode runs passed and executed their requested tests: routing,
+  chat selection, hardware guidance, settings migration/resolution, agent,
+  image, warmup, picker, model scan, and runtime-policy suites.
+- After the exhaustive Memory Safety trace found the remaining chat-send,
+  materialized-load-refusal, flexible-eviction, and prefix-store gaps, the
+  OsaurusCore SwiftPM build completed again. Focused Xcode routing, hardware,
+  settings, RAM-feasibility, and warmup tests passed. The first runtime-policy
+  source run found two stale exact-string assertions after a function signature
+  changed; after making those assertions signature-tolerant, the complete
+  89-test `RuntimePolicySourceTests` suite passed serially. Current result:
+  `/tmp/osaurus-routing-guidance-derived/Logs/Test/Test-OsaurusCoreTests-2026.07.15_19-11-14--0700.xcresult`.
+- The full parallel OsaurusCore scheme is not green: 6,005 passed, 20 skipped,
+  and 11 failed under shared global-state/timing contention. A serial rerun of
+  all failing suites passed every failure except the local Gemma tokenizer
+  assertion at `SwiftTransformersTokenizerLoaderTests.swift:701`. That test
+  expects `capabilities_discover` in the Default-agent schema, while the current
+  Default-agent source contract explicitly excludes discovery and exposes the
+  consolidated `osaurus_*` configuration surface directly. This is a
+  source-template control failure, not live inference evidence, and this PR has
+  not changed either side of that contract.
+- Next: inspect the final diff for scope, build an isolated Release app/bundle
+  ID, and execute the full live rows above through Computer Use. The installed
+  MXFP8/JANG_4M inference controls remain mandatory; MXFP4 remains out of scope.
 
 ## Merge gate
 

--- a/docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md
+++ b/docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md
@@ -1,0 +1,32 @@
+# Automatic Routing and Hardware Guidance Proof Ledger
+
+Date: 2026-07-14 (America/Los_Angeles)
+
+This PR has exactly two product goals. A row becomes `CONFIRMED` only when the
+source trace, automated coverage, and live verification named below all exist.
+Source inspection or unit tests without final-app behavior remain `PARTIAL`.
+
+## Scope
+
+| Goal | Product contract | Current status |
+| --- | --- | --- |
+| Better automatic model routing | Agents can explicitly choose `Automatic (on device)`. The persisted sentinel resolves to a concrete installed on-device chat model that has a compatible hardware verdict. Normal turns keep the current safe route for cache locality; media turns can upgrade before send. Automatic never chooses a cloud provider or a tight, too-large, unknown, embedding, AppleScript-only, image-generation, or non-MLX route. Manual model selection exits Automatic. | PARTIAL — implementation and tests in progress; final app proof pending |
+| Clearer hardware guidance | Model selection surfaces distinguish physical unified memory from the smaller recommended local-model working-set budget. Picker rows, model detail, onboarding, download status, and agent settings use the same `GPUMemoryBudget` verdict as routing, and state that current free RAM is checked again at load time. | PARTIAL — implementation and tests in progress; final app proof pending |
+
+## Required proof matrix
+
+| Row | Source/automated evidence required | Live evidence required | Status |
+| --- | --- | --- | --- |
+| Text route | Policy tests exclude remote and unsafe candidates, choose the strongest compatible local route, and preserve the persisted Automatic sentinel | Fresh isolated app shows `Auto → <concrete model>` and returns a coherent answer | NOT YET VERIFIED |
+| Multi-turn stability | Policy test proves a current compatible route wins over a gratuitous stronger switch | At least three related turns stay on the same route and produce coherent answers without raw protocol markers | NOT YET VERIFIED |
+| Media upgrade | Policy and composer tests prove only modalities with a concrete compatible local route are advertised, and send-time resolution happens before request construction | Attach real supported media in the isolated app; observe the route upgrade and a concrete media-grounded answer. If this Mac has no safe media route, verify the control is honestly absent/rejected instead | NOT YET VERIFIED |
+| No-cloud boundary | Policy tests include connected remote candidates and prove none can win Automatic | With a connected provider visible in the picker, Automatic still names an on-device route and records no remote request | NOT YET VERIFIED |
+| Hardware wording | Formatting tests pin unified-memory, recommended-budget, estimated-working-set, and fit wording to `GPUMemoryBudget` | Visually inspect agent settings, local model picker, model detail/onboarding or download status; displayed numbers must agree across surfaces | NOT YET VERIFIED |
+| Runtime safety | Existing load preflight remains the final current-free-RAM gate; this PR does not change memory limits, sampler defaults, cache topology, or model generation config | Monitor the selected local model load and generation for responsiveness and a bounded physical footprint; no beachball or hidden cloud fallback | NOT YET VERIFIED |
+
+## Merge gate
+
+Before merge: focused policy/settings/chat tests, full OsaurusCore tests, clean
+Release build, isolated signed-app Computer Use proof, PR CI, merge, and
+merged-main CI. The sidebar layout report and all other community issues are
+explicitly outside this PR.

--- a/docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md
+++ b/docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md
@@ -11,9 +11,9 @@ Source inspection or unit tests without final-app behavior remain `PARTIAL`.
 
 | Goal | Product contract | Current status |
 | --- | --- | --- |
-| Better automatic model routing | Agents can explicitly choose `Automatic (on device)`. The persisted sentinel resolves to a concrete installed on-device chat model that has a compatible hardware verdict. Normal turns keep the current safe route for cache locality; media turns can upgrade before send. Automatic never chooses a cloud provider or a tight, too-large, unknown, embedding, AppleScript-only, image-generation, or non-MLX route. Manual model selection exits Automatic. | PARTIAL — source and focused Xcode tests complete; final app proof pending |
-| Clearer hardware guidance | Model selection surfaces distinguish physical unified memory from the smaller recommended local-model working-set budget. Picker rows, model detail, onboarding, download status, and agent settings use the same `GPUMemoryBudget` verdict as routing, and state that current free RAM is checked again at load time. | PARTIAL — source and focused Xcode tests complete; final app proof pending |
-| Memory Safety settings are truthful | UI preview, `/admin/cache-stats`, cache construction, and actual model loads use one Osaurus resolver. `No Automatic Limits (Dangerous)` removes mode-derived load, allocator, prefix, KV, concurrency, chat-send, materialized-load-refusal, flexible-eviction, and prefix-store percentage caps when the corresponding advanced fields are blank. Explicit user overrides remain in force; physical/Metal guidance remains visible, and engine/platform allocation failures are still possible. | PARTIAL — source and focused Xcode tests complete; live settings/load proof pending |
+| Better automatic model routing | Agents can explicitly choose `Automatic (on device)`. The persisted sentinel resolves to a concrete installed on-device chat model that has a compatible hardware verdict. Normal turns keep the current safe route for cache locality; media turns can upgrade before send. Automatic never chooses a cloud provider or a tight, too-large, unknown, embedding, AppleScript-only, image-generation, or non-MLX route. Manual model selection exits Automatic. | PARTIAL — source, focused tests, explicit UI selection, and three-turn text-route proof exist; real-media upgrade and a live connected-provider boundary remain unverified |
+| Clearer hardware guidance | Model selection surfaces distinguish physical unified memory from the smaller recommended local-model working-set budget. Picker rows, model detail, onboarding, download status, and agent settings use the same `GPUMemoryBudget` verdict as routing, and state that current free RAM is checked again at load time. | PARTIAL — source, focused tests, model picker, and agent-settings UI agree; onboarding/download surfaces were not operated in this proof |
+| Memory Safety settings are truthful | UI preview, `/admin/cache-stats`, cache construction, and actual model loads use one Osaurus resolver. `No Automatic Limits (Dangerous)` removes mode-derived load, allocator, prefix, KV, concurrency, chat-send, materialized-load-refusal, flexible-eviction, and prefix-store percentage caps when the corresponding advanced fields are blank. Explicit user overrides remain in force; physical/Metal guidance remains visible, and engine/platform allocation failures are still possible. | CONFIRMED — source, 89 focused runtime-policy tests, Release UI mode toggles, persisted values, diagnostics, and subsequent Safe Auto model loads agree |
 
 ## Scope guard
 
@@ -30,14 +30,14 @@ Source inspection or unit tests without final-app behavior remain `PARTIAL`.
 
 | Row | Source/automated evidence required | Live evidence required | Status |
 | --- | --- | --- | --- |
-| Text route | Policy tests exclude remote and unsafe candidates, choose the strongest compatible local route, and preserve the persisted Automatic sentinel | Fresh isolated app shows `Auto → <concrete model>` and returns a coherent answer | NOT YET VERIFIED |
-| Multi-turn stability | Policy test proves a current compatible route wins over a gratuitous stronger switch | At least three related turns stay on the same route and produce coherent answers without raw protocol markers | NOT YET VERIFIED |
+| Text route | Policy tests exclude remote and unsafe candidates, choose the strongest compatible local route, and preserve the persisted Automatic sentinel | Fresh isolated app shows `Auto → <concrete model>` and returns a coherent answer | CONFIRMED — agent setting saved `Automatic (on device)`; chat displayed `Auto → OsaurusAI Gemma 4 12B it qat JANG_4M` and stayed local |
+| Multi-turn stability | Policy test proves a current compatible route wins over a gratuitous stronger switch | At least three related turns stay on the same route and produce coherent answers without raw protocol markers | CONFIRMED — three related Jupiter turns stayed on the same JANG_4M route at 64.2, 39.8, and 69.7 tok/s |
 | Media upgrade | Policy and composer tests prove only modalities with a concrete compatible local route are advertised, and send-time resolution happens before request construction | Attach real supported media in the isolated app; observe the route upgrade and a concrete media-grounded answer. If this Mac has no safe media route, verify the control is honestly absent/rejected instead | NOT YET VERIFIED |
 | No-cloud boundary | Policy tests include connected remote candidates and prove none can win Automatic | With a connected provider visible in the picker, Automatic still names an on-device route and records no remote request | NOT YET VERIFIED |
-| Hardware wording | Formatting tests pin unified-memory, recommended-budget, estimated-working-set, and fit wording to `GPUMemoryBudget` | Visually inspect agent settings, local model picker, model detail/onboarding or download status; displayed numbers must agree across surfaces | NOT YET VERIFIED |
-| Settings persistence | Store tests pin mode/slider round-trip, legacy implicit prefix-cap migration, true unlimited resolution, explicit-override preservation, and the no-limit switch used by Osaurus-owned gates | Change Safe Auto -> No Automatic Limits -> Safe Auto in the isolated app; save/reload each state and compare the visible resolved plan with `/admin/cache-stats.memory_safety` | NOT YET VERIFIED |
-| Runtime setting effect | Source trace must show the same resolver feeding settings preview, diagnostics JSON, cache construction, `loadContainer` configuration, chat send severity, materialized-load refusal, flexible residency, and prefix-store policy | Unload between modes, load an installed control model, and observe the resolved load/allocator/KV/prefix/concurrency values change in diagnostics; no stale next-load-only state | NOT YET VERIFIED |
-| Runtime safety | Existing current-free-RAM/load-pressure telemetry remains visible; this PR does not change sampler defaults, model generation config, parser behavior, or model templates | Monitor the selected local model load and generation for responsiveness and physical footprint; no beachball or hidden cloud fallback | NOT YET VERIFIED |
+| Hardware wording | Formatting tests pin unified-memory, recommended-budget, estimated-working-set, and fit wording to `GPUMemoryBudget` | Visually inspect agent settings, local model picker, model detail/onboarding or download status; displayed numbers must agree across surfaces | PARTIAL — picker and agent settings both showed 128 GB unified memory, 107.5 GB recommended budget, current-free-memory recheck wording, and identical per-model working sets; onboarding/download UI not operated |
+| Settings persistence | Store tests pin mode/slider round-trip, legacy implicit prefix-cap migration, true unlimited resolution, explicit-override preservation, and the no-limit switch used by Osaurus-owned gates | Change Safe Auto -> No Automatic Limits -> Safe Auto in the isolated app; save/reload each state and compare the visible resolved plan with `/admin/cache-stats.memory_safety` | CONFIRMED — clean Settings entry stayed saved, No Automatic Limits saved with null KV/concurrency and unlimited load/allocator, then Safe Auto restored 70%/128 MB/65,536/1 in both UI and diagnostics |
+| Runtime setting effect | Source trace must show the same resolver feeding settings preview, diagnostics JSON, cache construction, `loadContainer` configuration, chat send severity, materialized-load refusal, flexible residency, and prefix-store policy | Unload between modes, load an installed control model, and observe the resolved load/allocator/KV/prefix/concurrency values change in diagnostics; no stale next-load-only state | CONFIRMED — the isolated app loaded JANG_4M while unlimited mode was active, then loaded Bonsai and JANG_4M after Safe Auto was restored; diagnostics reflected the active plan in each phase |
+| Runtime safety | Existing current-free-RAM/load-pressure telemetry remains visible; this PR does not change sampler defaults, model generation config, parser behavior, or model templates | Monitor the selected local model load and generation for responsiveness and physical footprint; no beachball or hidden cloud fallback | PARTIAL — app remained responsive and routes stayed local, but the JANG_4M low-RAM row failed at 9,847-9,855 MB footprint against 10,135,442,741 weight bytes |
 
 ## Current execution status
 
@@ -55,8 +55,10 @@ Source inspection or unit tests without final-app behavior remain `PARTIAL`.
   settings, RAM-feasibility, and warmup tests passed. The first runtime-policy
   source run found two stale exact-string assertions after a function signature
   changed; after making those assertions signature-tolerant, the complete
-  89-test `RuntimePolicySourceTests` suite passed serially. Current result:
-  `/tmp/osaurus-routing-guidance-derived/Logs/Test/Test-OsaurusCoreTests-2026.07.15_19-11-14--0700.xcresult`.
+  89-test `RuntimePolicySourceTests` suite passed serially. The final rerun also
+  covers the Settings-opening concurrency regression and has 89 passed, 0
+  failed, 0 skipped:
+  `/tmp/osaurus-routing-guidance-derived/Logs/Test/Test-OsaurusCoreTests-2026.07.15_19-28-46--0700.xcresult`.
 - The full parallel OsaurusCore scheme is not green: 6,005 passed, 20 skipped,
   and 11 failed under shared global-state/timing contention. A serial rerun of
   all failing suites passed every failure except the local Gemma tokenizer
@@ -66,13 +68,43 @@ Source inspection or unit tests without final-app behavior remain `PARTIAL`.
   consolidated `osaurus_*` configuration surface directly. This is a
   source-template control failure, not live inference evidence, and this PR has
   not changed either side of that contract.
-- Next: inspect the final diff for scope, build an isolated Release app/bundle
-  ID, and execute the full live rows above through Computer Use. The installed
-  MXFP8/JANG_4M inference controls remain mandatory; MXFP4 remains out of scope.
+- The final source used an isolated Release app at
+  `/tmp/osaurus-routing-guidance-release/Build/Products/Release/osaurus.app`,
+  ad-hoc signed under `com.dinoki.osaurus.routingguidanceproof`, with isolated
+  files and UserDefaults. Merely opening Settings no longer wrote the visible
+  concurrency fallback of `1` into an unset advanced override.
+
+## Live inference controls and residuals
+
+No Gemma MXFP4 bundle was loaded or tested.
+
+| Control | Live Release-app result | Verdict |
+| --- | --- | --- |
+| `OsaurusAI/OsaurusAI--gemma-4-12B-it-MXFP8` | Thinking was toggled on then off in the UI and persisted as `disableThinking=true`. The exact `CEST` `invalid_args` tool error was shown in the tool card, followed by a successful `Europe/Berlin` retry and coherent answer. TTFT 0.63 s, 41.9 tok/s, 34 tokens; post-run footprint 5,132 MB. | PASS for the reported tool-error/streaming loop control; no protocol-marker loop or leak observed |
+| `OsaurusAI/OsaurusAI--gemma-4-12B-it-qat-JANG_4M` | Thinking was toggled on then off and persisted. The same `CEST` failure recovered successfully at TTFT 0.51 s, 55.6 tok/s, 34 tokens. A later Safe Auto plain-text load answered at 64.2 tok/s. Cache topology was 48 layers, 8 KV, 40 rotating, disk-backed restore, TurboQuant-KV layer count 0, effective KV fp16, paged off. | PASS for the reported tool-error/streaming loop control; FAIL for the repo low-RAM gate because Safe Auto footprint remained about full weight size |
+| `dealign.ai/Bonsai-27b-1bit-JANG-CRACK` | Safe Auto, 64 layers with 16 KV and 48 Mamba layers, SSM companion hits, disk-backed restore, paged off, 4,666,222,032 weight bytes. First turn was coherent at 48.7 tok/s. With Thinking on, a simple recall consumed 2,380 tokens at 28.7 tok/s without a final answer before stop. After toggling Thinking off and confirming `disableThinking=true`, the same recall answered coherently in 28 tokens at 59.2 tok/s; footprint fell to 2,596 MB. | PASS for real-user Thinking-off multi-turn/speed/RAM; FAIL for the adjacent Thinking-on verbosity/no-final-answer row |
+
+The two installed Gemma controls did not reproduce the MXFP4 report's
+post-tool-error protocol-marker loop. Per the scope guard, this narrows the
+report to the untested MXFP4 bundle or another condition absent from both
+controls and does not justify a shared content-delta, tool-schema, parser,
+template, sampler, or generation-config change.
+
+## Final scope audit
+
+- Production additions contain no `Gemma`, `Bonsai`, `Qwen`, or `JANG`
+  model-specific branches.
+- Production additions contain no MXFP4, parser, template, sampler,
+  content-delta, tool-JSON, or generation-config behavior changes.
+- The branch is a follow-up to already-merged PR #2041. It contains automatic
+  on-device routing, shared hardware-budget guidance, truthful Memory Safety
+  resolution/wiring, their UI surfaces, tests, and this ledger only.
 
 ## Merge gate
 
-Before merge: focused policy/settings/chat tests, full OsaurusCore tests, clean
-Release build, isolated signed-app Computer Use proof, PR CI, merge, and
-merged-main CI. The sidebar layout report and all other community issues are
-explicitly outside this PR.
+Before merge: commit the final concurrency regression, rerun the scoped tests,
+push, open a separate follow-up PR, and require its CI. Media upgrade and a live
+connected-provider boundary remain PARTIAL and must not be described as live
+verified. The JANG_4M low-RAM failure and Bonsai Thinking-on failure are
+recorded residuals rather than silently reclassified as passes. The sidebar
+layout report and all other community issues are explicitly outside this PR.


### PR DESCRIPTION
## Summary

- add an explicit Automatic on-device agent route that resolves only installed compatible local MLX models and preserves a safe warm route
- use one physical-memory and Metal working-set budget across routing, picker rows, agent settings, model detail, onboarding, and status surfaces
- make Memory Safety modes truthful across UI preview, diagnostics, cache/load configuration, residency gates, and concurrency; merely opening Settings no longer writes a hidden concurrency cap

## Scope guard

- no Gemma, Bonsai, Qwen, or JANG model-specific production branches
- no MXFP4, parser, template, sampler, content-delta, tool-JSON, or generation-config changes
- this is a follow-up to merged PR #2041, not a re-bundle of its Bonsai/chart fix

## Current source and test evidence

- final production diff is restricted to routing, hardware-budget, Memory Safety, their UI consumers, tests, and the proof ledger
- 89 RuntimePolicySourceTests passed, 0 failed, 0 skipped in `/tmp/osaurus-routing-guidance-derived/Logs/Test/Test-OsaurusCoreTests-2026.07.15_19-28-46--0700.xcresult`
- isolated Release app built and was ad-hoc signed as `com.dinoki.osaurus.routingguidanceproof`
- full parallel local OsaurusCore run still has pre-existing shared-state/timing failures plus the existing Default-agent tokenizer schema assertion; PR CI is required before merge

## Live Release-app evidence

- visually changed Safe Auto to No Automatic Limits and back; saved UI summaries and `/admin/cache-stats.memory_safety` agreed in each mode
- explicitly selected Automatic in agent settings; chat displayed `Auto -> OsaurusAI Gemma 4 12B it qat JANG_4M` and preserved that local route for three coherent turns at 64.2, 39.8, and 69.7 tok/s
- picker and agent settings agreed on 128 GB physical unified memory, 107.5 GB recommended local-model budget, and per-model working-set estimates
- exact installed MXFP8 and JANG_4M controls recovered the reported CEST invalid_args tool error without a protocol-marker loop; no MXFP4 model was loaded or tested, so this PR makes no Gemma behavior change
- Bonsai Thinking-off multi-turn recall answered at 59.2 tok/s with a 2,596 MB footprint

## Honest residuals

- real-media Automatic upgrade and a live connected-provider boundary are PARTIAL / not live-verified
- JANG_4M Safe Auto low-RAM row failed: 9,847-9,855 MB process footprint against 10,135,442,741 weight bytes
- Bonsai Thinking-on simple recall produced 2,380 tokens without a final answer before stop; Thinking-off passed

The full evidence matrix and exact cache topology are in `docs/AUTOMATIC_ROUTING_HARDWARE_GUIDANCE_PROOF_2026-07-14.md`.