### PR TITLE
Fix AppleScript query completion outcomes

### DIFF
--- a/Packages/OsaurusCore/AppleScript/Loop/AppleScriptLoop.swift
+++ b/Packages/OsaurusCore/AppleScript/Loop/AppleScriptLoop.swift
@@ -576,6 +576,21 @@ public enum AppleScriptLoop {
                     succeeded: succeeded,
                     failed: failed
                 )
+                // A plain-text completion after attempted work does not erase
+                // its real outcome. `steps` also includes malformed tool calls
+                // and compile/placeholder rejections that never reached the
+                // executor, so do not mistake `scriptsExecuted == 0` for a
+                // clean no-tool explanation when such attempts exist.
+                if succeeded == 0, scriptsExecuted > 0 || !steps.isEmpty {
+                    let reason: String
+                    if scriptsExecuted == 0 {
+                        let detail = steps.last?.error ?? "The generated script call was invalid."
+                        reason = "No valid script executed successfully. \(detail)"
+                    } else {
+                        reason = summary
+                    }
+                    return terminate(.failed(reason: reason))
+                }
                 return terminate(.done(summary: summary))
             }
 
@@ -958,6 +973,24 @@ public enum AppleScriptLoop {
                 errorNumber: execution.errorNumber,
                 script: script
             )
+
+            // `mac_query` is complete as soon as a read succeeds with a real
+            // return value. Continuing to ask the model after that point lets
+            // small dedicated models repeat the identical successful script
+            // until the step cap, wasting an entire generation per repeat.
+            // Empty successful reads still continue into the existing
+            // verification path so the runtime can obtain the requested value.
+            if mode == .query, execution.isSuccess, let trimmedOutput, !trimmedOutput.isEmpty {
+                let summary = completionSummary(
+                    modelText: nil,
+                    lastOutput: trimmedOutput,
+                    scriptsExecuted: scriptsExecuted,
+                    succeeded: succeeded,
+                    failed: failed
+                )
+                return terminate(.done(summary: summary))
+            }
+
             messages.append(
                 ChatMessage(role: "tool", content: toolResult, tool_calls: nil, tool_call_id: call.id)
             )

--- a/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
@@ -318,16 +318,26 @@ final class AppleScriptKind: SubagentKind, @unchecked Sendable {
     }
 
     /// Map a finished `AppleScriptLoop` run onto the shared subagent result
-    /// contract. `done` → the rich success payload. `interrupted` → a
-    /// `user_denied` envelope. A `stepCapReached` / `failed` run that ACTUALLY
-    /// RAN scripts still returns the rich payload (with an honest
-    /// `failed`/`partial` status + the transcript) so the parent can
-    /// troubleshoot — only a run where nothing executed is a hard tool failure.
+    /// contract. A completed run with no attempted scripts may carry the
+    /// model's useful explanation. Once script work was attempted (including
+    /// malformed calls that never reached the executor), at least one script
+    /// must have succeeded for a successful outer envelope. `interrupted` → a
+    /// `user_denied` envelope. A `stepCapReached` / `failed` run with at least
+    /// one successful script still returns the rich partial payload so the
+    /// parent can use the real value and troubleshoot later failures.
     static func mapOutcome(
         _ result: AppleScriptRunResult,
         model: String,
         mode: AppleScriptRunMode
     ) throws -> SubagentResult {
+        let attemptedWork = result.scriptsExecuted > 0 || !result.steps.isEmpty
+        if attemptedWork, result.succeeded == 0 {
+            throw SubagentError.executionFailed(
+                message: result.outcome.summary,
+                retryable: false
+            )
+        }
+
         switch result.outcome {
         case .done(let summary):
             return successResult(result, model: model, mode: mode, summary: summary)
@@ -347,8 +357,8 @@ final class AppleScriptKind: SubagentKind, @unchecked Sendable {
     /// Assemble the parent-facing payload: the headline `values`, an honest
     /// aggregate `status` (`succeeded` / `partial` / `failed`), and a capped
     /// per-step transcript plus convenience `errors` / `permission_needed`. The
-    /// top-level envelope `ok` means "the tool ran"; the task outcome lives in
-    /// `status`, so the two never collide.
+    /// top-level envelope remains successful only when at least one script
+    /// succeeded; the task's aggregate outcome lives in `status`.
     private static func successResult(
         _ result: AppleScriptRunResult,
         model: String,

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
@@ -1069,8 +1069,8 @@ struct AppleScriptLoopTests {
         #expect(await exec.count == 0)
     }
 
-    @Test("an invalid call is re-asked, then the model completes")
-    func invalidThenComplete() async {
+    @Test("an invalid call followed by completion stays failed")
+    func invalidThenCompleteStaysFailed() async {
         let feed = SubagentFeed(toolCallId: "t-invalid", kindId: "applescript", title: "task")
         let exec = ExecRecorder(result: successResult())
         let confirm = ConfirmCounter(approve: true)
@@ -1088,10 +1088,19 @@ struct AppleScriptLoopTests {
             nextScript: { _ in await seq.next() }
         )
 
-        #expect(result.outcome.isSuccess)
+        guard case .failed(let reason) = result.outcome else {
+            Issue.record("expected .failed, got \(result.outcome)")
+            return
+        }
+        #expect(reason.contains("No valid script executed successfully"))
         #expect(result.scriptsExecuted == 0)
         #expect(await exec.count == 0)
         #expect(feed.currentEvents().contains { $0.kind == .retry })
+        if case .finished(let success, _) = feed.currentStatus() {
+            #expect(success == false)
+        } else {
+            Issue.record("expected a finished feed status")
+        }
     }
 
     @Test("the step cap terminates a model that keeps proposing scripts")
@@ -1121,6 +1130,38 @@ struct AppleScriptLoopTests {
             Issue.record("expected .stepCapReached, got \(result.outcome)")
         }
         #expect(result.scriptsExecuted == 1)
+    }
+
+    @Test("query mode stops after the first successful read with a returned value")
+    func queryStopsAfterSuccessfulValue() async {
+        let feed = SubagentFeed(toolCallId: "t-query-done", kindId: "applescript", title: "q")
+        let exec = ExecRecorder(result: successResult("4"))
+        let seq = ScriptSequencer(repeating: call("return 2 + 2"))
+
+        let result = await AppleScriptLoop.run(
+            task: "return the integer result of 2 + 2",
+            modelId: "applescript-test",
+            feed: feed,
+            interrupt: InterruptToken(),
+            executionMode: .confirmEach,
+            confirm: { _ in true },
+            limits: RunLimits(maxSteps: 8),
+            sessionId: "s",
+            mode: .query,
+            execute: { script, _ in await exec.run(script) },
+            nextScript: { _ in await seq.next() }
+        )
+
+        guard case .done(let summary) = result.outcome else {
+            Issue.record("expected .done, got \(result.outcome)")
+            return
+        }
+        #expect(summary.contains("4"))
+        #expect(result.scriptsExecuted == 1)
+        #expect(result.succeeded == 1)
+        #expect(result.failed == 0)
+        #expect(result.lastOutput == "4")
+        #expect(await exec.count == 1)
     }
 
     /// Build a `run_applescript` call carrying `script` (JSON-encoded so quotes
@@ -1190,6 +1231,47 @@ struct AppleScriptLoopTests {
         #expect(result.steps.first?.status == "runtime_error")
         #expect(result.steps.first?.errorNumber == -1728)
         #expect(result.steps.first?.error == "Can’t get name")
+    }
+
+    @Test("plain-text completion after only failed scripts keeps the run and feed failed")
+    func completionAfterOnlyFailuresStaysFailed() async {
+        let feed = SubagentFeed(toolCallId: "t-all-failed", kindId: "applescript", title: "q")
+        let exec = ExecRecorder(
+            result: AppleScriptExecutionResult(
+                status: .runtimeError,
+                output: nil,
+                errorNumber: -1728,
+                errorMessage: "Can’t get the requested property"
+            )
+        )
+        let seq = ScriptSequencer([call("get missing property"), nil])
+
+        let result = await AppleScriptLoop.run(
+            task: "read the missing property",
+            modelId: "applescript-test",
+            feed: feed,
+            interrupt: InterruptToken(),
+            executionMode: .confirmEach,
+            confirm: { _ in true },
+            sessionId: "s",
+            mode: .query,
+            execute: { script, _ in await exec.run(script) },
+            nextScript: { _ in await seq.next() }
+        )
+
+        guard case .failed(let reason) = result.outcome else {
+            Issue.record("expected .failed, got \(result.outcome)")
+            return
+        }
+        #expect(reason.contains("all failed"))
+        #expect(result.scriptsExecuted == 1)
+        #expect(result.succeeded == 0)
+        #expect(result.failed == 1)
+        if case .finished(let success, _) = feed.currentStatus() {
+            #expect(success == false)
+        } else {
+            Issue.record("expected a finished feed status")
+        }
     }
 
     @Test("query mode runs the verification read-back to capture a value")
@@ -1406,7 +1488,7 @@ struct AppleScriptMapOutcomeTests {
         )
     }
 
-    @Test("a failed run that executed scripts returns the transcript instead of throwing")
+    @Test("a failed run with a successful script returns the transcript instead of throwing")
     func failedWithScriptsReturnsTranscript() throws {
         let result = AppleScriptRunResult(
             outcome: .failed(reason: "boom"),
@@ -1439,6 +1521,60 @@ struct AppleScriptMapOutcomeTests {
         )
         #expect(throws: SubagentError.self) {
             _ = try AppleScriptKind.mapOutcome(result, model: "m", mode: .automate)
+        }
+    }
+
+    @Test("a failed run where every executed script failed throws executionFailed")
+    func failedWithOnlyFailedScriptsThrows() {
+        let result = AppleScriptRunResult(
+            outcome: .failed(reason: "Every generated script failed."),
+            scriptsExecuted: 2,
+            succeeded: 0,
+            failed: 2,
+            modelTokens: 100,
+            lastOutput: nil,
+            steps: [
+                step(1, "compile_error", error: "syntax", errorNumber: -2741),
+                step(2, "runtime_error", error: "missing value", errorNumber: -1728),
+            ]
+        )
+
+        #expect(throws: SubagentError.self) {
+            _ = try AppleScriptKind.mapOutcome(result, model: "m", mode: .query)
+        }
+    }
+
+    @Test("a done run where every executed script failed still throws executionFailed")
+    func doneWithOnlyFailedScriptsThrows() {
+        let result = AppleScriptRunResult(
+            outcome: .done(summary: "I could not read the requested value."),
+            scriptsExecuted: 1,
+            succeeded: 0,
+            failed: 1,
+            modelTokens: 50,
+            lastOutput: nil,
+            steps: [step(1, "runtime_error", error: "not found", errorNumber: -1728)]
+        )
+
+        #expect(throws: SubagentError.self) {
+            _ = try AppleScriptKind.mapOutcome(result, model: "m", mode: .query)
+        }
+    }
+
+    @Test("a done run with invalid attempts but no executed script throws executionFailed")
+    func doneWithOnlyInvalidAttemptsThrows() {
+        let result = AppleScriptRunResult(
+            outcome: .done(summary: "Completed the task."),
+            scriptsExecuted: 0,
+            succeeded: 0,
+            failed: 0,
+            modelTokens: 100,
+            lastOutput: nil,
+            steps: [step(1, "invalid", error: "Missing required property: script")]
+        )
+
+        #expect(throws: SubagentError.self) {
+            _ = try AppleScriptKind.mapOutcome(result, model: "m", mode: .query)
         }
     }
 


### PR DESCRIPTION
## Scope

This is a narrow AppleScript host-contract fix. The commit changes only:

- `AppleScriptLoop.swift`
- `AppleScriptKind.swift`
- focused AppleScript tests

It does not change vMLX, model routing, RAM admission, TurboQuant, Computer Use, Calendar/spawn behavior, prompts, templates, parsers, samplers, stop tokens, or output caps.

## Source trace

- Query mode previously appended a successful non-empty read result back to the child and asked it to generate again. Small dedicated models could repeat the identical successful script until the eight-step cap. The loop now terminates after the first successful non-empty query value; an empty success retains the existing read-back path.
- A plain-text completion could overwrite real failed work with `.done`. Recorded malformed calls also have `scriptsExecuted == 0`, so that counter alone cannot distinguish untouched explanation from an invalid attempted call. The loop now marks any attempted zero-success run failed, where attempted work means executed scripts or recorded invalid/compile/placeholder steps.
- `AppleScriptKind.mapOutcome` now applies the same invariant before constructing the parent envelope. Mixed success/failure remains a rich partial result.
- Both layers are required because `SubagentFeed.finish` is idempotent: an outer mapping error cannot turn an already-finished green feed red.

## Tests

Full Xcode selected suites:

- `AppleScriptLoopTests`
- `AppleScriptMapOutcomeTests`
- 32 passed, 0 failed, 0 skipped
- Result: `/tmp/osaurus-agent-cu-applescript-focused-tests/Logs/Test/Test-OsaurusCoreTests-2026.07.17_00-58-48--0700.xcresult`

New regressions cover:

- query stops after first successful returned value
- plain-text completion after only failed scripts stays failed
- malformed call followed by completion stays failed
- failed and done outcomes with only failed scripts throw
- invalid attempts with no executed script throw
- mixed partial results remain available

Bare `swift test` is blocked by the selected Command Line Tools environment reporting `no such module Testing`; the Xcode scheme above is the authoritative run.

## Live Release UI evidence

Exact candidate:

- base `f25d89acb`
- pinned vMLX `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`
- isolated bundle id `com.dinoki.osaurus.agentcuapplescriptproof`
- isolated root `/tmp/osaurus-agent-cu-applescript-root-d16b`
- exact parent `OsaurusAI/gemma-4-12B-it-MXFP8`
- exact child `/Users/eric/models/OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`
- ad-hoc signed Release app; `codesign --verify --deep --strict` passed

No MXFP4 bundle was downloaded, loaded, tested, or used for inference.

Fresh Computer Use settings inspection showed AppleScript 8B installed/selected at 7.95 GB, 16B not installed, Confirm each selected, Keep Warm selected, Fast reads off, Accessibility and Screen Recording granted, and Automation Not yet granted. No permission grant/test button was pressed.

Live behavior:

- Pre-patch `2 + 2` and same-chat `3 + 3` each repeated eight identical successful scripts to the cap.
- First patched candidate returned 4 and 6 with `scripts_run=1`, `succeeded=1`, `failed=0`, at 43.4 and 44.5 child tok/s. Its all-failed property attempts surfaced red `ok:false` rows rather than a green raw-JSON success.
- That candidate later reproduced a separate malformed zero-script false success: two missing-`script` calls, `scripts_run=0`, `succeeded=0`, yet `ok:true`. This reproduction motivated the second invariant.
- Replacement candidate containing the complete commit visibly returned 4, 6, and 10 in one AppleScript row each at 3.5s, 3.4s, and 3.7s; parent rows were 32.1, 32.0, and 31.4 tok/s.
- Replacement invalid/malformed injection attempts were not faithful: JANG_6M repaired the call or substituted unrelated Finder/Safari reads and obtained at least one success. The exact new malformed zero-success branch is therefore **PARTIAL / live-unverified** in the replacement binary despite the focused regression.
- Valid `run_applescript` dispatches and structured results show that the reproduced failures occur after tool JSON assembly. The evidence does not support content-delta streaming or tool-schema assembly as the root cause.

Kernel telemetry after seven replacement turns reported current `phys_footprint=2382 MB` and process-lifetime peak `7973 MB`. Activity Monitor All Processes omitted exact live PID 21520 even when filtered by PID, so visual main-process RAM proof is **BLOCKED**; no helper-process value is substituted.

## Remaining separate work

Thinking off/on, exact Computer Use A-to-B-to-A observation persistence, Memory Safety override/refusal UI behavior, image/delegation RAM admission, Gemma 4 and Qwen 3.5 TurboQuant/prefix/L2 cache matrices, and broader Gemma/Bonsai regression rows are not changed or promoted by this PR.
