### PR TITLE
Recover observed Bonsai chart argument drift

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/RenderChartToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/RenderChartToolTests.swift
@@ -57,6 +57,69 @@ struct RenderChartToolTests {
         #expect(marker.contains("\"data\":[1,2,3]"))
     }
 
+    @Test func nestedChartArgumentsAndQuotedHeaderRecoverOnFirstCall() async throws {
+        let argumentsJSON = #"""
+            {
+              "chartType": "bar",
+              "data": "{\"dataFormat\":\"csv\",\"chartType\":\"bar\",\"data\":\"\\\"month,sales\\\"\\nJan,10\\nFeb,15\\nMar,12\",\"title\":\"Quarterly Sales\"}"
+            }
+            """#
+        let tool = RenderChartTool()
+        let normalizedJSON: String
+        switch await ToolRegistry.shared.preflightForTest(
+            argumentsJSON: argumentsJSON,
+            schema: tool.parameters,
+            toolName: tool.name
+        ) {
+        case .ready(let normalized):
+            normalizedJSON = normalized
+        case .rejected(let envelope):
+            Issue.record("preflight rejected the observed nested Bonsai chart arguments: \(envelope)")
+            return
+        }
+
+        let result = try await tool.execute(argumentsJSON: normalizedJSON)
+        #expect(ToolEnvelope.isSuccess(result))
+        let payload = try #require(ToolEnvelope.successPayload(result) as? [String: Any])
+        let marker = try #require(payload["text"] as? String)
+        #expect(marker.contains("\"categories\":[\"Jan\",\"Feb\",\"Mar\"]"))
+        #expect(marker.contains("\"name\":\"sales\""))
+        #expect(marker.contains("\"data\":[10,15,12]"))
+    }
+
+    @Test func yColumnAliasMapsToSingleSeries() async throws {
+        let argumentsJSON = #"""
+            {
+              "chartType": "bar",
+              "data": "month,sales\nJan,10\nFeb,15\nMar,12",
+              "dataFormat": "csv",
+              "xColumn": "month",
+              "yColumn": "sales",
+              "title": "Quarterly Sales"
+            }
+            """#
+        let tool = RenderChartTool()
+        let normalizedJSON: String
+        switch await ToolRegistry.shared.preflightForTest(
+            argumentsJSON: argumentsJSON,
+            schema: tool.parameters,
+            toolName: tool.name
+        ) {
+        case .ready(let normalized):
+            normalizedJSON = normalized
+        case .rejected(let envelope):
+            Issue.record("preflight rejected the observed Bonsai yColumn alias: \(envelope)")
+            return
+        }
+
+        let result = try await tool.execute(argumentsJSON: normalizedJSON)
+        #expect(ToolEnvelope.isSuccess(result))
+        let payload = try #require(ToolEnvelope.successPayload(result) as? [String: Any])
+        let marker = try #require(payload["text"] as? String)
+        #expect(marker.contains("\"categories\":[\"Jan\",\"Feb\",\"Mar\"]"))
+        #expect(marker.contains("\"name\":\"sales\""))
+    }
+
     @Test func omittedSeriesAndHeaderlessRowsPreserveFirstPoint() async throws {
         let argumentsJSON = #"""
             {

--- a/Packages/OsaurusCore/Tools/RenderChartTool.swift
+++ b/Packages/OsaurusCore/Tools/RenderChartTool.swift
@@ -92,6 +92,12 @@ struct RenderChartTool: OsaurusTool {
                         + "Use an array; a string-encoded array is accepted for local-model compatibility."
                 ),
             ]),
+            "yColumn": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Compatibility alias for one `series` column. Prefer `series`; accepted to recover local-model argument drift."
+                ),
+            ]),
             "xPath": .object([
                 "type": .string("string"),
                 "description": .string(
@@ -128,7 +134,8 @@ struct RenderChartTool: OsaurusTool {
 
     func execute(argumentsJSON: String) async throws -> String {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
-        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+        guard case .value(let parsedArgs) = argsReq else { return argsReq.failureEnvelope ?? "" }
+        let args = Self.recoverNestedChartArguments(parsedArgs)
 
         let chartType: String
         if args["chartType"] == nil {
@@ -237,6 +244,7 @@ struct RenderChartTool: OsaurusTool {
         }
 
         let xColumn = args["xColumn"] as? String
+        let requestedSeries = args["series"] ?? args["yColumn"]
 
         var headers: [String]
         var rows: [[String]]
@@ -274,7 +282,7 @@ struct RenderChartTool: OsaurusTool {
         // values) before inferring series, so the first point is not lost.
         // Explicit series/xColumn requests continue through the stricter
         // requested-column recovery below.
-        if args["series"] == nil,
+        if requestedSeries == nil,
             xColumn == nil,
             format != "json",
             let recovered = recoverOmittedSeriesHeaderlessDelimited(
@@ -292,13 +300,13 @@ struct RenderChartTool: OsaurusTool {
         // numeric. Never replace an explicit list: misspelled or otherwise
         // invalid user/model-selected columns still fail below.
         let seriesCols: [String]
-        if args["series"] == nil {
+        if requestedSeries == nil {
             seriesCols = Self.inferredSeriesColumns(
                 headers: headers,
                 rows: rows,
                 excluding: xColumn
             )
-        } else if let requested = Self.parseRequestedSeries(args["series"]), !requested.isEmpty {
+        } else if let requested = Self.parseRequestedSeries(requestedSeries), !requested.isEmpty {
             seriesCols = requested
         } else {
             seriesCols = []
@@ -750,19 +758,70 @@ struct RenderChartTool: OsaurusTool {
         }
     }
 
+    /// Some local models serialize a complete render_chart argument object
+    /// into the `data` string instead of placing those fields at the tool-call
+    /// root. Recover exactly one such layer only when it contains an inner
+    /// data payload plus a chart-control key and no unknown fields. Explicit
+    /// root fields continue to win, so this cannot override a valid call.
+    private static func recoverNestedChartArguments(_ args: [String: Any]) -> [String: Any] {
+        guard let wrapped = args["data"] as? String,
+            let encoded = wrapped.data(using: .utf8),
+            let nested = try? JSONSerialization.jsonObject(with: encoded) as? [String: Any],
+            nested["data"] is String
+        else { return args }
+
+        let allowedKeys: Set<String> = [
+            "data", "dataRef", "format", "dataFormat", "chartType", "xColumn", "series",
+            "yColumn", "xPath", "seriesPaths", "title", "tooltipSuffix",
+        ]
+        guard Set(nested.keys).isSubset(of: allowedKeys),
+            nested.keys.contains(where: { $0 != "data" && $0 != "title" })
+        else { return args }
+
+        var recovered = nested
+        for (key, value) in args where key != "data" {
+            recovered[key] = value
+        }
+        return recovered
+    }
+
     /// Some local models wrap an entire CSV/TSV payload in one extra pair of
     /// quotes. JSON decoding has already handled escaping by this point, so
     /// remove only that dataset-wide wrapper when the first record still has
     /// multiple delimited columns. Ordinary quoted fields remain untouched.
     private static func unwrapQuotedDelimitedPayload(_ raw: String, format: String) -> String {
-        guard format == "csv" || format == "tsv",
+        guard format == "csv" || format == "tsv" else { return raw }
+        let separator = format == "tsv" ? "\t" : ","
+
+        // A second observed Bonsai drift quotes only the complete header row,
+        // turning `month,sales` into one CSV field while the body still has two
+        // columns. Remove that wrapper only when every non-empty body row has
+        // the same multi-column shape as the unquoted header.
+        var lines = raw.components(separatedBy: .newlines)
+        if let first = lines.first,
+            first.first == "\"",
+            first.last == "\"",
+            first.count >= 2
+        {
+            let candidate = String(first.dropFirst().dropLast())
+            let columnCount = candidate.components(separatedBy: separator).count
+            let body = lines.dropFirst().filter { !$0.isEmpty }
+            if columnCount > 1,
+                !body.isEmpty,
+                body.allSatisfy({ $0.components(separatedBy: separator).count == columnCount })
+            {
+                lines[0] = candidate
+                return lines.joined(separator: "\n")
+            }
+        }
+
+        guard
             raw.first == "\"",
             raw.last == "\"",
             raw.contains("\n"),
             raw.count >= 2
         else { return raw }
         let candidate = String(raw.dropFirst().dropLast())
-        let separator = format == "tsv" ? "\t" : ","
         guard candidate.components(separatedBy: .newlines).first?.contains(separator) == true else {
             return raw
         }


### PR DESCRIPTION
## Scope

This is a two-file Bonsai chart-compatibility change only:

- `Packages/OsaurusCore/Tools/RenderChartTool.swift`
- `Packages/OsaurusCore/Tests/Tool/RenderChartToolTests.swift`

It does not change model routing, RAM policy, caches, TurboQuant, Gemma runtime code, generation parameters, prompt behavior, or output limits.

## Current-main reproduction and root cause

In an isolated Release build of `1cae8487c33797a1647d03358b142654df4ec7ca`, operated through the actual app UI with Tools and Charts visibly enabled and the exact local bundle `/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`, the chart request reached `render_chart` as intact JSON but repeatedly failed schema/semantic validation before eventually rendering.

Observed argument drift included:

- `yColumn: "sales"` instead of the declared single-series field
- a complete chart argument object serialized into the outer `data` string
- a CSV header serialized as one quoted field while body rows retained the expected column width

This evidence locates the chart failure in tool JSON schema/output compatibility, not content-delta streaming: the full arguments were logged at execution and validation rejected their shape.

## Change

- Declare `yColumn` as a compatibility alias for one `series` column.
- Recover exactly one nested chart-argument object from `data` only when it contains an inner data string, at least one chart control, and no unknown keys.
- Preserve explicit outer fields when recovering nested arguments.
- Recover the observed quoted-header CSV shape only when every non-empty body row has the same multi-column width.
- Keep malformed or ambiguous inputs on the existing error path.

## Verification

Source-level focused suite:

```text
xcodebuild test -workspace osaurus.xcworkspace -scheme OsaurusCoreTests -configuration Debug \
  -derivedDataPath /tmp/osaurus-bonsai-chart-tests \
  -only-testing:OsaurusCoreTests/RenderChartToolTests

** TEST SUCCEEDED **
xcresult: /tmp/osaurus-bonsai-chart-tests/Logs/Test/Test-OsaurusCoreTests-2026.07.17_02-24-40--0700.xcresult
```

Both new cases passed inside the full workspace graph:

- `nestedChartArgumentsAndQuotedHeaderRecoverOnFirstCall`
- `yColumnAliasMapsToSingleSeries`

Live Release-app proof:

- app: `/tmp/osaurus-bonsai-chart-recovery.app`
- bundle ID: `com.dinoki.osaurus.bonsaichartproof`
- source base: `1cae8487c33797a1647d03358b142654df4ec7ca`
- vMLX pin: `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`
- keychain disabled and isolated test root: `/tmp/osaurus-bonsai-chart-recovery-root-0241`
- exact UI state: Bonsai 27B 1-bit selected; Tools, Charts, Memory, and Web Search visibly enabled

Trial 1 emitted `yColumn:"sales"`; the first `render_chart` call returned `ok:true`, rendered Jan=10, Feb=15, Mar=12 inline, showed no failed tool row, and completed its visible answer at 44.7 tok/s (118 tokens).

Trial 2 again emitted `yColumn:"sales"`; the first `render_chart` call returned `ok:true` and rendered all three points. The broader agent later made an unnecessary `share_artifact` call that failed safely before `complete`, so agent tool-overuse remains PARTIAL and is not claimed as solved by this PR.

The chart trials captured the brain chip visually, but macOS accessibility exposed no selected/value state, so those rows are not used to claim Thinking-off behavior. A later controlled real-UI check explicitly changed the Bonsai chip from purple/active to gray/off, triggered an option-specific warmup, then returned `2 + 2 = 4.` at 35.8 tok/s with one content delta, zero reasoning deltas, and zero tool hints. The inverse on-state produced a visible 9.2-second Thought block and a normal final answer; runtime telemetry recorded 304 reasoning deltas, three content deltas, and no tool hints. The chip was restored to gray/off afterward. This proves the explicit plain-chat toggle wiring in this exact candidate, not every tool workflow.

## Explicit non-claims

- No MXFP4 model was loaded, tested, or used to justify this change.
- Better automatic model routing and hardware guidance remain deferred.
- RAM override, TurboQuant, prefix/L2 cache, image-model, and delegation matrices remain separate follow-up gates.
- This PR proves the bounded chart-argument recovery; it does not claim all Bonsai agent behavior is resolved.

CI is required before merge.
