### PR TITLE
Normalize Bonsai recommendations for onboarding

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -271,9 +271,10 @@ final class ModelManager: NSObject, ObservableObject {
     func loadAvailableModels() {
         // Seed sizes synchronously from the on-disk cache so the first
         // paint shows last-known-accurate download sizes even offline.
-        // Sizes are no longer hand-coded; they're fetched + cached by the
-        // OsaurusAI org refresh / on-demand estimate and persisted in
-        // `ModelSizeCache`.
+        // Sizes normally come from the OsaurusAI org refresh / on-demand
+        // estimate and persist in `ModelSizeCache`. A model whose mixed
+        // precision cannot be inferred from its id may carry a bootstrap size;
+        // a cached Hub measurement still replaces it here.
         let curated = Self.curatedSuggestedModels.map { model in
             model.withDownloadSize(ModelSizeCache.bytes(forId: model.id))
         }
@@ -661,6 +662,7 @@ extension ModelManager {
         id: String,
         description: String,
         isTopSuggestion: Bool = false,
+        bootstrapDownloadSizeBytes: Int64? = nil,
         modelType: String? = nil,
         releasedAt: Date? = nil,
         useCase: ModelUseCase? = nil
@@ -671,7 +673,7 @@ extension ModelManager {
             description: description,
             downloadURL: "https://huggingface.co/\(id)",
             isTopSuggestion: isTopSuggestion,
-            downloadSizeBytes: nil,
+            downloadSizeBytes: bootstrapDownloadSizeBytes,
             modelType: modelType,
             releasedAt: releasedAt,
             useCase: useCase
@@ -698,7 +700,9 @@ extension ModelManager {
         // Onboarding recommendation spine (2026-07-08, GUI-verified in the
         // dev-built app — every model below loads, calls tools, reasons with
         // thinking on, and leaks no markup into visible content):
-        //   • Larger RAM  → Ornith 1.0 MXFP8 (9B / 35B, below).
+        //   • Mainstream RAM → Bonsai 27B, selecting its 1-bit or ternary
+        //                      variant from the machine's model-memory budget.
+        //   • Larger RAM     → Ornith 1.0 MXFP8 (9B / 35B, below).
         //   • Smaller RAM → official OsaurusAI Gemma 4 at the highest non-QAT,
         //                    non-MXFP4 precision that exists: `12B-it-MXFP8`
         //                    (the only MXFP8 Gemma the org ships) and the
@@ -871,12 +875,18 @@ extension ModelManager {
         // prism-ml's Bonsai checkpoints. Text matrices use affine JANG
         // (schema-2 discrete storage — not JANGTQ/MXTQ or a codebook
         // sidecar); vision components stay 4-bit affine. Same `qwen3_5`
-        // runtime class as Qwen 3.6 / Ornith dense builds.
+        // runtime class as Qwen 3.6 / Ornith dense builds. Both variants are
+        // Top Picks so the normalized Bonsai family can select the best build
+        // for this Mac. Their mixed text/vision precision cannot be estimated
+        // accurately from `27B × bit-width`, so the current Hub sizes bootstrap
+        // first-launch hardware selection until `ModelSizeCache` refreshes.
 
         curated(
             id: "OsaurusAI/Bonsai-27b-Ternary-JANG",
             description:
                 "Bonsai 27B dense vision model on a Qwen 3.5 backbone. Ternary (2-bit slot) affine JANG text weights — ~8 GB on disk.",
+            isTopSuggestion: true,
+            bootstrapDownloadSizeBytes: 8_040_700_199,
             modelType: "qwen3_5",
             releasedAt: date("2026-07-14"),
             useCase: .vision
@@ -886,6 +896,8 @@ extension ModelManager {
             id: "OsaurusAI/Bonsai-27b-1bit-JANG",
             description:
                 "Bonsai 27B dense vision model on a Qwen 3.5 backbone. 1-bit affine JANG text weights — smallest of the family at ~4.7 GB.",
+            isTopSuggestion: true,
+            bootstrapDownloadSizeBytes: 4_679_030_015,
             modelType: "qwen3_5",
             releasedAt: date("2026-07-14"),
             useCase: .vision

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -147,6 +147,7 @@ struct MLXModel: Identifiable, Codable {
             // Precision / quantization tokens.
             if t.range(of: #"^mxfp\d+$"#, options: .regularExpression) != nil { return true }
             if t.range(of: #"^\d+-?bit$"#, options: .regularExpression) != nil { return true }
+            if t == "ternary" || t == "jang" { return true }
             if t == "fp16" || t == "bf16" || t == "fp32" { return true }
             if t.range(of: #"^jangtq\d*$"#, options: .regularExpression) != nil { return true }
             if t.range(of: #"^jang_?\d+[a-z]?$"#, options: .regularExpression) != nil { return true }
@@ -518,9 +519,10 @@ struct MLXModel: Identifiable, Codable {
         // and under-estimated every MXFP8 model at ~half its real footprint.
         if quant.contains("mxfp8") || quant.contains("fp8") { return 1.0 }
         if quant.contains("mxfp4") { return 0.5 }
+        if quant == "ternary" { return 0.25 }
 
         let bitWidths: [(String, Double)] = [
-            ("2-bit", 0.25), ("3-bit", 0.375), ("4-bit", 0.5),
+            ("1-bit", 0.125), ("2-bit", 0.25), ("3-bit", 0.375), ("4-bit", 0.5),
             ("5-bit", 0.625), ("6-bit", 0.75), ("8-bit", 1.0),
         ]
         for (label, bytes) in bitWidths {

--- a/Packages/OsaurusCore/Models/Configuration/ModelMetadataParser.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMetadataParser.swift
@@ -124,11 +124,13 @@ enum ModelMetadataParser {
             #"(?i)\bbf16\b"#,
             #"(?i)\bq\d+(_[a-z0-9]+)*\b"#,  // q4_0, q8_k_m
             #"(?i)\b\d+-?bit\b"#,  // 4bit, 4-bit, 8-bit
+            #"(?i)\bternary\b"#,  // ternary / two-bit storage variant
             #"(?i)\bmlx\b"#,
             #"(?i)\bit\b"#,  // "it" = instruction tuned
             #"(?i)\binstruct\b"#,
             #"(?i)\bchat\b"#,
             #"(?i)\bjangtq[_0-9a-z]*\b"#,  // TurboQuant variants (JANGTQ4, JANGTQ_K)
+            #"(?i)\bjang\b"#,  // plain affine JANG storage marker
             #"(?i)\ba\d+(\.\d+)?b\b"#,  // A3B / A2.5B active param count
         ]
         for pat in dropPatterns {
@@ -184,6 +186,8 @@ enum ModelMetadataParser {
             #"^qat$"#,  // quantization-aware-training marker
             #"^jangtq[_0-9a-z]*$"#,  // JANGTQ / JANGTQ4 / JANGTQ_K TurboQuant
             #"^jang_?\d+[a-z]?$"#,  // JANG_4M / JANG_2S mixed precision
+            #"^jang$"#,  // plain affine JANG storage
+            #"^ternary$"#,  // ternary / two-bit storage variant
             #"^\d+-?bit$"#,  // 4bit / 8bit / 4-bit
             #"^(fp16|bf16|fp32)$"#,
             #"^q\d+(_[a-z0-9]+)*$"#,  // GGUF-style q4_0 / q8_k_m
@@ -285,6 +289,16 @@ enum ModelMetadataParser {
             options: .regularExpression
         ) {
             return String(text[match]).uppercased().replacingOccurrences(of: "_", with: " ")
+        }
+        // Bonsai's ternary checkpoint uses plain affine JANG storage. Ternary
+        // is the useful precision label; the trailing `JANG` token identifies
+        // the storage format rather than a separate model family.
+        if text.contains("ternary") { return "Ternary" }
+        if text.range(
+            of: #"(^|[-_/])jang($|[-_/])"#,
+            options: .regularExpression
+        ) != nil {
+            return "JANG"
         }
         if text.contains("fp16") { return "FP16" }
         if text.contains("bf16") { return "BF16" }

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeGitSyncService.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeGitSyncService.swift
@@ -191,7 +191,11 @@ public actor KnowledgeGitSyncService {
     // MARK: - Repo probes
 
     private func headCommit(in folder: URL) -> String? {
-        let result = runGit(["rev-parse", "HEAD"], cwd: folder, timeout: Self.localTimeout)
+        let result = runGit(
+            ["rev-parse", "HEAD"],
+            cwd: folder,
+            timeout: Self.localTimeout
+        )
         guard result.succeeded else { return nil }
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -220,7 +224,11 @@ public actor KnowledgeGitSyncService {
         return stdout.isEmpty ? "git exited with status \(result.exitCode)." : stdout
     }
 
-    private func runGit(_ arguments: [String], cwd: URL, timeout: TimeInterval) -> GitResult {
+    private func runGit(
+        _ arguments: [String],
+        cwd: URL,
+        timeout: TimeInterval
+    ) -> GitResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: Self.gitPath)
         process.arguments = arguments
@@ -238,9 +246,17 @@ public actor KnowledgeGitSyncService {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        // `Process.waitUntilExit()` can remain blocked after a short-lived
+        // child has disappeared on macOS 26. Observe Foundation's termination
+        // callback instead, while preserving the actor's serial operation
+        // ordering.
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+
         do {
             try process.run()
         } catch {
+            process.terminationHandler = nil
             return GitResult(
                 exitCode: -1,
                 stdout: "",
@@ -249,21 +265,17 @@ public actor KnowledgeGitSyncService {
             )
         }
 
-        // Watchdog: terminate a wedged process at the deadline. Reads
-        // happen on the pipes after exit; git's output volumes here are
-        // small (no --progress), so pipe back-pressure is not a concern.
-        let deadline = DispatchTime.now() + timeout
-        var timedOut = false
-        let group = DispatchGroup()
-        group.enter()
-        DispatchQueue.global(qos: .utility).async {
-            process.waitUntilExit()
-            group.leave()
-        }
-        if group.wait(timeout: deadline) == .timedOut {
-            timedOut = true
-            process.terminate()
-            group.wait()
+        guard exited.wait(timeout: .now() + timeout) == .success else {
+            process.terminationHandler = nil
+            if process.isRunning {
+                process.terminate()
+            }
+            return GitResult(
+                exitCode: -1,
+                stdout: "",
+                stderr: "",
+                timedOut: true
+            )
         }
 
         let stdout =
@@ -284,7 +296,7 @@ public actor KnowledgeGitSyncService {
             exitCode: process.terminationStatus,
             stdout: stdout,
             stderr: stderr,
-            timedOut: timedOut
+            timedOut: false
         )
     }
 }

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeGitSyncTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeGitSyncTests.swift
@@ -14,10 +14,8 @@ import Testing
 
 @testable import OsaurusCore
 
-/// These integration tests synchronously wait on real `Process` instances and
-/// share the service actor. Running every case concurrently can exhaust Swift's
-/// cooperative executor in the full Xcode suite, leaving one random git process
-/// test suspended until the per-test timeout kills it.
+/// These integration tests run real git processes through one shared service
+/// actor, so keep the cases from competing with one another.
 @Suite(.serialized)
 struct KnowledgeGitSyncTests {
 
@@ -31,34 +29,49 @@ struct KnowledgeGitSyncTests {
 
     /// Run raw git for test setup (distinct from the service under test).
     @discardableResult
-    private func git(_ args: [String], cwd: URL) throws -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: Self.gitPath)
-        process.arguments = args
-        process.currentDirectoryURL = cwd
-        var env = ProcessInfo.processInfo.environment
-        env["GIT_TERMINAL_PROMPT"] = "0"
-        env["GIT_CONFIG_GLOBAL"] = "/dev/null"
-        env["GIT_CONFIG_SYSTEM"] = "/dev/null"
-        env["GIT_AUTHOR_NAME"] = "Test"
-        env["GIT_AUTHOR_EMAIL"] = "test@example.com"
-        env["GIT_COMMITTER_NAME"] = "Test"
-        env["GIT_COMMITTER_EMAIL"] = "test@example.com"
-        process.environment = env
-        let out = Pipe()
-        process.standardOutput = out
-        process.standardError = out
-        try process.run()
-        process.waitUntilExit()
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        let text = String(data: data, encoding: .utf8) ?? ""
-        if process.terminationStatus != 0 {
-            throw NSError(
-                domain: "git", code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: "git \(args.joined(separator: " ")): \(text)"]
-            )
+    private func git(_ args: [String], cwd: URL) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: Self.gitPath)
+            process.arguments = args
+            process.currentDirectoryURL = cwd
+            var env = ProcessInfo.processInfo.environment
+            env["GIT_TERMINAL_PROMPT"] = "0"
+            env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+            env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+            env["GIT_AUTHOR_NAME"] = "Test"
+            env["GIT_AUTHOR_EMAIL"] = "test@example.com"
+            env["GIT_COMMITTER_NAME"] = "Test"
+            env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+            process.environment = env
+            let out = Pipe()
+            process.standardOutput = out
+            process.standardError = out
+            process.terminationHandler = { terminatedProcess in
+                let data = out.fileHandleForReading.readDataToEndOfFile()
+                let text = String(data: data, encoding: .utf8) ?? ""
+                guard terminatedProcess.terminationStatus == 0 else {
+                    continuation.resume(
+                        throwing: NSError(
+                            domain: "git",
+                            code: Int(terminatedProcess.terminationStatus),
+                            userInfo: [
+                                NSLocalizedDescriptionKey:
+                                    "git \(args.joined(separator: " ")): \(text)"
+                            ]
+                        )
+                    )
+                    return
+                }
+                continuation.resume(returning: text)
+            }
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                continuation.resume(throwing: error)
+            }
         }
-        return text
     }
 
     private func tempDir() throws -> URL {
@@ -68,26 +81,26 @@ struct KnowledgeGitSyncTests {
         return dir
     }
 
-    private func configureIdentity(_ repo: URL) throws {
-        try git(["config", "user.name", "Test"], cwd: repo)
-        try git(["config", "user.email", "test@example.com"], cwd: repo)
+    private func configureIdentity(_ repo: URL) async throws {
+        try await git(["config", "user.name", "Test"], cwd: repo)
+        try await git(["config", "user.email", "test@example.com"], cwd: repo)
     }
 
     /// Create a bare "remote" plus a working clone with one initial commit
     /// pushed. Returns (remote, workingClone).
-    private func makeRemoteAndClone() throws -> (remote: URL, work: URL) {
+    private func makeRemoteAndClone() async throws -> (remote: URL, work: URL) {
         let root = try tempDir()
         let remote = root.appendingPathComponent("remote.git", isDirectory: true)
-        try git(["init", "--bare", "--initial-branch=main", remote.path], cwd: root)
+        try await git(["init", "--bare", "--initial-branch=main", remote.path], cwd: root)
         let work = root.appendingPathComponent("work", isDirectory: true)
-        try git(["clone", remote.path, work.path], cwd: root)
-        try configureIdentity(work)
+        try await git(["clone", remote.path, work.path], cwd: root)
+        try await configureIdentity(work)
         try "seed\n".write(
             to: work.appendingPathComponent("index.md"), atomically: true, encoding: .utf8
         )
-        try git(["add", "-A"], cwd: work)
-        try git(["commit", "-m", "seed"], cwd: work)
-        try git(["push", "origin", "main"], cwd: work)
+        try await git(["add", "-A"], cwd: work)
+        try await git(["commit", "-m", "seed"], cwd: work)
+        try await git(["push", "origin", "main"], cwd: work)
         return (remote, work)
     }
 
@@ -100,7 +113,7 @@ struct KnowledgeGitSyncTests {
     @Test
     func detectsOriginOfAdoptedRepo() async throws {
         guard Self.gitAvailable else { return }
-        let (remote, work) = try makeRemoteAndClone()
+        let (remote, work) = try await makeRemoteAndClone()
 
         let detected = await KnowledgeGitSyncService.shared.remoteURL(of: work)
         #expect(detected == remote.path)
@@ -110,7 +123,10 @@ struct KnowledgeGitSyncTests {
     func remoteURLIsNilForRepoWithoutRemote() async throws {
         guard Self.gitAvailable else { return }
         let repo = try tempDir()
-        try git(["init", "--initial-branch=main", repo.path], cwd: repo.deletingLastPathComponent())
+        try await git(
+            ["init", "--initial-branch=main", repo.path],
+            cwd: repo.deletingLastPathComponent()
+        )
 
         let detected = await KnowledgeGitSyncService.shared.remoteURL(of: repo)
         #expect(detected == nil)
@@ -121,7 +137,7 @@ struct KnowledgeGitSyncTests {
     @Test
     func commitDocumentThenPushAdvancesRemote() async throws {
         guard Self.gitAvailable else { return }
-        let (remote, work) = try makeRemoteAndClone()
+        let (remote, work) = try await makeRemoteAndClone()
         let coll = collection(at: work)
 
         try "updated body\n".write(
@@ -136,14 +152,14 @@ struct KnowledgeGitSyncTests {
         if case .updated = push {} else { Issue.record("expected push .updated, got \(push)") }
 
         // The bare remote now carries the new commit's file content.
-        let show = try git(["show", "HEAD:index.md"], cwd: remote)
+        let show = try await git(["show", "HEAD:index.md"], cwd: remote)
         #expect(show.contains("updated body"))
     }
 
     @Test
     func commitWithNoChangesIsUpToDate() async throws {
         guard Self.gitAvailable else { return }
-        let (_, work) = try makeRemoteAndClone()
+        let (_, work) = try await makeRemoteAndClone()
         let coll = collection(at: work)
 
         // Rewrite identical bytes: git finds nothing to commit.
@@ -161,19 +177,19 @@ struct KnowledgeGitSyncTests {
     @Test
     func pullFastForwardsFromRemote() async throws {
         guard Self.gitAvailable else { return }
-        let (remote, work) = try makeRemoteAndClone()
+        let (remote, work) = try await makeRemoteAndClone()
 
         // A second clone pushes a new commit to the remote.
         let root = remote.deletingLastPathComponent()
         let other = root.appendingPathComponent("other", isDirectory: true)
-        try git(["clone", remote.path, other.path], cwd: root)
-        try configureIdentity(other)
+        try await git(["clone", remote.path, other.path], cwd: root)
+        try await configureIdentity(other)
         try "from other\n".write(
             to: other.appendingPathComponent("note.md"), atomically: true, encoding: .utf8
         )
-        try git(["add", "-A"], cwd: other)
-        try git(["commit", "-m", "add note"], cwd: other)
-        try git(["push", "origin", "main"], cwd: other)
+        try await git(["add", "-A"], cwd: other)
+        try await git(["commit", "-m", "add note"], cwd: other)
+        try await git(["push", "origin", "main"], cwd: other)
 
         let coll = collection(at: work)
         let pulled = await KnowledgeGitSyncService.shared.pull(coll)
@@ -192,26 +208,26 @@ struct KnowledgeGitSyncTests {
     @Test
     func divergentHistoryNeedsAttention() async throws {
         guard Self.gitAvailable else { return }
-        let (remote, work) = try makeRemoteAndClone()
+        let (remote, work) = try await makeRemoteAndClone()
 
         // Remote gains a commit via a second clone...
         let root = remote.deletingLastPathComponent()
         let other = root.appendingPathComponent("other", isDirectory: true)
-        try git(["clone", remote.path, other.path], cwd: root)
-        try configureIdentity(other)
+        try await git(["clone", remote.path, other.path], cwd: root)
+        try await configureIdentity(other)
         try "remote side\n".write(
             to: other.appendingPathComponent("r.md"), atomically: true, encoding: .utf8
         )
-        try git(["add", "-A"], cwd: other)
-        try git(["commit", "-m", "remote commit"], cwd: other)
-        try git(["push", "origin", "main"], cwd: other)
+        try await git(["add", "-A"], cwd: other)
+        try await git(["commit", "-m", "remote commit"], cwd: other)
+        try await git(["push", "origin", "main"], cwd: other)
 
         // ...while the working clone makes its own conflicting local commit.
         try "local side\n".write(
             to: work.appendingPathComponent("l.md"), atomically: true, encoding: .utf8
         )
-        try git(["add", "-A"], cwd: work)
-        try git(["commit", "-m", "local commit"], cwd: work)
+        try await git(["add", "-A"], cwd: work)
+        try await git(["commit", "-m", "local commit"], cwd: work)
 
         let coll = collection(at: work)
         let outcome = await KnowledgeGitSyncService.shared.sync(coll)

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeGitSyncTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeGitSyncTests.swift
@@ -14,6 +14,11 @@ import Testing
 
 @testable import OsaurusCore
 
+/// These integration tests synchronously wait on real `Process` instances and
+/// share the service actor. Running every case concurrently can exhaust Swift's
+/// cooperative executor in the full Xcode suite, leaving one random git process
+/// test suspended until the per-test timeout kills it.
+@Suite(.serialized)
 struct KnowledgeGitSyncTests {
 
     // MARK: - Git harness

--- a/Packages/OsaurusCore/Tests/Model/MLXModelTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MLXModelTests.swift
@@ -178,6 +178,13 @@ struct MLXModelTests {
         #expect(highPrecision == efficient)
     }
 
+    @Test func simplifiedName_normalizesBonsaiLowBitVariants() {
+        let ternary = model(named: "Bonsai 27b Ternary JANG").simplifiedName
+        let oneBit = model(named: "Bonsai 27b 1bit JANG").simplifiedName
+        #expect(ternary == "Bonsai 27b")
+        #expect(oneBit == ternary)
+    }
+
     /// If stripping would leave nothing, fall back to the original name rather
     /// than rendering an empty row title.
     @Test func simplifiedName_fallsBackWhenAllTokensAreJargon() {

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -135,13 +135,29 @@ struct ModelManagerSuggestedTests {
 
             #expect(mxfp8 != nil)
             #expect(mxfp8?.modelType == "lfm2_moe")
-            // Catalog-only (2026-07-08): the recommendation spine is Ornith
-            // MXFP8 + official Gemma; LFM2.5 stays installable but is not a
-            // Top Pick.
+            // Catalog-only: the recommendation spine is Bonsai + Ornith MXFP8
+            // + official Gemma; LFM2.5 stays installable but is not a Top Pick.
             #expect(mxfp8?.isTopSuggestion == false)
             // Sizes now come from `ModelSizeCache` (empty here), not literals.
             #expect(mxfp8?.downloadSizeBytes == nil)
             #expect(mxfp8?.releasedAt != nil)
+        }
+    }
+
+    @Test @MainActor func bonsaiEntries_areNormalizedTopPickVariants() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let ternary = suggested.first { $0.id == "OsaurusAI/Bonsai-27b-Ternary-JANG" }
+            let oneBit = suggested.first { $0.id == "OsaurusAI/Bonsai-27b-1bit-JANG" }
+
+            #expect(ternary?.isTopSuggestion == true)
+            #expect(oneBit?.isTopSuggestion == true)
+            #expect(ternary?.downloadSizeBytes == 8_040_700_199)
+            #expect(oneBit?.downloadSizeBytes == 4_679_030_015)
+            #expect(
+                ModelMetadataParser.familyKey(from: ternary?.id ?? "")
+                    == ModelMetadataParser.familyKey(from: oneBit?.id ?? "")
+            )
         }
     }
 
@@ -234,24 +250,29 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Top-pick reorg (precision-first)
 
-    @Test @MainActor func topPicks_recommendOrnithMXFP8AndOfficialGemma() async {
+    @Test @MainActor func topPicks_recommendBonsaiOrnithAndOfficialGemma() async {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
             // Recommendation spine (2026-07-08, GUI-verified in the dev app —
             // each loads, calls tools, reasons with thinking on, no marker
-            // leakage): Ornith 1.0 MXFP8 for the larger tiers, official
-            // OsaurusAI Gemma 4 at the highest non-QAT/non-MXFP4 precision that
-            // exists (12B-it-MXFP8; E4B/E2B-it-8bit — no E-series MXFP8 exists)
-            // for the smaller tiers. These are the ONLY Top Picks.
+            // leakage): Bonsai 27B low-bit builds for mainstream RAM, Ornith
+            // 1.0 MXFP8 for the larger tiers, and official OsaurusAI Gemma 4
+            // at the highest non-QAT/non-MXFP4 precision that exists for the
+            // smaller tiers. These are the ONLY Top Picks.
             let expectedTopPicks: Set<String> = [
                 "OsaurusAI/Ornith-1.0-9B-MXFP8",
                 "OsaurusAI/Ornith-1.0-35B-MXFP8",
+                "OsaurusAI/Bonsai-27b-Ternary-JANG",
+                "OsaurusAI/Bonsai-27b-1bit-JANG",
                 "OsaurusAI/gemma-4-12B-it-MXFP8",
                 "OsaurusAI/gemma-4-E4B-it-8bit",
                 "OsaurusAI/gemma-4-E2B-it-8bit",
             ]
-            #expect(topIds == expectedTopPicks, "Top Picks should be exactly Ornith MXFP8 + official Gemma; got \(topIds.sorted())")
+            #expect(
+                topIds == expectedTopPicks,
+                "Top Picks should be exactly Bonsai + Ornith MXFP8 + official Gemma; got \(topIds.sorted())"
+            )
             // Gemma QAT/MXFP4, plus Qwen 3.6 / Nemotron-3 / LFM2.5, are
             // catalog-only for now — installable and selectable, just not part
             // of the auto-default recommendation spine.
@@ -404,19 +425,46 @@ struct ModelManagerSuggestedTests {
                     !droppedGemma,
                     "auto-default \(pick.id) at \(gb)GB must not be a Gemma QAT/MXFP4 build")
 
-                // The pick is the LARGEST Top Pick that comfortably fits — the
-                // strongest proven model for this RAM tier. (When nothing is
-                // comfortable, the fallback smallest-candidate is allowed.)
+                // The pick is the largest-base-parameter Top Pick that
+                // comfortably fits. Equal-size variants prefer the larger,
+                // higher-quality footprint. (When nothing is comfortable, the
+                // fallback smallest candidate is allowed.)
                 let comfortable = candidates.filter {
                     $0.compatibility(totalMemoryGB: gb) == .compatible
                 }
                 if !comfortable.isEmpty {
-                    let maxMem = comfortable.compactMap(\.estimatedMemoryGB).max() ?? 0
+                    let maxParameters = comfortable.compactMap(\.parameterCountBillions).max() ?? 0
+                    #expect(
+                        (pick.parameterCountBillions ?? -1) == maxParameters,
+                        "auto-default at \(gb)GB should have the largest comfortable base model"
+                    )
+                    let strongestFamily = comfortable.filter {
+                        ($0.parameterCountBillions ?? 0) == maxParameters
+                    }
+                    let maxMem = strongestFamily.compactMap(\.estimatedMemoryGB).max() ?? 0
                     #expect(
                         (pick.estimatedMemoryGB ?? -1) == maxMem,
-                        "auto-default at \(gb)GB should be the largest comfortable Top Pick")
+                        "auto-default at \(gb)GB should prefer the highest-quality fitting variant"
+                    )
                 }
             }
+        }
+    }
+
+    @Test @MainActor func onboardingDefault_selectsBonsaiVariantForMainstreamRAM() async {
+        await withIsolatedModelSizeCache {
+            let candidates = ModelManager().suggestedModels.filter(\.isTopSuggestion)
+            let sixteenGB = ConfigureAIState.recommendedLocalPick(
+                from: candidates,
+                totalMemoryGB: 16
+            )
+            let twentyFourGB = ConfigureAIState.recommendedLocalPick(
+                from: candidates,
+                totalMemoryGB: 24
+            )
+
+            #expect(sixteenGB?.id == "OsaurusAI/Bonsai-27b-1bit-JANG")
+            #expect(twentyFourGB?.id == "OsaurusAI/Bonsai-27b-Ternary-JANG")
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelMetadataParserFamilyKeyTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMetadataParserFamilyKeyTests.swift
@@ -75,6 +75,15 @@ struct ModelMetadataParserFamilyKeyTests {
         )
     }
 
+    @Test func bonsaiLowBitVariantsShareOneNormalizedFamily() {
+        let ternary = "OsaurusAI/Bonsai-27b-Ternary-JANG"
+        let oneBit = "OsaurusAI/Bonsai-27b-1bit-JANG"
+        #expect(ModelMetadataParser.familyKey(from: ternary) == "osaurusai/bonsai-27b")
+        #expect(ModelMetadataParser.familyKey(from: ternary) == ModelMetadataParser.familyKey(from: oneBit))
+        #expect(ModelMetadataParser.familyDisplayName(from: ternary) == "Bonsai 27b")
+        #expect(ModelMetadataParser.familyDisplayName(from: oneBit) == "Bonsai 27b")
+    }
+
     @Test func idWithoutVariantTokensIsItsOwnFamily() {
         #expect(
             ModelMetadataParser.familyKey(from: "OsaurusAI/rampart-mlx")

--- a/Packages/OsaurusCore/Tests/Model/ModelMetadataParserQuantLabelTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMetadataParserQuantLabelTests.swift
@@ -39,4 +39,15 @@ struct ModelMetadataParserQuantLabelTests {
         #expect(ModelMetadataParser.quantization(from: "OsaurusAI/gemma-4-12B-it-qat-MXFP4") == "MXFP4")
         #expect(ModelMetadataParser.quantization(from: "OsaurusAI/gemma-4-E4B-it-8bit") == "8-bit")
     }
+
+    @Test func parsesBonsaiLowBitLabels() {
+        #expect(
+            ModelMetadataParser.quantization(from: "OsaurusAI/Bonsai-27b-Ternary-JANG")
+                == "Ternary"
+        )
+        #expect(
+            ModelMetadataParser.quantization(from: "OsaurusAI/Bonsai-27b-1bit-JANG")
+                == "1-bit"
+        )
+    }
 }

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -226,12 +226,10 @@ final class ConfigureAIState: ObservableObject {
     ///   1. If a curated top pick is already on disk, keep it. The user
     ///      downloaded (and presumably ran) it before, so the compat
     ///      heuristic shouldn't lock them out.
-    ///   2. Otherwise defer to `recommendedLocalPick`: the largest dense
-    ///      Gemma 4 QAT model that *comfortably* fits, with the E-series
-    ///      8-bit retention builds as the gated small-tier fallback. We no
-    ///      longer auto-default into the `.tight` band or onto the largest
-    ///      MoE/flagship — that pushed users onto models they couldn't really
-    ///      run (the 26B-A4B 36%-bounce case).
+    ///   2. Otherwise defer to `recommendedLocalPick`: the largest proven
+    ///      base model that *comfortably* fits, using resident footprint to
+    ///      choose between equal-size variants. We never auto-default into
+    ///      the `.tight` band.
     ///
     /// `.unknown` (no param info / monitor not yet populated) fails open via
     /// the final `candidates.first` fallback so onboarding never dead-ends.
@@ -258,15 +256,17 @@ final class ConfigureAIState: ObservableObject {
     /// top-pick `candidates` and the machine RAM, returns the model onboarding
     /// should pre-select (or `nil` when there are no candidates).
     ///
-    /// Rule: auto-default to the **largest** curated Top Pick that
-    /// **comfortably** fits (`.compatible`, so never into the `.tight` band).
+    /// Rule: auto-default to the curated Top Pick with the **largest base
+    /// parameter count** that **comfortably** fits (`.compatible`, so never
+    /// into the `.tight` band). For variants of the same base model, prefer
+    /// the larger resident footprint as the higher-quality precision.
     /// Every curated Top Pick is a GUI-verified-good model — coherent output
     /// with clean tool-calling and reasoning and no control-marker leakage
-    /// (verified live in the dev app across the Ornith / Qwen 3.6 / Qwen
-    /// AgentWorld / Nemotron families) — so "largest that comfortably fits"
-    /// lands each RAM tier on the strongest proven model for that Mac. When
-    /// nothing is comfortable (very low RAM), fall back to the smallest
-    /// candidate overall so onboarding never dead-ends.
+    /// (verified live in the dev app across the curated families). Ranking by
+    /// base parameters rather than quantized bytes matters for Bonsai: its 27B
+    /// 1-bit build is smaller on disk than a 9B MXFP8 model without becoming a
+    /// 4B-class model. When nothing is comfortable (very low RAM), fall back
+    /// to the smallest candidate overall so onboarding never dead-ends.
     ///
     /// This replaced the earlier Gemma-4-QAT auto-default spine: the Gemma 4
     /// `qat-MXFP4` builds are no longer curated Top Picks, so they are neither
@@ -280,8 +280,15 @@ final class ConfigureAIState: ObservableObject {
             $0.compatibility(totalMemoryGB: totalMemoryGB) == .compatible
         }
 
-        func largest(_ pool: [MLXModel]) -> MLXModel? {
-            pool.max(by: { ($0.estimatedMemoryGB ?? 0) < ($1.estimatedMemoryGB ?? 0) })
+        func strongest(_ pool: [MLXModel]) -> MLXModel? {
+            pool.max { lhs, rhs in
+                let lhsParameters = lhs.parameterCountBillions ?? 0
+                let rhsParameters = rhs.parameterCountBillions ?? 0
+                if lhsParameters != rhsParameters {
+                    return lhsParameters < rhsParameters
+                }
+                return (lhs.estimatedMemoryGB ?? 0) < (rhs.estimatedMemoryGB ?? 0)
+            }
         }
         func smallest(_ pool: [MLXModel]) -> MLXModel? {
             pool.min(by: {
@@ -290,7 +297,7 @@ final class ConfigureAIState: ObservableObject {
             })
         }
 
-        return largest(comfortable) ?? smallest(candidates)
+        return strongest(comfortable) ?? smallest(candidates)
     }
 
     /// Collapses same-family quant variants — rows whose titles collapse to
@@ -305,7 +312,7 @@ final class ConfigureAIState: ObservableObject {
     ///      user into re-downloading a near-duplicate of bits already on
     ///      disk. Largest wins if several are on disk.
     ///   3. The variant `recommendedLocalPick` chose — the tuned auto-default
-    ///      (QAT spine) must survive dedupe, or the "Picked for your Mac"
+    ///      must survive dedupe, or the "Picked for your Mac"
     ///      badge would point at a hidden row.
     ///   4. Quality first, comfort permitting: the largest (highest-
     ///      precision) build inside the best compatibility band a variant


### PR DESCRIPTION
## Summary
- normalize Bonsai 27B ternary and 1-bit builds into one model family
- promote both variants to Top Picks with accurate bootstrap sizes
- select the strongest comfortably fitting Bonsai variant during onboarding

## Test plan
- [x] Run targeted model metadata, recommendation, family-grouping, and onboarding tests (83 passed)
- [ ] Run full `make test` suite (interrupted before completion)