### PR TITLE
Reliability audit: run repository, test-kit, and StatsPack suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,88 @@ jobs:
         if: always()
         run: echo "::notice title=test-cli duration::$SECONDS seconds"
 
+  test-packages:
+    # Unit tests for the small SPM packages that had no CI lane at all:
+    #   - Packages/OsaurusRepository (plugin install manager, spec
+    #     resolution, bounded archive extraction — the security-sensitive
+    #     install path)
+    #   - Packages/OsaurusPluginTestKit (the harness plugin authors build
+    #     against)
+    # Both depend only on Foundation / OsaurusNetworking, so a cold build
+    # is a couple of minutes — no build cache needed.
+    #
+    # Pinned (was `macos-latest`) for the same reason as test-core.
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Same toolchain pinning rationale as test-cli: the packages require
+      # `swift-tools-version: 6.2`, which ships with the pinned Xcode.
+      - name: Verify Swift toolchain
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+        run: swift --version
+
+      - name: Run OsaurusRepository tests
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          # Keychain wrappers no-op so hosted runners never hit the
+          # "wants to use your confidential information" prompt.
+          OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS: "1"
+        run: swift test --package-path Packages/OsaurusRepository --parallel
+
+      - name: Run OsaurusPluginTestKit tests
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS: "1"
+        run: swift test --package-path Packages/OsaurusPluginTestKit --parallel
+
+      - name: Annotate timing
+        if: always()
+        run: echo "::notice title=test-packages duration::$SECONDS seconds"
+
+  test-statspack:
+    # Unit tests for the bundled StatsPack plugin
+    # (Packages/OsaurusPlugins/StatsPack), previously not run anywhere in
+    # CI. StatsPack depends on OsaurusCore, so a cold build compiles the
+    # whole graph (mlx-swift Cmlx C++ + SQLCipher amalgamation) under
+    # SwiftPM — the same ~25-30 min floor as test-evals. The .build cache
+    # below returns warm runs to single-digit minutes; the cache-key shape
+    # deliberately mirrors test-evals'.
+    runs-on: macos-26
+    timeout-minutes: 45
+    env:
+      SPM_BUILD: Packages/OsaurusPlugins/StatsPack/.build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.SPM_BUILD }}
+          key: statspack-build-${{ runner.os }}-${{ env.CACHE_SALT }}-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/*.swift', 'Packages/**/*.c', 'Packages/**/*.h') }}
+          restore-keys: |
+            statspack-build-${{ runner.os }}-${{ env.CACHE_SALT }}-xcode${{ env.XCODE_VERSION }}-
+            statspack-build-${{ runner.os }}-${{ env.CACHE_SALT }}-
+
+      - name: Run StatsPack tests
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS: "1"
+        run: swift test --package-path Packages/OsaurusPlugins/StatsPack
+
+      - name: Annotate timing
+        if: always()
+        run: echo "::notice title=test-statspack duration::$SECONDS seconds"
+
   test-evals:
     # Harness unit tests for Packages/OsaurusEvals (fixture decode, scorer
     # contracts, regression-lab plumbing, judge resolution). Deterministic


### PR DESCRIPTION
## Summary

Host/harness fixes from the July 2026 plugin reliability audit (ci-coverage theme). Part of a 5-branch series; each branch is independent and separately mergeable. Full campaign notes cover all five themes.

### 5. `audit/ci-coverage` (1 commit)

Commit:
- `a6e1737b` Add CI lanes for OsaurusRepository, OsaurusPluginTestKit, and StatsPack tests

Changes (`.github/workflows/ci.yml`):
- New `test-packages` job: `swift test --package-path Packages/OsaurusRepository --parallel` and `swift test --package-path Packages/OsaurusPluginTestKit --parallel` on `macos-26` with the pinned Xcode toolchain and `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` (matching test-evals). Both packages are light (Foundation/OsaurusNetworking deps), no build cache needed.
- New `test-statspack` job: `swift test --package-path Packages/OsaurusPlugins/StatsPack` with its own SwiftPM `.build` cache mirroring the `test-evals` cache shape, because StatsPack depends on the full OsaurusCore graph (mlx `Cmlx` C++ + SQLCipher amalgamation, ~25–30 min cold).

Verification:
- YAML validated (`ruby -ryaml`).
- All three suites run green locally with the CI env: OsaurusRepository 59 tests (XCTest), OsaurusPluginTestKit 10 tests, StatsPack 20 tests.

Release-config loader verification (documented, not implemented):
`PluginManager.verifyDylibBeforeLoadWithError` short-circuits to `.success` under `#if DEBUG`; the Release-only body (receipt presence/parse, SHA-256 match, `SecStaticCodeCheckValidity` code-signature check, `.user_consent` gate) is compiled only in Release and never executes under any test lane (xcodebuild tests and all `swift test` lanes build Debug). A cheap Release test invocation is NOT feasible:
- `swift test -c release --package-path Packages/OsaurusCore` (or a Release xcodebuild test lane) cold-builds the whole OsaurusCore graph again in a second configuration — an additional ~25–30 min lane and a second DerivedData/.build cache for one function.
- The function is `private`, so even a Release test bundle can't call it directly; testing it properly would require a production refactor (extract the verification body into an always-compiled internal helper testable from Debug), which is out of scope for a CI-only branch. That refactor is the recommended follow-up (see proposals).

## Investigated, decided NOT to change

- `ToolsVerify` "verified OK" wording and output format were preserved; only the skip-vs-fail semantics changed, to keep script consumers working.
- `PluginConfigView` / `ToolSecretsSheet` exact-namespace keychain reads: intentional (they edit a specific agent's values); the shared resolution policy applies to what is fed to plugins, not to the editing UI.
- `handleAgentRemoved`'s notification-driven `tunnel_url=""` push was kept (not removed) as an idempotent backstop for any other `.agentRemoved` poster; plugin-side delivery dedup prevents double `on_config_changed` firing.
- The route-timeout fix deliberately leaves the abandoned blocking C callback running on the plugin's invoke queue (matching `runToolBody` semantics) — forcibly killing plugin threads would be an architectural change.
- v2 entry path (`osaurus_plugin_entry_v2`) already receives the host struct and returns the full current `osr_plugin_api`; only the v1 path had the prefix-read hazard.
- No out-of-process isolation, TUF metadata, or hot-reload rework, per instructions.

## Checks that still require live credentials/permissions

- Code-signature verification (`SecStaticCodeCheckValidity`) and the full Release-only `verifyDylibBeforeLoadWithError` path need a signed dylib and a Release build — not exercised by unit tests (see ci-coverage notes).
- Real Keychain behavior: unit tests use the in-memory test store (`XCTestConfigurationFilePath`/xctest detection) or the disabled-keychain mode; securityd interaction paths (auth prompts, XPC stalls) are not covered.
- Live registry installs (minisign verification against the production registry, network download paths) and real tunnel/relay webhook deregistration (Telegram etc.) require network and credentials.
- The full OsaurusCoreTests xcodebuild scheme (as CI runs it) was not run locally end-to-end; per task instructions, targeted plugin/lifecycle/route suites were run via `swift test --filter` (exact commands and results listed per branch above). Note for local repro: OsaurusCore `swift test` runs need `XCTestConfigurationFilePath` set (any value) for the in-memory keychain store to activate under `swiftpm-testing-helper`; CI's xcodebuild sets it natively.

## Optional upgrade proposals (NOT implemented)

1. Extract the Release-only dylib verification body into an always-compiled internal `verifyInstalledDylib(receiptURL:dylibURL:)` helper so Debug tests can cover receipt/SHA/consent failures; keep only the "skip in DEBUG" decision behind `#if DEBUG`.
2. `ToolsInstall` manual installs bypass minisign entirely (by design, gated on `--consent`); consider requiring a `--insecure` style acknowledgment or checksum argument for remote URLs.
3. The `.agentRemoved`/`.agentAdded` NotificationCenter plumbing could become an async-awaitable protocol on a PluginLifecycle coordinator, removing the need for the belt-and-braces double push after deletion.
4. `resolveBestVersion` filters incompatible artifacts silently; surfacing "newer version exists but requires macOS X / Osaurus Y" to the UI would help users understand why updates don't appear.
5. Consider running the StatsPack CI job only on paths touching `Packages/OsaurusPlugins/**` or `Packages/OsaurusCore/**` to save runner minutes.
