### PR TITLE
Improve Models catalog browsability and tuck runtime diagnostics away

### DIFF
--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -70,6 +70,9 @@ struct ModelDetailView: View, Identifiable {
     /// Whether the Advanced section is expanded
     @State private var isAdvancedExpanded = false
 
+    /// Whether the developer-oriented Runtime Diagnostics section is expanded
+    @State private var isDiagnosticsExpanded = false
+
     /// Rendered model card markdown (README with front-matter stripped).
     @State private var readme: String? = nil
 
@@ -132,8 +135,6 @@ struct ModelDetailView: View, Identifiable {
 
                     variantPickerSection
 
-                    runtimeDiagnosticsCard
-
                     modelCardSection
 
                     detailsCard
@@ -141,6 +142,8 @@ struct ModelDetailView: View, Identifiable {
                     filesSection
 
                     advancedSection
+
+                    runtimeDiagnosticsSection
                 }
                 .padding(.horizontal, 24)
                 .padding(.top, 18)
@@ -408,57 +411,81 @@ struct ModelDetailView: View, Identifiable {
         return model.isVLM
     }
 
-    @ViewBuilder
-    private var runtimeDiagnosticsCard: some View {
-        if let report = diagnostics {
-            diagnosticsCard(for: report)
-        } else {
-            diagnosticsLoadingCard
-        }
-    }
-
-    /// Placeholder shown while `diagnostics` is being read from disk so the
-    /// card slot keeps its place and the layout doesn't jump when the real
-    /// report lands.
-    private var diagnosticsLoadingCard: some View {
-        HStack(spacing: 10) {
-            ProgressView()
-                .controlSize(.small)
-            Text("Checking runtime compatibility…", bundle: .module)
-                .font(.system(size: 12))
-                .foregroundColor(theme.tertiaryText)
-            Spacer(minLength: 0)
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .detailCardSurface()
-    }
-
-    private func diagnosticsCard(
-        for report: ModelCompatibilityDiagnostics.Report
-    ) -> some View {
-        let tint = runtimeDiagnosticTint(report.runtime.kind)
-
-        return VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 10) {
-                Image(systemName: runtimeDiagnosticIcon(report.runtime.kind))
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(tint)
-                    .frame(width: 18, height: 18)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(report.primaryTitle)
+    /// Collapsible, developer-oriented runtime diagnostics. Collapsed by
+    /// default and placed last so the runtime-proof details (bundle status,
+    /// preflight, evidence keys) don't lead the sheet for regular users.
+    /// The header still surfaces the one-line verdict so a blocked or
+    /// unproven runtime is visible without expanding.
+    private var runtimeDiagnosticsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isDiagnosticsExpanded.toggle()
+                }
+            }) {
+                HStack(spacing: 8) {
+                    Text("Runtime Diagnostics", bundle: .module)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(theme.primaryText)
 
-                    Text(report.primaryDetail)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.tertiaryText)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                    if let report = diagnostics {
+                        HStack(spacing: 4) {
+                            Image(systemName: runtimeDiagnosticIcon(report.runtime.kind))
+                                .font(.system(size: 10, weight: .semibold))
+                            Text(report.primaryTitle)
+                                .font(.system(size: 11, weight: .medium))
+                                .lineLimit(1)
+                        }
+                        .foregroundColor(runtimeDiagnosticTint(report.runtime.kind))
+                    } else {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.6)
+                            .frame(width: 12, height: 12)
+                    }
 
-                Spacer(minLength: 0)
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(theme.tertiaryText)
+                        .rotationEffect(.degrees(isDiagnosticsExpanded ? 90 : 0))
+                }
+                .padding(14)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(PlainButtonStyle())
+
+            if isDiagnosticsExpanded {
+                Group {
+                    if let report = diagnostics {
+                        diagnosticsDetail(for: report)
+                    } else {
+                        HStack(spacing: 10) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Checking runtime compatibility…", bundle: .module)
+                                .font(.system(size: 12))
+                                .foregroundColor(theme.tertiaryText)
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.bottom, 14)
+            }
+        }
+        .detailCardSurface()
+    }
+
+    private func diagnosticsDetail(
+        for report: ModelCompatibilityDiagnostics.Report
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(report.primaryDetail)
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
 
             LazyVGrid(
                 columns: [
@@ -536,9 +563,7 @@ struct ModelDetailView: View, Identifiable {
                 }
             }
         }
-        .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .detailCardSurface()
     }
 
     private func runtimeDiagnosticTint(_ kind: ModelCompatibilityDiagnostics.RuntimeStatus.Kind) -> Color {

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -116,7 +116,6 @@ struct ModelDownloadView: View {
     /// Import-from-Hugging-Face sheet state
     @State private var showImportSheet = false
 
-
     /// Index of the leading Top Picks card the edge arrows scroll to. Desktop
     /// mice can't scroll horizontally, so the carousel is driven by these
     /// buttons; the index is clamped to the model count on every step.
@@ -949,13 +948,10 @@ struct ModelDownloadView: View {
                 loadingState
             } else {
                 VStack(spacing: 0) {
-                    sortFilterBar
-                        .padding(.horizontal, 24)
-                        .padding(.top, 12)
-                        .padding(.bottom, 12)
-
                     ScrollView {
                         VStack(spacing: 12) {
+                            sortFilterBar
+
                             if !modelManager.deprecationNotices.isEmpty {
                                 deprecationBanner
                             }
@@ -980,12 +976,15 @@ struct ModelDownloadView: View {
                     }
                     .mask(
                         VStack(spacing: 0) {
+                            // Kept within the scroll content's 12pt top padding so
+                            // the sort/filter row (now scrolling with the grid) is
+                            // fully opaque at rest and only fades once it scrolls.
                             LinearGradient(
                                 gradient: Gradient(colors: [.clear, .black]),
                                 startPoint: .top,
                                 endPoint: .bottom
                             )
-                            .frame(height: 16)
+                            .frame(height: 12)
                             Color.black
                             LinearGradient(
                                 gradient: Gradient(colors: [.black, .clear]),


### PR DESCRIPTION
## Summary
- Models catalog: the Search / Sort / Filter row now scrolls away with the model grid instead of staying pinned, reclaiming vertical space while browsing. The scroll mask's top fade was trimmed to 12pt so the row is fully opaque at rest and only fades as it scrolls under the edge.
- Model detail sheet: the developer-oriented runtime diagnostics card (bundle status, preflight, tool-use proof, evidence keys, feature hooks) no longer leads the sheet. It is now a collapsed "Runtime Diagnostics" disclosure section at the bottom, below Advanced; the collapsed header keeps the one-line verdict with its status tint so blocked/unproven runtimes stay visible at a glance.
- The user-facing "Should run smoothly on this Mac" compatibility line stays at the top, unchanged.

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` compiles cleanly
- [x] `swift-format lint` clean on both changed files
- [ ] Visually confirm the toolbar scrolls with cards on Catalog and On Device tabs (popovers, empty state)
- [ ] Visually confirm the collapsed Runtime Diagnostics section expands to the full report and shows the verdict while collapsed