### PR TITLE
Enforce selected memory safety limits during model loads

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
+++ b/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
@@ -25,6 +25,16 @@ import Foundation
 enum GPUMemoryBudget {
 
     private static let bytesPerGB: Double = 1024 * 1024 * 1024
+    private static let chatRuntimeInflation = 1.25
+
+    /// Shared picker/load-admission estimate for static weights plus ordinary
+    /// chat activations and runtime buffers.
+    static func estimatedChatWorkingSetBytes(onDiskBytes: Int64) -> UInt64? {
+        guard onDiskBytes > 0 else { return nil }
+        let bytes = Double(onDiskBytes) * chatRuntimeInflation
+        guard bytes.isFinite, bytes > 0 else { return nil }
+        return UInt64(min(Double(UInt64.max), bytes.rounded(.up)))
+    }
 
     /// Apple's default split between the GPU working set and everything else.
     /// Machines at or below 36 GB hold back proportionally more for the OS.

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -502,11 +502,6 @@ struct MLXModel: Identifiable, Codable {
     // MARK: - Memory Estimation & Hardware Compatibility
 
     private static let bytesPerGB: Double = 1024 * 1024 * 1024
-    /// Runtime headroom over raw weight size — covers KV cache, activations,
-    /// and Metal/runtime buffers. Bumped from 1.2 → 1.25 so the onboarding
-    /// default leaves more slack and stops landing users on a model that
-    /// "fits" the estimate but chokes once a long-context KV cache grows.
-    private static let overheadMultiplier: Double = 1.25
 
     /// Numeric parameter count in billions (e.g. "7B" -> 7.0, "270M" -> 0.27)
     var parameterCountBillions: Double? {
@@ -549,10 +544,12 @@ struct MLXModel: Identifiable, Codable {
     /// only the fallback for entries we haven't sized yet.
     var estimatedMemoryGB: Double? {
         if let dlBytes = downloadSizeBytes, dlBytes > 0 {
-            return Double(dlBytes) * Self.overheadMultiplier / Self.bytesPerGB
+            return GPUMemoryBudget.estimatedChatWorkingSetBytes(
+                onDiskBytes: dlBytes
+            ).map { Double($0) / Self.bytesPerGB }
         }
         if let params = parameterCountBillions {
-            return params * bytesPerParameter * 1e9 * Self.overheadMultiplier / Self.bytesPerGB
+            return params * bytesPerParameter * 1e9 * 1.25 / Self.bytesPerGB
         }
         return nil
     }

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -55,6 +55,8 @@ public enum ServerRuntimeSettingsStore {
         ".server-runtime-cache-defaults-v2-migrated"
     private static let pagedCacheDefaultOffMigrationMarkerName =
         ".server-runtime-paged-cache-default-off-v3-migrated"
+    private static let memorySafetyOwnedCacheDefaultsMigrationMarkerName =
+        ".server-runtime-memory-safety-cache-defaults-v4-migrated"
 
     // MARK: - Load / Save
 
@@ -160,12 +162,91 @@ public enum ServerRuntimeSettingsStore {
         cachedSnapshot = settings
     }
 
-    public nonisolated static func modelLoadRAMThresholds() -> (soft: Double, hard: Double) {
+    /// Whether the user explicitly selected the dangerous profile with no
+    /// replacement physical-memory ceiling. This is the shared switch for
+    /// Osaurus-owned load refusal/send/eviction gates; keeping it here prevents
+    /// the settings UI and runtime from assigning different meanings to the
+    /// final slider position.
+    public nonisolated static func automaticMemoryLimitsDisabled(
+        for settings: VMLXServerRuntimeSettings? = nil
+    ) -> Bool {
+        let settings = settings ?? snapshot()
+        return settings.memorySafety.mode == .diagnosticDangerous
+            && settings.memorySafety.customPhysicalMemoryFraction == nil
+    }
+
+    public nonisolated static func modelLoadRAMThresholds(
+        for settings: VMLXServerRuntimeSettings? = nil
+    ) -> (soft: Double, hard: Double) {
+        if automaticMemoryLimitsDisabled(for: settings) {
+            return (soft: 1.0, hard: 1.0)
+        }
         let configuration = diskBackedServerConfiguration() ?? .default
         return ServerConfiguration.normalizedModelLoadRAMThresholds(
             soft: configuration.modelLoadRAMSoftThreshold,
             hard: configuration.modelLoadRAMHardThreshold
         )
+    }
+
+    /// The one Osaurus-owned memory-plan resolver used by settings,
+    /// diagnostics, cache construction, and model loads. In the explicit No
+    /// Automatic Limits mode, blank custom fields remove Osaurus percentage
+    /// caps while explicit advanced/cache/concurrency overrides remain in
+    /// force. Engine/platform allocation failures can still occur.
+    public nonisolated static func resolvedMemorySafetyPlan(
+        for settings: VMLXServerRuntimeSettings,
+        baseLoadConfiguration: LoadConfiguration = .default,
+        bundleFacts: LoadBundleFacts? = nil,
+        host: MemoryStatus? = nil,
+        request: VMLXMemoryRequestEstimate? = nil
+    ) -> VMLXResolvedMemorySafetyPlan {
+        var plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: baseLoadConfiguration,
+            bundleFacts: bundleFacts,
+            host: host,
+            request: request
+        )
+        if settings.memorySafety.mode == .diagnosticDangerous {
+            if settings.memorySafety.customPhysicalMemoryFraction == nil {
+                plan.loadConfiguration.memoryLimit = .unlimited
+                plan.resolvedLoadBudgetBytes = nil
+            }
+            if settings.memorySafety.customMaxConcurrentSequences == nil,
+                settings.concurrency.maxConcurrentSequences == nil
+            {
+                plan.concurrency.maxConcurrentSequences = nil
+            }
+            plan.warnings.append(
+                "No automatic Osaurus memory caps, load refusals, or percentage-based evictions are applied. Explicit advanced/cache/concurrency overrides remain in force; physical and Metal working-set guidance stays visible, and engine/platform allocations can still fail."
+            )
+        } else {
+            plan.resolvedLoadBudgetBytes = plan.loadConfiguration.memoryLimit.resolve(
+                physicalMemory: plan.resolvedPhysicalMemoryBytes
+            )
+        }
+        plan.displaySummary = memorySafetyDisplaySummary(settings: settings, plan: plan)
+        return plan
+    }
+
+    private nonisolated static func memorySafetyDisplaySummary(
+        settings: VMLXServerRuntimeSettings,
+        plan: VMLXResolvedMemorySafetyPlan
+    ) -> String {
+        let concurrency = plan.concurrency.maxConcurrentSequences.map(String.init) ?? "default"
+        let kv = plan.cache.defaultMaxKVSize.map(String.init) ?? "unlimited"
+        return
+            "mode=\(settings.memorySafety.mode.rawValue) slider=\(settings.memorySafety.slider) load_cap=\(residentCapSummary(plan.loadConfiguration.memoryLimit)) allocator_cap=\(residentCapSummary(plan.loadConfiguration.maxResidentBytes)) max_concurrent=\(concurrency) kv_cap=\(kv)"
+    }
+
+    private nonisolated static func residentCapSummary(_ cap: ResidentCap) -> String {
+        switch cap {
+        case .unlimited:
+            return "unlimited"
+        case .fraction(let fraction):
+            return String(format: "%.2f", fraction)
+        case .absolute(let bytes):
+            return String(bytes)
+        }
     }
 
     private nonisolated static func normalizeLoadedSettings(
@@ -225,6 +306,10 @@ public enum ServerRuntimeSettingsStore {
         if shouldRepairPagedCacheDefault(normalized.cache) {
             normalized.cache.pagedKV.enabled = false
             writePagedCacheDefaultOffMigrationMarker()
+        }
+        if shouldRepairMemorySafetyOwnedCacheDefaults(normalized.cache) {
+            normalized.cache.prefix.memoryPercent = nil
+            writeMemorySafetyOwnedCacheDefaultsMigrationMarker()
         }
         return normalized
     }
@@ -293,6 +378,36 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func writePagedCacheDefaultOffMigrationMarker() {
         let url = pagedCacheDefaultOffMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
+    }
+
+    private nonisolated static func shouldRepairMemorySafetyOwnedCacheDefaults(
+        _ cache: VMLXServerCacheSettings
+    ) -> Bool {
+        guard
+            !FileManager.default.fileExists(
+                atPath: memorySafetyOwnedCacheDefaultsMigrationMarkerURL().path
+            )
+        else { return false }
+        return cache.prefix.enabled
+            && cache.prefix.legacyEntryCountCache == false
+            && cache.prefix.memoryLimitMB == nil
+            && cache.prefix.memoryPercent == 15.0
+            && cache.prefix.ttlMinutes == nil
+            && cache.pagedKV.enabled == false
+            && (cache.liveKVCodec == .engineSelected || cache.liveKVCodec == .none)
+            && cache.turboQuantKeyBits == nil
+            && cache.turboQuantValueBits == nil
+            && (cache.defaultMaxKVSize == nil || cache.defaultMaxKVSize == 65536)
+            && cache.longPromptMultiplier == 2.0
+            && cache.legacyDisk.enabled == false
+            && cache.blockDisk.enabled
+            && cache.enableSSMReDerive
+    }
+
+    private nonisolated static func writeMemorySafetyOwnedCacheDefaultsMigrationMarker() {
+        let url = memorySafetyOwnedCacheDefaultsMigrationMarkerURL()
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         try? Data().write(to: url, options: [.atomic])
     }
@@ -368,7 +483,7 @@ public enum ServerRuntimeSettingsStore {
                 enabled: true,
                 legacyEntryCountCache: false,
                 memoryLimitMB: nil,
-                memoryPercent: 15,
+                memoryPercent: nil,
                 ttlMinutes: nil
             ),
             pagedKV: VMLXPagedKVCacheSettings(
@@ -402,6 +517,10 @@ public enum ServerRuntimeSettingsStore {
             ),
             enableSSMReDerive: true
         )
+        // A fresh install already uses the profile-owned nil default. Mark the
+        // migration complete now so a later user-selected 15% cap is not
+        // mistaken for the historical implicit 15% default.
+        writeMemorySafetyOwnedCacheDefaultsMigrationMarker()
 
         // Multimodal: keep media-salt requirement on (paired with any
         // reuse tier) and default to vmlx auto behavior.
@@ -497,6 +616,10 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func pagedCacheDefaultOffMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(pagedCacheDefaultOffMigrationMarkerName)
+    }
+
+    private nonisolated static func memorySafetyOwnedCacheDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(memorySafetyOwnedCacheDefaultsMigrationMarkerName)
     }
 
     private nonisolated static func legacyConfigurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -855,6 +855,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         runRequestTask(priority: .userInitiated) {
             let cached = await ModelRuntime.shared.cachedModelSummaries(refreshTopology: true)
+            let lastMemorySafetyLoadDecision =
+                await ModelRuntime.shared.lastMemorySafetyLoadDecisionSnapshot()
             let batchDiagnostics = await MLXBatchAdapter.snapshotDiagnostics()
             let lastEffectiveGenerationSettings =
                 await MLXBatchAdapter.lastEffectiveGenerationSettingsSnapshot()
@@ -1027,7 +1029,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let runtimeSettings = ServerRuntimeSettingsStore.snapshot()
             let memoryStatus = MemoryStatus.snapshot()
-            let memorySafetyPlan = runtimeSettings.resolvedMemorySafetyPlan(
+            let memorySafetyPlan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+                for: runtimeSettings,
                 baseLoadConfiguration: .osaurusProduction,
                 host: memoryStatus
             )
@@ -1040,7 +1043,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 "memory_safety": Self.memorySafetyJSONObject(
                     settings: runtimeSettings,
                     plan: memorySafetyPlan,
-                    memoryStatus: memoryStatus
+                    memoryStatus: memoryStatus,
+                    lastLoadDecision: lastMemorySafetyLoadDecision
                 ),
                 "storage_locations": Self.storageLocationsJSONObject(),
             ]
@@ -1463,14 +1467,17 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     private static func memorySafetyJSONObject(
         settings: VMLXServerRuntimeSettings,
         plan: VMLXResolvedMemorySafetyPlan,
-        memoryStatus: MemoryStatus
+        memoryStatus: MemoryStatus,
+        lastLoadDecision: ModelRuntime.MemorySafetyLoadDecision?
     ) -> [String: Any] {
         let memorySafety = settings.memorySafety
         let validationIssues = memorySafety.validationIssues()
         let issues = validationIssues + plan.blockingIssues
-        return [
+        var object: [String: Any] = [
             "mode": memorySafety.mode.rawValue,
             "slider": memorySafety.slider,
+            "automatic_memory_limits_disabled":
+                ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings),
             "allowed": plan.blockingIssues.isEmpty,
             "display_summary": plan.displaySummary,
             "resolved_physical_memory_bytes": plan.resolvedPhysicalMemoryBytes,
@@ -1484,6 +1491,24 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             "validation_issues": validationIssues.map(settingsIssueJSONObject),
             "issues": issues.map(settingsIssueJSONObject),
         ]
+        if let decision = lastLoadDecision {
+            object["last_load_decision"] =
+                [
+                    "model": decision.modelName,
+                    "estimated_working_set_bytes":
+                        decision.estimatedWorkingSetBytes as Any? ?? NSNull(),
+                    "resolved_load_budget_bytes":
+                        decision.resolvedLoadBudgetBytes as Any? ?? NSNull(),
+                    "allowed": decision.allowed,
+                    "display_summary": decision.displaySummary,
+                    "use_mmap_safetensors": decision.useMmapSafetensors,
+                    "blocking_issues": decision.blockingIssues,
+                    "timestamp": decision.timestamp.ISO8601Format(),
+                ] as [String: Any]
+        } else {
+            object["last_load_decision"] = NSNull()
+        }
+        return object
     }
 
     private static func loadConfigurationJSONObject(
@@ -9081,6 +9106,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         "required_available_bytes": f.requiredAvailableBytes,
                         "soft_limit_bytes": f.softLimitBytes,
                         "hard_limit_bytes": f.hardLimitBytes,
+                        "automatic_memory_limits_disabled":
+                            f.automaticMemoryLimitsDisabled,
                         // What Metal actually keeps resident. A load past this
                         // is paged by macOS rather than refused, so support
                         // needs to see it to explain a "fits but crawls" model.

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -97161,6 +97161,40 @@
         }
       }
     },
+    "No Automatic Limits (Dangerous)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine automatischen Limits (Gefährlich)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 제한 없음(위험)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Без автоматических ограничений (опасно)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无自动限制（危险）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無自動限制（危險）"
+          }
+        }
+      }
+    },
     "No token saved" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -229,6 +229,10 @@ public actor ModelRuntime {
     /// show why a load was flagged as tight without re-scanning.
     private var lastRAMFeasibility: RAMFeasibility?
 
+    /// Exact bundle-aware Memory Safety result for the most recent cold load
+    /// attempt, including refused attempts.
+    private var lastMemorySafetyLoadDecision: MemorySafetyLoadDecision?
+
     /// Every in-flight generation wrapper task, keyed by a monotonic id.
     /// `ModelLease` is the authoritative "is anyone still using the model"
     /// signal; these records exist so shutdown / same-model unload can
@@ -1050,9 +1054,16 @@ public actor ModelRuntime {
     /// `SubagentResidency`'s coexistence gate, which must stay under it —
     /// loading past this triggers `unloadForFlexibleResidentBudget`'s own
     /// eviction, which would evict the orchestrator with no restore lease.
-    static func flexibleResidentBudgetBytes() -> Int64 {
+    static func flexibleResidentBudgetBytes(
+        physicalMemoryBytes: Int64 = Int64(ProcessInfo.processInfo.physicalMemory),
+        automaticMemoryLimitsDisabled: Bool =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled()
+    ) -> Int64 {
+        if automaticMemoryLimitsDisabled {
+            return .max
+        }
         let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
-        return Int64(Double(ProcessInfo.processInfo.physicalMemory) * thresholds.soft)
+        return Int64(Double(physicalMemoryBytes) * thresholds.soft)
     }
 
     /// Snapshot of the most recent pre-load RAM feasibility assessment.
@@ -1079,6 +1090,7 @@ public actor ModelRuntime {
         public let requiredAvailableBytes: Int64
         public let softLimitBytes: Int64
         public let hardLimitBytes: Int64
+        public let automaticMemoryLimitsDisabled: Bool
         /// What Metal will actually keep resident on this machine. Zero when
         /// it can't be determined.
         public let gpuBudgetBytes: Int64
@@ -1129,7 +1141,7 @@ public actor ModelRuntime {
             if residentProjection > hardLimitBytes
                 || incomingLoadFootprintBytes > physicalMemoryBytes
             {
-                return .block
+                return automaticMemoryLimitsDisabled ? .warn : .block
             }
             // A working set past the GPU budget gets paged even on an
             // otherwise idle Mac, so it warns no matter how much RAM happens
@@ -1144,6 +1156,17 @@ public actor ModelRuntime {
             if projectedBytes > softLimitBytes { return .warn }
             return .none
         }
+    }
+
+    public struct MemorySafetyLoadDecision: Sendable, Equatable {
+        public let modelName: String
+        public let estimatedWorkingSetBytes: UInt64?
+        public let resolvedLoadBudgetBytes: UInt64?
+        public let allowed: Bool
+        public let displaySummary: String
+        public let useMmapSafetensors: Bool
+        public let blockingIssues: [String]
+        public let timestamp: Date
     }
 
     /// Estimated KV-cache + activation headroom an incoming load needs beyond
@@ -1337,6 +1360,38 @@ public actor ModelRuntime {
         lastRAMFeasibility
     }
 
+    public func lastMemorySafetyLoadDecisionSnapshot() -> MemorySafetyLoadDecision? {
+        lastMemorySafetyLoadDecision
+    }
+
+    static func estimatedMemorySafetyWorkingSetBytes(
+        loadFootprintBytes: Int64,
+        physicalMemoryBytes: UInt64
+    ) -> UInt64? {
+        guard physicalMemoryBytes > 0 else { return nil }
+        return GPUMemoryBudget.estimatedChatWorkingSetBytes(
+            onDiskBytes: loadFootprintBytes
+        )
+    }
+
+    static func memorySafetyRequestEstimateMessage(
+        estimatedWorkingSetBytes: UInt64?,
+        resolvedLoadBudgetBytes: UInt64?
+    ) -> String {
+        guard let estimatedWorkingSetBytes, let resolvedLoadBudgetBytes else {
+            return "The request exceeds the selected Memory Safety load budget."
+        }
+        let bytesPerGB = Double(1 << 30)
+        let estimatedGB = Double(estimatedWorkingSetBytes) / bytesPerGB
+        let budgetGB = Double(resolvedLoadBudgetBytes) / bytesPerGB
+        return String(
+            format:
+                "Estimated request working set ~%.1f GB exceeds the selected ~%.1f GB load budget.",
+            estimatedGB,
+            budgetGB
+        )
+    }
+
     /// Shared verdict math for the pre-load advisory gate
     /// (`checkRAMFeasibility`) and the chat input's candidate-load projection
     /// (`projectedLoadFeasibility`), so the two assessments can't drift.
@@ -1358,7 +1413,9 @@ public actor ModelRuntime {
         inflightOther: Int64,
         kvHeadroom: Int64,
         physical: Int64,
-        available: Int64
+        available: Int64,
+        automaticMemoryLimitsDisabled: Bool =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled()
     ) -> RAMFeasibility {
         let requiredAvailable = incomingLoadFootprintBytes + kvHeadroom
         let projected = resident + inflightOther + incomingLoadFootprintBytes + kvHeadroom
@@ -1393,6 +1450,7 @@ public actor ModelRuntime {
             requiredAvailableBytes: requiredAvailable,
             softLimitBytes: softLimit,
             hardLimitBytes: hardLimit,
+            automaticMemoryLimitsDisabled: automaticMemoryLimitsDisabled,
             gpuBudgetBytes: Self.gpuBudgetBytes(physicalMemoryBytes: physical),
             timestamp: Date()
         )
@@ -1423,7 +1481,9 @@ public actor ModelRuntime {
         incomingLoadFootprintBytes: Int64,
         excludingResident excludedName: String?,
         modelDirectory: URL? = nil,
-        refuseOnShortfall: Bool = false
+        refuseOnShortfall: Bool = false,
+        automaticMemoryLimitsDisabled: Bool =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled()
     ) throws {
         let physical = Int64(ProcessInfo.processInfo.physicalMemory)
         guard physical > 0, incomingWeightsBytes > 0 else { return }
@@ -1446,7 +1506,8 @@ public actor ModelRuntime {
             inflightOther: inflightOther,
             kvHeadroom: kvHeadroom,
             physical: physical,
-            available: Self.availableMemoryBytes()
+            available: Self.availableMemoryBytes(),
+            automaticMemoryLimitsDisabled: automaticMemoryLimitsDisabled
         )
 
         lastRAMFeasibility = assessment
@@ -2023,14 +2084,20 @@ public actor ModelRuntime {
         // reclaims file cache, so proceeding into a shortfall dies as a
         // Metal command-buffer abort mid-load, not graceful pressure
         // (observed live: available 101 GB loaded clean, 89 GB crashed).
+        let preloadServerSettings = ServerRuntimeSettingsStore.snapshot()
+        let automaticMemoryLimitsDisabled =
+            ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(
+                for: preloadServerSettings
+            )
+        let preliminaryMemorySafetyPlan = Self.resolveMemorySafetyLoadPlan(
+            modelName: name,
+            modelDirectory: localURL,
+            settings: preloadServerSettings,
+            baseLoadConfiguration: .osaurusProduction,
+            inspectBundleFacts: true
+        )
         let willMaterialize =
-            !Self.resolveMemorySafetyLoadPlan(
-                modelName: name,
-                modelDirectory: localURL,
-                settings: ServerRuntimeSettingsStore.snapshot(),
-                baseLoadConfiguration: .osaurusProduction,
-                inspectBundleFacts: true
-            ).loadConfiguration.useMmapSafetensors
+            !preliminaryMemorySafetyPlan.loadConfiguration.useMmapSafetensors
         let loadFootprintBytes =
             willMaterialize
             ? weightsBytes
@@ -2042,6 +2109,52 @@ public actor ModelRuntime {
         genLog.info(
             "loadContainer: pre-load checks done model=\(name, privacy: .public) weightsBytes=\(weightsBytes, privacy: .public) loadFootprintBytes=\(loadFootprintBytes, privacy: .public) materialized=\(willMaterialize, privacy: .public)"
         )
+
+        let estimatedWorkingSetBytes = Self.estimatedMemorySafetyWorkingSetBytes(
+            loadFootprintBytes: loadFootprintBytes,
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory
+        )
+        let admissionPlan = Self.resolveMemorySafetyLoadPlan(
+            modelName: name,
+            modelDirectory: localURL,
+            settings: preloadServerSettings,
+            baseLoadConfiguration: .osaurusProduction,
+            inspectBundleFacts: true,
+            request: VMLXMemoryRequestEstimate(
+                workingSetBytes: estimatedWorkingSetBytes
+            )
+        )
+        let blockingIssueMessages = admissionPlan.blockingIssues.map { issue in
+            if issue.field == "memorySafety.requestEstimate" {
+                return
+                    "\(issue.field): \(Self.memorySafetyRequestEstimateMessage(estimatedWorkingSetBytes: estimatedWorkingSetBytes, resolvedLoadBudgetBytes: admissionPlan.resolvedLoadBudgetBytes))"
+            }
+            return "\(issue.field): \(issue.message)"
+        }
+        lastMemorySafetyLoadDecision = MemorySafetyLoadDecision(
+            modelName: name,
+            estimatedWorkingSetBytes: estimatedWorkingSetBytes,
+            resolvedLoadBudgetBytes: admissionPlan.resolvedLoadBudgetBytes,
+            allowed: blockingIssueMessages.isEmpty,
+            displaySummary: admissionPlan.displaySummary,
+            useMmapSafetensors: admissionPlan.loadConfiguration.useMmapSafetensors,
+            blockingIssues: blockingIssueMessages,
+            timestamp: Date()
+        )
+        if !blockingIssueMessages.isEmpty {
+            let issueSummary = blockingIssueMessages.joined(separator: "; ")
+            genLog.error(
+                "loadContainer: memory safety refused \(name, privacy: .public): \(issueSummary, privacy: .public)"
+            )
+            throw NSError(
+                domain: "ModelRuntime",
+                code: 507,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Memory Safety refused to load \(name). \(issueSummary) Increase the selected budget or choose Safe Auto / No Automatic Limits in Server Settings, then retry."
+                ]
+            )
+        }
 
         // Reserve this load's footprint the instant it's known, BEFORE the
         // feasibility gate and the task registration below, so a concurrent
@@ -2076,7 +2189,8 @@ public actor ModelRuntime {
             incomingLoadFootprintBytes: loadFootprintBytes,
             excludingResident: name,
             modelDirectory: localURL,
-            refuseOnShortfall: willMaterialize
+            refuseOnShortfall: willMaterialize && !automaticMemoryLimitsDisabled,
+            automaticMemoryLimitsDisabled: automaticMemoryLimitsDisabled
         )
 
         // Tool-call format + reasoning parser are stamped automatically by
@@ -2279,7 +2393,8 @@ public actor ModelRuntime {
         // the two diverged and the slider never reached the coordinator.
         var resolvedSettings = settings
         resolvedSettings.cache =
-            settings.resolvedMemorySafetyPlan(
+            ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+                for: settings,
                 host: MemoryStatus.snapshot()
             ).cache
         let diskCacheDir = Self.cacheDiskDirectoryOverride(for: resolvedSettings.cache)
@@ -3325,7 +3440,16 @@ public actor ModelRuntime {
         } else {
             unsetenv("VMLX_ENABLE_UNSAFE_COMPILE")
         }
-        CacheStoreBudget.policy = settings.memorySafety.mode.cacheStorePolicy
+        CacheStoreBudget.policy = cacheStorePolicy(for: settings)
+    }
+
+    nonisolated static func cacheStorePolicy(
+        for settings: VMLXServerRuntimeSettings
+    ) -> CacheStorePolicy {
+        if ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings) {
+            return CacheStorePolicy(headroomFraction: 1.0)
+        }
+        return settings.memorySafety.mode.cacheStorePolicy
     }
 
     nonisolated static func makeGenerateParameters(
@@ -3478,24 +3602,26 @@ public actor ModelRuntime {
         modelDirectory: URL,
         settings: VMLXServerRuntimeSettings,
         baseLoadConfiguration: LoadConfiguration,
-        inspectBundleFacts: Bool
+        inspectBundleFacts: Bool,
+        request: VMLXMemoryRequestEstimate? = nil
     ) -> VMLXResolvedMemorySafetyPlan {
         let bundleFacts =
             inspectBundleFacts
             ? LoadBundleFacts.inspect(bundleURL: modelDirectory)
             : nil
-        let plan = settings.resolvedMemorySafetyPlan(
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+            for: settings,
             baseLoadConfiguration: baseLoadConfiguration,
             bundleFacts: bundleFacts,
             host: MemoryStatus.snapshot(),
-            request: nil
+            request: request
         )
         if !plan.blockingIssues.isEmpty {
             let issueSummary = plan.blockingIssues
                 .map { "\($0.field): \($0.message)" }
                 .joined(separator: "; ")
             genLog.warning(
-                "loadContainer: memory safety plan produced advisory blocking issues for \(modelName, privacy: .public): \(issueSummary, privacy: .public)"
+                "loadContainer: memory safety plan produced blocking issues for \(modelName, privacy: .public): \(issueSummary, privacy: .public)"
             )
         }
         return plan

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -160,6 +160,7 @@ struct ChatWarmupControllerRAMGateTests {
             requiredAvailableBytes: requiredAvailable,
             softLimitBytes: soft,
             hardLimitBytes: hard,
+            automaticMemoryLimitsDisabled: false,
             // Budget unknown, so it never influences these warmup assertions.
             gpuBudgetBytes: 0,
             timestamp: Date()

--- a/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
@@ -85,6 +85,22 @@ struct GPUMemoryBudgetTests {
         #expect(ornith.compatibility(totalMemoryGB: 128) == .compatible)
     }
 
+    @Test("Picker and runtime share the exact chat working-set estimate")
+    func pickerAndRuntimeWorkingSetMatch() throws {
+        let onDiskBytes = Int64(12.48 * Self.bytesPerGB)
+        let model = Self.model("gemma-12b-mxfp8", gbOnDisk: 12.48)
+        let pickerGB = try #require(model.estimatedMemoryGB)
+        let runtimeBytes = try #require(
+            ModelRuntime.estimatedMemorySafetyWorkingSetBytes(
+                loadFootprintBytes: onDiskBytes,
+                physicalMemoryBytes: UInt64(128 * Self.bytesPerGB)
+            )
+        )
+
+        #expect(abs(pickerGB - Double(runtimeBytes) / Self.bytesPerGB) < 0.001)
+        #expect(abs(pickerGB - 15.6) < 0.001)
+    }
+
     @Test("Small bundles stay comfortable on base-RAM Macs")
     func smallModelsRemainCompatible() {
         // A ~2 GB 4-bit bundle: 2.5 GB resident against a 5.33 GB budget.

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -40,6 +40,7 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(migrated.cache.blockDisk.enabled == true)
             #expect(migrated.cache.legacyDisk.enabled == false)
             #expect(migrated.cache.liveKVCodec == .engineSelected)
+            #expect(migrated.cache.prefix.memoryPercent == nil)
             // nil: the seed leaves the default KV cap to the RAM-safety slider
             // (safe_auto resolves to 65536 in vmlx, so the effective out-of-box
             // cap is unchanged, but the slider now governs it).
@@ -54,6 +55,13 @@ struct ServerRuntimeSettingsStoreTests {
             // File should now exist.
             let url = dir.appendingPathComponent("server-runtime.json")
             #expect(FileManager.default.fileExists(atPath: url.path))
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: dir.appendingPathComponent(
+                        ".server-runtime-memory-safety-cache-defaults-v4-migrated"
+                    ).path
+                )
+            )
         }
     }
 
@@ -72,6 +80,7 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(snapshot.cache.blockDisk.enabled == true)
             #expect(snapshot.cache.legacyDisk.enabled == false)
             #expect(snapshot.cache.liveKVCodec == .engineSelected)
+            #expect(snapshot.cache.prefix.memoryPercent == nil)
             // nil: slider governs the default KV cap (see migrate test above).
             #expect(snapshot.cache.defaultMaxKVSize == nil)
             #expect(snapshot.cache.longPromptMultiplier == 2.0)
@@ -80,6 +89,156 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(snapshot.memorySafety.mode == .safeAuto)
             #expect(snapshot.memorySafety.slider == 2)
             #expect(snapshot.memorySafety.allowExperimentalMLXPress == false)
+        }
+    }
+
+    @Test func noAutomaticLimitsRemovesOnlyImplicitCaps() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.cache.prefix.memoryPercent = nil
+        settings.cache.defaultMaxKVSize = nil
+        settings.concurrency.maxConcurrentSequences = nil
+
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(for: settings)
+
+        #expect(plan.loadConfiguration.memoryLimit == .unlimited)
+        #expect(plan.loadConfiguration.maxResidentBytes == .unlimited)
+        #expect(plan.resolvedLoadBudgetBytes == nil)
+        #expect(plan.cache.prefix.memoryPercent == nil)
+        #expect(plan.cache.defaultMaxKVSize == nil)
+        #expect(plan.concurrency.maxConcurrentSequences == nil)
+        #expect(plan.displaySummary.contains("load_cap=unlimited"))
+        #expect(plan.displaySummary.contains("allocator_cap=unlimited"))
+        #expect(plan.displaySummary.contains("max_concurrent=default"))
+        #expect(plan.displaySummary.contains("kv_cap=unlimited"))
+    }
+
+    @Test func noAutomaticLimitsDisablesOsaurusOwnedPercentageGates() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.memorySafety.customPhysicalMemoryFraction = nil
+
+        #expect(ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings))
+        #expect(ServerRuntimeSettingsStore.modelLoadRAMThresholds(for: settings).soft == 1.0)
+        #expect(ServerRuntimeSettingsStore.modelLoadRAMThresholds(for: settings).hard == 1.0)
+        #expect(
+            ModelRuntime.flexibleResidentBudgetBytes(
+                physicalMemoryBytes: 128 << 30,
+                automaticMemoryLimitsDisabled: true
+            ) == .max
+        )
+        #expect(ModelRuntime.cacheStorePolicy(for: settings).headroomFraction == 1.0)
+    }
+
+    @Test func explicitPhysicalFractionKeepsAUserSelectedLimit() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.memorySafety.customPhysicalMemoryFraction = 0.82
+
+        #expect(!ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled(for: settings))
+    }
+
+    @Test func noAutomaticLimitsPreservesExplicitOverrides() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .diagnosticDangerous
+        settings.memorySafety.customPhysicalMemoryFraction = 0.82
+        settings.memorySafety.customAllocatorCacheBytes = 256 << 20
+        settings.memorySafety.customDefaultMaxKVSize = 32_768
+        settings.memorySafety.customMaxConcurrentSequences = 3
+        settings.cache.prefix.memoryPercent = 12
+
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(for: settings)
+
+        #expect(plan.loadConfiguration.memoryLimit == .fraction(0.82))
+        #expect(plan.loadConfiguration.maxResidentBytes == .absolute(256 << 20))
+        #expect(plan.resolvedLoadBudgetBytes != nil)
+        #expect(plan.cache.prefix.memoryPercent == 12)
+        #expect(plan.cache.defaultMaxKVSize == 32_768)
+        #expect(plan.concurrency.maxConcurrentSequences == 3)
+    }
+
+    @Test func bundleSpecificPlanReportsItsActualRaisedLoadBudget() throws {
+        let physical: UInt64 = 128 << 30
+        let weights: UInt64 = 94 << 30
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: weights,
+            isRouted: true,
+            physicalMemory: physical,
+            modelType: "hy_v3",
+            weightFormat: "jang-affine-mixed"
+        )
+
+        let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+            for: VMLXServerRuntimeSettings(),
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: facts
+        )
+        guard case .fraction(let actualFraction) = plan.loadConfiguration.memoryLimit else {
+            Issue.record("Near-RAM Safe Auto plan must resolve to a fractional load budget.")
+            return
+        }
+        let expectedBudget = UInt64(Double(physical) * actualFraction)
+
+        #expect(!plan.loadConfiguration.useMmapSafetensors)
+        #expect(plan.resolvedLoadBudgetBytes == expectedBudget)
+        #expect(plan.displaySummary.contains("load_cap=0.79"))
+    }
+
+    @Test @MainActor func load_movesLegacyImplicitPrefixCapUnderMemorySafety() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var oldDefault = VMLXServerRuntimeSettings()
+            oldDefault.cache.pagedKV.enabled = true
+            oldDefault.cache.liveKVCodec = .none
+            oldDefault.cache.enableSSMReDerive = false
+            oldDefault.cache.defaultMaxKVSize = 65_536
+            try writeSettings(oldDefault, to: dir)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+
+            #expect(loaded.cache.prefix.memoryPercent == nil)
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: dir.appendingPathComponent(
+                        ".server-runtime-memory-safety-cache-defaults-v4-migrated"
+                    ).path
+                )
+            )
+        }
+    }
+
+    @Test @MainActor func load_preservesExplicitPrefixCap() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var explicit = ServerRuntimeSettingsStore.migratedFromLegacy(
+                serverConfiguration: .default,
+                userDefaults: throwawayDefaults()
+            )
+            explicit.cache.prefix.memoryPercent = 12
+            try writeSettings(explicit, to: dir)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+
+            #expect(loaded.cache.prefix.memoryPercent == 12)
+        }
+    }
+
+    @Test @MainActor func freshInstall_preservesLaterExplicitFifteenPercentCap() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var settings = ServerRuntimeSettingsStore.migratedFromLegacy(
+                serverConfiguration: .default,
+                userDefaults: throwawayDefaults()
+            )
+            settings.cache.prefix.memoryPercent = 15
+            try writeSettings(settings, to: dir)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+
+            #expect(loaded.cache.prefix.memoryPercent == 15)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -72,7 +72,8 @@ struct ModelRuntimeRAMFeasibilityTests {
             inflightOther: inflightOther,
             kvHeadroom: kvHeadroom,
             physical: physical,
-            available: available
+            available: available,
+            automaticMemoryLimitsDisabled: false
         )
     }
 
@@ -237,6 +238,7 @@ struct ModelRuntimeRAMFeasibilityTests {
             requiredAvailableBytes: 95 * gb,
             softLimitBytes: 70 * gb,
             hardLimitBytes: 90 * gb,
+            automaticMemoryLimitsDisabled: false,
             // Isolate the byte math: no budget, so `exceedsGPUBudget` is false.
             gpuBudgetBytes: 0,
             timestamp: Date()
@@ -259,10 +261,29 @@ struct ModelRuntimeRAMFeasibilityTests {
             requiredAvailableBytes: 10 * gb,
             softLimitBytes: 70 * gb,
             hardLimitBytes: 90 * gb,
+            automaticMemoryLimitsDisabled: false,
             gpuBudgetBytes: 75 * gb,
             timestamp: Date()
         )
         #expect(lowAvailableOnly.loadPressureSeverity == .none)
+    }
+
+    @Test("No Automatic Limits downgrades the send block to visible guidance")
+    func noAutomaticLimitsDoesNotBlockSend() {
+        let f = ModelRuntime.buildRAMFeasibility(
+            modelName: "dangerous-test-model",
+            incomingWeightsBytes: 110 * gb,
+            incomingLoadFootprintBytes: 110 * gb,
+            resident: 0,
+            inflightOther: 0,
+            kvHeadroom: 0,
+            physical: 100 * gb,
+            available: 20 * gb,
+            automaticMemoryLimitsDisabled: true
+        )
+
+        #expect(f.automaticMemoryLimitsDisabled)
+        #expect(f.loadPressureSeverity == .warn)
     }
 
     // MARK: - GPU working-set budget
@@ -286,7 +307,8 @@ struct ModelRuntimeRAMFeasibilityTests {
             kvHeadroom: required - weights,
             physical: physical,
             // 77% "used" — an ordinary idle macOS desktop.
-            available: Int64(0.23 * Double(physical))
+            available: Int64(0.23 * Double(physical)),
+            automaticMemoryLimitsDisabled: false
         )
         #expect(f.requiredAvailableBytes == required)
         #expect(!f.exceedsGPUBudget)
@@ -309,7 +331,8 @@ struct ModelRuntimeRAMFeasibilityTests {
             inflightOther: 0,
             kvHeadroom: 0,
             physical: physical,
-            available: physical
+            available: physical,
+            automaticMemoryLimitsDisabled: false
         )
         #expect(f.exceedsGPUBudget)
         #expect(f.loadPressureSeverity == .warn)
@@ -336,6 +359,39 @@ struct ModelRuntimeRAMFeasibilityTests {
     @Test("A 48 GB Mac budgets 36 GB to the GPU")
     func gpuBudgetForFortyEightGigMac() {
         #expect(ModelRuntime.gpuBudgetBytes(physicalMemoryBytes: 48 * gb) == 36 * gb)
+    }
+
+    @Test("Strict admission estimate includes picker-equivalent runtime headroom")
+    func strictAdmissionEstimateIncludesHeadroom() throws {
+        let footprint = Int64(12.48 * Double(gb))
+        let estimated = try #require(
+            ModelRuntime.estimatedMemorySafetyWorkingSetBytes(
+                loadFootprintBytes: footprint,
+                physicalMemoryBytes: UInt64(128 * gb)
+            )
+        )
+
+        #expect(Double(estimated) / Double(gb) > 15.59)
+        #expect(Double(estimated) / Double(gb) < 15.61)
+        #expect(
+            ModelRuntime.estimatedMemorySafetyWorkingSetBytes(
+                loadFootprintBytes: 0,
+                physicalMemoryBytes: UInt64(128 * gb)
+            ) == nil
+        )
+    }
+
+    @Test("Admission error does not advertise an unproven cache codec")
+    func admissionErrorUsesArchitectureNeutralAdvice() {
+        let message = ModelRuntime.memorySafetyRequestEstimateMessage(
+            estimatedWorkingSetBytes: 16_700_329_790,
+            resolvedLoadBudgetBytes: 13_743_895_347
+        )
+
+        #expect(message.contains("~15.6 GB"))
+        #expect(message.contains("~12.8 GB"))
+        #expect(!message.localizedCaseInsensitiveContains("TurboQuant"))
+        #expect(!message.localizedCaseInsensitiveContains("cache codec"))
     }
 
     // MARK: - projectedLoadFeasibility guards

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1151,7 +1151,7 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("flexibleResidentBudgetBytes"))
         #expect(serverConfig.contains("defaultModelLoadRAMSoftThreshold"))
         #expect(serverConfig.contains("defaultModelLoadRAMHardThreshold"))
-        #expect(runtimeSettings.contains("modelLoadRAMThresholds()"))
+        #expect(runtimeSettings.contains("modelLoadRAMThresholds("))
         #expect(runtime.contains("unloadForFlexibleResidentBudget"))
         #expect(runtime.contains("policy == .manualMultiModel"))
         #expect(runtime.contains("flexible budget eviction"))
@@ -2031,9 +2031,13 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("loadConfiguration: mtpPlan.loadConfiguration"))
         #expect(runtime.contains("resolvedLoadConfiguration("))
         #expect(runtime.contains("resolveMemorySafetyLoadPlan("))
-        #expect(runtime.contains("settings.resolvedMemorySafetyPlan("))
+        #expect(runtime.contains("ServerRuntimeSettingsStore.resolvedMemorySafetyPlan("))
         #expect(runtime.contains("baseLoadConfiguration: loadConfiguration"))
-        #expect(runtime.contains("request: nil"))
+        #expect(runtime.contains("request: request"))
+        #expect(runtime.contains("VMLXMemoryRequestEstimate("))
+        #expect(runtime.contains("estimatedMemorySafetyWorkingSetBytes("))
+        #expect(runtime.contains("lastMemorySafetyLoadDecision = MemorySafetyLoadDecision("))
+        #expect(runtime.contains("if !blockingIssueMessages.isEmpty"))
         #expect(runtime.contains("memorySafetySummary: memorySafetyPlan.displaySummary"))
         #expect(runtime.contains("base: .osaurusProduction"))
         #expect(runtime.contains("baseLoadConfiguration: .osaurusProduction"))
@@ -2106,9 +2110,25 @@ struct RuntimePolicySourceTests {
             "Routed mmap/JANGTQ loads must feed the RAM gate with vMLX's effective hot working set; materialized near-RAM-scale loads must budget the full weight size instead."
         )
         #expect(
-            loadPreflight.contains("!Self.resolveMemorySafetyLoadPlan(")
-                && loadPreflight.contains("refuseOnShortfall: willMaterialize"),
-            "Whether a load materializes must come from the resolved memory-safety plan (single source of truth with vmlx), and materialized loads must make the RAM verdict authoritative — proceeding into a shortfall aborts in a Metal completion handler instead of degrading."
+            loadPreflight.contains(
+                "let preliminaryMemorySafetyPlan = Self.resolveMemorySafetyLoadPlan("
+            )
+                && loadPreflight.contains(
+                    "!preliminaryMemorySafetyPlan.loadConfiguration.useMmapSafetensors"
+                )
+                && loadPreflight.contains(
+                    "refuseOnShortfall: willMaterialize && !automaticMemoryLimitsDisabled"
+                )
+                && loadPreflight.contains(
+                    "ServerRuntimeSettingsStore.automaticMemoryLimitsDisabled("
+                ),
+            "Materialization and load refusal must follow the same resolved Memory Safety plan and explicit No Automatic Limits setting as the settings UI."
+        )
+        #expect(
+            loadPreflight.contains("request: VMLXMemoryRequestEstimate(")
+                && loadPreflight.contains("workingSetBytes: estimatedWorkingSetBytes")
+                && loadPreflight.contains("throw NSError("),
+            "Strict/custom-budget blocking issues must be enforced from the real pre-load working-set estimate before vMLX begins loading."
         )
         // Feasibility gate + concurrent-load reservation must run before the
         // load task is allocated, so a cold load can't bypass RAM accounting.
@@ -2129,7 +2149,7 @@ struct RuntimePolicySourceTests {
             "All policies must record the pre-load RAM feasibility assessment before vmlx starts loading."
         )
         #expect(
-            runtime.contains("ServerRuntimeSettingsStore.modelLoadRAMThresholds()")
+            runtime.contains("ServerRuntimeSettingsStore.modelLoadRAMThresholds(")
                 && !runtime.contains("ramHardThreshold = 0.90")
                 && !runtime.contains("ramSoftThreshold = 0.70")
                 && !runtime.contains("* 0.70"),
@@ -2173,6 +2193,10 @@ struct RuntimePolicySourceTests {
         #expect(health.contains("\"available_memory_bytes\": f.availableMemoryBytes"))
         #expect(health.contains("\"required_available_bytes\": f.requiredAvailableBytes"))
         #expect(health.contains("\"incoming_load_footprint_bytes\": f.incomingLoadFootprintBytes"))
+        #expect(
+            health.contains("\"automatic_memory_limits_disabled\":")
+                && health.contains("f.automaticMemoryLimitsDisabled")
+        )
     }
 
     @Test("MiMo and N2 text runtime metadata avoids VLM bundle reads")
@@ -2294,7 +2318,7 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("MLXBatchAdapter.recordPendingEffectiveGenerationSettings("))
     }
 
-    @Test("admin cache stats exposes resolved memory safety status without load refusal")
+    @Test("admin cache stats exposes resolved and per-load memory safety status")
     func adminCacheStatsExposesResolvedMemorySafetyStatus() throws {
         let httpHandler = try Self.source("Networking/HTTPHandler.swift")
         let runtimeSettingsTests = try Self.source("Tests/Networking/ServerRuntimeSettingsStoreTests.swift")
@@ -2302,7 +2326,7 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains("@preconcurrency import MLXLMCommon"))
         #expect(httpHandler.contains("let runtimeSettings = ServerRuntimeSettingsStore.snapshot()"))
         #expect(httpHandler.contains("let memoryStatus = MemoryStatus.snapshot()"))
-        #expect(httpHandler.contains("resolvedMemorySafetyPlan("))
+        #expect(httpHandler.contains("ServerRuntimeSettingsStore.resolvedMemorySafetyPlan("))
         #expect(httpHandler.contains("\"memory_safety\""))
         #expect(httpHandler.contains("\"mode\": memorySafety.mode.rawValue"))
         #expect(httpHandler.contains("\"slider\": memorySafety.slider"))
@@ -2311,6 +2335,9 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains("\"memory_status\": memoryStatusJSONObject(memoryStatus)"))
         #expect(httpHandler.contains("\"warnings\": plan.warnings"))
         #expect(httpHandler.contains("\"blocking_issues\": plan.blockingIssues.map(settingsIssueJSONObject)"))
+        #expect(httpHandler.contains("lastMemorySafetyLoadDecisionSnapshot()"))
+        #expect(httpHandler.contains("\"last_load_decision\""))
+        #expect(httpHandler.contains("\"estimated_working_set_bytes\""))
         #expect(httpHandler.contains("case .disabled:"))
         #expect(httpHandler.contains("case .enabled(let coldFraction):"))
         #expect(httpHandler.contains("case .auto(let envFallback):"))
@@ -2980,6 +3007,20 @@ struct RuntimePolicySourceTests {
         #expect(runtimeDoc.contains("AGX::ComputeContext::endComputePass"))
         #expect(lingDoc.contains("EXC_BAD_ACCESS"))
         #expect(lingDoc.contains("BatchEngine.stepPrefill"))
+    }
+
+    @Test("No Automatic Limits clears stale physical load cap from both controls")
+    func noAutomaticLimitsClearsStalePhysicalLoadCap() throws {
+        let source = try Self.source("Views/Settings/ServerSettings/MemorySafetySection.swift")
+
+        #expect(source.contains("Picker(\"\", selection: memorySafetyModeBinding)"))
+        #expect(source.contains("if level == 4"))
+        #expect(source.contains("if newMode == .diagnosticDangerous"))
+        #expect(
+            source.components(separatedBy: "draft.memorySafety.customPhysicalMemoryFraction = nil")
+                .count == 3,
+            "Both the slider and mode picker must clear the stale custom fraction."
+        )
     }
 
     @Test("SwiftUI previews are gated out of CLI SwiftPM builds")

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift
@@ -15,7 +15,8 @@ struct MemorySafetySection: View {
     @Binding var draft: VMLXServerRuntimeSettings
 
     private var resolvedPlan: VMLXResolvedMemorySafetyPlan {
-        draft.resolvedMemorySafetyPlan(
+        ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
+            for: draft,
             baseLoadConfiguration: .osaurusProduction,
             host: MemoryStatus.snapshot()
         )
@@ -33,7 +34,7 @@ struct MemorySafetySection: View {
                 hint:
                     "Safe Auto is the default. Strict can refuse before load when a request cannot fit the selected budget."
             ) {
-                Picker("", selection: $draft.memorySafety.mode) {
+                Picker("", selection: memorySafetyModeBinding) {
                     ForEach(VMLXMemorySafetyMode.allCases, id: \.self) { mode in
                         Text(modeTitle(mode)).tag(mode)
                     }
@@ -45,7 +46,7 @@ struct MemorySafetySection: View {
             SettingsField(
                 label: "Safety Level",
                 hint:
-                    "0 favors performance, 2 is Safe Auto, 3 is strict, and 4 is diagnostic/custom."
+                    "0 favors performance, 2 is Safe Auto, 3 is strict, and 4 removes automatic Osaurus caps."
             ) {
                 VStack(alignment: .leading, spacing: 8) {
                     Slider(value: sliderBinding, in: 0 ... 4, step: 1)
@@ -136,7 +137,23 @@ struct MemorySafetySection: View {
         Binding(
             get: { Double(draft.memorySafety.slider) },
             set: { newValue in
-                draft.memorySafety.slider = Int(newValue.rounded()).clamped(to: 0 ... 4)
+                let level = Int(newValue.rounded()).clamped(to: 0 ... 4)
+                draft.memorySafety.slider = level
+                if level == 4 {
+                    draft.memorySafety.customPhysicalMemoryFraction = nil
+                }
+            }
+        )
+    }
+
+    private var memorySafetyModeBinding: Binding<VMLXMemorySafetyMode> {
+        Binding(
+            get: { draft.memorySafety.mode },
+            set: { newMode in
+                draft.memorySafety.mode = newMode
+                if newMode == .diagnosticDangerous {
+                    draft.memorySafety.customPhysicalMemoryFraction = nil
+                }
             }
         )
     }
@@ -164,7 +181,7 @@ struct MemorySafetySection: View {
         case 1: return L("Balanced")
         case 2: return L("Safe Auto")
         case 3: return L("Strict")
-        default: return L("Diagnostic / Custom")
+        default: return L("No Automatic Limits (Dangerous)")
         }
     }
 
@@ -177,7 +194,8 @@ struct MemorySafetySection: View {
     }
 
     private var kvCapSummary: String {
-        resolvedPlan.cache.defaultMaxKVSize.map(String.init) ?? "default"
+        resolvedPlan.cache.defaultMaxKVSize.map(String.init)
+            ?? (draft.memorySafety.mode == .diagnosticDangerous ? "unlimited" : "default")
     }
 
     private var concurrencySummary: String {
@@ -218,7 +236,7 @@ struct MemorySafetySection: View {
         case .balanced: return L("Balanced")
         case .safeAuto: return L("Safe Auto")
         case .strict: return L("Strict")
-        case .diagnosticDangerous: return L("Diagnostic / Dangerous")
+        case .diagnosticDangerous: return L("No Automatic Limits (Dangerous)")
         }
     }
 }

--- a/docs/MEMORY_SAFETY_LOAD_ADMISSION_PROOF_2026-07-15.md
+++ b/docs/MEMORY_SAFETY_LOAD_ADMISSION_PROOF_2026-07-15.md
@@ -1,0 +1,103 @@
+# Memory Safety Load Admission Proof — 2026-07-15
+
+Status: PARTIAL overall. The focused source, automated-test, and isolated
+Release-app UI matrix is complete. Commit, current-head CI, GitHub diff audit,
+and merge are still pending.
+
+## Scope
+
+This branch starts at `eaba91d05d784348215bc4c940f23d4486e0a4c5`, the
+merged Bonsai chart/hybrid-memory fix. It does not include PR #2044's automatic
+model-routing or hardware-guidance feature.
+
+The change is limited to the user-selected Memory Safety contract:
+
+- pass a concrete, picker-equivalent request working-set estimate into the
+  bundle-aware vMLX resolver before a cold load;
+- enforce Strict/custom blocking issues before MLX/Metal allocation;
+- make No Automatic Limits remove only implicit Osaurus caps while preserving
+  explicit cache, concurrency, allocator, and physical-fraction overrides;
+- expose the exact last cold-load decision in `/admin/cache-stats`;
+- keep the visible refusal architecture-neutral instead of recommending an
+  unproven cache codec;
+- migrate the historical implicit 15% prefix cap once while preserving a
+  later user-selected 15% value.
+
+There is no content-delta, tool-schema, tool-output, reasoning-parser,
+chat-template, sampler, generation-default, dependency-pin, model-selection,
+or MXFP4-specific behavior change.
+
+## Source trace
+
+Before this change, `ModelRuntime.resolveMemorySafetyLoadPlan` always passed
+`request: nil`; production cold loads could therefore never produce the
+documented Strict/custom request-budget refusal. Blocking issues were logged as
+advisory. The Settings UI and generic cache-stat plan could show a cap that the
+real mmap load did not enforce.
+
+The focused implementation now:
+
+1. computes the same 1.25x chat working-set estimate used by the picker;
+2. resolves bundle facts first to determine mmap versus materialized footprint;
+3. supplies `VMLXMemoryRequestEstimate` for the actual cold load;
+4. stores and exposes estimate, resolved budget, mmap choice, allow/refuse
+   result, blocking issues, and timestamp;
+5. throws a clear load error before the loading-task reservation when the
+   selected policy refuses the request.
+
+The generic `/admin/cache-stats.memory_safety.allowed` field still describes a
+request-free settings plan. `last_load_decision.allowed` is the authoritative
+field for the most recent real cold-load attempt.
+
+## Current automated evidence
+
+- Xcode result: `/tmp/osaurus-memory-admission-tests-final3.xcresult`
+- Result: 144 passed, 0 failed, 0 skipped
+- Localization catalogs parse; 2,508 Swift keys resolve; 0 suspect literals
+- `git diff --check`: clean
+- vMLX pin remains `1ca402953bf941341889bb00b186e46bf0c18d6f`
+
+Focused coverage includes Strict request estimation, architecture-neutral error
+text, No Automatic Limits send/load/eviction/cache-store behavior, explicit
+advanced-override preservation, clearing the stale custom physical-load cap
+when No Automatic Limits is selected, actual bundle-specific budget reporting,
+last-load diagnostics wiring, historical prefix-cap migration, and later
+explicit 15% preservation.
+
+## Live verification environment
+
+- App: `/tmp/osaurus-memory-admission-release/Build/Products/Release/osaurus.app`
+- Bundle identifier: `com.dinoki.osaurus.memoryadmissionproof`
+- Isolated root: `/tmp/osaurus-memory-admission-proof-root.ps0jny`
+- Process: PID 96241, ad-hoc signed, keychain disabled, localhost port 1337
+- Models root: `/Users/eric/models`
+- Build source: this production-code diff on clean base
+  `eaba91d05d784348215bc4c940f23d4486e0a4c5`
+- Production-code diff SHA-256 at proof completion:
+  `ec64c7f5a1ae1f1aa7e70c8861b59c2d801acc10ff03ff67615b950066ce5447`
+- Model under proof: exact local `OsaurusAI  Gemma 4 12B it MXFP8`
+  (`osaurusai--gemma-4-12b-it-mxfp8`), never MXFP4
+
+All UI actions below were performed through the real app's model picker and
+Settings > Server > Settings > Memory Safety controls with Thinking visibly
+off. Runtime values came from the same process's `/admin/cache-stats` endpoint.
+
+## Live verification matrix
+
+| Row | Current live evidence | Status |
+| --- | --- | --- |
+| Strict refusal | Strict slider 3 with custom physical fraction 0.10; picker showed exact Gemma MXFP8 cold; visible refusal reported ~15.6 GB estimate over ~12.8 GB budget; `models=[]`; `last_load_decision.allowed=false`, estimate 16,700,329,790, budget 13,743,895,347, mmap true | PASS |
+| User override | Selected No Automatic Limits in the real Settings UI; the stale 0.10 physical fraction cleared automatically; visible resolved settings showed Load/Allocator/KV unlimited and Concurrency 1; Save Changes succeeded | PASS |
+| Cold load | Regenerated the same refused prompt without changing model; exact Gemma MXFP8 cold-loaded and visibly returned `MXFP8 admission toggle works.`; TTFT 3.62 s, 24.5 tok/s, 11 tokens; `allowed=true`, budget null, automatic limits disabled; footprint 3,431 MB, peak 4,450 MB | PASS |
+| Warm multi-turn | Asked the resident model to repeat its prior exact sentence; visible grounded reply was exactly `MXFP8 admission toggle works.`; TTFT 0.64 s, 27.2 tok/s, 11 tokens; no loop, protocol marker, or hidden reasoning | PASS |
+| Cache/topology truthfulness | Warm row reported block-disk hits 3, misses 5, stores 6; 8 global KV plus 40 rotating layers; disk-backed restore required; effective KV fp16 and `turbo_quant_kv_layer_count=0`; footprint 3,436 MB, peak 4,450 MB | PASS |
+| Restored policy | Returned through the real Settings UI to Strict 0.10, saved, switched away to Bonsai and back to exact Gemma MXFP8; picker showed Gemma cold; visible refusal repeated; final telemetry again showed `models=[]`, allowed false, estimate 16,700,329,790, budget 13,743,895,347, mmap true | PASS |
+| Model switch | Exact Bonsai 27b 1bit JANG CRACK became the sole resident model before selecting exact Gemma MXFP8; Gemma then appeared cold and its refused attempt left zero loaded models, proving the decision was not stale resident state | PASS |
+
+No MXFP4 model is permitted in this proof lane. TurboQuant rotating/SWA,
+prefix/L2 disk cache growth, Qwen 3.5 hybrid/VL, image generation/edit, and
+spawn/delegation RAM behavior are separate unproven follow-up matrices recorded
+on PR #2044; this focused PR does not claim them.
+
+The live matrix above proves only this focused Memory Safety load-admission and
+user-override contract. It does not make the broader follow-up rows verified.


### PR DESCRIPTION
## Scope\n\nUrgent focused follow-up on current main (including merged Bonsai PR #2041). This PR only fixes the user-selected Memory Safety load-admission/settings contract used by the Gemma/Bonsai app flows. It does not include PR #2044 automatic routing or hardware guidance.\n\n### Source changes\n\n- Share the picker 1.25x working-set estimate with the real cold-load admission path.\n- Resolve bundle facts before admission so mmap/materialized footprint is evaluated from the actual local bundle.\n- Enforce Strict/custom blocking issues before MLX/Metal allocation.\n- Make No Automatic Limits remove implicit Osaurus load/send/eviction/cache-store caps while preserving explicit advanced/cache/concurrency overrides.\n- Clear a stale custom physical-load fraction when the user selects No Automatic Limits from either real Settings control.\n- Expose the exact last cold-load estimate, budget, mmap decision, allow/refuse result, issues, and timestamp at /admin/cache-stats.memory_safety.last_load_decision.\n- Keep refusal guidance architecture-neutral.\n- Move the historical implicit 15% prefix-cache cap under the profile default while preserving later explicit 15% selections.\n\n### Current local evidence\n\n- /tmp/osaurus-memory-admission-tests-final3.xcresult: 144 passed, 0 failed, 0 skipped.\n- Localization audit: 2,508 referenced Swift keys resolved; 0 suspect literals.\n- git diff --check: clean.\n- vMLX pin unchanged at 1ca402953bf941341889bb00b186e46bf0c18d6f.\n- Isolated ad-hoc Release app: com.dinoki.osaurus.memoryadmissionproof, isolated test root, keychain disabled.\n\nReal UI flow with exact OsaurusAI Gemma 4 12B it MXFP8, never MXFP4:\n\n1. Strict 0.10, cold picker: visible refusal at ~15.6 GB estimate over ~12.8 GB budget; models=[], allowed=false.\n2. Settings UI to No Automatic Limits: stale 0.10 cleared automatically; visible Load/Allocator/KV unlimited; save succeeded.\n3. Regenerate: exact coherent answer, TTFT 3.62 s, 24.5 tok/s, 11 tokens; footprint 3,431 MB, peak 4,450 MB.\n4. Warm multi-turn exact recall: TTFT 0.64 s, 27.2 tok/s, 11 tokens; no loop, protocol marker, or hidden reasoning.\n5. Reported topology remained truthful: 8 global KV + 40 rotating, disk restore required, effective KV fp16, TurboQuant layer count 0; block-disk hits grew to 3.\n6. Restored Strict 0.10, switched Gemma -> Bonsai -> exact Gemma: Gemma showed cold and visibly refused again; final models=[], allowed=false, estimate 16,700,329,790, budget 13,743,895,347.\n\nFull proof record: docs/MEMORY_SAFETY_LOAD_ADMISSION_PROOF_2026-07-15.md\n\n## Explicit exclusions\n\nNo MXFP4 testing or code. No content-delta, tool-schema/output, reasoning-parser, chat-template, sampler, generation-config, dependency-pin, model-selection, automatic-routing, or hardware-guidance changes.\n\nTurboQuant rotating/SWA, prefix/L2 size-growth proof, Qwen 3.5 hybrid/VL async rederive, image generation/edit admission, and spawn/delegation RAM notifications remain separate unproven follow-up matrices and are not claimed by this PR.\n\nCurrent-head GitHub CI is still required before merge.