### PR TITLE
Reliability audit: enforce route timeouts, segment-boundary mount matching

### DIFF
--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -1088,12 +1088,13 @@ final class PluginManager {
         if let mount = manifest.capabilities.web?.mount,
             let routes = manifest.capabilities.routes
         {
-            let normalizedMount = mount.hasPrefix("/") ? mount : "/\(mount)"
             for route in routes {
                 let routePath = route.path.hasPrefix("/") ? route.path : "/\(route.path)"
-                let isShadowed =
-                    routePath == normalizedMount
-                    || routePath.hasPrefix(normalizedMount + "/")
+                // Same segment-boundary helper HTTPHandler uses for static
+                // dispatch, so validation and runtime can never disagree
+                // about which paths the mount captures.
+                let isShadowed = PluginManifest.WebSpec.mountCaptures(
+                    subpath: routePath, mount: mount)
                 if isShadowed {
                     let errorMsg =
                         "Plugin \(manifest.plugin_id) declares route '\(route.path)' under web mount '\(mount)'; the static web branch would shadow this route. Move the route outside the web mount or remove the web mount overlap."

--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -417,6 +417,40 @@ public struct PluginManifest: Decodable, Sendable {
 
         /// Computed convenience: treats nil as the default (false).
         public var isTunnelExposed: Bool { tunnel_exposed == true }
+
+        // MARK: Mount matching (shared by load-time validation and dispatch)
+
+        /// Canonical mount shape: leading `/`, no trailing `/` (except the
+        /// root mount `/` itself).
+        public static func normalizedMount(_ mount: String) -> String {
+            var m = mount.trimmingCharacters(in: .whitespaces)
+            if !m.hasPrefix("/") { m = "/" + m }
+            while m.count > 1 && m.hasSuffix("/") { m.removeLast() }
+            return m
+        }
+
+        /// Segment-boundary mount matching: mount `/ui` captures `/ui` and
+        /// `/ui/...` but NOT `/ui-other`. A bare prefix check disagreed with
+        /// the load-time overlap validation and let one plugin's static
+        /// branch swallow sibling paths. The root mount `/` captures
+        /// everything. Both `PluginManager`'s web/route overlap validation
+        /// and `HTTPHandler`'s static dispatch call this single helper so
+        /// they can never diverge again.
+        public static func mountCaptures(subpath: String, mount: String) -> Bool {
+            let m = normalizedMount(mount)
+            if m == "/" { return true }
+            return subpath == m || subpath.hasPrefix(m + "/")
+        }
+
+        /// Remainder of `subpath` after the mount: `""` for the mount root,
+        /// otherwise a `/`-prefixed path (`/ui/x` under mount `/ui` → `/x`).
+        /// Only meaningful when `mountCaptures` is true.
+        public static func relativeSubpath(subpath: String, mount: String) -> String {
+            let m = normalizedMount(mount)
+            if m == "/" { return subpath == "/" ? "" : subpath }
+            guard mountCaptures(subpath: subpath, mount: mount) else { return subpath }
+            return String(subpath.dropFirst(m.count))
+        }
     }
 
     // MARK: - Docs Spec
@@ -530,6 +564,75 @@ public struct PluginManifest: Decodable, Sendable {
         // Must have actually used the parameter mechanism to be a "param" match;
         // exact matches were already returned above and shouldn't reach here.
         return hadParam ? params : nil
+    }
+}
+
+/// Timer queue for the route-handler wall-clock race. A dedicated GCD queue
+/// (not `Task.sleep`) so a saturated Swift executor cannot delay the timeout
+/// behind unrelated async work — same rationale as `ToolRegistry`'s
+/// tool-body timeout queue.
+private let routeHandlerTimeoutQueue = DispatchQueue(label: "com.osaurus.plugin.route-timeout")
+
+/// One-shot race between a route-handler body and its timeout, mirroring
+/// `ToolBodyRaceState` in `ToolRegistry`. Whichever side completes first
+/// resumes the continuation; the loser is cancelled/ignored. Crucially the
+/// caller is resumed WITHOUT waiting for the body task to finish — a
+/// blocking C callback that ignores cancellation keeps running on the
+/// plugin's invoke queue, but the HTTP request gets its timeout response.
+private final class RouteHandlerRaceState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+    private var pendingResult: Result<String, Error>?
+    private var continuation: CheckedContinuation<String, Error>?
+    private var bodyTask: Task<Void, Never>?
+    private var timeoutTimer: DispatchSourceTimer?
+
+    func install(continuation: CheckedContinuation<String, Error>) {
+        lock.lock()
+        if didResume, let pendingResult {
+            self.pendingResult = nil
+            lock.unlock()
+            continuation.resume(with: pendingResult)
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func setTasks(bodyTask: Task<Void, Never>, timeoutTimer: DispatchSourceTimer) {
+        lock.lock()
+        if didResume {
+            lock.unlock()
+            bodyTask.cancel()
+            timeoutTimer.cancel()
+            return
+        }
+        self.bodyTask = bodyTask
+        self.timeoutTimer = timeoutTimer
+        lock.unlock()
+    }
+
+    func complete(_ result: Result<String, Error>) {
+        lock.lock()
+        guard !didResume else {
+            lock.unlock()
+            return
+        }
+        didResume = true
+        let continuation = self.continuation
+        if continuation == nil {
+            pendingResult = result
+        }
+        self.continuation = nil
+        let bodyTask = self.bodyTask
+        let timeoutTimer = self.timeoutTimer
+        self.bodyTask = nil
+        self.timeoutTimer = nil
+        lock.unlock()
+
+        bodyTask?.cancel()
+        timeoutTimer?.cancel()
+        continuation?.resume(with: result)
     }
 }
 
@@ -962,29 +1065,47 @@ final class ExternalPlugin: @unchecked Sendable {
             }
         }
 
-        return try await withThrowingTaskGroup(of: String?.self) { group in
-            group.addTask { try await work() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
-                return nil
+        // Unstructured task + GCD timer race (mirrors `ToolRegistry.runToolBody`).
+        // A `withThrowingTaskGroup` here would drain its children before
+        // returning, so a blocking C route callback that ignores cancellation
+        // held the caller for the FULL duration of the call — the 30s timeout
+        // never actually fired from the request's point of view. The race
+        // resumes the caller as soon as the timer wins; the abandoned body
+        // task keeps running on the plugin's invoke queue until the C call
+        // returns, but the HTTP request is no longer held hostage.
+        let timeoutError = NSError(
+            domain: "ExternalPlugin",
+            code: 5,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Plugin route handler timed out after \(Int(timeoutSeconds))s"
+            ]
+        )
+        let race = RouteHandlerRaceState()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                race.install(continuation: continuation)
+                let timeoutTimer = DispatchSource.makeTimerSource(queue: routeHandlerTimeoutQueue)
+                let timeoutNanoseconds = max(0, Int(timeoutSeconds * 1_000_000_000))
+                timeoutTimer.schedule(deadline: .now() + .nanoseconds(timeoutNanoseconds))
+                timeoutTimer.setEventHandler {
+                    race.complete(.failure(timeoutError))
+                }
+                timeoutTimer.resume()
+
+                let bodyTask = Task {
+                    do {
+                        let result = try await work()
+                        race.complete(.success(result))
+                    } catch {
+                        race.complete(.failure(error))
+                    }
+                }
+                race.setTasks(bodyTask: bodyTask, timeoutTimer: timeoutTimer)
             }
-            for try await first in group {
-                group.cancelAll()
-                if let value = first { return value }
-                throw NSError(
-                    domain: "ExternalPlugin",
-                    code: 5,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "Plugin route handler timed out after \(Int(timeoutSeconds))s"
-                    ]
-                )
-            }
-            throw NSError(
-                domain: "ExternalPlugin",
-                code: 5,
-                userInfo: [NSLocalizedDescriptionKey: "Plugin route handler returned without result"]
-            )
+        } onCancel: {
+            race.complete(.failure(CancellationError()))
         }
     }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1755,10 +1755,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let manifest = loaded.plugin.manifest
 
-            // Check for static web serving first
+            // Check for static web serving first. Segment-boundary matching
+            // via the shared helper: mount `/ui` must NOT capture `/ui-other`
+            // (a bare `hasPrefix` did, disagreeing with the load-time
+            // web/route overlap validation in PluginManager).
             if let webSpec = loaded.webConfig {
-                let mountPrefix = webSpec.mount.hasPrefix("/") ? webSpec.mount : "/\(webSpec.mount)"
-                if subpath.hasPrefix(mountPrefix) {
+                if PluginManifest.WebSpec.mountCaptures(subpath: subpath, mount: webSpec.mount) {
                     // Tunnel exposure gate: web UIs are loopback-only by
                     // default. Plugins must opt in via `capabilities.web.tunnel_exposed`
                     // for the static UI to be reachable over the tunnel.
@@ -1795,7 +1797,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
                     // Check for dev proxy configuration
                     if let proxyURL = Self.loadDevProxyURL(for: pluginId) {
-                        let relPath = String(subpath.dropFirst(mountPrefix.count))
+                        let relPath = PluginManifest.WebSpec.relativeSubpath(
+                            subpath: subpath, mount: webSpec.mount)
                         let targetPath = relPath.isEmpty ? "/" : relPath
                         // Forward the original method/headers/body so HMR,
                         // POST APIs, and any non-GET dev-server traffic
@@ -1824,7 +1827,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         )
                     }
 
-                    let relPath = String(subpath.dropFirst(mountPrefix.count))
+                    let relPath = PluginManifest.WebSpec.relativeSubpath(
+                        subpath: subpath, mount: webSpec.mount)
                     let filePath: String
                     if relPath.isEmpty || relPath == "/" {
                         filePath = webSpec.entry

--- a/Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift
@@ -1,0 +1,237 @@
+//
+//  PluginRouteReliabilityTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for two route-dispatch reliability defects:
+//
+//  1. `ExternalPlugin.handleRoute` used `withThrowingTaskGroup` for its 30s
+//     timeout. Task groups drain their children before returning, so a
+//     blocking C route callback (which never observes Swift cancellation)
+//     held the HTTP request for the FULL duration of the call — the timeout
+//     never fired from the caller's point of view. The fix races an
+//     unstructured body task against a GCD timer (same pattern as
+//     `ToolRegistry.runToolBody`) and resumes the caller as soon as the
+//     timer wins. The test below pins ELAPSED WALL TIME with a deliberately
+//     blocking route callback.
+//
+//  2. Static web mount matching used a bare `subpath.hasPrefix(mountPrefix)`,
+//     so mount `/ui` captured `/ui-other` — disagreeing with the load-time
+//     web/route overlap validation. Both validation and dispatch now share
+//     `PluginManifest.WebSpec.mountCaptures`, tested here for the exact
+//     paths from the audit (`/ui`, `/ui/x`, `/ui-other`, `/`).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct PluginRouteReliabilityTests {
+
+    // MARK: - Route handler timeout race
+
+    /// Shared with the C route callback via the plugin's opaque `ctx`.
+    final class RouteRecorder: @unchecked Sendable {
+        /// Signaled once the blocking callback is inside plugin code.
+        let callbackStarted = DispatchSemaphore(value: 0)
+        /// The blocking callback waits on this before returning, so the test
+        /// controls exactly how long the "hung" C call lasts.
+        let releaseCallback = DispatchSemaphore(value: 0)
+        /// Signaled when the blocking callback finally returns (cleanup sync).
+        let callbackFinished = DispatchSemaphore(value: 0)
+    }
+
+    private func makeManifest(pluginId: String) -> PluginManifest {
+        PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(tools: nil, routes: nil, config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+    }
+
+    private func makePlugin(
+        recorder: RouteRecorder,
+        pluginId: String,
+        handleRoute: @escaping osr_handle_route_t
+    ) -> (plugin: ExternalPlugin, retain: Unmanaged<RouteRecorder>) {
+        let retain = Unmanaged.passRetained(recorder)
+        let ctx = retain.toOpaque()
+        let api = osr_plugin_api(
+            free_string: { ptr in
+                guard let ptr else { return }
+                free(UnsafeMutableRawPointer(mutating: ptr))
+            },
+            init: nil,
+            destroy: { _ in },
+            get_manifest: nil,
+            invoke: { _, _, _, _ in nil },
+            version: 6,
+            handle_route: handleRoute,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+        let plugin = ExternalPlugin(
+            handle: ctx,
+            api: api,
+            ctx: ctx,
+            manifest: makeManifest(pluginId: pluginId),
+            path: "/tmp/route-reliability-\(pluginId)",
+            abiVersion: 6
+        )
+        return (plugin, retain)
+    }
+
+    /// Async-safe semaphore wait (Swift 6 forbids blocking a concurrency-pool
+    /// thread), mirroring the helper in `PluginShutdownRaceTests`.
+    private func signaled(_ sem: DispatchSemaphore, within timeout: TimeInterval = 10) async -> Bool {
+        await withCheckedContinuation { cont in
+            DispatchQueue.global().async {
+                cont.resume(returning: sem.wait(timeout: .now() + timeout) == .success)
+            }
+        }
+    }
+
+    /// The core regression: a route callback that blocks inside C code
+    /// (ignoring Swift cancellation entirely) must NOT hold the caller past
+    /// the timeout. Before the fix, `handleRoute` returned only after the
+    /// blocking callback itself returned — wall time equaled the callback's
+    /// block duration, not the timeout.
+    @Test
+    func blockingRouteCallbackDoesNotDefeatTimeout() async throws {
+        let recorder = RouteRecorder()
+        let (plugin, retain) = makePlugin(
+            recorder: recorder,
+            pluginId: "com.test.route-timeout.\(UUID().uuidString)"
+        ) { ctxPtr, _ in
+            guard let ctxPtr else { return nil }
+            let recorder = Unmanaged<RouteRecorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+            recorder.callbackStarted.signal()
+            // Deliberately blocking, non-cooperative — models a plugin stuck
+            // in a synchronous network call or a deadlocked mutex.
+            recorder.releaseCallback.wait()
+            recorder.callbackFinished.signal()
+            return UnsafePointer(strdup(#"{"status":200,"body":"too late"}"#))
+        }
+
+        let timeoutSeconds: TimeInterval = 0.5
+        let start = ContinuousClock.now
+        var thrownError: NSError?
+        do {
+            _ = try await plugin.handleRoute(
+                requestJSON: #"{"path":"/hook"}"#,
+                timeoutSeconds: timeoutSeconds
+            )
+        } catch {
+            thrownError = error as NSError
+        }
+        let elapsed = start.duration(to: .now)
+
+        // The callback really was inside plugin code when the timeout fired.
+        #expect(await signaled(recorder.callbackStarted))
+
+        // Timeout error surfaced...
+        let error = try #require(thrownError, "handleRoute must throw on timeout")
+        #expect(error.domain == "ExternalPlugin")
+        #expect(error.code == 5)
+        #expect(error.localizedDescription.contains("timed out"))
+
+        // ...and — the actual regression — the caller was resumed at
+        // timeout-time, not when the blocked callback eventually returned.
+        // Generous ceiling for loaded CI machines; before the fix the wall
+        // time here was unbounded (the callback blocks until we signal).
+        #expect(
+            elapsed < .seconds(5),
+            "caller must be released at the timeout, not when the blocking callback returns (elapsed: \(elapsed))"
+        )
+
+        // Cleanup: unblock the abandoned callback and wait for it to leave
+        // plugin code before the recorder is released.
+        recorder.releaseCallback.signal()
+        #expect(await signaled(recorder.callbackFinished))
+        // Give the abandoned dispatchPluginCall a beat to consume the result.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        retain.release()
+    }
+
+    /// Happy-path control: a fast route handler returns its own response
+    /// well before a generous timeout — the race must not fire spuriously.
+    @Test
+    func fastRouteCallbackReturnsItsResponse() async throws {
+        let recorder = RouteRecorder()
+        let (plugin, retain) = makePlugin(
+            recorder: recorder,
+            pluginId: "com.test.route-fast.\(UUID().uuidString)"
+        ) { _, _ in
+            UnsafePointer(strdup(#"{"status":200,"body":"ok"}"#))
+        }
+        defer { retain.release() }
+
+        let result = try await plugin.handleRoute(
+            requestJSON: #"{"path":"/hook"}"#,
+            timeoutSeconds: 60
+        )
+        #expect(result == #"{"status":200,"body":"ok"}"#)
+    }
+
+    // MARK: - Mount segment-boundary matching
+
+    @Test
+    func mountUiCapturesItselfAndChildrenOnly() {
+        typealias Web = PluginManifest.WebSpec
+        // Exact mount and children are captured.
+        #expect(Web.mountCaptures(subpath: "/ui", mount: "/ui"))
+        #expect(Web.mountCaptures(subpath: "/ui/x", mount: "/ui"))
+        #expect(Web.mountCaptures(subpath: "/ui/x/y", mount: "/ui"))
+        // The regression: `/ui-other` shares the character prefix but is a
+        // different path segment and must NOT be captured.
+        #expect(!Web.mountCaptures(subpath: "/ui-other", mount: "/ui"))
+        #expect(!Web.mountCaptures(subpath: "/ui-other/x", mount: "/ui"))
+        // Unrelated paths.
+        #expect(!Web.mountCaptures(subpath: "/", mount: "/ui"))
+        #expect(!Web.mountCaptures(subpath: "/api", mount: "/ui"))
+    }
+
+    @Test
+    func rootMountCapturesEverything() {
+        typealias Web = PluginManifest.WebSpec
+        #expect(Web.mountCaptures(subpath: "/", mount: "/"))
+        #expect(Web.mountCaptures(subpath: "/ui", mount: "/"))
+        #expect(Web.mountCaptures(subpath: "/ui-other/x", mount: "/"))
+    }
+
+    @Test
+    func mountNormalizationHandlesMissingSlashAndTrailingSlash() {
+        typealias Web = PluginManifest.WebSpec
+        #expect(Web.normalizedMount("ui") == "/ui")
+        #expect(Web.normalizedMount("/ui/") == "/ui")
+        #expect(Web.normalizedMount("/") == "/")
+        #expect(Web.normalizedMount("ui/") == "/ui")
+        // Manifest authors who write `mount: "ui"` or `mount: "/ui/"` get
+        // the same matching behavior as `/ui`.
+        #expect(Web.mountCaptures(subpath: "/ui/x", mount: "ui"))
+        #expect(Web.mountCaptures(subpath: "/ui/x", mount: "/ui/"))
+        #expect(!Web.mountCaptures(subpath: "/ui-other", mount: "ui"))
+    }
+
+    @Test
+    func relativeSubpathMatchesLegacyDispatchExpectations() {
+        typealias Web = PluginManifest.WebSpec
+        // Mount root serves the entry file (dispatch checks isEmpty/"/").
+        #expect(Web.relativeSubpath(subpath: "/ui", mount: "/ui") == "")
+        #expect(Web.relativeSubpath(subpath: "/ui/x", mount: "/ui") == "/x")
+        #expect(Web.relativeSubpath(subpath: "/ui/x/y.js", mount: "/ui") == "/x/y.js")
+        // Root mount: keep the full subpath (entry for bare "/").
+        #expect(Web.relativeSubpath(subpath: "/", mount: "/") == "")
+        #expect(Web.relativeSubpath(subpath: "/x", mount: "/") == "/x")
+    }
+}


### PR DESCRIPTION
## Summary

Host/harness fixes from the July 2026 plugin reliability audit (route-reliability theme). Part of a 5-branch series; each branch is independent and separately mergeable. Full campaign notes cover all five themes.

### 3. `audit/route-reliability` (1 commit)

Commit:
- `22b84a1f` Fix route handler timeout race and segment-boundary web mount matching

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift` — `handleRoute` implemented its 30s timeout with `withThrowingTaskGroup`; task groups drain children before returning, so a blocking C route callback (which never observes Swift cancellation) held the HTTP caller for the full duration of the call — the timeout never fired from the request's perspective. Replaced with the unstructured-body-task + GCD-timer race already used by `ToolRegistry.runToolBody` (new `RouteHandlerRaceState`), so the caller is resumed the moment the timer wins while the abandoned callback finishes on the plugin's invoke queue.
- **Medium** `Networking/HTTPHandler.swift` + `Managers/Plugin/PluginManager.swift` — static web mount dispatch used bare `subpath.hasPrefix(mountPrefix)`, so mount `/ui` captured `/ui-other`, disagreeing with the load-time web/route overlap validation (which already used segment-boundary logic). Both now call one shared helper, `PluginManifest.WebSpec.mountCaptures` / `relativeSubpath` / `normalizedMount`, so validation and dispatch cannot diverge.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift` — elapsed wall-time assertion with a deliberately blocking C route callback (semaphore-held; asserts the caller returns at the 0.5s timeout instead of blocking until release), fast-path control, and mount matching for `/ui`, `/ui/x`, `/ui-other`, `/`, plus normalization (`ui`, `/ui/`) and relative-subpath expectations.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginRouteReliabilityTests|PluginRoutingTests'` — 22 tests in 6 suites passed (includes existing routing/static-file containment suites).

### 4. `audit/lifecycle-config` (1 commit)

Commit:
- `c601dd68` Order plugin teardown before secret sweep on agent delete; unify config default resolution

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Managers/AgentManager.swift` + `Managers/Plugin/PluginManager.swift` — `AgentManager.delete(id:)` swept `ToolSecretsKeychain` for the agent BEFORE posting `.agentRemoved`; the `.agentRemoved` handler was additionally fire-and-forget (Task + detached push), so plugins reading config (e.g. Telegram's `bot_token`) during webhook deregistration found nothing — the webhook stayed registered upstream. New awaitable `PluginManager.tearDownPluginsForRemovedAgent(agentId:)` delivers `tunnel_url=""` to every routed plugin via the synchronous config path and returns only after each plugin's `on_config_changed` completes; `delete` awaits it and only then sweeps. The notification-driven handler remains as an idempotent backstop (deduped plugin-side).
- **Medium** `Services/Keychain/ToolSecretsKeychain.swift` + `Services/Plugin/PluginHostAPI.swift` + `Managers/Plugin/PluginManager.swift` — inconsistent default semantics: tool payload injection merged `Agent.defaultId` values as global defaults (`resolvedSecretsWithDefaults`), but `config_get`, initial config delivery, and required-secret checks (`hasAllRequiredSecrets` / `getMissingRequiredSecrets`) read only the exact agent namespace — a key saved once on the Plugins tab was "configured" for injection but invisible to `config_get`. Centralized one policy, `ToolSecretsKeychain.resolvedSecret(id:for:agentId:)` (exact agent first, then default-agent fallback), and pointed all three paths at it. The anonymous-context guard (no agent → nil) is unchanged; UI editors (`PluginConfigView`, `ToolSecretsSheet`) intentionally keep exact-namespace reads since they edit a specific agent's values.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift` — ordering test driving a real `ExternalPlugin` whose C `on_config_changed` reads `bot_token` mid-teardown (asserts the token is readable during deregistration and swept afterwards, all before `delete` returns); resolution-policy tests: exact-wins, default fallback, missing-everywhere, required-secret checks honoring the fallback, and `config_get` through a TLS-scoped `PluginHostContext` (fallback + exact + anonymous-refusal).

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'AgentDeletionPluginTeardownOrderingTests|ToolSecretsResolutionPolicyTests|AgentManagerLifecycleNotificationTests|ResolvedSecretsMergingTests'` — 18 tests in 4 suites passed (includes the pre-existing lifecycle-notification and secrets-merge suites, confirming no ordering regressions).

### 5. `audit/ci-coverage` (1 commit)

Commit:
- `a6e1737b` Add CI lanes for OsaurusRepository, OsaurusPluginTestKit, and StatsPack tests

Changes (`.github/workflows/ci.yml`):
- New `test-packages` job: `swift test --package-path Packages/OsaurusRepository --parallel` and `swift test --package-path Packages/OsaurusPluginTestKit --parallel` on `macos-26` with the pinned Xcode toolchain and `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` (matching test-evals). Both packages are light (Foundation/OsaurusNetworking deps), no build cache needed.
- New `test-statspack` job: `swift test --package-path Packages/OsaurusPlugins/StatsPack` with its own SwiftPM `.build` cache mirroring the `test-evals` cache shape, because StatsPack depends on the full OsaurusCore graph (mlx `Cmlx` C++ + SQLCipher amalgamation, ~25–30 min cold).

Verification:
- YAML validated (`ruby -ryaml`).
- All three suites run green locally with the CI env: OsaurusRepository 59 tests (XCTest), OsaurusPluginTestKit 10 tests, StatsPack 20 tests.

Release-config loader verification (documented, not implemented):
`PluginManager.verifyDylibBeforeLoadWithError` short-circuits to `.success` under `#if DEBUG`; the Release-only body (receipt presence/parse, SHA-256 match, `SecStaticCodeCheckValidity` code-signature check, `.user_consent` gate) is compiled only in Release and never executes under any test lane (xcodebuild tests and all `swift test` lanes build Debug). A cheap Release test invocation is NOT feasible:
- `swift test -c release --package-path Packages/OsaurusCore` (or a Release xcodebuild test lane) cold-builds the whole OsaurusCore graph again in a second configuration — an additional ~25–30 min lane and a second DerivedData/.build cache for one function.
- The function is `private`, so even a Release test bundle can't call it directly; testing it properly would require a production refactor (extract the verification body into an always-compiled internal helper testable from Debug), which is out of scope for a CI-only branch. That refactor is the recommended follow-up (see proposals).

## Investigated, decided NOT to change

- `ToolsVerify` "verified OK" wording and output format were preserved; only the skip-vs-fail semantics changed, to keep script consumers working.
- `PluginConfigView` / `ToolSecretsSheet` exact-namespace keychain reads: intentional (they edit a specific agent's values); the shared resolution policy applies to what is fed to plugins, not to the editing UI.
- `handleAgentRemoved`'s notification-driven `tunnel_url=""` push was kept (not removed) as an idempotent backstop for any other `.agentRemoved` poster; plugin-side delivery dedup prevents double `on_config_changed` firing.
- The route-timeout fix deliberately leaves the abandoned blocking C callback running on the plugin's invoke queue (matching `runToolBody` semantics) — forcibly killing plugin threads would be an architectural change.
- v2 entry path (`osaurus_plugin_entry_v2`) already receives the host struct and returns the full current `osr_plugin_api`; only the v1 path had the prefix-read hazard.
- No out-of-process isolation, TUF metadata, or hot-reload rework, per instructions.

## Checks that still require live credentials/permissions

- Code-signature verification (`SecStaticCodeCheckValidity`) and the full Release-only `verifyDylibBeforeLoadWithError` path need a signed dylib and a Release build — not exercised by unit tests (see ci-coverage notes).
- Real Keychain behavior: unit tests use the in-memory test store (`XCTestConfigurationFilePath`/xctest detection) or the disabled-keychain mode; securityd interaction paths (auth prompts, XPC stalls) are not covered.
- Live registry installs (minisign verification against the production registry, network download paths) and real tunnel/relay webhook deregistration (Telegram etc.) require network and credentials.
- The full OsaurusCoreTests xcodebuild scheme (as CI runs it) was not run locally end-to-end; per task instructions, targeted plugin/lifecycle/route suites were run via `swift test --filter` (exact commands and results listed per branch above). Note for local repro: OsaurusCore `swift test` runs need `XCTestConfigurationFilePath` set (any value) for the in-memory keychain store to activate under `swiftpm-testing-helper`; CI's xcodebuild sets it natively.

## Optional upgrade proposals (NOT implemented)

1. Extract the Release-only dylib verification body into an always-compiled internal `verifyInstalledDylib(receiptURL:dylibURL:)` helper so Debug tests can cover receipt/SHA/consent failures; keep only the "skip in DEBUG" decision behind `#if DEBUG`.
2. `ToolsInstall` manual installs bypass minisign entirely (by design, gated on `--consent`); consider requiring a `--insecure` style acknowledgment or checksum argument for remote URLs.
3. The `.agentRemoved`/`.agentAdded` NotificationCenter plumbing could become an async-awaitable protocol on a PluginLifecycle coordinator, removing the need for the belt-and-braces double push after deletion.
4. `resolveBestVersion` filters incompatible artifacts silently; surfacing "newer version exists but requires macOS X / Osaurus Y" to the UI would help users understand why updates don't appear.
5. Consider running the StatsPack CI job only on paths touching `Packages/OsaurusPlugins/**` or `Packages/OsaurusCore/**` to save runner minutes.
