### PR TITLE
Add combined-mode file_copy bridge for binary files between workspace and sandbox

### DIFF
--- a/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
+++ b/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
@@ -120,6 +120,15 @@ public enum ChatExecutionContext {
     /// when `hostReadOnlyScope` is non-nil.
     @TaskLocal public static var allowHostSecretReads: Bool = false
 
+    /// Combined-mode write grant: `true` when the active agent's
+    /// `allowHostFolderWrites` opt-in is on for the current execution.
+    /// Bound by `ToolRegistry.execute` alongside `hostReadOnlyScope` so
+    /// tool BODIES that route by path (`file_copy`) can gate host-bound
+    /// destinations at execute time — schema visibility alone can't,
+    /// because the same tool serves both directions. `false` in every
+    /// other mode (and in read-only combined mode).
+    @TaskLocal public static var allowHostFolderWrites: Bool = false
+
     /// Sandbox identity for combined mode, letting the unified host
     /// `file_*` tools serve an absolute `/workspace/...` path from the
     /// Linux sandbox (path-routed file access). Bound by

--- a/Packages/OsaurusCore/Folder/FileCopyTool.swift
+++ b/Packages/OsaurusCore/Folder/FileCopyTool.swift
@@ -1,0 +1,292 @@
+//
+//  FileCopyTool.swift
+//  osaurus
+//
+//  Combined-mode bridge tool: copies file BYTES between the user's host
+//  workspace folder and the Linux sandbox's VirtioFS-backed storage
+//  (`/workspace/...`), host-side via FileManager. This is the only way a
+//  binary file (PDF, image, archive) crosses the boundary — `file_read`
+//  extracts text and `file_write` carries text through tokens, so neither
+//  can deliver raw bytes. Registered with the folder tools but visible
+//  ONLY in combined sandbox + host-read mode.
+//
+
+import Foundation
+
+struct FileCopyTool: OsaurusTool, PermissionedTool {
+    let name = "file_copy"
+    let description =
+        "Copy a file between the user's workspace folder and the sandbox — the only way to move "
+        + "binary files (PDFs, images, archives) between them. Bytes are copied directly; nothing "
+        + "passes through the conversation. Each path routes like the other file tools: a relative "
+        + "path is the workspace, an absolute `/workspace/...` path is the sandbox. To process a "
+        + "workspace file with sandbox commands, copy it to a path under your sandbox home first. "
+        + "Pass `overwrite: true` to replace an existing destination. "
+        + "Example: {\"source\": \"data/report.pdf\", \"destination\": \"/workspace/agents/NAME/report.pdf\"} "
+        + "(where `/workspace/agents/NAME` is your sandbox home)"
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "source": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "File to copy: relative path = workspace, `/workspace/...` = sandbox"
+                ),
+            ]),
+            "destination": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Where to copy it (including the filename): relative path = workspace, "
+                        + "`/workspace/...` = sandbox"
+                ),
+            ]),
+            "overwrite": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Replace the destination if it already exists (default: false)"
+                ),
+            ]),
+        ]),
+        "required": .array([.string("source"), .string("destination")]),
+    ])
+
+    var requirements: [String] { [] }
+    var defaultPermissionPolicy: ToolPermissionPolicy { .auto }
+    /// A host-bound copy mutates the selected folder; the registry's dual
+    /// checkpoint (host + sandbox in combined mode) makes every copy land
+    /// in the Changes sheet and stay undoable, whichever side it touched.
+    var mutatesHostFolder: Bool { true }
+
+    /// Same 512 MB precedent as `SandboxManager.maxArtifactDownloadBytes`:
+    /// far above any realistic document, but stops a runaway copy of a
+    /// disk image / model checkpoint from filling the sandbox share.
+    static let defaultMaxCopyBytes = 512 * 1024 * 1024
+
+    private let rootPath: URL
+    private let maxCopyBytes: Int
+
+    init(rootPath: URL, maxCopyBytes: Int = FileCopyTool.defaultMaxCopyBytes) {
+        self.rootPath = rootPath
+        self.maxCopyBytes = maxCopyBytes
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let sourceReq = requireString(
+            args,
+            "source",
+            expected: "relative workspace path or absolute `/workspace/...` sandbox path",
+            tool: name
+        )
+        guard case .value(let source) = sourceReq else {
+            return sourceReq.failureEnvelope ?? ""
+        }
+        let destinationReq = requireString(
+            args,
+            "destination",
+            expected: "relative workspace path or absolute `/workspace/...` sandbox path",
+            tool: name
+        )
+        guard case .value(let destination) = destinationReq else {
+            return destinationReq.failureEnvelope ?? ""
+        }
+        let overwrite = coerceBool(args["overwrite"]) ?? false
+
+        // Combined-mode-only surface: without the sandbox identity there is
+        // no second filesystem to bridge to, so refuse instead of guessing
+        // (plain folder mode has shell `cp`; plain sandbox mode has no
+        // workspace).
+        guard ChatExecutionContext.sandboxReadBridge != nil else {
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message:
+                    "`file_copy` is only available in combined sandbox + workspace mode. "
+                    + "Use `shell_run` (`cp`) in folder mode, or `sandbox_exec` (`cp`) in sandbox mode.",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        let sourceRoute = combinedFileRoute(path: source)
+        let destinationRoute = combinedFileRoute(path: destination)
+
+        // Host-bound destinations are writes to the user's folder — gated
+        // on the same per-agent opt-in as `file_write` / `file_edit`.
+        if destinationRoute == .host, !ChatExecutionContext.allowHostFolderWrites {
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message:
+                    "Refused to copy to '\(destination)': the workspace is read-only in sandbox "
+                    + "mode, so `file_copy` can only copy INTO the sandbox (a `/workspace/...` "
+                    + "destination). The user can enable folder writes in the agent's sandbox "
+                    + "settings; meanwhile, deliver files to the user with `share_artifact`.",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        let sourceURL: URL
+        switch sourceRoute {
+        case .host:
+            sourceURL = try FolderToolHelpers.resolvePath(source, rootPath: rootPath)
+            // Copying a secret INTO the sandbox is exactly the exfiltration
+            // path the combined-mode read denylist exists to block.
+            if FolderToolHelpers.shouldRefuseSecret(fileURL: sourceURL) {
+                return FolderToolHelpers.secretRefusalEnvelope(relativePath: source, tool: name)
+            }
+        case .sandbox:
+            sourceURL = try Self.resolveSandboxURL(source)
+        }
+
+        var sourceIsDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: sourceURL.path, isDirectory: &sourceIsDirectory)
+        else {
+            throw FolderToolError.fileNotFound(source)
+        }
+        if sourceIsDirectory.boolValue {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "`source` '\(source)' is a directory — `file_copy` copies a single file. "
+                    + "Copy files individually (sandbox-to-sandbox directory copies can use "
+                    + "`sandbox_exec` with `cp -r`).",
+                field: "source",
+                expected: "path to a single file",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        let sourceBytes =
+            (try? FileManager.default.attributesOfItem(atPath: sourceURL.path))?[.size]
+            as? Int64 ?? 0
+        if sourceBytes > Int64(maxCopyBytes) {
+            return ToolEnvelope.failure(
+                kind: .executionError,
+                message:
+                    "'\(source)' is \(Self.formatBytes(sourceBytes)), which exceeds the "
+                    + "\(Self.formatBytes(Int64(maxCopyBytes))) copy limit. This is not retryable.",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        let destinationURL: URL
+        switch destinationRoute {
+        case .host:
+            destinationURL = try FolderToolHelpers.resolvePath(destination, rootPath: rootPath)
+            // Same tamper gate as `file_write`: a sandbox-driven agent must
+            // not create or overwrite secret-shaped files in the workspace.
+            if FolderToolHelpers.shouldRefuseSecret(fileURL: destinationURL) {
+                return FolderToolHelpers.secretWriteRefusalEnvelope(
+                    relativePath: destination,
+                    tool: name
+                )
+            }
+        case .sandbox:
+            destinationURL = try Self.resolveSandboxURL(destination)
+        }
+
+        if destinationURL.standardizedFileURL.path == sourceURL.standardizedFileURL.path {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "`source` and `destination` resolve to the same file.",
+                field: "destination",
+                expected: "a path different from `source`",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        var destinationIsDirectory: ObjCBool = false
+        let destinationExists = FileManager.default.fileExists(
+            atPath: destinationURL.path,
+            isDirectory: &destinationIsDirectory
+        )
+        if destinationExists, destinationIsDirectory.boolValue {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "`destination` '\(destination)' is an existing directory — include the "
+                    + "target filename in the path.",
+                field: "destination",
+                expected: "a file path including the filename",
+                tool: name,
+                retryable: false
+            )
+        }
+        if destinationExists, !overwrite {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "Destination '\(destination)' already exists. Pass `overwrite: true` to "
+                    + "replace it, or choose a different destination.",
+                field: "overwrite",
+                expected: "`true` to replace the existing file",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: destinationURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if destinationExists {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        } catch {
+            throw FolderToolError.operationFailed(
+                "Copy failed: \(error.localizedDescription)"
+            )
+        }
+
+        return ToolEnvelope.success(
+            tool: name,
+            result: [
+                "source": source,
+                "destination": destination,
+                "source_area": Self.areaLabel(sourceRoute),
+                "destination_area": Self.areaLabel(destinationRoute),
+                "bytes": sourceBytes,
+                "overwrote": destinationExists,
+            ]
+        )
+    }
+
+    /// Map an absolute `/workspace/...` path to its host-side URL inside
+    /// the VirtioFS share (`OsaurusPaths.containerWorkspace()` is mounted
+    /// as `/workspace` in the VM). Reuses `resolvePath` for the
+    /// symlink-safe containment check, so `..` traversal and in-share
+    /// symlinks cannot escape the container workspace.
+    private static func resolveSandboxURL(_ path: String) throws -> URL {
+        var relative = String(path.dropFirst("/workspace".count))
+        if relative.hasPrefix("/") { relative.removeFirst() }
+        guard !relative.isEmpty else {
+            throw FolderToolError.invalidArguments(
+                "'/workspace' itself is a directory — pass a file path under it "
+                    + "(e.g. under your sandbox home)."
+            )
+        }
+        return try FolderToolHelpers.resolvePath(
+            relative,
+            rootPath: OsaurusPaths.containerWorkspace()
+        )
+    }
+
+    private static func areaLabel(_ route: CombinedFileRoute) -> String {
+        switch route {
+        case .host: return "workspace"
+        case .sandbox: return "sandbox"
+        }
+    }
+
+    private static func formatBytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -3389,6 +3389,10 @@ enum FolderToolFactory {
             FileUndoTool(rootPath: rootPath),
             FileSearchTool(rootPath: rootPath),
             ShellRunTool(rootPath: rootPath),
+            // Combined-mode bridge: registered with the folder set (it
+            // needs the root) but hidden outside combined sandbox +
+            // host-read mode (`ToolRegistry.combinedModeBridgeToolNames`).
+            FileCopyTool(rootPath: rootPath),
         ]
     }
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1210,10 +1210,15 @@ public enum SystemPromptTemplates {
             hostWritable
             ? "- Multi-line code/scripts: `file_write` the script to a `/workspace/...` path, then `sandbox_exec` to run it (e.g. `python3 script.py`). NEVER embed multi-line code in `python3 -c` / `node -e`: the JSON→shell→code escaping breaks."
             : "- Multi-line code/scripts: `sandbox_write_file` the script, then `sandbox_exec` to run it (e.g. `python3 script.py`). NEVER embed multi-line code in `python3 -c` / `node -e`: the JSON→shell→code escaping breaks."
+        let copyBullet =
+            hostWritable
+            ? "- Move a file between the two areas: `file_copy(source, destination)` — raw byte copy, binary-safe (PDFs, images, archives). Same path rule: relative = workspace, `/workspace/...` = sandbox."
+            : "- Stage a workspace file into the sandbox: `file_copy(source, destination)` — raw byte copy, binary-safe (PDFs, images, archives). The destination must be a `/workspace/...` path (the workspace is read-only)."
         return """
             Tool dispatch:
             - Read files / list dirs / search: `file_read` (reads a file or lists a directory — the path decides), `file_search` (they reach both your workspace and `/workspace/...` sandbox paths — see `## Files`).
             \(writeBullet)
+            \(copyBullet)
             \(shellBullet)
             \(scriptBullet)
             - Run independent calls in parallel; chain dependent shell steps with `&&`.
@@ -1261,8 +1266,8 @@ public enum SystemPromptTemplates {
             : "`sandbox_exec` (single-line)"
         let filesLine =
             hostWritable
-            ? "- Read/list/search: `file_read`, `file_search`; write/edit: `file_write` / `file_edit`. The path picks the filesystem: relative = the user's workspace (tracked, undoable), `/workspace/...` = sandbox — see `## Files`."
-            : "- Read/list/search: `file_read`, `file_search` (reach your workspace and `/workspace/...` sandbox paths — see `## Files`). Sandbox writes: `sandbox_write_file` (`path` FIRST, then `content` whole-file or `old_string`+`new_string` edit; workspace is read-only)."
+            ? "- Read/list/search: `file_read`, `file_search`; write/edit: `file_write` / `file_edit`. The path picks the filesystem: relative = the user's workspace (tracked, undoable), `/workspace/...` = sandbox — see `## Files`. `file_copy(source, destination)` moves a file (binary-safe) between the areas."
+            : "- Read/list/search: `file_read`, `file_search` (reach your workspace and `/workspace/...` sandbox paths — see `## Files`). Sandbox writes: `sandbox_write_file` (`path` FIRST, then `content` whole-file or `old_string`+`new_string` edit; workspace is read-only). `file_copy(source, destination)` stages a workspace file (binary-safe) into a `/workspace/...` path for commands."
         let scriptWriter = hostWritable ? "`file_write` a `/workspace/...` script" : "`sandbox_write_file` a script"
         return """
             Tool dispatch:
@@ -1510,7 +1515,7 @@ public enum SystemPromptTemplates {
                 Rules:
                 - Read / list / search either area with `file_read` and `file_search`.
                 - Write either area with `file_write` (whole file) or `file_edit` (`old_string`+`new_string`).
-                - Commands run ONLY in the sandbox (`sandbox_exec`), which has no copy of the workspace. To run code against a workspace file, `file_read` it and pass the content in; write results back with `file_write`.
+                - Commands run ONLY in the sandbox (`sandbox_exec`), which has no copy of the workspace. To process a workspace file with a command, first copy it into the sandbox with `file_copy(source, destination)` — a raw byte copy that also works for binaries (PDFs, images, archives) that `file_read`/`file_write` cannot carry. Copy results back to a relative path to put them in the folder.
                 - Prefer `/workspace/...` for scratch and iterative work; write to the workspace when the user wants the file in their folder. Surface chat deliverables with `share_artifact`. \(secretLine) Secret files also cannot be written.
                 """
         }
@@ -1521,7 +1526,7 @@ public enum SystemPromptTemplates {
             - **Workspace** (your read-only host folder) — the default. For "what's in my workspace / on my Desktop", use `file_read` (it reads a file or lists a directory) and `file_search`. Relative paths and `/Users/...` paths are the workspace.
             - **Sandbox** scratch area — pass a `/workspace/...` path to the SAME `file_read` / `file_search`.
 
-            The workspace is read-only — you cannot create, edit, or delete files in it, so never offer to; say so if asked (the user can enable folder writes in the agent's sandbox settings). Create or change files with `sandbox_write_file` (pass `content` to write the whole file, or `old_string`+`new_string` to edit one match — it writes the sandbox), and run commands with `sandbox_exec` (it runs in the sandbox, which has no copy of the workspace — `file_read` a workspace file and pass its content in if a command needs it). Surface results with `share_artifact`. \(secretLine)
+            The workspace is read-only — you cannot create, edit, or delete files in it, so never offer to; say so if asked (the user can enable folder writes in the agent's sandbox settings). Create or change files with `sandbox_write_file` (pass `content` to write the whole file, or `old_string`+`new_string` to edit one match — it writes the sandbox), and run commands with `sandbox_exec` (it runs in the sandbox, which has no copy of the workspace). To process a workspace file with a command, first copy it into the sandbox with `file_copy(source, destination)` — a raw byte copy that also works for binaries (PDFs, images, archives) that `file_read` cannot open; the destination must be a `/workspace/...` path while the workspace is read-only. Surface results with `share_artifact`. \(secretLine)
             """
     }
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1213,7 +1213,7 @@ public enum SystemPromptTemplates {
         let copyBullet =
             hostWritable
             ? "- Move a file between the two areas: `file_copy(source, destination)` — raw byte copy, binary-safe (PDFs, images, archives). Same path rule: relative = workspace, `/workspace/...` = sandbox."
-            : "- Stage a workspace file into the sandbox: `file_copy(source, destination)` — raw byte copy, binary-safe (PDFs, images, archives). The destination must be a `/workspace/...` path (the workspace is read-only)."
+            : "- Stage a workspace file into the sandbox: `file_copy(source, destination)` — raw byte copy, binary-safe (PDFs, images, archives); the destination must be a `/workspace/...` path."
         return """
             Tool dispatch:
             - Read files / list dirs / search: `file_read` (reads a file or lists a directory — the path decides), `file_search` (they reach both your workspace and `/workspace/...` sandbox paths — see `## Files`).
@@ -1526,7 +1526,7 @@ public enum SystemPromptTemplates {
             - **Workspace** (your read-only host folder) — the default. For "what's in my workspace / on my Desktop", use `file_read` (it reads a file or lists a directory) and `file_search`. Relative paths and `/Users/...` paths are the workspace.
             - **Sandbox** scratch area — pass a `/workspace/...` path to the SAME `file_read` / `file_search`.
 
-            The workspace is read-only — you cannot create, edit, or delete files in it, so never offer to; say so if asked (the user can enable folder writes in the agent's sandbox settings). Create or change files with `sandbox_write_file` (pass `content` to write the whole file, or `old_string`+`new_string` to edit one match — it writes the sandbox), and run commands with `sandbox_exec` (it runs in the sandbox, which has no copy of the workspace). To process a workspace file with a command, first copy it into the sandbox with `file_copy(source, destination)` — a raw byte copy that also works for binaries (PDFs, images, archives) that `file_read` cannot open; the destination must be a `/workspace/...` path while the workspace is read-only. Surface results with `share_artifact`. \(secretLine)
+            The workspace is read-only — you cannot create, edit, or delete files in it, so never offer to; say so if asked (the user can enable folder writes in the agent's sandbox settings). Create or change files with `sandbox_write_file` (pass `content` to write the whole file, or `old_string`+`new_string` to edit one match — it writes the sandbox), and run commands with `sandbox_exec` (it runs in the sandbox, which has no copy of the workspace — to process a workspace file with a command, first stage it into a `/workspace/...` path with `file_copy`, a byte copy that also carries binaries `file_read` cannot open). Surface results with `share_artifact`. \(secretLine)
             """
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -113,6 +113,9 @@ struct ChatViewSandboxTests {
         #expect(prompt.contains("file_write") == false)
         #expect(prompt.contains("file_edit") == false)
         #expect(prompt.contains("sandbox_write_file"))
+        // The byte bridge is taught even in read-only combined mode —
+        // staging a workspace file INTO the sandbox is semantically a read.
+        #expect(prompt.contains("file_copy"))
     }
 
     @Test
@@ -148,6 +151,8 @@ struct ChatViewSandboxTests {
         // Exec is still sandbox-only — no host shell.
         #expect(prompt.contains("sandbox_exec"))
         #expect(prompt.contains("shell_run") == false)
+        // The byte bridge for binaries is taught in the writable variant too.
+        #expect(prompt.contains("file_copy"))
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -405,6 +405,10 @@ struct SystemPromptComposerToolResolutionTests {
                     #expect(names.contains("sandbox_write_file"))
                     // `sandbox_edit_file` folded into `sandbox_write_file`.
                     #expect(!names.contains("sandbox_edit_file"))
+                    // The workspace<->sandbox byte bridge is visible even
+                    // in read-only combined mode (host-bound destinations
+                    // are gated at execute time).
+                    #expect(names.contains("file_copy"))
                     // Global egress + loop tools remain.
                     #expect(names.contains("share_artifact"))
                 }
@@ -440,6 +444,8 @@ struct SystemPromptComposerToolResolutionTests {
                     #expect(!names.contains("shell_run"))
                     #expect(!names.contains("git_commit"))
                     #expect(!names.contains("file_undo"))
+                    // The byte bridge stays visible in the writable variant.
+                    #expect(names.contains("file_copy"))
 
                     // Hidden ≠ unregistered: the sandbox writer must stay
                     // callable (the bridge routes `/workspace/...` writes
@@ -553,6 +559,43 @@ struct SystemPromptComposerToolResolutionTests {
                 }
                 // `file_tree` no longer exists as a separate tool.
                 #expect(byName["file_tree"] == nil)
+                // `file_copy` is combined-mode-only: plain folder mode has
+                // no sandbox to bridge to (`shell_run` `cp` covers copies).
+                #expect(byName["file_copy"] == nil)
+            }
+        }
+    }
+
+    @Test
+    func fileCopy_hiddenOutsideCombinedMode_andExecAdvertisesStagingInCombined() async {
+        await withSandboxAgent(autonomous: true) { agentId in
+            withRegisteredSandboxBuiltins {
+                withRegisteredFolderTools { folder in
+                    // Plain sandbox mode (no host folder): every folder tool
+                    // is hidden, including the bridge.
+                    let plainSandbox = Set(
+                        SystemPromptComposer.resolveTools(
+                            agentId: agentId,
+                            executionMode: .sandbox(hostRead: nil)
+                        ).map { $0.function.name }
+                    )
+                    #expect(!plainSandbox.contains("file_copy"))
+
+                    // Combined mode: `sandbox_exec`'s rendered spec must
+                    // point at `file_copy` for staging workspace files —
+                    // commands can't see the workspace, and this is where
+                    // small models look first.
+                    let specs = ToolRegistry.shared.alwaysLoadedSpecs(
+                        mode: .sandbox(hostRead: folder)
+                    )
+                    let execDesc =
+                        specs.first { $0.function.name == "sandbox_exec" }?
+                        .function.description ?? ""
+                    #expect(
+                        execDesc.contains("file_copy"),
+                        "sandbox_exec must advertise the file_copy staging path in combined mode"
+                    )
+                }
             }
         }
     }

--- a/Packages/OsaurusCore/Tests/Folder/FileCopyToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileCopyToolTests.swift
@@ -1,0 +1,369 @@
+//
+//  FileCopyToolTests.swift
+//  osaurusTests
+//
+//  Verifies the combined-mode `file_copy` bridge: the four-direction
+//  routing matrix (workspace/sandbox on each endpoint), the write-grant
+//  gate on host-bound destinations, secret source/destination refusal,
+//  overwrite and size-cap envelopes, and the combined-mode-only guard.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FileCopyToolTests {
+
+    private static let agent = "copy-test-agent"
+
+    private struct Env: Sendable {
+        let tmp: URL
+        let hostRoot: URL
+        /// Host-side directory backing the sandbox agent home
+        /// (`/workspace/agents/<agent>` in VM terms).
+        let agentDir: URL
+        let bridge: SandboxReadBridge
+        let previousOverrideRoot: URL?
+
+        func cleanup() {
+            OsaurusPaths.overrideRoot = previousOverrideRoot
+            try? FileManager.default.removeItem(at: tmp)
+        }
+    }
+
+    private func makeEnv() throws -> Env {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory
+            .appendingPathComponent("osu-file-copy-\(UUID().uuidString)", isDirectory: true)
+        let hostRoot = tmp.appendingPathComponent("host", isDirectory: true)
+        try fm.createDirectory(at: hostRoot, withIntermediateDirectories: true)
+
+        let previousOverrideRoot = OsaurusPaths.overrideRoot
+        OsaurusPaths.overrideRoot = tmp.appendingPathComponent("osaurus-root", isDirectory: true)
+        let agentDir = OsaurusPaths.containerAgentDir(Self.agent)
+        try fm.createDirectory(at: agentDir, withIntermediateDirectories: true)
+
+        return Env(
+            tmp: tmp,
+            hostRoot: hostRoot,
+            agentDir: agentDir,
+            bridge: SandboxReadBridge(
+                agentName: Self.agent,
+                home: OsaurusPaths.inContainerAgentHome(Self.agent)
+            ),
+            previousOverrideRoot: previousOverrideRoot
+        )
+    }
+
+    /// Build an isolated environment under the process-wide storage-path
+    /// lock (`OsaurusPaths.overrideRoot` is a global other suites also
+    /// rewrite), run `body`, then restore + delete.
+    private func withEnv(
+        _ body: @MainActor @Sendable (Env) async throws -> Void
+    ) async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let env = try makeEnv()
+            defer { env.cleanup() }
+            try await body(env)
+        }
+    }
+
+    /// Execute the tool with the task-locals `ToolRegistry.execute` binds
+    /// in combined mode: the sandbox bridge, the read-only host scope, and
+    /// the folder-write grant.
+    private func run(
+        _ env: Env,
+        args: String,
+        bridge: Bool = true,
+        allowWrites: Bool = false,
+        maxCopyBytes: Int = FileCopyTool.defaultMaxCopyBytes
+    ) async throws -> String {
+        let tool = FileCopyTool(rootPath: env.hostRoot, maxCopyBytes: maxCopyBytes)
+        return try await ChatExecutionContext.$sandboxReadBridge.withValue(
+            bridge ? env.bridge : nil
+        ) {
+            try await ChatExecutionContext.$hostReadOnlyScope.withValue(env.hostRoot) {
+                try await ChatExecutionContext.$allowHostFolderWrites.withValue(allowWrites) {
+                    try await tool.execute(argumentsJSON: args)
+                }
+            }
+        }
+    }
+
+    private func payload(_ output: String) throws -> [String: Any] {
+        try #require(
+            try JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+    }
+
+    private func successResult(_ output: String) throws -> [String: Any] {
+        let dict = try payload(output)
+        #expect(dict["ok"] as? Bool == true, "expected success envelope, got: \(output)")
+        return try #require(dict["result"] as? [String: Any])
+    }
+
+    private func write(_ url: URL, _ data: Data) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url)
+    }
+
+    /// Binary payload (NUL byte, invalid UTF-8) that `file_read` /
+    /// `file_write` could never carry — the whole point of the byte bridge.
+    private let binaryBytes = Data([0x89, 0x50, 0x4E, 0x47, 0x00, 0x01, 0xFF])
+
+    // MARK: - Routing matrix
+
+    @Test
+    func workspaceToSandbox_copiesBytes_withoutWriteGrant() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent("assets/logo.png"), self.binaryBytes)
+
+            let output = try await self.run(
+                env,
+                args: #"{"source":"assets/logo.png","destination":"/workspace/agents/copy-test-agent/logo.png"}"#
+            )
+
+            let result = try self.successResult(output)
+            #expect(result["source_area"] as? String == "workspace")
+            #expect(result["destination_area"] as? String == "sandbox")
+            #expect(result["bytes"] as? Int == self.binaryBytes.count)
+            #expect(result["overwrote"] as? Bool == false)
+
+            let copied = try Data(contentsOf: env.agentDir.appendingPathComponent("logo.png"))
+            #expect(copied == self.binaryBytes, "byte-exact copy expected on the sandbox side")
+        }
+    }
+
+    @Test
+    func sandboxToWorkspace_requiresWriteGrant() async throws {
+        try await withEnv { env in
+            try self.write(env.agentDir.appendingPathComponent("out.png"), self.binaryBytes)
+            let args =
+                #"{"source":"/workspace/agents/copy-test-agent/out.png","destination":"results/out.png"}"#
+
+            // Read-only combined mode: refused, pointing at the setting.
+            let refused = try await self.run(env, args: args, allowWrites: false)
+            let refusedPayload = try self.payload(refused)
+            #expect(refusedPayload["ok"] as? Bool == false)
+            #expect(refusedPayload["kind"] as? String == "rejected")
+            let message = refusedPayload["message"] as? String ?? ""
+            #expect(message.contains("read-only"))
+            #expect(message.contains("folder writes"))
+
+            // Writable combined mode: the copy lands in the workspace.
+            let output = try await self.run(env, args: args, allowWrites: true)
+            let result = try self.successResult(output)
+            #expect(result["source_area"] as? String == "sandbox")
+            #expect(result["destination_area"] as? String == "workspace")
+            let copied = try Data(
+                contentsOf: env.hostRoot.appendingPathComponent("results/out.png")
+            )
+            #expect(copied == self.binaryBytes)
+        }
+    }
+
+    @Test
+    func workspaceToWorkspace_requiresWriteGrant() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent("a.bin"), self.binaryBytes)
+            let args = #"{"source":"a.bin","destination":"backup/a.bin"}"#
+
+            let refused = try await self.run(env, args: args, allowWrites: false)
+            #expect(try self.payload(refused)["kind"] as? String == "rejected")
+
+            let output = try await self.run(env, args: args, allowWrites: true)
+            let result = try self.successResult(output)
+            #expect(result["source_area"] as? String == "workspace")
+            #expect(result["destination_area"] as? String == "workspace")
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: env.hostRoot.appendingPathComponent("backup/a.bin").path
+                )
+            )
+        }
+    }
+
+    @Test
+    func sandboxToSandbox_allowedWithoutWriteGrant() async throws {
+        try await withEnv { env in
+            try self.write(env.agentDir.appendingPathComponent("in.dat"), self.binaryBytes)
+
+            let output = try await self.run(
+                env,
+                args:
+                    #"{"source":"/workspace/agents/copy-test-agent/in.dat","destination":"/workspace/agents/copy-test-agent/copies/in.dat"}"#
+            )
+
+            let result = try self.successResult(output)
+            #expect(result["source_area"] as? String == "sandbox")
+            #expect(result["destination_area"] as? String == "sandbox")
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: env.agentDir.appendingPathComponent("copies/in.dat").path
+                )
+            )
+        }
+    }
+
+    // MARK: - Gates
+
+    @Test
+    func withoutSandboxBridge_refusedAsCombinedModeOnly() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent("a.bin"), self.binaryBytes)
+
+            let output = try await self.run(
+                env,
+                args: #"{"source":"a.bin","destination":"/workspace/agents/copy-test-agent/a.bin"}"#,
+                bridge: false
+            )
+
+            let dict = try self.payload(output)
+            #expect(dict["ok"] as? Bool == false)
+            #expect(dict["kind"] as? String == "rejected")
+            #expect((dict["message"] as? String ?? "").contains("combined"))
+        }
+    }
+
+    @Test
+    func secretSource_refused() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent(".env"), Data("API_KEY=x\n".utf8))
+
+            let output = try await self.run(
+                env,
+                args: #"{"source":".env","destination":"/workspace/agents/copy-test-agent/.env"}"#
+            )
+
+            let dict = try self.payload(output)
+            #expect(dict["ok"] as? Bool == false)
+            #expect(dict["kind"] as? String == "rejected")
+            #expect((dict["message"] as? String ?? "").contains("secret"))
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: env.agentDir.appendingPathComponent(".env").path
+                ),
+                "the secret must never reach the sandbox side"
+            )
+        }
+    }
+
+    @Test
+    func secretDestination_refused_evenWithWriteGrant() async throws {
+        try await withEnv { env in
+            try self.write(env.agentDir.appendingPathComponent("payload.txt"), Data("X=1\n".utf8))
+
+            let output = try await self.run(
+                env,
+                args: #"{"source":"/workspace/agents/copy-test-agent/payload.txt","destination":".env"}"#,
+                allowWrites: true
+            )
+
+            let dict = try self.payload(output)
+            #expect(dict["ok"] as? Bool == false)
+            #expect(dict["kind"] as? String == "rejected")
+            #expect((dict["message"] as? String ?? "").contains("secret"))
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: env.hostRoot.appendingPathComponent(".env").path
+                )
+            )
+        }
+    }
+
+    // MARK: - Overwrite / size / shape envelopes
+
+    @Test
+    func existingDestination_requiresOverwriteTrue() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent("src.bin"), self.binaryBytes)
+            try self.write(env.agentDir.appendingPathComponent("dst.bin"), Data("old".utf8))
+            let base =
+                #"{"source":"src.bin","destination":"/workspace/agents/copy-test-agent/dst.bin"#
+
+            let refused = try await self.run(env, args: base + "\"}")
+            let refusedPayload = try self.payload(refused)
+            #expect(refusedPayload["ok"] as? Bool == false)
+            #expect(refusedPayload["kind"] as? String == "invalid_args")
+            #expect(refusedPayload["field"] as? String == "overwrite")
+
+            let output = try await self.run(env, args: base + "\",\"overwrite\":true}")
+            let result = try self.successResult(output)
+            #expect(result["overwrote"] as? Bool == true)
+            let copied = try Data(contentsOf: env.agentDir.appendingPathComponent("dst.bin"))
+            #expect(copied == self.binaryBytes)
+        }
+    }
+
+    @Test
+    func oversizedSource_refusedWithCapEnvelope() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent("big.bin"), Data(count: 64))
+
+            let output = try await self.run(
+                env,
+                args: #"{"source":"big.bin","destination":"/workspace/agents/copy-test-agent/big.bin"}"#,
+                maxCopyBytes: 16
+            )
+
+            let dict = try self.payload(output)
+            #expect(dict["ok"] as? Bool == false)
+            #expect(dict["kind"] as? String == "execution_error")
+            #expect(dict["retryable"] as? Bool == false)
+            #expect((dict["message"] as? String ?? "").contains("copy limit"))
+        }
+    }
+
+    @Test
+    func directorySource_refused() async throws {
+        try await withEnv { env in
+            try FileManager.default.createDirectory(
+                at: env.hostRoot.appendingPathComponent("folder"),
+                withIntermediateDirectories: true
+            )
+
+            let output = try await self.run(
+                env,
+                args: #"{"source":"folder","destination":"/workspace/agents/copy-test-agent/folder"}"#
+            )
+
+            let dict = try self.payload(output)
+            #expect(dict["ok"] as? Bool == false)
+            #expect(dict["kind"] as? String == "invalid_args")
+            #expect(dict["field"] as? String == "source")
+        }
+    }
+
+    @Test
+    func missingSource_throwsFileNotFound() async throws {
+        try await withEnv { env in
+            await #expect(throws: FolderToolError.self) {
+                _ = try await self.run(
+                    env,
+                    args: #"{"source":"nope.bin","destination":"/workspace/agents/copy-test-agent/nope.bin"}"#
+                )
+            }
+        }
+    }
+
+    @Test
+    func workspaceEscapePath_rejected() async throws {
+        try await withEnv { env in
+            try self.write(env.hostRoot.appendingPathComponent("a.bin"), self.binaryBytes)
+
+            // `/workspace/../...` routes to the sandbox resolver, whose
+            // containment check must refuse the traversal.
+            await #expect(throws: FolderToolError.self) {
+                _ = try await self.run(
+                    env,
+                    args: #"{"source":"a.bin","destination":"/workspace/../escape.bin"}"#
+                )
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxWorkspaceChangeTrackerTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxWorkspaceChangeTrackerTests.swift
@@ -614,6 +614,49 @@ struct SandboxWorkspaceChangeTrackerTests {
         #expect(await env.tracker.changes(for: Self.session).isEmpty)
     }
 
+    /// A real `file_copy` execution inside a host checkpoint (the wrap the
+    /// registry takes for `mutatesHostFolder` tools) must land as a
+    /// created, undoable row attributed to `file_copy` — the bridge tool's
+    /// copies show up in the Changes sheet like any other host write.
+    @Test
+    func fileCopy_hostBoundCopy_recordsUndoableCreatedRow() async throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        let bytes = Data([0x89, 0x50, 0x4E, 0x47, 0x00, 0xFF])
+        let source = env.hostFolder.appendingPathComponent("photo.png")
+        try bytes.write(to: source)
+
+        let tool = FileCopyTool(rootPath: env.hostFolder)
+        let bridge = SandboxReadBridge(
+            agentName: Self.agent, home: "/workspace/agents/\(Self.agent)")
+        let token = await env.tracker.beginHostCheckpoint(
+            sessionId: Self.session, folderPath: env.hostFolder.path, sourceTool: "file_copy")
+        _ = try await ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+            try await ChatExecutionContext.$allowHostFolderWrites.withValue(true) {
+                try await tool.execute(
+                    argumentsJSON: #"{"source":"photo.png","destination":"photo-copy.png"}"#
+                )
+            }
+        }
+        await env.tracker.endCheckpoint(token)
+
+        let changes = await env.tracker.changes(for: Self.session)
+        #expect(changes.count == 1)
+        let row = try #require(changes.first)
+        #expect(row.root == .hostFolder)
+        #expect(row.kind == .created)
+        #expect(row.relativePath == "photo-copy.png")
+        #expect(row.sourceTool == "file_copy")
+
+        // Undo removes the copied file (binary-safe, like any created row).
+        let result = await env.tracker.undoChange(id: row.id, sessionId: Self.session)
+        #expect(result == .undone)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: env.hostFolder.appendingPathComponent("photo-copy.png").path))
+        #expect(try Data(contentsOf: source) == bytes, "the source must be untouched")
+    }
+
     @Test
     func hostFolderKey_isStableAndFilesystemSafe() {
         let key = SandboxWorkspaceChangeTracker.hostFolderKey("/Users/me/My Projects/app")

--- a/Packages/OsaurusCore/Tools/ToolEnvelope.swift
+++ b/Packages/OsaurusCore/Tools/ToolEnvelope.swift
@@ -254,11 +254,26 @@ public enum ToolEnvelope {
                 )
             case .binaryContent(let path, let ext, let detail):
                 let extLabel = ext.map { " (.\($0))" } ?? ""
-                let pivotTail = detail.pivotHint.map { " \($0)" } ?? ""
+                // Combined mode has no `shell_run` — the fail-forward path
+                // is `file_copy` into the sandbox, then `sandbox_exec`.
+                // Without this the model dead-ends on binaries (observed
+                // live: a PDF-to-PNG request flailed for turns).
+                let combinedMode = ChatExecutionContext.hostReadOnlyScope != nil
+                let pivot =
+                    combinedMode
+                    ? "copy it into the sandbox with `file_copy` (a `/workspace/...` destination), then process it there with `sandbox_exec` (e.g. `unzip`, `pdftotext`, `file`)"
+                    : "pivot to shell_run with an appropriate tool (e.g. `unzip`, `pdftotext`, `file`)"
+                var pivotTail = detail.pivotHint.map { " \($0)" } ?? ""
+                if combinedMode {
+                    pivotTail = pivotTail.replacingOccurrences(
+                        of: "shell_run",
+                        with: "`file_copy` + `sandbox_exec`"
+                    )
+                }
                 return failure(
                     kind: .executionError,
                     message:
-                        "file_read only supports text. '\(path)' looks like a binary file\(extLabel) — pivot to shell_run with an appropriate tool (e.g. `unzip`, `pdftotext`, `file`) instead of retrying.\(pivotTail)",
+                        "file_read only supports text. '\(path)' looks like a binary file\(extLabel) — \(pivot) instead of retrying.\(pivotTail)",
                     tool: tool,
                     retryable: false
                 )

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -450,7 +450,7 @@ public final class ToolRegistry: ObservableObject {
     /// list below stays a derived union with a single source of truth per
     /// tool family.
     nonisolated static let externallyDeniedHostToolNames: Set<String> = [
-        "file_write", "file_edit", "shell_run", "git_commit", "file_undo",
+        "file_write", "file_edit", "file_copy", "shell_run", "git_commit", "file_undo",
         // Curator draft path: never invocable from external surfaces.
         "propose_knowledge_update",
     ]
@@ -874,25 +874,27 @@ public final class ToolRegistry: ObservableObject {
             do {
                 result = try await ChatExecutionContext.$hostReadOnlyScope.withValue(policy.scope) {
                     try await ChatExecutionContext.$allowHostSecretReads.withValue(policy.allowSecretReads) {
-                        try await ChatExecutionContext.$sandboxReadBridge.withValue(readBridge) {
-                            try await ChatExecutionContext.$sandboxAgentName.withValue(sandboxAgent) {
-                                if tool.bypassRegistryTimeout {
+                        try await ChatExecutionContext.$allowHostFolderWrites.withValue(policy.allowFolderWrites) {
+                            try await ChatExecutionContext.$sandboxReadBridge.withValue(readBridge) {
+                                try await ChatExecutionContext.$sandboxAgentName.withValue(sandboxAgent) {
+                                    if tool.bypassRegistryTimeout {
+                                        return Self.normalizeToolResult(
+                                            try await Self.runToolBodyUntimed(
+                                                tool,
+                                                argumentsJSON: effectiveArgumentsJSON
+                                            ),
+                                            tool: name
+                                        )
+                                    }
                                     return Self.normalizeToolResult(
-                                        try await Self.runToolBodyUntimed(
+                                        try await Self.runToolBody(
                                             tool,
-                                            argumentsJSON: effectiveArgumentsJSON
+                                            argumentsJSON: effectiveArgumentsJSON,
+                                            timeoutSeconds: Self.defaultToolTimeoutSeconds
                                         ),
                                         tool: name
                                     )
                                 }
-                                return Self.normalizeToolResult(
-                                    try await Self.runToolBody(
-                                        tool,
-                                        argumentsJSON: effectiveArgumentsJSON,
-                                        timeoutSeconds: Self.defaultToolTimeoutSeconds
-                                    ),
-                                    tool: name
-                                )
                             }
                         }
                     }
@@ -926,11 +928,16 @@ public final class ToolRegistry: ObservableObject {
     /// `.sandbox(hostRead: ctx)`. Resolved once per call so the two
     /// task-locals stay consistent, and inert (`nil` / `false`) in plain
     /// folder and plain sandbox modes.
-    private var combinedHostReadPolicy: (scope: URL?, allowSecretReads: Bool) {
+    private var combinedHostReadPolicy: (scope: URL?, allowSecretReads: Bool, allowFolderWrites: Bool) {
         guard toolsByName.keys.contains("sandbox_exec"),
             let root = FolderContextService.cachedRootPath
-        else { return (nil, false) }
-        return (root, resolvedAutonomousExecConfig?.allowHostSecretReads ?? false)
+        else { return (nil, false, false) }
+        let config = resolvedAutonomousExecConfig
+        return (
+            root,
+            config?.allowHostSecretReads ?? false,
+            config?.allowHostFolderWrites ?? false
+        )
     }
 
     /// Sandbox identity bound around every tool body in combined mode so the
@@ -1657,6 +1664,16 @@ public final class ToolRegistry: ObservableObject {
         "file_write", "file_edit",
     ]
 
+    /// Folder tools that exist ONLY for combined mode. `file_copy` bridges
+    /// file bytes between the workspace and the sandbox — meaningless in
+    /// plain folder mode (shell `cp` covers host-side copies) and in plain
+    /// sandbox mode (no workspace). Visible in BOTH read-only and writable
+    /// combined mode; host-bound destinations are gated at execute time on
+    /// the `allowHostFolderWrites` grant, not by hiding the tool.
+    static let combinedModeBridgeToolNames: Set<String> = [
+        "file_copy"
+    ]
+
     /// Runtime-managed tools are execution infrastructure, always loaded when registered.
     var runtimeManagedToolNames: Set<String> {
         Self.folderToolNames.union(builtInSandboxToolNames)
@@ -1713,11 +1730,20 @@ public final class ToolRegistry: ObservableObject {
             var folderExcluded = Self.folderToolNames
             if mode.allowsHostReadTools {
                 folderExcluded.subtract(Self.folderReadOnlyToolNames)
+                // The workspace<->sandbox byte bridge is visible in BOTH
+                // combined variants — copies INTO the workspace are gated
+                // at execute time on the write grant.
+                folderExcluded.subtract(Self.combinedModeBridgeToolNames)
             }
             if mode.allowsHostWriteTools {
                 folderExcluded.subtract(Self.folderWriteToolNames)
             }
             excluded.formUnion(folderExcluded)
+        } else {
+            // Plain folder mode: hide the combined-mode-only bridge —
+            // there is no sandbox to bridge to, and `shell_run` (`cp`)
+            // covers host-side copies.
+            excluded.formUnion(Self.combinedModeBridgeToolNames)
         }
         if !mode.usesSandboxTools {
             excluded.formUnion(builtInSandboxToolNames)
@@ -2001,6 +2027,15 @@ public final class ToolRegistry: ObservableObject {
         + "folder (tracked, undoable), an absolute `/workspace/...` path writes the Linux "
         + "sandbox scratch area."
 
+    /// Staging hint appended to `sandbox_exec`'s rendered description in
+    /// combined mode: commands cannot see the workspace, and `file_copy`
+    /// (not `file_read`+`file_write`) is how bytes — especially binaries —
+    /// get into the sandbox first.
+    private static let combinedModeExecStagingNote =
+        " The sandbox has no mount of the user's workspace — stage a workspace file "
+        + "(any type, including binaries like PDFs and images) into `/workspace/...` "
+        + "with `file_copy` before processing it."
+
     /// In combined sandbox + host-read mode the host `file_*` tools are the
     /// single, path-routed read family (and, with the write grant, the
     /// single write family). Annotate their rendered specs so the model
@@ -2020,10 +2055,21 @@ public final class ToolRegistry: ObservableObject {
                 description = base + Self.combinedModeFileRoutingNote
             } else if writable, Self.folderWriteToolNames.contains(name) {
                 description = base + Self.combinedModeWriteRoutingNote
+            } else if name == "sandbox_exec" {
+                var updated = base
+                if writable {
+                    // `sandbox_write_file` is hidden in writable combined
+                    // mode; don't advertise a tool that isn't in the schema
+                    // — point at the unified writer.
+                    updated = updated.replacingOccurrences(
+                        of: "`sandbox_write_file`",
+                        with: "`file_write` (with a `/workspace/...` path)"
+                    )
+                }
+                description = updated + Self.combinedModeExecStagingNote
             } else if writable, base.contains("`sandbox_write_file`") {
-                // `sandbox_write_file` is hidden in writable combined mode;
-                // don't let `sandbox_exec` (and friends) advertise a tool
-                // that isn't in the schema — point at the unified writer.
+                // Any other tool referencing the hidden `sandbox_write_file`
+                // in writable combined mode gets the same retarget.
                 description = base.replacingOccurrences(
                     of: "`sandbox_write_file`",
                     with: "`file_write` (with a `/workspace/...` path)"

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -378,6 +378,8 @@
     "SandboxFrontier": [
       "sandbox.artifact-from-sandbox",
       "sandbox.background-process",
+      "sandbox.binary-bridge-roundtrip",
+      "sandbox.binary-bridge-stage",
       "sandbox.code-exec-basics",
       "sandbox.exec-discipline",
       "sandbox.fix-failing-tests",

--- a/Packages/OsaurusEvals/Suites/SandboxFrontier/README.md
+++ b/Packages/OsaurusEvals/Suites/SandboxFrontier/README.md
@@ -71,7 +71,10 @@ container.
 - `hostFolder: true` → **combined mode**: the case temp workspace (with
   `workspaceFiles`) becomes the read-only host context
   (`ExecutionMode.sandbox(hostRead: ctx)`); `file_read` / `file_search` stay
-  host-side. Omitted/false → pure sandbox mode.
+  host-side. Omitted/false → pure sandbox mode. Combined mode also surfaces
+  `file_copy`, the byte bridge that moves files (including binaries) between
+  the workspace and the sandbox; host-bound destinations require
+  `allowHostFolderWrites`.
 - `allowHostFolderWrites: true` (combined mode only) → **writable combined
   mode** (`ExecutionMode.sandbox(hostRead: ctx, hostWrite: true)`):
   `file_write` / `file_edit` join the schema, path-routed like the readers

--- a/Packages/OsaurusEvals/Suites/SandboxFrontier/binary-bridge-roundtrip.json
+++ b/Packages/OsaurusEvals/Suites/SandboxFrontier/binary-bridge-roundtrip.json
@@ -1,0 +1,37 @@
+{
+  "id": "sandbox.binary-bridge-roundtrip",
+  "domain": "agent_loop",
+  "label": "sandbox • writable combined mode: file_copy in, sandbox_exec transform, file_copy back to the workspace",
+  "query": "The workspace contains assets/logo.png, a binary file. Copy it into your sandbox with file_copy, base64-encode it there with sandbox_exec into a file named logo.b64, then copy that encoded file back into the workspace at out/logo.b64 with file_copy.",
+  "notes": "Writable combined mode roundtrip (allowHostFolderWrites=true) — the exact stage->convert->deliver flow from the live transcript (PDF-to-PNG). The result must land back in the HOST workspace via a host-bound file_copy, which is change-tracked. base64('PNGDATA-OSAURUS-EVAL-BRIDGE-1\\n') = UE5HREFUQS1PU0FVUlVTLUVWQUwtQlJJREdFLTEK.",
+  "fixtures": {
+    "sandbox": {
+      "hostFolder": true,
+      "allowHostFolderWrites": true
+    },
+    "workspaceFiles": [
+      {
+        "path": "assets/logo.png",
+        "contents": "PNGDATA-OSAURUS-EVAL-BRIDGE-1\n"
+      }
+    ]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 14,
+      "mustCallTools": [
+        "file_copy",
+        "sandbox_exec"
+      ],
+      "mustNotCallTools": [
+        "shell_run"
+      ],
+      "files": [
+        {
+          "path": "out/logo.b64",
+          "contains": "UE5HREFUQS1PU0FVUlVTLUVWQUwtQlJJREdFLTEK"
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/SandboxFrontier/binary-bridge-stage.json
+++ b/Packages/OsaurusEvals/Suites/SandboxFrontier/binary-bridge-stage.json
@@ -1,0 +1,34 @@
+{
+  "id": "sandbox.binary-bridge-stage",
+  "domain": "agent_loop",
+  "label": "sandbox • combined mode: file_copy stages a host binary into the VM for sandbox_exec",
+  "query": "My workspace contains assets/logo.png — a binary asset that file_read cannot open. Stage it into your sandbox with file_copy, then compute its SHA-256 hash with sandbox_exec (sha256sum) and report the full 64-character hash.",
+  "notes": "Pins the binary-bridge dead end from the live transcript: in combined mode raw bytes only cross via file_copy (file_read extracts text, sandbox_exec has no workspace mount). Read-only variant — the workspace->sandbox direction needs no write grant. The .png is seeded with pinned text bytes so the hash is deterministic while file_read still refuses it by extension. sha256('PNGDATA-OSAURUS-EVAL-BRIDGE-1\\n') = 937790e7...",
+  "fixtures": {
+    "sandbox": {
+      "hostFolder": true
+    },
+    "workspaceFiles": [
+      {
+        "path": "assets/logo.png",
+        "contents": "PNGDATA-OSAURUS-EVAL-BRIDGE-1\n"
+      }
+    ]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 12,
+      "mustCallToolsInOrder": [
+        "file_copy",
+        "sandbox_exec"
+      ],
+      "mustNotCallTools": [
+        "file_write",
+        "shell_run"
+      ],
+      "finalTextContains": [
+        "937790e79ba6e433c7d895a7be1df49752556e56c43b1d45467be5ff17496047"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a path-routed `file_copy(source, destination)` tool for combined sandbox + workspace mode: a host-side byte copy over the VirtioFS share, the only way binary files (PDFs, images, archives) can cross between the workspace and the sandbox (`file_read` extracts text, `file_write` carries text through tokens, `sandbox_exec` has no workspace mount).
- Direction rules: workspace→sandbox and sandbox→sandbox always allowed in combined mode; sandbox→workspace and workspace→workspace require the `allowHostFolderWrites` opt-in (new `ChatExecutionContext.allowHostFolderWrites` task-local bound in `ToolRegistry.execute`). Secret-shaped sources and destinations are refused, a 512 MB size cap applies, and `overwrite` defaults to false with a typed failure.
- Host-bound copies are marked `mutatesHostFolder`, so they land in the Changes sheet and are undoable; `file_copy` is visible only in combined mode (hidden in plain folder and plain sandbox modes) and denied on external surfaces.
- Prompts teach the staging flow: the combined-mode files block, tool dispatch guides, and `sandbox_exec`'s annotation now point at `file_copy`, and `file_read`'s binary-content error fails forward to `file_copy` + `sandbox_exec` instead of dead-ending the model.

## Testing

- New `FileCopyToolTests` suite: routing matrix (4 directions), write-grant gating, secret refusal both ways, overwrite/size-cap envelopes, directory/missing-source errors, `/workspace/..` escape rejection.
- Change-tracking test: a real `file_copy` execution inside a host checkpoint records a created, undoable row.
- Prompt/visibility assertions in `ChatViewSandboxTests` and `SystemPromptComposerToolResolutionTests`; targeted sweep of 92 tests across 11 adjacent suites passes.
- Two new live SandboxFrontier eval cases, both passing against the real sandbox VM (grok): `sandbox.binary-bridge-stage` (read-only: `file_copy` → `sandbox_exec` sha256) and `sandbox.binary-bridge-roundtrip` (writable: copy in, transform, copy back to the workspace).