### PR TITLE
Fix app-owned Sentry crashes and main-thread I/O stalls

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -1318,7 +1318,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         PluginRepositoryService.shared.stopBackgroundRefresh()
         ToastWindowController.shared.teardown()
         NotchWindowController.shared.teardown()
-        SharedConfigurationService.shared.remove()
+        // Server-state publications run on an ordered utility queue so the UI
+        // never blocks on runtime discovery I/O. Drain that queue before the
+        // hard process exit below, then remove the final instance directory.
+        SharedConfigurationService.shared.removeSynchronously()
         // `applicationWillTerminate` is sync and the process exits as
         // soon as it returns. Bridge to the actor synchronously so
         // any debounced greeting-pool entries land on disk — without
@@ -1333,6 +1336,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
 
         // Same for the Computer Use autonomy policy (its own coalescing writer).
         ComputerUsePolicyStore.flushPendingWrites()
+
+        // Agent-delegation, AppleScript, and image-generation settings use an
+        // ordered utility writer as well. Preserve a last-second toggle before
+        // the hard exit just like the other UI-facing configuration stores.
+        SubagentConfigurationStore.flushPendingWrites()
 
         // Aptabase batches analytics in an in-memory queue and normally drains
         // it from its own `willTerminate` observer — but that flush is async and

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfigurationStore.swift
@@ -11,6 +11,10 @@ enum SubagentConfigurationStore {
     private nonisolated(unsafe) static var overrideDirectory: URL?
     private nonisolated(unsafe) static var cachedSnapshot: SubagentConfiguration?
     private static let snapshotLock = NSLock()
+    private static let persistenceQueue = DispatchQueue(
+        label: "ai.osaurus.subagent-configuration.persistence",
+        qos: .utility
+    )
     private static let fileName = "agent-delegation.json"
 
     nonisolated static func setOverrideDirectory(_ url: URL?) {
@@ -40,25 +44,67 @@ enum SubagentConfigurationStore {
     nonisolated static func save(_ configuration: SubagentConfiguration) {
         let normalized = configuration.normalized
         let url = fileURL()
+        persistenceQueue.sync {
+            persist(normalized, to: url)
+        }
+        publish(normalized)
+    }
+
+    /// UI-facing save path. Snapshot publication is immediate so a toggle
+    /// affects subsequent agent resolution in the same run-loop turn, while
+    /// the atomic filesystem rename runs on one ordered utility queue instead
+    /// of beachballing SwiftUI (Sentry APPLE-MACOS-150). Serial ordering keeps
+    /// rapid edits last-write-wins on disk.
+    nonisolated static func saveAsync(_ configuration: SubagentConfiguration) {
+        let normalized = configuration.normalized
+        let url = fileURL()
+        publish(normalized)
+        persistenceQueue.async {
+            persist(normalized, to: url)
+        }
+    }
+
+    private nonisolated static func persist(
+        _ normalized: SubagentConfiguration,
+        to url: URL
+    ) {
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         do {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let data = try encoder.encode(normalized)
             try data.write(to: url, options: [.atomic])
-            snapshotLock.lock()
-            cachedSnapshot = normalized
-            snapshotLock.unlock()
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(
-                    name: .subagentConfigurationChanged,
-                    object: normalized
-                )
-            }
         } catch {
             print("[Osaurus] Failed to save SubagentConfiguration: \(error)")
         }
     }
+
+    private nonisolated static func publish(_ normalized: SubagentConfiguration) {
+        snapshotLock.lock()
+        cachedSnapshot = normalized
+        snapshotLock.unlock()
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .subagentConfigurationChanged,
+                object: normalized
+            )
+        }
+    }
+
+    /// Bounded drain for the hard-exit path. UI saves are deliberately
+    /// asynchronous, so a toggle followed immediately by Quit must wait for
+    /// the ordered atomic write before AppDelegate calls `_exit`.
+    nonisolated static func flushPendingWrites(timeout: TimeInterval = 1.5) {
+        let done = DispatchSemaphore(value: 0)
+        persistenceQueue.async { done.signal() }
+        _ = done.wait(timeout: .now() + timeout)
+    }
+
+    #if DEBUG
+        nonisolated static func flushPendingWritesForTests() {
+            flushPendingWrites()
+        }
+    #endif
 
     nonisolated static func snapshot() -> SubagentConfiguration {
         snapshotLock.lock()

--- a/Packages/OsaurusCore/Services/AgentBridge/LocalAgentBridge.swift
+++ b/Packages/OsaurusCore/Services/AgentBridge/LocalAgentBridge.swift
@@ -33,6 +33,13 @@ public final class LocalAgentBridge: @unchecked Sendable, AgentRuntimeBridge {
 
     private let lock = NSLock()
     private var actorQueues: [UUID: DispatchQueue] = [:]
+    private var schemaSnapshotCache: [UUID: String] = [:]
+    private var schemaSnapshotRefreshes: Set<UUID> = []
+
+    #if DEBUG
+        nonisolated(unsafe) static var schemaSnapshotOverrideForTests:
+            ((UUID) throws -> String)?
+    #endif
 
     init() {}
 
@@ -52,6 +59,8 @@ public final class LocalAgentBridge: @unchecked Sendable, AgentRuntimeBridge {
     public func forget(agentId: UUID) {
         lock.lock()
         actorQueues.removeValue(forKey: agentId)
+        schemaSnapshotCache.removeValue(forKey: agentId)
+        schemaSnapshotRefreshes.remove(agentId)
         lock.unlock()
     }
 
@@ -84,8 +93,41 @@ public final class LocalAgentBridge: @unchecked Sendable, AgentRuntimeBridge {
     }
 
     public func schemaSnapshot(agentId: UUID) throws -> String {
+        #if DEBUG
+            if let override = Self.schemaSnapshotOverrideForTests {
+                let rendered = try override(agentId)
+                cacheSchemaSnapshot(rendered, agentId: agentId)
+                return rendered
+            }
+        #endif
         let schema = try AgentDatabaseStore.shared.database(for: agentId).schema()
-        return SchemaSnapshot.render(schema)
+        let rendered = SchemaSnapshot.render(schema)
+        cacheSchemaSnapshot(rendered, agentId: agentId)
+        return rendered
+    }
+
+    /// Return the last rendered schema without opening or querying SQLite.
+    /// A miss starts one utility-queue refresh and returns immediately. This
+    /// is the preview/UI contract: the real send path still calls
+    /// `schemaSnapshot(agentId:)` for a live snapshot, while SwiftUI body
+    /// evaluation never waits on database open/WAL locks (Sentry
+    /// APPLE-MACOS-13D and APPLE-MACOS-152).
+    public func cachedSchemaSnapshot(agentId: UUID) -> String? {
+        lock.lock()
+        let cached = schemaSnapshotCache[agentId]
+        let shouldRefresh = cached == nil && schemaSnapshotRefreshes.insert(agentId).inserted
+        lock.unlock()
+
+        if shouldRefresh {
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                guard let self else { return }
+                _ = try? self.schemaSnapshot(agentId: agentId)
+                self.lock.lock()
+                self.schemaSnapshotRefreshes.remove(agentId)
+                self.lock.unlock()
+            }
+        }
+        return cached
     }
 
     // MARK: - AgentRuntimeBridge (writes)
@@ -760,7 +802,23 @@ public final class LocalAgentBridge: @unchecked Sendable, AgentRuntimeBridge {
     /// schema change too.
     private func refreshSchemaArtifacts(agentId: UUID, database: AgentDatabase) {
         guard let schema = try? database.schema() else { return }
+        cacheSchemaSnapshot(SchemaSnapshot.render(schema), agentId: agentId)
         SchemaDumper.dump(schema, for: agentId)
+    }
+
+    private func cacheSchemaSnapshot(_ rendered: String, agentId: UUID) {
+        lock.lock()
+        let changed = schemaSnapshotCache[agentId] != rendered
+        schemaSnapshotCache[agentId] = rendered
+        schemaSnapshotRefreshes.remove(agentId)
+        lock.unlock()
+        guard changed else { return }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .agentDatabaseSchemaSnapshotChanged,
+                object: agentId
+            )
+        }
     }
 
     /// If `date` falls inside the quiet-hours window, push it forward to
@@ -831,4 +889,10 @@ public final class LocalAgentBridge: @unchecked Sendable, AgentRuntimeBridge {
         }
         return probe
     }
+}
+
+extension Notification.Name {
+    static let agentDatabaseSchemaSnapshotChanged = Notification.Name(
+        "agentDatabaseSchemaSnapshotChanged"
+    )
 }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -258,6 +258,7 @@ public struct SystemPromptComposer: Sendable {
             agentId: agentId,
             executionMode: executionMode,
             soulSection: soulSection,
+            useCachedAgentDBSchema: false,
             trace: trace
         )
         let manifest = comp.manifest()
@@ -726,6 +727,7 @@ public struct SystemPromptComposer: Sendable {
         agentId: UUID,
         executionMode: ExecutionMode,
         soulSection: String? = nil,
+        useCachedAgentDBSchema: Bool,
         trace: TTFTTrace? = nil
     ) {
         let tools = toolset.tools
@@ -801,7 +803,10 @@ public struct SystemPromptComposer: Sendable {
                     content: OnboardingPrompt.block
                 )
             )
-            let snapshotText = Self.renderSchemaSnapshot(agentId: agentId)
+            let snapshotText = Self.renderSchemaSnapshot(
+                agentId: agentId,
+                cachedOnly: useCachedAgentDBSchema
+            )
             if !snapshotText.isEmpty {
                 agentDBSchemaSection = snapshotText
             }
@@ -1687,7 +1692,11 @@ public struct SystemPromptComposer: Sendable {
     /// open hasn't run yet) falls back to the empty-state block so the
     /// agent never sees a half-rendered prompt. Sync because the
     /// underlying `LocalAgentBridge.schemaSnapshot` is sync.
-    static func renderSchemaSnapshot(agentId: UUID) -> String {
+    static func renderSchemaSnapshot(agentId: UUID, cachedOnly: Bool = false) -> String {
+        if cachedOnly {
+            return LocalAgentBridge.shared.cachedSchemaSnapshot(agentId: agentId)
+                ?? SchemaSnapshot.emptyStateBlock
+        }
         do {
             return try LocalAgentBridge.shared.schemaSnapshot(agentId: agentId)
         } catch {
@@ -1808,7 +1817,8 @@ public struct SystemPromptComposer: Sendable {
             toolset: toolset,
             agentId: agentId,
             executionMode: executionMode,
-            soulSection: soulSection
+            soulSection: soulSection,
+            useCachedAgentDBSchema: true
         )
 
         let manifest = composer.manifest()

--- a/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
@@ -322,8 +322,16 @@ struct OpenAICompatibleToolCallAccumulator {
         var repaired = ""
         var inString = false
         var isEscaped = false
-        var braceCount = 0
-        var bracketCount = 0
+        // Track the exact expected closing-delimiter order instead of two
+        // independent counters. A streamed provider can emit a malformed
+        // suffix with an extra or mismatched `}` / `]`; the old counters then
+        // went negative and `0 ..< bracketCount` trapped in Swift's
+        // `Range` initializer (Sentry APPLE-MACOS-12S). Such a suffix is not
+        // safely repairable. Preserve it as a typed truncated-tool failure;
+        // only append delimiters that are genuinely missing from an otherwise
+        // well-nested prefix.
+        var expectedClosers: [Character] = []
+        var hasMismatchedClosingDelimiter = false
 
         for ch in trimmed {
             if inString {
@@ -349,13 +357,15 @@ struct OpenAICompatibleToolCallAccumulator {
                 if ch == "\"" {
                     inString = true
                 } else if ch == "{" {
-                    braceCount += 1
-                } else if ch == "}" {
-                    braceCount -= 1
+                    expectedClosers.append("}")
                 } else if ch == "[" {
-                    bracketCount += 1
-                } else if ch == "]" {
-                    bracketCount -= 1
+                    expectedClosers.append("]")
+                } else if ch == "}" || ch == "]" {
+                    if expectedClosers.last == ch {
+                        expectedClosers.removeLast()
+                    } else {
+                        hasMismatchedClosingDelimiter = true
+                    }
                 }
                 repaired.append(ch)
             }
@@ -373,11 +383,15 @@ struct OpenAICompatibleToolCallAccumulator {
             repaired = String(trimmedForComma.dropLast())
         }
 
-        for _ in 0 ..< bracketCount {
-            repaired.append("]")
+        if hasMismatchedClosingDelimiter {
+            print(
+                "[Osaurus] Warning: Tool call JSON has an unmatched closing delimiter and cannot be repaired: \(json.prefix(200))"
+            )
+            return ValidatedToolCallJSON(json: json, wasRepaired: true)
         }
-        for _ in 0 ..< braceCount {
-            repaired.append("}")
+
+        for closer in expectedClosers.reversed() {
+            repaired.append(closer)
         }
 
         if let data = repaired.data(using: .utf8),

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
@@ -3266,8 +3266,8 @@
         /// per-step durations into `SandboxConfiguration.lastBootDurations`
         /// for future ETA seeding, and clear the legacy provisioning flag.
         private func finishJourney(success: Bool) async {
-            await MainActor.run {
-                guard var journey = State.shared.journey else { return }
+            let completedJourney: ProvisioningJourney? = await MainActor.run {
+                guard var journey = State.shared.journey else { return nil }
                 let now = Date()
                 journey.finishedAt = now
                 journey.failed = !success
@@ -3288,10 +3288,14 @@
                 State.shared.journey = journey
                 Self.clearLegacyProvisioningScalars()
                 State.shared.currentActivity = nil
+                return success ? journey : nil
+            }
 
-                if success {
-                    Self.persistLearnedDurations(from: journey)
-                }
+            // SandboxConfigurationStore performs an atomic filesystem write.
+            // SandboxManager is already an actor, so persist after leaving the
+            // MainActor instead of stalling the progress UI at completion.
+            if let completedJourney {
+                Self.persistLearnedDurations(from: completedJourney)
             }
         }
 
@@ -3300,7 +3304,6 @@
         /// can seed ETAs from real history. Coalesces on the existing
         /// map so unrelated keys aren't blown away, and only re-saves
         /// when the map actually changed.
-        @MainActor
         private static func persistLearnedDurations(from journey: ProvisioningJourney) {
             var config = SandboxConfigurationStore.load()
             var durations = config.lastBootDurations ?? [:]

--- a/Packages/OsaurusCore/Services/SharedConfigurationService.swift
+++ b/Packages/OsaurusCore/Services/SharedConfigurationService.swift
@@ -7,15 +7,35 @@
 
 import Foundation
 
-@MainActor
-final class SharedConfigurationService {
+final class SharedConfigurationService: @unchecked Sendable {
     static let shared = SharedConfigurationService()
-    private let instanceId = UUID().uuidString
+    private let instanceId: String
+    private let baseDirectoryOverride: URL?
+    private let ioQueue = DispatchQueue(
+        label: "com.osaurus.shared-configuration",
+        qos: .utility
+    )
 
-    private init() {}
+    private enum Publication: Sendable {
+        case running(port: Int, address: String, exposeToNetwork: Bool)
+        case status(String)
+        case remove
+    }
+
+    init(
+        instanceId: String = UUID().uuidString,
+        baseDirectoryOverride: URL? = nil
+    ) {
+        self.instanceId = instanceId
+        self.baseDirectoryOverride = baseDirectoryOverride
+    }
 
     private func baseDirectoryURL() -> URL {
-        OsaurusPaths.resolvePath(new: OsaurusPaths.runtime(), legacy: "SharedConfiguration")
+        if let baseDirectoryOverride { return baseDirectoryOverride }
+        return OsaurusPaths.resolvePath(
+            new: OsaurusPaths.runtime(),
+            legacy: "SharedConfiguration"
+        )
     }
 
     private func instanceDirectoryURL() -> URL {
@@ -36,79 +56,97 @@ final class SharedConfigurationService {
 
     /// Update or remove the shared configuration based on server health
     func update(health: ServerHealth, configuration: ServerConfiguration, localAddress: String) {
-        guard let instanceDir = ensureDirectories() else { return }
-
-        let fileURL = instanceDir.appendingPathComponent("configuration.json")
-
-        switch health {
+        let publication: Publication = switch health {
         case .running:
-            let values: [String: Any] = [
+            .running(
+                port: configuration.port,
+                address: localAddress,
+                exposeToNetwork: configuration.exposeToNetwork
+            )
+        case .starting:
+            .status("starting")
+        case .restarting:
+            .status("restarting")
+        case .stopped, .stopping, .error:
+            .remove
+        }
+
+        // Server state is published by a main-thread Combine sink. Keep the
+        // filesystem work ordered, but never make that sink wait on mkdir,
+        // atomic rename, or recursive removal.
+        ioQueue.async { [self] in
+            perform(publication)
+        }
+    }
+
+    private func perform(_ publication: Publication) {
+        if case .remove = publication {
+            performRemove()
+            return
+        }
+
+        guard let instanceDir = ensureDirectories() else { return }
+        let fileURL = instanceDir.appendingPathComponent("configuration.json")
+        let values: [String: Any]
+
+        switch publication {
+        case .running(let port, let address, let exposeToNetwork):
+            values = [
                 "instanceId": instanceId,
                 "updatedAt": ISO8601DateFormatter().string(from: Date()),
-                "port": configuration.port,
-                "address": localAddress,
-                "url": "http://\(localAddress):\(configuration.port)",
-                "exposeToNetwork": configuration.exposeToNetwork,
+                "port": port,
+                "address": address,
+                "url": "http://\(address):\(port)",
+                "exposeToNetwork": exposeToNetwork,
                 "health": "running",
             ]
-            do {
-                let jsonData = try JSONSerialization.data(
-                    withJSONObject: values,
-                    options: [.prettyPrinted, .sortedKeys]
-                )
-                try jsonData.write(to: fileURL, options: [.atomic])
-                // Touch base directory mtime for discoverability of latest instance
-                _ = try? FileManager.default.setAttributes(
-                    [.modificationDate: Date()],
-                    ofItemAtPath: instanceDir.path
-                )
-            } catch {
-                print("[Osaurus] SharedConfigurationService: failed to write configuration: \(error)")
-            }
-        case .starting:
-            // Publish minimal metadata while starting
-            let values: [String: Any] = [
+        case .status(let status):
+            values = [
                 "instanceId": instanceId,
                 "updatedAt": ISO8601DateFormatter().string(from: Date()),
-                "health": "starting",
+                "health": status,
             ]
-            do {
-                let jsonData = try JSONSerialization.data(
-                    withJSONObject: values,
-                    options: [.prettyPrinted, .sortedKeys]
-                )
-                try jsonData.write(to: fileURL, options: [.atomic])
-            } catch {
-                print(
-                    "[Osaurus] SharedConfigurationService: failed to write starting configuration: \(error)"
-                )
-            }
-        case .restarting:
-            // Publish minimal metadata while restarting
-            let values: [String: Any] = [
-                "instanceId": instanceId,
-                "updatedAt": ISO8601DateFormatter().string(from: Date()),
-                "health": "restarting",
-            ]
-            do {
-                let jsonData = try JSONSerialization.data(
-                    withJSONObject: values,
-                    options: [.prettyPrinted, .sortedKeys]
-                )
-                try jsonData.write(to: fileURL, options: [.atomic])
-            } catch {
-                print(
-                    "[Osaurus] SharedConfigurationService: failed to write restarting configuration: \(error)"
-                )
-            }
-        case .stopped, .stopping, .error:
-            // Remove the file to indicate this instance is not serving
-            remove()
+        case .remove:
+            return
+        }
+
+        do {
+            let jsonData = try JSONSerialization.data(
+                withJSONObject: values,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try jsonData.write(to: fileURL, options: [.atomic])
+            // Touch the instance directory mtime for discovery ordering.
+            _ = try? FileManager.default.setAttributes(
+                [.modificationDate: Date()],
+                ofItemAtPath: instanceDir.path
+            )
+        } catch {
+            print("[Osaurus] SharedConfigurationService: failed to write configuration: \(error)")
         }
     }
 
     /// Remove this instance's shared files
     func remove() {
+        ioQueue.async { [self] in
+            performRemove()
+        }
+    }
+
+    /// Drain preceding publications and remove synchronously before `_exit`.
+    func removeSynchronously() {
+        ioQueue.sync { [self] in
+            performRemove()
+        }
+    }
+
+    #if DEBUG
+        func flushPendingIOForTests() {
+            ioQueue.sync {}
+        }
+    #endif
+
+    private func performRemove() {
         let instance = instanceDirectoryURL()
         do {
             if FileManager.default.fileExists(atPath: instance.path) {

--- a/Packages/OsaurusCore/Tests/AgentDelegation/SubagentConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/SubagentConfigurationStoreTests.swift
@@ -87,6 +87,24 @@ struct SubagentConfigurationStoreTests {
         #expect(decoded.defaultImageGenerationModelId == "flux")
     }
 
+    @Test("async UI save publishes immediately and persists in order")
+    func asyncSavePublishesAndPersistsInOrder() async throws {
+        let lease = await acquireSubagentStoreSandbox("agent-delegation-store-async")
+        defer { lease.release() }
+
+        SubagentConfigurationStore.saveAsync(
+            SubagentConfiguration(defaultAppleScriptModelId: "first")
+        )
+        SubagentConfigurationStore.saveAsync(
+            SubagentConfiguration(defaultAppleScriptModelId: "second")
+        )
+
+        #expect(SubagentConfigurationStore.snapshot().defaultAppleScriptModelId == "second")
+        SubagentConfigurationStore.flushPendingWritesForTests()
+        SubagentConfigurationStore.invalidateSnapshot()
+        #expect(SubagentConfigurationStore.snapshot().defaultAppleScriptModelId == "second")
+    }
+
     @Test("override directory swaps between sandboxes")
     func overrideDirectorySwapsBetweenSandboxes() async throws {
         // `lease.sandbox` is the first override; `lease.release()` resets

--- a/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
@@ -5,8 +5,9 @@
 //  Pins the contract for `ChatSession.selectedModelIsLocal` /
 //  `isStreamingLocalModel` — the detection that gates the "one local
 //  generation at a time, never interrupt an in-flight chat" behavior. A
-//  model counts as local iff it resolves in the installed-model catalog
-//  (`ModelManager.findInstalledModel`). That catalog merges osaurus-downloaded
+//  model counts as local iff it resolves in the installed-model catalog.
+//  Main-thread callers use the catalog snapshot rather than waiting for a cold
+//  scan. That catalog merges osaurus-downloaded
 //  models with externally-discovered ones (LM Studio, Hugging Face cache); the
 //  external discovery/merge itself is covered by `ModelManagerTests`, so here
 //  we drive the catalog through `scanLocalModelsOverrideForTests` and assert
@@ -102,6 +103,58 @@ struct LocalModelDetectionTests {
                 session.selectedModel = "Llama-3.2-3B-Instruct"
                 #expect(session.selectedModelIsLocal)
             }
+        }
+    }
+
+    @Test
+    func selectedModelIsLocal_neverWaitsForAColdCatalogScan() async throws {
+        try await ChatHistoryTestStorage.run {
+            let prevScan = ModelManager.scanLocalModelsOverrideForTests
+            let prevWait = ModelManager.localModelsScanWaitLimitOverrideForTests
+            let prevExternal = ExternalModelLocator.testRootsOverride
+            defer {
+                ModelManager.scanLocalModelsOverrideForTests = prevScan
+                ModelManager.localModelsScanWaitLimitOverrideForTests = prevWait
+                ExternalModelLocator.testRootsOverride = prevExternal
+                ExternalModelLocator.invalidateInMemory()
+                ModelManager.invalidateLocalModelsCache()
+            }
+
+            ExternalModelLocator.testRootsOverride = []
+            ModelManager.localModelsScanWaitLimitOverrideForTests = 2
+            let coldCatalog = [
+                MLXModel(
+                    id: "fixture/Cold-Scan-Only-Model",
+                    name: "Cold scan fixture",
+                    description: "not present in the picker cache",
+                    downloadURL: "https://example.invalid/cold"
+                )
+            ]
+            ModelManager.scanLocalModelsOverrideForTests = { _ in
+                Thread.sleep(forTimeInterval: 0.25)
+                return coldCatalog
+            }
+            ModelManager.invalidateLocalModelsCache()
+
+            let session = ChatSession()
+            session.selectedModel = "Cold-Scan-Only-Model"
+            let started = ContinuousClock.now
+            let initial = session.selectedModelIsLocal
+            let elapsed = started.duration(to: .now)
+
+            // A selection observer may already have started the background
+            // refresh, so either boolean is valid. The contract here is that
+            // reading it never waits for that refresh.
+            _ = initial
+            #expect(elapsed < .milliseconds(100))
+
+            // The UI getter is deliberately read-only. A normal background
+            // catalog refresh populates the snapshot without making the first
+            // main-thread lookup pay for the scan.
+            await Task.detached(priority: .utility) {
+                _ = ModelManager.discoverLocalModels()
+            }.value
+            #expect(session.selectedModelIsLocal)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/SchemaSnapshotPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SchemaSnapshotPreviewTests.swift
@@ -1,0 +1,48 @@
+//
+//  SchemaSnapshotPreviewTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SchemaSnapshotPreviewTests {
+    @Test
+    func cachedPreviewDoesNotWaitForSlowSQLiteRefresh() async throws {
+        let agentId = UUID()
+        let bridge = LocalAgentBridge.shared
+        bridge.forget(agentId: agentId)
+
+        LocalAgentBridge.schemaSnapshotOverrideForTests = { requestedId in
+            #expect(requestedId == agentId)
+            Thread.sleep(forTimeInterval: 0.25)
+            return "slow-schema-marker"
+        }
+        defer {
+            LocalAgentBridge.schemaSnapshotOverrideForTests = nil
+            bridge.forget(agentId: agentId)
+        }
+
+        let started = ContinuousClock.now
+        let first = SystemPromptComposer.renderSchemaSnapshot(
+            agentId: agentId,
+            cachedOnly: true
+        )
+        let elapsed = started.duration(to: .now)
+
+        #expect(first == SchemaSnapshot.emptyStateBlock)
+        #expect(elapsed < .milliseconds(100))
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        var cached: String?
+        while ContinuousClock.now < deadline {
+            cached = bridge.cachedSchemaSnapshot(agentId: agentId)
+            if cached == "slow-schema-marker" { break }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(cached == "slow-schema-marker")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -5,6 +5,42 @@ import Testing
 
 @Suite("OpenAI-compatible stream parser")
 struct OpenAICompatibleStreamParserTests {
+    @Test func malformedExtraClosingToolDelimiterDoesNotTrapOrDispatch() {
+        let accumulated: [Int: RemoteProviderService.StreamingState.ToolSlot] = [
+            0: (
+                id: "call_1",
+                name: "file_write",
+                args: #"{"path":"a"}}"#,
+                thoughtSignature: nil
+            )
+        ]
+
+        let result = OpenAICompatibleToolCallAccumulator.resolveAccumulatedToolCall(
+            from: accumulated,
+            finishMarker: "tool_calls"
+        )
+
+        guard case .truncated(let error) = result else {
+            Issue.record("Expected malformed extra closer to be quarantined, got \(result)")
+            return
+        }
+        #expect(error.localizedDescription.contains("file_write"))
+    }
+
+    @Test func malformedMismatchedToolDelimitersDoNotTrapOrDispatch() {
+        let validated = OpenAICompatibleToolCallAccumulator.validateToolCallJSON(#"{"x":[1}}"#)
+
+        #expect(validated.wasRepaired)
+        #expect(validated.json == #"{"x":[1}}"#)
+    }
+
+    @Test func truncatedNestedToolJSONClosesInNestingOrder() {
+        let validated = OpenAICompatibleToolCallAccumulator.validateToolCallJSON(#"{"x":[{"y":1}"#)
+
+        #expect(validated.wasRepaired)
+        #expect(validated.json == #"{"x":[{"y":1}]}"#)
+    }
+
     @Test func framer_joinsCRLFMultilineDataEvent() {
         let payload = "data: {\r\ndata:   \"x\":1\r\ndata: }\r\n\r\n"
         var parser = OpenAICompatibleStreamFramer.SSELineParser()

--- a/Packages/OsaurusCore/Tests/Service/CreditsTopUpSheetTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/CreditsTopUpSheetTests.swift
@@ -1,0 +1,26 @@
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Credits top-up amount parsing")
+struct CreditsTopUpSheetTests {
+    @Test func ordinaryDollarAmountsConvertToMicroUSD() {
+        #expect(CreditsTopUpSheet.parseMicroUSD("25") == 25_000_000)
+        #expect(CreditsTopUpSheet.parseMicroUSD(" $5.50 ") == 5_500_000)
+    }
+
+    @Test func oversizedFiniteAmountIsRejectedWithoutIntOverflow() {
+        #expect(CreditsTopUpSheet.parseMicroUSD("1e300") == nil)
+        #expect(CreditsTopUpSheet.parseMicroUSD(String(Double.greatestFiniteMagnitude)) == nil)
+        // `Double(Int.max)` is represented as 2^63, not Int.max. This amount
+        // reaches that exact post-scaling boundary and must remain failable.
+        #expect(CreditsTopUpSheet.parseMicroUSD("9223372036854.775808") == nil)
+    }
+
+    @Test func nonPositiveAndNonFiniteAmountsRemainInvalid() {
+        #expect(CreditsTopUpSheet.parseMicroUSD("0") == nil)
+        #expect(CreditsTopUpSheet.parseMicroUSD("-1") == nil)
+        #expect(CreditsTopUpSheet.parseMicroUSD("nan") == nil)
+        #expect(CreditsTopUpSheet.parseMicroUSD("inf") == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/SharedConfigurationServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SharedConfigurationServiceTests.swift
@@ -1,0 +1,71 @@
+//
+//  SharedConfigurationServiceTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SharedConfigurationServiceTests {
+    @Test
+    func publicationsAreOrderedAndSynchronousQuitRemovalDrainsThem() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-shared-config-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let service = SharedConfigurationService(
+            instanceId: "test-instance",
+            baseDirectoryOverride: root
+        )
+        var configuration = ServerConfiguration.default
+        configuration.port = 4242
+        configuration.exposeToNetwork = true
+
+        service.update(
+            health: .running,
+            configuration: configuration,
+            localAddress: "127.0.0.1"
+        )
+        service.flushPendingIOForTests()
+
+        let instance = root.appendingPathComponent("test-instance", isDirectory: true)
+        let file = instance.appendingPathComponent("configuration.json")
+        let data = try Data(contentsOf: file)
+        let json = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(json["health"] as? String == "running")
+        #expect(json["port"] as? Int == 4242)
+        #expect(json["exposeToNetwork"] as? Bool == true)
+
+        // Rapid state changes must be applied in submission order. A terminal
+        // state cannot be overtaken by an older pending write and resurrect a
+        // stale discovery file.
+        service.update(
+            health: .restarting,
+            configuration: configuration,
+            localAddress: "127.0.0.1"
+        )
+        service.update(
+            health: .stopped,
+            configuration: configuration,
+            localAddress: "127.0.0.1"
+        )
+        service.flushPendingIOForTests()
+        #expect(!FileManager.default.fileExists(atPath: instance.path))
+
+        // applicationWillTerminate uses this drain before its hard `_exit`.
+        service.update(
+            health: .running,
+            configuration: configuration,
+            localAddress: "127.0.0.1"
+        )
+        service.removeSynchronously()
+        #expect(!FileManager.default.fileExists(atPath: instance.path))
+    }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -6512,16 +6512,31 @@ struct AgentDetailView: View {
     }
 
     private func loadMemoryData() {
-        let db = MemoryDatabase.shared
-        if !db.isOpen { try? db.open() }
-        pinnedFacts = (try? db.loadPinnedFacts(agentId: agent.id.uuidString, limit: 200)) ?? []
-        episodes = (try? db.loadEpisodes(agentId: agent.id.uuidString, limit: 100)) ?? []
-        // Counts come from `sessions.turn_count` directly so the row's
-        // "N turns" label is accurate without hydrating each session's
-        // turn array (which only happens on click — the prior root cause
-        // of the persistent "0 turns" display).
-        let agentFilter: UUID? = (agent.id == Agent.defaultId) ? nil : agent.id
-        sessionTurnCounts = ChatHistoryDatabase.shared.turnCounts(forAgent: agentFilter)
+        let agentId = agent.id
+        let agentFilter: UUID? = (agentId == Agent.defaultId) ? nil : agentId
+
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                let db = MemoryDatabase.shared
+                if !db.isOpen { try? db.open() }
+                let facts =
+                    (try? db.loadPinnedFacts(agentId: agentId.uuidString, limit: 200)) ?? []
+                let episodes =
+                    (try? db.loadEpisodes(agentId: agentId.uuidString, limit: 100)) ?? []
+                // Counts come from `sessions.turn_count` directly so the row's
+                // "N turns" label is accurate without hydrating each session's
+                // turn array (which only happens on click).
+                let counts = ChatHistoryDatabase.shared.turnCounts(forAgent: agentFilter)
+                return (facts, episodes, counts)
+            }.value
+
+            // AgentDetailView can be reused while the detached query is live;
+            // never publish another agent's rows into the current editor.
+            guard agent.id == agentId else { return }
+            pinnedFacts = result.0
+            episodes = result.1
+            sessionTurnCounts = result.2
+        }
     }
 
     // MARK: - Agent Secrets

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -768,6 +768,7 @@ final class ChatSession: ObservableObject {
             voidNotification(.agentUpdated),
             voidNotification(.activeAgentChanged),
             voidNotification(.toolsListChanged),
+            voidNotification(.agentDatabaseSchemaSnapshotChanged),
             FolderContextService.shared.objectWillChange
                 .map { _ in () }.eraseToAnyPublisher(),
             $selectedModel.map { _ in () }.eraseToAnyPublisher(),
@@ -1222,11 +1223,19 @@ final class ChatSession: ObservableObject {
     /// models and externally-discovered ones (LM Studio, Hugging Face cache),
     /// since `findInstalledModel` resolves the merged local catalog. Foundation
     /// (Apple on-device) and remote provider models run on separate engines and
-    /// don't contend. Resolved against the catalog so it doesn't depend on
-    /// `pickerItems` being populated.
+    /// don't contend. The picker source is authoritative when available;
+    /// the fallback reads only the non-blocking installed-model snapshot.
+    /// Never run a cold disk scan here: this getter participates in warm-up
+    /// policy during SwiftUI/Combine callbacks, and the old blocking catalog
+    /// lookup parked the main thread for up to ten seconds (Sentry
+    /// APPLE-MACOS-158).
     var selectedModelIsLocal: Bool {
         guard let model = selectedModel else { return false }
-        return ModelManager.findInstalledModel(named: model) != nil
+        if let item = selectedPickerItem {
+            if case .local = item.source { return true }
+            return false
+        }
+        return ModelManager.findInstalledMLXModelFromCache(named: model) != nil
     }
 
     /// True while this session is streaming a reply from a local model.

--- a/Packages/OsaurusCore/Views/Credits/CreditsTopUpSheet.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsTopUpSheet.swift
@@ -275,11 +275,25 @@ struct CreditsTopUpSheet: View {
     /// Parse the amount field as a dollar amount into micro-USD. Tolerates a
     /// leading "$". Returns nil when empty or not a positive number.
     private var currentMicro: Int? {
-        let trimmed = amountTrimmed
+        Self.parseMicroUSD(amountTrimmed)
+    }
+
+    /// Parse user-entered dollars without ever invoking a trapping
+    /// floating-point-to-Int conversion. The checkout API accepts `Int`
+    /// micro-USD, so values above that representable range are invalid input,
+    /// not a reason to terminate the app (Sentry APPLE-MACOS-11A).
+    static func parseMicroUSD(_ amount: String) -> Int? {
+        let trimmed = amount.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return nil }
         let cleaned = trimmed.hasPrefix("$") ? String(trimmed.dropFirst()) : trimmed
         guard let dollars = Double(cleaned), dollars.isFinite, dollars > 0 else { return nil }
-        return Int((dollars * 1_000_000).rounded())
+        let micro = (dollars * 1_000_000).rounded()
+        guard micro.isFinite else { return nil }
+        // `Double(Int.max)` rounds up to 2^63 on 64-bit platforms, so a
+        // comparison against that value can still admit one trapping input.
+        // The failable exact initializer owns both the integral and range
+        // checks without ever invoking a trapping conversion.
+        return Int(exactly: micro)
     }
 
     private var isValid: Bool {

--- a/Packages/OsaurusCore/Views/ImageGeneration/ImageGenerationView.swift
+++ b/Packages/OsaurusCore/Views/ImageGeneration/ImageGenerationView.swift
@@ -250,7 +250,7 @@ private struct ImageGenerationSettingsTab: View {
         // Gated on `hasLoaded` so only real user edits write back.
         .onChange(of: configuration) { _, newValue in
             guard hasLoaded else { return }
-            SubagentConfigurationStore.save(newValue)
+            SubagentConfigurationStore.saveAsync(newValue)
         }
         // Re-snapshot if another surface mutates the shared store.
         .onReceive(

--- a/Packages/OsaurusCore/Views/Model/AppleScriptModelsView.swift
+++ b/Packages/OsaurusCore/Views/Model/AppleScriptModelsView.swift
@@ -73,7 +73,7 @@ struct AppleScriptModelsView: View {
         }
         .onChange(of: configuration) { _, newValue in
             guard hasLoaded else { return }
-            SubagentConfigurationStore.save(newValue)
+            SubagentConfigurationStore.saveAsync(newValue)
         }
         .onReceive(
             NotificationCenter.default.publisher(for: .subagentConfigurationChanged)

--- a/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
@@ -521,7 +521,7 @@ struct ConfigurationView: View {
         // `saveConfiguration`). The re-snapshot on the change notification keeps
         // this in sync if an agent's Subagents tab edits the shared store.
         .onChange(of: subagentConfiguration) { _, newValue in
-            SubagentConfigurationStore.save(newValue)
+            SubagentConfigurationStore.saveAsync(newValue)
         }
         .onReceive(
             NotificationCenter.default.publisher(for: .subagentConfigurationChanged)


### PR DESCRIPTION
## Summary

Fixes the app-owned failure paths in the current Sentry inventory without changing model prompts, samplers, routing, generation defaults, or runtime/cache policy.

- `APPLE-MACOS-12S`: replace independent streamed tool-JSON brace/bracket counters with an exact expected-closer stack. Extra or mismatched delimiters are quarantined as a typed truncated tool call and are never dispatched.
- `APPLE-MACOS-11A`: convert credit amounts with `Int(exactly:)` after finite/positive scaling checks, covering the rounded `Double(Int.max)` boundary without a trapping conversion.
- `APPLE-MACOS-158`: make chat warmup locality checks read picker/cache state instead of running cold model discovery from a main-thread getter.
- `APPLE-MACOS-152` / `13D`: keep live Agent DB schema generation on the real send path while context-budget previews use an asynchronously refreshed snapshot.
- `APPLE-MACOS-151` / `14Z`: move Agent Memory SQLite reads off the main thread and reject stale results when the viewed agent changes.
- `APPLE-MACOS-150` / `14Y`: move subagent settings and sandbox learned-duration writes off the main thread; preserve ordered last-write-wins persistence and bounded quit flushing.
- `APPLE-MACOS-12J`: serialize shared runtime publication/removal on a utility queue and synchronously drain/remove the instance directory before the app's hard exit.

## Source and test evidence

- Base: `8fd75506e773b186a8604aee3a8e727a435e072f`
- Pinned vMLX used by the workspace and proof app: `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`
- Focused result: 76 passed, 0 failed, 0 skipped
  - `/tmp/osaurus-sentry-cu-derived/Logs/Test/Test-OsaurusCoreTests-2026.07.18_15-44-21--0700.xcresult`
- Exact overflow/quit follow-up: 8 passed, 0 failed, 0 skipped
  - `/tmp/osaurus-sentry-cu-derived/Logs/Test/Test-OsaurusCoreTests-2026.07.18_15-56-41--0700.xcresult`
- `git diff --check` passes.

## Isolated Release app evidence

- Release build: `/tmp/osaurus-sentry-fixes-release-derived/Build/Products/Release/osaurus.app`
- Proof app: `/private/tmp/Osaurus-Sentry-Fix-Proof-20260718-1604.app`
- Dedicated bundle ID: `com.dinoki.osaurus.sentryfixproof20260718`
- Executable SHA-256: `3a4b1570d523eac6b7a8958e385ff43e07ebad5bb1f226e6afdaea01117ad87c`
- Dedicated root: `/private/tmp/osaurus-sentry-live-root-20260718-1604`

The app was operated through its real UI:

- Selected local `Gemma 4 12B it MXFP8` from `/Users/eric/models` (not MXFP4). The picker displayed 69 models without a beachball, warmup reached `Model warm`, and `Reply with exactly READY.` returned exactly `READY`: TTFT 0.96 s, 31.4 tok/s, 5 tokens. Physical footprint was about 2.1 GB after the response.
- Toggled RAM-Safety Preflight off/on and confirmed it remained on after relaunch.
- Enabled AppleScript delegation and selected installed `Osaurus AppleScript 8B JANG_6M`; both settings persisted after relaunch. This proves selection/persistence, not AppleScript model execution.
- Opened Agent Memory, saw the real READY chat, enabled the agent Database, and observed the context estimate update from about 3.2k to 5.7k without a UI stall. The breakdown showed about 2.6k system prompt and 3.1k tools and remained available after relaunch.
- Changed the isolated server from occupied port 1337 to 21337 through Settings. After relaunch, direct `/health` returned HTTP 200 with model root `/Users/eric/models`, model count 64, disk L2 hit/miss/store counts 1/1/1, `turboquant_compressions=0`, and RAM feasibility `ok`.
- Command-Q exited the process, stopped port 21337, and removed the exact runtime publication directory before termination.
- Configured a localhost-only OpenAI-compatible provider through the Providers UI. Its strict SSE response emitted `web_search` arguments `{"query":"test"}}`. The UI displayed a typed streaming error; logs showed the unmatched closer was quarantined on the initial request plus two bounded retries. No tool dispatch and no crash occurred.
- No new Osaurus report appeared in `~/Library/Logs/DiagnosticReports` during the proof window.

## Boundaries

- This is a draft until canonical CI completes.
- The Credits sheet's live boundary is blocked by the isolated/keychain-free app having no Osaurus Identity; no identity or financial action was created for this proof. Source and exact boundary unit tests pass.
- Sandbox learned-duration persistence has source/unit coverage but was not live-provisioned.
- `APPLE-MACOS-12W` is not changed: its current events are macOS 27 AppKit/SafariPlatformSupport remote-view assertions with no app-owned stack frame identifying a safe fix.
- Cross-user Sentry recurrence is not claimed resolved by one local run.
- This PR contains no Gemma/Bonsai runtime fix, model-routing or hardware-guidance change, forced reasoning behavior, sampler/prompt/template coercion, TurboQuant/cache change, or MXFP4 claim.
