### PR TITLE
Reliability audit: install integrity, loader/ABI validation, route timeouts, lifecycle ordering, CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,88 @@ jobs:
         if: always()
         run: echo "::notice title=test-cli duration::$SECONDS seconds"
 
+  test-packages:
+    # Unit tests for the small SPM packages that had no CI lane at all:
+    #   - Packages/OsaurusRepository (plugin install manager, spec
+    #     resolution, bounded archive extraction — the security-sensitive
+    #     install path)
+    #   - Packages/OsaurusPluginTestKit (the harness plugin authors build
+    #     against)
+    # Both depend only on Foundation / OsaurusNetworking, so a cold build
+    # is a couple of minutes — no build cache needed.
+    #
+    # Pinned (was `macos-latest`) for the same reason as test-core.
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Same toolchain pinning rationale as test-cli: the packages require
+      # `swift-tools-version: 6.2`, which ships with the pinned Xcode.
+      - name: Verify Swift toolchain
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+        run: swift --version
+
+      - name: Run OsaurusRepository tests
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          # Keychain wrappers no-op so hosted runners never hit the
+          # "wants to use your confidential information" prompt.
+          OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS: "1"
+        run: swift test --package-path Packages/OsaurusRepository --parallel
+
+      - name: Run OsaurusPluginTestKit tests
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS: "1"
+        run: swift test --package-path Packages/OsaurusPluginTestKit --parallel
+
+      - name: Annotate timing
+        if: always()
+        run: echo "::notice title=test-packages duration::$SECONDS seconds"
+
+  test-statspack:
+    # Unit tests for the bundled StatsPack plugin
+    # (Packages/OsaurusPlugins/StatsPack), previously not run anywhere in
+    # CI. StatsPack depends on OsaurusCore, so a cold build compiles the
+    # whole graph (mlx-swift Cmlx C++ + SQLCipher amalgamation) under
+    # SwiftPM — the same ~25-30 min floor as test-evals. The .build cache
+    # below returns warm runs to single-digit minutes; the cache-key shape
+    # deliberately mirrors test-evals'.
+    runs-on: macos-26
+    timeout-minutes: 45
+    env:
+      SPM_BUILD: Packages/OsaurusPlugins/StatsPack/.build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Xcode ${{ env.XCODE_VERSION }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.SPM_BUILD }}
+          key: statspack-build-${{ runner.os }}-${{ env.CACHE_SALT }}-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('Packages/**/Package.swift', 'Packages/**/*.swift', 'Packages/**/*.c', 'Packages/**/*.h') }}
+          restore-keys: |
+            statspack-build-${{ runner.os }}-${{ env.CACHE_SALT }}-xcode${{ env.XCODE_VERSION }}-
+            statspack-build-${{ runner.os }}-${{ env.CACHE_SALT }}-
+
+      - name: Run StatsPack tests
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS: "1"
+        run: swift test --package-path Packages/OsaurusPlugins/StatsPack
+
+      - name: Annotate timing
+        if: always()
+        run: echo "::notice title=test-statspack duration::$SECONDS seconds"
+
   test-evals:
     # Harness unit tests for Packages/OsaurusEvals (fixture decode, scorer
     # contracts, regression-lab plumbing, judge resolution). Deterministic

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
@@ -13,24 +13,19 @@ public struct ToolsInstall {
     public static func execute(args: [String]) async {
         guard let src = args.first, !src.isEmpty else {
             fputs(
-                "Usage: osaurus tools install <plugin_id|url-or-path> [--version <semver>] [--no-consent]\n",
+                "Usage: osaurus tools install <plugin_id|url-or-path> [--version <semver>] [--consent]\n",
                 stderr
             )
             exit(EXIT_FAILURE)
         }
 
-        // The release-build loader requires a `.user_consent` marker
-        // alongside `receipt.json` before it will dlopen a plugin. The
-        // registry-install path (`PluginInstallManager.install`) writes
-        // it automatically; manual sideload via `tools install` should
-        // be symmetric so authors iterating with `tools install
-        // ./my-plugin-1.0.0` don't get a silent `consent_required:`
-        // load failure they then have to clear in the UI. `--no-consent`
-        // opts out for users who want the explicit Approve gate.
-        let grantConsent = !args.contains("--no-consent")
-
         // Check if argument is a local path or URL
         if isManualInstallSource(src) {
+            // Manual sideloads bypass the registry's checksum/signature
+            // verification, so the release loader's `.user_consent` gate is
+            // NOT waived implicitly: pass `--consent` to grant it at install
+            // time, otherwise approve the plugin in Osaurus settings.
+            let grantConsent = args.contains("--consent")
             await installManual(src: src, grantConsent: grantConsent)
         } else {
             await installFromRegistry(pluginId: src, args: args)
@@ -93,7 +88,11 @@ public struct ToolsInstall {
         var sourceName: String = ""
         var preferManifestIdentity = false
 
-        // 1. Unpack/Copy to staging
+        // 1. Unpack/Copy to staging. Archives go through the same bounded
+        // in-process extractor as registry installs (path-safety, resource
+        // limits) instead of shelling out to /usr/bin/unzip, and remote
+        // archives are streamed to disk instead of buffered in memory.
+        let stageRoot = tmpDir.appendingPathComponent("extracted", isDirectory: true)
         if src.hasPrefix("http://") || src.hasPrefix("https://") {
             guard let url = URL(string: src) else {
                 fputs("Invalid URL: \(src)\n", stderr)
@@ -103,13 +102,14 @@ public struct ToolsInstall {
             sourceName = url.lastPathComponent
             let zipFile = tmpDir.appendingPathComponent("download.zip")
             do {
-                let (data, resp) = try await URLSession.shared.data(from: url)
+                let (downloadedURL, resp) = try await URLSession.shared.download(from: url)
                 guard let http = resp as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) else {
+                    try? fm.removeItem(at: downloadedURL)
                     fputs("Download failed (status \((resp as? HTTPURLResponse)?.statusCode ?? -1))\n", stderr)
                     exit(EXIT_FAILURE)
                 }
-                try data.write(to: zipFile)
-                try unzip(zipURL: zipFile, to: tmpDir)
+                try fm.moveItem(at: downloadedURL, to: zipFile)
+                try PluginInstallManager.extractPluginArchive(at: zipFile, to: stageRoot)
             } catch {
                 fputs("Download/Unzip error: \(error)\n", stderr)
                 exit(EXIT_FAILURE)
@@ -121,11 +121,12 @@ public struct ToolsInstall {
             if fm.fileExists(atPath: pathURL.path, isDirectory: &isDir) {
                 if isDir.boolValue {
                     preferManifestIdentity = true
-                    // Copy contents to tmpDir
+                    // Copy contents to the staging root
                     do {
+                        try fm.createDirectory(at: stageRoot, withIntermediateDirectories: true)
                         let contents = try fm.contentsOfDirectory(at: pathURL, includingPropertiesForKeys: nil)
                         for item in contents {
-                            try fm.copyItem(at: item, to: tmpDir.appendingPathComponent(item.lastPathComponent))
+                            try fm.copyItem(at: item, to: stageRoot.appendingPathComponent(item.lastPathComponent))
                         }
                     } catch {
                         fputs("Failed to copy directory: \(error)\n", stderr)
@@ -133,7 +134,7 @@ public struct ToolsInstall {
                     }
                 } else if pathURL.pathExtension.lowercased() == "zip" {
                     do {
-                        try unzip(zipURL: pathURL, to: tmpDir)
+                        try PluginInstallManager.extractPluginArchive(at: pathURL, to: stageRoot)
                     } catch {
                         fputs("Unzip error: \(error)\n", stderr)
                         exit(EXIT_FAILURE)
@@ -148,11 +149,11 @@ public struct ToolsInstall {
             }
         }
 
-        // Find the plugin root (unzip might create a wrapper directory)
-        var pluginRoot: URL = tmpDir
+        // Find the plugin root (the archive might contain a wrapper directory)
+        var pluginRoot: URL = stageRoot
         do {
             let contents = try fm.contentsOfDirectory(
-                at: tmpDir,
+                at: stageRoot,
                 includingPropertiesForKeys: nil,
                 options: [.skipsHiddenFiles]
             )
@@ -161,7 +162,7 @@ public struct ToolsInstall {
                 pluginRoot = contents[0]
             }
         } catch {
-            // ignore - use tmpDir as root
+            // ignore - use stageRoot as root
         }
 
         // 2. Resolve plugin_id and version. Packaged zips keep using
@@ -187,36 +188,19 @@ public struct ToolsInstall {
             exit(EXIT_FAILURE)
         }
 
-        // 3. Install to Tools/<id>/<version>
-        let installDir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: semver)
-
+        // 3. Publish the staged payload to Tools/<id>/<version>
         do {
-            if fm.fileExists(atPath: installDir.path) {
-                try fm.removeItem(at: installDir)
-            }
-            try fm.createDirectory(at: installDir.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try fm.moveItem(at: pluginRoot, to: installDir)
-
-            // 4. Create receipt.json for manual installs
-            try createManualInstallReceipt(pluginId: pluginId, version: semver, installDir: installDir)
-
-            // 4b. Auto-grant consent (matches registry install). The
-            // release loader checks for `.user_consent` next to the
-            // receipt; without it, the plugin fails verification with
-            // `consent_required:` and the user has to tap Approve in
-            // the app. `--no-consent` keeps the explicit gate.
-            if grantConsent {
-                let consentURL = installDir.appendingPathComponent(".user_consent", isDirectory: false)
-                try Data().write(to: consentURL)
-            }
-
-            // 5. Update Current Symlink
-            try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: semver)
+            let installDir = try publishManualInstall(
+                pluginRoot: pluginRoot,
+                pluginId: pluginId,
+                version: semver,
+                grantConsent: grantConsent
+            )
 
             print("Installed \(pluginId) @ \(semver) to \(installDir.path)")
             if !grantConsent {
                 print(
-                    "Consent NOT granted (--no-consent). Approve in Osaurus settings before the plugin will load."
+                    "Consent NOT granted. Approve in Osaurus settings before the plugin will load, or reinstall with --consent."
                 )
             }
 
@@ -228,6 +212,50 @@ public struct ToolsInstall {
             fputs("Installation failed: \(error)\n", stderr)
             exit(EXIT_FAILURE)
         }
+    }
+
+    /// Completes the staged payload (receipt + optional consent marker) and
+    /// then publishes it into `Tools/<id>/<version>` in one atomic swap. Any
+    /// previously installed copy of this version is only replaced by a
+    /// complete, valid layout — never deleted up front, so a failure while
+    /// preparing the new payload leaves the existing install untouched.
+    /// Fails (before touching the destination) when the payload contains no
+    /// dylib, so a manual install can no longer produce a receipt-less or
+    /// binary-less tree.
+    static func publishManualInstall(
+        pluginRoot: URL,
+        pluginId: String,
+        version: SemanticVersion,
+        grantConsent: Bool
+    ) throws -> URL {
+        let fm = FileManager.default
+        let installDir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: version)
+
+        try createManualInstallReceipt(pluginId: pluginId, version: version, installDir: pluginRoot)
+        if grantConsent {
+            try Data().write(to: pluginRoot.appendingPathComponent(".user_consent", isDirectory: false))
+        }
+
+        let parent = installDir.deletingLastPathComponent()
+        try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        // Move the payload next to its final location first (the temp dir may
+        // be on another volume), then swap it in atomically.
+        let staging = parent.appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
+        try fm.moveItem(at: pluginRoot, to: staging)
+        do {
+            if fm.fileExists(atPath: installDir.path) {
+                _ = try fm.replaceItemAt(installDir, withItemAt: staging)
+            } else {
+                try fm.moveItem(at: staging, to: installDir)
+            }
+        } catch {
+            try? fm.removeItem(at: staging)
+            throw error
+        }
+
+        try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: version)
+        return installDir
     }
 
     /// Parses plugin_id and version from a filename like "my-plugin-1.0.0" or "my-plugin-1.0.0.zip"
@@ -429,6 +457,7 @@ public struct ToolsInstall {
 
     enum ManualInstallError: Error, CustomStringConvertible {
         case identityUnavailable(sourceName: String)
+        case noDylibFound
         case invalidManifestField(String, String)
         case invalidManifestVersion(String, String)
         case manifestReadFailed(String, String)
@@ -441,6 +470,9 @@ public struct ToolsInstall {
             case .identityUnavailable:
                 return
                     "Invalid naming format. Expected <plugin_id>-<version>.zip, or install a project directory containing osaurus-plugin.json with plugin_id and version."
+            case .noDylibFound:
+                return
+                    "No .dylib found in the plugin payload. Build the plugin first (e.g. `osaurus tools build`) — an install without a binary would produce a broken receipt-less tree."
             case .invalidManifestField(let filename, let field):
                 return "`\(filename)` must include a non-empty `\(field)` for directory installs."
             case .invalidManifestVersion(let filename, let value):
@@ -457,12 +489,13 @@ public struct ToolsInstall {
         }
     }
 
-    /// Creates a receipt.json for manual installations
+    /// Creates a receipt.json for manual installations. Throws when the
+    /// payload contains no dylib: the loader requires receipt + binary, so
+    /// silently skipping the receipt used to publish an install that could
+    /// never load (and that `tools verify` then ignored).
     static func createManualInstallReceipt(pluginId: String, version: SemanticVersion, installDir: URL) throws {
-        // Find the dylib in the install directory
         guard let dylibURL = findFirstDylib(in: installDir) else {
-            // No dylib found - skip receipt creation (plugin might not be fully built)
-            return
+            throw ManualInstallError.noDylibFound
         }
 
         // Calculate SHA256 of the dylib
@@ -507,20 +540,5 @@ public struct ToolsInstall {
             return fileURL
         }
         return nil
-    }
-
-    private static func unzip(zipURL: URL, to destDir: URL) throws {
-        let unzip = Process()
-        unzip.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        unzip.arguments = ["-o", "-q", zipURL.path, "-d", destDir.path]
-        try unzip.run()
-        unzip.waitUntilExit()
-        if unzip.terminationStatus != 0 {
-            throw NSError(
-                domain: "ToolsInstall",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "unzip command failed"]
-            )
-        }
     }
 }

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsVerify.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsVerify.swift
@@ -10,44 +10,105 @@ import CryptoKit
 import OsaurusRepository
 
 public struct ToolsVerify {
+    struct Report {
+        var lines: [String] = []
+        var failures: Int = 0
+
+        mutating func ok(_ message: String) {
+            lines.append("OK  \(message)")
+        }
+
+        mutating func fail(_ message: String) {
+            lines.append("FAIL  \(message)")
+            failures += 1
+        }
+    }
+
     public static func execute(args: [String]) {
-        let fm = FileManager.default
         let root = PluginInstallManager.toolsRootDirectory()
-        guard let pluginDirs = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else {
+        guard FileManager.default.fileExists(atPath: root.path) else {
             print("(no tools installed)")
             exit(EXIT_SUCCESS)
         }
-        var failures = 0
-        for pluginDir in pluginDirs where pluginDir.hasDirectoryPath {
+        let report = verifyInstalledTools(root: root)
+        if report.lines.isEmpty {
+            print("(no tools installed)")
+        } else {
+            for line in report.lines {
+                print(line)
+            }
+        }
+        exit(report.failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE)
+    }
+
+    /// Verifies every installed plugin version under `root`. Any missing,
+    /// unreadable, or malformed receipt/dylib is a FAILURE — a broken install
+    /// must not verify clean just because the evidence of the breakage is the
+    /// file that cannot be read.
+    static func verifyInstalledTools(root: URL) -> Report {
+        let fm = FileManager.default
+        var report = Report()
+        guard let pluginDirs = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil) else {
+            return report
+        }
+        for pluginDir in pluginDirs.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+        where pluginDir.hasDirectoryPath {
+            let pluginId = pluginDir.lastPathComponent
             let versionsToCheck: [URL]
             let currentLink = pluginDir.appendingPathComponent("current")
             if let dest = try? fm.destinationOfSymbolicLink(atPath: currentLink.path) {
-                versionsToCheck = [pluginDir.appendingPathComponent(dest, isDirectory: true)]
+                let target = pluginDir.appendingPathComponent(dest, isDirectory: true)
+                guard fm.fileExists(atPath: target.path) else {
+                    report.fail("\(pluginId)  'current' symlink points to missing version \(dest)")
+                    continue
+                }
+                versionsToCheck = [target]
             } else {
                 versionsToCheck =
                     (try? fm.contentsOfDirectory(at: pluginDir, includingPropertiesForKeys: nil))?.filter {
                         $0.hasDirectoryPath
                     } ?? []
             }
-            for vdir in versionsToCheck {
-                let receiptURL = vdir.appendingPathComponent("receipt.json")
-                guard let rdata = try? Data(contentsOf: receiptURL),
-                    let receipt = try? JSONDecoder().decode(PluginReceipt.self, from: rdata)
-                else {
-                    continue
-                }
-                let dylibURL = vdir.appendingPathComponent(receipt.dylib_filename)
-                guard let dylibData = try? Data(contentsOf: dylibURL) else { continue }
-                let digest = CryptoKit.SHA256.hash(data: dylibData)
-                let sha = Data(digest).map { String(format: "%02x", $0) }.joined()
-                if sha.lowercased() == receipt.dylib_sha256.lowercased() {
-                    print("OK  \(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename)")
-                } else {
-                    print("FAIL  \(receipt.plugin_id)@\(receipt.version)  expected \(receipt.dylib_sha256) got \(sha)")
-                    failures += 1
-                }
+            for vdir in versionsToCheck.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+                verifyVersionDirectory(vdir, pluginId: pluginId, report: &report)
             }
         }
-        exit(failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE)
+        return report
+    }
+
+    private static func verifyVersionDirectory(_ vdir: URL, pluginId: String, report: inout Report) {
+        let fm = FileManager.default
+        let versionName = vdir.lastPathComponent
+        let receiptURL = vdir.appendingPathComponent("receipt.json")
+
+        guard fm.fileExists(atPath: receiptURL.path) else {
+            report.fail("\(pluginId)@\(versionName)  receipt.json missing")
+            return
+        }
+        guard let rdata = try? Data(contentsOf: receiptURL) else {
+            report.fail("\(pluginId)@\(versionName)  receipt.json unreadable")
+            return
+        }
+        guard let receipt = try? JSONDecoder().decode(PluginReceipt.self, from: rdata) else {
+            report.fail("\(pluginId)@\(versionName)  receipt.json malformed")
+            return
+        }
+
+        let dylibURL = vdir.appendingPathComponent(receipt.dylib_filename)
+        guard fm.fileExists(atPath: dylibURL.path) else {
+            report.fail("\(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename) missing")
+            return
+        }
+        guard let dylibData = try? Data(contentsOf: dylibURL) else {
+            report.fail("\(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename) unreadable")
+            return
+        }
+        let digest = CryptoKit.SHA256.hash(data: dylibData)
+        let sha = Data(digest).map { String(format: "%02x", $0) }.joined()
+        if sha.lowercased() == receipt.dylib_sha256.lowercased() {
+            report.ok("\(receipt.plugin_id)@\(receipt.version)  \(receipt.dylib_filename)")
+        } else {
+            report.fail("\(receipt.plugin_id)@\(receipt.version)  expected \(receipt.dylib_sha256) got \(sha)")
+        }
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsInstallTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsInstallTests.swift
@@ -268,14 +268,18 @@ final class ToolsInstallTests: XCTestCase {
         )
     }
 
-    func testManualInstallReceiptSkipsWhenNoDylibExists() throws {
+    func testManualInstallReceiptFailsWhenNoDylibExists() throws {
         let version = try XCTUnwrap(SemanticVersion.parse("1.2.3"))
 
-        try ToolsInstall.createManualInstallReceipt(
-            pluginId: "com.example.empty",
-            version: version,
-            installDir: tempDir
-        )
+        XCTAssertThrowsError(
+            try ToolsInstall.createManualInstallReceipt(
+                pluginId: "com.example.empty",
+                version: version,
+                installDir: tempDir
+            )
+        ) { error in
+            XCTAssertTrue(String(describing: error).contains("No .dylib"))
+        }
 
         let receiptURL = tempDir.appendingPathComponent("receipt.json", isDirectory: false)
         XCTAssertFalse(FileManager.default.fileExists(atPath: receiptURL.path))

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsManualInstallPublishTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsManualInstallPublishTests.swift
@@ -1,0 +1,138 @@
+//
+//  ToolsManualInstallPublishTests.swift
+//  osaurus
+//
+//  Regression coverage for the manual `tools install` publication path:
+//  transactional replacement, explicit consent, and mandatory dylib/receipt.
+//
+
+import CryptoKit
+import Foundation
+import OsaurusRepository
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ToolsManualInstallPublishTests: XCTestCase {
+    private var tempRoot: URL!
+    private var previousOverride: URL?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-manual-publish-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousOverride = ToolsPaths.overrideRoot
+        ToolsPaths.overrideRoot = tempRoot
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func makePayload(named name: String, dylibContents: String = "binary") throws -> URL {
+        let payload = tempRoot.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: true)
+        try Data(dylibContents.utf8).write(to: payload.appendingPathComponent("Plugin.dylib"))
+        return payload
+    }
+
+    func testPublishInstallsReceiptAndSymlinkWithoutConsentByDefault() throws {
+        let payload = try makePayload(named: "payload")
+        let version = try XCTUnwrap(SemanticVersion.parse("1.0.0"))
+
+        let installDir = try ToolsInstall.publishManualInstall(
+            pluginRoot: payload,
+            pluginId: "com.example.manual",
+            version: version,
+            grantConsent: false
+        )
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: installDir.appendingPathComponent("Plugin.dylib").path))
+        XCTAssertTrue(fm.fileExists(atPath: installDir.appendingPathComponent("receipt.json").path))
+        XCTAssertFalse(
+            fm.fileExists(atPath: installDir.appendingPathComponent(".user_consent").path),
+            "manual installs must not grant consent implicitly"
+        )
+        XCTAssertEqual(
+            try fm.destinationOfSymbolicLink(
+                atPath: PluginInstallManager.currentSymlinkURL(pluginId: "com.example.manual").path
+            ),
+            "1.0.0"
+        )
+        XCTAssertFalse(fm.fileExists(atPath: payload.path), "staged payload should have been moved into place")
+    }
+
+    func testPublishGrantsConsentOnlyWhenExplicitlyRequested() throws {
+        let payload = try makePayload(named: "payload-consent")
+        let version = try XCTUnwrap(SemanticVersion.parse("1.0.0"))
+
+        let installDir = try ToolsInstall.publishManualInstall(
+            pluginRoot: payload,
+            pluginId: "com.example.consent",
+            version: version,
+            grantConsent: true
+        )
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: installDir.appendingPathComponent(".user_consent").path)
+        )
+    }
+
+    func testPublishReplacesExistingVersionAtomicallyAndKeepsItOnFailure() throws {
+        let fm = FileManager.default
+        let version = try XCTUnwrap(SemanticVersion.parse("1.0.0"))
+        let pluginId = "com.example.replace"
+
+        // First install
+        let first = try makePayload(named: "first", dylibContents: "old-binary")
+        let installDir = try ToolsInstall.publishManualInstall(
+            pluginRoot: first,
+            pluginId: pluginId,
+            version: version,
+            grantConsent: false
+        )
+        let oldDylib = try Data(contentsOf: installDir.appendingPathComponent("Plugin.dylib"))
+        XCTAssertEqual(oldDylib, Data("old-binary".utf8))
+
+        // A broken payload (no dylib) must fail BEFORE touching the existing install
+        let broken = tempRoot.appendingPathComponent("broken", isDirectory: true)
+        try fm.createDirectory(at: broken, withIntermediateDirectories: true)
+        XCTAssertThrowsError(
+            try ToolsInstall.publishManualInstall(
+                pluginRoot: broken,
+                pluginId: pluginId,
+                version: version,
+                grantConsent: false
+            )
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: installDir.appendingPathComponent("Plugin.dylib")),
+            Data("old-binary".utf8),
+            "failed install must leave the existing version untouched"
+        )
+
+        // A valid payload replaces it
+        let second = try makePayload(named: "second", dylibContents: "new-binary")
+        _ = try ToolsInstall.publishManualInstall(
+            pluginRoot: second,
+            pluginId: pluginId,
+            version: version,
+            grantConsent: false
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: installDir.appendingPathComponent("Plugin.dylib")),
+            Data("new-binary".utf8)
+        )
+
+        // No staging leftovers next to the version directories
+        let leftovers = try fm.contentsOfDirectory(atPath: installDir.deletingLastPathComponent().path)
+            .filter { $0.hasPrefix(".staging-") }
+        XCTAssertTrue(leftovers.isEmpty)
+    }
+}

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsVerifyTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsVerifyTests.swift
@@ -1,0 +1,141 @@
+//
+//  ToolsVerifyTests.swift
+//  osaurus
+//
+//  Regression coverage for `osaurus tools verify`: missing/unreadable/
+//  malformed receipts and dylibs must be reported as failures instead of
+//  being silently skipped (which let broken installs verify clean).
+//
+
+import CryptoKit
+import Foundation
+import OsaurusRepository
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ToolsVerifyTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-tools-verify-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let root {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
+    private func makeVersionDir(pluginId: String, version: String) throws -> URL {
+        let dir = root.appendingPathComponent(pluginId, isDirectory: true)
+            .appendingPathComponent(version, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func writeValidInstall(pluginId: String, version: String, dylibContents: String = "binary") throws
+        -> URL
+    {
+        let dir = try makeVersionDir(pluginId: pluginId, version: version)
+        let dylibData = Data(dylibContents.utf8)
+        try dylibData.write(to: dir.appendingPathComponent("Plugin.dylib"))
+        let sha = Data(SHA256.hash(data: dylibData)).map { String(format: "%02x", $0) }.joined()
+        let receipt = PluginReceipt(
+            plugin_id: pluginId,
+            version: SemanticVersion.parse(version)!,
+            installed_at: Date(),
+            dylib_filename: "Plugin.dylib",
+            dylib_sha256: sha,
+            platform: "macos",
+            arch: "arm64",
+            public_keys: nil,
+            artifact: .init(url: "file:///dev/null", sha256: sha, minisign: nil, size: dylibData.count)
+        )
+        try JSONEncoder().encode(receipt).write(to: dir.appendingPathComponent("receipt.json"))
+        return dir
+    }
+
+    func testHealthyInstallVerifiesClean() throws {
+        _ = try writeValidInstall(pluginId: "com.example.good", version: "1.0.0")
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 0)
+        XCTAssertEqual(report.lines.count, 1)
+        XCTAssertTrue(report.lines[0].hasPrefix("OK"))
+    }
+
+    func testMissingReceiptIsAFailure() throws {
+        let dir = try makeVersionDir(pluginId: "com.example.noreceipt", version: "1.0.0")
+        try Data("binary".utf8).write(to: dir.appendingPathComponent("Plugin.dylib"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("receipt.json missing"))
+    }
+
+    func testMalformedReceiptIsAFailure() throws {
+        let dir = try makeVersionDir(pluginId: "com.example.badreceipt", version: "1.0.0")
+        try Data("not json".utf8).write(to: dir.appendingPathComponent("receipt.json"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("receipt.json malformed"))
+    }
+
+    func testMissingDylibIsAFailure() throws {
+        let dir = try writeValidInstall(pluginId: "com.example.nodylib", version: "1.0.0")
+        try FileManager.default.removeItem(at: dir.appendingPathComponent("Plugin.dylib"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("Plugin.dylib missing"))
+    }
+
+    func testShaMismatchIsAFailure() throws {
+        let dir = try writeValidInstall(pluginId: "com.example.tampered", version: "1.0.0")
+        try Data("tampered".utf8).write(to: dir.appendingPathComponent("Plugin.dylib"))
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("expected"))
+    }
+
+    func testDanglingCurrentSymlinkIsAFailure() throws {
+        _ = try writeValidInstall(pluginId: "com.example.dangling", version: "1.0.0")
+        let pluginDir = root.appendingPathComponent("com.example.dangling", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: pluginDir.appendingPathComponent("current").path,
+            withDestinationPath: "9.9.9"
+        )
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 1)
+        XCTAssertTrue(report.lines[0].contains("missing version 9.9.9"))
+    }
+
+    func testHealthyCurrentSymlinkChecksOnlyThatVersion() throws {
+        _ = try writeValidInstall(pluginId: "com.example.linked", version: "1.0.0")
+        _ = try writeValidInstall(pluginId: "com.example.linked", version: "2.0.0")
+        let pluginDir = root.appendingPathComponent("com.example.linked", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: pluginDir.appendingPathComponent("current").path,
+            withDestinationPath: "2.0.0"
+        )
+
+        let report = ToolsVerify.verifyInstalledTools(root: root)
+
+        XCTAssertEqual(report.failures, 0)
+        XCTAssertEqual(report.lines.count, 1)
+    }
+}

--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -556,11 +556,19 @@ public final class AgentManager: ObservableObject {
 
         refresh()
 
+        // Tear down plugin state FIRST and wait for it to finish. Plugins
+        // deregister webhooks inside `on_config_changed(tunnel_url="")`
+        // and read their per-agent config (e.g. Telegram's `bot_token`)
+        // while doing so — the secrets must still exist at that point.
+        // Sweeping the keychain before this call left webhooks registered
+        // upstream forever because the plugin found no token to
+        // deregister with.
+        await PluginManager.shared.tearDownPluginsForRemovedAgent(agentId: id)
+
         // Sweep every plugin's per-agent secrets for this agent. Without
         // this, deleting an agent would leave its `bot_token` / OAuth
         // credentials / `tunnel_url` / etc. in Keychain Access forever.
-        // Done before posting `.agentRemoved` so subscribers see the
-        // post-cleanup keychain state.
+        // Done only AFTER plugin teardown completed (see above).
         ToolSecretsKeychain.deleteAllSecrets(forAgent: id)
 
         // Drop any greetings the pool was holding for this agent. We
@@ -573,9 +581,10 @@ public final class AgentManager: ObservableObject {
         // doesn't accumulate one VecturaKit instance per deleted agent.
         await MemorySearchService.shared.evictAgent(agentId: id.uuidString)
 
-        // Notify subscribers (e.g. PluginManager) so plugins can
-        // deregister webhooks (push tunnel_url=nil) and tear down any
-        // per-agent state of their own.
+        // Notify remaining subscribers. Plugin webhook deregistration
+        // already happened synchronously above; PluginManager's own
+        // `.agentRemoved` handler only performs an idempotent repeat
+        // (deduped plugin-side).
         NotificationCenter.default.post(
             name: .agentRemoved,
             object: nil,

--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -283,6 +283,24 @@ final class PluginManager {
         for entry in scanResult.loadResults {
             switch entry.result {
             case .success(let loaded):
+                // Loaded plugin IDs must be unique: tools, routes, host
+                // contexts, and secrets are all keyed by plugin ID, so a
+                // second instance would silently shadow (or corrupt) the
+                // first. Keep the already-loaded instance and reject the
+                // newcomer (e.g. a version dir that contains two dylibs).
+                if let existing = plugins.first(where: { $0.plugin.id == loaded.plugin.id }) {
+                    let pluginId = loaded.plugin.id
+                    let errorMsg =
+                        "Duplicate plugin id '\(pluginId)': already loaded from \(existing.plugin.bundlePath); ignoring \(entry.url.path)"
+                    NSLog("[Osaurus] %@", errorMsg)
+                    failedPlugins[pluginId] = FailedPlugin(
+                        pluginId: pluginId,
+                        error: errorMsg,
+                        lastKnownManifest: loaded.plugin.manifest
+                    )
+                    await loaded.plugin.shutdown()
+                    continue
+                }
                 plugins.append(loaded)
                 loadedPluginPaths.insert(entry.url.path)
                 loadedNew = true
@@ -920,6 +938,60 @@ final class PluginManager {
         return current.patchVersion >= required.patchVersion
     }
 
+    // MARK: - Load-time validation (pure helpers)
+
+    /// Returns a message when the plugin's ABI table is missing any of the
+    /// five required function pointers. Every plugin — v1 or v2+ — must
+    /// provide the full required prefix; optional v2 callbacks stay optional.
+    nonisolated static func abiTableValidationFailure(_ api: osr_plugin_api) -> String? {
+        var missing: [String] = []
+        if api.free_string == nil { missing.append("free_string") }
+        if api.`init` == nil { missing.append("init") }
+        if api.destroy == nil { missing.append("destroy") }
+        if api.get_manifest == nil { missing.append("get_manifest") }
+        if api.invoke == nil { missing.append("invoke") }
+        guard !missing.isEmpty else { return nil }
+        return "Plugin ABI table is missing required function(s): \(missing.joined(separator: ", "))"
+    }
+
+    /// Returns a message when the manifest's `plugin_id` does not match the
+    /// install-directory-derived ID the receipt/consent/quarantine machinery
+    /// is keyed by.
+    nonisolated static func manifestIdentityValidationFailure(
+        manifest: PluginManifest,
+        directoryId: String
+    ) -> String? {
+        guard manifest.plugin_id != directoryId else { return nil }
+        return
+            "Plugin manifest declares plugin_id '\(manifest.plugin_id)' but is installed as '\(directoryId)'. Reinstall the plugin under its canonical ID."
+    }
+
+    /// Returns a message when the manifest declares an empty or duplicate
+    /// tool ID, or an empty or duplicate route ID.
+    nonisolated static func manifestCapabilityValidationFailure(_ manifest: PluginManifest) -> String? {
+        var seenToolIds = Set<String>()
+        for tool in manifest.capabilities.tools ?? [] {
+            let id = tool.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            if id.isEmpty {
+                return "Plugin \(manifest.plugin_id) declares a tool with an empty id"
+            }
+            if !seenToolIds.insert(id).inserted {
+                return "Plugin \(manifest.plugin_id) declares duplicate tool id '\(id)'"
+            }
+        }
+        var seenRouteIds = Set<String>()
+        for route in manifest.capabilities.routes ?? [] {
+            let id = route.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            if id.isEmpty {
+                return "Plugin \(manifest.plugin_id) declares a route with an empty id"
+            }
+            if !seenRouteIds.insert(id).inserted {
+                return "Plugin \(manifest.plugin_id) declares duplicate route id '\(id)'"
+            }
+        }
+        return nil
+    }
+
     /// Loads a single plugin from a dylib URL via dlopen + C ABI handshake.
     /// Tries v2 entry point first (with host API injection), then falls back to v1.
     nonisolated private static func loadPluginWithError(at url: URL) -> Result<LoadedPlugin, PluginLoadError> {
@@ -988,8 +1060,11 @@ final class PluginManager {
                 return .failure(PluginLoadError(message: errorMsg))
             }
 
-            let apiPtr = apiRawPtr.assumingMemoryBound(to: osr_plugin_api.self)
-            api = apiPtr.pointee
+            // Historical v1 structs contain ONLY the required prefix — reading
+            // the full `osr_plugin_api` here would read past the end of the
+            // plugin's static struct. Decode via the explicit prefix layout.
+            let prefixPtr = apiRawPtr.assumingMemoryBound(to: osr_plugin_api_v1.self)
+            api = osr_plugin_api(v1: prefixPtr.pointee)
             abiVersion = 1
             print(
                 "[Osaurus] Loaded plugin from \(url.lastPathComponent) (entry=v1 legacy). "
@@ -999,6 +1074,19 @@ final class PluginManager {
         } else {
             let errorMsg = "Missing plugin entry point (osaurus_plugin_entry_v2 or osaurus_plugin_entry)"
             print("[Osaurus] \(errorMsg) in \(url.lastPathComponent)")
+            dlclose(handle)
+            return .failure(PluginLoadError(message: errorMsg))
+        }
+
+        // Reject incomplete ABI tables BEFORE calling init. Accepting a nil
+        // `free_string` leaks every returned string, a nil `destroy` makes
+        // teardown impossible, and a nil `invoke` produces tools that can
+        // never run — none of which the plugin can fix after init has
+        // already handed out a live context.
+        if let abiError = abiTableValidationFailure(api) {
+            let errorMsg = "\(abiError) in \(url.lastPathComponent)"
+            print("[Osaurus] \(errorMsg)")
+            hostContext?.teardown()
             dlclose(handle)
             return .failure(PluginLoadError(message: errorMsg))
         }
@@ -1054,10 +1142,33 @@ final class PluginManager {
             return .failure(PluginLoadError(message: errorMsg))
         }
 
-        // If the manifest plugin_id differs from the directory-derived ID,
-        // re-register the host context under the canonical ID.
-        if let hc = hostContext, manifest.plugin_id != hc.pluginId {
-            PluginHostContext.rekeyContext(from: hc.pluginId, to: manifest.plugin_id)
+        // The install layout (`Tools/<plugin_id>/<version>/`) and the receipt
+        // are keyed by the directory-derived ID; verification, consent,
+        // quarantine, and secrets all use it. A manifest that declares a
+        // different ID would let a plugin masquerade under another plugin's
+        // identity (and previously just re-keyed the host context to the
+        // manifest's claim). Fail the load instead.
+        let directoryId = extractPluginId(from: url)
+        if let identityError = manifestIdentityValidationFailure(
+            manifest: manifest,
+            directoryId: directoryId
+        ) {
+            print("[Osaurus] \(identityError)")
+            api.destroy?(ctx)
+            hostContext?.teardown()
+            dlclose(handle)
+            return .failure(PluginLoadError(message: identityError, manifest: manifest))
+        }
+
+        // Reject empty or duplicate tool/route IDs up front — duplicate tool
+        // IDs would silently overwrite each other in the tool registry, and
+        // empty/duplicate route IDs break route dispatch and diagnostics.
+        if let capabilityError = manifestCapabilityValidationFailure(manifest) {
+            print("[Osaurus] \(capabilityError)")
+            api.destroy?(ctx)
+            hostContext?.teardown()
+            dlclose(handle)
+            return .failure(PluginLoadError(message: capabilityError, manifest: manifest))
         }
 
         // Enforce manifest-declared compatibility constraints. Authors

--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -1088,12 +1088,13 @@ final class PluginManager {
         if let mount = manifest.capabilities.web?.mount,
             let routes = manifest.capabilities.routes
         {
-            let normalizedMount = mount.hasPrefix("/") ? mount : "/\(mount)"
             for route in routes {
                 let routePath = route.path.hasPrefix("/") ? route.path : "/\(route.path)"
-                let isShadowed =
-                    routePath == normalizedMount
-                    || routePath.hasPrefix(normalizedMount + "/")
+                // Same segment-boundary helper HTTPHandler uses for static
+                // dispatch, so validation and runtime can never disagree
+                // about which paths the mount captures.
+                let isShadowed = PluginManifest.WebSpec.mountCaptures(
+                    subpath: routePath, mount: mount)
                 if isShadowed {
                     let errorMsg =
                         "Plugin \(manifest.plugin_id) declares route '\(route.path)' under web mount '\(mount)'; the static web branch would shadow this route. Move the route outside the web mount or remove the web mount overlap."

--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -466,12 +466,18 @@ final class PluginManager {
         else { return }
 
         let allFieldKeys = Set(configSpec.sections.flatMap { $0.fields.map { $0.key } })
-        var values = ToolSecretsKeychain.getAllSecrets(for: pluginId, agentId: agentId)
+        // Shared resolution policy (exact agent overlaid on default-agent
+        // globals) so initial delivery matches tool payload injection —
+        // a key saved once on the Plugins tab reaches every agent's
+        // `on_config_changed`, not just the Default agent's.
+        var values = ToolSecretsKeychain.resolvedSecretsWithDefaults(
+            pluginId: pluginId, agentId: agentId)
 
         for section in configSpec.sections {
             for field in section.fields {
                 if values[field.key] == nil, field.type != .readonly, field.type != .status,
-                    let val = ToolSecretsKeychain.getSecret(id: field.key, for: pluginId, agentId: agentId)
+                    let val = ToolSecretsKeychain.resolvedSecret(
+                        id: field.key, for: pluginId, agentId: agentId)
                 {
                     values[field.key] = val
                 }
@@ -479,7 +485,8 @@ final class PluginManager {
                     values[field.key] = def.stringValue
                 }
                 if let connKey = field.connected_when, values[connKey] == nil,
-                    let val = ToolSecretsKeychain.getSecret(id: connKey, for: pluginId, agentId: agentId)
+                    let val = ToolSecretsKeychain.resolvedSecret(
+                        id: connKey, for: pluginId, agentId: agentId)
                 {
                     values[connKey] = val
                 }
@@ -564,8 +571,12 @@ final class PluginManager {
 
     /// Tear down per-agent state on every loaded plugin when an agent is
     /// deleted: push `tunnel_url=""` so plugins can deregister their
-    /// webhooks. Per-agent keychain secrets are swept by
-    /// `AgentManager.delete(id:)` itself before this handler runs.
+    /// webhooks. `AgentManager.delete(id:)` already ran the awaitable
+    /// `tearDownPluginsForRemovedAgent` before sweeping keychain secrets;
+    /// this notification-driven pass is a belt-and-braces repeat for any
+    /// other `.agentRemoved` poster — the plugin-side delivery dedup
+    /// filters the duplicate `tunnel_url=""` so `on_config_changed`
+    /// doesn't re-fire.
     private func handleAgentRemoved(_ agentId: UUID) {
         for loaded in plugins where !loaded.routes.isEmpty {
             pushTunnelURL(nil, to: loaded, agentId: agentId)
@@ -576,6 +587,41 @@ final class PluginManager {
         for pluginId in lastPushedTunnelURL.keys {
             lastPushedTunnelURL[pluginId]?.removeValue(forKey: agentId)
         }
+    }
+
+    /// Awaitable per-agent plugin teardown for agent deletion. Pushes
+    /// `tunnel_url=""` to every routed plugin through the SYNCHRONOUS
+    /// config-delivery path and returns only after each plugin's
+    /// `on_config_changed` has run.
+    ///
+    /// Ordering contract: `AgentManager.delete(id:)` must call this
+    /// BEFORE `ToolSecretsKeychain.deleteAllSecrets(forAgent:)`. Plugins
+    /// deregister webhooks inside this callback and read their config
+    /// (e.g. Telegram's `bot_token`) while doing so — sweeping the
+    /// keychain first made those reads return nothing, leaving the
+    /// webhook registered upstream forever.
+    func tearDownPluginsForRemovedAgent(agentId: UUID) async {
+        // Drop the host-side tunnel-push dedup entries regardless of
+        // whether any plugin needs a delivery.
+        for pluginId in lastPushedTunnelURL.keys {
+            lastPushedTunnelURL[pluginId]?.removeValue(forKey: agentId)
+        }
+
+        let routed = plugins.filter { !$0.routes.isEmpty }
+        guard !routed.isEmpty else { return }
+
+        // Off the main actor: the keychain write blocks on security-daemon
+        // XPC and `notifyConfigBatchSync` blocks until the plugin's C
+        // callback returns.
+        await Task.detached(priority: .userInitiated) {
+            for loaded in routed {
+                Self.persistTunnelURLSecret(nil, pluginId: loaded.plugin.id, agentId: agentId)
+                loaded.plugin.notifyConfigBatchSync(
+                    [(key: "tunnel_url", value: "")],
+                    agentId: agentId
+                )
+            }
+        }.value
     }
 
     private func handleTunnelStatusChange(_ statuses: [UUID: AgentRelayStatus]) {

--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -197,6 +197,40 @@ struct osr_plugin_api {
     var on_task_event: osr_on_task_event_t?
 }
 
+/// Historical v1 layout: plugins compiled against the original header
+/// exported a static struct containing ONLY the five required function
+/// pointers — no `version` field, no optional callbacks. The v1 entry
+/// path must decode through this prefix instead of the full
+/// `osr_plugin_api`, otherwise the loader reads past the end of the
+/// plugin's static struct (out-of-bounds read into whatever the plugin
+/// binary placed after it).
+struct osr_plugin_api_v1 {
+    var free_string: osr_free_string_t?
+    var `init`: osr_init_t?
+    var destroy: osr_destroy_t?
+    var get_manifest: osr_get_manifest_t?
+    var invoke: osr_invoke_t?
+}
+
+extension osr_plugin_api {
+    /// Widens a legacy v1 prefix into the current layout with every
+    /// optional v2+ slot zeroed (`version == 0` matches the header's
+    /// "0 (or absent) for v1 plugins" contract).
+    init(v1 prefix: osr_plugin_api_v1) {
+        self.init(
+            free_string: prefix.free_string,
+            init: prefix.`init`,
+            destroy: prefix.destroy,
+            get_manifest: prefix.get_manifest,
+            invoke: prefix.invoke,
+            version: 0,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+    }
+}
+
 // Entry point types
 typealias osr_plugin_entry_t = @convention(c) () -> UnsafeRawPointer?
 typealias osr_plugin_entry_v2_t = @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?

--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -417,6 +417,40 @@ public struct PluginManifest: Decodable, Sendable {
 
         /// Computed convenience: treats nil as the default (false).
         public var isTunnelExposed: Bool { tunnel_exposed == true }
+
+        // MARK: Mount matching (shared by load-time validation and dispatch)
+
+        /// Canonical mount shape: leading `/`, no trailing `/` (except the
+        /// root mount `/` itself).
+        public static func normalizedMount(_ mount: String) -> String {
+            var m = mount.trimmingCharacters(in: .whitespaces)
+            if !m.hasPrefix("/") { m = "/" + m }
+            while m.count > 1 && m.hasSuffix("/") { m.removeLast() }
+            return m
+        }
+
+        /// Segment-boundary mount matching: mount `/ui` captures `/ui` and
+        /// `/ui/...` but NOT `/ui-other`. A bare prefix check disagreed with
+        /// the load-time overlap validation and let one plugin's static
+        /// branch swallow sibling paths. The root mount `/` captures
+        /// everything. Both `PluginManager`'s web/route overlap validation
+        /// and `HTTPHandler`'s static dispatch call this single helper so
+        /// they can never diverge again.
+        public static func mountCaptures(subpath: String, mount: String) -> Bool {
+            let m = normalizedMount(mount)
+            if m == "/" { return true }
+            return subpath == m || subpath.hasPrefix(m + "/")
+        }
+
+        /// Remainder of `subpath` after the mount: `""` for the mount root,
+        /// otherwise a `/`-prefixed path (`/ui/x` under mount `/ui` → `/x`).
+        /// Only meaningful when `mountCaptures` is true.
+        public static func relativeSubpath(subpath: String, mount: String) -> String {
+            let m = normalizedMount(mount)
+            if m == "/" { return subpath == "/" ? "" : subpath }
+            guard mountCaptures(subpath: subpath, mount: mount) else { return subpath }
+            return String(subpath.dropFirst(m.count))
+        }
     }
 
     // MARK: - Docs Spec
@@ -530,6 +564,75 @@ public struct PluginManifest: Decodable, Sendable {
         // Must have actually used the parameter mechanism to be a "param" match;
         // exact matches were already returned above and shouldn't reach here.
         return hadParam ? params : nil
+    }
+}
+
+/// Timer queue for the route-handler wall-clock race. A dedicated GCD queue
+/// (not `Task.sleep`) so a saturated Swift executor cannot delay the timeout
+/// behind unrelated async work — same rationale as `ToolRegistry`'s
+/// tool-body timeout queue.
+private let routeHandlerTimeoutQueue = DispatchQueue(label: "com.osaurus.plugin.route-timeout")
+
+/// One-shot race between a route-handler body and its timeout, mirroring
+/// `ToolBodyRaceState` in `ToolRegistry`. Whichever side completes first
+/// resumes the continuation; the loser is cancelled/ignored. Crucially the
+/// caller is resumed WITHOUT waiting for the body task to finish — a
+/// blocking C callback that ignores cancellation keeps running on the
+/// plugin's invoke queue, but the HTTP request gets its timeout response.
+private final class RouteHandlerRaceState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+    private var pendingResult: Result<String, Error>?
+    private var continuation: CheckedContinuation<String, Error>?
+    private var bodyTask: Task<Void, Never>?
+    private var timeoutTimer: DispatchSourceTimer?
+
+    func install(continuation: CheckedContinuation<String, Error>) {
+        lock.lock()
+        if didResume, let pendingResult {
+            self.pendingResult = nil
+            lock.unlock()
+            continuation.resume(with: pendingResult)
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func setTasks(bodyTask: Task<Void, Never>, timeoutTimer: DispatchSourceTimer) {
+        lock.lock()
+        if didResume {
+            lock.unlock()
+            bodyTask.cancel()
+            timeoutTimer.cancel()
+            return
+        }
+        self.bodyTask = bodyTask
+        self.timeoutTimer = timeoutTimer
+        lock.unlock()
+    }
+
+    func complete(_ result: Result<String, Error>) {
+        lock.lock()
+        guard !didResume else {
+            lock.unlock()
+            return
+        }
+        didResume = true
+        let continuation = self.continuation
+        if continuation == nil {
+            pendingResult = result
+        }
+        self.continuation = nil
+        let bodyTask = self.bodyTask
+        let timeoutTimer = self.timeoutTimer
+        self.bodyTask = nil
+        self.timeoutTimer = nil
+        lock.unlock()
+
+        bodyTask?.cancel()
+        timeoutTimer?.cancel()
+        continuation?.resume(with: result)
     }
 }
 
@@ -962,29 +1065,47 @@ final class ExternalPlugin: @unchecked Sendable {
             }
         }
 
-        return try await withThrowingTaskGroup(of: String?.self) { group in
-            group.addTask { try await work() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
-                return nil
+        // Unstructured task + GCD timer race (mirrors `ToolRegistry.runToolBody`).
+        // A `withThrowingTaskGroup` here would drain its children before
+        // returning, so a blocking C route callback that ignores cancellation
+        // held the caller for the FULL duration of the call — the 30s timeout
+        // never actually fired from the request's point of view. The race
+        // resumes the caller as soon as the timer wins; the abandoned body
+        // task keeps running on the plugin's invoke queue until the C call
+        // returns, but the HTTP request is no longer held hostage.
+        let timeoutError = NSError(
+            domain: "ExternalPlugin",
+            code: 5,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Plugin route handler timed out after \(Int(timeoutSeconds))s"
+            ]
+        )
+        let race = RouteHandlerRaceState()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                race.install(continuation: continuation)
+                let timeoutTimer = DispatchSource.makeTimerSource(queue: routeHandlerTimeoutQueue)
+                let timeoutNanoseconds = max(0, Int(timeoutSeconds * 1_000_000_000))
+                timeoutTimer.schedule(deadline: .now() + .nanoseconds(timeoutNanoseconds))
+                timeoutTimer.setEventHandler {
+                    race.complete(.failure(timeoutError))
+                }
+                timeoutTimer.resume()
+
+                let bodyTask = Task {
+                    do {
+                        let result = try await work()
+                        race.complete(.success(result))
+                    } catch {
+                        race.complete(.failure(error))
+                    }
+                }
+                race.setTasks(bodyTask: bodyTask, timeoutTimer: timeoutTimer)
             }
-            for try await first in group {
-                group.cancelAll()
-                if let value = first { return value }
-                throw NSError(
-                    domain: "ExternalPlugin",
-                    code: 5,
-                    userInfo: [
-                        NSLocalizedDescriptionKey:
-                            "Plugin route handler timed out after \(Int(timeoutSeconds))s"
-                    ]
-                )
-            }
-            throw NSError(
-                domain: "ExternalPlugin",
-                code: 5,
-                userInfo: [NSLocalizedDescriptionKey: "Plugin route handler returned without result"]
-            )
+        } onCancel: {
+            race.complete(.failure(CancellationError()))
         }
     }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1755,10 +1755,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let manifest = loaded.plugin.manifest
 
-            // Check for static web serving first
+            // Check for static web serving first. Segment-boundary matching
+            // via the shared helper: mount `/ui` must NOT capture `/ui-other`
+            // (a bare `hasPrefix` did, disagreeing with the load-time
+            // web/route overlap validation in PluginManager).
             if let webSpec = loaded.webConfig {
-                let mountPrefix = webSpec.mount.hasPrefix("/") ? webSpec.mount : "/\(webSpec.mount)"
-                if subpath.hasPrefix(mountPrefix) {
+                if PluginManifest.WebSpec.mountCaptures(subpath: subpath, mount: webSpec.mount) {
                     // Tunnel exposure gate: web UIs are loopback-only by
                     // default. Plugins must opt in via `capabilities.web.tunnel_exposed`
                     // for the static UI to be reachable over the tunnel.
@@ -1795,7 +1797,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
                     // Check for dev proxy configuration
                     if let proxyURL = Self.loadDevProxyURL(for: pluginId) {
-                        let relPath = String(subpath.dropFirst(mountPrefix.count))
+                        let relPath = PluginManifest.WebSpec.relativeSubpath(
+                            subpath: subpath, mount: webSpec.mount)
                         let targetPath = relPath.isEmpty ? "/" : relPath
                         // Forward the original method/headers/body so HMR,
                         // POST APIs, and any non-GET dev-server traffic
@@ -1824,7 +1827,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         )
                     }
 
-                    let relPath = String(subpath.dropFirst(mountPrefix.count))
+                    let relPath = PluginManifest.WebSpec.relativeSubpath(
+                        subpath: subpath, mount: webSpec.mount)
                     let filePath: String
                     if relPath.isEmpty || relPath == "/" {
                         filePath = webSpec.entry

--- a/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
@@ -105,6 +105,27 @@ public enum ToolSecretsKeychain {
         resolvedSecretsMerging(pluginId: pluginId, primary: agentId, defaults: Agent.defaultId)
     }
 
+    /// THE single per-key resolution policy: exact agent namespace first,
+    /// then the `Agent.defaultId` namespace as the global-default fallback
+    /// (Plugins-tab writes land there). This is the per-key equivalent of
+    /// `resolvedSecretsWithDefaults` and must be used by every read path
+    /// that feeds plugins — `config_get`, initial config delivery, and
+    /// required-secret checks — so they can't disagree with tool payload
+    /// injection about whether a key is configured.
+    public static func resolvedSecret(id: String, for pluginId: String, agentId: UUID) -> String? {
+        if let exact = getSecret(id: id, for: pluginId, agentId: agentId) {
+            return exact
+        }
+        guard agentId != Agent.defaultId else { return nil }
+        return getSecret(id: id, for: pluginId, agentId: Agent.defaultId)
+    }
+
+    /// `resolvedSecret` presence check (exact agent, then default-agent
+    /// fallback).
+    public static func hasResolvedSecret(id: String, for pluginId: String, agentId: UUID) -> Bool {
+        resolvedSecret(id: id, for: pluginId, agentId: agentId) != nil
+    }
+
     /// Two-id merge primitive: `primary` agent's secrets overlaid on `defaults`.
     public static func resolvedSecretsMerging(pluginId: String, primary: UUID, defaults: UUID) -> [String: String] {
         let defaultDict = getAllSecrets(for: pluginId, agentId: defaults)
@@ -115,11 +136,15 @@ public enum ToolSecretsKeychain {
         return merged
     }
 
+    /// Required-secret check under the shared resolution policy: a key
+    /// satisfied by a Plugins-tab (default-agent) write counts as
+    /// configured for every agent, matching what tool payload injection
+    /// actually delivers via `resolvedSecretsWithDefaults`.
     public static func hasAllRequiredSecrets(specs: [PluginManifest.SecretSpec], for pluginId: String, agentId: UUID)
         -> Bool
     {
         for spec in specs where spec.required {
-            if !hasSecret(id: spec.id, for: pluginId, agentId: agentId) {
+            if !hasResolvedSecret(id: spec.id, for: pluginId, agentId: agentId) {
                 return false
             }
         }
@@ -132,7 +157,7 @@ public enum ToolSecretsKeychain {
         agentId: UUID
     ) -> [PluginManifest.SecretSpec] {
         return specs.filter { spec in
-            spec.required && !hasSecret(id: spec.id, for: pluginId, agentId: agentId)
+            spec.required && !hasResolvedSecret(id: spec.id, for: pluginId, agentId: agentId)
         }
     }
 

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -295,7 +295,11 @@ final class PluginHostContext: @unchecked Sendable {
             Self.warnNoAgentContextOnce(pluginId: pluginId, op: "config_get")
             return nil
         }
-        return ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: agentId)
+        // Shared resolution policy (exact agent, then default-agent
+        // fallback) so `config_get` agrees with tool payload injection —
+        // a `bot_token` saved as a Plugins-tab global default must be
+        // readable here, not only via the injected payload.
+        return ToolSecretsKeychain.resolvedSecret(id: key, for: pluginId, agentId: agentId)
     }
 
     /// Maximum config value byte size accepted by `config_set`. The

--- a/Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift
@@ -1,0 +1,302 @@
+//
+//  AgentLifecycleConfigResolutionTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for two lifecycle/config defects:
+//
+//  1. Teardown ordering: `AgentManager.delete(id:)` swept the agent's
+//     Keychain secrets BEFORE posting `.agentRemoved`, so plugins that
+//     read config (e.g. Telegram's `bot_token`) inside their webhook
+//     deregistration callback found nothing — the webhook stayed
+//     registered upstream forever. Deletion now awaits
+//     `PluginManager.tearDownPluginsForRemovedAgent` (synchronous
+//     `tunnel_url=""` delivery to every routed plugin) and only then
+//     sweeps. The test drives a real `ExternalPlugin` with a C
+//     `on_config_changed` that reads the secret mid-teardown.
+//
+//  2. Config default resolution: tool payload injection merged
+//     `Agent.defaultId` values as global defaults, but `config_get`,
+//     initial config delivery, and required-secret checks read only the
+//     exact agent namespace — a key saved once on the Plugins tab was
+//     "configured" for injection but invisible to `config_get`. All
+//     paths now share `ToolSecretsKeychain.resolvedSecret` (exact agent
+//     first, then default-agent fallback).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Teardown ordering
+
+@MainActor
+@Suite(.serialized)
+struct AgentDeletionPluginTeardownOrderingTests {
+
+    /// Shared with the C `on_config_changed` callback via the plugin's
+    /// opaque `ctx` pointer. The callback simulates a Telegram-style
+    /// plugin: on `tunnel_url=""` (webhook deregistration signal) it
+    /// reads its `bot_token` from the keychain — exactly what the real
+    /// plugin needs to call Telegram's `deleteWebhook` API.
+    final class TeardownRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _pluginId = ""
+        private var _agentId: UUID?
+        private var _sawDeregister = false
+        private var _tokenDuringDeregister: String?
+
+        var pluginId: String {
+            get { lock.withLock { _pluginId } }
+            set { lock.withLock { _pluginId = newValue } }
+        }
+        var agentId: UUID? {
+            get { lock.withLock { _agentId } }
+            set { lock.withLock { _agentId = newValue } }
+        }
+        var sawDeregister: Bool { lock.withLock { _sawDeregister } }
+        var tokenDuringDeregister: String? { lock.withLock { _tokenDuringDeregister } }
+
+        func recordDeregister(token: String?) {
+            lock.withLock {
+                _sawDeregister = true
+                _tokenDuringDeregister = token
+            }
+        }
+    }
+
+    private static let deregisteringConfigChanged: osr_on_config_changed_t = { ctxPtr, keyPtr, valuePtr in
+        guard let ctxPtr, let keyPtr, let valuePtr else { return }
+        let key = String(cString: keyPtr)
+        let value = String(cString: valuePtr)
+        guard key == "tunnel_url", value.isEmpty else { return }
+        let recorder = Unmanaged<TeardownRecorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+        guard let agentId = recorder.agentId else {
+            recorder.recordDeregister(token: nil)
+            return
+        }
+        // The regression: this read returned nil because the keychain
+        // sweep ran before plugin teardown.
+        let token = ToolSecretsKeychain.getSecret(
+            id: "bot_token",
+            for: recorder.pluginId,
+            agentId: agentId
+        )
+        recorder.recordDeregister(token: token)
+    }
+
+    private func makeRoutedPlugin(
+        recorder: TeardownRecorder,
+        pluginId: String
+    ) -> (loaded: PluginManager.LoadedPlugin, retain: Unmanaged<TeardownRecorder>) {
+        let retain = Unmanaged.passRetained(recorder)
+        let ctx = retain.toOpaque()
+        let api = osr_plugin_api(
+            free_string: { ptr in
+                guard let ptr else { return }
+                free(UnsafeMutableRawPointer(mutating: ptr))
+            },
+            init: nil,
+            destroy: { _ in },
+            get_manifest: nil,
+            invoke: { _, _, _, _ in nil },
+            version: 6,
+            handle_route: { _, _ in UnsafePointer(strdup(#"{"status":200}"#)) },
+            on_config_changed: Self.deregisteringConfigChanged,
+            on_task_event: nil
+        )
+        let route = PluginManifest.RouteSpec(
+            id: "webhook",
+            path: "/webhook",
+            methods: ["POST"]
+        )
+        let manifest = PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(
+                tools: nil, routes: [route], config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+        let plugin = ExternalPlugin(
+            handle: ctx,
+            api: api,
+            ctx: ctx,
+            manifest: manifest,
+            path: "/tmp/teardown-order-\(pluginId)",
+            abiVersion: 6
+        )
+        let loaded = PluginManager.LoadedPlugin(
+            plugin: plugin,
+            handle: ctx,
+            tools: [],
+            skills: [],
+            routes: [route],
+            webConfig: nil,
+            readmePath: nil,
+            changelogPath: nil
+        )
+        return (loaded, retain)
+    }
+
+    /// Deleting an agent must deliver the webhook-deregistration signal
+    /// (`tunnel_url=""`) to routed plugins WHILE the agent's secrets are
+    /// still in the keychain, and only sweep afterwards — all completed
+    /// by the time `delete(id:)` returns.
+    @Test
+    func deleteNotifiesPluginsBeforeSweepingSecrets() async throws {
+        try await ChatHistoryTestStorage.run {
+            let pluginId = "com.test.teardown-order.\(UUID().uuidString)"
+            let recorder = TeardownRecorder()
+            recorder.pluginId = pluginId
+
+            let (loaded, retain) = self.makeRoutedPlugin(recorder: recorder, pluginId: pluginId)
+            PluginManager.shared.injectLoadedPluginForTesting(loaded)
+            defer {
+                PluginManager.shared.removeLoadedPluginForTesting(pluginId: pluginId)
+                retain.release()
+            }
+
+            let agent = Agent(
+                name: "TeardownOrder-\(UUID().uuidString.prefix(6))",
+                systemPrompt: "Test identity",
+                agentAddress: "test-teardown-\(UUID().uuidString)"
+            )
+            AgentManager.shared.add(agent)
+            recorder.agentId = agent.id
+
+            ToolSecretsKeychain.saveSecret("tok-123", id: "bot_token", for: pluginId, agentId: agent.id)
+
+            let result = await AgentManager.shared.delete(id: agent.id)
+            #expect(result.deleted)
+
+            // Teardown ran, and — the ordering regression — the plugin
+            // could still read its bot_token during deregistration.
+            #expect(recorder.sawDeregister, "plugin must receive tunnel_url=\"\" during delete()")
+            #expect(
+                recorder.tokenDuringDeregister == "tok-123",
+                "secrets must still exist while the plugin deregisters its webhook"
+            )
+
+            // ...and the sweep still happened afterwards.
+            #expect(
+                ToolSecretsKeychain.getSecret(id: "bot_token", for: pluginId, agentId: agent.id) == nil,
+                "secrets must be swept once teardown completed"
+            )
+
+            // Let the belt-and-braces `.agentRemoved` handler task run
+            // while the injected plugin is still registered (its delivery
+            // is deduped plugin-side, so the recorder must not fire again).
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+    }
+}
+
+// MARK: - Config default resolution policy
+
+/// Pins `ToolSecretsKeychain.resolvedSecret` — THE single resolution
+/// policy (exact agent, then `Agent.defaultId` fallback) shared by
+/// `config_get`, initial config delivery, and required-secret checks.
+/// Uses a synthetic "defaults" write under `Agent.defaultId` and cleans
+/// it up, since that UUID is shared process state.
+struct ToolSecretsResolutionPolicyTests {
+
+    @Test func exactAgentValueWins() {
+        let pluginId = "com.test.resolve.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: agent)
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+
+        ToolSecretsKeychain.saveSecret("global", id: "api_key", for: pluginId, agentId: Agent.defaultId)
+        ToolSecretsKeychain.saveSecret("mine", id: "api_key", for: pluginId, agentId: agent)
+
+        #expect(ToolSecretsKeychain.resolvedSecret(id: "api_key", for: pluginId, agentId: agent) == "mine")
+    }
+
+    @Test func fallsBackToDefaultAgentNamespace() {
+        let pluginId = "com.test.resolve.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+
+        ToolSecretsKeychain.saveSecret("global", id: "api_key", for: pluginId, agentId: Agent.defaultId)
+
+        #expect(ToolSecretsKeychain.resolvedSecret(id: "api_key", for: pluginId, agentId: agent) == "global")
+        #expect(ToolSecretsKeychain.hasResolvedSecret(id: "api_key", for: pluginId, agentId: agent))
+    }
+
+    @Test func missingEverywhereResolvesNil() {
+        let pluginId = "com.test.resolve.\(UUID().uuidString)"
+        let agent = UUID()
+        #expect(ToolSecretsKeychain.resolvedSecret(id: "api_key", for: pluginId, agentId: agent) == nil)
+        #expect(!ToolSecretsKeychain.hasResolvedSecret(id: "api_key", for: pluginId, agentId: agent))
+    }
+
+    /// Required-secret checks must agree with what tool payload injection
+    /// delivers: a key satisfied by a Plugins-tab (default-agent) write
+    /// counts as configured for every agent.
+    @Test func requiredSecretChecksHonorDefaultFallback() {
+        let pluginId = "com.test.resolve.required.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+        let specs = [
+            PluginManifest.SecretSpec(id: "bot_token", label: "Bot Token"),
+            PluginManifest.SecretSpec(id: "optional_key", label: "Optional", required: false),
+        ]
+
+        #expect(!ToolSecretsKeychain.hasAllRequiredSecrets(specs: specs, for: pluginId, agentId: agent))
+        #expect(
+            ToolSecretsKeychain.getMissingRequiredSecrets(specs: specs, for: pluginId, agentId: agent)
+                .map(\.id) == ["bot_token"]
+        )
+
+        ToolSecretsKeychain.saveSecret("tok", id: "bot_token", for: pluginId, agentId: Agent.defaultId)
+
+        #expect(ToolSecretsKeychain.hasAllRequiredSecrets(specs: specs, for: pluginId, agentId: agent))
+        #expect(
+            ToolSecretsKeychain.getMissingRequiredSecrets(specs: specs, for: pluginId, agentId: agent).isEmpty
+        )
+    }
+
+    /// `config_get` (via the host context, inside a TLS scope bound to a
+    /// real agent) must resolve through the same policy — the Telegram
+    /// `bot_token` saved as a global default is readable from plugin code.
+    @Test func configGetResolvesDefaultAgentFallback() throws {
+        let pluginId = "com.test.resolve.configget.\(UUID().uuidString)"
+        let agent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: agent)
+            ToolSecretsKeychain.deleteAllSecrets(for: pluginId, agentId: Agent.defaultId)
+        }
+
+        ToolSecretsKeychain.saveSecret("tok-global", id: "bot_token", for: pluginId, agentId: Agent.defaultId)
+        ToolSecretsKeychain.saveSecret("mine", id: "other_key", for: pluginId, agentId: agent)
+
+        let ctx = try PluginHostContext(pluginId: pluginId)
+        defer { ctx.teardown() }
+
+        let (fallback, exact): (String?, String?) = PluginHostContext.withTLSScope(
+            pluginId: pluginId, agentId: agent
+        ) {
+            (ctx.configGet(key: "bot_token"), ctx.configGet(key: "other_key"))
+        }
+        #expect(fallback == "tok-global", "config_get must fall back to the default-agent namespace")
+        #expect(exact == "mine", "exact-agent values keep winning")
+
+        // Anonymous context (no bound agent) still refuses to read anything.
+        let anonymous = ctx.configGet(key: "bot_token")
+        #expect(anonymous == nil, "no agent context must not leak the default namespace")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift
@@ -1,0 +1,279 @@
+//
+//  PluginLoaderAbiValidationTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the loader's load-time validation:
+//  - a plugin ABI table missing any required function pointer is rejected
+//    BEFORE `init` is called (previously only `init`/`get_manifest` were
+//    checked, so nil `free_string`/`destroy`/`invoke` leaked or broke tools);
+//  - the legacy v1 entry path decodes through the explicit
+//    `osr_plugin_api_v1` prefix instead of the full struct (out-of-bounds
+//    read on historical v1 plugins otherwise);
+//  - manifest plugin_id must equal the install-directory-derived ID;
+//  - tool and route IDs must be non-empty and unique.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct PluginLoaderAbiValidationTests {
+
+    // MARK: - Fixtures
+
+    private static let dummyFree: osr_free_string_t = { _ in }
+    private static let dummyInit: osr_init_t = { nil }
+    private static let dummyDestroy: osr_destroy_t = { _ in }
+    private static let dummyManifest: osr_get_manifest_t = { _ in nil }
+    private static let dummyInvoke: osr_invoke_t = { _, _, _, _ in nil }
+
+    private func completeAPI() -> osr_plugin_api {
+        osr_plugin_api(
+            free_string: Self.dummyFree,
+            init: Self.dummyInit,
+            destroy: Self.dummyDestroy,
+            get_manifest: Self.dummyManifest,
+            invoke: Self.dummyInvoke,
+            version: 2,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+    }
+
+    private func makeManifest(
+        pluginId: String = "com.test.loader",
+        tools: [PluginManifest.ToolSpec]? = nil,
+        routes: [PluginManifest.RouteSpec]? = nil
+    ) -> PluginManifest {
+        PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(tools: tools, routes: routes, config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+    }
+
+    private func tool(_ id: String) -> PluginManifest.ToolSpec {
+        PluginManifest.ToolSpec(
+            id: id,
+            description: "test tool",
+            parameters: nil,
+            requirements: nil,
+            permission_policy: nil
+        )
+    }
+
+    private func route(_ id: String, path: String = "/x") -> PluginManifest.RouteSpec {
+        PluginManifest.RouteSpec(id: id, path: path, methods: ["GET"])
+    }
+
+    // MARK: - ABI table validation
+
+    @Test func completeTablePassesValidation() {
+        #expect(PluginManager.abiTableValidationFailure(completeAPI()) == nil)
+    }
+
+    @Test func missingFreeStringIsRejected() throws {
+        var api = completeAPI()
+        api.free_string = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("free_string"))
+    }
+
+    @Test func missingDestroyIsRejected() throws {
+        var api = completeAPI()
+        api.destroy = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("destroy"))
+    }
+
+    @Test func missingInvokeIsRejected() throws {
+        var api = completeAPI()
+        api.invoke = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("invoke"))
+    }
+
+    @Test func missingInitIsRejected() throws {
+        var api = completeAPI()
+        api.`init` = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("init"))
+    }
+
+    @Test func missingGetManifestIsRejected() throws {
+        var api = completeAPI()
+        api.get_manifest = nil
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        #expect(msg.contains("get_manifest"))
+    }
+
+    @Test func allMissingFunctionsAreListed() throws {
+        let api = osr_plugin_api(
+            free_string: nil,
+            init: nil,
+            destroy: nil,
+            get_manifest: nil,
+            invoke: nil,
+            version: 0,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+        let msg = try #require(PluginManager.abiTableValidationFailure(api))
+        for name in ["free_string", "init", "destroy", "get_manifest", "invoke"] {
+            #expect(msg.contains(name))
+        }
+    }
+
+    @Test func nilOptionalV2CallbacksAreStillAccepted() {
+        // Optional v2+ callbacks (handle_route / on_config_changed /
+        // on_task_event) remain optional; only the required prefix is gated.
+        var api = completeAPI()
+        api.handle_route = nil
+        api.on_config_changed = nil
+        api.on_task_event = nil
+        #expect(PluginManager.abiTableValidationFailure(api) == nil)
+    }
+
+    // MARK: - v1 prefix decode
+
+    @Test func v1PrefixLayoutIsExactlyTheFiveRequiredPointers() {
+        // The v1 entry path reads plugin memory through this struct — its
+        // size must be exactly five function pointers so the loader never
+        // reads past the end of a historical v1 plugin's static table.
+        #expect(MemoryLayout<osr_plugin_api_v1>.size == 5 * MemoryLayout<UnsafeRawPointer?>.size)
+        #expect(MemoryLayout<osr_plugin_api_v1>.size < MemoryLayout<osr_plugin_api>.size)
+    }
+
+    @Test func v1PrefixWidensWithOptionalFieldsZeroed() {
+        let prefix = osr_plugin_api_v1(
+            free_string: Self.dummyFree,
+            init: Self.dummyInit,
+            destroy: Self.dummyDestroy,
+            get_manifest: Self.dummyManifest,
+            invoke: Self.dummyInvoke
+        )
+
+        let widened = osr_plugin_api(v1: prefix)
+
+        #expect(widened.free_string != nil)
+        #expect(widened.`init` != nil)
+        #expect(widened.destroy != nil)
+        #expect(widened.get_manifest != nil)
+        #expect(widened.invoke != nil)
+        #expect(widened.version == 0)
+        #expect(widened.handle_route == nil)
+        #expect(widened.on_config_changed == nil)
+        #expect(widened.on_task_event == nil)
+    }
+
+    @Test func v1PrefixWideningPassesAbiValidationWhenComplete() {
+        let prefix = osr_plugin_api_v1(
+            free_string: Self.dummyFree,
+            init: Self.dummyInit,
+            destroy: Self.dummyDestroy,
+            get_manifest: Self.dummyManifest,
+            invoke: Self.dummyInvoke
+        )
+        #expect(PluginManager.abiTableValidationFailure(osr_plugin_api(v1: prefix)) == nil)
+    }
+
+    @Test func v1PrefixWideningStillRejectsIncompleteTable() throws {
+        let prefix = osr_plugin_api_v1(
+            free_string: nil,
+            init: Self.dummyInit,
+            destroy: nil,
+            get_manifest: Self.dummyManifest,
+            invoke: nil
+        )
+        let msg = try #require(
+            PluginManager.abiTableValidationFailure(osr_plugin_api(v1: prefix))
+        )
+        #expect(msg.contains("free_string"))
+        #expect(msg.contains("destroy"))
+        #expect(msg.contains("invoke"))
+    }
+
+    // MARK: - Manifest identity validation
+
+    @Test func matchingManifestAndDirectoryIdPasses() {
+        let manifest = makeManifest(pluginId: "com.test.match")
+        #expect(
+            PluginManager.manifestIdentityValidationFailure(
+                manifest: manifest,
+                directoryId: "com.test.match"
+            ) == nil
+        )
+    }
+
+    @Test func mismatchedManifestIdIsRejected() throws {
+        let manifest = makeManifest(pluginId: "com.test.impostor")
+        let msg = try #require(
+            PluginManager.manifestIdentityValidationFailure(
+                manifest: manifest,
+                directoryId: "com.test.victim"
+            )
+        )
+        #expect(msg.contains("com.test.impostor"))
+        #expect(msg.contains("com.test.victim"))
+    }
+
+    // MARK: - Tool / route ID validation
+
+    @Test func absentCapabilitiesPass() {
+        #expect(PluginManager.manifestCapabilityValidationFailure(makeManifest()) == nil)
+    }
+
+    @Test func uniqueToolAndRouteIdsPass() {
+        let manifest = makeManifest(
+            tools: [tool("a"), tool("b")],
+            routes: [route("r1"), route("r2", path: "/y")]
+        )
+        #expect(PluginManager.manifestCapabilityValidationFailure(manifest) == nil)
+    }
+
+    @Test func emptyToolIdIsRejected() throws {
+        let manifest = makeManifest(tools: [tool("")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("empty"))
+        #expect(msg.contains("tool"))
+    }
+
+    @Test func whitespaceOnlyToolIdIsRejected() throws {
+        let manifest = makeManifest(tools: [tool("   ")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("empty"))
+    }
+
+    @Test func duplicateToolIdIsRejected() throws {
+        let manifest = makeManifest(tools: [tool("dup"), tool("dup")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("duplicate"))
+        #expect(msg.contains("dup"))
+    }
+
+    @Test func emptyRouteIdIsRejected() throws {
+        let manifest = makeManifest(routes: [route("")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("empty"))
+        #expect(msg.contains("route"))
+    }
+
+    @Test func duplicateRouteIdIsRejected() throws {
+        let manifest = makeManifest(routes: [route("dup"), route("dup", path: "/other")])
+        let msg = try #require(PluginManager.manifestCapabilityValidationFailure(manifest))
+        #expect(msg.contains("duplicate"))
+        #expect(msg.contains("dup"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift
@@ -1,0 +1,237 @@
+//
+//  PluginRouteReliabilityTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for two route-dispatch reliability defects:
+//
+//  1. `ExternalPlugin.handleRoute` used `withThrowingTaskGroup` for its 30s
+//     timeout. Task groups drain their children before returning, so a
+//     blocking C route callback (which never observes Swift cancellation)
+//     held the HTTP request for the FULL duration of the call — the timeout
+//     never fired from the caller's point of view. The fix races an
+//     unstructured body task against a GCD timer (same pattern as
+//     `ToolRegistry.runToolBody`) and resumes the caller as soon as the
+//     timer wins. The test below pins ELAPSED WALL TIME with a deliberately
+//     blocking route callback.
+//
+//  2. Static web mount matching used a bare `subpath.hasPrefix(mountPrefix)`,
+//     so mount `/ui` captured `/ui-other` — disagreeing with the load-time
+//     web/route overlap validation. Both validation and dispatch now share
+//     `PluginManifest.WebSpec.mountCaptures`, tested here for the exact
+//     paths from the audit (`/ui`, `/ui/x`, `/ui-other`, `/`).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct PluginRouteReliabilityTests {
+
+    // MARK: - Route handler timeout race
+
+    /// Shared with the C route callback via the plugin's opaque `ctx`.
+    final class RouteRecorder: @unchecked Sendable {
+        /// Signaled once the blocking callback is inside plugin code.
+        let callbackStarted = DispatchSemaphore(value: 0)
+        /// The blocking callback waits on this before returning, so the test
+        /// controls exactly how long the "hung" C call lasts.
+        let releaseCallback = DispatchSemaphore(value: 0)
+        /// Signaled when the blocking callback finally returns (cleanup sync).
+        let callbackFinished = DispatchSemaphore(value: 0)
+    }
+
+    private func makeManifest(pluginId: String) -> PluginManifest {
+        PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(tools: nil, routes: nil, config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+    }
+
+    private func makePlugin(
+        recorder: RouteRecorder,
+        pluginId: String,
+        handleRoute: @escaping osr_handle_route_t
+    ) -> (plugin: ExternalPlugin, retain: Unmanaged<RouteRecorder>) {
+        let retain = Unmanaged.passRetained(recorder)
+        let ctx = retain.toOpaque()
+        let api = osr_plugin_api(
+            free_string: { ptr in
+                guard let ptr else { return }
+                free(UnsafeMutableRawPointer(mutating: ptr))
+            },
+            init: nil,
+            destroy: { _ in },
+            get_manifest: nil,
+            invoke: { _, _, _, _ in nil },
+            version: 6,
+            handle_route: handleRoute,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+        let plugin = ExternalPlugin(
+            handle: ctx,
+            api: api,
+            ctx: ctx,
+            manifest: makeManifest(pluginId: pluginId),
+            path: "/tmp/route-reliability-\(pluginId)",
+            abiVersion: 6
+        )
+        return (plugin, retain)
+    }
+
+    /// Async-safe semaphore wait (Swift 6 forbids blocking a concurrency-pool
+    /// thread), mirroring the helper in `PluginShutdownRaceTests`.
+    private func signaled(_ sem: DispatchSemaphore, within timeout: TimeInterval = 10) async -> Bool {
+        await withCheckedContinuation { cont in
+            DispatchQueue.global().async {
+                cont.resume(returning: sem.wait(timeout: .now() + timeout) == .success)
+            }
+        }
+    }
+
+    /// The core regression: a route callback that blocks inside C code
+    /// (ignoring Swift cancellation entirely) must NOT hold the caller past
+    /// the timeout. Before the fix, `handleRoute` returned only after the
+    /// blocking callback itself returned — wall time equaled the callback's
+    /// block duration, not the timeout.
+    @Test
+    func blockingRouteCallbackDoesNotDefeatTimeout() async throws {
+        let recorder = RouteRecorder()
+        let (plugin, retain) = makePlugin(
+            recorder: recorder,
+            pluginId: "com.test.route-timeout.\(UUID().uuidString)"
+        ) { ctxPtr, _ in
+            guard let ctxPtr else { return nil }
+            let recorder = Unmanaged<RouteRecorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+            recorder.callbackStarted.signal()
+            // Deliberately blocking, non-cooperative — models a plugin stuck
+            // in a synchronous network call or a deadlocked mutex.
+            recorder.releaseCallback.wait()
+            recorder.callbackFinished.signal()
+            return UnsafePointer(strdup(#"{"status":200,"body":"too late"}"#))
+        }
+
+        let timeoutSeconds: TimeInterval = 0.5
+        let start = ContinuousClock.now
+        var thrownError: NSError?
+        do {
+            _ = try await plugin.handleRoute(
+                requestJSON: #"{"path":"/hook"}"#,
+                timeoutSeconds: timeoutSeconds
+            )
+        } catch {
+            thrownError = error as NSError
+        }
+        let elapsed = start.duration(to: .now)
+
+        // The callback really was inside plugin code when the timeout fired.
+        #expect(await signaled(recorder.callbackStarted))
+
+        // Timeout error surfaced...
+        let error = try #require(thrownError, "handleRoute must throw on timeout")
+        #expect(error.domain == "ExternalPlugin")
+        #expect(error.code == 5)
+        #expect(error.localizedDescription.contains("timed out"))
+
+        // ...and — the actual regression — the caller was resumed at
+        // timeout-time, not when the blocked callback eventually returned.
+        // Generous ceiling for loaded CI machines; before the fix the wall
+        // time here was unbounded (the callback blocks until we signal).
+        #expect(
+            elapsed < .seconds(5),
+            "caller must be released at the timeout, not when the blocking callback returns (elapsed: \(elapsed))"
+        )
+
+        // Cleanup: unblock the abandoned callback and wait for it to leave
+        // plugin code before the recorder is released.
+        recorder.releaseCallback.signal()
+        #expect(await signaled(recorder.callbackFinished))
+        // Give the abandoned dispatchPluginCall a beat to consume the result.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        retain.release()
+    }
+
+    /// Happy-path control: a fast route handler returns its own response
+    /// well before a generous timeout — the race must not fire spuriously.
+    @Test
+    func fastRouteCallbackReturnsItsResponse() async throws {
+        let recorder = RouteRecorder()
+        let (plugin, retain) = makePlugin(
+            recorder: recorder,
+            pluginId: "com.test.route-fast.\(UUID().uuidString)"
+        ) { _, _ in
+            UnsafePointer(strdup(#"{"status":200,"body":"ok"}"#))
+        }
+        defer { retain.release() }
+
+        let result = try await plugin.handleRoute(
+            requestJSON: #"{"path":"/hook"}"#,
+            timeoutSeconds: 60
+        )
+        #expect(result == #"{"status":200,"body":"ok"}"#)
+    }
+
+    // MARK: - Mount segment-boundary matching
+
+    @Test
+    func mountUiCapturesItselfAndChildrenOnly() {
+        typealias Web = PluginManifest.WebSpec
+        // Exact mount and children are captured.
+        #expect(Web.mountCaptures(subpath: "/ui", mount: "/ui"))
+        #expect(Web.mountCaptures(subpath: "/ui/x", mount: "/ui"))
+        #expect(Web.mountCaptures(subpath: "/ui/x/y", mount: "/ui"))
+        // The regression: `/ui-other` shares the character prefix but is a
+        // different path segment and must NOT be captured.
+        #expect(!Web.mountCaptures(subpath: "/ui-other", mount: "/ui"))
+        #expect(!Web.mountCaptures(subpath: "/ui-other/x", mount: "/ui"))
+        // Unrelated paths.
+        #expect(!Web.mountCaptures(subpath: "/", mount: "/ui"))
+        #expect(!Web.mountCaptures(subpath: "/api", mount: "/ui"))
+    }
+
+    @Test
+    func rootMountCapturesEverything() {
+        typealias Web = PluginManifest.WebSpec
+        #expect(Web.mountCaptures(subpath: "/", mount: "/"))
+        #expect(Web.mountCaptures(subpath: "/ui", mount: "/"))
+        #expect(Web.mountCaptures(subpath: "/ui-other/x", mount: "/"))
+    }
+
+    @Test
+    func mountNormalizationHandlesMissingSlashAndTrailingSlash() {
+        typealias Web = PluginManifest.WebSpec
+        #expect(Web.normalizedMount("ui") == "/ui")
+        #expect(Web.normalizedMount("/ui/") == "/ui")
+        #expect(Web.normalizedMount("/") == "/")
+        #expect(Web.normalizedMount("ui/") == "/ui")
+        // Manifest authors who write `mount: "ui"` or `mount: "/ui/"` get
+        // the same matching behavior as `/ui`.
+        #expect(Web.mountCaptures(subpath: "/ui/x", mount: "ui"))
+        #expect(Web.mountCaptures(subpath: "/ui/x", mount: "/ui/"))
+        #expect(!Web.mountCaptures(subpath: "/ui-other", mount: "ui"))
+    }
+
+    @Test
+    func relativeSubpathMatchesLegacyDispatchExpectations() {
+        typealias Web = PluginManifest.WebSpec
+        // Mount root serves the entry file (dispatch checks isEmpty/"/").
+        #expect(Web.relativeSubpath(subpath: "/ui", mount: "/ui") == "")
+        #expect(Web.relativeSubpath(subpath: "/ui/x", mount: "/ui") == "/x")
+        #expect(Web.relativeSubpath(subpath: "/ui/x/y.js", mount: "/ui") == "/x/y.js")
+        // Root mount: keep the full subpath (entry for bare "/").
+        #expect(Web.relativeSubpath(subpath: "/", mount: "/") == "")
+        #expect(Web.relativeSubpath(subpath: "/x", mount: "/") == "/x")
+    }
+}

--- a/Packages/OsaurusCore/Tools/PluginABI/osaurus_plugin.h
+++ b/Packages/OsaurusCore/Tools/PluginABI/osaurus_plugin.h
@@ -1,6 +1,6 @@
 // osaurus_plugin.h
 //
-// Osaurus Plugin ABI — current documented surface is v5.
+// Osaurus Plugin ABI — current documented surface is v6.
 //
 // COMPATIBILITY
 // =============
@@ -9,9 +9,9 @@
 //   - osaurus_plugin_entry      (v1 — never received the host API)
 //   - osaurus_plugin_entry_v2   (current — receives `osr_host_api*`)
 //
-// New plugins should target v5 by exporting `osaurus_plugin_entry_v2`
-// and reading `host->version >= 5`. Plugins compiled against an older
-// version (v3 / v4) keep working — `host->version` advertises the
+// New plugins should target v6 by exporting `osaurus_plugin_entry_v2`
+// and reading `host->version >= 6`. Plugins compiled against an older
+// version (v3 / v4 / v5) keep working — `host->version` advertises the
 // highest documented surface the host implements; new slots present
 // on a newer host are simply unused by older plugins. Plugins
 // compiled against a newer ABI than the host implements should
@@ -20,7 +20,7 @@
 //
 // See `docs/plugins/ABI_VERSIONS.md` for the per-version evolution
 // (v1 base, v2 host injection, v3 streaming cancel, v4 agent
-// introspection, v5 structured logging).
+// introspection, v5 structured logging, v6 host-side free_string).
 //
 // The struct layout is FROZEN —
 // position of every callback is preserved across versions. Two slots

--- a/Packages/OsaurusPluginTestKit/Sources/OsaurusPluginTestKit/ABI.swift
+++ b/Packages/OsaurusPluginTestKit/Sources/OsaurusPluginTestKit/ABI.swift
@@ -2,9 +2,9 @@
 //  ABI.swift
 //  OsaurusPluginTestKit
 //
-//  Swift mirror of the v4 `osr_host_api` C struct and the function-
-//  pointer typealiases the plugin compiles against. Kept in sync with
-//  `Packages/OsaurusCore/Tools/PluginABI/osaurus_plugin.h`.
+//  Swift mirror of the current (v6) `osr_host_api` C struct and the
+//  function-pointer typealiases the plugin compiles against. Kept in
+//  sync with `Packages/OsaurusCore/Tools/PluginABI/osaurus_plugin.h`.
 //
 //  The struct layout is FROZEN per the ABI contract — fields are only
 //  ever appended. If a future host bump introduces v5+ slots, append
@@ -56,7 +56,7 @@ public typealias OsrLogStructured =
     ) -> Void
 public typealias OsrHostFreeString = @convention(c) (UnsafePointer<CChar>?) -> Void
 
-/// Swift mirror of `osr_host_api` (v4). Field order is FROZEN. Future
+/// Swift mirror of `osr_host_api` (current: v6). Field order is FROZEN. Future
 /// host versions append new optional slots at the end; the synthesized
 /// memberwise init lets older mock hosts keep working because trailing
 /// optionals default to nil.

--- a/Packages/OsaurusRepository/PluginInstallManager.swift
+++ b/Packages/OsaurusRepository/PluginInstallManager.swift
@@ -66,25 +66,21 @@ public final class PluginInstallManager: @unchecked Sendable {
             throw PluginInstallError.specNotFound(pluginId)
         }
 
-        // TOFU: when the author's signing key changes, the new artifact is verified against
-        // the updated key from the registry. We capture the prior version here so we can
-        // remove it *after* the new install + symlink swap succeed. Eagerly deleting it now
-        // would leave the user with no installed version (and a dangling `current` symlink)
-        // if any later step throws (network, checksum, signature, extraction).
-        let keyRotatedFromVersion: SemanticVersion? = {
-            guard let latest = InstalledPluginsStore.shared.latestInstalledVersion(pluginId: spec.plugin_id),
-                let existing = InstalledPluginsStore.shared.receipt(pluginId: spec.plugin_id, version: latest),
-                let existingKey = existing.public_keys?["minisign"],
-                let newKey = spec.public_keys?["minisign"],
-                existingKey != newKey
-            else { return nil }
+        // TOFU pinning: once a signing key has been trusted for this plugin, a
+        // registry that suddenly advertises a different key is NOT silently
+        // trusted. Fail closed; the explicit recovery path is uninstalling the
+        // plugin (which drops the pinned key) and reinstalling to accept the
+        // new key — the flow the `authorKeyMismatch` UI alert walks users through.
+        if Self.pinnedSigningKeyMismatch(
+            spec: spec,
+            installedReceipt: Self.latestInstalledReceipt(pluginId: spec.plugin_id)
+        ) {
             NSLog(
-                "[Osaurus] Signing key changed for %@ — will remove old version %@ after new install succeeds",
-                spec.plugin_id,
-                latest.description
+                "[Osaurus] Signing key changed for %@ — refusing to install without explicit re-trust (uninstall + reinstall)",
+                spec.plugin_id
             )
-            return latest
-        }()
+            throw PluginInstallError.authorKeyMismatch
+        }
 
         let targetPlatform: Platform = .macos
         // Arm64 only per project policy
@@ -95,8 +91,9 @@ public final class PluginInstallManager: @unchecked Sendable {
             resolution = try spec.resolveBestVersion(
                 targetPlatform: targetPlatform,
                 targetArch: targetArch,
-                minimumOsaurusVersion: nil,
-                preferredVersion: preferredVersion
+                minimumOsaurusVersion: Self.currentHostVersion(),
+                preferredVersion: preferredVersion,
+                currentMacOSVersion: ProcessInfo.processInfo.operatingSystemVersion
             )
         } catch {
             throw PluginInstallError.resolutionFailed("\(error)")
@@ -148,13 +145,35 @@ public final class PluginInstallManager: @unchecked Sendable {
             throw PluginInstallError.archiveRejected(error.localizedDescription)
         }
 
-        guard let dylibURL = findFirstDylib(in: tmpDir) else {
-            throw PluginInstallError.layoutInvalid("No .dylib found in archive")
-        }
+        return try installVerifiedArtifact(
+            extractedAt: tmpDir,
+            spec: spec,
+            versionEntry: resolution.version,
+            artifact: artifact,
+            targetPlatform: targetPlatform,
+            targetArch: targetArch
+        )
+    }
+
+    /// Lays out an already-downloaded, checksum/signature-verified, extracted
+    /// artifact into the versioned install directory: dylib, web assets,
+    /// skills, docs, receipt, consent marker, and the `current` symlink swap.
+    /// Internal (not private) so the layout contract is unit-testable without
+    /// network access.
+    func installVerifiedArtifact(
+        extractedAt tmpDir: URL,
+        spec: PluginSpec,
+        versionEntry: PluginVersionEntry,
+        artifact: PluginArtifact,
+        targetPlatform: Platform,
+        targetArch: CPUArch
+    ) throws -> InstallResult {
+        let pluginId = spec.plugin_id
+        let dylibURL = try Self.locateSingleDylib(in: tmpDir)
 
         let installDir = PluginInstallManager.toolsVersionDirectory(
-            pluginId: spec.plugin_id,
-            version: resolution.version.version
+            pluginId: pluginId,
+            version: versionEntry.version
         )
         try ensureDirectoryExists(installDir)
         let finalDylibURL = installDir.appendingPathComponent(dylibURL.lastPathComponent, isDirectory: false)
@@ -162,6 +181,17 @@ public final class PluginInstallManager: @unchecked Sendable {
             try FileManager.default.removeItem(at: finalDylibURL)
         }
         try FileManager.default.copyItem(at: dylibURL, to: finalDylibURL)
+
+        // Copy the static web UI directory when the artifact bundles one
+        // (docs/plugins/PACKAGING.md promises `web/` survives the install).
+        if let webDir = Self.findWebDirectory(in: tmpDir, near: dylibURL) {
+            let destWebDir = installDir.appendingPathComponent(webDir.lastPathComponent, isDirectory: true)
+            if FileManager.default.fileExists(atPath: destWebDir.path) {
+                try FileManager.default.removeItem(at: destWebDir)
+            }
+            try FileManager.default.copyItem(at: webDir, to: destWebDir)
+            NSLog("[Osaurus] Installed web assets for plugin \(pluginId)")
+        }
 
         // Copy any SKILL.md files found in the artifact
         let skillFileURLs = findSkillFiles(in: tmpDir)
@@ -203,8 +233,8 @@ public final class PluginInstallManager: @unchecked Sendable {
         let dylibSha = try Self.sha256Hex(ofFile: finalDylibURL)
 
         let receipt = PluginReceipt(
-            plugin_id: spec.plugin_id,
-            version: resolution.version.version,
+            plugin_id: pluginId,
+            version: versionEntry.version,
             installed_at: Date(),
             dylib_filename: finalDylibURL.lastPathComponent,
             dylib_sha256: dylibSha,
@@ -226,19 +256,7 @@ public final class PluginInstallManager: @unchecked Sendable {
         let consentURL = installDir.appendingPathComponent(".user_consent", isDirectory: false)
         try Data().write(to: consentURL)
 
-        try Self.updateCurrentSymlink(pluginId: spec.plugin_id, version: resolution.version.version)
-
-        // Deferred TOFU cleanup: now that the new version is fully on disk and `current`
-        // points at it, it's safe to remove the prior key-rotated version.
-        if let old = keyRotatedFromVersion, old != resolution.version.version {
-            let oldDir = PluginInstallManager.toolsVersionDirectory(pluginId: spec.plugin_id, version: old)
-            try? FileManager.default.removeItem(at: oldDir)
-            NSLog(
-                "[Osaurus] Key rotated for %@ — removed prior version %@",
-                spec.plugin_id,
-                old.description
-            )
-        }
+        try Self.updateCurrentSymlink(pluginId: pluginId, version: versionEntry.version)
 
         return InstallResult(
             receipt: receipt,
@@ -246,6 +264,50 @@ public final class PluginInstallManager: @unchecked Sendable {
             dylibURL: finalDylibURL,
             skillFiles: installedSkillFiles
         )
+    }
+
+    // MARK: - Trust decisions
+
+    /// Latest installed receipt for `pluginId`, if any.
+    static func latestInstalledReceipt(pluginId: String) -> PluginReceipt? {
+        guard let latest = InstalledPluginsStore.shared.latestInstalledVersion(pluginId: pluginId) else {
+            return nil
+        }
+        return InstalledPluginsStore.shared.receipt(pluginId: pluginId, version: latest)
+    }
+
+    /// True when the registry advertises a minisign key that differs from the
+    /// key pinned by an existing install's receipt. No pinned key (fresh
+    /// install, or a manual sideload without keys) is not a mismatch.
+    static func pinnedSigningKeyMismatch(spec: PluginSpec, installedReceipt: PluginReceipt?) -> Bool {
+        guard let pinnedKey = installedReceipt?.public_keys?["minisign"],
+            let newKey = spec.public_keys?["minisign"]
+        else { return false }
+        return pinnedKey != newKey
+    }
+
+    /// Host app version used for `osaurus_min_version` filtering during
+    /// registry resolution. Lenient parse: Xcode's default MARKETING_VERSION
+    /// is often `1.0` (or `1`), so missing components are treated as zero.
+    /// Returns nil (fail open, matching the loader) when bundle metadata is
+    /// absent or unparseable.
+    static nonisolated(unsafe) var hostVersionOverrideForTesting: SemanticVersion?
+    static func currentHostVersion() -> SemanticVersion? {
+        if let hostVersionOverrideForTesting { return hostVersionOverrideForTesting }
+        guard let raw = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return nil
+        }
+        return parseLenientHostVersion(raw)
+    }
+
+    static func parseLenientHostVersion(_ s: String) -> SemanticVersion? {
+        if let strict = SemanticVersion.parse(s) { return strict }
+        let core = s.split(separator: "-", maxSplits: 1).first.map(String.init) ?? s
+        let parts = core.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard let major = parts.first.flatMap(Int.init) else { return nil }
+        let minor = parts.count > 1 ? Int(parts[1]) ?? 0 : 0
+        let patch = parts.count > 2 ? Int(parts[2]) ?? 0 : 0
+        return SemanticVersion(major: major, minor: minor, patch: patch)
     }
 
     // MARK: - Paths
@@ -458,6 +520,17 @@ public final class PluginInstallManager: @unchecked Sendable {
         try Data(contentsOf: url, options: [.mappedIfSafe])
     }
 
+    /// Public facade over the bounded in-process ZIP extractor so other
+    /// install surfaces (e.g. the CLI's manual `tools install`) share the
+    /// same hardened extraction instead of shelling out to /usr/bin/unzip.
+    public static func extractPluginArchive(at archive: URL, to destination: URL) throws {
+        do {
+            try BoundedArchiveExtractor.extract(archive: archive, to: destination, policy: .plugin)
+        } catch let error as ArchiveExtractionError {
+            throw PluginInstallError.archiveRejected(error.localizedDescription)
+        }
+    }
+
     /// Finds a documentation file (case-insensitive) in the extracted archive directory
     private func findDocFile(named filename: String, in directory: URL) -> URL? {
         let fm = FileManager.default
@@ -500,7 +573,11 @@ public final class PluginInstallManager: @unchecked Sendable {
         return results
     }
 
-    private func findFirstDylib(in directory: URL) -> URL? {
+    /// The extracted artifact must contain exactly one dylib. Zero means the
+    /// archive is broken; more than one means "pick the first the enumerator
+    /// happens to return" — a nondeterministic choice a signed artifact must
+    /// never rely on.
+    static func locateSingleDylib(in directory: URL) throws -> URL {
         let fm = FileManager.default
         guard
             let enumerator = fm.enumerator(
@@ -509,14 +586,47 @@ public final class PluginInstallManager: @unchecked Sendable {
                 options: [.skipsHiddenFiles]
             )
         else {
-            return nil
+            throw PluginInstallError.layoutInvalid("Could not enumerate extracted archive")
         }
+        var found: [URL] = []
         for case let fileURL as URL in enumerator {
             if fileURL.pathExtension == "dylib" && Self.isRegularPayloadFile(fileURL) {
-                return fileURL
+                found.append(fileURL)
             }
         }
-        return nil
+        guard let dylib = found.first else {
+            throw PluginInstallError.layoutInvalid("No .dylib found in archive")
+        }
+        guard found.count == 1 else {
+            let names = found.map { $0.lastPathComponent }.sorted().joined(separator: ", ")
+            throw PluginInstallError.layoutInvalid(
+                "Archive must contain exactly one .dylib, found \(found.count): \(names)"
+            )
+        }
+        return dylib
+    }
+
+    /// Locates the artifact's static web UI directory (`web/`, the name
+    /// `osaurus tools package` bundles and PACKAGING.md documents). Prefers a
+    /// `web/` sibling of the dylib, then falls back to a top-level `web/`
+    /// under the extraction root (archives may nest payloads one level deep).
+    static func findWebDirectory(in directory: URL, near dylibURL: URL?) -> URL? {
+        let fm = FileManager.default
+        func directoryIfExists(_ url: URL) -> URL? {
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue,
+                (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink != true
+            else { return nil }
+            return url
+        }
+        if let dylibURL,
+            let sibling = directoryIfExists(
+                dylibURL.deletingLastPathComponent().appendingPathComponent("web", isDirectory: true)
+            )
+        {
+            return sibling
+        }
+        return directoryIfExists(directory.appendingPathComponent("web", isDirectory: true))
     }
 
     /// Signed archives should contribute real files only; symlinked payload files would let

--- a/Packages/OsaurusRepository/PluginSpec.swift
+++ b/Packages/OsaurusRepository/PluginSpec.swift
@@ -122,7 +122,8 @@ public extension PluginSpec {
         targetPlatform: Platform,
         targetArch: CPUArch,
         minimumOsaurusVersion: SemanticVersion?,
-        preferredVersion: SemanticVersion? = nil
+        preferredVersion: SemanticVersion? = nil,
+        currentMacOSVersion: OperatingSystemVersion? = nil
     ) throws -> PluginResolution {
         guard !versions.isEmpty else { throw PluginResolutionError.noVersions }
 
@@ -134,22 +135,69 @@ public extension PluginSpec {
         }
         let sorted = filtered.sorted { $0.version > $1.version }
 
+        func eligibleArtifact(in entry: PluginVersionEntry) -> PluginArtifact? {
+            entry.artifacts.first { art in
+                art.os == targetPlatform.rawValue
+                    && art.arch == targetArch.rawValue
+                    && Self.artifactSupportsMacOSVersion(art, current: currentMacOSVersion)
+            }
+        }
+
         if let preferred = preferredVersion {
             if let match = sorted.first(where: { $0.version == preferred }),
-                let art = match.artifacts.first(where: {
-                    $0.os == targetPlatform.rawValue && $0.arch == targetArch.rawValue
-                })
+                let art = eligibleArtifact(in: match)
             {
                 return PluginResolution(spec: self, version: match, artifact: art)
             }
         }
 
         for v in sorted {
-            if let art = v.artifacts.first(where: { $0.os == targetPlatform.rawValue && $0.arch == targetArch.rawValue }
-            ) {
+            if let art = eligibleArtifact(in: v) {
                 return PluginResolution(spec: self, version: v, artifact: art)
             }
         }
         throw PluginResolutionError.noMatchingArtifact
+    }
+
+    /// True when `artifact.min_macos` is satisfied by `current`. Fails open when
+    /// the caller passes no current version, the artifact declares no minimum,
+    /// or the declared minimum is unparseable (registry data problem — the
+    /// artifact should not become uninstallable because of a typo the loader
+    /// would also ignore).
+    internal static func artifactSupportsMacOSVersion(
+        _ artifact: PluginArtifact,
+        current: OperatingSystemVersion?
+    ) -> Bool {
+        guard let current,
+            let declared = artifact.min_macos, !declared.isEmpty,
+            let required = parseMacOSVersion(declared)
+        else { return true }
+        return osVersion(current, isAtLeast: required)
+    }
+
+    /// Parses a "MAJOR[.MINOR[.PATCH]]" macOS version string. Trailing
+    /// components default to zero (`"14"` / `"14.5"` / `"14.5.1"` are all
+    /// valid). Returns nil when no leading integer can be parsed.
+    internal static func parseMacOSVersion(_ s: String) -> OperatingSystemVersion? {
+        let parts = s.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard let major = parts.first.flatMap(Int.init) else { return nil }
+        let minor = parts.count > 1 ? Int(parts[1]) ?? 0 : 0
+        let patch = parts.count > 2 ? Int(parts[2]) ?? 0 : 0
+        return OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    /// `OperatingSystemVersion` has no `Comparable` conformance; lexicographic
+    /// comparison keeps this testable with injected values.
+    internal static func osVersion(
+        _ current: OperatingSystemVersion,
+        isAtLeast required: OperatingSystemVersion
+    ) -> Bool {
+        if current.majorVersion != required.majorVersion {
+            return current.majorVersion > required.majorVersion
+        }
+        if current.minorVersion != required.minorVersion {
+            return current.minorVersion > required.minorVersion
+        }
+        return current.patchVersion >= required.patchVersion
     }
 }

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift
@@ -1,0 +1,477 @@
+//
+//  PluginInstallIntegrityTests.swift
+//  OsaurusRepository
+//
+//  Regression coverage for registry-install integrity:
+//    - web/ assets survive the install (PACKAGING.md contract)
+//    - exactly-one-dylib layout enforcement
+//    - host / macOS minimum-version filtering during resolution
+//    - fail-closed TOFU pinned-signing-key mismatch
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusRepository
+
+final class PluginInstallIntegrityTests: XCTestCase {
+    private var tempRoot: URL!
+    private var previousOverride: URL?
+    private var previousDownloadOverride: (@Sendable (URL, URL) throws -> Void)?
+    private var previousHostVersionOverride: SemanticVersion?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let fm = FileManager.default
+        tempRoot = fm.temporaryDirectory.appendingPathComponent(
+            "osaurus-install-integrity-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        previousOverride = ToolsPaths.overrideRoot
+        ToolsPaths.overrideRoot = tempRoot
+        previousDownloadOverride = CentralRepositoryManager.downloadFileOverride
+        previousHostVersionOverride = PluginInstallManager.hostVersionOverrideForTesting
+    }
+
+    override func tearDownWithError() throws {
+        ToolsPaths.overrideRoot = previousOverride
+        CentralRepositoryManager.downloadFileOverride = previousDownloadOverride
+        PluginInstallManager.hostVersionOverrideForTesting = previousHostVersionOverride
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private func sv(_ s: String) -> SemanticVersion { SemanticVersion.parse(s)! }
+
+    private func makeArtifact(minMacOS: String? = nil) -> PluginArtifact {
+        artifactJSONDecoded(os: "macos", arch: "arm64", minMacOS: minMacOS)
+    }
+
+    private func artifactJSONDecoded(os: String, arch: String, minMacOS: String?) -> PluginArtifact {
+        var dict: [String: Any] = [
+            "os": os,
+            "arch": arch,
+            "url": "https://example.invalid/plugin.zip",
+            "sha256": String(repeating: "0", count: 64),
+            "size": 4,
+        ]
+        if let minMacOS { dict["min_macos"] = minMacOS }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        return try! JSONDecoder().decode(PluginArtifact.self, from: data)
+    }
+
+    private func makeVersionEntry(
+        _ version: String,
+        minOsaurus: String? = nil,
+        artifacts: [PluginArtifact]? = nil
+    ) -> PluginVersionEntry {
+        var dict: [String: Any] = [
+            "version": version,
+            "artifacts": [
+                [
+                    "os": "macos",
+                    "arch": "arm64",
+                    "url": "https://example.invalid/plugin-\(version).zip",
+                    "sha256": String(repeating: "0", count: 64),
+                    "size": 4,
+                ]
+            ],
+        ]
+        if let minOsaurus {
+            dict["requires"] = ["osaurus_min_version": minOsaurus]
+        }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        var entry = try! JSONDecoder().decode(PluginVersionEntry.self, from: data)
+        if let artifacts {
+            entry = PluginVersionEntry(
+                version: entry.version,
+                release_date: entry.release_date,
+                notes: entry.notes,
+                artifacts: artifacts,
+                requires: entry.requires
+            )
+        }
+        return entry
+    }
+
+    private func makeSpec(
+        pluginId: String = "com.test.integrity",
+        publicKey: String? = "RWTtestkey",
+        versions: [PluginVersionEntry]
+    ) -> PluginSpec {
+        PluginSpec(
+            plugin_id: pluginId,
+            public_keys: publicKey.map { ["minisign": $0] },
+            versions: versions
+        )
+    }
+
+    private func writeReceipt(
+        pluginId: String,
+        version: String,
+        minisignKey: String?
+    ) throws {
+        let semver = sv(version)
+        let dir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: semver)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let receipt = PluginReceipt(
+            plugin_id: pluginId,
+            version: semver,
+            installed_at: Date(),
+            dylib_filename: "Plugin.dylib",
+            dylib_sha256: String(repeating: "0", count: 64),
+            platform: "macos",
+            arch: "arm64",
+            public_keys: minisignKey.map { ["minisign": $0] },
+            artifact: .init(
+                url: "https://example.invalid/\(pluginId)-\(version).zip",
+                sha256: String(repeating: "0", count: 64),
+                minisign: nil,
+                size: 0
+            )
+        )
+        try JSONEncoder().encode(receipt)
+            .write(to: dir.appendingPathComponent("receipt.json", isDirectory: false))
+    }
+
+    /// Seeds the on-disk registry cache with `spec` and blocks all registry
+    /// network refreshes so `install()` resolves entirely offline.
+    private func seedRegistryCache(with spec: PluginSpec) throws {
+        let pluginsDir = ToolsPaths.pluginSpecsRoot()
+            .appendingPathComponent("central", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+        try FileManager.default.createDirectory(at: pluginsDir, withIntermediateDirectories: true)
+        try JSONEncoder().encode(spec)
+            .write(to: pluginsDir.appendingPathComponent("\(spec.plugin_id).json", isDirectory: false))
+        CentralRepositoryManager.downloadFileOverride = { _, _ in
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    // MARK: - Version resolution: osaurus_min_version
+
+    func test_resolveBestVersion_skipsVersionsRequiringNewerHost() throws {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", minOsaurus: "9.0.0"),
+            makeVersionEntry("1.0.0"),
+        ])
+
+        let resolution = try spec.resolveBestVersion(
+            targetPlatform: .macos,
+            targetArch: .arm64,
+            minimumOsaurusVersion: sv("1.2.3")
+        )
+
+        XCTAssertEqual(resolution.version.version, sv("1.0.0"))
+    }
+
+    func test_resolveBestVersion_failsWhenEveryVersionRequiresNewerHost() {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", minOsaurus: "9.0.0")
+        ])
+
+        XCTAssertThrowsError(
+            try spec.resolveBestVersion(
+                targetPlatform: .macos,
+                targetArch: .arm64,
+                minimumOsaurusVersion: sv("1.2.3")
+            )
+        )
+    }
+
+    func test_resolveBestVersion_unknownHostVersionFailsOpen() throws {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", minOsaurus: "9.0.0")
+        ])
+
+        let resolution = try spec.resolveBestVersion(
+            targetPlatform: .macos,
+            targetArch: .arm64,
+            minimumOsaurusVersion: nil
+        )
+
+        XCTAssertEqual(resolution.version.version, sv("2.0.0"))
+    }
+
+    // MARK: - Version resolution: artifact min_macos
+
+    func test_resolveBestVersion_skipsArtifactsRequiringNewerMacOS() throws {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("2.0.0", artifacts: [makeArtifact(minMacOS: "99.0")]),
+            makeVersionEntry("1.0.0", artifacts: [makeArtifact(minMacOS: "14.0")]),
+        ])
+
+        let resolution = try spec.resolveBestVersion(
+            targetPlatform: .macos,
+            targetArch: .arm64,
+            minimumOsaurusVersion: nil,
+            currentMacOSVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+        )
+
+        XCTAssertEqual(resolution.version.version, sv("1.0.0"))
+    }
+
+    func test_resolveBestVersion_failsWhenNoArtifactSupportsThisMacOS() {
+        let spec = makeSpec(versions: [
+            makeVersionEntry("1.0.0", artifacts: [makeArtifact(minMacOS: "99.0")])
+        ])
+
+        XCTAssertThrowsError(
+            try spec.resolveBestVersion(
+                targetPlatform: .macos,
+                targetArch: .arm64,
+                minimumOsaurusVersion: nil,
+                currentMacOSVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+            )
+        ) { error in
+            guard case PluginResolutionError.noMatchingArtifact = error else {
+                return XCTFail("expected noMatchingArtifact, got \(error)")
+            }
+        }
+    }
+
+    func test_artifactSupportsMacOSVersion_failsOpenForMissingOrUnparseableDeclarations() {
+        let current = OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: nil), current: current))
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "banana"), current: current))
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "15.0"), current: nil))
+        XCTAssertTrue(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "15"), current: current))
+        XCTAssertFalse(PluginSpec.artifactSupportsMacOSVersion(makeArtifact(minMacOS: "15.1"), current: current))
+    }
+
+    func test_parseLenientHostVersion_acceptsShortBundleVersions() {
+        XCTAssertEqual(PluginInstallManager.parseLenientHostVersion("1.2.3"), sv("1.2.3"))
+        XCTAssertEqual(PluginInstallManager.parseLenientHostVersion("1.0"), sv("1.0.0"))
+        XCTAssertEqual(PluginInstallManager.parseLenientHostVersion("2"), sv("2.0.0"))
+        XCTAssertNil(PluginInstallManager.parseLenientHostVersion("dev"))
+    }
+
+    func test_install_rejectsVersionsIncompatibleWithHost() async throws {
+        let pluginId = "com.test.minversion"
+        let spec = makeSpec(
+            pluginId: pluginId,
+            versions: [makeVersionEntry("2.0.0", minOsaurus: "99.0.0")]
+        )
+        try seedRegistryCache(with: spec)
+        PluginInstallManager.hostVersionOverrideForTesting = sv("1.0.0")
+
+        do {
+            _ = try await PluginInstallManager.shared.install(pluginId: pluginId)
+            XCTFail("expected install to fail resolution")
+        } catch let error as PluginInstallError {
+            guard case .resolutionFailed = error else {
+                return XCTFail("expected resolutionFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - TOFU pinned key
+
+    func test_pinnedSigningKeyMismatch_detectsRotation() throws {
+        let pluginId = "com.test.pinned"
+        try writeReceipt(pluginId: pluginId, version: "1.0.0", minisignKey: "RWTold")
+
+        let installed = PluginInstallManager.latestInstalledReceipt(pluginId: pluginId)
+        XCTAssertNotNil(installed)
+
+        let rotated = makeSpec(pluginId: pluginId, publicKey: "RWTnew", versions: [makeVersionEntry("2.0.0")])
+        XCTAssertTrue(PluginInstallManager.pinnedSigningKeyMismatch(spec: rotated, installedReceipt: installed))
+
+        let same = makeSpec(pluginId: pluginId, publicKey: "RWTold", versions: [makeVersionEntry("2.0.0")])
+        XCTAssertFalse(PluginInstallManager.pinnedSigningKeyMismatch(spec: same, installedReceipt: installed))
+
+        XCTAssertFalse(
+            PluginInstallManager.pinnedSigningKeyMismatch(spec: rotated, installedReceipt: nil),
+            "fresh installs have no pinned key and must not be blocked"
+        )
+    }
+
+    func test_pinnedSigningKeyMismatch_ignoresKeylessSideloadReceipts() throws {
+        let pluginId = "com.test.keyless"
+        try writeReceipt(pluginId: pluginId, version: "1.0.0", minisignKey: nil)
+        let installed = PluginInstallManager.latestInstalledReceipt(pluginId: pluginId)
+
+        let spec = makeSpec(pluginId: pluginId, publicKey: "RWTnew", versions: [makeVersionEntry("2.0.0")])
+        XCTAssertFalse(PluginInstallManager.pinnedSigningKeyMismatch(spec: spec, installedReceipt: installed))
+    }
+
+    func test_install_failsClosedOnPinnedKeyRotation_andKeepsInstalledVersion() async throws {
+        let pluginId = "com.test.rotation"
+        try writeReceipt(pluginId: pluginId, version: "1.0.0", minisignKey: "RWTold")
+        try PluginInstallManager.updateCurrentSymlink(pluginId: pluginId, version: sv("1.0.0"))
+
+        let spec = makeSpec(pluginId: pluginId, publicKey: "RWTnew", versions: [makeVersionEntry("2.0.0")])
+        try seedRegistryCache(with: spec)
+
+        do {
+            _ = try await PluginInstallManager.shared.install(pluginId: pluginId)
+            XCTFail("expected install to fail closed on pinned-key rotation")
+        } catch let error as PluginInstallError {
+            guard case .authorKeyMismatch = error else {
+                return XCTFail("expected authorKeyMismatch, got \(error)")
+            }
+        }
+
+        let oldDir = PluginInstallManager.toolsVersionDirectory(pluginId: pluginId, version: sv("1.0.0"))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: oldDir.appendingPathComponent("receipt.json").path),
+            "the previously installed version must remain untouched when the install is refused"
+        )
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(
+                atPath: PluginInstallManager.currentSymlinkURL(pluginId: pluginId).path
+            ),
+            "1.0.0"
+        )
+    }
+
+    // MARK: - Layout: exactly one dylib
+
+    func test_locateSingleDylib_findsTheOnlyDylib() throws {
+        let dir = tempRoot.appendingPathComponent("payload-one", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("bin".utf8).write(to: dir.appendingPathComponent("Plugin.dylib"))
+
+        let found = try PluginInstallManager.locateSingleDylib(in: dir)
+        XCTAssertEqual(found.lastPathComponent, "Plugin.dylib")
+    }
+
+    func test_locateSingleDylib_rejectsZeroDylibs() throws {
+        let dir = tempRoot.appendingPathComponent("payload-zero", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try PluginInstallManager.locateSingleDylib(in: dir)) { error in
+            XCTAssertTrue(String(describing: error).contains("No .dylib"))
+        }
+    }
+
+    func test_locateSingleDylib_rejectsMultipleDylibs() throws {
+        let dir = tempRoot.appendingPathComponent("payload-two", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("a".utf8).write(to: dir.appendingPathComponent("A.dylib"))
+        try Data("b".utf8).write(to: dir.appendingPathComponent("B.dylib"))
+
+        XCTAssertThrowsError(try PluginInstallManager.locateSingleDylib(in: dir)) { error in
+            XCTAssertTrue(String(describing: error).contains("exactly one"))
+        }
+    }
+
+    // MARK: - Layout: web assets
+
+    /// Regression: registry installs previously copied the dylib, skills, and
+    /// docs but silently dropped `web/`, breaking every plugin with a static UI.
+    func test_installVerifiedArtifact_copiesWebDirectory() throws {
+        let pluginId = "com.test.web"
+        let payload = tempRoot.appendingPathComponent("extracted-web", isDirectory: true)
+        let webDir = payload.appendingPathComponent("web/assets", isDirectory: true)
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        try Data("bin".utf8).write(to: payload.appendingPathComponent("Plugin.dylib"))
+        try Data("<html>ui</html>".utf8).write(
+            to: payload.appendingPathComponent("web/index.html")
+        )
+        try Data("body{}".utf8).write(to: webDir.appendingPathComponent("app.css"))
+
+        let spec = makeSpec(pluginId: pluginId, versions: [makeVersionEntry("1.0.0")])
+        let result = try PluginInstallManager.shared.installVerifiedArtifact(
+            extractedAt: payload,
+            spec: spec,
+            versionEntry: spec.versions[0],
+            artifact: spec.versions[0].artifacts[0],
+            targetPlatform: .macos,
+            targetArch: .arm64
+        )
+
+        let installedWeb = result.installDirectory.appendingPathComponent("web", isDirectory: true)
+        XCTAssertEqual(
+            try String(contentsOf: installedWeb.appendingPathComponent("index.html"), encoding: .utf8),
+            "<html>ui</html>"
+        )
+        XCTAssertEqual(
+            try String(
+                contentsOf: installedWeb.appendingPathComponent("assets/app.css"),
+                encoding: .utf8
+            ),
+            "body{}"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: result.installDirectory.appendingPathComponent("receipt.json").path
+            )
+        )
+    }
+
+    func test_installVerifiedArtifact_prefersWebDirectoryNextToDylib() throws {
+        let payload = tempRoot.appendingPathComponent("extracted-nested", isDirectory: true)
+        let inner = payload.appendingPathComponent("bundle", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: inner.appendingPathComponent("web", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("bin".utf8).write(to: inner.appendingPathComponent("Plugin.dylib"))
+        try Data("nested".utf8).write(to: inner.appendingPathComponent("web/index.html"))
+
+        let spec = makeSpec(pluginId: "com.test.nestedweb", versions: [makeVersionEntry("1.0.0")])
+        let result = try PluginInstallManager.shared.installVerifiedArtifact(
+            extractedAt: payload,
+            spec: spec,
+            versionEntry: spec.versions[0],
+            artifact: spec.versions[0].artifacts[0],
+            targetPlatform: .macos,
+            targetArch: .arm64
+        )
+
+        XCTAssertEqual(
+            try String(
+                contentsOf: result.installDirectory.appendingPathComponent("web/index.html"),
+                encoding: .utf8
+            ),
+            "nested"
+        )
+    }
+
+    func test_installVerifiedArtifact_withoutWebDirectoryInstallsNothingExtra() throws {
+        let payload = tempRoot.appendingPathComponent("extracted-noweb", isDirectory: true)
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: true)
+        try Data("bin".utf8).write(to: payload.appendingPathComponent("Plugin.dylib"))
+
+        let spec = makeSpec(pluginId: "com.test.noweb", versions: [makeVersionEntry("1.0.0")])
+        let result = try PluginInstallManager.shared.installVerifiedArtifact(
+            extractedAt: payload,
+            spec: spec,
+            versionEntry: spec.versions[0],
+            artifact: spec.versions[0].artifacts[0],
+            targetPlatform: .macos,
+            targetArch: .arm64
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: result.installDirectory.appendingPathComponent("web").path
+            )
+        )
+    }
+
+    func test_installVerifiedArtifact_rejectsMultiDylibPayload() throws {
+        let payload = tempRoot.appendingPathComponent("extracted-multi", isDirectory: true)
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: true)
+        try Data("a".utf8).write(to: payload.appendingPathComponent("A.dylib"))
+        try Data("b".utf8).write(to: payload.appendingPathComponent("B.dylib"))
+
+        let spec = makeSpec(pluginId: "com.test.multi", versions: [makeVersionEntry("1.0.0")])
+        XCTAssertThrowsError(
+            try PluginInstallManager.shared.installVerifiedArtifact(
+                extractedAt: payload,
+                spec: spec,
+                versionEntry: spec.versions[0],
+                artifact: spec.versions[0].artifacts[0],
+                targetPlatform: .macos,
+                targetArch: .arm64
+            )
+        )
+    }
+}

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift
@@ -48,21 +48,16 @@ final class PluginInstallIntegrityTests: XCTestCase {
 
     private func sv(_ s: String) -> SemanticVersion { SemanticVersion.parse(s)! }
 
-    private func makeArtifact(minMacOS: String? = nil) -> PluginArtifact {
-        artifactJSONDecoded(os: "macos", arch: "arm64", minMacOS: minMacOS)
-    }
-
-    private func artifactJSONDecoded(os: String, arch: String, minMacOS: String?) -> PluginArtifact {
-        var dict: [String: Any] = [
-            "os": os,
-            "arch": arch,
-            "url": "https://example.invalid/plugin.zip",
-            "sha256": String(repeating: "0", count: 64),
-            "size": 4,
-        ]
-        if let minMacOS { dict["min_macos"] = minMacOS }
-        let data = try! JSONSerialization.data(withJSONObject: dict)
-        return try! JSONDecoder().decode(PluginArtifact.self, from: data)
+    private func makeArtifact(minMacOS: String? = nil, url: String = "https://example.invalid/plugin.zip") -> PluginArtifact {
+        PluginArtifact(
+            os: "macos",
+            arch: "arm64",
+            min_macos: minMacOS,
+            url: url,
+            sha256: String(repeating: "0", count: 64),
+            minisign: nil,
+            size: 4
+        )
     }
 
     private func makeVersionEntry(
@@ -70,33 +65,13 @@ final class PluginInstallIntegrityTests: XCTestCase {
         minOsaurus: String? = nil,
         artifacts: [PluginArtifact]? = nil
     ) -> PluginVersionEntry {
-        var dict: [String: Any] = [
-            "version": version,
-            "artifacts": [
-                [
-                    "os": "macos",
-                    "arch": "arm64",
-                    "url": "https://example.invalid/plugin-\(version).zip",
-                    "sha256": String(repeating: "0", count: 64),
-                    "size": 4,
-                ]
-            ],
-        ]
-        if let minOsaurus {
-            dict["requires"] = ["osaurus_min_version": minOsaurus]
-        }
-        let data = try! JSONSerialization.data(withJSONObject: dict)
-        var entry = try! JSONDecoder().decode(PluginVersionEntry.self, from: data)
-        if let artifacts {
-            entry = PluginVersionEntry(
-                version: entry.version,
-                release_date: entry.release_date,
-                notes: entry.notes,
-                artifacts: artifacts,
-                requires: entry.requires
-            )
-        }
-        return entry
+        PluginVersionEntry(
+            version: sv(version),
+            release_date: nil,
+            notes: nil,
+            artifacts: artifacts ?? [makeArtifact(url: "https://example.invalid/plugin-\(version).zip")],
+            requires: minOsaurus.map { PluginRequirements(osaurus_min_version: sv($0)) }
+        )
     }
 
     private func makeSpec(


### PR DESCRIPTION
## Summary

Consolidated host/harness fixes from the July 2026 plugin reliability audit (replaces #2056–#2060 per review preference for one PR per repo). Five themes, each verified independently and re-verified after merge (68 targeted plugin/route/lifecycle tests pass on the combined branch; OsaurusRepository 77 and OsaurusCLI 130 tests pass).


Repository: `/Users/tpae/dev/osaurus-audit/osaurus` (baseline `f8140597`, branch `main`).
Per task instructions (exception to the shared guide), fixes are split across five
self-contained branches off `main`, one per theme. No pushes / PRs / tags.

## Branch summaries

### 1. `audit/install-integrity` (3 commits)

Commits:
- `773df291` Enforce host/macOS version checks, TOFU key pinning, single dylib, and web asset install in registry installer
- `5fb17ae0` Fail tools verify on missing or malformed receipts and dylibs
- `686608bb` Use bounded extraction, atomic publication, and explicit consent for manual tools install

Confirmed defects fixed:
- **High** `Packages/OsaurusRepository/PluginInstallManager.swift` — registry installs copied only the dylib (+ SKILL.md/docs); the `web/` directory promised by `docs/plugins/PACKAGING.md` was silently dropped, so installed plugins' static UIs 404'd. `installVerifiedArtifact` now locates and copies the artifact's `web/` directory (preferring the one next to the dylib).
- **High** `PluginInstallManager.swift` + `PluginSpec.swift` — `resolveBestVersion` was called with `minimumOsaurusVersion: nil` (so `osaurus_min_version` never filtered) and `PluginArtifact.min_macos` was never consulted. Resolution now receives the real host version (`CFBundleShortVersionString`) and `ProcessInfo.operatingSystemVersion`, and filters artifacts by `min_macos`.
- **High** `PluginInstallManager.swift` — `PluginInstallError.authorKeyMismatch` existed but was never thrown; a changed registry signing key was silently trusted (TOFU without the "trust" part) and the previous version was deleted before the new install proved good. Now: pinned-key mismatch fails closed with `authorKeyMismatch` (the existing UI alert directs users through explicit uninstall/reinstall approval), and the rollback version is only deleted after the install fully succeeds.
- **Medium** `PluginInstallManager.swift` — artifact containing zero or multiple dylibs nondeterministically picked the first; now `locateSingleDylib` requires exactly one and errors otherwise.
- **High** `Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsVerify.swift` — missing/unreadable `receipt.json`, missing dylibs, and dangling `current` symlinks were silently `continue`d, so `osaurus tools verify` exited 0 for broken installs. Every missing/malformed/mismatched file is now a reported failure and the command exits non-zero.
- **High** `Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift` — manual remote install buffered the whole archive in memory (`URLSession.data`), shelled out to `/usr/bin/unzip` (no entry/size/ratio/path-escape limits), replaced an existing version non-transactionally (delete-then-copy), and granted consent by default. Now: streaming download (`URLSession.download`), extraction through the same `BoundedArchiveExtractor` the registry installer uses (via a new `PluginInstallManager.extractPluginArchive` facade), staging + atomic publication (`replaceItemAt`), consent only with an explicit `--consent` flag, and failure when the payload produces no dylib (receipt creation now throws instead of silently skipping).

Tests added:
- `Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallIntegrityTests.swift` — min_osaurus/min_macos filtering, pinned-key mismatch, single-dylib enforcement, web directory discovery/copy, verified-artifact install shape.
- `Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsVerifyTests.swift` — missing receipt, malformed receipt, missing dylib, SHA mismatch, dangling `current` symlink all fail; healthy install passes.
- `Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsManualInstallPublishTests.swift` — atomic publish over existing version, no-dylib failure, consent-only-when-granted.

Verification (all green):
- `swift test --package-path Packages/OsaurusRepository --parallel` — 77 tests passed.
- `swift test --package-path Packages/OsaurusCLI --parallel` — 130 tests passed.
- `swift build -c release --package-path Packages/OsaurusRepository` and `--package-path Packages/OsaurusCLI` — build complete.

### 2. `audit/loader-abi` (1 commit)

Commit:
- `82135263` Validate plugin ABI table, v1 prefix decode, and manifest/tool/route identity at load

Confirmed defects fixed (all in `Packages/OsaurusCore/Managers/Plugin/PluginManager.swift` and `Models/Plugin/ExternalPlugin.swift`):
- **High** — loader only required `init` and `get_manifest`; nil `free_string` (leaks every returned string), `destroy` (no teardown), or `invoke` (broken tools) were accepted. `abiTableValidationFailure` now rejects incomplete ABI tables before `init` is called.
- **High** — the v1 entry path read `apiPtr.pointee` as the full current `osr_plugin_api` struct, reading past the end of a historical v1 plugin's static struct (out-of-bounds read of whatever follows it in the binary). New `osr_plugin_api_v1` prefix struct decodes exactly the five required members and widens into the full layout with v2+ slots zeroed.
- **Medium** — no load-time identity validation: manifest `plugin_id` could differ from the receipt/install-directory id (previously "re-keyed" silently), two plugins could load under the same id, and duplicate/empty tool or route ids were accepted. Load now fails on manifest/directory id mismatch, rejects duplicate loaded plugin ids (newcomer is shut down), and rejects empty or duplicate tool/route ids.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginLoaderAbiValidationTests.swift` — ABI completeness matrix, v1 prefix widening (zeroed v2+ slots, version 0), id-mismatch failure, duplicate/empty tool and route id failures.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginLoaderAbiValidationTests|PluginAbiHandshakeTests'` — 28 tests passed.

### 3. `audit/route-reliability` (1 commit)

Commit:
- `22b84a1f` Fix route handler timeout race and segment-boundary web mount matching

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift` — `handleRoute` implemented its 30s timeout with `withThrowingTaskGroup`; task groups drain children before returning, so a blocking C route callback (which never observes Swift cancellation) held the HTTP caller for the full duration of the call — the timeout never fired from the request's perspective. Replaced with the unstructured-body-task + GCD-timer race already used by `ToolRegistry.runToolBody` (new `RouteHandlerRaceState`), so the caller is resumed the moment the timer wins while the abandoned callback finishes on the plugin's invoke queue.
- **Medium** `Networking/HTTPHandler.swift` + `Managers/Plugin/PluginManager.swift` — static web mount dispatch used bare `subpath.hasPrefix(mountPrefix)`, so mount `/ui` captured `/ui-other`, disagreeing with the load-time web/route overlap validation (which already used segment-boundary logic). Both now call one shared helper, `PluginManifest.WebSpec.mountCaptures` / `relativeSubpath` / `normalizedMount`, so validation and dispatch cannot diverge.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/PluginRouteReliabilityTests.swift` — elapsed wall-time assertion with a deliberately blocking C route callback (semaphore-held; asserts the caller returns at the 0.5s timeout instead of blocking until release), fast-path control, and mount matching for `/ui`, `/ui/x`, `/ui-other`, `/`, plus normalization (`ui`, `/ui/`) and relative-subpath expectations.

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'PluginRouteReliabilityTests|PluginRoutingTests'` — 22 tests in 6 suites passed (includes existing routing/static-file containment suites).

### 4. `audit/lifecycle-config` (1 commit)

Commit:
- `c601dd68` Order plugin teardown before secret sweep on agent delete; unify config default resolution

Confirmed defects fixed:
- **High** `Packages/OsaurusCore/Managers/AgentManager.swift` + `Managers/Plugin/PluginManager.swift` — `AgentManager.delete(id:)` swept `ToolSecretsKeychain` for the agent BEFORE posting `.agentRemoved`; the `.agentRemoved` handler was additionally fire-and-forget (Task + detached push), so plugins reading config (e.g. Telegram's `bot_token`) during webhook deregistration found nothing — the webhook stayed registered upstream. New awaitable `PluginManager.tearDownPluginsForRemovedAgent(agentId:)` delivers `tunnel_url=""` to every routed plugin via the synchronous config path and returns only after each plugin's `on_config_changed` completes; `delete` awaits it and only then sweeps. The notification-driven handler remains as an idempotent backstop (deduped plugin-side).
- **Medium** `Services/Keychain/ToolSecretsKeychain.swift` + `Services/Plugin/PluginHostAPI.swift` + `Managers/Plugin/PluginManager.swift` — inconsistent default semantics: tool payload injection merged `Agent.defaultId` values as global defaults (`resolvedSecretsWithDefaults`), but `config_get`, initial config delivery, and required-secret checks (`hasAllRequiredSecrets` / `getMissingRequiredSecrets`) read only the exact agent namespace — a key saved once on the Plugins tab was "configured" for injection but invisible to `config_get`. Centralized one policy, `ToolSecretsKeychain.resolvedSecret(id:for:agentId:)` (exact agent first, then default-agent fallback), and pointed all three paths at it. The anonymous-context guard (no agent → nil) is unchanged; UI editors (`PluginConfigView`, `ToolSecretsSheet`) intentionally keep exact-namespace reads since they edit a specific agent's values.

Tests added:
- `Packages/OsaurusCore/Tests/Plugin/AgentLifecycleConfigResolutionTests.swift` — ordering test driving a real `ExternalPlugin` whose C `on_config_changed` reads `bot_token` mid-teardown (asserts the token is readable during deregistration and swept afterwards, all before `delete` returns); resolution-policy tests: exact-wins, default fallback, missing-everywhere, required-secret checks honoring the fallback, and `config_get` through a TLS-scoped `PluginHostContext` (fallback + exact + anonymous-refusal).

Verification (all green):
- `swift build --package-path Packages/OsaurusCore` — build complete.
- `swift test --package-path Packages/OsaurusCore --filter 'AgentDeletionPluginTeardownOrderingTests|ToolSecretsResolutionPolicyTests|AgentManagerLifecycleNotificationTests|ResolvedSecretsMergingTests'` — 18 tests in 4 suites passed (includes the pre-existing lifecycle-notification and secrets-merge suites, confirming no ordering regressions).

### 5. `audit/ci-coverage` (1 commit)

Commit:
- `a6e1737b` Add CI lanes for OsaurusRepository, OsaurusPluginTestKit, and StatsPack tests

Changes (`.github/workflows/ci.yml`):
- New `test-packages` job: `swift test --package-path Packages/OsaurusRepository --parallel` and `swift test --package-path Packages/OsaurusPluginTestKit --parallel` on `macos-26` with the pinned Xcode toolchain and `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` (matching test-evals). Both packages are light (Foundation/OsaurusNetworking deps), no build cache needed.
- New `test-statspack` job: `swift test --package-path Packages/OsaurusPlugins/StatsPack` with its own SwiftPM `.build` cache mirroring the `test-evals` cache shape, because StatsPack depends on the full OsaurusCore graph (mlx `Cmlx` C++ + SQLCipher amalgamation, ~25–30 min cold).

Verification:
- YAML validated (`ruby -ryaml`).
- All three suites run green locally with the CI env: OsaurusRepository 59 tests (XCTest), OsaurusPluginTestKit 10 tests, StatsPack 20 tests.

Release-config loader verification (documented, not implemented):
`PluginManager.verifyDylibBeforeLoadWithError` short-circuits to `.success` under `#if DEBUG`; the Release-only body (receipt presence/parse, SHA-256 match, `SecStaticCodeCheckValidity` code-signature check, `.user_consent` gate) is compiled only in Release and never executes under any test lane (xcodebuild tests and all `swift test` lanes build Debug). A cheap Release test invocation is NOT feasible:
- `swift test -c release --package-path Packages/OsaurusCore` (or a Release xcodebuild test lane) cold-builds the whole OsaurusCore graph again in a second configuration — an additional ~25–30 min lane and a second DerivedData/.build cache for one function.
- The function is `private`, so even a Release test bundle can't call it directly; testing it properly would require a production refactor (extract the verification body into an always-compiled internal helper testable from Debug), which is out of scope for a CI-only branch. That refactor is the recommended follow-up (see proposals).

## Investigated, decided NOT to change

- `ToolsVerify` "verified OK" wording and output format were preserved; only the skip-vs-fail semantics changed, to keep script consumers working.
- `PluginConfigView` / `ToolSecretsSheet` exact-namespace keychain reads: intentional (they edit a specific agent's values); the shared resolution policy applies to what is fed to plugins, not to the editing UI.
- `handleAgentRemoved`'s notification-driven `tunnel_url=""` push was kept (not removed) as an idempotent backstop for any other `.agentRemoved` poster; plugin-side delivery dedup prevents double `on_config_changed` firing.
- The route-timeout fix deliberately leaves the abandoned blocking C callback running on the plugin's invoke queue (matching `runToolBody` semantics) — forcibly killing plugin threads would be an architectural change.
- v2 entry path (`osaurus_plugin_entry_v2`) already receives the host struct and returns the full current `osr_plugin_api`; only the v1 path had the prefix-read hazard.
- No out-of-process isolation, TUF metadata, or hot-reload rework, per instructions.

## Checks that still require live credentials/permissions

- Code-signature verification (`SecStaticCodeCheckValidity`) and the full Release-only `verifyDylibBeforeLoadWithError` path need a signed dylib and a Release build — not exercised by unit tests (see ci-coverage notes).
- Real Keychain behavior: unit tests use the in-memory test store (`XCTestConfigurationFilePath`/xctest detection) or the disabled-keychain mode; securityd interaction paths (auth prompts, XPC stalls) are not covered.
- Live registry installs (minisign verification against the production registry, network download paths) and real tunnel/relay webhook deregistration (Telegram etc.) require network and credentials.
- The full OsaurusCoreTests xcodebuild scheme (as CI runs it) was not run locally end-to-end; per task instructions, targeted plugin/lifecycle/route suites were run via `swift test --filter` (exact commands and results listed per branch above). Note for local repro: OsaurusCore `swift test` runs need `XCTestConfigurationFilePath` set (any value) for the in-memory keychain store to activate under `swiftpm-testing-helper`; CI's xcodebuild sets it natively.

## Optional upgrade proposals (NOT implemented)

1. Extract the Release-only dylib verification body into an always-compiled internal `verifyInstalledDylib(receiptURL:dylibURL:)` helper so Debug tests can cover receipt/SHA/consent failures; keep only the "skip in DEBUG" decision behind `#if DEBUG`.
2. `ToolsInstall` manual installs bypass minisign entirely (by design, gated on `--consent`); consider requiring a `--insecure` style acknowledgment or checksum argument for remote URLs.
3. The `.agentRemoved`/`.agentAdded` NotificationCenter plumbing could become an async-awaitable protocol on a PluginLifecycle coordinator, removing the need for the belt-and-braces double push after deletion.
4. `resolveBestVersion` filters incompatible artifacts silently; surfacing "newer version exists but requires macOS X / Osaurus Y" to the UI would help users understand why updates don't appear.
5. Consider running the StatsPack CI job only on paths touching `Packages/OsaurusPlugins/**` or `Packages/OsaurusCore/**` to save runner minutes.
