### PR TITLE
Fix singular and plural count labels

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
@@ -112,13 +112,15 @@ enum PrivacyFilterPipelineError: Error, Equatable, LocalizedError {
             return
                 "Privacy Filter is enabled but the on-device model isn't available: \(detail). Open Settings → Privacy to re-download, or disable the filter to send without redaction."
         case .scrubNoOp(let count):
-            return
-                "Privacy Filter: \(count) approved redaction(s) didn't apply (substitution mismatch). The message was not sent. This is a bug — please report."
+            return count == 1
+                ? "Privacy Filter: 1 approved redaction didn't apply (substitution mismatch). The message was not sent. This is a bug — please report."
+                : "Privacy Filter: \(count) approved redactions didn't apply (substitution mismatch). The message was not sent. This is a bug — please report."
         case .scrubLeaked(let counts):
             return Self.formatScrubLeaked(categoryCounts: counts)
         case .reviewRequiresInteractive(let count):
-            return
-                "Privacy Filter detected \(count) item(s) of PII in this request. Non-interactive requests (HTTP API, plugins) cannot show the review sheet, so the send was blocked. Approve redactions in the Osaurus chat first, disable 'Require review for non-interactive requests' in Settings → Privacy, or disable the filter for this provider."
+            return count == 1
+                ? "Privacy Filter detected 1 item of PII in this request. Non-interactive requests (HTTP API, plugins) cannot show the review sheet, so the send was blocked. Approve redactions in the Osaurus chat first, disable 'Require review for non-interactive requests' in Settings → Privacy, or disable the filter for this provider."
+                : "Privacy Filter detected \(count) items of PII in this request. Non-interactive requests (HTTP API, plugins) cannot show the review sheet, so the send was blocked. Approve redactions in the Osaurus chat first, disable 'Require review for non-interactive requests' in Settings → Privacy, or disable the filter for this provider."
         }
     }
 

--- a/Packages/OsaurusCore/PrivacyFilter/Views/PrivacyView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/PrivacyView.swift
@@ -1345,12 +1345,9 @@ private struct PrivacyDryRunTester: View {
 
     private var summaryText: String {
         let count = uniqueResults.count
-        let format = String(
-            localized: "\(count) item(s) would be redacted",
-            bundle: .module,
-            comment: "Dry-run match count"
-        )
-        return format
+        return count == 1
+            ? L("1 item would be redacted", comment: "Dry-run match count")
+            : L("\(count) items would be redacted", comment: "Dry-run match count")
     }
 
     private func runTest() {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,6 +4,243 @@
     "" : {
       "shouldTranslate" : false
     },
+    "+1 more finding in copied report" : {
+
+    },
+    "1 artifact" : {
+
+    },
+    "1 blocking finding must be fixed before provisioning." : {
+
+    },
+    "1 character" : {
+
+    },
+    "1 earlier step" : {
+
+    },
+    "1 external candidate skipped" : {
+
+    },
+    "1 external model found" : {
+
+    },
+    "1 file" : {
+
+    },
+    "1 item installed" : {
+
+    },
+    "1 item would be redacted" : {
+
+    },
+    "1 manual-model provider" : {
+
+    },
+    "1 model" : {
+
+    },
+    "1 model currently available." : {
+
+    },
+    "1 model found" : {
+
+    },
+    "1 model • %@" : {
+
+    },
+    "1 plugin available" : {
+
+    },
+    "1 redaction" : {
+
+    },
+    "1 request" : {
+
+    },
+    "1 result" : {
+
+    },
+    "1 session" : {
+
+    },
+    "1 setting matches \"%@\"" : {
+
+    },
+    "1 setup finding needs attention before tools are fully ready." : {
+
+    },
+    "1 skill" : {
+
+    },
+    "1 skill available" : {
+
+    },
+    "1 stdio provider" : {
+
+    },
+    "1 store couldn't be converted because the encryption key is unavailable." : {
+
+    },
+    "1 store failed to convert." : {
+
+    },
+    "1 tool" : {
+
+    },
+    "1 tool assigned" : {
+
+    },
+    "1 tool discovered via %@." : {
+
+    },
+    "1 tool discovered." : {
+
+    },
+    "1 transaction" : {
+
+    },
+    "1 turn" : {
+
+    },
+    "Connected! (1 tool)" : {
+
+    },
+    "Decrypted 1 store; now plaintext at rest." : {
+
+    },
+    "Decrypted %lld stores; now plaintext at rest." : {
+
+    },
+    "Delete 1 Row" : {
+
+    },
+    "Delete 1 row?" : {
+
+    },
+    "Encrypted 1 store at rest." : {
+
+    },
+    "Encrypted %lld stores at rest." : {
+
+    },
+    "Exported 1 row to %@." : {
+
+    },
+    "Exported %lld rows to %@." : {
+
+    },
+    "Imported 1 item" : {
+
+    },
+    "Installed 1 item" : {
+
+    },
+    "MCP server" : {
+
+    },
+    "Preview shows the first row." : {
+
+    },
+    "Probe completed initialize/listTools and found 1 tool." : {
+
+    },
+    "Probe completed initialize/listTools and found %lld tools." : {
+
+    },
+    "SUCCESS: Authorized (Found 1 calendar)" : {
+
+    },
+    "SUCCESS: Authorized (Found 1 list)" : {
+
+    },
+    "This plugin declared an option you can configure (1 field)." : {
+
+    },
+    "This plugin declared options you can configure (%lld fields)." : {
+
+    },
+    "Use Mock Data (1 model)" : {
+
+    },
+    "Use Mock Data (%lld models)" : {
+
+    },
+    "Warming up — prefilling context %lld%% (%lld/1 token)" : {
+
+    },
+    "%lld results" : {
+
+    },
+    "%lld blocking findings must be fixed before provisioning." : {
+
+    },
+    "%lld external candidates skipped" : {
+
+    },
+    "%lld items would be redacted" : {
+
+    },
+    "%lld models currently available." : {
+
+    },
+    "%lld models found" : {
+
+    },
+    "%lld redactions" : {
+
+    },
+    "%lld setup findings need attention before tools are fully ready." : {
+
+    },
+    "%lld stores couldn't be converted because the encryption key is unavailable." : {
+
+    },
+    "%lld stores failed to convert." : {
+
+    },
+    "%lld tools discovered." : {
+
+    },
+    "%lld of 1 ability on" : {
+
+    },
+    "%lld of 1 fact" : {
+
+    },
+    "%lld sessions" : {
+
+    },
+    "%lld manual-model providers" : {
+
+    },
+    "%lld artifacts" : {
+
+    },
+    "%lld tools discovered via %@." : {
+
+    },
+    "%@ · 1 line" : {
+
+    },
+    "%lld transactions" : {
+
+    },
+    "%lld stdio providers" : {
+
+    },
+    "%lld tools assigned" : {
+
+    },
+    "%lld of 1 theme" : {
+
+    },
+    "session" : {
+
+    },
+    "Warming up — prefilling context %lld% (%lld/1 token)" : {
+
+    },
     " — %@" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -437,12 +437,14 @@ public struct BusinessDocumentStudioService: Sendable {
             try rejectTextExportPackageTarget(url)
             let delimiter: CSVDelimiter = normalizedTarget == "tsv" ? .tab : .comma
             let result = try await CSVTableWorkflowService.export(document, to: url, delimiter: delimiter)
+            let rowLabel = result.rowCount == 1 ? "1 row" : "\(result.rowCount) rows"
+            let columnLabel = result.columnCount == 1 ? "1 column" : "\(result.columnCount) columns"
             return BusinessDocumentStudioExportResult(
                 url: result.url,
                 sourceFormatId: document.formatId,
                 targetFormatId: result.formatId,
                 bytesWritten: result.bytesWritten,
-                message: "Exported \(result.rowCount) row(s) and \(result.columnCount) column(s)."
+                message: "Exported \(rowLabel) and \(columnLabel)."
             )
 
         case "xlsx":
@@ -538,7 +540,9 @@ public struct BusinessDocumentStudioService: Sendable {
             let message =
                 canExport
                 ? "CSV/TSV table can be exported through the delimited-text emitter."
-                : "CSV/TSV export is blocked by \(issues.count) validation issue(s)."
+                : (issues.count == 1
+                    ? "CSV/TSV export is blocked by 1 validation issue."
+                    : "CSV/TSV export is blocked by \(issues.count) validation issues.")
             options.append(
                 BusinessDocumentStudioExportOption(
                     targetFormatId: "csv",

--- a/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
@@ -45,7 +45,9 @@ public enum MCPLocalProviderDiagnostics {
         let result = snapshot.lastProbe
         var detail =
             result.succeeded
-            ? L("\(result.toolCount) tool(s) discovered via \(snapshot.transportSummary).")
+            ? (result.toolCount == 1
+                ? L("1 tool discovered via \(snapshot.transportSummary).")
+                : L("\(result.toolCount) tools discovered via \(snapshot.transportSummary)."))
             : result.redactedMessage
         if let state, state.isConnected != result.succeeded {
             detail += " "

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -116,7 +116,11 @@ public struct MCPProviderProbeResult: Codable, Identifiable, Sendable, Equatable
         startedAt: Date,
         tools: [MCP.Tool]
     ) -> MCPProviderProbeResult {
-        MCPProviderProbeResult(
+        let toolCountMessage =
+            tools.count == 1
+            ? L("Probe completed initialize/listTools and found 1 tool.")
+            : L("Probe completed initialize/listTools and found \(tools.count) tools.")
+        return MCPProviderProbeResult(
             providerId: provider.id,
             providerName: provider.name,
             transportSummary: MCPProviderProbeService.transportSummary(for: provider),
@@ -128,7 +132,7 @@ public struct MCPProviderProbeResult: Codable, Identifiable, Sendable, Equatable
             toolCount: tools.count,
             // Server order, which for a paginated tools/list is page order.
             toolNames: tools.map(\.name),
-            message: L("Probe completed initialize/listTools and found \(tools.count) tool(s)."),
+            message: toolCountMessage,
             action: nil
         )
     }

--- a/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
@@ -123,10 +123,13 @@ public struct MCPServerHubSnapshot: Sendable {
     }
 
     public var pasteboardText: String {
+        let toolLabel = toolCount == 1 ? L("1 tool") : L("\(toolCount) tools")
+        let providerLabel =
+            stdioCount == 1 ? L("1 stdio provider") : L("\(stdioCount) stdio providers")
         var lines = [
             L("MCP Server Hub diagnostics"),
             L(
-                "\(connectedCount)/\(totalCount) connected, \(attentionCount) attention, \(toolCount) tools, \(stdioCount) stdio provider(s)"
+                "\(connectedCount)/\(totalCount) connected, \(attentionCount) attention, \(toolLabel), \(providerLabel)"
             ),
             L("Global proxy: \(proxy.summaryText)"),
         ]

--- a/Packages/OsaurusCore/Services/Memory/MemoryManagementConsoleService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryManagementConsoleService.swift
@@ -365,7 +365,11 @@ public struct MemoryManagementConsoleService: Sendable {
             diagnostics.append("FTS mirrors are missing or unavailable; text search may fall back to LIKE scans.")
         }
         if vectorFailures > 0 {
-            diagnostics.append("Vector index recorded \(vectorFailures) write failure(s); rebuild may be needed.")
+            diagnostics.append(
+                vectorFailures == 1
+                    ? "Vector index recorded 1 write failure; rebuild may be needed."
+                    : "Vector index recorded \(vectorFailures) write failures; rebuild may be needed."
+            )
         }
         if let lastOpenError = db.lastOpenErrorDescription, !lastOpenError.isEmpty {
             diagnostics.append("Last open error: \(lastOpenError)")
@@ -377,10 +381,18 @@ public struct MemoryManagementConsoleService: Sendable {
             diagnostics.append("Turns are buffered, but distillation has only skipped so far.")
         }
         if currentErrorNeedsAttention {
-            diagnostics.append("Distillation recorded \(processingStats.errorCount) error row(s).")
+            diagnostics.append(
+                processingStats.errorCount == 1
+                    ? "Distillation recorded 1 error row."
+                    : "Distillation recorded \(processingStats.errorCount) error rows."
+            )
         }
         if emptyOnlyNoEpisode {
-            diagnostics.append("Distillation recorded \(processingStats.emptyCount) empty result row(s).")
+            diagnostics.append(
+                processingStats.emptyCount == 1
+                    ? "Distillation recorded 1 empty result row."
+                    : "Distillation recorded \(processingStats.emptyCount) empty result rows."
+            )
         }
         if deadLetterNeedsAttention {
             diagnostics.append("Some memory signals were dead-lettered after repeated distillation failures.")

--- a/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
@@ -218,10 +218,15 @@ public struct ProviderConnectivitySnapshot: Sendable {
     }
 
     public var pasteboardText: String {
+        let modelLabel = modelCount == 1 ? L("1 model") : L("\(modelCount) models")
+        let providerLabel =
+            manualModelProviderCount == 1
+            ? L("1 manual-model provider")
+            : L("\(manualModelProviderCount) manual-model providers")
         var lines = [
             L("Provider connectivity diagnostics"),
             L(
-                "\(connectedCount)/\(totalCount) connected, \(attentionCount) attention, \(modelCount) models, \(manualModelProviderCount) manual-model provider(s)"
+                "\(connectedCount)/\(totalCount) connected, \(attentionCount) attention, \(modelLabel), \(providerLabel)"
             ),
             L("Global proxy: \(proxy.summaryText)"),
         ]

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -175,12 +175,15 @@ public enum ProviderNetworkDiagnostics {
         }
 
         if state?.isConnected == true {
+            let count = state?.modelCount ?? 0
             return ProviderDiagnosticRow(
                 id: "connection",
                 title: L("Connection"),
                 value: L("Connected"),
                 severity: .ok,
-                detail: L("\(state?.modelCount ?? 0) model(s) currently available.")
+                detail: count == 1
+                    ? L("1 model currently available.")
+                    : L("\(count) models currently available.")
             )
         }
 
@@ -471,7 +474,8 @@ public enum ProviderNetworkDiagnostics {
             )
         }
         if state?.isConnected == true {
-            var detail = L("\(state?.discoveredToolCount ?? 0) tool(s) discovered.")
+            let count = state?.discoveredToolCount ?? 0
+            var detail = count == 1 ? L("1 tool discovered.") : L("\(count) tools discovered.")
             if let connectedAt = state?.lastConnectedAt {
                 let formatted = connectedAt.formatted(date: .abbreviated, time: .shortened)
                 detail += " " + L("Last connected \(formatted).")

--- a/Packages/OsaurusCore/Services/SystemPermissionService.swift
+++ b/Packages/OsaurusCore/Services/SystemPermissionService.swift
@@ -952,7 +952,9 @@ final class SystemPermissionService: NSObject, ObservableObject, CLLocationManag
             // Try to fetch calendars to verify
             let calendars = store.calendars(for: .event)
             if !calendars.isEmpty {
-                return L("SUCCESS: Authorized (Found \(calendars.count) calendars)")
+                return calendars.count == 1
+                    ? L("SUCCESS: Authorized (Found 1 calendar)")
+                    : L("SUCCESS: Authorized (Found \(calendars.count) calendars)")
             } else {
                 return L("SUCCESS: Authorized (No calendars found)")
             }
@@ -977,7 +979,9 @@ final class SystemPermissionService: NSObject, ObservableObject, CLLocationManag
             let store = EKEventStore()
             let calendars = store.calendars(for: .reminder)
             if !calendars.isEmpty {
-                return L("SUCCESS: Authorized (Found \(calendars.count) lists)")
+                return calendars.count == 1
+                    ? L("SUCCESS: Authorized (Found 1 list)")
+                    : L("SUCCESS: Authorized (Found \(calendars.count) lists)")
             } else {
                 return L("SUCCESS: Authorized (No lists found)")
             }

--- a/Packages/OsaurusCore/Tests/Memory/MemoryManagementConsoleTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/MemoryManagementConsoleTests.swift
@@ -238,8 +238,8 @@ struct MemoryManagementConsoleTests {
         #expect(health.processingStats.errorCount == 1)
         #expect(health.processingStats.emptyCount == 1)
         #expect(health.processingStats.deadLetterCount == 1)
-        #expect(health.diagnostics.contains("Distillation recorded 1 error row(s)."))
-        #expect(health.diagnostics.contains("Distillation recorded 1 empty result row(s)."))
+        #expect(health.diagnostics.contains("Distillation recorded 1 error row."))
+        #expect(health.diagnostics.contains("Distillation recorded 1 empty result row."))
         #expect(health.diagnostics.contains("Some memory signals were dead-lettered after repeated distillation failures."))
     }
 
@@ -367,7 +367,7 @@ struct MemoryManagementConsoleTests {
         #expect(health.activeEpisodeCount == 1)
         #expect(health.processingStats.successCount == 1)
         #expect(health.processingStats.errorCount == 1)
-        #expect(health.diagnostics.contains("Distillation recorded 1 error row(s)."))
+        #expect(health.diagnostics.contains("Distillation recorded 1 error row."))
     }
 
     @Test func privacyRedactorMasksSensitiveValuesAndBoundsPreview() {

--- a/Packages/OsaurusCore/Views/Agent/AgentAbilitiesOverviewView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentAbilitiesOverviewView.swift
@@ -107,7 +107,11 @@ struct AgentAbilitiesHeroCard: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("\(enabledCount) of \(totalCount) abilities on", bundle: .module)
+                    Text(
+                        totalCount == 1
+                            ? L("\(enabledCount) of 1 ability on")
+                            : L("\(enabledCount) of \(totalCount) abilities on")
+                    )
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(theme.primaryText)
                         .contentTransition(.numericText())

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -6331,7 +6331,7 @@ struct AgentDetailView: View {
                                         let turnCount =
                                             sessionTurnCounts[session.id]
                                             ?? session.turns.count
-                                        Text("\(turnCount) turns", bundle: .module)
+                                        Text(turnCount == 1 ? L("1 turn") : L("\(turnCount) turns"))
                                             .font(.system(size: 10))
                                             .foregroundColor(theme.tertiaryText)
                                         Image(systemName: "arrow.up.right")
@@ -7338,7 +7338,11 @@ private struct AgentConnectionsSection: View {
         HStack(spacing: 6) {
             Image(systemName: "chart.bar.fill")
                 .font(.system(size: 8))
-            Text("\(activity.requestCount) requests", bundle: .module)
+            Text(
+                activity.requestCount == 1
+                    ? L("1 request")
+                    : L("\(activity.requestCount) requests")
+            )
             if let last = activity.lastUsed {
                 Text(verbatim: "·")
                 Text(
@@ -7829,7 +7833,8 @@ private struct AgentEditorSheet: View {
             draftMode == .auto
             ? L("Loaded on demand from your assigned set.")
             : L("All assigned tools are sent every turn.")
-        return L("\(toolCount) tools assigned · \(modeBlurb)")
+        let countLabel = toolCount == 1 ? L("1 tool assigned") : L("\(toolCount) tools assigned")
+        return "\(countLabel) · \(modeBlurb)"
     }
 
     private var promptField: some View {

--- a/Packages/OsaurusCore/Views/Agent/Database/DatabaseSavedViewsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/Database/DatabaseSavedViewsView.swift
@@ -164,7 +164,11 @@ struct DatabaseSavedViewsView: View {
                     } else {
                         previewGrid(preview)
                         if preview.truncated {
-                            Text("Preview shows the first \(preview.rows.count) rows.", bundle: .module)
+                            Text(
+                                preview.rows.count == 1
+                                    ? L("Preview shows the first row.")
+                                    : L("Preview shows the first \(preview.rows.count) rows.")
+                            )
                                 .font(.system(size: 10))
                                 .foregroundColor(theme.tertiaryText)
                                 .padding(.horizontal, 12)

--- a/Packages/OsaurusCore/Views/Agent/Database/DatabaseSharedUI.swift
+++ b/Packages/OsaurusCore/Views/Agent/Database/DatabaseSharedUI.swift
@@ -21,7 +21,7 @@ func agentSQLDisplayString(_ value: AgentSQLValue) -> String {
     case .integer(let v): return String(v)
     case .double(let v): return String(v)
     case .text(let v): return v
-    case .blob(let v): return "<\(v.count) bytes>"
+    case .blob(let v): return v.count == 1 ? "<1 byte>" : "<\(v.count) bytes>"
     case .bool(let v): return v ? "true" : "false"
     }
 }

--- a/Packages/OsaurusCore/Views/Agent/Database/DatabaseTablesView.swift
+++ b/Packages/OsaurusCore/Views/Agent/Database/DatabaseTablesView.swift
@@ -146,12 +146,20 @@ struct DatabaseTablesView: View {
             )
         }
         .confirmationDialog(
-            "Delete \(selectedRowKeys.count) rows?",
+            selectedRowKeys.count == 1
+                ? L("Delete 1 row?")
+                : L("Delete \(selectedRowKeys.count) rows?"),
             isPresented: $showBulkDeleteConfirm,
             titleVisibility: .visible
         ) {
-            Button(localized: "Delete \(selectedRowKeys.count) Rows", role: .destructive) {
+            Button(role: .destructive) {
                 Task { await bulkSoftDelete() }
+            } label: {
+                Text(
+                    selectedRowKeys.count == 1
+                        ? L("Delete 1 Row")
+                        : L("Delete \(selectedRowKeys.count) Rows")
+                )
             }
             Button(localized: "Cancel", role: .cancel) {}
         } message: {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2847,11 +2847,11 @@ extension FloatingInputCard {
                     return String(localized: "Warming up — prefilling context…", bundle: .module)
                 }
                 let percent = Int(state.percentCompleted.rounded())
-                return String(
-                    localized:
-                        "Warming up — prefilling context \(percent)% (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)",
-                    bundle: .module
-                )
+                return state.totalUnitCount == 1
+                    ? L("Warming up — prefilling context \(percent)% (\(state.completedUnitCount)/1 token)")
+                    : L(
+                        "Warming up — prefilling context \(percent)% (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)"
+                    )
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
@@ -353,7 +353,7 @@ final class NativeThinkingView: NSView {
     @objc private func headerTapped() { onToggle?() }
 
     private func formatCharCount(_ count: Int) -> String {
-        if count < 1000 { return "\(count) chars" }
+        if count < 1000 { return count == 1 ? "1 char" : "\(count) chars" }
         if count < 10_000 { return String(format: "%.1fk chars", Double(count) / 1000) }
         return "\(count / 1000)k chars"
     }

--- a/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
@@ -201,7 +201,8 @@ enum PreviewGenerator {
                 let itemDescriptions = array.prefix(3).map { formatValue($0) }
                 let preview = itemDescriptions.joined(separator: ", ")
                 let suffix = array.count > 3 ? " +\(array.count - 3) more" : ""
-                let result = "[\(array.count) items] \(preview)\(suffix)"
+                let countLabel = array.count == 1 ? "1 item" : "\(array.count) items"
+                let result = "[\(countLabel)] \(preview)\(suffix)"
                 if result.count > maxLength {
                     return String(result.prefix(maxLength - 3)) + "..."
                 }
@@ -217,7 +218,7 @@ enum PreviewGenerator {
                 if let preview = jsonPreview(trimmed, maxLength: maxLength) {
                     return preview
                 }
-                return "{\(dict.count) keys}"
+                return dict.count == 1 ? "{1 key}" : "{\(dict.count) keys}"
             }
         }
 
@@ -229,7 +230,10 @@ enum PreviewGenerator {
 
         if firstLine.count <= maxLength {
             if lines.count > 1 {
-                return "\(firstLine) (+\(lines.count - 1) lines)"
+                let remaining = lines.count - 1
+                return remaining == 1
+                    ? "\(firstLine) (+1 line)"
+                    : "\(firstLine) (+\(remaining) lines)"
             }
             return firstLine
         }
@@ -267,7 +271,7 @@ enum PreviewGenerator {
         case let bool as Bool:
             return bool ? "true" : "false"
         case let arr as [Any]:
-            return "[\(arr.count) items]"
+            return arr.count == 1 ? "[1 item]" : "[\(arr.count) items]"
         case let dict as [String: Any]:
             // Try to get a meaningful preview from the dict
             if let name = dict["title"] as? String ?? dict["name"] as? String {
@@ -277,7 +281,7 @@ enum PreviewGenerator {
                 }
                 return clean
             }
-            return "{\(dict.count) keys}"
+            return dict.count == 1 ? "{1 key}" : "{\(dict.count) keys}"
         default:
             return String(describing: value)
         }

--- a/Packages/OsaurusCore/Views/Chat/PastedContentSheet.swift
+++ b/Packages/OsaurusCore/Views/Chat/PastedContentSheet.swift
@@ -135,7 +135,11 @@ struct PastedContentSheet: View {
                     .foregroundColor(theme.primaryText)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text("\(sizeFormatted) · \(lineCount) lines")
+                Text(
+                    lineCount == 1
+                        ? L("\(sizeFormatted) · 1 line")
+                        : L("\(sizeFormatted) · \(lineCount) lines")
+                )
                     .font(theme.font(size: 11, weight: .regular))
                     .foregroundColor(theme.secondaryText)
             }

--- a/Packages/OsaurusCore/Views/Chat/SubagentFeedView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SubagentFeedView.swift
@@ -257,7 +257,7 @@ struct SubagentFeedView: View {
                 .font(.system(size: 11))
                 .foregroundColor(theme.tertiaryText)
                 .frame(width: 16)
-            Text("\(count) earlier steps", bundle: .module)
+            Text(count == 1 ? L("1 earlier step") : L("\(count) earlier steps"))
                 .font(.system(size: 10))
                 .foregroundColor(theme.tertiaryText)
             Spacer(minLength: 0)

--- a/Packages/OsaurusCore/Views/Common/NotchNavigationRails.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchNavigationRails.swift
@@ -35,6 +35,8 @@ struct NotchAgentTabRail: View {
     private func tabChip(_ group: NotchAgentGroup) -> some View {
         let isSelected = group.agentId == selectedAgentId
         let agent = agentResolver(group.agentId)
+        let sessionCount = group.tasks.count
+        let sessionLabel = sessionCount == 1 ? L("1 session") : L("\(sessionCount) sessions")
         return HStack(spacing: 8) {
             avatarBuilder(agent, 24)
 
@@ -100,7 +102,7 @@ struct NotchAgentTabRail: View {
         .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .onTapGesture { onSelect(group) }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(Text("\(agent.name), \(group.tasks.count) session(s)"))
+        .accessibilityLabel(Text("\(agent.name), \(sessionLabel)"))
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 }

--- a/Packages/OsaurusCore/Views/Common/NotchView.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchView.swift
@@ -1240,7 +1240,8 @@ struct NotchView: View {
                 : "\(L("Needs your input")) · \(group.tasks.count) \(L("sessions"))"
         }
         if group.activeTaskCount > 0 {
-            return "\(group.activeTaskCount) \(L("active")) · \(group.tasks.count) \(L("sessions"))"
+            let sessionLabel = group.tasks.count == 1 ? L("session") : L("sessions")
+            return "\(group.activeTaskCount) \(L("active")) · \(group.tasks.count) \(sessionLabel)"
         }
         return group.tasks.count == 1
             ? L("Recent session")

--- a/Packages/OsaurusCore/Views/Credits/CreditsView.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsView.swift
@@ -1201,10 +1201,10 @@ struct CreditsView: View {
         do {
             let data = try encoder.encode(diagnostics)
             try data.write(to: url, options: .atomic)
-            diagnosticsMessage = String(
-                localized: "Exported \(diagnostics.entries.count) row(s) to \(url.lastPathComponent).",
-                bundle: .module
-            )
+            let count = diagnostics.entries.count
+            diagnosticsMessage = count == 1
+                ? L("Exported 1 row to \(url.lastPathComponent).")
+                : L("Exported \(count) rows to \(url.lastPathComponent).")
         } catch {
             diagnosticsMessage = error.localizedDescription
         }

--- a/Packages/OsaurusCore/Views/Identity/IdentityView.swift
+++ b/Packages/OsaurusCore/Views/Identity/IdentityView.swift
@@ -171,9 +171,16 @@ struct IdentityView: View {
     private var repairConfirmMessage: LocalizedStringKey {
         let agents = drift?.mismatchedAgents.count ?? 0
         let keys = drift?.staleAccessKeys.count ?? 0
-        return LocalizedStringKey(
-            "Repair will derive fresh addresses for \(agents) agent(s) and revoke \(keys) stale access key(s) under the current master. Existing pairings and clients holding those keys will stop working until they're re-issued."
-        )
+        switch (agents == 1, keys == 1) {
+        case (true, true):
+            return "Repair will derive a fresh address for 1 agent and revoke 1 stale access key under the current master. Existing pairings and clients holding that key will stop working until it's re-issued."
+        case (true, false):
+            return "Repair will derive a fresh address for 1 agent and revoke \(keys) stale access keys under the current master. Existing pairings and clients holding those keys will stop working until they're re-issued."
+        case (false, true):
+            return "Repair will derive fresh addresses for \(agents) agents and revoke 1 stale access key under the current master. Existing pairings and clients holding that key will stop working until it's re-issued."
+        case (false, false):
+            return "Repair will derive fresh addresses for \(agents) agents and revoke \(keys) stale access keys under the current master. Existing pairings and clients holding those keys will stop working until they're re-issued."
+        }
     }
 
     private func actionResultBanner(_ result: ActionResult) -> some View {
@@ -516,10 +523,18 @@ private struct IdentityDriftBanner: View {
         let keys = drift.staleAccessKeys.count
         switch (agents, keys) {
         case (0, 0): return "Drift detected"
-        case (let a, 0): return "\(a) agent address(es) no longer derive from this master."
-        case (0, let k): return "\(k) access key(s) signed by a previous master."
+        case (1, 0): return "1 agent address no longer derives from this master."
+        case (let a, 0): return "\(a) agent addresses no longer derive from this master."
+        case (0, 1): return "1 access key signed by a previous master."
+        case (0, let k): return "\(k) access keys signed by a previous master."
+        case (1, 1):
+            return "1 agent address and 1 access key reference a previous master."
+        case (1, let k):
+            return "1 agent address and \(k) access keys reference a previous master."
+        case (let a, 1):
+            return "\(a) agent addresses and 1 access key reference a previous master."
         case (let a, let k):
-            return "\(a) agent address(es) and \(k) access key(s) reference a previous master."
+            return "\(a) agent addresses and \(k) access keys reference a previous master."
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Insights/InsightsView.swift
+++ b/Packages/OsaurusCore/Views/Insights/InsightsView.swift
@@ -147,7 +147,8 @@ struct InsightsView: View {
 
             Spacer()
 
-            Text("\(insightsService.totalRequestCount) requests", bundle: .module)
+            let requestCount = insightsService.totalRequestCount
+            Text(requestCount == 1 ? L("1 request") : L("\(requestCount) requests"))
                 .font(.system(size: 11, weight: .medium))
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
@@ -535,6 +536,8 @@ private struct ToolsBadge: View {
     let count: Int
 
     var body: some View {
+        let helpText: LocalizedStringKey =
+            count == 1 ? "1 tool sent" : "\(count) tools sent"
         InlineTag(tint: .teal) {
             HStack(spacing: 3) {
                 Image(systemName: "wrench.and.screwdriver.fill")
@@ -543,7 +546,7 @@ private struct ToolsBadge: View {
                     .font(.system(size: 9, weight: .bold, design: .monospaced))
             }
         }
-        .localizedHelp("\(count) tool(s) sent")
+        .localizedHelp(helpText)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
+++ b/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
@@ -111,8 +111,12 @@ struct KnowledgeView: View {
                                                     showSuccess(L("Every document has a category (type)"))
                                                 } else {
                                                     let sample = failing.prefix(3).joined(separator: ", ")
+                                                    let summary =
+                                                        failing.count == 1
+                                                        ? "1 document needs a category"
+                                                        : "\(failing.count) documents need a category"
                                                     showSuccess(
-                                                        "\(failing.count) document(s) need a category — add a `type:` line to: \(sample)\(failing.count > 3 ? "…" : "")"
+                                                        "\(summary) — add a `type:` line to: \(sample)\(failing.count > 3 ? "…" : "")"
                                                     )
                                                 }
                                             }
@@ -503,8 +507,9 @@ private struct KnowledgeCollectionCard: View {
             return
                 "Every document has a category, so agents can filter the library by it. Following the Open Knowledge Format (OKF)."
         case .nonconforming(let count):
-            return
-                "\(count) document(s) have no category. Add a `type:` line (e.g. `type: policy`) to the top of each file so agents can filter by it. Click for the list."
+            return count == 1
+                ? "1 document has no category. Add a `type:` line (e.g. `type: policy`) to the top of the file so agents can filter by it. Click for the list."
+                : "\(count) documents have no category. Add a `type:` line (e.g. `type: policy`) to the top of each file so agents can filter by it. Click for the list."
         case .unknown:
             return "Checking that every document declares a category (its `type`)…"
         }

--- a/Packages/OsaurusCore/Views/Management/SettingsSearchResultsView.swift
+++ b/Packages/OsaurusCore/Views/Management/SettingsSearchResultsView.swift
@@ -48,7 +48,11 @@ struct SettingsSearchResultsView: View {
             Text("Search Results", bundle: .module)
                 .font(.system(size: 22, weight: .bold))
                 .foregroundColor(theme.primaryText)
-            Text("\(results.count) settings match \"\(query)\"", bundle: .module)
+            Text(
+                results.count == 1
+                    ? L("1 setting matches \"\(query)\"")
+                    : L("\(results.count) settings match \"\(query)\"")
+            )
                 .font(.system(size: 13))
                 .foregroundColor(theme.secondaryText)
         }

--- a/Packages/OsaurusCore/Views/Memory/MemoryComponents.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryComponents.swift
@@ -55,7 +55,11 @@ struct PinnedFactsPanel: View {
             )
 
             HStack {
-                Text("\(filteredFacts.count) of \(facts.count) facts", bundle: .module)
+                Text(
+                    facts.count == 1
+                        ? L("\(filteredFacts.count) of 1 fact")
+                        : L("\(filteredFacts.count) of \(facts.count) facts")
+                )
                     .font(.system(size: 10))
                     .foregroundColor(theme.tertiaryText)
                 Spacer()
@@ -227,9 +231,11 @@ struct EpisodeRow: View {
     let episode: Episode
 
     var body: some View {
+        let tokenLabel =
+            episode.tokenCount == 1 ? L("1 token") : L("\(episode.tokenCount) tokens")
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
-                Text("\(episode.tokenCount) tokens", bundle: .module)
+                Text(tokenLabel)
                     .font(.system(size: 10, weight: .medium))
                     .foregroundColor(theme.tertiaryText)
 
@@ -258,7 +264,7 @@ struct EpisodeRow: View {
         .padding(.vertical, 6)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
-            "Episode: \(episode.summary). \(episode.tokenCount) tokens, \(episode.conversationAt)"
+            "Episode: \(episode.summary). \(tokenLabel), \(episode.conversationAt)"
         )
     }
 }

--- a/Packages/OsaurusCore/Views/Memory/MemoryDiagnosticsViews.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryDiagnosticsViews.swift
@@ -248,17 +248,23 @@ extension MemoryView {
     }
 
     private static func summarize(backfill final: MemoryBackfillProgress) -> String {
+        let sessions =
+            final.sessionsProcessed == 1
+            ? L("1 session")
+            : L("\(final.sessionsProcessed) sessions")
+        let turns =
+            final.turnsBuffered == 1
+            ? L("1 turn")
+            : L("\(final.turnsBuffered) turns")
         switch final.stage {
         case .cancelled:
-            return
-                L(
-                    "Backfill cancelled after \(final.sessionsProcessed) session(s) — \(final.turnsBuffered) turns buffered. Run 'Distill pending' to drain them."
-                )
+            return L(
+                "Backfill cancelled after \(sessions) — \(turns) buffered. Run 'Distill pending' to drain them."
+            )
         default:
-            return
-                L(
-                    "Backfill complete: \(final.sessionsProcessed) session(s) buffered (\(final.turnsBuffered) turns), \(final.sessionsSkipped) skipped. Distillation finished."
-                )
+            return L(
+                "Backfill complete: \(sessions) buffered (\(turns)), \(final.sessionsSkipped) skipped. Distillation finished."
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Views/Memory/MemoryManagementConsoleView.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryManagementConsoleView.swift
@@ -296,9 +296,9 @@ struct MemoryManagementConsoleView: View {
                         Spacer()
 
                         if contextPreview.redactedContext.redactionCount > 0 {
+                            let count = contextPreview.redactedContext.redactionCount
                             Text(
-                                "\(contextPreview.redactedContext.redactionCount) redaction(s)",
-                                bundle: .module
+                                count == 1 ? L("1 redaction") : L("\(count) redactions")
                             )
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(theme.warningColor)

--- a/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
@@ -1067,7 +1067,11 @@ struct ModelPickerView: View {
                     // toggle for mock data
                     HStack {
                         Toggle(isOn: $useMockData) {
-                            Text("Use Mock Data (\(mockModels.count) models)", bundle: .module)
+                            Text(
+                                mockModels.count == 1
+                                    ? L("Use Mock Data (1 model)")
+                                    : L("Use Mock Data (\(mockModels.count) models)")
+                            )
                         }
                         .padding()
                         Spacer()

--- a/Packages/OsaurusCore/Views/Plugin/ClaudeMarketplaceDetailView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudeMarketplaceDetailView.swift
@@ -434,7 +434,7 @@ struct ClaudeMarketplaceDetailView: View {
                 )
             }
             if summary.mcp {
-                componentGroup(kind: .mcp, count: 1, names: ["MCP server(s)"])
+                componentGroup(kind: .mcp, count: 1, names: [L("MCP server")])
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Plugin/ClaudePluginDetailView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudePluginDetailView.swift
@@ -235,7 +235,9 @@ struct ClaudePluginDetailView: View {
                     if plugin.totalCount > 0 {
                         heroStatBadge(
                             icon: "shippingbox.fill",
-                            text: "\(plugin.totalCount) artifacts",
+                            text: plugin.totalCount == 1
+                                ? L("1 artifact")
+                                : L("\(plugin.totalCount) artifacts"),
                             color: theme.accentColor
                         )
                     }
@@ -300,9 +302,11 @@ struct ClaudePluginDetailView: View {
                 Text("Configuration available", bundle: .module)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundColor(theme.primaryText)
+                let fieldCount = snapshot?.userConfigSpec.count ?? 0
                 Text(
-                    "This plugin declared options you can configure (\(snapshot?.userConfigSpec.count ?? 0) field(s)).",
-                    bundle: .module
+                    fieldCount == 1
+                        ? L("This plugin declared an option you can configure (1 field).")
+                        : L("This plugin declared options you can configure (\(fieldCount) fields).")
                 )
                 .font(.system(size: 12))
                 .foregroundColor(theme.secondaryText)

--- a/Packages/OsaurusCore/Views/Plugin/GitHubImportSheet.swift
+++ b/Packages/OsaurusCore/Views/Plugin/GitHubImportSheet.swift
@@ -173,15 +173,19 @@ struct GitHubImportSheet: View {
         case .urlInput: return L("Paste a repository URL to get started")
         case .loading: return L("Fetching repository information")
         case .skillSelection(let result):
-            return L("\(result.skills.count) skills available")
+            return result.skills.count == 1
+                ? L("1 skill available")
+                : L("\(result.skills.count) skills available")
         case .pluginSelection(let result):
-            return L("\(result.plugins.count) plugins available")
+            return result.plugins.count == 1
+                ? L("1 plugin available")
+                : L("\(result.plugins.count) plugins available")
         case .importing: return L("Installing selected plugins")
         case .installComplete(let report):
             let totals =
                 report.totalImportedSkills + report.totalImportedAgents
                 + report.totalImportedCommands + report.totalImportedMCPProviders
-            return L("\(totals) items installed")
+            return totals == 1 ? L("1 item installed") : L("\(totals) items installed")
         case .error(let error): return error.localizedDescription
         }
     }

--- a/Packages/OsaurusCore/Views/Plugin/PluginsView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/PluginsView.swift
@@ -285,7 +285,9 @@ struct PluginsView: View {
                         _ = await claudeSkillManager.importSkillsFromMarkdown(skills)
                         showGitHubImport = false
                         claudeAggregator.refresh()
-                        showSuccess(L("Imported \(skills.count) items"))
+                        showSuccess(
+                            skills.count == 1 ? L("Imported 1 item") : L("Imported \(skills.count) items")
+                        )
                     }
                 },
                 onCancel: { showGitHubImport = false },
@@ -298,7 +300,7 @@ struct PluginsView: View {
                             report.totalImportedSkills + report.totalImportedAgents
                             + report.totalImportedCommands + report.totalImportedMCPProviders
                         if total > 0 {
-                            showSuccess(L("Installed \(total) items"))
+                            showSuccess(total == 1 ? L("Installed 1 item") : L("Installed \(total) items"))
                         }
                     }
                 }
@@ -1762,10 +1764,18 @@ private struct PluginDetailView: View {
                         let toolCount = caps.tools?.count ?? 0
                         let skillCount = caps.skills?.count ?? 0
                         if toolCount > 0 {
-                            heroStatBadge(icon: "wrench.and.screwdriver", text: L("\(toolCount) tools"), color: .orange)
+                            heroStatBadge(
+                                icon: "wrench.and.screwdriver",
+                                text: toolCount == 1 ? L("1 tool") : L("\(toolCount) tools"),
+                                color: .orange
+                            )
                         }
                         if skillCount > 0 {
-                            heroStatBadge(icon: "lightbulb", text: L("\(skillCount) skills"), color: .cyan)
+                            heroStatBadge(
+                                icon: "lightbulb",
+                                text: skillCount == 1 ? L("1 skill") : L("\(skillCount) skills"),
+                                color: .cyan
+                            )
                         }
                     }
                     if loadedPlugin?.webConfig != nil {

--- a/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
+++ b/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
@@ -562,7 +562,7 @@ struct ProviderCredentialPromptSheet: View {
         if let count = testSucceededModelCount {
             badgePill(
                 icon: "checkmark.circle.fill",
-                text: String(format: L("%d model(s) found"), count),
+                text: count == 1 ? L("1 model found") : L("\(count) models found"),
                 tint: theme.successColor
             )
         } else if let error = testError {

--- a/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterView.swift
+++ b/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterView.swift
@@ -102,7 +102,9 @@ struct RouterAccountUsageCenterView: View {
             metricTile(
                 title: L("Net credits"),
                 value: OsaurusRouter.formatMicroUSDPrecise(snapshot.transactions.netMicro),
-                detail: L("\(snapshot.transactions.transactionCount) transaction(s)"),
+                detail: snapshot.transactions.transactionCount == 1
+                    ? L("1 transaction")
+                    : L("\(snapshot.transactions.transactionCount) transactions"),
                 icon: "plus.forwardslash.minus",
                 color: RouterAccountUsageCenter.microValue(snapshot.transactions.netMicro) >= 0
                     ? theme.successColor : theme.warningColor

--- a/Packages/OsaurusCore/Views/Sandbox/SandboxView.swift
+++ b/Packages/OsaurusCore/Views/Sandbox/SandboxView.swift
@@ -471,7 +471,11 @@ private extension SandboxView {
                     preflightFindingRow(finding)
                 }
                 if hiddenCount > 0 {
-                    Text("+\(hiddenCount) more findings in copied report", bundle: .module)
+                    Text(
+                        hiddenCount == 1
+                            ? L("+1 more finding in copied report")
+                            : L("+\(hiddenCount) more findings in copied report")
+                    )
                         .font(.system(size: 10))
                         .foregroundColor(theme.tertiaryText)
                 }
@@ -523,9 +527,15 @@ private extension SandboxView {
         case .ready:
             return L("Host paths and permissions are ready for sandbox tooling.")
         case .needsSetup:
-            return L("\(report.warningFindings.count) setup finding(s) need attention before tools are fully ready.")
+            let count = report.warningFindings.count
+            return count == 1
+                ? L("1 setup finding needs attention before tools are fully ready.")
+                : L("\(count) setup findings need attention before tools are fully ready.")
         case .blocked:
-            return L("\(report.blockingFindings.count) blocking finding(s) must be fixed before provisioning.")
+            let count = report.blockingFindings.count
+            return count == 1
+                ? L("1 blocking finding must be fixed before provisioning.")
+                : L("\(count) blocking findings must be fixed before provisioning.")
         case .unproven:
             return L("One or more checks could not be proven; copy the report for support or CI proof.")
         }

--- a/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
@@ -73,9 +73,9 @@ struct ExternalModelsSettingsView: View {
                         .font(.system(size: 11))
                         .foregroundColor(theme.tertiaryText)
                 } else {
+                    let count = hfCount + lmStudioCount + customFolderCount
                     Text(
-                        "\(hfCount + lmStudioCount + customFolderCount) external models found",
-                        bundle: .module
+                        count == 1 ? L("1 external model found") : L("\(count) external models found")
                     )
                         .font(.system(size: 11))
                         .foregroundColor(theme.tertiaryText)
@@ -104,7 +104,12 @@ struct ExternalModelsSettingsView: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 10, weight: .semibold))
                             .foregroundColor(theme.warningColor)
-                        Text("\(scanReport.skipped.count) external candidate(s) skipped", bundle: .module)
+                        let count = scanReport.skipped.count
+                        Text(
+                            count == 1
+                                ? L("1 external candidate skipped")
+                                : L("\(count) external candidates skipped")
+                        )
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(theme.secondaryText)
                     }

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -501,8 +501,9 @@ private struct MCPServerHubPanel: View {
     }
 
     private var summaryText: String {
-        L(
-            "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(snapshot.toolCount) tools"
+        let toolLabel = snapshot.toolCount == 1 ? L("1 tool") : L("\(snapshot.toolCount) tools")
+        return L(
+            "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(toolLabel)"
         )
     }
 }
@@ -648,7 +649,7 @@ private struct ProviderCard: View {
                             HStack(spacing: 4) {
                                 Image(systemName: "wrench.and.screwdriver")
                                     .font(.system(size: 10))
-                                Text("\(toolCount) tools", bundle: .module)
+                                Text(toolCount == 1 ? L("1 tool") : L("\(toolCount) tools"))
                                     .font(.system(size: 11, weight: .medium))
                             }
                             .foregroundColor(theme.secondaryText)
@@ -1547,7 +1548,11 @@ private struct ProviderEditSheet: View {
                 if let result = testResult {
                     switch result {
                     case .success(let probe):
-                        Text("Connected! (\(probe.toolCount) tools)", bundle: .module)
+                        Text(
+                            probe.toolCount == 1
+                                ? L("Connected! (1 tool)")
+                                : L("Connected! (\(probe.toolCount) tools)")
+                        )
                             .font(.system(size: 12, weight: .medium))
                     case .failure(let probe):
                         Text("Failed - \(probe.reasonCode.rawValue)", bundle: .module)

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -2378,7 +2378,8 @@ private struct EditProviderFlow: View {
         if isTesting { return L("Testing...") }
         if let result = testResult {
             switch result {
-            case .success(let models): return L("\(models.count) models")
+            case .success(let models):
+                return models.count == 1 ? L("1 model") : L("\(models.count) models")
             case .failure: return L("Retry")
             }
         }

--- a/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
@@ -532,8 +532,9 @@ private struct ProviderConnectivityCenterPanel: View {
     }
 
     private var summaryText: String {
-        L(
-            "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(snapshot.modelCount) models"
+        let modelLabel = snapshot.modelCount == 1 ? L("1 model") : L("\(snapshot.modelCount) models")
+        return L(
+            "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(modelLabel)"
         )
     }
 

--- a/Packages/OsaurusCore/Views/Settings/SearchView.swift
+++ b/Packages/OsaurusCore/Views/Settings/SearchView.swift
@@ -484,7 +484,7 @@ struct SearchView: View {
                     Text(
                         "\(index + 1). \(providerDisplayName(attempt.provider)) — "
                             + (attempt.ok
-                                ? "\(attempt.count) result(s)"
+                                ? (attempt.count == 1 ? L("1 result") : L("\(attempt.count) results"))
                                 : (attempt.error ?? "failed"))
                     )
                     .font(.system(size: 10, design: .monospaced))

--- a/Packages/OsaurusCore/Views/Settings/StorageSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/StorageSettingsView.swift
@@ -689,27 +689,23 @@ public struct StorageSettingsView: View {
                     self.isWorking = false
                     self.desiredEncrypted = enabled
                     if !report.locked.isEmpty {
-                        self.errorMessage = String(
-                            format: L(
-                                "%lld store(s) couldn't be converted because the encryption key is unavailable."
-                            ),
-                            report.locked.count
-                        )
+                        let count = report.locked.count
+                        self.errorMessage = count == 1
+                            ? L("1 store couldn't be converted because the encryption key is unavailable.")
+                            : L("\(count) stores couldn't be converted because the encryption key is unavailable.")
                     } else if !report.failed.isEmpty {
-                        self.errorMessage = String(
-                            format: L("%lld store(s) failed to convert."),
-                            report.failed.count
-                        )
+                        let count = report.failed.count
+                        self.errorMessage = count == 1
+                            ? L("1 store failed to convert.")
+                            : L("\(count) stores failed to convert.")
                     } else if enabled {
-                        self.lastSummary = String(
-                            format: L("Encrypted %lld store(s) at rest."),
-                            report.converted
-                        )
+                        self.lastSummary = report.converted == 1
+                            ? L("Encrypted 1 store at rest.")
+                            : L("Encrypted \(report.converted) stores at rest.")
                     } else {
-                        self.lastSummary = String(
-                            format: L("Decrypted %lld store(s); now plaintext at rest."),
-                            report.converted
-                        )
+                        self.lastSummary = report.converted == 1
+                            ? L("Decrypted 1 store; now plaintext at rest.")
+                            : L("Decrypted \(report.converted) stores; now plaintext at rest.")
                     }
                 }
                 await refresh()

--- a/Packages/OsaurusCore/Views/Skill/SkillEditorSheet.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillEditorSheet.swift
@@ -304,7 +304,7 @@ struct SkillEditorSheet: View {
 
                 Spacer()
 
-                Text("\(instructions.count) characters", bundle: .module)
+                Text(instructions.count == 1 ? L("1 character") : L("\(instructions.count) characters"))
                     .font(.system(size: 11))
                     .foregroundColor(themeManager.currentTheme.tertiaryText)
             }

--- a/Packages/OsaurusCore/Views/Skill/SkillsView.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillsView.swift
@@ -577,7 +577,11 @@ private struct SkillRow: View {
                         HStack(spacing: 4) {
                             Image(systemName: "doc.text")
                                 .font(.system(size: 10))
-                            Text("\(skill.instructions.count) chars", bundle: .module)
+                            Text(
+                                skill.instructions.count == 1
+                                    ? L("1 character")
+                                    : L("\(skill.instructions.count) characters")
+                            )
                                 .font(.system(size: 11, weight: .medium))
                         }
                         .foregroundColor(theme.secondaryText)
@@ -627,7 +631,11 @@ private struct SkillRow: View {
 
                             if skill.hasAssociatedFiles {
                                 Label {
-                                    Text("\(skill.totalFileCount) files", bundle: .module)
+                                    Text(
+                                        skill.totalFileCount == 1
+                                            ? L("1 file")
+                                            : L("\(skill.totalFileCount) files")
+                                    )
                                 } icon: {
                                     Image(systemName: "folder")
                                 }

--- a/Packages/OsaurusCore/Views/Theme/ThemesView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemesView.swift
@@ -579,7 +579,9 @@ struct ThemesView: View {
     }
 
     private var resultsSubtitle: String {
-        L("\(visibleThemes.count) of \(installedThemes.count) themes")
+        installedThemes.count == 1
+            ? L("\(visibleThemes.count) of 1 theme")
+            : L("\(visibleThemes.count) of \(installedThemes.count) themes")
     }
 
     // MARK: - Loading & Error States

--- a/Packages/OsaurusCore/Views/Voice/VoiceView.swift
+++ b/Packages/OsaurusCore/Views/Voice/VoiceView.swift
@@ -128,7 +128,10 @@ struct VoiceView: View {
         if !isSetupComplete {
             return L("Complete setup to enable voice")
         } else if modelManager.downloadedModelsCount > 0 {
-            return L("\(modelManager.downloadedModelsCount) models • \(modelManager.totalDownloadedSizeString)")
+            let count = modelManager.downloadedModelsCount
+            return count == 1
+                ? L("1 model • \(modelManager.totalDownloadedSizeString)")
+                : L("\(count) models • \(modelManager.totalDownloadedSizeString)")
         } else {
             return L("Voice transcription ready")
         }


### PR DESCRIPTION
## Summary
- use count-aware singular and plural labels throughout user-facing UI, accessibility text, and diagnostics
- correct related noun and verb agreement in confirmations, status messages, and provider/MCP summaries
- update memory diagnostic assertions for the corrected singular copy

## Test plan
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test OSU_MODELS_DIR=/tmp/osaurus-test-models swift test --package-path Packages/OsaurusCore --filter MemoryManagementConsoleTests` (10 tests)
- [x] package compilation completed as part of the targeted test run
- [ ] full `make test` not completed; stopped at request (the partial run reported an unrelated `exposureSnapshotClassifiesSourcesStatesAndReasons` failure)