### PR TITLE
Reliability audit: reject incomplete ABI tables, safe v1 decoding, identity validation

### DIFF
--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -283,6 +283,24 @@ final class PluginManager {
         for entry in scanResult.loadResults {
             switch entry.result {
             case .success(let loaded):
+                // Loaded plugin IDs must be unique: tools, routes, host
+                // contexts, and secrets are all keyed by plugin ID, so a
+                // second instance would silently shadow (or corrupt) the
+                // first. Keep the already-loaded instance and reject the
+                // newcomer (e.g. a version dir that contains two dylibs).
+                if let existing = plugins.first(where: { $0.plugin.id == loaded.plugin.id }) {
+                    let pluginId = loaded.plugin.id
+                    let errorMsg =
+                        "Duplicate plugin id '\(pluginId)': already loaded from \(existing.plugin.bundlePath); ignoring \(entry.url.path)"
+                    NSLog("[Osaurus] %@", errorMsg)
+                    failedPlugins[pluginId] = FailedPlugin(
+                        pluginId: pluginId,
+                        error: errorMsg,
+                        lastKnownManifest: loaded.plugin.manifest
+                    )
+                    await loaded.plugin.shutdown()
+                    continue
+                }
                 plugins.append(loaded)
                 loadedPluginPaths.insert(entry.url.path)
                 loadedNew = true
@@ -920,6 +938,60 @@ final class PluginManager {
         return current.patchVersion >= required.patchVersion
     }
 
+    // MARK: - Load-time validation (pure helpers)
+
+    /// Returns a message when the plugin's ABI table is missing any of the
+    /// five required function pointers. Every plugin — v1 or v2+ — must
+    /// provide the full required prefix; optional v2 callbacks stay optional.
+    nonisolated static func abiTableValidationFailure(_ api: osr_plugin_api) -> String? {
+        var missing: [String] = []
+        if api.free_string == nil { missing.append("free_string") }
+        if api.`init` == nil { missing.append("init") }
+        if api.destroy == nil { missing.append("destroy") }
+        if api.get_manifest == nil { missing.append("get_manifest") }
+        if api.invoke == nil { missing.append("invoke") }
+        guard !missing.isEmpty else { return nil }
+        return "Plugin ABI table is missing required function(s): \(missing.joined(separator: ", "))"
+    }
+
+    /// Returns a message when the manifest's `plugin_id` does not match the
+    /// install-directory-derived ID the receipt/consent/quarantine machinery
+    /// is keyed by.
+    nonisolated static func manifestIdentityValidationFailure(
+        manifest: PluginManifest,
+        directoryId: String
+    ) -> String? {
+        guard manifest.plugin_id != directoryId else { return nil }
+        return
+            "Plugin manifest declares plugin_id '\(manifest.plugin_id)' but is installed as '\(directoryId)'. Reinstall the plugin under its canonical ID."
+    }
+
+    /// Returns a message when the manifest declares an empty or duplicate
+    /// tool ID, or an empty or duplicate route ID.
+    nonisolated static func manifestCapabilityValidationFailure(_ manifest: PluginManifest) -> String? {
+        var seenToolIds = Set<String>()
+        for tool in manifest.capabilities.tools ?? [] {
+            let id = tool.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            if id.isEmpty {
+                return "Plugin \(manifest.plugin_id) declares a tool with an empty id"
+            }
+            if !seenToolIds.insert(id).inserted {
+                return "Plugin \(manifest.plugin_id) declares duplicate tool id '\(id)'"
+            }
+        }
+        var seenRouteIds = Set<String>()
+        for route in manifest.capabilities.routes ?? [] {
+            let id = route.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            if id.isEmpty {
+                return "Plugin \(manifest.plugin_id) declares a route with an empty id"
+            }
+            if !seenRouteIds.insert(id).inserted {
+                return "Plugin \(manifest.plugin_id) declares duplicate route id '\(id)'"
+            }
+        }
+        return nil
+    }
+
     /// Loads a single plugin from a dylib URL via dlopen + C ABI handshake.
     /// Tries v2 entry point first (with host API injection), then falls back to v1.
     nonisolated private static func loadPluginWithError(at url: URL) -> Result<LoadedPlugin, PluginLoadError> {
@@ -988,8 +1060,11 @@ final class PluginManager {
                 return .failure(PluginLoadError(message: errorMsg))
             }
 
-            let apiPtr = apiRawPtr.assumingMemoryBound(to: osr_plugin_api.self)
-            api = apiPtr.pointee
+            // Historical v1 structs contain ONLY the required prefix — reading
+            // the full `osr_plugin_api` here would read past the end of the
+            // plugin's static struct. Decode via the explicit prefix layout.
+            let prefixPtr = apiRawPtr.assumingMemoryBound(to: osr_plugin_api_v1.self)
+            api = osr_plugin_api(v1: prefixPtr.pointee)
             abiVersion = 1
             print(
                 "[Osaurus] Loaded plugin from \(url.lastPathComponent) (entry=v1 legacy). "
@@ -999,6 +1074,19 @@ final class PluginManager {
         } else {
             let errorMsg = "Missing plugin entry point (osaurus_plugin_entry_v2 or osaurus_plugin_entry)"
             print("[Osaurus] \(errorMsg) in \(url.lastPathComponent)")
+            dlclose(handle)
+            return .failure(PluginLoadError(message: errorMsg))
+        }
+
+        // Reject incomplete ABI tables BEFORE calling init. Accepting a nil
+        // `free_string` leaks every returned string, a nil `destroy` makes
+        // teardown impossible, and a nil `invoke` produces tools that can
+        // never run — none of which the plugin can fix after init has
+        // already handed out a live context.
+        if let abiError = abiTableValidationFailure(api) {
+            let errorMsg = "\(abiError) in \(url.lastPathComponent)"
+            print("[Osaurus] \(errorMsg)")
+            hostContext?.teardown()
             dlclose(handle)
             return .failure(PluginLoadError(message: errorMsg))
         }
@@ -1054,10 +1142,33 @@ final class PluginManager {
             return .failure(PluginLoadError(message: errorMsg))
         }
 
-        // If the manifest plugin_id differs from the directory-derived ID,
-        // re-register the host context under the canonical ID.
-        if let hc = hostContext, manifest.plugin_id != hc.pluginId {
-            PluginHostContext.rekeyContext(from: hc.pluginId, to: manifest.plugin_id)
+        // The install layout (`Tools/<plugin_id>/<version>/`) and the receipt
+        // are keyed by the directory-derived ID; verification, consent,
+        // quarantine, and secrets all use it. A manifest that declares a
+        // different ID would let a plugin masquerade under another plugin's
+        // identity (and previously just re-keyed the host context to the
+        // manifest's claim). Fail the load instead.
+        let directoryId = extractPluginId(from: url)
+        if let identityError = manifestIdentityValidationFailure(
+            manifest: manifest,
+            directoryId: directoryId
+        ) {
+            print("[Osaurus] \(identityError)")
+            api.destroy?(ctx)
+            hostContext?.teardown()
+            dlclose(handle)
+            return .failure(PluginLoadError(message: identityError, manifest: manifest))
+        }
+
+        // Reject empty or duplicate tool/route IDs up front — duplicate tool
+        // IDs would silently overwrite each other in the tool registry, and
+        // empty/duplicate route IDs break route dispatch and diagnostics.
+        if let capabilityError = manifestCapabilityValidationFailure(manifest) {
+            print("[Osaurus] \(capabilityError)")
+            api.destroy?(ctx)
+            hostContext?.teardown()
+            dlclose(handle)
+            return .failure(PluginLoadError(message: capabilityError, manifest: manifest))
         }
 
         // Enforce manifest-declared compatibility constraints. Authors

--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -197,6 +197,40 @@ struct osr_plugin_api {
     var on_task_event: osr_on_task_event_t?
 }
 
+/// Historical v1 layout: plugins compiled against the original header
+/// exported a static struct containing ONLY the five required function
+/// pointers — no `version` field, no optional callbacks. The v1 entry
+/// path must decode through this prefix instead of the full
+/// `osr_plugin_api`, otherwise the loader reads past the end of the
+/// plugin's static struct (out-of-bounds read into whatever the plugin
+/// binary placed after it).
+struct osr_plugin_api_v1 {
+    var free_string: osr_free_string_t?
+    var `init`: osr_init_t?
+    var destroy: osr_destroy_t?
+    var get_manifest: osr_get_manifest_t?
+    var invoke: osr_invoke_t?
+}
+
+extension osr_plugin_api {
+    /// Widens a legacy v1 prefix into the current layout with every
+    /// optional v2+ slot zeroed (`version == 0` matches the header's
+    /// "0 (or absent) for v1 plugins" contract).
+    init(v1 prefix: osr_plugin_api_v1) {
+        self.init(
+            free_string: prefix.free_string,
+            init: prefix.`init`,
+            destroy: prefix.destroy,
+            get_manifest: prefix.get_manifest,
+            invoke: prefix.invoke,
+            version: 0,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+    }
+}
+
 // Entry point types
 typealias osr_plugin_entry_t = @convention(c) () -> UnsafeRawPointer?
 typealias osr_plugin_entry_v2_t = @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?

--- a/Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift
@@ -1,0 +1,279 @@
+//
+//  PluginLoaderAbiValidationTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the loader's load-time validation:
+//  - a plugin ABI table missing any required function pointer is rejected
+//    BEFORE `init` is called (previously only `init`/`get_manifest` were
+//    checked, so nil `free_string`/`destroy`/`invoke` leaked or broke tools);
+//  - the legacy v1 entry path decodes through the explicit
+//    `osr_plugin_api_v1` prefix instead of the full struct (out-of-bounds
+//    read on historical v1 plugins otherwise);
+//  - manifest plugin_id must equal the install-directory-derived ID;
+//  - tool and route IDs must be non-empty and unique.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct PluginLoaderAbiValidationTests {
+
+    // MARK: - Fixtures
+
+    private static let dummyFree: osr_free_string_t = { _ in }
+    private static let dummyInit: osr_init_t = { nil }
+    private static let dummyDestroy: osr_destroy_t = { _ in }
+    private static let dummyManifest: osr_get_manifest_t = { _ in nil }
+    private static let dummyInvoke: osr_invoke_t = { _, _, _, _ in nil }
+
+    private func completeAPI() -> osr_plugin_api {
+        osr_plugin_api(
+            free_string: Self.dummyFree,
+            init: Self.dummyInit,
+            destroy: Self.dummyDestroy,
+            get_manifest: Self.dummyManifest,
+            invoke: Self.dummyInvoke,
+            version: 2,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+    }
+
+    private func makeManifest(
+        pluginId: String = "com.test.loader",
+        tools: [PluginManifest.ToolSpec]? = nil,
+        routes: [PluginManifest.RouteSpec]? = nil
+    ) -> PluginManifest {
+        PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(tools: tools, routes: routes, config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+    }
+
+    private func tool(_ id: String) -> PluginManifest.ToolSpec {
+        PluginManifest.ToolSpec(
+            id: id,
+            description: "test tool",
+            parameters: nil,
+            requirements: nil,
+            permission_policy: nil
+        )
+    }
+
+    private func route(_ id: String, path: String = "/x") -> PluginManifest.RouteSpec {
+        PluginManifest.RouteSpec(id: id, path: path, methods: ["GET"])
+    }
+
+    // MARK: - ABI table validation
+
+    @Test func completeTablePassesValidation() {
+        #expect(PluginManager.abiTableValidationFailure(completeAPI()) == nil)
+    }
+
+    @Test func missingFreeStringIsRejected() throws {
+        var api = completeAPI()
+        api.free_string = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("free_string"))
+    }
+
+    @Test func missingDestroyIsRejected() throws {
+        var api = completeAPI()
+        api.destroy = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("destroy"))
+    }
+
+    @Test func missingInvokeIsRejected() throws {
+        var api = completeAPI()
+        api.invoke = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("invoke"))
+    }
+
+    @Test func missingInitIsRejected() throws {
+        var api = completeAPI()
+        api.`init` = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("init"))
+    }
+
+    @Test func missingGetManifestIsRejected() throws {
+        var api = completeAPI()
+        api.get_manifest = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("get_manifest"))
+    }
+
+    @Test func allMissingFunctionsAreListed() throws {
+        let api = osr_plugin_api(
+            free_string: nil,
+            init: nil,
+            destroy: nil,
+            get_manifest: nil,
+            invoke: nil,
+            version: 0,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        for name in ["free_string", "init", "destroy", "get_manifest", "invoke"] {
+            #expect(msg.contains(name))
+        }
+    }
+
+    @Test func nilOptionalV2CallbacksAreStillAccepted() {
+        // Optional v2+ callbacks (handle_route / on_config_changed /
+        // on_task_event) remain optional; only the required prefix is gated.
+        var api = completeAPI()
+        api.handle_route = nil
+        api.on_config_changed = nil
+        api.on_task_event = nil
+        #expect(PluginManager.abiTableValidationFailure(api) == nil)
+    }
+
+    // MARK: - v1 prefix decode
+
+    @Test func v1PrefixLayoutIsExactlyTheFiveRequiredPointers() {
+        // The v1 entry path reads plugin memory through this struct — its
+        // size must be exactly five function pointers so the loader never
+        // reads past the end of a historical v1 plugin's static table.
+        #expect(MemoryLayout<osr_plugin_api_v1>.size == 5 * MemoryLayout<UnsafeRawPointer?>.size)
+        #expect(MemoryLayout<osr_plugin_api_v1>.size < MemoryLayout<osr_plugin_api>.size)
+    }
+
+    @Test func v1PrefixWidensWithOptionalFieldsZeroed() {
+        let prefix = osr_plugin_api_v1(
+            free_string: Self.dummyFree,
+            init: Self.dummyInit,
+            destroy: Self.dummyDestroy,
+            get_manifest: Self.dummyManifest,
+            invoke: Self.dummyInvoke
+        )
+
+        let widened = osr_plugin_api(v1: prefix)
+
+        #expect(widened.free_string != nil)
+        #expect(widened.`init` != nil)
+        #expect(widened.destroy != nil)
+        #expect(widened.get_manifest != nil)
+        #expect(widened.invoke != nil)
+        #expect(widened.version == 0)
+        #expect(widened.handle_route == nil)
+        #expect(widened.on_config_changed == nil)
+        #expect(widened.on_task_event == nil)
+    }
+
+    @Test func v1PrefixWideningPassesAbiValidationWhenComplete() {
+        let prefix = osr_plugin_api_v1(
+            free_string: Self.dummyFree,
+            init: Self.dummyInit,
+            destroy: Self.dummyDestroy,
+            get_manifest: Self.dummyManifest,
+            invoke: Self.dummyInvoke
+        )
+        #expect(PluginManager.abiTableValidationFailure(osr_plugin_api(v1: prefix)) == nil)
+    }
+
+    @Test func v1PrefixWideningStillRejectsIncompleteTable() throws {
+        let prefix = osr_plugin_api_v1(
+            free_string: nil,
+            init: Self.dummyInit,
+            destroy: nil,
+            get_manifest: Self.dummyManifest,
+            invoke: nil
+        )
+        let msg = try #require(
+            PluginManager.abiTableValidationFailure(osr_plugin_api(v1: prefix))
+        )
+        #expect(msg.contains("free_string"))
+        #expect(msg.contains("destroy"))
+        #expect(msg.contains("invoke"))
+    }
+
+    // MARK: - Manifest identity validation
+
+    @Test func matchingManifestAndDirectoryIdPasses() {
+        let manifest = makeManifest(pluginId: "com.test.match")
+        #expect(
+            PluginManager.manifestIdentityValidationFailure(
+                manifest: manifest,
+                directoryId: "com.test.match"
+            ) == nil
+        )
+    }
+
+    @Test func mismatchedManifestIdIsRejected() throws {
+        let manifest = makeManifest(pluginId: "com.test.impostor")
+        let msg = try #require(
+            PluginManager.manifestIdentityValidationFailure(
+                manifest: manifest,
+                directoryId: "com.test.victim"
+            )
+        )
+        #expect(msg.contains("com.test.impostor"))
+        #expect(msg.contains("com.test.victim"))
+    }
+
+    // MARK: - Tool / route ID validation
+
+    @Test func absentCapabilitiesPass() {
+        #expect(PluginManager.manifestCapabilityValidationFailure(makeManifest()) == nil)
+    }
+
+    @Test func uniqueToolAndRouteIdsPass() {
+        let manifest = makeManifest(
+            tools: [tool("a"), tool("b")],
+            routes: [route("r1"), route("r2", path: "/y")]
+        )
+        #expect(PluginManager.manifestCapabilityValidationFailure(manifest) == nil)
+    }
+
+    @Test func emptyToolIdIsRejected() throws {
+        let manifest = makeManifest(tools: [tool("")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("empty"))
+        #expect(msg.contains("tool"))
+    }
+
+    @Test func whitespaceOnlyToolIdIsRejected() throws {
+        let manifest = makeManifest(tools: [tool("   ")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("empty"))
+    }
+
+    @Test func duplicateToolIdIsRejected() throws {
+        let manifest = makeManifest(tools: [tool("dup"), tool("dup")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("duplicate"))
+        #expect(msg.contains("dup"))
+    }
+
+    @Test func emptyRouteIdIsRejected() throws {
+        let manifest = makeManifest(routes: [route("")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("empty"))
+        #expect(msg.contains("route"))
+    }
+
+    @Test func duplicateRouteIdIsRejected() throws {
+        let manifest = makeManifest(routes: [route("dup"), route("dup", path: "/other")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("duplicate"))
+        #expect(msg.contains("dup"))
+    }
+}


### PR DESCRIPTION
## Summary

Host/harness fixes from the July 2026 plugin reliability audit (loader-abi theme). Part of a 5-branch series; each branch is independent and separately mergeable. Full campaign notes cover all five themes.

### 2. `audit/loader-abi` (1 commit)

Commit:
- `82135263` Validate plugin ABI table, v1 prefix decode, and manifest/tool/route identity at load

Confirmed defects fixed (all in `Packages/OsaurusCore/Managers/Plugin/PluginManager.swift` and `Models/Plugin/ExternalPlugin.swift`):
- **High** — loader only required `init` and `get_manifest`; nil `free_string` (leaks every returned string), `destroy` (no teardown), or `invoke` (broken tools) were accepted. `abiTableValidationFailure` now rejects incomplete ABI tables before `init` is called.
- **High** — the v1 entry path read `apiPtr.pointee` as the full current `osr_plugin_api` struct, reading past the end of a historical v1 plugin's static struct (out-of-bounds read of whatever follows it in the binary). New `osr_plugin_api_v1` prefix struct decodes exactly the five required members and widens into the full layout with v2+ slots zeroed.
- **Medium** — no load-time identity validation: manifest `plugin_id` could differ from the receipt/install-directory id (previously "re-keyed" silently), two plugins could load under the same id, and duplicate/empty tool or route ids were accepted. Load now fails on manifest/directory id mismatch, rejects duplicate loaded plugin ids (newcomer is shut down), and rejects empty or duplicate tool/route ids.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift` — ABI completeness matrix, v1 prefix widening (zeroed v2+ slots, version 0), id-mismatch failure, duplicate/empty tool and route id failures.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginLoaderAbiValidationTests|PluginAbiHandshakeTests'` — 28 tests passed.

### 3. `audit/route-reliability` (1 commit)

Commit:
- `22b84a1f` Fix route handler timeout race and segment-boundary web mount matching

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift` — `handleRoute` implemented its 30s timeout with `withThrowingTaskGroup`; task groups drain children before returning, so a blocking C route callback (which never observes Swift cancellation) held the HTTP caller for the full duration of the call — the timeout never fired from the request's perspective. Replaced with the unstructured-body-task + GCD-timer race already used by `ToolRegistry.runToolBody` (new `RouteHandlerRaceState`), so the caller is resumed the moment the timer wins while the abandoned callback finishes on the plugin's invoke queue.
- **Medium** `Networking/HTTPHandler.swift` + `Managers/Plugin/PluginManager.swift` — static web mount dispatch used bare `subpath.hasPrefix(mountPrefix)`, so mount `/ui` captured `/ui-other`, disagreeing with the load-time web/route overlap validation (which already used segment-boundary logic). Both now call one shared helper, `PluginManifest.WebSpec.mountCaptures` / `relativeSubpath` / `normalizedMount`, so validation and dispatch cannot diverge.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift` — elapsed wall-time assertion with a deliberately blocking C route callback (semaphore-held; asserts the caller returns at the 0.5s timeout instead of blocking until release), fast-path control, and mount matching for `/ui`, `/ui/x`, `/ui-other`, `/`, plus normalization (`ui`, `/ui/`) and relative-subpath expectations.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginRouteReliabilityTests|PluginRoutingTests'` — 22 tests in 6 suites passed (includes existing routing/static-file containment suites).

### 4. `audit/lifecycle-config` (1 commit)

Commit:
- `c601dd68` Order plugin teardown before secret sweep on agent delete; unify config default resolution

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Managers/AgentManager.swift` + `Managers/Plugin/PluginManager.swift` — `AgentManager.delete(id:)` swept `ToolSecretsKeychain` for the agent BEFORE posting `.agentRemoved`; the `.agentRemoved` handler was additionally fire-and-forget (Task + detached push), so plugins reading config (e.g. Telegram's `bot_token`) during webhook deregistration found nothing — the webhook stayed registered upstream. New awaitable `PluginManager.tearDownPluginsForRemovedAgent(agentId:)` delivers `tunnel_url=""` to every routed plugin via the synchronous config path and returns only after each plugin's `on_config_changed` completes; `delete` awaits it and only then sweeps. The notification-driven handler remains as an idempotent backstop (deduped plugin-side).
- **Medium** `Services/Keychain/ToolSecretsKeychain.swift` + `Services/Plugin/PluginHostAPI.swift` + `Managers/Plugin/PluginManager.swift` — inconsistent default semantics: tool payload injection merged `Agent.defaultId` values as global defaults (`resolvedSecretsWithDefaults`), but `config_get`, initial config delivery, and required-secret checks (`hasAllRequiredSecrets` / `getMissingRequiredSecrets`) read only the exact agent namespace — a key saved once on the Plugins tab was "configured" for injection but invisible to `config_get`. Centralized one policy, `ToolSecretsKeychain.resolvedSecret(id:for:agentId:)` (exact agent first, then default-agent fallback), and pointed all three paths at it. The anonymous-context guard (no agent → nil) is unchanged; UI editors (`PluginConfigView`, `ToolSecretsSheet`) intentionally keep exact-namespace reads since they edit a specific agent's values.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift` — ordering test driving a real `ExternalPlugin` whose C `on_config_changed` reads `bot_token` mid-teardown (asserts the token is readable during deregistration and swept afterwards, all before `delete` returns); resolution-policy tests: exact-wins, default fallback, missing-everywhere, required-secret checks honoring the fallback, and `config_get` through a TLS-scoped `PluginHostContext` (fallback + exact + anonymous-refusal).

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'AgentDeletionPluginTeardownOrderingTests|ToolSecretsResolutionPolicyTests|AgentManagerLifecycleNotificationTests|ResolvedSecretsMergingTests'` — 18 tests in 4 suites passed (includes the pre-existing lifecycle-notification and secrets-merge suites, confirming no ordering regressions).

### 5. `audit/ci-coverage` (1 commit)

Commit:
- `a6e1737b` Add CI lanes for OsaurusRepository, OsaurusPluginTestKit, and StatsPack tests

Changes (`.github/workflows/ci.yml`):
- New `test-packages` job: `swift test --package-path Packages/OsaurusRepository --parallel` and `swift test --package-path Packages/OsaurusPluginTestKit --parallel` on `macos-26` with the pinned Xcode toolchain and `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` (matching test-evals). Both packages are light (Foundation/OsaurusNetworking deps), no build cache needed.
- New `test-statspack` job: `swift test --package-path Packages/OsaurusPlugins/StatsPack` with its own SwiftPM `.build` cache mirroring the `test-evals` cache shape, because StatsPack depends on the full OsaurusCore graph (mlx `Cmlx` C++ + SQLCipher amalgamation, ~25–30 min cold).

Verification:
- YAML validated (`ruby -ryaml`).
- All three suites run green locally with the CI env: OsaurusRepository 59 tests (XCTest), OsaurusPluginTestKit 10 tests, StatsPack 20 tests.

Release-config loader verification (documented, not implemented):
`PluginManager.verifyDylibBeforeLoadWithError` short-circuits to `.success` under `#if DEBUG`; the Release-only body (receipt presence/parse, SHA-256 match, `SecStaticCodeCheckValidity` code-signature check, `.user_consent` gate) is compiled only in Release and never executes under any test lane (xcodebuild tests and all `swift test` lanes build Debug). A cheap Release test invocation is NOT feasible:
- `swift test -c release --package-path Packages/OsaurusCore` (or a Release xcodebuild test lane) cold-builds the whole OsaurusCore graph again in a second configuration — an additional ~25–30 min lane and a second DerivedData/.build cache for one function.
- The function is `private`, so even a Release test bundle can't call it directly; testing it properly would require a production refactor (extract the verification body into an always-compiled internal helper testable from Debug), which is out of scope for a CI-only branch. That refactor is the recommended follow-up (see proposals).

## Investigated, decided NOT to change

- `ToolsVerify` "verified OK" wording and output format were preserved; only the skip-vs-fail semantics changed, to keep script consumers working.
- `PluginConfigView` / `ToolSecretsSheet` exact-namespace keychain reads: intentional (they edit a specific agent's values); the shared resolution policy applies to what is fed to plugins, not to the editing UI.
- `handleAgentRemoved`'s notification-driven `tunnel_url=""` push was kept (not removed) as an idempotent backstop for any other `.agentRemoved` poster; plugin-side delivery dedup prevents double `on_config_changed` firing.
- The route-timeout fix deliberately leaves the abandoned blocking C callback running on the plugin's invoke queue (matching `runToolBody` semantics) — forcibly killing plugin threads would be an architectural change.
- v2 entry path (`osaurus_plugin_entry_v2`) already receives the host struct and returns the full current `osr_plugin_api`; only the v1 path had the prefix-read hazard.
- No out-of-process isolation, TUF metadata, or hot-reload rework, per instructions.

## Checks that still require live credentials/permissions

- Code-signature verification (`SecStaticCodeCheckValidity`) and the full Release-only `verifyDylibBeforeLoadWithError` path need a signed dylib and a Release build — not exercised by unit tests (see ci-coverage notes).
- Real Keychain behavior: unit tests use the in-memory test store (`XCTestConfigurationFilePath`/xctest detection) or the disabled-keychain mode; securityd interaction paths (auth prompts, XPC stalls) are not covered.
