### PR TITLE
Reliability audit: transactional installs, web assets, key pinning, strict verify

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
@@ -13,24 +13,19 @@ public struct ToolsInstall {
     public static func execute(args: [String]) async {
         guard let src = args.first, !src.isEmpty else {
             fputs(
-                "Usage: osaurus tools install <plugin_id|url-or-path> [--version <semver>] [--no-consent]\n",
+                "Usage: osaurus tools install <plugin_id|url-or-path> [--version <semver>] [--consent]\n",
                 stderr
             )
             exit(EXIT_FAILURE)
         }
 
-        // The release-build loader requires a `.user_consent` marker
-        // alongside `receipt.json` before it will dlopen a plugin. The
-        // registry-install path (`PluginInstallManager.install`) writes
-        // it automatically; manual sideload via `tools install` should
-        // be symmetric so authors iterating with `tools install
-        // ./my-plugin-1.0.0` don't get a silent `consent_required:`
-        // load failure they then have to clear in the UI. `--no-consent`
-        // opts out for users who want the explicit Approve gate.
-        let grantConsent = !args.contains("--no-consent")
-
         // Check if argument is a local path or URL
         if isManualInstallSource(src) {
+            // Manual sideloads bypass the registry's checksum/signature
+            // verification, so the release loader's `.user_consent` gate is
+            // NOT waived implicitly: pass `--consent` to grant it at install
+            // time, otherwise approve the plugin in Osaurus settings.
+            let grantConsent = args.contains("--consent")
             await installManual(src: src, grantConsent: grantConsent)
         } else {
             await installFromRegistry(pluginId: src, args: args)
@@ -93,7 +88,11 @@ public struct ToolsInstall {
         var sourceName: String = ""
         var preferManifestIdentity = false
 
-        // 1. Unpack/Copy to staging
+        // 1. Unpack/Copy to staging. Archives go through the same bounded
+        // in-process extractor as registry installs (path-safety, resource
+        // limits) instead of shelling out to /usr/bin/unzip, and remote
+        // archives are streamed to disk instead of buffered in memory.
+        let stageRoot = tmpDir.appendingPathComponent("extracted", isDirectory: true)
         if src.hasPrefix("http://") || src.hasPrefix("https://") {
             guard let url = URL(string: src) else {
                 fputs("Invalid URL: \(src)\n", stderr)
@@ -103,13 +102,14 @@ public struct ToolsInstall {
             sourceName = url.lastPathComponent
             let zipFile = tmpDir.appendingPathComponent("download.zip")
             do {
-                let (data, resp) = try await URLSession.shared.data(from: url)
+                let (downloadedURL, resp) = try await URLSession.shared.download(from: url)
                 guard let http = resp as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
+                    try? fm.removeItem(at: downloadedURL)
                     fputs("Download failed (status \((resp as? HTTPURLResponse)?.statusCode ?? -1))\n", stderr)
                     exit(EXIT_FAILURE)
                 }
-                try data.write(to: zipFile)
-                try unzip(zipURL: zipFile, to: tmpDir)
+                try fm.moveItem(at: downloadedURL, to: zipFile)
+                try PluginInstallManager.extractPluginArchive(at: zipFile, to: stageRoot)
             } catch {
                 fputs("Download/Unzip error: \(error)\n", stderr)
                 exit(EXIT_FAILURE)
@@ -121,11 +121,12 @@ public struct ToolsInstall {
             if fm.fileExists(atPath: pathURL.path, isDirectory: &isDir) {
                 if isDir.boolValue {
                     preferManifestIdentity = true
-                    // Copy contents to tmpDir
+                    // Copy contents to the staging root
                     do {
+                        try fm.createDirectory(at: stageRoot, withIntermediateDirectories: true)
                         let contents = try fm.contentsOfDirectory(at: pathURL, includingPropertiesForKeys: nil)
                         for item in contents {
-                            try fm.copyItem(at: item, to: tmpDir.appendingPathComponent(item.lastPathComponent))
+                            try fm.copyItem(at: item, to: stageRoot.appendingPathComponent(item.lastPathComponent))
                         }
                     } catch {
                         fputs("Failed to copy directory: \(error)\n", stderr)
@@ -133,7 +134,7 @@ public struct ToolsInstall {
                     }
                 } else if pathURL.pathExtension.lowercased() == "zip" {
                     do {
-                        try unzip(zipURL: pathURL, to: tmpDir)
+                        try PluginInstallManager.extractPluginArchive(at: pathURL, to: stageRoot)
                     } catch {
                         fputs("Unzip error: \(error)\n", stderr)
                         exit(EXIT_FAILURE)
@@ -148,11 +149,11 @@ public struct ToolsInstall {
             }
         }
 
-        // Find the plugin root (unzip might create a wrapper directory)
-        var pluginRoot: URL = tmpDir
+        // Find the plugin root (the archive might contain a wrapper directory)
+        var pluginRoot: URL = stageRoot
         do {
             let contents = try fm.contentsOfDirectory(
-                at: tmpDir,
+                at: stageRoot,
                 includingPropertiesForKeys: nil,
                 options: [.skipsHiddenFiles]
             )
@@ -161,7 +162,7 @@ public struct ToolsInstall {
                 pluginRoot = contents[0]
             }
         } catch {
-            // ignore - use tmpDir as root
+            // ignore - use stageRoot as root
         }
 
         // 2. Resolve plugin_id and version. Packaged zips keep using
@@ -187,36 +188,19 @@ public struct ToolsInstall {
             exit(EXIT_FAILURE)
         }
 
-        // 3. Install to Tools/<id>/<version>
-        let installDir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: semver)
-
+        // 3. Publish the staged payload to Tools/<id>/<version>
         do {
-            if fm.fileExists(atPath: installDir.path) {
-                try fm.removeItem(at: installDir)
-            }
-            try fm.createDirectory(at: installDir.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try fm.moveItem(at: pluginRoot, to: installDir)
-
-            // 4. Create receipt.json for manual installs
-            try createManualInstallReceipt(pluginId: pluginId, version: semver, installDir: installDir)
-
-            // 4b. Auto-grant consent (matches registry install). The
-            // release loader checks for `.user_consent` next to the
-            // receipt; without it, the plugin fails verification with
-            // `consent_required:` and the user has to tap Approve in
-            // the app. `--no-consent` keeps the explicit gate.
-            if grantConsent {
-                let consentURL = installDir.appendingPathComponent(".user_consent", isDirectory: false)
-                try Data().write(to: consentURL)
-            }
-
-            // 5. Update Current Symlink
-            try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: semver)
+            let installDir = try publishManualInstall(
+                pluginRoot: pluginRoot,
+                pluginId: pluginId,
+                version: semver,
+                grantConsent: grantConsent
+            )
 
             print("Installed \(pluginId) @ \(semver) to \(installDir.path)")
             if !grantConsent {
                 print(
-                    "Consent NOT granted (--no-consent). Approve in Osaurus settings before the plugin will load."
+                    "Consent NOT granted. Approve in Osaurus settings before the plugin will load, or reinstall with --consent."
                 )
             }
 
@@ -228,6 +212,50 @@ public struct ToolsInstall {
             fputs("Installation failed: \(error)\n", stderr)
             exit(EXIT_FAILURE)
         }
+    }
+
+    /// Completes the staged payload (receipt + optional consent marker) and
+    /// then publishes it into `Tools/<id>/<version>` in one atomic swap. Any
+    /// previously installed copy of this version is only replaced by a
+    /// complete, valid layout — never deleted up front, so a failure while
+    /// preparing the new payload leaves the existing install untouched.
+    /// Fails (before touching the destination) when the payload contains no
+    /// dylib, so a manual install can no longer produce a receipt-less or
+    /// binary-less tree.
+    static func publishManualInstall(
+        pluginRoot: URL,
+        pluginId: String,
+        version: SemanticVersion,
+        grantConsent: Bool
+    ) throws -> URL {
+        let fm = FileManager.default
+        let installDir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: version)
+
+        try createManualInstallReceipt(pluginId: pluginId, version: version, installDir: pluginRoot)
+        if grantConsent {
+            try Data().write(to: pluginRoot.appendingPathComponent(".user_consent", isDirectory: false))
+        }
+
+        let parent = installDir.deletingLastPathComponent()
+        try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        // Move the payload next to its final location first (the temp dir may
+        // be on another volume), then swap it in atomically.
+        let staging = parent.appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
+        try fm.moveItem(at: pluginRoot, to: staging)
+        do {
+            if fm.fileExists(atPath: installDir.path) {
+                _ = try fm.replaceItemAt(installDir, withItemAt: staging)
+            } else {
+                try fm.moveItem(at: staging, to: installDir)
+            }
+        } catch {
+            try? fm.removeItem(at: staging)
+            throw error
+        }
+
+        try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: version)
+        return installDir
     }
 
     /// Parses plugin_id and version from a filename like "my-plugin-1.0.0" or "my-plugin-1.0.0.zip"
@@ -429,6 +457,7 @@ public struct ToolsInstall {
 
     enum ManualInstallError: Error, CustomStringConvertible {
         case identityUnavailable(sourceName: String)
+        case noDylibFound
         case invalidManifestField(String, String)
         case invalidManifestVersion(String, String)
         case manifestReadFailed(String, String)
@@ -441,6 +470,9 @@ public struct ToolsInstall {
             case .identityUnavailable:
                 return
                     "Invalid naming format. Expected <plugin_id>-<version>.zip, or install a project directory containing osaurus-plugin.json with plugin_id and version."
+            case .noDylibFound:
+                return
+                    "No .dylib found in the plugin payload. Build the plugin first (e.g. `osaurus tools build`) — an install without a binary would produce a broken receipt-less tree."
             case .invalidManifestField(let filename, let field):
                 return "`\(filename)` must include a non-empty `\(field)` for directory installs."
             case .invalidManifestVersion(let filename, let value):
@@ -457,12 +489,13 @@ public struct ToolsInstall {
         }
     }
 
-    /// Creates a receipt.json for manual installations
+    /// Creates a receipt.json for manual installations. Throws when the
+    /// payload contains no dylib: the loader requires receipt + binary, so
+    /// silently skipping the receipt used to publish an install that could
+    /// never load (and that `tools verify` then ignored).
     static func createManualInstallReceipt(pluginId: String, version: SemanticVersion, installDir: URL) throws {
-        // Find the dylib in the install directory
         guard let dylibURL = findFirstDylib(in: installDir) else {
-            // No dylib found - skip receipt creation (plugin might not be fully built)
-            return
+            throw ManualInstallError.noDylibFound
         }
 
         // Calculate SHA256 of the dylib
@@ -507,20 +540,5 @@ public struct ToolsInstall {
             return fileURL
         }
         return nil
-    }
-
-    private static func unzip(zipURL: URL, to destDir: URL) throws {
-        let unzip = Process()
-        unzip.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        unzip.arguments = ["-o", "-q", zipURL.path, "-d", destDir.path]
-        try unzip.run()
-        unzip.waitUntilExit()
-        if unzip.terminationStatus != 0 {
-            throw NSError(
-                domain: "ToolsInstall",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "unzip command failed"]
-            )
-        }
     }
 }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsVerify.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsVerify.swift
@@ -10,44 +10,105 @@ import CryptoKit
 import OsaurusRepository
 
 public struct ToolsVerify {
+    struct Report {
+        var lines: [String] = []
+        var failures: Int = 0
+
+        mutating func ok(_ message: String) {
+            lines.append("OK  \(message)")
+        }
+
+        mutating func fail(_ message: String) {
+            lines.append("FAIL  \(message)")
+            failures += 1
+        }
+    }
+
     public static func execute(args: [String]) {
-        let fm = FileManager.default
         let root = PluginInstallManager.toolsRootDirectory()
-        guard let pluginDirs = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else {
+        guard FileManager.default.fileExists(atPath: root.path) else {
             print("(no tools installed)")
             exit(EXIT_SUCCESS)
         }
-        var failures = 0
-        for pluginDir in pluginDirs where pluginDir.hasDirectoryPath {
+        let report = verifyInstalledTools(root: root)
+        if report.lines.isEmpty {
+            print("(no tools installed)")
+        } else {
+            for line in report.lines {
+                print(line)
+            }
+        }
+        exit(report.failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE)
+    }
+
+    /// Verifies every installed plugin version under `root`. Any missing,
+    /// unreadable, or malformed receipt/dylib is a FAILURE — a broken install
+    /// must not verify clean just because the evidence of the breakage is the
+    /// file that cannot be read.
+    static func verifyInstalledTools(root: URL) -> Report {
+        let fm = FileManager.default
+        var report = Report()
+        guard let pluginDirs = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else {
+            return report
+        }
+        for pluginDir in pluginDirs.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+        where pluginDir.hasDirectoryPath {
+            let pluginId = pluginDir.lastPathComponent
             let versionsToCheck: [URL]
             let currentLink = pluginDir.appendingPathComponent("current")
             if let dest = try? fm.destinationOfSymbolicLink(atPath: currentLink.path) {
-                versionsToCheck = [pluginDir.appendingPathComponent(dest, isDirectory: true)]
+                let target = pluginDir.appendingPathComponent(dest, isDirectory: true)
+                guard fm.fileExists(atPath: target.path) else {
+                    report.fail("\(pluginId)  'current' symlink points to missing version \(dest)")
+                    continue
+                }
+                versionsToCheck = [target]
             } else {
                 versionsToCheck =
                     (try? fm.contentsOfDirectory(at: pluginDir, includingPropertiesForKeys: nil))?.filter {
                         $0.hasDirectoryPath
                     } ?? []
             }
-            for vdir in versionsToCheck {
-                let receiptURL = vdir.appendingPathComponent("receipt.json")
-                guard let rdata = try? Data(contentsOf: receiptURL),
-                    let receipt = try? JSONDecoder().decode(PluginReceipt.self, from: rdata)
-                else {
-                    continue
-                }
-                let dylibURL = vdir.appendingPathComponent(receipt.dylib_filename)
-                guard let dylibData = try? Data(contentsOf: dylibURL) else { continue }
-                let digest = CryptoKit.SHA256.hash(data: dylibData)
-                let sha = Data(digest).map { String(format: "%02x", $0) }.joined()
-                if sha.lowercased() == receipt.dylib_sha256.lowercased() {
-                    print("OK  \(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename)")
-                } else {
-                    print("FAIL  \(receipt.plugin_id)@\(receipt.version)  expected \(receipt.dylib_sha256) got \(sha)")
-                    failures += 1
-                }
+            for vdir in versionsToCheck.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+                verifyVersionDirectory(vdir, pluginId: pluginId, report: &report)
             }
         }
-        exit(failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE)
+        return report
+    }
+
+    private static func verifyVersionDirectory(_ vdir: URL, pluginId: String, report: inout Report) {
+        let fm = FileManager.default
+        let versionName = vdir.lastPathComponent
+        let receiptURL = vdir.appendingPathComponent("receipt.json")
+
+        guard fm.fileExists(atPath: receiptURL.path) else {
+            report.fail("\(pluginId)@\(versionName)  receipt.json missing")
+            return
+        }
+        guard let rdata = try? Data(contentsOf: receiptURL) else {
+            report.fail("\(pluginId)@\(versionName)  receipt.json unreadable")
+            return
+        }
+        guard let receipt = try? JSONDecoder().decode(PluginReceipt.self, from: rdata) else {
+            report.fail("\(pluginId)@\(versionName)  receipt.json malformed")
+            return
+        }
+
+        let dylibURL = vdir.appendingPathComponent(receipt.dylib_filename)
+        guard fm.fileExists(atPath: dylibURL.path) else {
+            report.fail("\(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename) missing")
+            return
+        }
+        guard let dylibData = try? Data(contentsOf: dylibURL) else {
+            report.fail("\(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename) unreadable")
+            return
+        }
+        let digest = CryptoKit.SHA256.hash(data: dylibData)
+        let sha = Data(digest).map { String(format: "%02x", $0) }.joined()
+        if sha.lowercased() == receipt.dylib_sha256.lowercased() {
+            report.ok("\(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename)")
+        } else {
+            report.fail("\(receipt.plugin_id)@\(receipt.version)  expected \(receipt.dylib_sha256) got \(sha)")
+        }
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsInstallTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsInstallTests.swift
@@ -268,14 +268,18 @@ final class ToolsInstallTests: XCTestCase {
         )
     }
 
-    func testManualInstallReceiptSkipsWhenNoDylibExists() throws {
+    func testManualInstallReceiptFailsWhenNoDylibExists() throws {
         let version = try XCTUnwrap(SemanticVersion.parse("1.2.3"))
 
-        try ToolsInstall.createManualInstallReceipt(
-            pluginId: "com.example.empty",
-            version: version,
-            installDir: tempDir
-        )
+        XCTAssertThrowsError(
+            try ToolsInstall.createManualInstallReceipt(
+                pluginId: "com.example.empty",
+                version: version,
+                installDir: tempDir
+            )
+        ) { error in
+            XCTAssertTrue(String(describing: error).contains("No .dylib"))
+        }
 
         let receiptURL = tempDir.appendingPathComponent("receipt.json", isDirectory: false)
         XCTAssertFalse(FileManager.default.fileExists(atPath: receiptURL.path))

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsManualInstallPublishTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsManualInstallPublishTests.swift
@@ -1,0 +1,138 @@
+//
+//  ToolsManualInstallPublishTests.swift
+//  osaurus
+//
+//  Regression coverage for the manual `tools install` publication path:
+//  transactional replacement, explicit consent, and mandatory dylib/receipt.
+//
+
+import CryptoKit
+import Foundation
+import OsaurusRepository
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ToolsManualInstallPublishTests: XCTestCase {
+    private var tempRoot: URL!
+    private var previousOverride: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-manual-publish-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousOverride = ToolsPaths.overrideRoot
+        ToolsPaths.overrideRoot = tempRoot
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func makePayload(named name: String, dylibContents: String = "binary") throws -> URL {
+        let payload = tempRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: true)
+        try Data(dylibContents.utf8).write(to: payload.appendingPathComponent("Plugin.dylib"))
+        return payload
+    }
+
+    func testPublishInstallsReceiptAndSymlinkWithoutConsentByDefault() throws {
+        let payload = try makePayload(named: "payload")
+        let version = try XCTUnwrap(SemanticVersion.parse("1.0.0"))
+
+        let installDir = try ToolsInstall.publishManualInstall(
+            pluginRoot: payload,
+            pluginId: "com.example.manual",
+            version: version,
+            grantConsent: false
+        )
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: installDir.appendingPathComponent("Plugin.dylib").path))
+        XCTAssertTrue(fm.fileExists(atPath: installDir.appendingPathComponent("receipt.json").path))
+        XCTAssertFalse(
+            fm.fileExists(atPath: installDir.appendingPathComponent(".user_consent").path),
+            "manual installs must not grant consent implicitly"
+        )
+        XCTAssertEqual(
+            try fm.destinationOfSymbolicLink(
+                atPath: PluginInstallManager.currentSymlinkURL(pluginId: "com.example.manual").path
+            ),
+            "1.0.0"
+        )
+        XCTAssertFalse(fm.fileExists(atPath: payload.path), "staged payload should have been moved into place")
+    }
+
+    func testPublishGrantsConsentOnlyWhenExplicitlyRequested() throws {
+        let payload = try makePayload(named: "payload-consent")
+        let version = try XCTUnwrap(SemanticVersion.parse("1.0.0"))
+
+        let installDir = try ToolsInstall.publishManualInstall(
+            pluginRoot: payload,
+            pluginId: "com.example.consent",
+            version: version,
+            grantConsent: true
+        )
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: installDir.appendingPathComponent(".user_consent").path)
+        )
+    }
+
+    func testPublishReplacesExistingVersionAtomicallyAndKeepsItOnFailure() throws {
+        let fm = FileManager.default
+        let version = try XCTUnwrap(SemanticVersion.parse("1.0.0"))
+        let pluginId = "com.example.replace"
+
+        // First install
+        let first = try makePayload(named: "first", dylibContents: "old-binary")
+        let installDir = try ToolsInstall.publishManualInstall(
+            pluginRoot: first,
+            pluginId: pluginId,
+            version: version,
+            grantConsent: false
+        )
+        let oldDylib = try Data(contentsOf: installDir.appendingPathComponent("Plugin.dylib"))
+        XCTAssertEqual(oldDylib, Data("old-binary".utf8))
+
+        // A broken payload (no dylib) must fail BEFORE touching the existing install
+        let broken = tempRoot.appendingPathComponent("broken", isDirectory: true)
+        try fm.createDirectory(at: broken, withIntermediateDirectories: true)
+        XCTAssertThrowsError(
+            try ToolsInstall.publishManualInstall(
+                pluginRoot: broken,
+                pluginId: pluginId,
+                version: version,
+                grantConsent: false
+            )
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: installDir.appendingPathComponent("Plugin.dylib")),
+            Data("old-binary".utf8),
+            "failed install must leave the existing version untouched"
+        )
+
+        // A valid payload replaces it
+        let second = try makePayload(named: "second", dylibContents: "new-binary")
+        _ = try ToolsInstall.publishManualInstall(
+            pluginRoot: second,
+            pluginId: pluginId,
+            version: version,
+            grantConsent: false
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: installDir.appendingPathComponent("Plugin.dylib")),
+            Data("new-binary".utf8)
+        )
+
+        // No staging leftovers next to the version directories
+        let leftovers = try fm.contentsOfDirectory(atPath: installDir.deletingLastPathComponent().path)
+            .filter { $0.hasPrefix(".staging-") }
+        XCTAssertTrue(leftovers.isEmpty)
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsVerifyTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsVerifyTests.swift
@@ -1,0 +1,141 @@
+//
+//  ToolsVerifyTests.swift
+//  osaurus
+//
+//  Regression coverage for `osaurus tools verify`: missing/unreadable/
+//  malformed receipts and dylibs must be reported as failures instead of
+//  being silently skipped (which let broken installs verify clean).
+//
+
+import CryptoKit
+import Foundation
+import OsaurusRepository
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ToolsVerifyTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-tools-verify-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func makeVersionDir(pluginId: String, version: String) throws -> URL {
+        let dir = root.appendingPathComponent(pluginId, isDirectory: true)
+            .appendingPathComponent(version, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func writeValidInstall(pluginId: String, version: String, dylibContents: String = "binary") throws
+        -> URL
+    {
+        let dir = try makeVersionDir(pluginId: pluginId, version: version)
+        let dylibData = Data(dylibContents.utf8)
+        try dylibData.write(to: dir.appendingPathComponent("Plugin.dylib"))
+        let sha = Data(SHA256.hash(data: dylibData)).map { String(format: "%02x", $0) }.joined()
+        let receipt = PluginReceipt(
+            plugin_id: pluginId,
+            version: SemanticVersion.parse(version)!,
+            installed_at: Date(),
+            dylib_filename: "Plugin.dylib",
+            dylib_sha256: sha,
+            platform: "macos",
+            arch: "arm64",
+            public_keys: nil,
+            artifact: .init(url: "file:///dev/null", sha256: sha, minisign: nil, size: dylibData.count)
+        )
+        try JSONEncoder().encode(receipt).write(to: dir.appendingPathComponent("receipt.json"))
+        return dir
+    }
+
+    func testHealthyInstallVerifiesClean() throws {
+        _ = try writeValidInstall(pluginId: "com.example.good", version: "1.0.0")
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 0)
+        XCTAssertEqual(report.lines.count, 1)
+        XCTAssertTrue(report.lines[0].hasPrefix("OK"))
+    }
+
+    func testMissingReceiptIsAFailure() throws {
+        let dir = try makeVersionDir(pluginId: "com.example.noreceipt", version: "1.0.0")
+        try Data("binary".utf8).write(to: dir.appendingPathComponent("Plugin.dylib"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("receipt.json missing"))
+    }
+
+    func testMalformedReceiptIsAFailure() throws {
+        let dir = try makeVersionDir(pluginId: "com.example.badreceipt", version: "1.0.0")
+        try Data("not json".utf8).write(to: dir.appendingPathComponent("receipt.json"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("receipt.json malformed"))
+    }
+
+    func testMissingDylibIsAFailure() throws {
+        let dir = try writeValidInstall(pluginId: "com.example.nodylib", version: "1.0.0")
+        try FileManager.default.removeItem(at: dir.appendingPathComponent("Plugin.dylib"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("Plugin.dylib missing"))
+    }
+
+    func testShaMismatchIsAFailure() throws {
+        let dir = try writeValidInstall(pluginId: "com.example.tampered", version: "1.0.0")
+        try Data("tampered".utf8).write(to: dir.appendingPathComponent("Plugin.dylib"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("expected"))
+    }
+
+    func testDanglingCurrentSymlinkIsAFailure() throws {
+        _ = try writeValidInstall(pluginId: "com.example.dangling", version: "1.0.0")
+        let pluginDir = root.appendingPathComponent("com.example.dangling", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: pluginDir.appendingPathComponent("current").path,
+            withDestinationPath: "9.9.9"
+        )
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("missing version 9.9.9"))
+    }
+
+    func testHealthyCurrentSymlinkChecksOnlyThatVersion() throws {
+        _ = try writeValidInstall(pluginId: "com.example.linked", version: "1.0.0")
+        _ = try writeValidInstall(pluginId: "com.example.linked", version: "2.0.0")
+        let pluginDir = root.appendingPathComponent("com.example.linked", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: pluginDir.appendingPathComponent("current").path,
+            withDestinationPath: "2.0.0"
+        )
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 0)
+        XCTAssertEqual(report.lines.count, 1)
+    }
+}

--- a/Packages/OsaurusRepository/PluginInstallManager.swift
+++ b/Packages/OsaurusRepository/PluginInstallManager.swift
@@ -66,25 +66,21 @@ public final class PluginInstallManager: @unchecked Sendable {
             throw PluginInstallError.specNotFound(pluginId)
         }
 
-        // TOFU: when the author's signing key changes, the new artifact is verified against
-        // the updated key from the registry. We capture the prior version here so we can
-        // remove it *after* the new install + symlink swap succeed. Eagerly deleting it now
-        // would leave the user with no installed version (and a dangling `current` symlink)
-        // if any later step throws (network, checksum, signature, extraction).
-        let keyRotatedFromVersion: SemanticVersion? = {
-            guard let latest = InstalledPluginsStore.shared.latestInstalledVersion(pluginId: spec.plugin_id),
-                let existing = InstalledPluginsStore.shared.receipt(pluginId: spec.plugin_id, version: latest),
-                let existingKey = existing.public_keys?["minisign"],
-                let newKey = spec.public_keys?["minisign"],
-                existingKey != newKey
-            else { return nil }
+        // TOFU pinning: once a signing key has been trusted for this plugin, a
+        // registry that suddenly advertises a different key is NOT silently
+        // trusted. Fail closed; the explicit recovery path is uninstalling the
+        // plugin (which drops the pinned key) and reinstalling to accept the
+        // new key — the flow the `authorKeyMismatch` UI alert walks users through.
+        if Self.pinnedSigningKeyMismatch(
+            spec: spec,
+            installedReceipt: Self.latestInstalledReceipt(pluginId: spec.plugin_id)
+        ) {
             NSLog(
-                "[Osaurus] Signing key changed for %@ — will remove old version %@ after new install succeeds",
-                spec.plugin_id,
-                latest.description
+                "[Osaurus] Signing key changed for %@ — refusing to install without explicit re-trust (uninstall + reinstall)",
+                spec.plugin_id
             )
-            return latest
-        }()
+            throw PluginInstallError.authorKeyMismatch
+        }
 
         let targetPlatform: Platform = .macos
         // Arm64 only per project policy
@@ -95,8 +91,9 @@ public final class PluginInstallManager: @unchecked Sendable {
             resolution = try spec.resolveBestVersion(
                 targetPlatform: targetPlatform,
                 targetArch: targetArch,
-                minimumOsaurusVersion: nil,
-                preferredVersion: preferredVersion
+                minimumOsaurusVersion: Self.currentHostVersion(),
+                preferredVersion: preferredVersion,
+                currentMacOSVersion: ProcessInfo.processInfo.operatingSystemVersion
             )
         } catch {
             throw PluginInstallError.resolutionFailed("\(error)")
@@ -148,13 +145,35 @@ public final class PluginInstallManager: @unchecked Sendable {
             throw PluginInstallError.archiveRejected(error.localizedDescription)
         }
 
-        guard let dylibURL = findFirstDylib(in: tmpDir) else {
-            throw PluginInstallError.layoutInvalid("No .dylib found in archive")
-        }
+        return try installVerifiedArtifact(
+            extractedAt: tmpDir,
+            spec: spec,
+            versionEntry: resolution.version,
+            artifact: artifact,
+            targetPlatform: targetPlatform,
+            targetArch: targetArch
+        )
+    }
+
+    /// Lays out an already-downloaded, checksum/signature-verified, extracted
+    /// artifact into the versioned install directory: dylib, web assets,
+    /// skills, docs, receipt, consent marker, and the `current` symlink swap.
+    /// Internal (not private) so the layout contract is unit-testable without
+    /// network access.
+    func installVerifiedArtifact(
+        extractedAt tmpDir: URL,
+        spec: PluginSpec,
+        versionEntry: PluginVersionEntry,
+        artifact: PluginArtifact,
+        targetPlatform: Platform,
+        targetArch: CPUArch
+    ) throws -> InstallResult {
+        let pluginId = spec.plugin_id
+        let dylibURL = try Self.locateSingleDylib(in: tmpDir)
 
         let installDir = PluginInstallManager.toolsVersionDirectory(
-            pluginId: spec.plugin_id,
-            version: resolution.version.version
+            pluginId: pluginId,
+            version: versionEntry.version
         )
         try ensureDirectoryExists(installDir)
         let finalDylibURL = installDir.appendingPathComponent(dylibURL.lastPathComponent, isDirectory: false)
@@ -162,6 +181,17 @@ public final class PluginInstallManager: @unchecked Sendable {
             try FileManager.default.removeItem(at: finalDylibURL)
         }
         try FileManager.default.copyItem(at: dylibURL, to: finalDylibURL)
+
+        // Copy the static web UI directory when the artifact bundles one
+        // (docs/plugins/PACKAGING.md promises `web/` survives the install).
+        if let webDir = Self.findWebDirectory(in: tmpDir, near: dylibURL) {
+            let destWebDir = installDir.appendingPathComponent(webDir.lastPathComponent, isDirectory: true)
+            if FileManager.default.fileExists(atPath: destWebDir.path) {
+                try FileManager.default.removeItem(at: destWebDir)
+            }
+            try FileManager.default.copyItem(at: webDir, to: destWebDir)
+            NSLog("[Osaurus] Installed web assets for plugin \(pluginId)")
+        }
 
         // Copy any SKILL.md files found in the artifact
         let skillFileURLs = findSkillFiles(in: tmpDir)
@@ -203,8 +233,8 @@ public final class PluginInstallManager: @unchecked Sendable {
         let dylibSha = try Self.sha256Hex(ofFile: finalDylibURL)
 
         let receipt = PluginReceipt(
-            plugin_id: spec.plugin_id,
-            version: resolution.version.version,
+            plugin_id: pluginId,
+            version: versionEntry.version,
             installed_at: Date(),
             dylib_filename: finalDylibURL.lastPathComponent,
             dylib_sha256: dylibSha,
@@ -226,19 +256,7 @@ public final class PluginInstallManager: @unchecked Sendable {
         let consentURL = installDir.appendingPathComponent(".user_consent", isDirectory: false)
         try Data().write(to: consentURL)
 
-        try Self.updateCurrentSymlink(pluginId: spec.plugin_id, version: resolution.version.version)
-
-        // Deferred TOFU cleanup: now that the new version is fully on disk and `current`
-        // points at it, it's safe to remove the prior key-rotated version.
-        if let old = keyRotatedFromVersion, old != resolution.version.version {
-            let oldDir = PluginInstallManager.toolsVersionDirectory(pluginId: spec.plugin_id, version: old)
-            try? FileManager.default.removeItem(at: oldDir)
-            NSLog(
-                "[Osaurus] Key rotated for %@ — removed prior version %@",
-                spec.plugin_id,
-                old.description
-            )
-        }
+        try Self.updateCurrentSymlink(pluginId: pluginId, version: versionEntry.version)
 
         return InstallResult(
             receipt: receipt,
@@ -246,6 +264,50 @@ public final class PluginInstallManager: @unchecked Sendable {
             dylibURL: finalDylibURL,
             skillFiles: installedSkillFiles
         )
+    }
+
+    // MARK: - Trust decisions
+
+    /// Latest installed receipt for `pluginId`, if any.
+    static func latestInstalledReceipt(pluginId: String) -> PluginReceipt? {
+        guard let latest = InstalledPluginsStore.shared.latestInstalledVersion(pluginId: pluginId) else {
+            return nil
+        }
+        return InstalledPluginsStore.shared.receipt(pluginId: pluginId, version: latest)
+    }
+
+    /// True when the registry advertises a minisign key that differs from the
+    /// key pinned by an existing install's receipt. No pinned key (fresh
+    /// install, or a manual sideload without keys) is not a mismatch.
+    static func pinnedSigningKeyMismatch(spec: PluginSpec, installedReceipt: PluginReceipt?) -> Bool {
+        guard let pinnedKey = installedReceipt?.public_keys?["minisign"],
+            let newKey = spec.public_keys?["minisign"]
+        else { return false }
+        return pinnedKey != newKey
+    }
+
+    /// Host app version used for `osaurus_min_version` filtering during
+    /// registry resolution. Lenient parse: Xcode's default MARKETING_VERSION
+    /// is often `1.0` (or `1`), so missing components are treated as zero.
+    /// Returns nil (fail open, matching the loader) when bundle metadata is
+    /// absent or unparseable.
+    static nonisolated(unsafe) var hostVersionOverrideForTesting: SemanticVersion?
+    static func currentHostVersion() -> SemanticVersion? {
+        if let hostVersionOverrideForTesting { return hostVersionOverrideForTesting }
+        guard let raw = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return nil
+        }
+        return parseLenientHostVersion(raw)
+    }
+
+    static func parseLenientHostVersion(_ s: String) -> SemanticVersion? {
+        if let strict = SemanticVersion.parse(s) { return strict }
+        let core = s.split(separator: "-", maxSplits: 1).first.map(String.init) ?? s
+        let parts = core.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard let major = parts.first.flatMap(Int.init) else { return nil }
+        let minor = parts.count > 1 ? Int(parts[1]) ?? 0 : 0
+        let patch = parts.count > 2 ? Int(parts[2]) ?? 0 : 0
+        return SemanticVersion(major: major, minor: minor, patch: patch)
     }
 
     // MARK: - Paths
@@ -458,6 +520,17 @@ public final class PluginInstallManager: @unchecked Sendable {
         try Data(contentsOf: url, options: [.mappedIfSafe])
     }
 
+    /// Public facade over the bounded in-process ZIP extractor so other
+    /// install surfaces (e.g. the CLI's manual `tools install`) share the
+    /// same hardened extraction instead of shelling out to /usr/bin/unzip.
+    public static func extractPluginArchive(at archive: URL, to destination: URL) throws {
+        do {
+            try BoundedArchiveExtractor.extract(archive: archive, to: destination, policy: .plugin)
+        } catch let error as ArchiveExtractionError {
+            throw PluginInstallError.archiveRejected(error.localizedDescription)
+        }
+    }
+
     /// Finds a documentation file (case-insensitive) in the extracted archive directory
     private func findDocFile(named filename: String, in directory: URL) -> URL? {
         let fm = FileManager.default
@@ -500,7 +573,11 @@ public final class PluginInstallManager: @unchecked Sendable {
         return results
     }
 
-    private func findFirstDylib(in directory: URL) -> URL? {
+    /// The extracted artifact must contain exactly one dylib. Zero means the
+    /// archive is broken; more than one means "pick the first the enumerator
+    /// happens to return" — a nondeterministic choice a signed artifact must
+    /// never rely on.
+    static func locateSingleDylib(in directory: URL) throws -> URL {
         let fm = FileManager.default
         guard
             let enumerator = fm.enumerator(
@@ -509,14 +586,47 @@ public final class PluginInstallManager: @unchecked Sendable {
                 options: [.skipsHiddenFiles]
             )
         else {
-            return nil
+            throw PluginInstallError.layoutInvalid("Could not enumerate extracted archive")
         }
+        var found: [URL] = []
         for case let fileURL as URL in enumerator {
             if fileURL.pathExtension == "dylib" && Self.isRegularPayloadFile(fileURL) {
-                return fileURL
+                found.append(fileURL)
             }
         }
-        return nil
+        guard let dylib = found.first else {
+            throw PluginInstallError.layoutInvalid("No .dylib found in archive")
+        }
+        guard found.count == 1 else {
+            let names = found.map { $0.lastPathComponent }.sorted().joined(separator: ", ")
+            throw PluginInstallError.layoutInvalid(
+                "Archive must contain exactly one .dylib, found \(found.count): \(names)"
+            )
+        }
+        return dylib
+    }
+
+    /// Locates the artifact's static web UI directory (`web/`, the name
+    /// `osaurus tools package` bundles and PACKAGING.md documents). Prefers a
+    /// `web/` sibling of the dylib, then falls back to a top-level `web/`
+    /// under the extraction root (archives may nest payloads one level deep).
+    static func findWebDirectory(in directory: URL, near dylibURL: URL?) -> URL? {
+        let fm = FileManager.default
+        func directoryIfExists(_ url: URL) -> URL? {
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue,
+                (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink != true
+            else { return nil }
+            return url
+        }
+        if let dylibURL,
+            let sibling = directoryIfExists(
+                dylibURL.deletingLastPathComponent().appendingPathComponent("web", isDirectory: true)
+            )
+        {
+            return sibling
+        }
+        return directoryIfExists(directory.appendingPathComponent("web", isDirectory: true))
     }
 
     /// Signed archives should contribute real files only; symlinked payload files would let

--- a/Packages/OsaurusRepository/PluginSpec.swift
+++ b/Packages/OsaurusRepository/PluginSpec.swift
@@ -122,7 +122,8 @@ public extension PluginSpec {
         targetPlatform: Platform,
         targetArch: CPUArch,
         minimumOsaurusVersion: SemanticVersion?,
-        preferredVersion: SemanticVersion? = nil
+        preferredVersion: SemanticVersion? = nil,
+        currentMacOSVersion: OperatingSystemVersion? = nil
     ) throws -> PluginResolution {
         guard !versions.isEmpty else { throw PluginResolutionError.noVersions }
 
@@ -134,22 +135,69 @@ public extension PluginSpec {
         }
         let sorted = filtered.sorted { $0.version > $1.version }
 
+        func eligibleArtifact(in entry: PluginVersionEntry) -> PluginArtifact? {
+            entry.artifacts.first { art in
+                art.os == targetPlatform.rawValue
+                    && art.arch == targetArch.rawValue
+                    && Self.artifactSupportsMacOSVersion(art, current: currentMacOSVersion)
+            }
+        }
+
         if let preferred = preferredVersion {
             if let match = sorted.first(where: { $0.version == preferred }),
-                let art = match.artifacts.first(where: {
-                    $0.os == targetPlatform.rawValue && $0.arch == targetArch.rawValue
-                })
+                let art = eligibleArtifact(in: match)
             {
                 return PluginResolution(spec: self, version: match, artifact: art)
             }
         }
 
         for v in sorted {
-            if let art = v.artifacts.first(where: { $0.os == targetPlatform.rawValue && $0.arch == targetArch.rawValue }
-            ) {
+            if let art = eligibleArtifact(in: v) {
                 return PluginResolution(spec: self, version: v, artifact: art)
             }
         }
         throw PluginResolutionError.noMatchingArtifact
+    }
+
+    /// True when `artifact.min_macos` is satisfied by `current`. Fails open when
+    /// the caller passes no current version, the artifact declares no minimum,
+    /// or the declared minimum is unparseable (registry data problem — the
+    /// artifact should not become uninstallable because of a typo the loader
+    /// would also ignore).
+    internal static func artifactSupportsMacOSVersion(
+        _ artifact: PluginArtifact,
+        current: OperatingSystemVersion?
+    ) -> Bool {
+        guard let current,
+            let declared = artifact.min_macos, !declared.isEmpty,
+            let required = parseMacOSVersion(declared)
+        else { return true }
+        return osVersion(current, isAtLeast: required)
+    }
+
+    /// Parses a "MAJOR[.MINOR[.PATCH]]" macOS version string. Trailing
+    /// components default to zero (`"14"` / `"14.5"` / `"14.5.1"` are all
+    /// valid). Returns nil when no leading integer can be parsed.
+    internal static func parseMacOSVersion(_ s: String) -> OperatingSystemVersion? {
+        let parts = s.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard let major = parts.first.flatMap(Int.init) else { return nil }
+        let minor = parts.count > 1 ? Int(parts[1]) ?? 0 : 0
+        let patch = parts.count > 2 ? Int(parts[2]) ?? 0 : 0
+        return OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    /// `OperatingSystemVersion` has no `Comparable` conformance; lexicographic
+    /// comparison keeps this testable with injected values.
+    internal static func osVersion(
+        _ current: OperatingSystemVersion,
+        isAtLeast required: OperatingSystemVersion
+    ) -> Bool {
+        if current.majorVersion != required.majorVersion {
+            return current.majorVersion > required.majorVersion
+        }
+        if current.minorVersion != required.minorVersion {
+            return current.minorVersion > required.minorVersion
+        }
+        return current.patchVersion >= required.patchVersion
     }
 }

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift
@@ -1,0 +1,477 @@
+//
+//  PluginInstallIntegrityTests.swift
+//  OsaurusRepository
+//
+//  Regression coverage for registry-install integrity:
+//    - web/ assets survive the install (PACKAGING.md contract)
+//    - exactly-one-dylib layout enforcement
+//    - host / macOS minimum-version filtering during resolution
+//    - fail-closed TOFU pinned-signing-key mismatch
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusRepository
+
+final class PluginInstallIntegrityTests: XCTestCase {
+    private var tempRoot: URL!
+    private var previousOverride: URL?
+    private var previousDownloadOverride: (@Sendable (URL, URL) throws -> Void)?
+    private var previousHostVersionOverride: SemanticVersion?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let fm = FileManager.default
+        tempRoot = fm.temporaryDirectory.appendingPathComponent(
+            "osaurus-install-integrity-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousOverride = ToolsPaths.overrideRoot
+        ToolsPaths.overrideRoot = tempRoot
+        previousDownloadOverride = CentralRepositoryManager.downloadFileOverride
+        previousHostVersionOverride = PluginInstallManager.hostVersionOverrideForTesting
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousOverride
+        CentralRepositoryManager.downloadFileOverride = previousDownloadOverride
+        PluginInstallManager.hostVersionOverrideForTesting = previousHostVersionOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private func sv(_ s: String) -> SemanticVersion { SemanticVersion.parse(s)! }
+
+    private func makeArtifact(minMacOS: String? = nil) -> PluginArtifact {
+        artifactJSONDecoded(os: "macos", arch: "arm64", minMacOS: minMacOS)
+    }
+
+    private func artifactJSONDecoded(os: String, arch: String, minMacOS: String?) -> PluginArtifact {
+        var dict: [String: Any] = [
+            "os": os,
+            "arch": arch,
+            "url": "https://example.invalid/plugin.zip",
+            "sha256": String(repeating: "0", count: 64),
+            "size": 4,
+        ]
+        if let minMacOS { dict["min_macos"] = minMacOS }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        return try! JSONDecoder().decode(PluginArtifact.self, from: data)
+    }
+
+    private func makeVersionEntry(
+        _ version: String,
+        minOsaurus: String? = nil,
+        artifacts: [PluginArtifact]? = nil
+    ) -> PluginVersionEntry {
+        var dict: [String: Any] = [
+            "version": version,
+            "artifacts": [
+                [
+                    "os": "macos",
+                    "arch": "arm64",
+                    "url": "https://example.invalid/plugin-\(version).zip",
+                    "sha256": String(repeating: "0", count: 64),
+                    "size": 4,
+                ]
+            ],
+        ]
+        if let minOsaurus {
+            dict["requires"] = ["osaurus_min_version": minOsaurus]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        var entry = try! JSONDecoder().decode(PluginVersionEntry.self, from: data)
+        if let artifacts {
+            entry = PluginVersionEntry(
+                version: entry.version,
+                release_date: entry.release_date,
+                notes: entry.notes,
+                artifacts: artifacts,
+                requires: entry.requires
+            )
+        }
+        return entry
+    }
+
+    private func makeSpec(
+        pluginId: String = "com.test.integrity",
+        publicKey: String? = "RWTtestkey",
+        versions: [PluginVersionEntry]
+    ) -> PluginSpec {
+        PluginSpec(
+            plugin_id: pluginId,
+            public_keys: publicKey.map { ["minisign": $0] },
+            versions: versions
+        )
+    }
+
+    private func writeReceipt(
+        pluginId: String,
+        version: String,
+        minisignKey: String?
+    ) throws {
+        let semver = sv(version)
+        let dir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: semver)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let receipt = PluginReceipt(
+            plugin_id: pluginId,
+            version: semver,
+            installed_at: Date(),
+            dylib_filename: "Plugin.dylib",
+            dylib_sha256: String(repeating: "0", count: 64),
+            platform: "macos",
+            arch: "arm64",
+            public_keys: minisignKey.map { ["minisign": $0] },
+            artifact: .init(
+                url: "https://example.invalid/\(pluginId)-\(version).zip",
+                sha256: String(repeating: "0", count: 64),
+                minisign: nil,
+                size: 0
+            )
+        )
+        try JSONEncoder().encode(receipt)
+            .write(to: dir.appendingPathComponent("receipt.json", isDirectory: false))
+    }
+
+    /// Seeds the on-disk registry cache with `spec` and blocks all registry
+    /// network refreshes so `install()` resolves entirely offline.
+    private func seedRegistryCache(with spec: PluginSpec) throws {
+        let pluginsDir = ToolsPaths.pluginSpecsRoot()
+            .appendingPathComponent("central", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginsDir, withIntermediateDirectories: true)
+        try JSONEncoder().encode(spec)
+            .write(to: pluginsDir.appendingPathComponent("\(spec.plugin_id).json", isDirectory: false))
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    // MARK: - Version resolution: osaurus_min_version
+
+    func test_resolveBestVersion_skipsVersionsRequiringNewerHost() throws {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", minOsaurus: "9.0.0"),
+            makeVersionEntry("1.0.0"),
+        ])
+
+        let resolution = try spec.resolveBestVersion(
+            targetPlatform: .macos,
+            targetArch: .arm64,
+            minimumOsaurusVersion: sv("1.2.3")
+        )
+
+        XCTAssertEqual(resolution.version.version, sv("1.0.0"))
+    }
+
+    func test_resolveBestVersion_failsWhenEveryVersionRequiresNewerHost() {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", minOsaurus: "9.0.0")
+        ])
+
+        XCTAssertThrowsError(
+            try spec.resolveBestVersion(
+                targetPlatform: .macos,
+                targetArch: .arm64,
+                minimumOsaurusVersion: sv("1.2.3")
+            )
+        )
+    }
+
+    func test_resolveBestVersion_unknownHostVersionFailsOpen() throws {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", minOsaurus: "9.0.0")
+        ])
+
+        let resolution = try spec.resolveBestVersion(
+            targetPlatform: .macos,
+            targetArch: .arm64,
+            minimumOsaurusVersion: nil
+        )
+
+        XCTAssertEqual(resolution.version.version, sv("2.0.0"))
+    }
+
+    // MARK: - Version resolution: artifact min_macos
+
+    func test_resolveBestVersion_skipsArtifactsRequiringNewerMacOS() throws {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", artifacts: [makeArtifact(minMacOS: "99.0")]),
+            makeVersionEntry("1.0.0", artifacts: [makeArtifact(minMacOS: "14.0")]),
+        ])
+
+        let resolution = try spec.resolveBestVersion(
+            targetPlatform: .macos,
+            targetArch: .arm64,
+            minimumOsaurusVersion: nil,
+            currentMacOSVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+        )
+
+        XCTAssertEqual(resolution.version.version, sv("1.0.0"))
+    }
+
+    func test_resolveBestVersion_failsWhenNoArtifactSupportsThisMacOS() {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("1.0.0", artifacts: [makeArtifact(minMacOS: "99.0")])
+        ])
+
+        XCTAssertThrowsError(
+            try spec.resolveBestVersion(
+                targetPlatform: .macos,
+                targetArch: .arm64,
+                minimumOsaurusVersion: nil,
+                currentMacOSVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+            )
+        ) { error in
+            guard case PluginResolutionError.noMatchingArtifact = error else {
+                return XCTFail("expected noMatchingArtifact, got \(error)")
+            }
+        }
+    }
+
+    func test_artifactSupportsMacOSVersion_failsOpenForMissingOrUnparseableDeclarations() {
+        let current = OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: nil), current: current))
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "banana"), current: current))
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "15.0"), current: nil))
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "15"), current: current))
+        XCTAssertFalse(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "15.1"), current: current))
+    }
+
+    func test_parseLenientHostVersion_acceptsShortBundleVersions() {
+        XCTAssertEqual(PluginInstallManager.parseLenientHostVersion("1.2.3"), sv("1.2.3"))
+        XCTAssertEqual(PluginInstallManager.parseLenientHostVersion("1.0"), sv("1.0.0"))
+        XCTAssertEqual(PluginInstallManager.parseLenientHostVersion("2"), sv("2.0.0"))
+        XCTAssertNil(PluginInstallManager.parseLenientHostVersion("dev"))
+    }
+
+    func test_install_rejectsVersionsIncompatibleWithHost() async throws {
+        let pluginId = "com.test.minversion"
+        let spec = makeSpec(
+            pluginId: pluginId,
+            versions: [makeVersionEntry("2.0.0", minOsaurus: "99.0.0")]
+        )
+        try seedRegistryCache(with: spec)
+        PluginInstallManager.hostVersionOverrideForTesting = sv("1.0.0")
+
+        do {
+            _ = try await PluginInstallManager.shared.install(pluginId: pluginId)
+            XCTFail("expected install to fail resolution")
+        } catch let error as PluginInstallError {
+            guard case .resolutionFailed = error else {
+                return XCTFail("expected resolutionFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - TOFU pinned key
+
+    func test_pinnedSigningKeyMismatch_detectsRotation() throws {
+        let pluginId = "com.test.pinned"
+        try writeReceipt(pluginId: pluginId, version: "1.0.0", minisignKey: "RWTold")
+
+        let installed = PluginInstallManager.latestInstalledReceipt(pluginId: pluginId)
+        XCTAssertNotNil(installed)
+
+        let rotated = makeSpec(pluginId: pluginId, publicKey: "RWTnew", versions: [makeVersionEntry("2.0.0")])
+        XCTAssertTrue(PluginInstallManager.pinnedSigningKeyMismatch(spec: rotated, installedReceipt: installed))
+
+        let same = makeSpec(pluginId: pluginId, publicKey: "RWTold", versions: [makeVersionEntry("2.0.0")])
+        XCTAssertFalse(PluginInstallManager.pinnedSigningKeyMismatch(spec: same, installedReceipt: installed))
+
+        XCTAssertFalse(
+            PluginInstallManager.pinnedSigningKeyMismatch(spec: rotated, installedReceipt: nil),
+            "fresh installs have no pinned key and must not be blocked"
+        )
+    }
+
+    func test_pinnedSigningKeyMismatch_ignoresKeylessSideloadReceipts() throws {
+        let pluginId = "com.test.keyless"
+        try writeReceipt(pluginId: pluginId, version: "1.0.0", minisignKey: nil)
+        let installed = PluginInstallManager.latestInstalledReceipt(pluginId: pluginId)
+
+        let spec = makeSpec(pluginId: pluginId, publicKey: "RWTnew", versions: [makeVersionEntry("2.0.0")])
+        XCTAssertFalse(PluginInstallManager.pinnedSigningKeyMismatch(spec: spec, installedReceipt: installed))
+    }
+
+    func test_install_failsClosedOnPinnedKeyRotation_andKeepsInstalledVersion() async throws {
+        let pluginId = "com.test.rotation"
+        try writeReceipt(pluginId: pluginId, version: "1.0.0", minisignKey: "RWTold")
+        try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: sv("1.0.0"))
+
+        let spec = makeSpec(pluginId: pluginId, publicKey: "RWTnew", versions: [makeVersionEntry("2.0.0")])
+        try seedRegistryCache(with: spec)
+
+        do {
+            _ = try await PluginInstallManager.shared.install(pluginId: pluginId)
+            XCTFail("expected install to fail closed on pinned-key rotation")
+        } catch let error as PluginInstallError {
+            guard case .authorKeyMismatch = error else {
+                return XCTFail("expected authorKeyMismatch, got \(error)")
+            }
+        }
+
+        let oldDir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: sv("1.0.0"))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: oldDir.appendingPathComponent("receipt.json").path),
+            "the previously installed version must remain untouched when the install is refused"
+        )
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(
+                atPath: PluginInstallManager.currentSymlinkURL(pluginId: pluginId).path
+            ),
+            "1.0.0"
+        )
+    }
+
+    // MARK: - Layout: exactly one dylib
+
+    func test_locateSingleDylib_findsTheOnlyDylib() throws {
+        let dir = tempRoot.appendingPathComponent("payload-one", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("bin".utf8).write(to: dir.appendingPathComponent("Plugin.dylib"))
+
+        let found = try PluginInstallManager.locateSingleDylib(in: dir)
+        XCTAssertEqual(found.lastPathComponent, "Plugin.dylib")
+    }
+
+    func test_locateSingleDylib_rejectsZeroDylibs() throws {
+        let dir = tempRoot.appendingPathComponent("payload-zero", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try PluginInstallManager.locateSingleDylib(in: dir)) { error in
+            XCTAssertTrue(String(describing: error).contains("No .dylib"))
+        }
+    }
+
+    func test_locateSingleDylib_rejectsMultipleDylibs() throws {
+        let dir = tempRoot.appendingPathComponent("payload-two", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("a".utf8).write(to: dir.appendingPathComponent("A.dylib"))
+        try Data("b".utf8).write(to: dir.appendingPathComponent("B.dylib"))
+
+        XCTAssertThrowsError(try PluginInstallManager.locateSingleDylib(in: dir)) { error in
+            XCTAssertTrue(String(describing: error).contains("exactly one"))
+        }
+    }
+
+    // MARK: - Layout: web assets
+
+    /// Regression: registry installs previously copied the dylib, skills, and
+    /// docs but silently dropped `web/`, breaking every plugin with a static UI.
+    func test_installVerifiedArtifact_copiesWebDirectory() throws {
+        let pluginId = "com.test.web"
+        let payload = tempRoot.appendingPathComponent("extracted-web", isDirectory: true)
+        let webDir = payload.appendingPathComponent("web/assets", isDirectory: true)
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        try Data("bin".utf8).write(to: payload.appendingPathComponent("Plugin.dylib"))
+        try Data("<html>ui</html>".utf8).write(
+            to: payload.appendingPathComponent("web/index.html")
+        )
+        try Data("body{}".utf8).write(to: webDir.appendingPathComponent("app.css"))
+
+        let spec = makeSpec(pluginId: pluginId, versions: [makeVersionEntry("1.0.0")])
+        let result = try PluginInstallManager.shared.installVerifiedArtifact(
+            extractedAt: payload,
+            spec: spec,
+            versionEntry: spec.versions[0],
+            artifact: spec.versions[0].artifacts[0],
+            targetPlatform: .macos,
+            targetArch: .arm64
+        )
+
+        let installedWeb = result.installDirectory.appendingPathComponent("web", isDirectory: true)
+        XCTAssertEqual(
+            try String(contentsOf: installedWeb.appendingPathComponent("index.html"), encoding: .utf8),
+            "<html>ui</html>"
+        )
+        XCTAssertEqual(
+            try String(
+                contentsOf: installedWeb.appendingPathComponent("assets/app.css"),
+                encoding: .utf8
+            ),
+            "body{}"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: result.installDirectory.appendingPathComponent("receipt.json").path
+            )
+        )
+    }
+
+    func test_installVerifiedArtifact_prefersWebDirectoryNextToDylib() throws {
+        let payload = tempRoot.appendingPathComponent("extracted-nested", isDirectory: true)
+        let inner = payload.appendingPathComponent("bundle", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: inner.appendingPathComponent("web", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("bin".utf8).write(to: inner.appendingPathComponent("Plugin.dylib"))
+        try Data("nested".utf8).write(to: inner.appendingPathComponent("web/index.html"))
+
+        let spec = makeSpec(pluginId: "com.test.nestedweb", versions: [makeVersionEntry("1.0.0")])
+        let result = try PluginInstallManager.shared.installVerifiedArtifact(
+            extractedAt: payload,
+            spec: spec,
+            versionEntry: spec.versions[0],
+            artifact: spec.versions[0].artifacts[0],
+            targetPlatform: .macos,
+            targetArch: .arm64
+        )
+
+        XCTAssertEqual(
+            try String(
+                contentsOf: result.installDirectory.appendingPathComponent("web/index.html"),
+                encoding: .utf8
+            ),
+            "nested"
+        )
+    }
+
+    func test_installVerifiedArtifact_withoutWebDirectoryInstallsNothingExtra() throws {
+        let payload = tempRoot.appendingPathComponent("extracted-noweb", isDirectory: true)
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: true)
+        try Data("bin".utf8).write(to: payload.appendingPathComponent("Plugin.dylib"))
+
+        let spec = makeSpec(pluginId: "com.test.noweb", versions: [makeVersionEntry("1.0.0")])
+        let result = try PluginInstallManager.shared.installVerifiedArtifact(
+            extractedAt: payload,
+            spec: spec,
+            versionEntry: spec.versions[0],
+            artifact: spec.versions[0].artifacts[0],
+            targetPlatform: .macos,
+            targetArch: .arm64
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: result.installDirectory.appendingPathComponent("web").path
+            )
+        )
+    }
+
+    func test_installVerifiedArtifact_rejectsMultiDylibPayload() throws {
+        let payload = tempRoot.appendingPathComponent("extracted-multi", isDirectory: true)
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: true)
+        try Data("a".utf8).write(to: payload.appendingPathComponent("A.dylib"))
+        try Data("b".utf8).write(to: payload.appendingPathComponent("B.dylib"))
+
+        let spec = makeSpec(pluginId: "com.test.multi", versions: [makeVersionEntry("1.0.0")])
+        XCTAssertThrowsError(
+            try PluginInstallManager.shared.installVerifiedArtifact(
+                extractedAt: payload,
+                spec: spec,
+                versionEntry: spec.versions[0],
+                artifact: spec.versions[0].artifacts[0],
+                targetPlatform: .macos,
+                targetArch: .arm64
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Host/harness fixes from the July 2026 plugin reliability audit (install-integrity theme). Part of a 5-branch series; each branch is independent and separately mergeable. Full campaign notes cover all five themes.

### 1. `audit/install-integrity` (3 commits)

Commits:
- `773df291` Enforce host/macOS version checks, TOFU key pinning, single dylib, and web asset install in registry installer
- `5fb17ae0` Fail tools verify on missing or malformed receipts and dylibs
- `686608bb` Use bounded extraction, atomic publication, and explicit consent for manual tools install

Confirmed defects fixed:
- **High** `Packages/OsaurusRepository/PluginInstallManager.swift` — registry installs copied only the dylib (+ SKILL.md/docs); the `web/` directory promised by `docs/plugins/PACKAGING.md` was silently dropped, so installed plugins' static UIs 404'd. `installVerifiedArtifact` now locates and copies the artifact's `web/` directory (preferring the one next to the dylib).
- **High** `PluginInstallManager.swift` + `PluginSpec.swift` — `resolveBestVersion` was called with `minimumOsaurusVersion: nil` (so `osaurus_min_version` never filtered) and `PluginArtifact.min_macos` was never consulted. Resolution now receives the real host version (`CFBundleShortVersionString`) and `ProcessInfo.operatingSystemVersion`, and filters artifacts by `min_macos`.
- **High** `PluginInstallManager.swift` — `PluginInstallError.authorKeyMismatch` existed but was never thrown; a changed registry signing key was silently trusted (TOFU without the "trust" part) and the previous version was deleted before the new install proved good. Now: pinned-key mismatch fails closed with `authorKeyMismatch` (the existing UI alert directs users through explicit uninstall/reinstall approval), and the rollback version is only deleted after the install fully succeeds.
- **Medium** `PluginInstallManager.swift` — artifact containing zero or multiple dylibs nondeterministically picked the first; now `locateSingleDylib` requires exactly one and errors otherwise.
- **High** `Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsVerify.swift` — missing/unreadable `receipt.json`, missing dylibs, and dangling `current` symlinks were silently `continue`d, so `osaurus tools verify` exited 0 for broken installs. Every missing/malformed/mismatched file is now a reported failure and the command exits non-zero.
- **High** `Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift` — manual remote install buffered the whole archive in memory (`URLSession.data`), shelled out to `/usr/bin/unzip` (no entry/size/ratio/path-escape limits), replaced an existing version non-transactionally (delete-then-copy), and granted consent by default. Now: streaming download (`URLSession.download`), extraction through the same `BoundedArchiveExtractor` the registry installer uses (via a new `PluginInstallManager.extractPluginArchive` facade), staging + atomic publication (`replaceItemAt`), consent only with an explicit `--consent` flag, and failure when the payload produces no dylib (receipt creation now throws instead of silently skipping).

Tests added:
- `Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift` — min_osaurus/min_macos filtering, pinned-key mismatch, single-dylib enforcement, web directory discovery/copy, verified-artifact install shape.
- `Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsVerifyTests.swift` — missing receipt, malformed receipt, missing dylib, SHA mismatch, dangling `current` symlink all fail; healthy install passes.
- `Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsManualInstallPublishTests.swift` — atomic publish over existing version, no-dylib failure, consent-only-when-granted.

Verification (all green):
- `swift test --package-path Packages/OsaurusRepository --parallel` — 77 tests passed.
- `swift test --package-path Packages/OsaurusCLI --parallel` — 130 tests passed.
- `swift build -c release --package-path Packages/OsaurusRepository` and `--package-path Packages/OsaurusCLI` — build complete.

### 2. `audit/loader-abi` (1 commit)

Commit:
- `82135263` Validate plugin ABI table, v1 prefix decode, and manifest/tool/route identity at load

Confirmed defects fixed (all in `Packages/OsaurusCore/Managers/Plugin/PluginManager.swift` and `Models/Plugin/ExternalPlugin.swift`):
- **High** — loader only required `init` and `get_manifest`; nil `free_string` (leaks every returned string), `destroy` (no teardown), or `invoke` (broken tools) were accepted. `abiTableValidationFailure` now rejects incomplete ABI tables before `init` is called.
- **High** — the v1 entry path read `apiPtr.pointee` as the full current `osr_plugin_api` struct, reading past the end of a historical v1 plugin's static struct (out-of-bounds read of whatever follows it in the binary). New `osr_plugin_api_v1` prefix struct decodes exactly the five required members and widens into the full layout with v2+ slots zeroed.
- **Medium** — no load-time identity validation: manifest `plugin_id` could differ from the receipt/install-directory id (previously "re-keyed" silently), two plugins could load under the same id, and duplicate/empty tool or route ids were accepted. Load now fails on manifest/directory id mismatch, rejects duplicate loaded plugin ids (newcomer is shut down), and rejects empty or duplicate tool/route ids.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift` — ABI completeness matrix, v1 prefix widening (zeroed v2+ slots, version 0), id-mismatch failure, duplicate/empty tool and route id failures.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginLoaderAbiValidationTests|PluginAbiHandshakeTests'` — 28 tests passed.

### 3. `audit/route-reliability` (1 commit)

Commit:
- `22b84a1f` Fix route handler timeout race and segment-boundary web mount matching

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift` — `handleRoute` implemented its 30s timeout with `withThrowingTaskGroup`; task groups drain children before returning, so a blocking C route callback (which never observes Swift cancellation) held the HTTP caller for the full duration of the call — the timeout never fired from the request's perspective. Replaced with the unstructured-body-task + GCD-timer race already used by `ToolRegistry.runToolBody` (new `RouteHandlerRaceState`), so the caller is resumed the moment the timer wins while the abandoned callback finishes on the plugin's invoke queue.
- **Medium** `Networking/HTTPHandler.swift` + `Managers/Plugin/PluginManager.swift` — static web mount dispatch used bare `subpath.hasPrefix(mountPrefix)`, so mount `/ui` captured `/ui-other`, disagreeing with the load-time web/route overlap validation (which already used segment-boundary logic). Both now call one shared helper, `PluginManifest.WebSpec.mountCaptures` / `relativeSubpath` / `normalizedMount`, so validation and dispatch cannot diverge.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift` — elapsed wall-time assertion with a deliberately blocking C route callback (semaphore-held; asserts the caller returns at the 0.5s timeout instead of blocking until release), fast-path control, and mount matching for `/ui`, `/ui/x`, `/ui-other`, `/`, plus normalization (`ui`, `/ui/`) and relative-subpath expectations.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginRouteReliabilityTests|PluginRoutingTests'` — 22 tests in 6 suites passed (includes existing routing/static-file containment suites).

### 4. `audit/lifecycle-config` (1 commit)

Commit:
- `c601dd68` Order plugin teardown before secret sweep on agent delete; unify config default resolution

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Managers/AgentManager.swift` + `Managers/Plugin/PluginManager.swift` — `AgentManager.delete(id:)` swept `ToolSecretsKeychain` for the agent BEFORE posting `.agentRemoved`; the `.agentRemoved` handler was additionally fire-and-forget (Task + detached push), so plugins reading config (e.g. Telegram's `bot_token`) during webhook deregistration found nothing — the webhook stayed registered upstream. New awaitable `PluginManager.tearDownPluginsForRemovedAgent(agentId:)` delivers `tunnel_url=""` to every routed plugin via the synchronous config path and returns only after each plugin's `on_config_changed` completes; `delete` awaits it and only then sweeps. The notification-driven handler remains as an idempotent backstop (deduped plugin-side).
- **Medium** `Services/Keychain/ToolSecretsKeychain.swift` + `Services/Plugin/PluginHostAPI.swift` + `Managers/Plugin/PluginManager.swift` — inconsistent default semantics: tool payload injection merged `Agent.defaultId` values as global defaults (`resolvedSecretsWithDefaults`), but `config_get`, initial config delivery, and required-secret checks (`hasAllRequiredSecrets` / `getMissingRequiredSecrets`) read only the exact agent namespace — a key saved once on the Plugins tab was "configured" for injection but invisible to `config_get`. Centralized one policy, `ToolSecretsKeychain.resolvedSecret(id:for:agentId:)` (exact agent first, then default-agent fallback), and pointed all three paths at it. The anonymous-context guard (no agent → nil) is unchanged; UI editors (`PluginConfigView`, `ToolSecretsSheet`) intentionally keep exact-namespace reads since they edit a specific agent's values.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift` — ordering test driving a real `ExternalPlugin` whose C `on_config_changed` reads `bot_token` mid-teardown (asserts the token is readable during deregistration and swept afterwards, all before `delete` returns); resolution-policy tests: exact-wins, default fallback, missing-everywhere, required-secret checks honoring the fallback, and `config_get` through a TLS-scoped `PluginHostContext` (fallback + exact + anonymous-refusal).

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'AgentDeletionPluginTeardownOrderingTests|ToolSecretsResolutionPolicyTests|AgentManagerLifecycleNotificationTests|ResolvedSecretsMergingTests'` — 18 tests in 4 suites passed (includes the pre-existing lifecycle-notification and secrets-merge suites, confirming no ordering regressions).

### 5. `audit/ci-coverage` (1 commit)

Commit:
- `a6e1737b` Add CI lanes for OsaurusRepository, OsaurusPluginTestKit, and StatsPack tests

Changes (`.github/workflows/ci.yml`):
