### PR TITLE
Fix AppleScript Computer Use finalization and failure containment

### DIFF
--- a/Packages/OsaurusCore/AppleScript/Tool/MacQueryTool.swift
+++ b/Packages/OsaurusCore/AppleScript/Tool/MacQueryTool.swift
@@ -29,8 +29,10 @@ final class MacQueryTool: OsaurusTool, @unchecked Sendable {
         + "nothing), and returns the actual value(s) plus a per-step transcript. Use it to READ state: "
         + "the front Safari tab/URL, selected Finder items, the current Music track, unread Mail, "
         + "Calendar events, clipboard, window titles, or system state (volume, brightness, battery, "
-        + "running apps). To CHANGE anything, use `applescript` instead. Not for shell, files, or web "
-        + "requests — those have dedicated tools."
+        + "running apps). Call it only when the current user request asks for Mac/app state, or that "
+        + "state is necessary to complete the requested task. Never invent a state question merely "
+        + "to acknowledge feedback or conversation. To CHANGE anything, use `applescript` instead. "
+        + "Not for shell, files, or web requests — those have dedicated tools."
 
     let description = MacQueryTool.toolDescription
 
@@ -42,7 +44,9 @@ final class MacQueryTool: OsaurusTool, @unchecked Sendable {
                 "type": .string("string"),
                 "description": .string(
                     "The information to read from the Mac, in plain language, naming the app when it "
-                        + "matters. Example: \"What is the URL of the front Safari tab?\""
+                        + "matters. It must answer or be necessary for the current user's request; do "
+                        + "not invent a question for conversational acknowledgements. Example: "
+                        + "\"What is the URL of the front Safari tab?\""
                 ),
             ]),
             "content": .object([

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -380,6 +380,15 @@ public enum ComputerUseLoop {
                 metrics.modelTokens += stepResult.tokens
                 metrics.recordDecodeTokensPerSecond(stepResult.tokensPerSecond)
                 parsed = stepResult.call
+            } catch where isMissingRequiredAgentActionError(error) {
+                // ChatEngine correctly fails closed when a named/required
+                // local tool turn reaches EOS without a parsed call. For
+                // Computer Use that error means exactly the same thing as a
+                // nil `agent_action`, so route it through the loop's bounded
+                // protocol re-ask below. Treating it as an inference failure
+                // here used to terminate a visibly successful desktop action
+                // before the model got one chance to emit `done`.
+                parsed = nil
             } catch {
                 return terminate(.failed(reason: error.localizedDescription))
             }
@@ -1310,6 +1319,16 @@ public enum ComputerUseLoop {
         var errorDescription: String? { "The model step timed out." }
     }
 
+    /// ChatEngine's fail-closed signal for a required/named local tool turn
+    /// that reached EOS without a parsed invocation. This is a protocol-shape
+    /// miss, not a transient inference transport failure: retrying the exact
+    /// same prompt inside `runModelStep` cannot supply the corrective
+    /// `agent_action` nudge owned by the outer Computer Use loop.
+    private static func isMissingRequiredAgentActionError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == "OsaurusToolChoice" && nsError.code == 422
+    }
+
     /// Run one model step with a per-step timeout and bounded retries. A throw
     /// or timeout is retried (with a short backoff) up to `maxRetries` times
     /// before propagating, so a single transient inference failure or hang
@@ -1328,6 +1347,9 @@ public enum ComputerUseLoop {
             } catch is CancellationError {
                 throw CancellationError()  // interrupt/teardown — don't retry
             } catch {
+                if isMissingRequiredAgentActionError(error) {
+                    throw error
+                }
                 if attempt >= maxRetries { throw error }
                 attempt += 1
                 feed.emit(

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -707,6 +707,36 @@ enum AgentToolLoop {
         return (obj["ok"] as? Bool) == true
     }
 
+    /// Interactive desktop subagents can partially affect external state
+    /// before returning a terminal failure. Once one reports a canonical,
+    /// non-retryable failure, the chat surface must not ask the parent model
+    /// to guess what happened or launch another blind automation attempt.
+    ///
+    /// `invalid_args` and `not_found` deliberately remain recoverable: the
+    /// parent can correct the call shape or choose a different target. Other
+    /// tools retain their existing envelope/pivot behavior; this safety stop
+    /// is scoped to the three desktop subagent entry points implicated by the
+    /// shared execution/finalization contract.
+    static func isTerminalDesktopSubagentFailure(toolName: String, result: String) -> Bool {
+        guard ["computer_use", "applescript", "mac_query"].contains(toolName) else {
+            return false
+        }
+        guard ToolEnvelope.isError(result),
+            let data = result.data(using: .utf8),
+            let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            envelope["retryable"] as? Bool == false,
+            let rawKind = envelope["kind"] as? String,
+            let kind = ToolEnvelope.Kind(rawValue: rawKind)
+        else { return false }
+
+        switch kind {
+        case .invalidArgs, .notFound:
+            return false
+        case .rejected, .timeout, .executionError, .toolNotFound, .unavailable, .userDenied:
+            return true
+        }
+    }
+
     /// Shared user-facing text for the `.overBudget` exit: the request
     /// cannot fit the model's context window even after every compaction
     /// lever was exhausted. Each surface wraps this in its own envelope
@@ -1192,12 +1222,17 @@ enum AgentToolLoop {
                         for (index, entry) in toExecute.enumerated()
                         where index < executions.count {
                             let execution = executions[index]
+                            let wasError = execution.isError
+                                || Self.isTerminalDesktopSubagentFailure(
+                                    toolName: entry.invocation.toolName,
+                                    result: execution.result
+                                )
                             slotted[entry.slot] = AgentLoopToolOutcome(
                                 invocation: entry.invocation,
                                 callId: entry.callId,
                                 result: execution.result,
                                 wasDeduped: false,
-                                wasError: execution.isError
+                                wasError: wasError
                             )
                             if execution.endRun {
                                 endRunSlots.insert(entry.slot)
@@ -1248,12 +1283,17 @@ enum AgentToolLoop {
                             } else if let execution = await executeBatch(
                                 [(deferred.invocation, deferred.callId)]
                             ).first {
+                                let wasError = execution.isError
+                                    || Self.isTerminalDesktopSubagentFailure(
+                                        toolName: deferred.invocation.toolName,
+                                        result: execution.result
+                                    )
                                 slotted[slot] = AgentLoopToolOutcome(
                                     invocation: deferred.invocation,
                                     callId: deferred.callId,
                                     result: execution.result,
                                     wasDeduped: false,
-                                    wasError: execution.isError
+                                    wasError: wasError
                                 )
                                 if execution.endRun {
                                     endRunSlots.insert(slot)
@@ -1345,6 +1385,11 @@ enum AgentToolLoop {
                         }
 
                         let execution = await hooks.executeTool(invocation, callId)
+                        let wasError = execution.isError
+                            || Self.isTerminalDesktopSubagentFailure(
+                                toolName: invocation.toolName,
+                                result: execution.result
+                            )
 
                         // Surface intercepts (chat `complete`/`clarify`) end the
                         // run before the call is recorded — the intercept already
@@ -1371,14 +1416,14 @@ enum AgentToolLoop {
                                 callId: callId,
                                 result: execution.result,
                                 wasDeduped: false,
-                                wasError: execution.isError
+                                wasError: wasError
                             )
                         )
 
                         if await hooks.isCancelled() {
                             return RunResult(exit: .cancelled, iterations: iteration)
                         }
-                        if execution.isError, policy.stopOnToolRejection {
+                        if wasError, policy.stopOnToolRejection {
                             return RunResult(exit: .toolRejected, iterations: iteration)
                         }
                     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -811,7 +811,7 @@ public enum SystemPromptTemplates {
         ## Mac automation (AppleScript)
 
         - Two tools drive this Mac with an on-device AppleScript model (Finder, Safari, Mail, Notes, Music, Calendar, System Events, app + system state). Both write and run the script for you — do NOT write AppleScript yourself from here.
-        - To READ information, call `mac_query` with the whole question (e.g. "the front Safari tab URL", "the selected Finder items", "the current track and volume"). It runs read-only, needs no confirmation, and returns the actual `values` plus a per-step transcript. Prefer it whenever you just need to know something.
+        - To READ information needed by the current user request, call `mac_query` with the whole question (e.g. "the front Safari tab URL", "the selected Finder items", "the current track and volume"). It runs read-only, needs no confirmation, and returns the actual `values` plus a per-step transcript. Do not invent a Mac-state question merely to acknowledge feedback or conversation.
         - To CHANGE something, call `applescript` with the whole task. Depending on the user's setting each script is shown for approval or auto-run with a warning, so write the task plainly and let that gate handle confirmation — don't ask the user for permission yourself first.
         - When the task must insert EXACT text (a verbatim transcription, quotes, code, or a long note body), pass that text in `applescript`'s `content` argument and keep `task` as the instruction (e.g. task "Set the body of the note 'Quotes' to the provided content", content = the exact text). The subagent inserts it verbatim via a placeholder, so nothing is dropped, reordered, or mis-escaped — never paste large literal text only into `task`.
         - When the task needs SEVERAL exact blocks (a subject and a body, say), pass them in `applescript`'s `contents` argument as a `{name: text}` map (e.g. contents = {"subject": …, "body": …}); the subagent inserts each verbatim via its own placeholder. Use `content` for a single block and `contents` for several.
@@ -825,7 +825,7 @@ public enum SystemPromptTemplates {
     /// result, and the not-for-shell/files/web boundary).
     public static let appleScriptGuidanceCompact = """
         ## Mac automation (AppleScript)
-        - To READ Mac/app state (Finder, Safari, Mail, Music, System Events, volume, …) use `mac_query(question)`: read-only, no confirmation, returns the actual `values`.
+        - To READ Mac/app state needed by the current user request (Finder, Safari, Mail, Music, System Events, volume, …) use `mac_query(question)`: read-only, no confirmation, returns the actual `values`. Never invent a state question just to acknowledge feedback/conversation.
         - To CHANGE something use `applescript(task)`: each script is shown for approval or auto-run per the user's setting. Don't write AppleScript yourself.
         - To insert EXACT/verbatim text (transcription, quote, code, long body) OR an exact existing identifier that must match precisely (a note title, file path, mailbox, or URL), pass it via `applescript(content=…)` or `applescript(contents={name:text})` and reference it by placeholder — reproduced verbatim instead of re-typed, so an exact name can't be mistyped. Use `contents` for several blocks.
         - Both return `status` + `values` + `errors` (with AppleScript error numbers) — read `values` to confirm, use `errors` to retry/fix. Not for shell, files, or web.

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
@@ -1837,6 +1837,37 @@ struct AppleScriptCapabilityGatingTests {
     }
 }
 
+// MARK: - Parent tool-selection contract
+
+@Suite("AppleScript parent tool-selection guidance")
+struct AppleScriptToolSelectionGuidanceTests {
+    @Test("mac_query is scoped to the current request, including its argument schema")
+    func macQueryDescriptionRejectsInventedConversationQueries() throws {
+        #expect(MacQueryTool.toolDescription.contains("current user request"))
+        #expect(MacQueryTool.toolDescription.contains("Never invent a state question"))
+
+        let parametersValue = try #require(MacQueryTool().parameters)
+        guard case .object(let parameters) = parametersValue,
+            case .object(let properties)? = parameters["properties"],
+            case .object(let question)? = properties["question"],
+            case .string(let description)? = question["description"]
+        else {
+            Issue.record("mac_query.question must keep a string description in its object schema")
+            return
+        }
+        #expect(description.contains("current user's request"))
+        #expect(description.contains("do not invent a question"))
+    }
+
+    @Test("full and compact parent prompts preserve the same selection boundary")
+    func parentPromptsRejectInventedConversationQueries() {
+        #expect(SystemPromptTemplates.appleScriptGuidance.contains("current user request"))
+        #expect(SystemPromptTemplates.appleScriptGuidance.contains("Do not invent a Mac-state question"))
+        #expect(SystemPromptTemplates.appleScriptGuidanceCompact.contains("current user request"))
+        #expect(SystemPromptTemplates.appleScriptGuidanceCompact.contains("Never invent a state question"))
+    }
+}
+
 // MARK: - Mock app world (evals executor double)
 
 @Suite("MockAppleScriptWorld")

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -376,6 +376,142 @@ struct AgentToolLoopTests {
         #expect(surface.batchOutcomes[0].map(\.wasError) == [true, false])
     }
 
+    @Test func terminalComputerUseEnvelopeStopsChatWithoutParentFollowUp() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("computer_use")]),
+            .toolCalls([inv("computer_use")]),
+        ])
+        surface.toolResults["computer_use"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .executionError,
+                message: "The model could not produce a valid action.",
+                tool: "computer_use",
+                retryable: false
+            ),
+            isError: false
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .toolRejected, iterations: 1))
+        #expect(surface.executedCalls.map(\.name) == ["computer_use"])
+    }
+
+    @Test func terminalMacQueryEnvelopeStopsChatBeforeHallucinatedAnswer() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("mac_query")]),
+            .finalResponse,
+        ])
+        surface.toolResults["mac_query"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .executionError,
+                message: "The query failed.",
+                tool: "mac_query",
+                retryable: false
+            ),
+            isError: false
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .toolRejected, iterations: 1))
+        #expect(surface.builtNotices.count == 1, "No second model iteration may fabricate a value")
+    }
+
+    @Test func batchExecutorMarksReturnedTerminalDesktopFailureAsRejection() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("mac_query")]),
+            .finalResponse,
+        ])
+        var hooks = surface.makeHooks()
+        hooks.executeBatch = { calls in
+            calls.map { call in
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.failure(
+                        kind: .executionError,
+                        message: "The query failed.",
+                        tool: call.invocation.toolName,
+                        retryable: false
+                    ),
+                    // Mirrors ToolRegistry-returned envelopes in ChatView:
+                    // the tool body returned JSON instead of throwing.
+                    isError: false
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .toolRejected, iterations: 1))
+        #expect(surface.batchOutcomes.count == 1)
+        #expect(surface.batchOutcomes[0].map(\.wasError) == [true])
+        #expect(surface.builtNotices.count == 1, "The real Chat batch path must not run the parent again")
+    }
+
+    @Test func correctableDesktopSubagentFailuresStillReachParentForPivot() async throws {
+        for kind in [ToolEnvelope.Kind.invalidArgs, .notFound] {
+            let surface = ScriptedLoopSurface(steps: [
+                .toolCalls([inv("mac_query")]),
+                .finalResponse,
+            ])
+            surface.toolResults["mac_query"] = AgentLoopToolExecution(
+                result: ToolEnvelope.failure(
+                    kind: kind,
+                    message: "correct this call",
+                    tool: "mac_query",
+                    retryable: false
+                ),
+                isError: false
+            )
+
+            let result = try await AgentToolLoop.run(
+                policy: chatPolicy(),
+                state: AgentTaskState(),
+                hooks: surface.makeHooks()
+            )
+
+            #expect(result.exit == .finalResponse, "kind=\(kind.rawValue)")
+            #expect(surface.builtNotices.count == 2, "kind=\(kind.rawValue)")
+        }
+    }
+
+    @Test func unrelatedNonretryableExecutionFailureKeepsExistingPivotBehavior() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("file_read")]),
+            .finalResponse,
+        ])
+        surface.toolResults["file_read"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .executionError,
+                message: "read failed",
+                tool: "file_read",
+                retryable: false
+            ),
+            isError: false
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result.exit == .finalResponse)
+        #expect(surface.builtNotices.count == 2)
+    }
+
     @Test func surfaceInterceptEndsRunWithoutRecording() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("complete", #"{"summary":"done the work"}"#), inv("never_runs")])

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -368,6 +368,46 @@ final class ComputerUseLoopRunTests: XCTestCase {
         XCTAssertEqual(attempts, 3, "Two retries after the initial attempt = three tries total")
     }
 
+    func testMissingRequiredAgentActionUsesProtocolReaskInsteadOfBlindInferenceRetry() async {
+        let d = driver([el("go", "button", "Go")])
+        let recorder = ModelStepInputRecorder()
+        let provider: AgentStepProvider = { input in
+            let attempt = await recorder.record(input)
+            if attempt == 1 {
+                throw NSError(
+                    domain: "OsaurusToolChoice",
+                    code: 422,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "The model did not produce a valid required tool call."
+                    ]
+                )
+            }
+            return ModelActionCall(
+                id: "done",
+                arguments: AgentAction(verb: .done, reason: "recovered").argumentsJSON()
+            )
+        }
+
+        let result = await run(
+            d,
+            provider: provider,
+            limits: RunLimits(
+                wallClockSeconds: 30,
+                modelStepTimeoutSeconds: 0,
+                maxInferenceRetries: 2
+            )
+        )
+
+        XCTAssertTrue(result.outcome.isSuccess, "The bounded protocol re-ask should recover; got \(result.outcome)")
+        let inputs = await recorder.inputs
+        XCTAssertEqual(inputs.count, 2, "The protocol error must bypass same-prompt inference retries")
+        XCTAssertTrue(
+            inputs[1].transcript.last?.text.contains("You must respond by calling the agent_action tool") == true,
+            "The second model step must include the Computer Use loop's corrective protocol nudge"
+        )
+    }
+
     func testInferenceFailsAfterExhaustingRetries() async {
         let d = driver([el("go", "button", "Go")])
         let counter = AttemptCounter()
@@ -497,6 +537,15 @@ private actor AttemptCounter {
     func bump() -> Int {
         value += 1
         return value
+    }
+}
+
+private actor ModelStepInputRecorder {
+    private(set) var inputs: [AgentStepInput] = []
+
+    func record(_ input: AgentStepInput) -> Int {
+        inputs.append(input)
+        return inputs.count
     }
 }
 

--- a/docs/AGENT_COMPUTER_USE_APPLESCRIPT_PROOF_2026-07-16.md
+++ b/docs/AGENT_COMPUTER_USE_APPLESCRIPT_PROOF_2026-07-16.md
@@ -1,15 +1,19 @@
 # Agent, Computer Use, and AppleScript 8B Proof Ledger
 
-Last updated: 2026-07-16 (America/Los_Angeles)
+Last updated: 2026-07-17 (America/Los_Angeles)
 
-Overall verdict: **PARTIAL.** Current `origin/main` contains earlier source
-changes for spawned-agent tool selection, foreground app opening, and
-AppleScript 8B catalog discovery. This branch adds the missing child execution
-scope binding. The direct Calendar Agent row and two patched spawned rows ran
-in the fresh isolated Release app with the exact MXFP8 control model after the
-installed plugin was loaded. Computer Use app switching and AppleScript 8B
-execution remain unverified, and a plugin hot-load stall plus test-root
-isolation gap remain open adjacent findings.
+Overall verdict: **PARTIAL.** The focused source candidate and isolated Release
+app now prove the narrow parent-loop safeguards for the two Osaurus 0.22.5
+reports: exact feedback-only text produced three acknowledgements with no tool
+call; returned non-retryable `computer_use` and `mac_query` failures stopped
+without another action or fabricated answer; and the Computer Use loop's exact
+`OsaurusToolChoice`/422 miss is covered by the real Xcode test graph. The
+successful AppleScript-8B-as-Computer-Use action/finalization row is still
+**BLOCKED**: JANG_6M emitted an invalid `agent_action` verb and JANG_4M exhausted
+the bounded corrective re-ask with model-step timeouts before either performed
+the requested action. This branch therefore fixes and live-proves failure
+containment and feedback tool selection, but does not claim that AppleScript 8B
+is a compatible or reliable Computer Use model.
 
 ## Scope and proof rules
 
@@ -37,14 +41,18 @@ isolation gap remain open adjacent findings.
 | P0 | Computer Use can leave the last-viewed window and visibly switch to another app | ADDRESSED IN SOURCE ON MAIN by PR #2032 (`69726a371`); `ComputerUseLoop.swift:1008` calls the driver with `background: false` | `ComputerUseEvidencePackTests.testOpenVerbLaunchesForegroundSoTheWindowIsVisibleAndVerifiable` PASS through Xcode | NOT RUN; reported stale-window behavior not yet reproduced or cleared |
 | P0 | Computer Use returns to the original app and continues multi-step work | Source audit pending | NOT RUN | NOT RUN |
 | P0 | AppleScript 8B appears under Settings -> Computer Use -> Models | ADDRESSED IN SOURCE ON MAIN by PR #2046 (`504d174ab`); `AppleScriptModelCatalog.swift:82,101-106` names the installed 8B bundle | Existing catalog/search tests still to identify and rerun | **PASS (VISUAL DISCOVERY ONLY):** Settings -> Computer Use -> Models displayed installed Osaurus AppleScript 8B (7.95 GB); 16B was available but not installed |
-| P0 | AppleScript 8B JANG_6M selects, loads, warms, and executes real Computer Use | Local 7.4 GB bundle exists; Zaya/JANG_6M runtime path still to trace | NOT RUN | NOT RUN |
-| P0 | 8B stays selected after relaunch and does not silently fall back to 16B | RISK FOUND: `AppleScriptModelCatalog.swift:160` automatic selection uses `installedModels().first`; with the catalog ordering this can choose 16B unless 8B is explicitly selected | NOT RUN | **PASS (VISUAL SETTINGS PERSISTENCE):** after rebuilt-app relaunch the popup still showed Osaurus AppleScript 8B; 16B remained available/not installed; Confirm each script, Keep Warm After Job, and Fast reads off all persisted. Runtime model id still requires execution |
-| P0 | Computer Use permissions/settings toggles actually change runtime behavior | Source audit pending | NOT RUN | **PARTIAL:** Setup visibly reports Accessibility and Screen Recording granted; AppleScript Automation reports “Not yet granted.” No grant/test button was pressed, so execution behavior remains unverified |
+| P0 | AppleScript 8B JANG_6M selects, loads, warms, and executes real Computer Use | Local bundle and Zaya/JANG path resolve through the shared local runtime; Computer Use requires strict named `agent_action` rather than the bundle's native `run_applescript` specialization | Protocol re-ask and terminal-envelope tests PASS; no model-coherency unit fixture | **PARTIAL/FAIL:** the UI selected and generated with JANG_6M, but Computer Use returned an invalid `verb`; a dedicated `mac_query` generated scripts but hit permission timeouts/compile/runtime errors. Load/selection is proven; successful execution is not |
+| P0 | A successful AppleScript 8B Computer Use action must finish without `The model did not produce a valid required tool call` | **ROOT CAUSE TRACED:** `ChatEngine` fails closed on missing named tool choice before `ComputerUseLoop` can treat the miss as `nil` and issue its bounded `agent_action` re-ask. Local candidate routes only `OsaurusToolChoice`/422 through that existing re-ask and bypasses blind same-prompt inference retries | **PASS:** exact protocol-error regression plus the neighboring `ComputerUseLoopRunTests` passed through Xcode | **BLOCKED (PATCHED RELEASE):** JANG_6M returned an invalid `verb`; JANG_4M visibly reached `Model did not call agent_action`, entered the bounded corrective re-ask, then timed out. Neither performed the action, so successful-action finalization is not claimed |
+| P0 | A feedback-only turn must acknowledge the user without inventing `mac_query` for date/time | **SOURCE TRACE:** normal chat resolves `.auto` from the current feedback text; no stale forced choice is present. The broad `mac_query` description permitted an unrelated model-selected read. Candidate schema/full/compact guidance binds selection to the current request without a keyword classifier | **PASS:** `AppleScriptToolSelectionGuidanceTests` and terminal-`mac_query` loop regression passed through Xcode | **PASS (PATCHED RELEASE, 3/3):** the exact reported sentence received acknowledgement-only replies at 62.7, 61.3, and 62.0 tok/s; no `mac_query`, AppleScript, Computer Use, or other tool row appeared |
+| P0 | A failed non-retryable `computer_use`, `applescript`, or `mac_query` must not launch another action or fabricate a value | **ROOT CAUSE LIVE-REPRODUCED:** subagent tools return canonical `ok:false` JSON rather than throwing, while Chat's `AgentLoopToolExecution.isError` remains false. `stopOnToolRejection` therefore never fires. Candidate recognizes only non-retryable terminal desktop-subagent failures; `invalid_args`, `not_found`, and unrelated tools retain pivot behavior | **PASS:** serial, real batch-path, terminal `mac_query`, correctable-error, and unrelated-tool controls passed through Xcode | **PASS (PATCHED RELEASE):** JANG_6M and JANG_4M Computer Use returned one terminal red row each with no parent retry/fabrication. A stopped dedicated-model `mac_query` returned `execution_error`, `retryable:false`; the parent emitted no follow-up answer or second tool call |
+| P0 | 8B stays selected after relaunch and does not silently fall back to 16B | RISK FOUND: `AppleScriptModelCatalog.swift:160` automatic selection uses `installedModels().first`; with the catalog ordering this can choose 16B unless 8B is explicitly selected | NOT RUN | **PASS (VISUAL SETTINGS/RUNTIME):** after rebuilt-app relaunch the popup still showed Osaurus AppleScript 8B; 16B remained available/not installed; Confirm each and Keep Warm persisted. With Fast reads OFF the live feed generated on exact JANG_6M; the setting was then restored ON |
+| P0 | Computer Use permissions/settings toggles actually change runtime behavior | `AppleScriptKind.resolveModel` reads `appleScriptQueryPrefersResidentModel`; ON reuses a resident tool-capable chat model, OFF resolves the selected dedicated AppleScript model | NOT RUN | **PARTIAL/PASS FOR TOGGLE:** Accessibility was visibly granted; Screen Recording remained optional/off. Fast reads ON generated `mac_query` scripts with Ornith MXFP8. Toggling OFF visibly unloaded Ornith and generated with exact `OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`; toggling ON again restored the default. Dedicated execution remained blocked by the isolated bundle's macOS Automation grant prompt |
 | P0 | Memory Safety warning -> user changes setting -> intended large model can load | Existing memory-admission work is on main; exact UI/runtime contract still to trace | NOT RUN | NOT RUN |
 | P0 | Re-enabling the safer RAM setting restores refusal/warning | Source audit pending | NOT RUN | NOT RUN |
 | P1 | AppleScript 8B Thinking off/on, plain task, multi-step task, tool error, retry, and multi-turn | Bundle declares tool and reasoning capabilities; parser/template wiring still to trace | NOT RUN | NOT RUN |
 | P1 | AppleScript 8B cold/warm TTFT, token/s, physical footprint, stop/cancel cleanup | Runtime telemetry surfaces exist; exact path pending | NOT RUN | NOT RUN |
 | P1 | Computer Use wrong app name, app absent, minimized window, multiple windows, permission denial, app launch delay | Source audit pending | NOT RUN | NOT RUN |
+| P1 | AppleScript 8B compatibility with Computer Use's `agent_action` schema, distinct from the AppleScript ability's `run_applescript` schema | Bundle declares `tool_parser: zaya_xml` and generic tool support, but its README and specialization describe native `run_applescript`; Computer Use forces a single named `agent_action` tool | NOT RUN | **ADJACENT FAIL:** patched JANG_6M emitted an invalid action verb; patched JANG_4M omitted `agent_action`, accepted the corrective re-ask, then timed out. Do not silently filter, coerce, or reroute the model in this urgent PR |
 | P1 | Spawned agent with no tools, disabled plugin, missing permission, denied tool, exhausted tool budget | Source path identified | NOT RUN | NOT RUN |
 | P1 | Spawn/delegation RAM admission and visible insufficient-RAM notification | Source audit pending | NOT RUN | NOT RUN |
 | P1 | Image generation/editing model RAM admission and safety-setting behavior | Deferred from the emergency pin PR; still required | NOT RUN | NOT RUN |
@@ -52,6 +60,180 @@ isolation gap remain open adjacent findings.
 | P1 | Qwen 3.5/3.5 VL hybrid SSM/GDN rederive plus TurboQuant/prefix/L2 restore | Deferred from the emergency pin PR; still required | NOT RUN | NOT RUN |
 | P1 | Gemma/Bonsai regression sweep after any shared runtime change | Prior narrow ledger exists; follow-up head not yet exercised | NOT RUN | NOT RUN |
 | P2 | MXFP4 structurally cut-off output fallback | DOCUMENTED ONLY in the Gemma/Bonsai ledger; explicitly excluded without an exact user-provided reproduction | NOT RUN | NOT RUN |
+
+## 2026-07-17 AppleScript 8B finalization and fallback investigation
+
+### Exact pre-patch visual candidate and settings
+
+The local reproduction used the ad-hoc signed isolated Release app
+`/tmp/osaurus-bonsai-chart-recovery.app`, bundle id
+`com.dinoki.osaurus.bonsaichartproof`, fresh app root
+`/tmp/osaurus-bonsai-chart-recovery-root-0241`, and model root
+`/Users/eric/models`. Its affected Computer Use, AppleScript, chat, and tool-loop
+sources are identical to tag `0.22.5`; the candidate includes only the already
+merged PR #2065 chart patch outside those unchanged paths. Exact vMLX revision
+is `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`. This is pre-patch reproduction
+evidence, not evidence for the new source candidate.
+
+The real Settings and agent UI visibly showed Accessibility granted, Screen
+Recording granted, Balanced global Computer Use policy, the agent's Computer
+Use ability enabled, and exact model
+`OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`. AppleScript was first enabled with
+the same dedicated 8B model and Confirm Each, then disabled to isolate the
+Computer Use path. No MXFP4 model was loaded or tested.
+
+With both abilities enabled, `Open Calculator` routed through the separate
+AppleScript ability, proposed `tell application "Calculator" to activate`, and
+completed with a green AppleScript row and parent text. That does not exercise
+Computer Use's forced `agent_action` contract.
+
+With AppleScript disabled and Computer Use still enabled on exact JANG_6M, a
+fresh `Open Calculator` turn called `computer_use` with goal `Open the
+Calculator app on macOS and show its default interface`. The child then
+proposed unrelated Save/Finder actions and an invalid `click` without a target.
+It returned the canonical envelope
+`{"ok":false,"kind":"execution_error",...,"retryable":false,"tool":"computer_use"}`.
+The parent did not stop: it immediately launched another Computer Use run with
+unrelated Save/Warp upgrade-flow actions. The user had to press Stop. A fresh
+`Open TextEdit` row likewise proposed `Open Finder` for a Save-dialog context
+and was stopped. These rows directly prove the failure-continuation boundary
+and an adjacent model/schema semantic mismatch; they do not reproduce the
+user's exact successful-action/finalization sequence.
+
+### Current source trace and candidate behavior
+
+This is not the chat `content.delta` streaming path. Computer Use performs its
+child model step through the non-streaming completion path with one strict,
+named `agent_action` tool. The first report is therefore a required-tool
+finalization/schema-contract failure at EOS; the second combines an overly
+broad auto-selected `mac_query` contract with a returned failure envelope that
+the parent chat loop did not classify as terminal.
+
+`ComputerUseLoop.modelStep` sends one `AgentAction.toolSpec` with named forced
+choice `agent_action`, and `ChatEngine` rejects a local EOS without a parsed
+call as `NSError(domain: "OsaurusToolChoice", code: 422)`. The loop already has
+a bounded `guard let call = parsed else` re-ask, but the thrown error was caught
+earlier as a terminal run failure. The candidate classifies that exact
+domain/code as a protocol-shape miss, bypasses the inner same-prompt inference
+retry, and lets the outer loop add its existing corrective nudge. Other errors
+keep the previous timeout/retry/failure behavior. No closer, sampler, prompt
+coercion, output cap, or parser repair is added.
+
+Normal chat uses `ChatToolChoicePolicy.resolve` against the current user text;
+the reported feedback sentence does not force any tool, so `mac_query` is a
+model selection under `.auto`, not source evidence of stale required-tool
+state. The candidate makes the tool description, `question` property schema,
+and full/compact AppleScript guidance explicit: call `mac_query` only when the
+current request asks for Mac/app state or that state is necessary to complete
+it, never to invent a conversational acknowledgement query. This is a model
+contract clarification, not a feedback keyword filter.
+
+`SubagentSession` maps Computer Use and all-failed AppleScript outcomes to
+canonical returned failure envelopes. Chat's tool executor treated those as
+ordinary results because they did not throw, leaving `isError=false`; the
+agent-loop rejection policy therefore allowed a second parent iteration. The
+candidate stops Chat only for canonical, non-retryable terminal failures from
+`computer_use`, `applescript`, and `mac_query`. Correctable `invalid_args` and
+`not_found` results still reach the parent for a changed call, and all unrelated
+tools retain their prior behavior.
+
+The exact AppleScript bundle declares `tool_parser: "zaya_xml"` and
+`supports_tools: true`, but its published specialization and examples target
+`run_applescript`, not Computer Use's `agent_action`. That is a concrete
+compatibility risk behind the unrelated actions. It is not yet promoted to the
+root cause of the user's successful-action finalization report, and this urgent
+candidate does not change automatic model routing or silently remove the model
+from the Computer Use picker.
+
+The focused Xcode run used the real `OsaurusCoreTests` workspace scheme and
+the exact resolved vMLX revision above. `ComputerUseLoopRunTests`,
+`AgentToolLoopTests`, and `AppleScriptToolSelectionGuidanceTests` all passed,
+including the new required-action protocol re-ask, Chat serial and batch
+terminal-failure stops, failed-`mac_query` no-follow-up control, correctable
+desktop-error pivot control, and unrelated-tool non-regression. Result bundle:
+`/tmp/osaurus-applescript-finalization-tests-dd/Logs/Test/Test-OsaurusCoreTests-2026.07.17_17-48-05--0700.xcresult`.
+The bare CommandLineTools `swift test` lane remains a runner-configuration
+blocker because that selected toolchain cannot import the existing `Testing`
+module; it is not counted as a code failure or a passing row.
+
+### Patched isolated Release live evidence
+
+The final UI rows used the Release app at
+`/tmp/osaurus-applescript-finalization-app-dd/Build/Products/Release/osaurus.app`,
+bundle id `com.dinoki.osaurus.applescriptfinalizationproof`, isolated root
+`/tmp/osaurus-applescript-finalization-live-root-20260717-1718`, local model
+root `/Users/eric/models`, and exact vMLX revision
+`a26c7ecec950f18e3d07c8402fbd8c80f40ac764`. The app was ad-hoc signed and
+`codesign --verify --deep --strict` succeeded. Its executable SHA-256 is
+`9dc8fff6dcfbd4fce5493b21ea3a99851ca08b61a555428710bd86ad5191faf4`.
+No production app preferences or model root were reused.
+
+While the live matrix was running, `origin/main` advanced to `2c76b9048` with
+PR #2069's Bonsai onboarding/model-metadata changes. Those files do not overlap
+this candidate. The branch was rebased, the focused suites passed again, and
+the same isolated Release app was rebuilt from exact rebased head `3783b0d57`.
+On relaunch the UI still showed Ornith MXFP8, Computer Use on with JANG_4M,
+screen context off, and AppleScript on with JANG_6M/Confirm each. The exact
+feedback sentence again produced an acknowledgement-only reply at 64.0 tok/s.
+An explicit nonexistent-app `mac_query` then returned the grounded error
+`Can't get application "DefinitelyNotARealMacApp"`; the parent reported that
+error at 63.3 tok/s without inventing a title/date or calling another tool.
+
+The real UI showed parent model `Ornith-1.0-9B-MXFP8`, Thinking unselected,
+Accessibility granted, Screen Recording optional/off, per-agent screen context
+off, Computer Use enabled, and AppleScript enabled with Confirm each. A quit
+and relaunch preserved the parent model, helper selections, toggles, and screen
+context setting. Computer Use was tested first with installed
+`AppleScript 8B JANG_6M`, then with installed `AppleScript 8B JANG_4M`; no
+MXFP4 model was loaded.
+
+- JANG_6M `Open Calculator` produced one `computer_use` call, then canonical
+  `execution_error`, `retryable:false` because its action `verb` was outside
+  the `agent_action` enum. Parent metrics were TTFT 1.31s, 20.5 tok/s, 51
+  tokens. The patched chat stopped after that red row: no second automation and
+  no fabricated success.
+- JANG_4M `Open Calculator` showed `Model did not call agent_action`, proving
+  the exact protocol miss reached the outer corrective re-ask. Its subsequent
+  model steps timed out and the run returned one terminal `execution_error`.
+  Parent metrics were TTFT 1.14s, 28.9 tok/s, 58 tokens. Again there was no
+  second automation or fabricated success. Neither AppleScript helper opened
+  Calculator in these rows, so successful-action finalization remains blocked.
+- With AppleScript and Computer Use both enabled, three fresh chats replayed
+  the exact feedback sentence from the report. The replies were plain
+  acknowledgements at 62.7, 61.3, and 62.0 tok/s. None selected `mac_query`,
+  AppleScript, Computer Use, or any other tool.
+- With global `Fast reads on the chat model` visibly ON, an explicit nonexistent
+  app query generated on resident Ornith MXFP8 as the setting promises. The
+  tool returned `status:partial` with the grounded value that the app was not
+  running or found; the parent reported that failure at 60.0 tok/s and did not
+  invent a document title.
+- Toggling Fast reads OFF through Settings changed the next live query's feed:
+  it waited for chat idle, unloaded Ornith, and generated on exact
+  `OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`. The dedicated row encountered two
+  45-second script timeouts, a compile error, and AppleScript error `-1728`
+  while macOS Automation still displayed `Not yet granted`; it was stopped at
+  2m57 rather than allowed to continue. The returned envelope was exact
+  `mac_query` `execution_error`, `retryable:false`. The patched parent emitted
+  no second iteration and no answer. Fast reads was then visibly restored ON.
+- CLI `footprint` during the JANG_4M handoff measured 5,942 MB for the proof app
+  while the UI showed the parent cold/unloaded. This is supporting telemetry,
+  not the requested Activity Monitor visual row; that visual footprint gate is
+  still missing.
+
+### Remaining live acceptance matrix
+
+- Replay TextEdit, Calculator, and Safari navigation through Computer Use. A
+  row passes only when the requested action is visibly correct and the same
+  turn finishes without contradictory required-tool failure.
+- Grant the isolated proof bundle's macOS Automation permission, then repeat a
+  dedicated-model read and a state-changing AppleScript row. The current
+  permission dialog is external to the Osaurus accessibility tree and the
+  Computer Use controller is not allowed to operate UserNotificationCenter.
+- Capture Activity Monitor `phys_footprint` visually during a helper load. The
+  current 5,942 MB value is CLI support only.
+- Resolve AppleScript 8B's `agent_action` compatibility separately from this
+  narrow containment patch. Do not hide it with forced prompts, parser repair,
+  sampler changes, or silent routing.
 
 ## Known current source evidence
 


### PR DESCRIPTION
## Summary

Fixes two Osaurus 0.22.5 AppleScript / Computer Use failure boundaries without changing model routing, samplers, parsers, RAM policy, or dependency pins.

- Route only NSError(domain: "OsaurusToolChoice", code: 422) through the existing bounded Computer Use protocol re-ask instead of terminating before the model can emit agent_action done.
- Treat canonical non-retryable failures returned by computer_use, applescript, and mac_query as Chat tool rejections, so the parent cannot launch another blind action or fabricate a value.
- Keep invalid_args and not_found correctable, keep headless behavior unchanged, and keep unrelated tools on their existing pivot path.
- Scope mac_query tool/schema/full+compact guidance to Mac state required by the current user request; do not invent a state query to acknowledge feedback.
- Add focused regressions and update the proof ledger.

## Source trace

This is not a content.delta streaming defect. Computer Use uses a non-streaming completion with strict named agent_action. ChatEngine emits OsaurusToolChoice/422 when local EOS has no parsed required call; that error previously bypassed the existing nil-call corrective re-ask.

Desktop subagents return canonical JSON failure envelopes rather than throwing. Chat therefore saw isError=false and stopOnToolRejection never fired. This patch recognizes only non-retryable terminal envelopes from the three desktop entry points.

## Tests

Rebased head: 115b767ec
Base: 2c76b9048
Resolved vMLX: a26c7ecec950f18e3d07c8402fbd8c80f40ac764

Focused Xcode suites passed after rebase:
- ComputerUseLoopRunTests
- AgentToolLoopTests
- AppleScriptToolSelectionGuidanceTests

Result:
`/tmp/osaurus-applescript-finalization-tests-dd/Logs/Test/Test-OsaurusCoreTests-2026.07.17_17-48-05--0700.xcresult`

Coverage includes exact 422 protocol re-ask, serial and real batch returned failures, terminal mac_query with no parent continuation, correctable invalid_args/not_found controls, unrelated-tool control, and guidance parity.

## Live Release UI proof

Exact rebased Release app:
- bundle id: com.dinoki.osaurus.applescriptfinalizationproof
- executable SHA-256: 9dc8fff6dcfbd4fce5493b21ea3a99851ca08b61a555428710bd86ad5191faf4
- isolated app root: /tmp/osaurus-applescript-finalization-live-root-20260717-1718
- model root: /Users/eric/models
- parent: Ornith-1.0-9B-MXFP8
- helpers: AppleScript 8B JANG_6M and JANG_4M
- no MXFP4 model loaded

Visual rows:
- Exact feedback sentence: 3/3 original candidate trials and one exact-rebased-head smoke produced acknowledgement-only replies, with no mac_query or other tool call. Rates: 62.7, 61.3, 62.0, 64.0 tok/s.
- JANG_6M Computer Use returned one non-retryable execution_error for an invalid action verb; parent stopped with no second automation or fabricated success.
- JANG_4M showed Model did not call agent_action, entered the bounded corrective re-ask, then timed out; parent stopped after one failure row.
- A stopped dedicated-model mac_query returned execution_error/retryable:false; parent emitted no second iteration and no answer.
- Exact-head nonexistent-app mac_query returned the grounded app-not-found error at 63.3 tok/s and did not invent a title/date or call another tool.
- Fast reads setting was toggled in the UI. ON used resident Ornith MXFP8; OFF visibly unloaded Ornith and generated on exact OsaurusAI/Osaurus-AppleScript-8B-JANG_6M; ON was restored.
- Relaunch preserved parent/helper selections, Computer Use and AppleScript toggles, screen-context off, and Confirm each.

## Explicit remaining gaps

PARTIAL, not a claim that AppleScript 8B is now a reliable Computer Use model:
- Neither JANG_6M nor JANG_4M completed the requested Calculator action in the patched Computer Use rows, so successful-action finalization remains blocked.
- The isolated proof bundle still needs macOS Automation permission for dedicated AppleScript execution.
- Activity Monitor visual phys_footprint is missing; CLI footprint during JANG_4M handoff was 5,942 MB and is supporting evidence only.

Full source/live ledger:
`docs/AGENT_COMPUTER_USE_APPLESCRIPT_PROOF_2026-07-16.md`

## Scope audit

Exactly 8 files: 4 owning source files, 3 focused test files, and 1 ledger. No Gemma, Bonsai, onboarding, model recommendation, automatic routing, RAM safety, TurboQuant, image, or package-pin changes.