### PR TITLE
Reduce redundant agent prompt context

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2892,7 +2892,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     private static func enrichWithAgentContext(
         _ request: ChatCompletionRequest,
         agentId: String?,
-        executionMode: ExecutionMode
+        executionMode: ExecutionMode,
+        modelOverride: String? = nil
     ) async -> ChatCompletionRequest {
         guard let agentId, !agentId.isEmpty,
             let agentUUID = UUID(uuidString: agentId)
@@ -2907,6 +2908,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let composed = await SystemPromptComposer.composeChatContext(
             agentId: agentUUID,
             executionMode: executionMode,
+            model: modelOverride,
             query: query,
             messages: enriched.messages,
             toolsDisabled: globalToolsDisabled
@@ -4967,7 +4969,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let enrichedReq = await Self.enrichWithAgentContext(
                 req,
                 agentId: agentId.uuidString,
-                executionMode: executionMode
+                executionMode: executionMode,
+                modelOverride: model
             )
             var messages = enrichedReq.messages
             let tools = enrichedReq.tools ?? []

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -687,7 +687,8 @@ public struct SystemPromptComposer: Sendable {
     ///                                (sandbox: build-ladder variant, canCreatePlugins-aware)
     ///  15. enabledManifest           static, frozen, gated on capabilities_load
     ///                                (all enabled tools + plugin skills + standalone skills)
-    ///  16. skillsGovern              static body, paired with enabledManifest
+    ///  16. skillsGovern              static body, only for verbose manifests
+    ///                                with a skill-governed tool group
     ///  17. pluginCreator             static, injected when plugin creation is enabled
     ///                                (session-constant gate — joins the cached prefix)
     ///  18. agentDBSchema             dynamic, live schema snapshot (mutates mid-session)
@@ -1133,26 +1134,32 @@ public struct SystemPromptComposer: Sendable {
             !effectiveToolsOff,
             tools.contains(where: { $0.function.name == "capabilities_discover" })
         {
-            // Sandbox mode swaps the terminus ("tell the user it is
-            // unavailable") for an escalation ladder that ends in a build
-            // step, not denial — the sandbox can assemble most integrations
-            // from primitives. Outside sandbox there are no such primitives,
-            // so the original nudge (with its terminus) stays. The ladder's
-            // plugin-build rung is further gated on `canCreatePlugins`.
-            let nudge =
-                executionMode.usesSandboxTools
-                ? SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+            // Sandbox mode needs its explicit build/escalation ladder.
+            // Verbose non-sandbox prompts retain the discover/load tutorial.
+            // Compact non-sandbox prompts already carry the complete contract
+            // in compact Grounding + the discovery/load tool schemas, so a
+            // second prose section would only repeat those instructions.
+            let nudge: String?
+            if executionMode.usesSandboxTools {
+                nudge = SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
                     canCreatePlugins: snapshot.canCreatePlugins,
                     compact: toolset.prefersCompactPrompt
                 )
-                : SystemPromptTemplates.capabilityDiscoveryNudge
-            composer.append(
-                .static(
-                    id: "capabilityNudge",
-                    label: L("Capability Discovery"),
-                    content: nudge
+            } else {
+                nudge =
+                    toolset.prefersCompactPrompt
+                    ? nil
+                    : SystemPromptTemplates.capabilityDiscoveryNudge
+            }
+            if let nudge {
+                composer.append(
+                    .static(
+                        id: "capabilityNudge",
+                        label: L("Capability Discovery"),
+                        content: nudge
+                    )
                 )
-            )
+            }
         }
 
         // Enabled capabilities manifest: the grounded answer to "do you
@@ -1167,12 +1174,12 @@ public struct SystemPromptComposer: Sendable {
         // the old "Plugin Companions" and "Skill Suggestions" sections.
         //
         // The string is rendered+frozen in `resolveEnabledManifest` and
-        // injected as a STATIC section (paired with `skillsGovern`) so it
-        // joins the cached KV prefix and stays byte-stable across turns —
-        // the manifest no longer shrinks as the agent loads tools. Together
-        // with `pluginCreator` below it closes out the static block, so both
-        // must precede every dynamic section (the static prefix ends at the
-        // first dynamic section).
+        // injected as a STATIC section so it joins the cached KV prefix and
+        // stays byte-stable across turns — the manifest no longer shrinks as
+        // the agent loads tools. Verbose manifests receive the companion
+        // `skillsGovern` block only when a plugin actually contains both a
+        // skill and tools; compact manifests already encode that workflow in
+        // their single `plugin/<id> — skill-governed` load action.
         if let manifestSection = toolset.enabledManifest, !manifestSection.isEmpty {
             composer.append(
                 .static(
@@ -1181,13 +1188,18 @@ public struct SystemPromptComposer: Sendable {
                     content: manifestSection
                 )
             )
-            composer.append(
-                .static(
-                    id: "skillsGovern",
-                    label: L("Skills that govern tool groups"),
-                    content: SystemPromptTemplates.skillsGovernToolGroups
+            if SystemPromptTemplates.enabledManifestNeedsSkillGovernance(
+                manifestSection,
+                compact: toolset.prefersCompactPrompt
+            ) {
+                composer.append(
+                    .static(
+                        id: "skillsGovern",
+                        label: L("Skills that govern tool groups"),
+                        content: SystemPromptTemplates.skillsGovernToolGroups
+                    )
                 )
-            )
+            }
         }
 
         // Plugin-creator injection: inject the `## Building new tools` section
@@ -1319,8 +1331,13 @@ public struct SystemPromptComposer: Sendable {
         // no enabled-minus-loaded subtraction, so the manifest stays constant
         // as the agent loads tools mid-session.
         var toolsByGroup: [String: [SystemPromptTemplates.ManifestCapability]] = [:]
+        let hasEnabledAgentChannel = AgentChannelConfigurationStore.load()
+            .connections
+            .contains(where: \.enabled)
         for entry in ToolRegistry.shared.listDynamicTools() {
             guard allowedTools?.contains(entry.name) ?? true,
+                hasEnabledAgentChannel
+                    || !ToolRegistry.agentChannelToolNames.contains(entry.name),
                 let group = ToolRegistry.shared.groupName(for: entry.name),
                 !group.isEmpty
             else { continue }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -157,9 +157,9 @@ public enum SystemPromptTemplates {
         ## Discovering more tools
 
         Your current tool list is a fixed starting set, not an exhaustive \
-        one. The Enabled capabilities list below names more you can pull in on \
-        demand and shows exactly how to load by id with capabilities_load. \
-        When a capability seems missing and is NOT named there, \
+        one. If an Enabled capabilities list appears below, its ids can be \
+        pulled in on demand with capabilities_load. When no list appears, or \
+        when a capability seems missing and is NOT named there, \
         `capabilities_discover({"query": "<what you need>"})` searches beyond \
         the listed set and returns IDs like `tool/sandbox_exec` or \
         `skill/plot-data` that you load the same way.
@@ -656,6 +656,40 @@ public enum SystemPromptTemplates {
         the tools directly afterward without a separate capabilities_load per \
         tool.
         """
+
+    /// Whether the rendered manifest needs the verbose skill-first teaching
+    /// block above. Compact manifests already collapse a governed plugin to a
+    /// single `plugin/<id> — skill-governed` load action, so repeating the
+    /// skill-loading workflow there is redundant. Verbose manifests need the
+    /// block only when one plugin actually contains both a skill and tools.
+    static func enabledManifestNeedsSkillGovernance(
+        _ manifest: String,
+        compact: Bool
+    ) -> Bool {
+        guard !compact else { return false }
+
+        var groupHasSkill = false
+        var groupHasTools = false
+
+        func currentGroupNeedsGuidance() -> Bool {
+            groupHasSkill && groupHasTools
+        }
+
+        for rawLine in manifest.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("<plugin:") || (line.hasPrefix("<") && line.hasSuffix(">")) {
+                if currentGroupNeedsGuidance() { return true }
+                groupHasSkill = false
+                groupHasTools = false
+            } else if line.hasPrefix("skill/") || line.contains("more skill(s)") {
+                groupHasSkill = true
+            } else if line.hasPrefix("tool/") || line.contains("more tool(s)") {
+                groupHasTools = true
+            }
+        }
+
+        return currentGroupNeedsGuidance()
+    }
 
     // MARK: - Cross-cutting Engineering Discipline
 

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -854,7 +854,9 @@ public enum AgentLoopEvaluator {
                 )
                 // No tool schema on the wrap-up call (mirrors chat's
                 // `tools: nil`), so the token estimate excludes toolTokens.
-                promptTokensTotal += ContextBudgetManager.estimateTokens(for: trimmed)
+                let wrapUpInputTokens = ContextBudgetManager.estimateTokens(for: trimmed)
+                promptTokensTotal += wrapUpInputTokens
+                peakContextTokens = max(peakContextTokens, wrapUpInputTokens)
                 modelStepCount += 1
                 // STREAMING, like ChatView's post-cap call (`stream: true`,
                 // `tools: nil`): the non-streaming local path is not what

--- a/Packages/OsaurusCore/Services/Context/CapabilityClaimsEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/CapabilityClaimsEvaluator.swift
@@ -77,6 +77,13 @@ public struct CapabilityClaimsTranscript: Sendable, Codable {
     /// Total generated tokens summed across the run's model steps. nil
     /// when no step reported a completion-token count.
     public let completionTokens: Int?
+    /// Estimated input tokens (messages + frozen tool schema) summed across
+    /// every model step. Deterministic and provider-independent.
+    public let promptTokensTotal: Int?
+    /// Largest single-step input estimate for the run.
+    public let peakContextTokens: Int?
+    /// Number of model requests included in the context-cost totals.
+    public let modelSteps: Int?
 
     public init(
         toolCalls: [ToolInvocation],
@@ -87,7 +94,10 @@ public struct CapabilityClaimsTranscript: Sendable, Codable {
         loadedToolNames: [String],
         error: String?,
         decodeTokensPerSecond: Double? = nil,
-        completionTokens: Int? = nil
+        completionTokens: Int? = nil,
+        promptTokensTotal: Int? = nil,
+        peakContextTokens: Int? = nil,
+        modelSteps: Int? = nil
     ) {
         self.toolCalls = toolCalls
         self.finalText = finalText
@@ -98,6 +108,9 @@ public struct CapabilityClaimsTranscript: Sendable, Codable {
         self.error = error
         self.decodeTokensPerSecond = decodeTokensPerSecond
         self.completionTokens = completionTokens
+        self.promptTokensTotal = promptTokensTotal
+        self.peakContextTokens = peakContextTokens
+        self.modelSteps = modelSteps
     }
 }
 
@@ -206,6 +219,9 @@ public enum CapabilityClaimsEvaluator {
         var decodeTpsWeightedSum = 0.0
         var decodeTpsTokenWeight = 0
         var completionTokensTotal = 0
+        var promptTokensTotal = 0
+        var peakContextTokens = 0
+        var modelStepCount = 0
         // Stable per-run session id so the engine's content-addressed KV
         // grouping sees one coherent conversation instead of N anonymous
         // requests.
@@ -265,6 +281,12 @@ public enum CapabilityClaimsEvaluator {
                         session_id: runSessionId
                     )
 
+                    let stepInputTokens =
+                        ContextBudgetManager.estimateTokens(for: requestMessages)
+                        + composed.toolTokens
+                    promptTokensTotal += stepInputTokens
+                    peakContextTokens = max(peakContextTokens, stepInputTokens)
+                    modelStepCount += 1
                     let response = try await engine.completeChat(request: request)
                     // Fold this step's authoritative runtime stats into the
                     // token-weighted decode-speed accumulators.
@@ -382,6 +404,12 @@ public enum CapabilityClaimsEvaluator {
                         tool_choice: nil,
                         session_id: runSessionId
                     )
+                    let wrapUpInputTokens = ContextBudgetManager.estimateTokens(
+                        for: wrapUpRequest.messages
+                    )
+                    promptTokensTotal += wrapUpInputTokens
+                    peakContextTokens = max(peakContextTokens, wrapUpInputTokens)
+                    modelStepCount += 1
                     // Same non-streaming call shape as this evaluator's own
                     // loop steps. A wrap-up failure must not sink the whole
                     // case (the loop itself succeeded) — but it must be
@@ -416,7 +444,10 @@ public enum CapabilityClaimsEvaluator {
                 decodeTokensPerSecond: decodeTpsTokenWeight > 0
                     ? decodeTpsWeightedSum / Double(decodeTpsTokenWeight)
                     : nil,
-                completionTokens: completionTokensTotal > 0 ? completionTokensTotal : nil
+                completionTokens: completionTokensTotal > 0 ? completionTokensTotal : nil,
+                promptTokensTotal: modelStepCount > 0 ? promptTokensTotal : nil,
+                peakContextTokens: modelStepCount > 0 ? peakContextTokens : nil,
+                modelSteps: modelStepCount > 0 ? modelStepCount : nil
             )
         }
 
@@ -431,7 +462,10 @@ public enum CapabilityClaimsEvaluator {
             decodeTokensPerSecond: decodeTpsTokenWeight > 0
                 ? decodeTpsWeightedSum / Double(decodeTpsTokenWeight)
                 : nil,
-            completionTokens: completionTokensTotal > 0 ? completionTokensTotal : nil
+            completionTokens: completionTokensTotal > 0 ? completionTokensTotal : nil,
+            promptTokensTotal: modelStepCount > 0 ? promptTokensTotal : nil,
+            peakContextTokens: modelStepCount > 0 ? peakContextTokens : nil,
+            modelSteps: modelStepCount > 0 ? modelStepCount : nil
         )
     }
 

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -806,10 +806,17 @@ final class PluginHostContext: @unchecked Sendable {
         activeAgentId: UUID? = nil
     ) async -> PreparedInference {
         let options = InferenceOptions(from: rawJSON)
+        let requestedModel = request.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let contextModelOverride =
+            requestedModel.isEmpty
+                || requestedModel.caseInsensitiveCompare("default") == .orderedSame
+            ? nil
+            : requestedModel
         let agentCtx = await resolveAgentContext(
             agentId: activeAgentId,
             messages: request.messages,
-            sessionId: request.session_id
+            sessionId: request.session_id,
+            modelOverride: contextModelOverride
         )
         let execMode = agentCtx?.executionMode ?? .none
         // Session-stable memory injection (parity with the chat surface's
@@ -900,7 +907,8 @@ final class PluginHostContext: @unchecked Sendable {
     static func resolveAgentContext(
         agentId: UUID?,
         messages: [ChatMessage] = [],
-        sessionId: String? = nil
+        sessionId: String? = nil,
+        modelOverride: String? = nil
     ) async -> AgentContext? {
         guard let agentId else { return nil }
 
@@ -951,7 +959,7 @@ final class PluginHostContext: @unchecked Sendable {
         let composed = await SystemPromptComposer.composeChatContext(
             agentId: agentId,
             executionMode: execMode,
-            model: agentModel,
+            model: modelOverride ?? agentModel,
             query: extractLatestUserQuery(from: messages),
             messages: messages,
             additionalToolNames: cachedSession?.loadedToolNames ?? [],

--- a/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
@@ -69,6 +69,87 @@ struct EnabledCapabilitiesManifestTests {
         #expect(skillIndex.lowerBound < toolIndex.lowerBound)
     }
 
+    @Test("skill governance is emitted only for verbose mixed groups")
+    func skillGovernanceGateMatchesManifestShape() throws {
+        let mixed = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: [
+                    Group(
+                        groupId: "browser",
+                        pluginDisplay: "Browser",
+                        skills: [Cap(name: "Browser Guide", description: "Use browser tools")],
+                        tools: [Cap(name: "browser_open", description: "Open a page")]
+                    )
+                ]
+            )
+        )
+        let toolsOnly = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: [
+                    Group(
+                        pluginDisplay: "Channels",
+                        skills: [],
+                        tools: [Cap(name: "list_channels", description: "List channels")]
+                    )
+                ]
+            )
+        )
+        let skillsOnly = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: [
+                    Group(
+                        pluginDisplay: "Standalone skills",
+                        skills: [Cap(name: "review", description: "Review code")],
+                        tools: []
+                    )
+                ]
+            )
+        )
+        let compactMixed = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: [
+                    Group(
+                        groupId: "browser",
+                        pluginDisplay: "Browser",
+                        skills: [Cap(name: "Browser Guide", description: "Use browser tools")],
+                        tools: [Cap(name: "browser_open", description: "Open a page")]
+                    )
+                ],
+                compact: true
+            )
+        )
+        let skillCap = SystemPromptTemplates.enabledManifestSkillCap
+        let overflowGoverned = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: [
+                    Group(
+                        pluginDisplay: "Earlier skills",
+                        skills: (0 ..< skillCap).map {
+                            Cap(name: "earlier_\($0)", description: "Earlier skill")
+                        },
+                        tools: []
+                    ),
+                    Group(
+                        pluginDisplay: "Overflow Browser",
+                        skills: [Cap(name: "Hidden Guide", description: "Use browser tools")],
+                        tools: [Cap(name: "browser_open", description: "Open a page")]
+                    ),
+                ]
+            )
+        )
+
+        #expect(SystemPromptTemplates.enabledManifestNeedsSkillGovernance(mixed, compact: false))
+        #expect(!SystemPromptTemplates.enabledManifestNeedsSkillGovernance(toolsOnly, compact: false))
+        #expect(!SystemPromptTemplates.enabledManifestNeedsSkillGovernance(skillsOnly, compact: false))
+        #expect(!SystemPromptTemplates.enabledManifestNeedsSkillGovernance(compactMixed, compact: true))
+        #expect(
+            SystemPromptTemplates.enabledManifestNeedsSkillGovernance(
+                overflowGoverned,
+                compact: false
+            )
+        )
+    }
+
     @Test("standalone skills render as a skills-only group with the loader intro")
     func standaloneSkillsGroupRenders() throws {
         // The composer enumerates every enabled non-plugin skill into a

--- a/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
@@ -30,7 +30,7 @@
 //   13. capabilityNudge           static, gated on capabilities_discover
 //   14. enabledManifest           static, frozen (all enabled tools +
 //                                  plugin skills + standalone skills)
-//   15. skillsGovern              static (paired with enabledManifest)
+//   15. skillsGovern              static (verbose governed manifests only)
 //   16. pluginCreator             static (session-constant gate)
 //   17. agentDBSchema             dynamic, live schema snapshot
 //   18. sandboxState              dynamic, installed packages + secrets

--- a/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
@@ -1,0 +1,210 @@
+//
+//  PromptSurfaceMatrixTests.swift
+//
+//  Scenario-level context audit for the production prompt composer. The
+//  printed table is the before/after measurement surface for prompt tuning;
+//  assertions pin feature gates so disabled capabilities cannot silently add
+//  prompt sections or tool schemas.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct PromptSurfaceMatrixTests {
+
+    private struct Row {
+        let name: String
+        let context: ComposedContext
+
+        var promptTokens: Int { context.manifest.totalEstimatedTokens }
+        var toolTokens: Int { context.toolTokens }
+        var totalTokens: Int { promptTokens + toolTokens }
+        var toolNames: Set<String> { Set(context.tools.map(\.function.name)) }
+        var sectionIds: Set<String> { Set(context.manifest.sections.map(\.id)) }
+    }
+
+    @Test("prompt and tool surface matrix")
+    func promptAndToolSurfaceMatrix() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            try await DynamicCatalogTestLock.shared.run {
+                let previousChannelDirectory = AgentChannelConfigurationStore.overrideDirectory
+                let channelDirectory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("prompt-surface-channels-\(UUID().uuidString)")
+                AgentChannelConfigurationStore.overrideDirectory = channelDirectory
+                defer {
+                    AgentChannelConfigurationStore.overrideDirectory = previousChannelDirectory
+                    try? FileManager.default.removeItem(at: channelDirectory)
+                }
+
+                let manager = AgentManager.shared
+                let query = "Summarize the project status and identify next steps."
+
+                let defaultAgent = Agent(
+                    name: "PromptMatrix-Default",
+                    systemPrompt: "Be concise and accurate.",
+                    agentAddress: "test-prompt-matrix-default-\(UUID().uuidString)",
+                    memoryEnabled: false
+                )
+                manager.add(defaultAgent)
+
+                var enabledAgent = Agent(
+                    name: "PromptMatrix-Enabled",
+                    systemPrompt: "Be concise and accurate.",
+                    agentAddress: "test-prompt-matrix-enabled-\(UUID().uuidString)",
+                    memoryEnabled: false
+                )
+                enabledAgent.settings.renderChartEnabled = true
+                enabledAgent.settings.speakEnabled = true
+                enabledAgent.settings.searchMemoryEnabled = true
+                enabledAgent.settings.selfSchedulingEnabled = true
+                enabledAgent.settings.computerUseEnabled = true
+                enabledAgent.settings.spawnDelegationEnabled = true
+                enabledAgent.settings.spawnableAgentNames = ["Researcher"]
+                manager.add(enabledAgent)
+
+                let sandboxConfig = AutonomousExecConfig(enabled: true, pluginCreate: false)
+                let sandboxAgent = Agent(
+                    name: "PromptMatrix-Sandbox",
+                    systemPrompt: "Be concise and accurate.",
+                    agentAddress: "test-prompt-matrix-sandbox-\(UUID().uuidString)",
+                    autonomousExec: sandboxConfig,
+                    memoryEnabled: false
+                )
+                manager.add(sandboxAgent)
+                BuiltinSandboxTools.register(
+                    agentId: sandboxAgent.id.uuidString,
+                    agentName: sandboxAgent.name,
+                    config: sandboxConfig
+                )
+
+                let toolsOff = await SystemPromptComposer.composeChatContext(
+                    agentId: defaultAgent.id,
+                    executionMode: .none,
+                    model: "google/gemma-4-4b-it",
+                    query: query,
+                    toolsDisabled: true
+                )
+                let trivial = await SystemPromptComposer.composeChatContext(
+                    agentId: defaultAgent.id,
+                    executionMode: .none,
+                    model: "google/gemma-4-4b-it",
+                    query: "hello"
+                )
+                let defaultContext = await SystemPromptComposer.composeChatContext(
+                    agentId: defaultAgent.id,
+                    executionMode: .none,
+                    model: "google/gemma-4-4b-it",
+                    query: query
+                )
+                let enabledContext = await SystemPromptComposer.composeChatContext(
+                    agentId: enabledAgent.id,
+                    executionMode: .none,
+                    model: "google/gemma-4-4b-it",
+                    query: query
+                )
+                let sandboxContext = await SystemPromptComposer.composeChatContext(
+                    agentId: sandboxAgent.id,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "google/gemma-4-4b-it",
+                    query: query
+                )
+                try AgentChannelConfigurationStore.save(
+                    AgentChannelConfiguration(
+                        connections: [
+                            AgentChannelConnection(
+                                id: "discord",
+                                name: "Discord",
+                                kind: .discord
+                            )
+                        ]
+                    )
+                )
+                let channelsContext = await SystemPromptComposer.composeChatContext(
+                    agentId: defaultAgent.id,
+                    executionMode: .none,
+                    model: "google/gemma-4-4b-it",
+                    query: query
+                )
+
+                let rows = [
+                    Row(name: "tools-off", context: toolsOff),
+                    Row(name: "trivial-turn", context: trivial),
+                    Row(name: "default-chat", context: defaultContext),
+                    Row(name: "features-on", context: enabledContext),
+                    Row(name: "sandbox", context: sandboxContext),
+                    Row(name: "channels-on", context: channelsContext),
+                ]
+                print("[PromptSurfaceMatrix] scenario context cost")
+                print("  scenario          prompt   tools   total  schemas  sections")
+                for row in rows {
+                    print(
+                        String(
+                            format: "  %-16@ %7d %7d %7d %8d %9d",
+                            row.name as NSString,
+                            row.promptTokens,
+                            row.toolTokens,
+                            row.totalTokens,
+                            row.context.tools.count,
+                            row.context.manifest.sections.count
+                        )
+                    )
+                    let sections = row.context.manifest.sections.map {
+                        "\($0.id)=\($0.estimatedTokens)"
+                    }.joined(separator: ",")
+                    let tools = row.context.tools.map(\.function.name).joined(separator: ",")
+                    print("    sections: [\(sections)]")
+                    print("    tools: [\(tools)]")
+                    if let enabledManifest = row.context.enabledManifest {
+                        print("    manifest:\n\(enabledManifest)")
+                    }
+                }
+
+                let gatedTools: Set<String> = [
+                    "render_chart", "speak", "search_memory",
+                    "schedule_next_run", "cancel_next_run", "notify",
+                    ComputerUseTool.toolName, "spawn_agent", "spawn_model", "image", "applescript",
+                ]
+
+                #expect(rows[0].context.tools.isEmpty)
+                #expect(!rows[0].sectionIds.contains("grounding"))
+                #expect(!rows[0].sectionIds.contains("agentLoopGuidance"))
+                #expect(!rows[0].sectionIds.contains("capabilityNudge"))
+
+                #expect(rows[1].context.tools.isEmpty)
+                #expect(rows[1].toolTokens == 0)
+
+                #expect(rows[2].toolNames.isDisjoint(with: gatedTools))
+                #expect(rows[2].sectionIds.contains("computerUse") == false)
+                #expect(rows[2].sectionIds.contains("spawn") == false)
+                #expect(!(rows[2].context.enabledManifest ?? "").contains("agent_channel_"))
+
+                for expected in [
+                    "render_chart", "speak", "search_memory",
+                    "schedule_next_run", "cancel_next_run", "notify",
+                    ComputerUseTool.toolName, "spawn_agent",
+                ] {
+                    #expect(rows[3].toolNames.contains(expected), "missing enabled tool \(expected)")
+                }
+                #expect(rows[3].sectionIds.contains("computerUse"))
+                #expect(rows[3].sectionIds.contains("spawn"))
+
+                #expect(rows[4].sectionIds.contains("sandbox"))
+                #expect(rows[4].toolNames.contains("sandbox_exec"))
+                #expect(!rows[4].sectionIds.contains("skillsGovern"))
+                #expect(rows[4].totalTokens > rows[2].totalTokens)
+
+                #expect((rows[5].context.enabledManifest ?? "").contains("agent_channel_"))
+                #expect(!rows[5].sectionIds.contains("skillsGovern"))
+
+                ToolRegistry.shared.unregisterAllSandboxTools()
+                _ = await manager.delete(id: defaultAgent.id)
+                _ = await manager.delete(id: enabledAgent.id)
+                _ = await manager.delete(id: sandboxAgent.id)
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
@@ -70,7 +70,11 @@ struct PromptTokenTableTests {
                     compact: true
                 )
             ),
-            Row("discoveryNudge(non-sandbox)", full: SystemPromptTemplates.capabilityDiscoveryNudge),
+            Row(
+                "discoveryNudge(non-sandbox)",
+                full: SystemPromptTemplates.capabilityDiscoveryNudge,
+                compact: ""
+            ),
             Row(
                 "secretHandling",
                 full: SystemPromptTemplates.secretHandlingGuidance,

--- a/Packages/OsaurusCore/Tests/Chat/TotalPromptBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TotalPromptBudgetTests.swift
@@ -154,7 +154,6 @@ struct TotalPromptBudgetTests {
             ),
             SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: true),
             manifest,
-            SystemPromptTemplates.skillsGovernToolGroups,
             PluginCreatorGate.section(
                 instructions: SystemPromptTemplates.pluginCreatorInstructions
             ),
@@ -196,7 +195,6 @@ struct TotalPromptBudgetTests {
             ),
             SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: false),
             manifest,
-            SystemPromptTemplates.skillsGovernToolGroups,
         ]
         return sections.joined(separator: "\n\n")
     }

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -19,19 +19,24 @@ Packages/OsaurusEvals/
     OsaurusEvalsKitTests/ — harness unit tests (fixture decode, scorers, labs; token-free)
   Suites/
     AgentDB/            — E2E db_* tool workflows against an isolated agent DB (LLM)
+    AgentChannels/      — deterministic agent/MCP channel and tool-policy fixtures
     AgentLoop/          — E2E agentic outcomes in a seeded workspace (LLM)
     AgentLoopFrontier/  — harder agent-loop tasks for the local-vs-frontier proof lane (LLM)
     AppleScript/        — AppleScript tool discipline: scripted CI lane + live lane (LLM or scripted)
     ArgumentCoercion/   — ArgumentCoercion.{stringArray,int,bool} pinning
     CapabilityClaims/   — agent-loop "do you have X" behaviour + LLM judge (LLM)
     CapabilitySearch/   — index-only recall measurements (no LLM)
+    CacheProof/         — live prefix/KV/L2 cache behavior and telemetry (LLM)
     ComputerUse/        — single-action gate / effect classification (no LLM)
     ComputerUseLoop/    — E2E Computer Use over a scripted screen (LLM or scripted)
     DefaultAgent/       — built-in "Configuring Osaurus" agent: read/write config tools + judge (LLM)
+    HTTPAPI/            — live HTTP chat/agent-run request behavior (LLM)
     JudgeCalibration/   — known-verdict fixtures that grade the JUDGE itself (judge LLM only)
+    Memory/             — multi-turn memory injection and recall behavior (LLM)
     MicroPerf/          — fixed-shape decode/TTFT/prefill micro-benchmarks, median ± stdev (LLM)
     PrefixHash/         — KV-cache prefix-hash stability
     PromptInjection/    — indirect-injection resistance over seeded agent_loop fixtures (LLM)
+    ReasoningChannel/   — visible-answer/reasoning-boundary behavior (LLM)
     SandboxDiagnostics/ — sandbox self-heal hint layer over canned stderr (no LLM, no VM)
     SandboxFrontier/    — live Linux-VM sandbox tools; skips without Apple Containerization (LLM)
     ScreenContext/      — deterministic AX-text screen-context distillation (no LLM)

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -1535,7 +1535,8 @@ public enum EvalRunner {
                     outcome: .errored,
                     notes: ["agent loop error: \(err)"],
                     modelId: modelId,
-                    latencyMs: elapsed
+                    latencyMs: elapsed,
+                    telemetry: claimsTelemetry(from: transcript)
                 ),
                 query: testCase.query
             )
@@ -1607,6 +1608,7 @@ public enum EvalRunner {
                 modelId: modelId,
                 latencyMs: elapsed,
                 judgeLatencyMs: judgeElapsed,
+                telemetry: claimsTelemetry(from: transcript),
                 judge: judgeAudit
             ),
             query: testCase.query
@@ -1640,6 +1642,27 @@ public enum EvalRunner {
             )
         )
         return report
+    }
+
+    /// Project shared capability-claims/default-agent loop telemetry into the
+    /// persisted report. Input estimates are deterministic and therefore
+    /// available for local and remote models even when runtime usage omits
+    /// completion/decode statistics.
+    private static func claimsTelemetry(
+        from transcript: CapabilityClaimsTranscript
+    ) -> EvalCaseTelemetry? {
+        let total = transcript.promptTokensTotal.map {
+            $0 + (transcript.completionTokens ?? 0)
+        }
+        let telemetry = EvalCaseTelemetry(
+            decodeTokensPerSecond: transcript.decodeTokensPerSecond,
+            completionTokens: transcript.completionTokens,
+            promptTokensTotal: transcript.promptTokensTotal,
+            peakContextTokens: transcript.peakContextTokens,
+            totalModelTokens: total,
+            modelSteps: transcript.modelSteps
+        )
+        return telemetry.isEmpty ? nil : telemetry
     }
 
     /// Agent-loop evaluator for `domain == "default_agent"`. Drives the
@@ -1735,7 +1758,8 @@ public enum EvalRunner {
                     outcome: .errored,
                     notes: ["agent loop error: \(err)"],
                     modelId: modelId,
-                    latencyMs: elapsed
+                    latencyMs: elapsed,
+                    telemetry: claimsTelemetry(from: transcript)
                 ),
                 query: testCase.query
             )
@@ -1834,10 +1858,7 @@ public enum EvalRunner {
                 modelId: modelId,
                 latencyMs: elapsed,
                 judgeLatencyMs: judgeElapsed,
-                telemetry: EvalCaseTelemetry(
-                    decodeTokensPerSecond: transcript.decodeTokensPerSecond,
-                    completionTokens: transcript.completionTokens
-                ),
+                telemetry: claimsTelemetry(from: transcript),
                 judge: judgeAudit
             ),
             query: testCase.query

--- a/scripts/evals/optimization-loop.sh
+++ b/scripts/evals/optimization-loop.sh
@@ -116,7 +116,7 @@ fi
 # `read -ra` is the robust, SC2206-clean way to split the space-separated
 # override/default into the array (and is bash 3.2-safe). The `${VAR:-...}`
 # default is expanded before `read` reassigns the same name.
-read -ra DET_SUITES <<< "${DET_SUITES:-ArgumentCoercion CapabilitySearch ComputerUse PrefixHash RequestValidation SandboxDiagnostics Schema ScreenContext StreamingHint ToolEnvelope}"
+read -ra DET_SUITES <<< "${DET_SUITES:-AgentChannels ArgumentCoercion CapabilitySearch ComputerUse PrefixHash SandboxDiagnostics Schema ScreenContext ToolEnvelope ToolResultGrounding}"
 # Suites that drive a model (or the sandbox VM) — run PER model.
 # `Subagent` runs all subagent flows through the one SubagentSession host:
 # its scripted cases are model-independent (identical per model) while the live
@@ -129,9 +129,35 @@ read -ra DET_SUITES <<< "${DET_SUITES:-ArgumentCoercion CapabilitySearch Compute
 # (real-model + mock/real executor) vary with the run model, so it lands real
 # `apple_script` rows in the cross-model matrix (same rationale as `Subagent`).
 # `read -ra` splits the override/default into the array (SC2206-clean, bash 3.2-safe).
-read -ra LLM_SUITES <<< "${LLM_SUITES:-AgentLoop AgentLoopFrontier AgentDB AppleScript CapabilityClaims ComputerUseLoop DefaultAgent MicroPerf PromptInjection SandboxFrontier Subagent}"
+read -ra LLM_SUITES <<< "${LLM_SUITES:-AgentDB AgentLoop AgentLoopFrontier AppleScript CacheProof CapabilityClaims ComputerUseLoop DefaultAgent HTTPAPI Memory MicroPerf PromptInjection ReasoningChannel SandboxFrontier Subagent}"
 
 log() { printf '[opt-loop] %s\n' "$*"; }
+
+# Fail before a long build/model load when a configured suite was renamed or
+# removed. A stale name previously produced only a late "no report" warning,
+# silently shrinking the optimization gate.
+validate_suite_list() {
+  local missing=0 suite
+  if [[ "${SKIP_DET}" != "1" ]]; then
+    for suite in "${DET_SUITES[@]}"; do
+      if [[ ! -d "${EVALS_PKG}/Suites/${suite}" ]]; then
+        log "ERROR: configured suite does not exist: Suites/${suite}"
+        missing=1
+      fi
+    done
+  fi
+  for suite in "${LLM_SUITES[@]}"; do
+    if [[ ! -d "${EVALS_PKG}/Suites/${suite}" ]]; then
+      log "ERROR: configured suite does not exist: Suites/${suite}"
+      missing=1
+    fi
+  done
+  [[ ${missing} -eq 0 ]]
+}
+
+if ! validate_suite_list; then
+  exit 2
+fi
 
 # ── 1. Prep + build ──────────────────────────────────────────────────────
 if [[ "${OSAURUS_EVALS_SKIP_PREP:-0}" != "1" ]]; then


### PR DESCRIPTION
## Summary
- omit redundant capability and skill-governance prompt sections when compact schemas or manifest shape already carry the contract
- hide Agent Channel capabilities unless a connection is enabled, while preserving session-stable manifests
- add prompt-surface audits and context telemetry for Agent Loop, Capability Claims, and Default Agent evals
- refresh the optimization-loop suite matrix and fail fast on stale suite names

## Results
- ordinary default chat prompt + tools: 2,614 → 2,095 estimated tokens (-19.9%)
- repeat-3 Gemma gate: no blocking regressions after syncing latest `main`
- capability claims held at 9/11; agent loop held at 44/50

## Test plan
- [x] Focused prompt suites: 29 tests passed
- [x] Catalog-isolation regression: `PromptSurfaceMatrixTests|ToolExposureControlCenterTests` passed
- [x] `bash -n` and `shellcheck` on `scripts/evals/optimization-loop.sh`
- [x] Repeat-3 AgentLoop, CapabilityClaims, DefaultAgent, and PromptInjection evaluation with calibrated Gemma 12B judge
- [ ] Full `make test`: ran once; 5,719 tests completed with 26 issues. Keychain-gated failures are expected under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`; remaining failures were unrelated timeout/environment flakes. The one branch-related catalog-count race was fixed and its affected suites pass when rerun together.