### PR TITLE
Fix management-window sheet-swap crash and wire Sentry release telemetry

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -158,6 +158,17 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: bash scripts/build/upload_dsyms_sentry.sh
 
+      # Register the Sentry release with commit + deploy association so triage
+      # can attribute regressions to shipped commits and read adoption against
+      # a real deploy timestamp. Best-effort: no-ops without the secrets.
+      - name: Register Sentry release (commits + deploy)
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: bash scripts/build/sentry_release.sh
+
       - name: Get Release Notes from Draft
         id: changelog
         env:

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -2301,7 +2301,29 @@ extension AppDelegate {
                 if hasDeeplink {
                     // Deeplink targets are baked into the view at creation, so the
                     // hosting controller has to be rebuilt to deliver them.
-                    existingWindow.contentViewController = NSHostingController(rootView: root)
+                    //
+                    // End any attached sheets FIRST: swapping the hosting
+                    // controller tears down the old SwiftUI graph, but a
+                    // SwiftUI `.sheet`'s presentation window stays attached to
+                    // this NSWindow and keeps observing parent frame changes.
+                    // The swap itself resizes the window (the new hosting
+                    // view's constraint pass updates the content-size extrema),
+                    // and the orphaned sheet's size callback then re-enters the
+                    // torn-down graph and traps inside SwiftUI
+                    // (Sentry APPLE-MACOS-EF).
+                    while let sheet = existingWindow.attachedSheet {
+                        existingWindow.endSheet(sheet)
+                    }
+                    let replacement = NSHostingController(rootView: root)
+                    // Match `WindowManager.createWindow`: AppKit owns this
+                    // window's size (defaultSize + frame autosave). Leaving the
+                    // default sizingOptions on lets the swapped-in hosting view
+                    // push its measured size back onto the window every layout
+                    // pass — the frame change seen in the EF crash stack.
+                    if #available(macOS 13.0, *) {
+                        replacement.sizingOptions = []
+                    }
+                    existingWindow.contentViewController = replacement
                 } else if let initialTab {
                     // No deeplink: drive navigation through the shared state the
                     // existing view already observes. Recreating the hosting

--- a/Packages/OsaurusCore/Services/CrashReportingService.swift
+++ b/Packages/OsaurusCore/Services/CrashReportingService.swift
@@ -144,11 +144,18 @@ public final class CrashReportingService {
     /// `static` and `nonisolated` so hot, off-main paths (such as plugin tool invocation) can
     /// annotate without hopping to the main actor, which can deadlock when the main thread is
     /// busy. A no-op when crash reporting isn't running (Sentry drops breadcrumbs with no SDK).
+    ///
+    /// Each breadcrumb is also mirrored as a structured Sentry Log row. Breadcrumbs only
+    /// travel attached to a captured event, so a release with few events has almost no
+    /// queryable timeline — the 0.22.6 triage had zero Logs rows to correlate hangs against.
+    /// The mirror gives release triage a searchable stream (same category/message contract:
+    /// identifiers only) without instrumenting every call site twice.
     public nonisolated static func recordBreadcrumb(category: String, message: String) {
         guard SentrySDK.isEnabled else { return }
         let crumb = Breadcrumb(level: .info, category: category)
         crumb.message = message
         SentrySDK.addBreadcrumb(crumb)
+        SentrySDK.logger.info(message, attributes: ["category": category])
     }
 
     // MARK: - DSN resolution
@@ -221,6 +228,17 @@ public final class CrashReportingService {
             options.enableAutoPerformanceTracing = false
             options.tracesSampleRate = 0.0
 
+            // Release health: sessions are what turn raw event counts into
+            // "N of M users affected" and crash-free rates per release. On by
+            // default in the SDK, but pinned explicitly because triage depends
+            // on it — 0.22.6 had to be triaged from bare event counts.
+            options.enableAutoSessionTracking = true
+
+            // Structured logs (mirrored from `recordBreadcrumb`): gives each
+            // release a queryable operation timeline in Sentry → Logs. Same
+            // privacy contract as breadcrumbs — identifiers only, no content.
+            options.enableLogs = true
+
             // Don't turn transient network failures into issues, and don't log
             // outgoing request URLs as breadcrumbs — both are on by default,
             // both are out of scope (a failed HTTP response isn't a crash), and
@@ -234,10 +252,17 @@ public final class CrashReportingService {
             // and don't exist on the macOS SDK, so there's nothing to disable.)
             options.sendDefaultPii = false
             options.beforeSend = { event in
-                // Defense-in-depth on top of `sendDefaultPii = false`: drop the
-                // user object and the device hostname (often "<Name>'s MacBook")
-                // from every event before it leaves the machine.
-                event.user = nil
+                // Defense-in-depth on top of `sendDefaultPii = false`: strip
+                // the device hostname (often "<Name>'s MacBook") and every
+                // identifying user field from the event before it leaves the
+                // machine. Keep ONLY the SDK's anonymous installation id — a
+                // random UUID stored locally, attached by the SDK as `user.id`
+                // when no user is set. Blanking the whole user (as 0.22.6 did)
+                // made Sentry report "Users Impacted: 0" on every issue, so
+                // release triage couldn't tell one broken machine from a fleet.
+                let anonymous = User()
+                anonymous.userId = event.user?.userId
+                event.user = anonymous
                 event.serverName = nil
                 return event
             }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2529,6 +2529,46 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    /// Management-window deeplink reuse swaps the hosting controller of a
+    /// live NSWindow. A SwiftUI `.sheet`'s presentation window stays attached
+    /// through that swap and keeps observing parent frame changes; when the
+    /// new hosting view resizes the window, the orphaned sheet re-enters its
+    /// torn-down graph and traps inside SwiftUI (Sentry APPLE-MACOS-EF).
+    /// Pin the two mitigations: end attached sheets before the swap, and
+    /// clear `sizingOptions` on the replacement controller so it can't push
+    /// content-size extrema frame changes onto the reused window.
+    @Test("Management window deeplink reuse detaches sheets before swapping the hosting controller")
+    func managementDeeplinkReuseDetachesSheetsBeforeControllerSwap() throws {
+        let appDelegate = try Self.source("AppDelegate.swift")
+
+        let reuseStart = try #require(
+            appDelegate.range(of: "if let existingWindow = windowManager.window(for: .management)")
+        )
+        let reuseWindow = String(
+            appDelegate[
+                reuseStart.lowerBound
+                    ..< appDelegate.index(
+                        reuseStart.lowerBound,
+                        offsetBy: 2400,
+                        limitedBy: appDelegate.endIndex
+                    )!
+            ]
+        )
+
+        let endSheets = try #require(
+            reuseWindow.range(of: "while let sheet = existingWindow.attachedSheet")
+        )
+        let swap = try #require(
+            reuseWindow.range(of: "existingWindow.contentViewController = replacement")
+        )
+        #expect(
+            endSheets.lowerBound < swap.lowerBound,
+            "attached sheets must be ended before the hosting controller swap"
+        )
+        #expect(reuseWindow.contains("existingWindow.endSheet(sheet)"))
+        #expect(reuseWindow.contains("replacement.sizingOptions = []"))
+    }
+
     @Test("Local bundle config readers preserve discovered bundle paths")
     func localBundleConfigReadersPreserveDiscoveredBundlePaths() throws {
         let defaults = try Self.source("Services/LocalGenerationDefaults.swift")
@@ -3107,5 +3147,30 @@ struct RuntimePolicySourceTests {
             "Sentry scrubs breadcrumbs containing prompt-like fields as content; token counts must remain visible for OOM/context-growth triage"
         )
         #expect(adapter.contains("submit model=\\(modelName) batch=\\(maxBatchSize)"))
+    }
+
+    /// Pins the release-observability wiring added after the 0.22.6 triage,
+    /// which had no structured Logs rows, no usable users-affected counts, and
+    /// no commit/deploy association to attribute regressions against.
+    @Test("Sentry release telemetry keeps sessions, logs, and the anonymous install id")
+    func sentryReleaseTelemetryWiring() throws {
+        let crashReporting = try Self.source("Services/CrashReportingService.swift")
+
+        // Release health sessions and structured logs must stay enabled.
+        #expect(crashReporting.contains("options.enableAutoSessionTracking = true"))
+        #expect(crashReporting.contains("options.enableLogs = true"))
+
+        // Breadcrumbs mirror into Sentry Logs so releases have a queryable
+        // timeline even when few events are captured.
+        #expect(crashReporting.contains("SentrySDK.logger.info(message, attributes: [\"category\": category])"))
+
+        // beforeSend must keep ONLY the SDK's anonymous installation id —
+        // blanking the whole user (`event.user = nil`, as 0.22.6 shipped)
+        // makes every issue report "Users Impacted: 0"; attaching anything
+        // more would break the "nothing is tied to you" consent promise.
+        #expect(crashReporting.contains("anonymous.userId = event.user?.userId"))
+        #expect(!crashReporting.contains("event.user = nil"))
+        #expect(crashReporting.contains("event.serverName = nil"))
+        #expect(crashReporting.contains("options.sendDefaultPii = false"))
     }
 }

--- a/scripts/build/sentry_release.sh
+++ b/scripts/build/sentry_release.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Registers this build as a Sentry Release and associates commits + a deploy
+# with it, so release triage can see which commits shipped, diff regressions
+# between releases ("suspect commits"), and read adoption/crash-free rates
+# against a real deploy timestamp. The 0.22.6 triage had none of this — no
+# commits, no deploys — so regressions couldn't be attributed.
+#
+# The release name MUST match what the Sentry Cocoa SDK reports at runtime,
+# which is its default "<bundle id>@<marketing version>+<build>". Our build
+# sets MARKETING_VERSION and CURRENT_PROJECT_VERSION to the same ${VERSION}
+# (see build_arm64.sh), so the runtime release is:
+#   com.dinoki.osaurus@${VERSION}+${VERSION}
+#
+# Best-effort by design, same contract as upload_dsyms_sentry.sh: missing
+# secrets (forks, local runs) log a warning and exit 0 rather than failing
+# the release.
+#
+# Required env (all three, or the step no-ops):
+#   SENTRY_AUTH_TOKEN — token with project:releases scope
+#   SENTRY_ORG        — org slug
+#   SENTRY_PROJECT    — project slug
+#   VERSION           — marketing/build version (from setup_env.sh, tag-derived)
+#
+# Optional:
+#   SENTRY_CLI_VERSION — pin the installed sentry-cli (default below)
+
+SENTRY_ORG="${SENTRY_ORG:-}"
+SENTRY_PROJECT="${SENTRY_PROJECT:-}"
+SENTRY_CLI_VERSION="${SENTRY_CLI_VERSION:-2.39.1}"
+
+if [[ -z "${SENTRY_AUTH_TOKEN:-}" || -z "${SENTRY_ORG}" || -z "${SENTRY_PROJECT}" ]]; then
+  echo "::warning::SENTRY_AUTH_TOKEN/SENTRY_ORG/SENTRY_PROJECT not all set; skipping Sentry release registration (release health won't have commits/deploys for this build)."
+  exit 0
+fi
+
+if [[ -z "${VERSION:-}" ]]; then
+  echo "::warning::VERSION not set; skipping Sentry release registration."
+  exit 0
+fi
+
+BUNDLE_ID="com.dinoki.osaurus"
+RELEASE="${BUNDLE_ID}@${VERSION}+${VERSION}"
+
+# Install a pinned sentry-cli (no sudo) if it isn't already on PATH — the
+# dSYM step usually ran first and left one installed.
+if ! command -v sentry-cli >/dev/null 2>&1; then
+  INSTALL_DIR="${RUNNER_TEMP:-/tmp}/sentry-cli-bin"
+  mkdir -p "${INSTALL_DIR}"
+  echo "Installing sentry-cli ${SENTRY_CLI_VERSION} into ${INSTALL_DIR} ..."
+  curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="${INSTALL_DIR}" SENTRY_CLI_VERSION="${SENTRY_CLI_VERSION}" bash
+  export PATH="${INSTALL_DIR}:${PATH}"
+fi
+
+echo "Registering Sentry release ${RELEASE} (${SENTRY_ORG}/${SENTRY_PROJECT})"
+
+sentry-cli releases new "${RELEASE}" \
+  --org "${SENTRY_ORG}" \
+  --project "${SENTRY_PROJECT}"
+
+# Commit association. `--auto` uses the org's linked repo integration; when
+# the repo isn't linked, fall back to `--local`, which reads the checked-out
+# git history directly (the workflow checks out with fetch-depth: 0).
+# `--ignore-missing` keeps the very first tracked release from failing when
+# the previous release has no commit recorded to diff against.
+if ! sentry-cli releases set-commits "${RELEASE}" \
+  --org "${SENTRY_ORG}" \
+  --project "${SENTRY_PROJECT}" \
+  --auto --ignore-missing; then
+  echo "::warning::set-commits --auto failed (repo not linked in Sentry?); falling back to --local."
+  sentry-cli releases set-commits "${RELEASE}" \
+    --org "${SENTRY_ORG}" \
+    --project "${SENTRY_PROJECT}" \
+    --local --ignore-missing
+fi
+
+sentry-cli releases finalize "${RELEASE}" \
+  --org "${SENTRY_ORG}" \
+  --project "${SENTRY_PROJECT}"
+
+# Deploy marker: stamps when this release actually went out to production, so
+# adoption and crash-free graphs have a real starting point.
+sentry-cli deploys new \
+  --org "${SENTRY_ORG}" \
+  --project "${SENTRY_PROJECT}" \
+  --release "${RELEASE}" \
+  --env production \
+  --name "github-release"
+
+echo "✅ Sentry release ${RELEASE} registered with commits + production deploy."


### PR DESCRIPTION
## Summary

Part of the 0.22.6 Sentry triage. Scoped to NOT overlap with #2079, which owns the main-thread I/O and UI-blocker fixes (APPLE-MACOS-158, 152/13D, 151/14Z, 150/14Y, 12J) — this PR covers the remaining app-owned fatal plus release observability.

- **Fixes APPLE-MACOS-EF** (140 fatal sheet/layout crashes): the management-window deeplink reuse path (chat toolbar → agent settings) replaced the window's `contentViewController` while SwiftUI sheets were still attached. The swap tears down the old SwiftUI graph, the new hosting view's constraint pass resizes the window, and the orphaned `SheetPresentationWindow`'s `parentWindowSizeChanged` → `sheetSize` callback re-enters the torn-down graph and traps inside SwiftUI. Fix: end attached sheets before the swap, and clear `sizingOptions` on the replacement controller (matching `WindowManager.createWindow`) so it can't push content-size extrema frame changes onto the reused window.
- **Users-impacted counts**: `beforeSend` kept blanking the whole user object, which made every issue report "Users Impacted: 0". It now keeps ONLY the SDK's anonymous installation id (a random local UUID) while still stripping the hostname; `sendDefaultPii` stays false.
- **Structured logs**: `recordBreadcrumb` now mirrors each breadcrumb into Sentry Logs (`options.enableLogs = true`), giving each release a queryable operation timeline — 0.22.6 had zero Logs rows to correlate hangs against. Same identifiers-only privacy contract.
- **Session tracking** pinned explicitly for release-health crash-free rates.
- **Commit/deploy association**: new `scripts/build/sentry_release.sh` + release-workflow step registers the release under the SDK's runtime name (`com.dinoki.osaurus@VERSION+VERSION`), sets commits (`--auto` with `--local` fallback), finalizes, and stamps a production deploy. Best-effort like the dSYM step — no-ops without the Sentry secrets.

Source-pin tests added to `RuntimePolicySourceTests` for both the sheet-swap ordering and the telemetry wiring.

Related fixes landing outside this repo: APPLE-MACOS-N (rank-0 error-array guards in vmlx-swift Qwen35 LLM/VLM mixers) and APPLE-MACOS-2V (swapped `SLEventPostToPid` arguments in the osaurus-macos-use plugin).

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` clean
- [x] Focused suites pass: `RuntimePolicySourceTests`, `CrashReportingServiceTests` (100 tests)
- [ ] Full suite on CI (local full run skipped per author)
- [ ] Post-release: verify the next release in Sentry shows sessions, users-impacted counts, Logs rows, and commit/deploy association