### PR TITLE
Fix JANG AppleScript success finalization

### DIFF
--- a/Packages/OsaurusCore/AppleScript/AppleScriptModelCatalog.swift
+++ b/Packages/OsaurusCore/AppleScript/AppleScriptModelCatalog.swift
@@ -118,17 +118,39 @@ enum AppleScriptModelCatalog {
         id.range(of: repoIdPrefix, options: [.caseInsensitive, .anchored]) != nil
     }
 
-    /// The catalog entries that are installed on disk (cheap, cache-backed
-    /// `isDownloaded`).
+    /// Whether a catalog/ad-hoc AppleScript bundle is available either in the
+    /// Osaurus models directory or through the user's external-model registry.
+    /// Runtime loading already resolves external bundles in place; the
+    /// availability gate must use the same source of truth or a valid model in
+    /// a Settings-selected folder is shown as installed but rejected at call
+    /// time.
+    private static func isInstalled(_ model: MLXModel) -> Bool {
+        if model.isDownloaded { return true }
+        guard let externalDirectory = ExternalModelLocator.path(forId: model.id) else {
+            return false
+        }
+        let external = MLXModel(
+            id: model.id,
+            name: model.name,
+            description: model.description,
+            downloadURL: model.downloadURL,
+            bundleDirectory: externalDirectory,
+            externalSource: ExternalModelLocator.Source.customModelFolder.rawValue
+        )
+        return external.isDownloaded
+    }
+
+    /// The catalog entries that are installed on disk, including bundles the
+    /// user registered in Settings -> Storage -> External Models.
     static func installedModels() -> [MLXModel] {
-        models.filter { $0.isDownloaded }
+        models.filter(isInstalled)
     }
 
     /// Whether ANY curated AppleScript model is installed. Cheap enough for the
     /// system-prompt compose hot path (each `isDownloaded` reads the warmed
     /// `MLXModelDownloadCache`, invalidated on `.localModelsChanged`).
     static var hasInstalledModel: Bool {
-        models.contains { $0.isDownloaded }
+        models.contains(where: isInstalled)
     }
 
     /// Resolve the model id the AppleScript subagent should load: the
@@ -141,7 +163,7 @@ enum AppleScriptModelCatalog {
     static func resolveInstalledModelId(preferred: String?) -> String? {
         let trimmed = preferred?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmed, !trimmed.isEmpty {
-            if let match = models.first(where: { $0.id == trimmed }), match.isDownloaded {
+            if let match = models.first(where: { $0.id == trimmed }), isInstalled(match) {
                 return match.id
             }
             // A non-catalog AppleScript bundle (matching the curated repo-id
@@ -154,7 +176,7 @@ enum AppleScriptModelCatalog {
                     description: "",
                     downloadURL: "https://huggingface.co/\(trimmed)"
                 )
-                if adHoc.isDownloaded { return trimmed }
+                if isInstalled(adHoc) { return trimmed }
             }
         }
         return installedModels().first?.id

--- a/Packages/OsaurusCore/AppleScript/Loop/AppleScriptLoop.swift
+++ b/Packages/OsaurusCore/AppleScript/Loop/AppleScriptLoop.swift
@@ -419,6 +419,9 @@ public enum AppleScriptLoop {
         // token count by contract, so counter division would understate).
         var decodeRates: [Double] = []
         var lastOutput: String? = nil
+        // A raw return from a mutating script remains part of the public run
+        // result, but only a read step can verify requested state.
+        var lastReadOutput: String? = nil
         var consecutiveInvalid = 0
         var consecutiveBlocked = 0
         // Consecutive confirm-gate dry-compile failures. Bounded separately so
@@ -546,7 +549,7 @@ public enum AppleScriptLoop {
             // value, so the parent gets a REAL result instead of "completed".
             guard let call = stepResult.call else {
                 let text = stepResult.text?.trimmingCharacters(in: .whitespacesAndNewlines)
-                let haveValue = !(lastOutput?.isEmpty ?? true)
+                let haveValue = !(lastReadOutput?.isEmpty ?? true)
                 if harness.verifyReadBack, !verifyAttempted, !haveValue, scriptsExecuted > 0,
                     shouldVerify(mode: mode, task: task)
                 {
@@ -571,7 +574,8 @@ public enum AppleScriptLoop {
                 }
                 let summary = completionSummary(
                     modelText: text,
-                    lastOutput: lastOutput,
+                    lastOutput: shouldVerify(mode: mode, task: task)
+                        ? lastReadOutput : lastOutput,
                     scriptsExecuted: scriptsExecuted,
                     succeeded: succeeded,
                     failed: failed
@@ -961,7 +965,16 @@ public enum AppleScriptLoop {
             let trimmedOutput = execution.output?.trimmingCharacters(in: .whitespacesAndNewlines)
             if execution.isSuccess {
                 succeeded += 1
-                if let trimmedOutput, !trimmedOutput.isEmpty { lastOutput = trimmedOutput }
+                // Only a read result is evidence for a requested value or
+                // post-action state. A mutating script can `return` any string
+                // without having applied it (the JANG_6M TextEdit reproduction
+                // returned the requested text from a local variable while the
+                // document remained unchanged). Keep that output in the step
+                // transcript, but require a later read for verification.
+                if let trimmedOutput, !trimmedOutput.isEmpty {
+                    lastOutput = trimmedOutput
+                    if effect == .read { lastReadOutput = trimmedOutput }
+                }
             } else {
                 failed += 1
             }
@@ -974,16 +987,22 @@ public enum AppleScriptLoop {
                 script: script
             )
 
-            // `mac_query` is complete as soon as a read succeeds with a real
-            // return value. Continuing to ask the model after that point lets
-            // small dedicated models repeat the identical successful script
-            // until the step cap, wasting an entire generation per repeat.
-            // Empty successful reads still continue into the existing
-            // verification path so the runtime can obtain the requested value.
-            if mode == .query, execution.isSuccess, let trimmedOutput, !trimmedOutput.isEmpty {
+            // A successful action-only automation is complete even when the
+            // script naturally returns no value (for example `activate`). Asking
+            // the small dedicated model for another turn after that point lets
+            // it repeat or expand the already-successful mutation until the user
+            // declines or the step cap fires. Data-bearing automation tasks keep
+            // the existing follow-up and read-back path. A returned value
+            // completes a read query, but is not by itself proof that a
+            // mutating automation changed state.
+            let hasOutput = !(trimmedOutput?.isEmpty ?? true)
+            let queryWithValue = mode == .query && hasOutput
+            let actionOnlyAutomation =
+                mode == .automate && !shouldVerify(mode: mode, task: task)
+            if execution.isSuccess, queryWithValue || actionOnlyAutomation {
                 let summary = completionSummary(
                     modelText: nil,
-                    lastOutput: trimmedOutput,
+                    lastOutput: queryWithValue ? trimmedOutput : nil,
                     scriptsExecuted: scriptsExecuted,
                     succeeded: succeeded,
                     failed: failed
@@ -1129,6 +1148,10 @@ public enum AppleScriptLoop {
             "state", "current", "name", "title", "url", "value", "count", "how many",
             "tell me", "show me", "check", "contents", "selected", "version", "summary",
             "is ", "are ", "does ",
+            // Exact/verbatim mutations need a post-action read. Do not
+            // classify them as fire-and-forget only because they are phrased
+            // as commands rather than questions.
+            "exactly", "contain", "insert ", "write ", "type ",
         ]
         return dataIntent.contains { t.contains($0) }
     }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -737,6 +737,52 @@ enum AgentToolLoop {
         }
     }
 
+    /// Recover one narrow post-success failure mode without executing a
+    /// second desktop mutation. Small local parent models can correctly run a
+    /// desktop subagent, receive its successful structured result, then emit
+    /// the same tool again with its primary required field omitted. The vMLX
+    /// parser truthfully turns that malformed call into an
+    /// `invalid_tool_arguments` envelope; feeding it back invites a blind
+    /// retry even though the requested desktop work already succeeded.
+    ///
+    /// This is intentionally NOT a general invalid-arguments repair. It only
+    /// returns the real summary from the immediately preceding successful
+    /// result when all of these are true: one of the three desktop subagent
+    /// tools is repeated, the parser reports that tool's primary required
+    /// field missing, and the prior success envelope belongs to that same
+    /// tool. Any other malformed call still executes normally and reaches the
+    /// parent for correction.
+    static func completedDesktopSummaryBeforeMalformedRepeat(
+        invocation: ServiceToolInvocation,
+        state: AgentTaskState
+    ) -> String? {
+        let requiredField: String
+        switch invocation.toolName {
+        case "computer_use": requiredField = "goal"
+        case "applescript": requiredField = "task"
+        case "mac_query": requiredField = "question"
+        default: return nil
+        }
+
+        guard
+            let argsData = invocation.jsonArguments.data(using: .utf8),
+            let args = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any],
+            args["_error"] as? String == "invalid_tool_arguments",
+            args["_tool"] as? String == invocation.toolName,
+            args["_field"] as? String == requiredField,
+            let priorEnvelope = state.lastResultEnvelope,
+            ToolEnvelope.isSuccess(priorEnvelope),
+            let priorData = priorEnvelope.data(using: .utf8),
+            let prior = try? JSONSerialization.jsonObject(with: priorData) as? [String: Any],
+            prior["tool"] as? String == invocation.toolName,
+            let result = prior["result"] as? [String: Any],
+            let rawSummary = result["summary"] as? String
+        else { return nil }
+
+        let summary = rawSummary.trimmingCharacters(in: .whitespacesAndNewlines)
+        return summary.isEmpty ? nil : summary
+    }
+
     /// Shared user-facing text for the `.overBudget` exit: the request
     /// cannot fit the model's context window even after every compaction
     /// lever was exhausted. Each surface wraps this in its own envelope
@@ -1138,6 +1184,26 @@ enum AgentToolLoop {
                 // A productive turn — reset the empty-turn recovery budget so
                 // a later unrelated empty turn gets its own fresh allowance.
                 consecutiveEmptyTurns = 0
+
+                // A desktop subagent already completed successfully, and the
+                // very next model step emitted only a malformed repeat of that
+                // same tool. Do not materialise or execute the duplicate call:
+                // finish with the prior tool's real summary. Requiring the
+                // surface text hook keeps this recovery on user-facing chat;
+                // headless/API surfaces retain their existing invalid-args
+                // contract instead of silently manufacturing a response.
+                if invocations.count == 1,
+                    let invocation = invocations.first,
+                    let summary = Self.completedDesktopSummaryBeforeMalformedRepeat(
+                        invocation: invocation,
+                        state: state
+                    ),
+                    let emitFinalText = hooks.emitFallbackText
+                {
+                    await emitFinalText(summary)
+                    return RunResult(exit: .finalResponse, iterations: iteration)
+                }
+
                 var outcomes: [AgentLoopToolOutcome] = []
                 outcomes.reserveCapacity(invocations.count)
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -827,7 +827,7 @@ public enum SystemPromptTemplates {
         ## Mac automation (AppleScript)
         - To READ Mac/app state needed by the current user request (Finder, Safari, Mail, Music, System Events, volume, …) use `mac_query(question)`: read-only, no confirmation, returns the actual `values`. Never invent a state question just to acknowledge feedback/conversation.
         - To CHANGE something use `applescript(task)`: each script is shown for approval or auto-run per the user's setting. Don't write AppleScript yourself.
-        - To insert EXACT/verbatim text (transcription, quote, code, long body) OR an exact existing identifier that must match precisely (a note title, file path, mailbox, or URL), pass it via `applescript(content=…)` or `applescript(contents={name:text})` and reference it by placeholder — reproduced verbatim instead of re-typed, so an exact name can't be mistyped. Use `contents` for several blocks.
+        - To insert EXACT/verbatim text (transcription, quote, code, long body) OR an exact existing identifier that must match precisely (a note title, file path, mailbox, or URL), always include the required instruction as `task` and pass the exact value separately: `applescript(task="Set the document to the provided content", content=…)` or `applescript(task="Use the provided named values", contents={name:text})`. `task` is still required when `content`/`contents` is present. Reference the supplied value by placeholder — it is reproduced verbatim instead of re-typed, so an exact name can't be mistyped. Use `contents` for several blocks.
         - Both return `status` + `values` + `errors` (with AppleScript error numbers) — read `values` to confirm, use `errors` to retry/fix. Not for shell, files, or web.
         """
 

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
@@ -789,6 +789,75 @@ struct AppleScriptLoopTests {
         #expect(await confirm.count == 1)
     }
 
+    @Test("a successful action-only automation stops before a repeating model can run it again")
+    func successfulActionStopsRepeatingModel() async {
+        let feed = SubagentFeed(toolCallId: "t-action-done", kindId: "applescript", title: "task")
+        let exec = ExecRecorder(result: successResult(nil))
+        let confirm = ConfirmCounter(approve: true)
+        // Reproduce the AppleScript 8B JANG_6M behavior seen for "Open
+        // TextEdit": after a successful no-output `activate`, it proposes
+        // another mutating script instead of emitting the terminal prose turn.
+        let seq = ScriptSequencer(repeating: call(#"tell application "TextEdit" to activate"#))
+
+        let result = await AppleScriptLoop.run(
+            task: "Open TextEdit",
+            modelId: "applescript-test",
+            feed: feed,
+            interrupt: InterruptToken(),
+            executionMode: .confirmEach,
+            confirm: { _ in await confirm.confirm() },
+            limits: RunLimits(maxSteps: 8),
+            sessionId: "s",
+            mode: .automate,
+            execute: { script, _ in await exec.run(script) },
+            nextScript: { _ in await seq.next() }
+        )
+
+        guard case .done(let summary) = result.outcome else {
+            Issue.record("expected .done, got \(result.outcome)")
+            return
+        }
+        #expect(summary == "Ran 1 script(s) successfully.")
+        #expect(result.scriptsExecuted == 1)
+        #expect(result.succeeded == 1)
+        #expect(result.failed == 0)
+        #expect(await exec.count == 1)
+        #expect(await confirm.count == 1)
+    }
+
+    @Test("a mutating script return is not accepted as exact-content verification")
+    func mutatingReturnNeedsReadBackForExactContent() async {
+        let feed = SubagentFeed(toolCallId: "t-exact-readback", kindId: "applescript", title: "task")
+        let exec = ExecRecorder(result: successResult("JANG6M LIVE PROOF"))
+        let confirm = ConfirmCounter(approve: true)
+        let write = call(
+            #"tell application "TextEdit" to set text of document 1 to "JANG6M LIVE PROOF""#,
+            id: "write"
+        )
+        let read = call(#"tell application "TextEdit" to get text of document 1"#, id: "read")
+        let seq = ScriptSequencer([write, read, nil])
+
+        let result = await AppleScriptLoop.run(
+            task: "Create a TextEdit document containing exactly JANG6M LIVE PROOF",
+            modelId: "applescript-test",
+            feed: feed,
+            interrupt: InterruptToken(),
+            executionMode: .confirmEach,
+            confirm: { _ in await confirm.confirm() },
+            sessionId: "s",
+            mode: .automate,
+            execute: { script, _ in await exec.run(script) },
+            nextScript: { _ in await seq.next() }
+        )
+
+        #expect(result.outcome.isSuccess)
+        #expect(result.scriptsExecuted == 2)
+        #expect(result.lastOutput == "JANG6M LIVE PROOF")
+        #expect(await exec.count == 2)
+        // The mutating write is confirmed; the read-back is auto-run.
+        #expect(await confirm.count == 1)
+    }
+
     private static let uiScriptingScript =
         #"tell application "System Events" to tell process "Safari" to click menu item "Save" of menu "File" of menu bar 1"#
 
@@ -1106,13 +1175,16 @@ struct AppleScriptLoopTests {
     @Test("the step cap terminates a model that keeps proposing scripts")
     func stepCapReached() async {
         let feed = SubagentFeed(toolCallId: "t-cap", kindId: "applescript", title: "task")
-        let exec = ExecRecorder(result: successResult())
+        // A data-bearing task still needs a returned value. Keep returning a
+        // successful empty result so a model that never supplies that value
+        // remains bounded by the step cap.
+        let exec = ExecRecorder(result: successResult(nil))
         let confirm = ConfirmCounter(approve: true)
         // Always proposes a valid script (never signals completion).
         let seq = ScriptSequencer(repeating: validCall())
 
         let result = await AppleScriptLoop.run(
-            task: "do it",
+            task: "report the resulting volume",
             modelId: "applescript-test",
             feed: feed,
             interrupt: InterruptToken(),
@@ -1865,6 +1937,73 @@ struct AppleScriptToolSelectionGuidanceTests {
         #expect(SystemPromptTemplates.appleScriptGuidance.contains("Do not invent a Mac-state question"))
         #expect(SystemPromptTemplates.appleScriptGuidanceCompact.contains("current user request"))
         #expect(SystemPromptTemplates.appleScriptGuidanceCompact.contains("Never invent a state question"))
+    }
+
+    @Test("compact exact-text guidance keeps task required alongside content")
+    func compactExactTextGuidanceKeepsRequiredTask() {
+        let prompt = SystemPromptTemplates.appleScriptGuidanceCompact
+        #expect(prompt.contains("always include the required instruction as `task`"))
+        #expect(prompt.contains("`task` is still required when `content`/`contents` is present"))
+        #expect(prompt.contains("applescript(task="))
+    }
+}
+
+@Suite("AppleScript external model availability")
+struct AppleScriptExternalModelAvailabilityTests {
+    @Test("a Settings-selected model folder satisfies the AppleScript availability gate")
+    func externalJANG6MIsInstalledAndResolves() async {
+        await OsaurusTestGlobals.withPathsLock {
+            let fm = FileManager.default
+            let manifestRoot = fm.temporaryDirectory.appendingPathComponent(
+                "osaurus-applescript-manifest-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let modelsRoot = fm.temporaryDirectory.appendingPathComponent(
+                "osaurus-applescript-models-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let bundle = modelsRoot.appendingPathComponent(
+                AppleScriptModelCatalog.model8BId,
+                isDirectory: true
+            )
+            let previousRoot = OsaurusPaths.overrideRoot
+            let previousOverride = ExternalModelLocator.testRootsOverride
+            OsaurusPaths.overrideRoot = manifestRoot
+            ExternalModelLocator.invalidateInMemory()
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                ExternalModelLocator.testRootsOverride = previousOverride
+                ExternalModelLocator.invalidateInMemory()
+                try? fm.removeItem(at: manifestRoot)
+                try? fm.removeItem(at: modelsRoot)
+            }
+
+            try? fm.createDirectory(at: bundle, withIntermediateDirectories: true)
+            try? Data("{}".utf8).write(to: bundle.appendingPathComponent("config.json"))
+            try? Data("{}".utf8).write(to: bundle.appendingPathComponent("tokenizer.json"))
+            try? Data("w".utf8).write(to: bundle.appendingPathComponent("model.safetensors"))
+
+            ExternalModelLocator.testRootsOverride = [
+                (root: modelsRoot, source: .customModelFolder)
+            ]
+            ExternalModelLocator.rescan()
+
+            #expect(
+                ExternalModelLocator.path(forId: AppleScriptModelCatalog.model8BId)?
+                    .standardizedFileURL.path == bundle.standardizedFileURL.path
+            )
+            #expect(
+                AppleScriptModelCatalog.installedModels().map(\.id).contains(
+                    AppleScriptModelCatalog.model8BId
+                )
+            )
+            #expect(AppleScriptModelCatalog.hasInstalledModel)
+            #expect(
+                AppleScriptModelCatalog.resolveInstalledModelId(
+                    preferred: AppleScriptModelCatalog.model8BId
+                ) == AppleScriptModelCatalog.model8BId
+            )
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -35,13 +35,14 @@ private final class ScriptedLoopSurface {
     var dedupedCalls: [(name: String, callId: String, held: String)] = []
     var willProcessCallIds: [String] = []
     var batchOutcomes: [[AgentLoopToolOutcome]] = []
+    var emittedFinalTexts: [String] = []
 
     init(steps: [AgentLoopModelStep]) {
         self.steps = steps
     }
 
-    func makeHooks() -> AgentLoopHooks {
-        AgentLoopHooks(
+    func makeHooks(includeFallbackText: Bool = true) -> AgentLoopHooks {
+        var hooks = AgentLoopHooks(
             isCancelled: { self.cancelled },
             buildMessages: { notices in
                 self.builtNotices.append(notices)
@@ -70,6 +71,12 @@ private final class ScriptedLoopSurface {
             },
             pendingTodoCount: pendingTodos.map { count in { count } }
         )
+        if includeFallbackText {
+            hooks.emitFallbackText = { text in
+                self.emittedFinalTexts.append(text)
+            }
+        }
+        return hooks
     }
 }
 
@@ -485,6 +492,148 @@ struct AgentToolLoopTests {
             #expect(result.exit == .finalResponse, "kind=\(kind.rawValue)")
             #expect(surface.builtNotices.count == 2, "kind=\(kind.rawValue)")
         }
+    }
+
+    @Test func malformedAppleScriptRepeatAfterSuccessFinishesFromRealSummary() async throws {
+        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task","_message":"missing required argument: task","_expected":"required parameter"}"#
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("applescript", #"{"task":"Open TextEdit"}"#)]),
+            .toolCalls([inv("applescript", malformed)]),
+            .toolCalls([inv("never_runs")]),
+        ])
+        surface.toolResults["applescript"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "applescript",
+                result: [
+                    "kind": "applescript",
+                    "status": "succeeded",
+                    "scripts_run": 1,
+                    "summary": "Ran 1 script(s) successfully.",
+                ]
+            )
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 2))
+        #expect(surface.executedCalls.map(\.name) == ["applescript"])
+        #expect(surface.willProcessCallIds.count == 1)
+        #expect(surface.emittedFinalTexts == ["Ran 1 script(s) successfully."])
+        #expect(surface.steps.count == 1)
+    }
+
+    @Test func malformedDesktopCallWithoutMatchingSuccessStillExecutes() async throws {
+        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task","_message":"missing required argument: task"}"#
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("file_read", #"{"path":"notes.txt"}"#)]),
+            .toolCalls([inv("applescript", malformed)]),
+        ])
+        surface.toolResults["applescript"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "missing required argument: task",
+                tool: "applescript"
+            )
+        )
+
+        _ = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(surface.executedCalls.map(\.name) == ["file_read", "applescript"])
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func malformedDesktopRepeatRecoveryRejectsNearMisses() {
+        let state = AgentTaskState()
+        state.record(
+            name: "applescript",
+            argsJSON: #"{"task":"Open TextEdit"}"#,
+            result: ToolEnvelope.success(
+                tool: "applescript",
+                result: ["summary": "Ran 1 script(s) successfully."]
+            )
+        )
+
+        let wrongField = inv(
+            "applescript",
+            #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"content"}"#
+        )
+        let wrongToolEnvelope = inv(
+            "applescript",
+            #"{"_error":"invalid_tool_arguments","_tool":"computer_use","_field":"task"}"#
+        )
+        let unrelatedTool = inv(
+            "file_read",
+            #"{"_error":"invalid_tool_arguments","_tool":"file_read","_field":"path"}"#
+        )
+
+        #expect(
+            AgentToolLoop.completedDesktopSummaryBeforeMalformedRepeat(
+                invocation: wrongField,
+                state: state
+            ) == nil
+        )
+        #expect(
+            AgentToolLoop.completedDesktopSummaryBeforeMalformedRepeat(
+                invocation: wrongToolEnvelope,
+                state: state
+            ) == nil
+        )
+        #expect(
+            AgentToolLoop.completedDesktopSummaryBeforeMalformedRepeat(
+                invocation: unrelatedTool,
+                state: state
+            ) == nil
+        )
+
+        let emptySummaryState = AgentTaskState()
+        emptySummaryState.record(
+            name: "applescript",
+            argsJSON: #"{"task":"Open TextEdit"}"#,
+            result: ToolEnvelope.success(tool: "applescript", result: ["summary": "  "])
+        )
+        let exactMalformed = inv(
+            "applescript",
+            #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task"}"#
+        )
+        #expect(
+            AgentToolLoop.completedDesktopSummaryBeforeMalformedRepeat(
+                invocation: exactMalformed,
+                state: emptySummaryState
+            ) == nil
+        )
+    }
+
+    @Test func malformedAppleScriptRepeatStillExecutesOnHeadlessSurface() async throws {
+        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task"}"#
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("applescript", #"{"task":"Open TextEdit"}"#)]),
+            .toolCalls([inv("applescript", malformed)]),
+            .finalResponse,
+        ])
+        surface.toolResults["applescript"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "applescript",
+                result: ["summary": "Ran 1 script(s) successfully."]
+            )
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: headlessPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeFallbackText: false)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 3))
+        #expect(surface.executedCalls.map(\.name) == ["applescript", "applescript"])
+        #expect(surface.emittedFinalTexts.isEmpty)
     }
 
     @Test func unrelatedNonretryableExecutionFailureKeepsExistingPivotBehavior() async throws {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5245,6 +5245,12 @@ final class ChatSession: ObservableObject {
                             // Empty-turn recovery exhausted: render a visible
                             // message into the assistant turn so the user never
                             // sees a silent "No visible text was produced".
+                            // The same hook finalises the narrowly recovered
+                            // post-success desktop-tool repeat. Clear any
+                            // committed pending preview first so a suppressed
+                            // malformed call cannot leave a tool card spinning.
+                            assistantTurn.pendingToolName = nil
+                            assistantTurn.clearPendingToolArgs()
                             assistantTurn.appendContentAndNotify(text)
                             self.rebuildVisibleBlocks()
                         }

--- a/Packages/OsaurusCore/Views/Model/AppleScriptModelsView.swift
+++ b/Packages/OsaurusCore/Views/Model/AppleScriptModelsView.swift
@@ -379,7 +379,7 @@ struct AppleScriptModelsView: View {
     }
 
     private func refreshInstalled() {
-        installedIds = Set(catalog.filter { $0.isDownloaded }.map(\.id))
+        installedIds = Set(AppleScriptModelCatalog.installedModels().map(\.id))
     }
 
     private func normalized(_ value: String) -> String? {

--- a/docs/AGENT_COMPUTER_USE_APPLESCRIPT_PROOF_2026-07-16.md
+++ b/docs/AGENT_COMPUTER_USE_APPLESCRIPT_PROOF_2026-07-16.md
@@ -2,18 +2,270 @@
 
 Last updated: 2026-07-17 (America/Los_Angeles)
 
-Overall verdict: **PARTIAL.** The focused source candidate and isolated Release
-app now prove the narrow parent-loop safeguards for the two Osaurus 0.22.5
-reports: exact feedback-only text produced three acknowledgements with no tool
-call; returned non-retryable `computer_use` and `mac_query` failures stopped
-without another action or fabricated answer; and the Computer Use loop's exact
-`OsaurusToolChoice`/422 miss is covered by the real Xcode test graph. The
-successful AppleScript-8B-as-Computer-Use action/finalization row is still
-**BLOCKED**: JANG_6M emitted an invalid `agent_action` verb and JANG_4M exhausted
-the bounded corrective re-ask with model-step timeouts before either performed
-the requested action. This branch therefore fixes and live-proves failure
-containment and feedback tool selection, but does not claim that AppleScript 8B
-is a compatible or reliable Computer Use model.
+## Reopened JANG_6M acceptance lane (2026-07-17)
+
+The earlier merge is not final acceptance for the two AppleScript 8B reports.
+It proved the bounded `agent_action` protocol re-ask, parent-chat failure
+containment, and feedback-only tool-selection guard, but it did not complete a
+successful AppleScript-8B-as-Computer-Use action. This lane is reopened on exact
+current `origin/main` with the following non-negotiable scope:
+
+- Do not download, load, compare, or draw conclusions from MXFP4. The primary
+  helper is the installed
+  `/Users/eric/models/OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`; the byte-identical
+  `/Users/eric/models/JANGQ-AI/AppleScript-8B-JANG_6M` mirror is inventory only.
+- Configure the real development app through visible Settings and agent UI.
+  Source tests, evaluator runs, and API calls are supporting evidence only.
+- A reported-success row passes only when the requested macOS state is visibly
+  achieved, the helper emits the terminal completion contract, the parent does
+  not display `The model did not produce a valid required tool call`, and the
+  UI records token/s.
+- Reproduce both reports in sequence: complete two real actions, then send the
+  exact feedback sentence and require a plain acknowledgement with no tool row.
+- No prompt keyword classifier, forced sampler, synthetic closer, parser
+  masking, hidden model reroute, or output-cap workaround is allowed.
+
+### Required live matrix
+
+| Group | Scenarios | Pass condition |
+| --- | --- | --- |
+| Settings and persistence | Select JANG_6M for Computer Use and AppleScript; toggle each ability; Confirm Each; Fast Reads; Keep Warm; quit/relaunch | Visible selections persist and the runtime feed names the selected helper rather than a fallback |
+| Reported Computer Use successes | Open TextEdit; open Calculator; open Safari and navigate to a harmless local/Osaurus page | Each requested app/state is visibly correct and the same turn ends once with a grounded success, no required-tool failure |
+| Completion variants | App closed vs already open; one-step open; multi-step open+type/navigation; repeat action in same chat; helper plain-text-after-action; explicit `done` | No duplicate action, contradictory failure, blind retry, or post-success loop |
+| Exact feedback regression | After two successes, send the quoted feedback sentence; repeat in fresh chat and paraphrased acknowledgement-only turns | Plain acknowledgement only; no `mac_query`, AppleScript, Computer Use, date/time invention, or other tool |
+| Requested reads and failure grounding | Explicit current date/time request; front-app/title read; nonexistent app; compile/runtime failure; timeout; user denial/cancel | Requested reads use real state; failures report the returned error and never fabricate a value or launch an unrelated fallback |
+| Ability routing | Computer Use only; AppleScript only; both enabled; Fast Reads on/off | The selected tool matches the request and its configured model path; no stale tool choice crosses turns |
+| Multi-turn and recovery | Success -> feedback -> success; failure -> corrected request; cancel -> new request; stop during generation -> retry | History remains coherent, tools remain available, and no orphaned feed/model residency remains |
+| Spawn/delegation boundary | Spawn before/after AppleScript; target with subagent toggles; disabled target; missing/denied target; parent resumes AppleScript | Spawned children do not receive recursive Computer Use/AppleScript schemas; parent tools remain usable and no inherited scope/tool-choice leaks |
+| Resource behavior | Cold/warm helper load, unload/reload handoff, Keep Warm expiry, stop cleanup, visible Activity Monitor footprint | Model identity, token/s, residency transitions, and physical footprint are recorded; no concurrent double-residency or zombie load |
+
+### Initial current-main source trace
+
+- `ComputerUseKind` can run on a per-agent model override and forces the single
+  strict `agent_action` schema. AppleScript 8B is native-trained for
+  `run_applescript`, so its generalization to `agent_action` must be proven live
+  rather than inferred from the model name or catalog placement.
+- `ComputerUseLoop` now maps only exact `OsaurusToolChoice` code 422 into its
+  bounded corrective re-ask. That is source/test coverage for the reported
+  finalization miss, not live proof that JANG_6M emits a valid terminal `done`.
+- `AppleScriptLoop` uses `tool_choice: auto`, not required, and accepts a
+  no-tool plain-text terminal response. Therefore the reported exact required-
+  tool error points to the Computer Use `agent_action` path, not the native
+  `run_applescript` loop.
+- Spawned text children intentionally exclude every subagent capability
+  (`computer_use`, `applescript`, `mac_query`, image, and nested spawn) from the
+  child schema. The adjacent acceptance target is boundary correctness and
+  parent recovery, not recursive desktop automation from the child.
+
+### Current-main live setup evidence
+
+- Exact source is current `origin/main` `4b96ae0ab8b3bc0d9c08315a1f138c7802fc0d50`.
+  The first isolated Release build completed, was ad-hoc signed, and passed
+  `codesign --verify --deep --strict`; its initial executable SHA-256 was
+  `9c57bcc31f73579f486ddf68b4a5255fc687ae56c82bc70db14678a2bbdcf980`.
+- Through the fresh onboarding and real agent Settings UI, the parent was set
+  to `Ornith-1.0-9B-MXFP8`; Computer Use was enabled with
+  `AppleScript 8B JANG_6M`; screen context was turned off; and the separate
+  AppleScript ability was enabled with `Osaurus AppleScript 8B JANG_6M` plus
+  Confirm Each. A quit/relaunch visibly preserved all of those selections.
+  This proves persistence only, not that either runtime route used the model.
+- The new proof bundle identity remained `Accessibility: Not Granted` even
+  after it was added to the visible Accessibility list and relaunched. Adding
+  a newly named client then surfaced macOS's Touch ID/password authorization
+  sheet. No credential was requested, entered, or automated. Computer Use
+  action rows therefore remain blocked on that identity.
+- Current main is being rebuilt under the already-authorized proof-only
+  `com.dinoki.osaurus.bonsai2041proof` identity shown enabled as
+  `Osaurus Bonsai PR2041 Proof` in System Settings. Production Osaurus
+  permissions and preferences are not being removed or toggled. That rebuild
+  must still show `Accessibility: Granted` in the app before it can supply any
+  Computer Use pass evidence.
+
+### Native JANG_6M reproduction on current main (2026-07-17 20:53-21:01 PDT)
+
+The first native-AppleScript row used the exact current-main Release executable
+SHA-256 `61087eb8033b8aedc20aacf9dbe6b32d167be638e8d4ee23d48fc25691783ecb`,
+bundle id `com.dinoki.osaurus.bonsai2041proof`, app path
+`/private/tmp/Osaurus-AppleScript-JANG6M-Current-Main.app`, and isolated root
+`/tmp/osaurus-applescript-jang6m-authorized-root-20260717-204905`. Visible
+Settings selected parent `Ornith-1.0-9B-MXFP8`, enabled only the AppleScript
+subagent, selected `Osaurus AppleScript 8B JANG_6M`, and kept Confirm Each on;
+Computer Use and Spawn were off. A new chat visibly switched the parent from
+the onboarding Gemma session to Ornith MXFP8 before the prompt was sent.
+
+`Open TextEdit` produced a valid `run_applescript` call, but the script did more
+than requested: it activated TextEdit and created a new document containing the
+unrelated text `Beginning of text fit until margin`. After approval, live
+TextEdit visibly showed that exact untitled document, proving the script really
+executed. The AppleScript run did not finish. It presented the same mutating
+confirmation again and, after that repeat was declined, generated a third,
+different mutating TextEdit script that would create more unrelated content.
+Stopping the run produced a red `Failed: Applescript` row with the canonical
+`user_denied` result. The unsaved TextEdit window was then closed.
+
+The owning source is `AppleScriptLoop.swift`: after recording a successful
+execution, lines 977-992 short-circuited only `mac_query` with a non-empty
+return value; automate mode always fed the success back for another helper-model
+turn. That exactly explains a real action followed by repeat/failure. The local
+candidate now terminates a successful action-only automation from the real
+execution record; data-bearing tasks with no returned value retain the read-back
+path, and execution failures retain correction/retry. No parser repair, sampler
+override, prompt classifier, synthetic tool call, or model reroute was added.
+
+Focused source proof is **PASS**: the new repeating-JANG regression executes
+and confirms exactly once, and the complete `AppleScriptLoopTests` suite passes
+through the workspace Xcode scheme. The first focused result bundle is
+`/tmp/osaurus-applescript-jang6m-tests-dd/Logs/Test/Test-OsaurusCoreTests-2026.07.17_21-04-59--0700.xcresult`;
+the full-suite rerun completed at 21:09 PDT. This is not yet patched-app live
+proof; the Release candidate is still rebuilding.
+
+### Exact-text success followed by malformed parent repeat (2026-07-17 21:39 PDT)
+
+The isolated live app then reproduced a second, outer-loop failure with the
+installed JANG_6M helper. The real-user prompt was `Use the native AppleScript
+helper to create a new unsaved TextEdit document containing exactly JANG6M LIVE
+PROOF and nothing else.` The first parent call included the required `task`
+with the exact value in that instruction; JANG_6M updated a real unsaved
+TextEdit document to exactly `JANG6M LIVE PROOF`; and the first tool envelope
+was a grounded success with
+`status:succeeded`, `scripts_run:1`, and summary `Done. Result: TextEdit
+document updated with JANG6M LIVE PROOF.` The helper generated at 43.5 tok/s.
+
+Despite that success, the parent immediately emitted a second `applescript`
+call omitting required `task`. The model's persisted reasoning said it should
+use the `content` parameter, but vMLX's canonical invalid envelope replaces the
+malformed raw arguments, so the presence of a raw `content` field is not
+claimed. vMLX correctly returned `_error:invalid_tool_arguments`,
+`_tool:applescript`, and `_field:task`; the
+chat displayed that failure and the parent proposed a third redundant call.
+The run was stopped before the duplicate mutation executed. The durable trace
+is session `D089CA3C-1190-4C64-B02B-589A64784F08`, sequence 12-16, in
+`/tmp/osaurus-applescript-jang6m-authorized-root-20260717-204905/chat-history/history.sqlite`.
+The Insights response at 21:39:14 showed the same canonical invalid envelope.
+
+This is **not** content-delta assembly. `ModelRuntime.streamWithTools` consumes
+the committed vMLX `.toolInvocation(name,argsJSON)` and converts that complete
+argument JSON into `ServiceToolInvocation`; `ChatView` catches that committed
+invocation directly. Its incremental argument fields are only a preview. At
+pinned vMLX revision `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`,
+`XMLFunctionParser.schemaValidationFailure` owns the exact missing-required-field
+envelope. The live compact system prompt and persisted model reasoning exposed
+the actual contract mismatch: compact guidance recommended `content` but did
+not repeat that `task` remains required, and the model reasoned that it should
+use the tool "with the `content` parameter."
+
+The current candidate fixes both owning boundaries without repairing arbitrary
+JSON or inventing output:
+
+- compact guidance now shows `applescript(task=..., content=...)` and states
+  that `task` remains required with `content` or `contents`;
+- if and only if the very next chat step repeats the same desktop tool with
+  vMLX's exact missing-primary-field envelope after a real successful envelope,
+  the UI finishes from that immediately preceding non-empty real summary and
+  does not execute or display the duplicate mutation;
+- mismatched prior tools, empty summaries, other required fields, unrelated
+  tools, API/headless surfaces, and other invalid arguments keep their existing
+  error behavior.
+
+Current source proof is **PASS**: after rebasing onto `origin/main`
+`39a764a52`, 66/66 focused tests passed at 23:08 PDT in
+`/tmp/osaurus-applescript-jang6m-tests-dd/Logs/Test/Test-OsaurusCoreTests-2026.07.17_23-08-12--0700.xcresult`.
+The selected suites cover the external-folder availability gate, action-only
+stop, exact-content readback, exact outer malformed repeat, mismatched-success
+negative control, and compact tool guidance. `git diff --check` is also clean.
+
+### Final patched Release live evidence (2026-07-17 22:18-22:58 PDT)
+
+The final candidate is the ad-hoc signed Release app
+`/private/tmp/Osaurus-AppleScript-JANG6M-Current-Main.app`, bundle id
+`com.dinoki.osaurus.bonsai2041proof`, isolated root
+`/tmp/osaurus-applescript-jang6m-authorized-root-20260717-204905`, exact vMLX
+revision `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`, and executable SHA-256
+`b6cfa6807de1d388586e06d729c414a048b56a7493fb71178fa4552a7c338980`.
+Its CDHash is `825f5eec5b6e77acbc2f33eccbd558636b6f888b`; deep/strict ad-hoc signature
+verification passed. The app was operated through visible UI only for the
+rows below. No MXFP4 bundle was downloaded, loaded, or used.
+
+After the final rebase, the Release app was rebuilt from the rebased source,
+copied, ad-hoc sealed, and deep/strict verified again. Its executable SHA-256
+was exactly the same
+`b6cfa6807de1d388586e06d729c414a048b56a7493fb71178fa4552a7c338980`
+as the visually exercised candidate. This is byte identity, not an inference
+that the upstream appcast-only commit could not affect the binary.
+
+Visible Settings selected parent `Ornith-1.0-9B-MXFP8`, enabled Computer Use
+and Spawn, allowed only local Ornith for Spawn, enabled AppleScript, selected
+`Osaurus AppleScript 8B JANG_6M`, and selected Confirm Each. Toggling
+AppleScript off hid its controls; toggling it back on restored JANG_6M and
+Confirm Each. After quitting and relaunching the exact executable with the
+same isolated root, all of those selections persisted. Models visibly listed
+AppleScript JANG_6M and Bonsai 1-bit as downloaded from the custom model
+folder. The live helper feed named
+`OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`, and the first load mapped all eight
+safetensor shards from `/Users/eric/models/OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`.
+
+Live rows on this exact candidate:
+
+- **PASS -- TextEdit activation:** the approval sheet showed only
+  `tell application "TextEdit" to activate`; TextEdit visibly became frontmost.
+  The tool returned `ok:true`, `status:succeeded`, `scripts_run:1`, one
+  successful step, and `Ran 1 script(s) successfully.` JANG_6M generated at
+  47.3 tok/s; the parent completed at 54.2 tok/s. No duplicate, malformed call,
+  required-tool failure, or contradictory failure appeared.
+- **PASS -- already-open correction:** JANG_6M first proposed the semantically
+  wrong `System Events` activation. Confirm Each exposed it and the user
+  declined. The model then produced the correct TextEdit activation; it ran
+  once and returned `ok:true`, `status:succeeded`. JANG_6M generated at
+  44.2 tok/s and the parent at 52.0 tok/s. This is a model-proposal defect with
+  a working user-safety/correction path, not a parser repair.
+- **PASS -- exact reported feedback:** after successful actions, the exact
+  sentence `For your information, both TextEdit and Calculator did open
+  successfully, it seems AppleScript did not report back to you correctly.`
+  received a plain acknowledgement at 66.2 tok/s. No `mac_query`, AppleScript,
+  Computer Use, date invention, or other tool row appeared.
+- **PASS -- spawn boundary and parent recovery:** a bounded local Spawn request
+  returned exactly `DELEGATED` in 5.0 seconds; the same parent then called the
+  native AppleScript helper, ran one correct TextEdit activation, and completed
+  with `ok:true`/`status:succeeded`. JANG_6M generated at 43.6 tok/s and the
+  parent at 66.7 tok/s. Parent AppleScript remained available after delegation.
+- **PARTIAL -- explicit current-time request:** the builtin current-time tool
+  grounded the correct local date/time, but the parent redundantly called
+  `mac_query`. The Fast Reads Ornith helper then made one successful read
+  followed by seven bad/time-out proposals before its step limit. The parent
+  used the builtin result and did not fabricate a value. Correctness passed;
+  redundant tool selection and helper efficiency did not.
+- **MODEL FAIL, HOST SAFETY PASS -- exact content:** the first JANG_6M script
+  correctly wrote `JANG6M FINAL READBACK PROOF`, visibly confirmed in TextEdit.
+  Because a mutating script's own return is not independent verification, the
+  host required a readback. JANG_6M instead repeated the identical write, then
+  proposed a nonsensical System Events script after the duplicate was declined.
+  Confirm Each exposed both; neither was auto-run, and Stop ended the row. This
+  is reproducible semantic/repetition behavior from the selected model after a
+  correct schema call. It is not counted as a host success and is not hidden by
+  a synthetic closer, automatic read, parser coercion, or false completion.
+
+The content/schema attribution is source- and runtime-grounded. vMLX
+`XMLFunctionParser.schemaValidationFailure` creates the exact
+`invalid_tool_arguments` envelope for a missing required field. Osaurus then
+maps the committed `.toolCall` to a complete `.toolInvocation(name,argsJSON)`;
+`ModelRuntime.streamWithTools` constructs the executable invocation only from
+that committed JSON. Incremental `toolCallProgress` is explicitly a native UI
+preview and is not dispatched. Therefore the observed missing-`task` repeat
+was a model/schema contract miss after a real success, not content-delta
+assembly. The final exact-content model failure used a valid outer
+`applescript(task,content)` call and valid first inner script, further excluding
+either streaming layer as its cause.
+
+Overall verdict for this follow-up: **PARTIAL BY MODEL, MERGEABLE FOR THE
+NARROW HOST FIXES AFTER CI.** The external-folder gate, action-only success
+finalization, feedback-only behavior, post-success malformed-repeat containment,
+settings persistence, Spawn boundary, and TextEdit state changes have current
+source plus final Release UI evidence. JANG_6M is not claimed reliable for
+arbitrary multi-step or exact-content automation, and AppleScript 8B is not
+claimed compatible with Computer Use's distinct `agent_action` contract.
+Calculator/Safari Computer Use, proof-identity Accessibility, Activity Monitor
+peak physical footprint, and the broader RAM/cache/routing matrix remain
+unproven or blocked and are not claims of this urgent patch.
 
 ## Scope and proof rules
 


### PR DESCRIPTION
## What this fixes

Two real host defects remained after #2071:

- AppleScript models found under a user selected external model folder were visible in Settings but rejected by the runtime availability gate.
- A successful native AppleScript action could keep asking JANG_6M for another script, repeat the mutation, and eventually surface a false failure. A related parent turn could repeat the same desktop tool with the required field missing after a real successful envelope.

This PR keeps the correction narrow. It does not add parser repair, forced prompts, sampler overrides, synthetic tool calls, automatic model rerouting, or false completion.

## Source changes

- Use the same external model registry for AppleScript discovery, selection, and runtime availability.
- End successful action-only native AppleScript automation after the first real successful execution.
- Keep mutating-script return values in the transcript, but require a separate read step before claiming exact-content or data-bearing state is verified.
- Clarify that task remains required when content or contents is supplied.
- On interactive chat only, suppress one exact malformed repeat after an immediately preceding successful result from the same desktop tool and finish from that real non-empty summary.
- Clear the pending UI preview when that recovered summary is rendered.
- Preserve existing behavior for mismatched tools, wrong fields, empty summaries, unrelated invalid calls, batches, and headless/API surfaces.

## Current source verification

Rebased onto origin/main 39a764a52.

Focused Xcode result: 66 passed, 0 failed, 0 skipped.

Result bundle:
`/tmp/osaurus-applescript-jang6m-tests-dd/Logs/Test/Test-OsaurusCoreTests-2026.07.17_23-08-12--0700.xcresult`

Coverage includes:

- external JANG_6M folder availability and resolution
- action-only stop before model repetition
- exact-content mutation requiring readback
- post-success malformed repeat recovery
- wrong field, wrong tool, unrelated tool, empty summary, batch, and headless negative controls
- compact tool guidance

`git diff --check` is clean. Local SwiftLint is unavailable; GitHub CI remains the lint gate.

## Exact Release UI evidence

No MXFP4 bundle was downloaded, loaded, or tested.

Visually exercised app:

- path: `/private/tmp/Osaurus-AppleScript-JANG6M-Current-Main.app`
- isolated bundle: `com.dinoki.osaurus.bonsai2041proof`
- isolated root: `/tmp/osaurus-applescript-jang6m-authorized-root-20260717-204905`
- vMLX: `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`
- executable SHA-256: `b6cfa6807de1d388586e06d729c414a048b56a7493fb71178fa4552a7c338980`

After the final rebase, a fresh Release rebuild was copied, ad-hoc sealed, deep/strict verified, and produced the exact same executable SHA-256. The live binary is byte-identical to the rebased build.

Visible Settings used Ornith-1.0-9B-MXFP8 as parent, Computer Use on, Spawn on with local Ornith allowed, AppleScript on, Osaurus AppleScript 8B JANG_6M selected, and Confirm Each selected. AppleScript off/on visibly hid/restored its controls. Quit/relaunch preserved the selections. Models visibly redetected JANG_6M and Bonsai 1-bit from the custom model folder. The helper loaded all eight shards from `/Users/eric/models/OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`.

Live rows:

- TextEdit activation: PASS. One approved script, visible frontmost TextEdit, ok true, status succeeded, scripts_run 1, JANG_6M 47.3 tok/s, parent 54.2 tok/s, no duplicate or required-tool failure.
- Already-open TextEdit: PASS with model warning. Confirm Each caught a wrong System Events proposal; JANG corrected, ran once, and completed. JANG_6M 44.2 tok/s, parent 52.0 tok/s.
- Exact reported feedback sentence: PASS. Plain acknowledgement at 66.2 tok/s; no mac_query, AppleScript, Computer Use, or invented date.
- Spawn then parent AppleScript: PASS. Spawn returned exactly DELEGATED; parent retained AppleScript, ran one TextEdit activation, and completed. JANG_6M 43.6 tok/s, parent 66.7 tok/s.
- Explicit current time: PARTIAL. Builtin time grounded the correct result, but the parent redundantly called mac_query and the Fast Reads helper wasted attempts. No value was fabricated.
- Exact TextEdit content: MODEL FAIL, HOST SAFETY PASS. The first valid script visibly wrote JANG6M FINAL READBACK PROOF. When independent verification was required, JANG_6M repeated the write and then proposed nonsensical System Events automation. Confirm Each exposed both; neither duplicate was auto-run and Stop returned user_denied. This is not claimed as a host success.

## Streaming versus schema attribution

The missing-task case is not content-delta assembly. vMLX schema validation creates the canonical invalid_tool_arguments envelope. Osaurus dispatches only the committed toolInvocation name plus complete args JSON; toolCallProgress is UI preview only. The exact-content model failure used a valid outer applescript task/content call and a valid first inner script, then failed semantically on the next model step.

## Scope and limitations

The diff is exactly nine AppleScript/JANG source, test, UI, and proof-ledger files. It contains no automatic routing, hardware guidance, Gemma runtime, Bonsai runtime, cache, RAM, image, or unrelated model changes.

This PR does not claim JANG_6M is reliable for arbitrary multi-step/exact-content automation or compatible with the distinct Computer Use agent_action schema. Calculator/Safari Computer Use, proof-identity Accessibility, Activity Monitor peak footprint, and broader RAM/cache/routing work remain unproven or blocked and are not release claims here.