### PR TITLE
Reliability audit: plugin teardown before secret sweep, unified config resolution

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -556,11 +556,19 @@ public final class AgentManager: ObservableObject {
 
         refresh()
 
+        // Tear down plugin state FIRST and wait for it to finish. Plugins
+        // deregister webhooks inside `on_config_changed(tunnel_url="")`
+        // and read their per-agent config (e.g. Telegram's `bot_token`)
+        // while doing so — the secrets must still exist at that point.
+        // Sweeping the keychain before this call left webhooks registered
+        // upstream forever because the plugin found no token to
+        // deregister with.
+        await PluginManager.shared.tearDownPluginsForRemovedAgent(agentId: id)
+
         // Sweep every plugin's per-agent secrets for this agent. Without
         // this, deleting an agent would leave its `bot_token` / OAuth
         // credentials / `tunnel_url` / etc. in Keychain Access forever.
-        // Done before posting `.agentRemoved` so subscribers see the
-        // post-cleanup keychain state.
+        // Done only AFTER plugin teardown completed (see above).
         ToolSecretsKeychain.deleteAllSecrets(forAgent: id)
 
         // Drop any greetings the pool was holding for this agent. We
@@ -573,9 +581,10 @@ public final class AgentManager: ObservableObject {
         // doesn't accumulate one VecturaKit instance per deleted agent.
         await MemorySearchService.shared.evictAgent(agentId: id.uuidString)
 
-        // Notify subscribers (e.g. PluginManager) so plugins can
-        // deregister webhooks (push tunnel_url=nil) and tear down any
-        // per-agent state of their own.
+        // Notify remaining subscribers. Plugin webhook deregistration
+        // already happened synchronously above; PluginManager's own
+        // `.agentRemoved` handler only performs an idempotent repeat
+        // (deduped plugin-side).
         NotificationCenter.default.post(
             name: .agentRemoved,
             object: nil,

--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -466,12 +466,18 @@ final class PluginManager {
         else { return }
 
         let allFieldKeys = Set(configSpec.sections.flatMap { $0.fields.map { $0.key } })
-        var values = ToolSecretsKeychain.getAllSecrets(for: pluginId, agentId: agentId)
+        // Shared resolution policy (exact agent overlaid on default-agent
+        // globals) so initial delivery matches tool payload injection —
+        // a key saved once on the Plugins tab reaches every agent's
+        // `on_config_changed`, not just the Default agent's.
+        var values = ToolSecretsKeychain.resolvedSecretsWithDefaults(
+            pluginId: pluginId, agentId: agentId)
 
         for section in configSpec.sections {
             for field in section.fields {
                 if values[field.key] == nil, field.type != .readonly, field.type != .status,
-                    let val = ToolSecretsKeychain.getSecret(id: field.key, for: pluginId, agentId: agentId)
+                    let val = ToolSecretsKeychain.resolvedSecret(
+                        id: field.key, for: pluginId, agentId: agentId)
                 {
                     values[field.key] = val
                 }
@@ -479,7 +485,8 @@ final class PluginManager {
                     values[field.key] = def.stringValue
                 }
                 if let connKey = field.connected_when, values[connKey] == nil,
-                    let val = ToolSecretsKeychain.getSecret(id: connKey, for: pluginId, agentId: agentId)
+                    let val = ToolSecretsKeychain.resolvedSecret(
+                        id: connKey, for: pluginId, agentId: agentId)
                 {
                     values[connKey] = val
                 }
@@ -564,8 +571,12 @@ final class PluginManager {
 
     /// Tear down per-agent state on every loaded plugin when an agent is
     /// deleted: push `tunnel_url=""` so plugins can deregister their
-    /// webhooks. Per-agent keychain secrets are swept by
-    /// `AgentManager.delete(id:)` itself before this handler runs.
+    /// webhooks. `AgentManager.delete(id:)` already ran the awaitable
+    /// `tearDownPluginsForRemovedAgent` before sweeping keychain secrets;
+    /// this notification-driven pass is a belt-and-braces repeat for any
+    /// other `.agentRemoved` poster — the plugin-side delivery dedup
+    /// filters the duplicate `tunnel_url=""` so `on_config_changed`
+    /// doesn't re-fire.
     private func handleAgentRemoved(_ agentId: UUID) {
         for loaded in plugins where !loaded.routes.isEmpty {
             pushTunnelURL(nil, to: loaded, agentId: agentId)
@@ -576,6 +587,41 @@ final class PluginManager {
         for pluginId in lastPushedTunnelURL.keys {
             lastPushedTunnelURL[pluginId]?.removeValue(forKey: agentId)
         }
+    }
+
+    /// Awaitable per-agent plugin teardown for agent deletion. Pushes
+    /// `tunnel_url=""` to every routed plugin through the SYNCHRONOUS
+    /// config-delivery path and returns only after each plugin's
+    /// `on_config_changed` has run.
+    ///
+    /// Ordering contract: `AgentManager.delete(id:)` must call this
+    /// BEFORE `ToolSecretsKeychain.deleteAllSecrets(forAgent:)`. Plugins
+    /// deregister webhooks inside this callback and read their config
+    /// (e.g. Telegram's `bot_token`) while doing so — sweeping the
+    /// keychain first made those reads return nothing, leaving the
+    /// webhook registered upstream forever.
+    func tearDownPluginsForRemovedAgent(agentId: UUID) async {
+        // Drop the host-side tunnel-push dedup entries regardless of
+        // whether any plugin needs a delivery.
+        for pluginId in lastPushedTunnelURL.keys {
+            lastPushedTunnelURL[pluginId]?.removeValue(forKey: agentId)
+        }
+
+        let routed = plugins.filter { !$0.routes.isEmpty }
+        guard !routed.isEmpty else { return }
+
+        // Off the main actor: the keychain write blocks on security-daemon
+        // XPC and `notifyConfigBatchSync` blocks until the plugin's C
+        // callback returns.
+        await Task.detached(priority: .userInitiated) {
+            for loaded in routed {
+                Self.persistTunnelURLSecret(nil, pluginId: loaded.plugin.id, agentId: agentId)
+                loaded.plugin.notifyConfigBatchSync(
+                    [(key: "tunnel_url", value: "")],
+                    agentId: agentId
+                )
+            }
+        }.value
     }
 
     private func handleTunnelStatusChange(_ statuses: [UUID: AgentRelayStatus]) {

--- a/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
@@ -105,6 +105,27 @@ public enum ToolSecretsKeychain {
         resolvedSecretsMerging(pluginId: pluginId, primary: agentId, defaults: Agent.defaultId)
     }
 
+    /// THE single per-key resolution policy: exact agent namespace first,
+    /// then the `Agent.defaultId` namespace as the global-default fallback
+    /// (Plugins-tab writes land there). This is the per-key equivalent of
+    /// `resolvedSecretsWithDefaults` and must be used by every read path
+    /// that feeds plugins — `config_get`, initial config delivery, and
+    /// required-secret checks — so they can't disagree with tool payload
+    /// injection about whether a key is configured.
+    public static func resolvedSecret(id: String, for pluginId: String, agentId: UUID) -> String? {
+        if let exact = getSecret(id: id, for: pluginId, agentId: agentId) {
+            return exact
+        }
+        guard agentId != Agent.defaultId else { return nil }
+        return getSecret(id: id, for: pluginId, agentId: Agent.defaultId)
+    }
+
+    /// `resolvedSecret` presence check (exact agent, then default-agent
+    /// fallback).
+    public static func hasResolvedSecret(id: String, for pluginId: String, agentId: UUID) -> Bool {
+        resolvedSecret(id: id, for: pluginId, agentId: agentId) != nil
+    }
+
     /// Two-id merge primitive: `primary` agent's secrets overlaid on `defaults`.
     public static func resolvedSecretsMerging(pluginId: String, primary: UUID, defaults: UUID) -> [String: String] {
         let defaultDict = getAllSecrets(for: pluginId, agentId: defaults)
@@ -115,11 +136,15 @@ public enum ToolSecretsKeychain {
         return merged
     }
 
+    /// Required-secret check under the shared resolution policy: a key
+    /// satisfied by a Plugins-tab (default-agent) write counts as
+    /// configured for every agent, matching what tool payload injection
+    /// actually delivers via `resolvedSecretsWithDefaults`.
     public static func hasAllRequiredSecrets(specs: [PluginManifest.SecretSpec], for pluginId: String, agentId: UUID)
         -> Bool
     {
         for spec in specs where spec.required {
-            if !hasSecret(id: spec.id, for: pluginId, agentId: agentId) {
+            if !hasResolvedSecret(id: spec.id, for: pluginId, agentId: agentId) {
                 return false
             }
         }
@@ -132,7 +157,7 @@ public enum ToolSecretsKeychain {
         agentId: UUID
     ) -> [PluginManifest.SecretSpec] {
         return specs.filter { spec in
-            spec.required && !hasSecret(id: spec.id, for: pluginId, agentId: agentId)
+            spec.required && !hasResolvedSecret(id: spec.id, for: pluginId, agentId: agentId)
         }
     }
 

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -295,7 +295,11 @@ final class PluginHostContext: @unchecked Sendable {
             Self.warnNoAgentContextOnce(pluginId: pluginId, op: "config_get")
             return nil
         }
-        return ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: agentId)
+        // Shared resolution policy (exact agent, then default-agent
+        // fallback) so `config_get` agrees with tool payload injection —
+        // a `bot_token` saved as a Plugins-tab global default must be
+        // readable here, not only via the injected payload.
+        return ToolSecretsKeychain.resolvedSecret(id: key, for: pluginId, agentId: agentId)
     }
 
     /// Maximum config value byte size accepted by `config_set`. The

--- a/Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift
@@ -1,0 +1,302 @@
+//
+//  AgentLifecycleConfigResolutionTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for two lifecycle/config defects:
+//
+//  1. Teardown ordering: `AgentManager.delete(id:)` swept the agent's
+//     Keychain secrets BEFORE posting `.agentRemoved`, so plugins that
+//     read config (e.g. Telegram's `bot_token`) inside their webhook
+//     deregistration callback found nothing — the webhook stayed
+//     registered upstream forever. Deletion now awaits
+//     `PluginManager.tearDownPluginsForRemovedAgent` (synchronous
+//     `tunnel_url=""` delivery to every routed plugin) and only then
+//     sweeps. The test drives a real `ExternalPlugin` with a C
+//     `on_config_changed` that reads the secret mid-teardown.
+//
+//  2. Config default resolution: tool payload injection merged
+//     `Agent.defaultId` values as global defaults, but `config_get`,
+//     initial config delivery, and required-secret checks read only the
+//     exact agent namespace — a key saved once on the Plugins tab was
+//     "configured" for injection but invisible to `config_get`. All
+//     paths now share `ToolSecretsKeychain.resolvedSecret` (exact agent
+//     first, then default-agent fallback).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Teardown ordering
+
+@MainActor
+@Suite(.serialized)
+struct AgentDeletionPluginTeardownOrderingTests {
+
+    /// Shared with the C `on_config_changed` callback via the plugin's
+    /// opaque `ctx` pointer. The callback simulates a Telegram-style
+    /// plugin: on `tunnel_url=""` (webhook deregistration signal) it
+    /// reads its `bot_token` from the keychain — exactly what the real
+    /// plugin needs to call Telegram's `deleteWebhook` API.
+    final class TeardownRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _pluginId = ""
+        private var _agentId: UUID?
+        private var _sawDeregister = false
+        private var _tokenDuringDeregister: String?
+
+        var pluginId: String {
+            get { lock.withLock { _pluginId } }
+            set { lock.withLock { _pluginId = newValue } }
+        }
+        var agentId: UUID? {
+            get { lock.withLock { _agentId } }
+            set { lock.withLock { _agentId = newValue } }
+        }
+        var sawDeregister: Bool { lock.withLock { _sawDeregister } }
+        var tokenDuringDeregister: String? { lock.withLock { _tokenDuringDeregister } }
+
+        func recordDeregister(token: String?) {
+            lock.withLock {
+                _sawDeregister = true
+                _tokenDuringDeregister = token
+            }
+        }
+    }
+
+    private static let deregisteringConfigChanged: osr_on_config_changed_t = { ctxPtr, keyPtr, valuePtr in
+        guard let ctxPtr, let keyPtr, let valuePtr else { return }
+        let key = String(cString: keyPtr)
+        let value = String(cString: valuePtr)
+        guard key == "tunnel_url", value.isEmpty else { return }
+        let recorder = Unmanaged<TeardownRecorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+        guard let agentId = recorder.agentId else {
+            recorder.recordDeregister(token: nil)
+            return
+        }
+        // The regression: this read returned nil because the keychain
+        // sweep ran before plugin teardown.
+        let token = ToolSecretsKeychain.getSecret(
+            id: "bot_token",
+            for: recorder.pluginId,
+            agentId: agentId
+        )
+        recorder.recordDeregister(token: token)
+    }
+
+    private func makeRoutedPlugin(
+        recorder: TeardownRecorder,
+        pluginId: String
+    ) -> (loaded: PluginManager.LoadedPlugin, retain: Unmanaged<TeardownRecorder>) {
+        let retain = Unmanaged.passRetained(recorder)
+        let ctx = retain.toOpaque()
+        let api = osr_plugin_api(
+            free_string: { ptr in
+                guard let ptr else { return }
+                free(UnsafeMutableRawPointer(mutating: ptr))
+            },
+            init: nil,
+            destroy: { _ in },
+            get_manifest: nil,
+            invoke: { _, _, _, _ in nil },
+            version: 6,
+            handle_route: { _, _ in UnsafePointer(strdup(#"{"status":200}"#)) },
+            on_config_changed: Self.deregisteringConfigChanged,
+            on_task_event: nil
+        )
+        let route = PluginManifest.RouteSpec(
+            id: "webhook",
+            path: "/webhook",
+            methods: ["POST"]
+        )
+        let manifest = PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(
+                tools: nil, routes: [route], config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+        let plugin = ExternalPlugin(
+            handle: ctx,
+            api: api,
+            ctx: ctx,
+            manifest: manifest,
+            path: "/tmp/teardown-order-\(pluginId)",
+            abiVersion: 6
+        )
+        let loaded = PluginManager.LoadedPlugin(
+            plugin: plugin,
+            handle: ctx,
+            tools: [],
+            skills: [],
+            routes: [route],
+            webConfig: nil,
+            readmePath: nil,
+            changelogPath: nil
+        )
+        return (loaded, retain)
+    }
+
+    /// Deleting an agent must deliver the webhook-deregistration signal
+    /// (`tunnel_url=""`) to routed plugins WHILE the agent's secrets are
+    /// still in the keychain, and only sweep afterwards — all completed
+    /// by the time `delete(id:)` returns.
+    @Test
+    func deleteNotifiesPluginsBeforeSweepingSecrets() async throws {
+        try await ChatHistoryTestStorage.run {
+            let pluginId = "com.test.teardown-order.\(UUID().uuidString)"
+            let recorder = TeardownRecorder()
+            recorder.pluginId = pluginId
+
+            let (loaded, retain) = self.makeRoutedPlugin(recorder: recorder, pluginId: pluginId)
+            PluginManager.shared.injectLoadedPluginForTesting(loaded)
+            defer {
+                PluginManager.shared.removeLoadedPluginForTesting(pluginId: pluginId)
+                retain.release()
+            }
+
+            let agent = Agent(
+                name: "TeardownOrder-\(UUID().uuidString.prefix(6))",
+                systemPrompt: "Test identity",
+                agentAddress: "test-teardown-\(UUID().uuidString)"
+            )
+            AgentManager.shared.add(agent)
+            recorder.agentId = agent.id
+
+            ToolSecretsKeychain.saveSecret("tok-123", id: "bot_token", for: pluginId, agentId: agent.id)
+
+            let result = await AgentManager.shared.delete(id: agent.id)
+            #expect(result.deleted)
+
+            // Teardown ran, and — the ordering regression — the plugin
+            // could still read its bot_token during deregistration.
+            #expect(recorder.sawDeregister, "plugin must receive tunnel_url=\"\" during delete()")
+            #expect(
+                recorder.tokenDuringDeregister == "tok-123",
+                "secrets must still exist while the plugin deregisters its webhook"
+            )
+
+            // ...and the sweep still happened afterwards.
+            #expect(
+                ToolSecretsKeychain.getSecret(id: "bot_token", for: pluginId, agentId: agent.id) == nil,
+                "secrets must be swept once teardown completed"
+            )
+
+            // Let the belt-and-braces `.agentRemoved` handler task run
+            // while the injected plugin is still registered (its delivery
+            // is deduped plugin-side, so the recorder must not fire again).
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+    }
+}
+
+// MARK: - Config default resolution policy
+
+/// Pins `ToolSecretsKeychain.resolvedSecret` — THE single resolution
+/// policy (exact agent, then `Agent.defaultId` fallback) shared by
+/// `config_get`, initial config delivery, and required-secret checks.
+/// Uses a synthetic "defaults" write under `Agent.defaultId` and cleans
+/// it up, since that UUID is shared process state.
+struct ToolSecretsResolutionPolicyTests {
+
+    @Test func exactAgentValueWins() {
+        let pluginId = "com.test.resolve.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: agent)
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+
+        ToolSecretsKeychain.saveSecret("global", id: "api_key", for: pluginId, agentId: Agent.defaultId)
+        ToolSecretsKeychain.saveSecret("mine", id: "api_key", for: pluginId, agentId: agent)
+
+        #expect(ToolSecretsKeychain.resolvedSecret(id: "api_key", for: pluginId, agentId: agent) == "mine")
+    }
+
+    @Test func fallsBackToDefaultAgentNamespace() {
+        let pluginId = "com.test.resolve.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+
+        ToolSecretsKeychain.saveSecret("global", id: "api_key", for: pluginId, agentId: Agent.defaultId)
+
+        #expect(ToolSecretsKeychain.resolvedSecret(id: "api_key", for: pluginId, agentId: agent) == "global")
+        #expect(ToolSecretsKeychain.hasResolvedSecret(id: "api_key", for: pluginId, agentId: agent))
+    }
+
+    @Test func missingEverywhereResolvesNil() {
+        let pluginId = "com.test.resolve.\(UUID().uuidString)"
+        let agent = UUID()
+        #expect(ToolSecretsKeychain.resolvedSecret(id: "api_key", for: pluginId, agentId: agent) == nil)
+        #expect(!ToolSecretsKeychain.hasResolvedSecret(id: "api_key", for: pluginId, agentId: agent))
+    }
+
+    /// Required-secret checks must agree with what tool payload injection
+    /// delivers: a key satisfied by a Plugins-tab (default-agent) write
+    /// counts as configured for every agent.
+    @Test func requiredSecretChecksHonorDefaultFallback() {
+        let pluginId = "com.test.resolve.required.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+        let specs = [
+            PluginManifest.SecretSpec(id: "bot_token", label: "Bot Token"),
+            PluginManifest.SecretSpec(id: "optional_key", label: "Optional", required: false),
+        ]
+
+        #expect(!ToolSecretsKeychain.hasAllRequiredSecrets(specs: specs, for: pluginId, agentId: agent))
+        #expect(
+            ToolSecretsKeychain.getMissingRequiredSecrets(specs: specs, for: pluginId, agentId: agent)
+                .map(\.id) == ["bot_token"]
+        )
+
+        ToolSecretsKeychain.saveSecret("tok", id: "bot_token", for: pluginId, agentId: Agent.defaultId)
+
+        #expect(ToolSecretsKeychain.hasAllRequiredSecrets(specs: specs, for: pluginId, agentId: agent))
+        #expect(
+            ToolSecretsKeychain.getMissingRequiredSecrets(specs: specs, for: pluginId, agentId: agent).isEmpty
+        )
+    }
+
+    /// `config_get` (via the host context, inside a TLS scope bound to a
+    /// real agent) must resolve through the same policy — the Telegram
+    /// `bot_token` saved as a global default is readable from plugin code.
+    @Test func configGetResolvesDefaultAgentFallback() throws {
+        let pluginId = "com.test.resolve.configget.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: agent)
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+
+        ToolSecretsKeychain.saveSecret("tok-global", id: "bot_token", for: pluginId, agentId: Agent.defaultId)
+        ToolSecretsKeychain.saveSecret("mine", id: "other_key", for: pluginId, agentId: agent)
+
+        let ctx = try PluginHostContext(pluginId: pluginId)
+        defer { ctx.teardown() }
+
+        let (fallback, exact): (String?, String?) = PluginHostContext.withTLSScope(
+            pluginId: pluginId, agentId: agent
+        ) {
+            (ctx.configGet(key: "bot_token"), ctx.configGet(key: "other_key"))
+        }
+        #expect(fallback == "tok-global", "config_get must fall back to the default-agent namespace")
+        #expect(exact == "mine", "exact-agent values keep winning")
+
+        // Anonymous context (no bound agent) still refuses to read anything.
+        let anonymous = ctx.configGet(key: "bot_token")
+        #expect(anonymous == nil, "no agent context must not leak the default namespace")
+    }
+}


### PR DESCRIPTION
## Summary

Host/harness fixes from the July 2026 plugin reliability audit (lifecycle-config theme). Part of a 5-branch series; each branch is independent and separately mergeable. Full campaign notes cover all five themes.

### 4. `audit/lifecycle-config` (1 commit)

Commit:
- `c601dd68` Order plugin teardown before secret sweep on agent delete; unify config default resolution

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Managers/AgentManager.swift` + `Managers/Plugin/PluginManager.swift` — `AgentManager.delete(id:)` swept `ToolSecretsKeychain` for the agent BEFORE posting `.agentRemoved`; the `.agentRemoved` handler was additionally fire-and-forget (Task + detached push), so plugins reading config (e.g. Telegram's `bot_token`) during webhook deregistration found nothing — the webhook stayed registered upstream. New awaitable `PluginManager.tearDownPluginsForRemovedAgent(agentId:)` delivers `tunnel_url=""` to every routed plugin via the synchronous config path and returns only after each plugin's `on_config_changed` completes; `delete` awaits it and only then sweeps. The notification-driven handler remains as an idempotent backstop (deduped plugin-side).
- **Medium** `Services/Keychain/ToolSecretsKeychain.swift` + `Services/Plugin/PluginHostAPI.swift` + `Managers/Plugin/PluginManager.swift` — inconsistent default semantics: tool payload injection merged `Agent.defaultId` values as global defaults (`resolvedSecretsWithDefaults`), but `config_get`, initial config delivery, and required-secret checks (`hasAllRequiredSecrets` / `getMissingRequiredSecrets`) read only the exact agent namespace — a key saved once on the Plugins tab was "configured" for injection but invisible to `config_get`. Centralized one policy, `ToolSecretsKeychain.resolvedSecret(id:for:agentId:)` (exact agent first, then default-agent fallback), and pointed all three paths at it. The anonymous-context guard (no agent → nil) is unchanged; UI editors (`PluginConfigView`, `ToolSecretsSheet`) intentionally keep exact-namespace reads since they edit a specific agent's values.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift` — ordering test driving a real `ExternalPlugin` whose C `on_config_changed` reads `bot_token` mid-teardown (asserts the token is readable during deregistration and swept afterwards, all before `delete` returns); resolution-policy tests: exact-wins, default fallback, missing-everywhere, required-secret checks honoring the fallback, and `config_get` through a TLS-scoped `PluginHostContext` (fallback + exact + anonymous-refusal).

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'AgentDeletionPluginTeardownOrderingTests|ToolSecretsResolutionPolicyTests|AgentManagerLifecycleNotificationTests|ResolvedSecretsMergingTests'` — 18 tests in 4 suites passed (includes the pre-existing lifecycle-notification and secrets-merge suites, confirming no ordering regressions).

### 5. `audit/ci-coverage` (1 commit)

Commit:
- `a6e1737b` Add CI lanes for OsaurusRepository, OsaurusPluginTestKit, and StatsPack tests

Changes (`.github/workflows/ci.yml`):
- New `test-packages` job: `swift test --package-path Packages/OsaurusRepository --parallel` and `swift test --package-path Packages/OsaurusPluginTestKit --parallel` on `macos-26` with the pinned Xcode toolchain and `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` (matching test-evals). Both packages are light (Foundation/OsaurusNetworking deps), no build cache needed.
- New `test-statspack` job: `swift test --package-path Packages/OsaurusPlugins/StatsPack` with its own SwiftPM `.build` cache mirroring the `test-evals` cache shape, because StatsPack depends on the full OsaurusCore graph (mlx `Cmlx` C++ + SQLCipher amalgamation, ~25–30 min cold).

Verification:
- YAML validated (`ruby -ryaml`).
- All three suites run green locally with the CI env: OsaurusRepository 59 tests (XCTest), OsaurusPluginTestKit 10 tests, StatsPack 20 tests.

Release-config loader verification (documented, not implemented):
`PluginManager.verifyDylibBeforeLoadWithError` short-circuits to `.success` under `#if DEBUG`; the Release-only body (receipt presence/parse, SHA-256 match, `SecStaticCodeCheckValidity` code-signature check, `.user_consent` gate) is compiled only in Release and never executes under any test lane (xcodebuild tests and all `swift test` lanes build Debug). A cheap Release test invocation is NOT feasible:
- `swift test -c release --package-path Packages/OsaurusCore` (or a Release xcodebuild test lane) cold-builds the whole OsaurusCore graph again in a second configuration — an additional ~25–30 min lane and a second DerivedData/.build cache for one function.
- The function is `private`, so even a Release test bundle can't call it directly; testing it properly would require a production refactor (extract the verification body into an always-compiled internal helper testable from Debug), which is out of scope for a CI-only branch. That refactor is the recommended follow-up (see proposals).

## Investigated, decided NOT to change

- `ToolsVerify` "verified OK" wording and output format were preserved; only the skip-vs-fail semantics changed, to keep script consumers working.
- `PluginConfigView` / `ToolSecretsSheet` exact-namespace keychain reads: intentional (they edit a specific agent's values); the shared resolution policy applies to what is fed to plugins, not to the editing UI.
- `handleAgentRemoved`'s notification-driven `tunnel_url=""` push was kept (not removed) as an idempotent backstop for any other `.agentRemoved` poster; plugin-side delivery dedup prevents double `on_config_changed` firing.
- The route-timeout fix deliberately leaves the abandoned blocking C callback running on the plugin's invoke queue (matching `runToolBody` semantics) — forcibly killing plugin threads would be an architectural change.
- v2 entry path (`osaurus_plugin_entry_v2`) already receives the host struct and returns the full current `osr_plugin_api`; only the v1 path had the prefix-read hazard.
- No out-of-process isolation, TUF metadata, or hot-reload rework, per instructions.

## Checks that still require live credentials/permissions

- Code-signature verification (`SecStaticCodeCheckValidity`) and the full Release-only `verifyDylibBeforeLoadWithError` path need a signed dylib and a Release build — not exercised by unit tests (see ci-coverage notes).
- Real Keychain behavior: unit tests use the in-memory test store (`XCTestConfigurationFilePath`/xctest detection) or the disabled-keychain mode; securityd interaction paths (auth prompts, XPC stalls) are not covered.
- Live registry installs (minisign verification against the production registry, network download paths) and real tunnel/relay webhook deregistration (Telegram etc.) require network and credentials.
- The full OsaurusCoreTests xcodebuild scheme (as CI runs it) was not run locally end-to-end; per task instructions, targeted plugin/lifecycle/route suites were run via `swift test --filter` (exact commands and results listed per branch above). Note for local repro: OsaurusCore `swift test` runs need `XCTestConfigurationFilePath` set (any value) for the in-memory keychain store to activate under `swiftpm-testing-helper`; CI's xcodebuild sets it natively.

## Optional upgrade proposals (NOT implemented)

1. Extract the Release-only dylib verification body into an always-compiled internal `verifyInstalledDylib(receiptURL:dylibURL:)` helper so Debug tests can cover receipt/SHA/consent failures; keep only the "skip in DEBUG" decision behind `#if DEBUG`.
2. `ToolsInstall` manual installs bypass minisign entirely (by design, gated on `--consent`); consider requiring a `--insecure` style acknowledgment or checksum argument for remote URLs.
3. The `.agentRemoved`/`.agentAdded` NotificationCenter plumbing could become an async-awaitable protocol on a PluginLifecycle coordinator, removing the need for the belt-and-braces double push after deletion.
4. `resolveBestVersion` filters incompatible artifacts silently; surfacing "newer version exists but requires macOS X / Osaurus Y" to the UI would help users understand why updates don't appear.
5. Consider running the StatsPack CI job only on paths touching `Packages/OsaurusPlugins/**` or `Packages/OsaurusCore/**` to save runner minutes.
