### PR TITLE
Fix built-in Data Visualizer chart tool activation

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -709,6 +709,32 @@ struct CapabilitiesLoadToolTests {
         }
     }
 
+    /// The built-in Data Visualizer skill is not plugin-backed, but its
+    /// instructions require the gated `render_chart` tool for raw tabular
+    /// data. Loading the skill must therefore make that exact tool callable in
+    /// the same session; instructions without the schema strand small models
+    /// in a deterministic `tool_not_found` loop.
+    @Test @MainActor
+    func dataVisualizerSkillLoadAutoLoadsRenderChart() async throws {
+        await SkillManager.shared.refresh()
+        _ = await CapabilityLoadBuffer.shared.drain()
+
+        let tool = CapabilitiesLoadTool()
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+            try await tool.execute(
+                argumentsJSON: #"{"ids":["skill/Data Visualizer"]}"#
+            )
+        }
+
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("## Skill: Data Visualizer"))
+        #expect(result.contains("Auto-loaded tools (callable NOW by name): render_chart"))
+        #expect(result.contains("Schema for `render_chart`"))
+
+        let buffered = await CapabilityLoadBuffer.shared.drain()
+        #expect(buffered.map(\.function.name) == ["render_chart"])
+    }
+
     @Test @MainActor
     func toolLoadReportsDisabledAvailability() async throws {
         try await DynamicCatalogTestLock.shared.run {

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -606,6 +606,16 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     /// injects for a single message only.
     static let skillReferenceBudget = 32_000
 
+    /// Built-in skills are not plugin-backed, so they have no dynamic tool
+    /// group for `loadSkill` to cascade automatically. Keep their concrete
+    /// tool dependencies explicit here instead of parsing tool names out of
+    /// prose. Data Visualizer otherwise teaches a small model to call
+    /// `render_chart` while leaving that gated built-in outside the live
+    /// execution scope.
+    private static let builtInSkillToolDependencies: [UUID: [String]] = [
+        UUID(uuidString: "00000001-0000-0000-0000-000000000007")!: ["render_chart"]
+    ]
+
     let name = "capabilities_load"
     let description =
         "Load capabilities into the current session by ID. IDs come from the Enabled capabilities list "
@@ -1069,6 +1079,12 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                 + (skill.isFromPlugin
                     ? "the plugin skill." : skill.isBuiltIn ? "the built-in." : "the user skill.")
             output += "\n\n"
+        }
+
+        if skill.isBuiltIn,
+            let requiredTools = Self.builtInSkillToolDependencies[skill.id]
+        {
+            output += await bufferToolSpecs(named: requiredTools)
         }
 
         // A plugin skill governs its sibling tools, so auto-load the plugin's


### PR DESCRIPTION
## Scope

Follow-up to #2041 for the remaining Bonsai chart capability-composition failure only.

- Built-in Data Visualizer instructions require the gated `render_chart` tool.
- Unlike plugin skills, built-in skills have no dynamic plugin tool group for `loadSkill` to cascade.
- Loading Data Visualizer therefore returned instructions but left `render_chart` outside the live execution scope when the agent Charts ability was off.
- This change gives that stable built-in skill ID one explicit dependency and buffers the existing `render_chart` schema in the same conversation. It does not change prompts, sampling, parsers, model routing, RAM policy, or chart argument validation.

## Source and tests

- Valid red control on the unpatched source: Data Visualizer loaded, but the result had no auto-loaded tool line, no `render_chart` schema, and the capability buffer stayed empty. Log: `/private/tmp/osaurus-bonsai-chart-red.log`.
- Patched focused test: `dataVisualizerSkillLoadAutoLoadsRenderChart` passed 1/1. Log: `/private/tmp/osaurus-bonsai-chart-green.log`.
- Adjacent `CapabilitiesLoadToolTests` plus `RenderChartToolTests`: 36/36 passed. Log: `/private/tmp/osaurus-bonsai-chart-adjacent.log`.
- `git diff --check` passed. A standalone `swiftlint` binary is not installed on this host; CI remains authoritative for lint.
- Release app build completed with `** BUILD SUCCEEDED **` and was ad-hoc sealed and strict-verified.

## Live Release-app proof

Artifact:
- App source base plus this exact two-file patch; committed tree `3b503fe29`
- Custom bundle ID `com.dinoki.osaurus.bonsaichartcapabilityproof`
- Isolated `OSAURUS_TEST_ROOT=/private/tmp/osaurus-bonsai-chart-capability-runtime-20260718-live1`
- Packaged vMLX revision `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`
- Exact local model `/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`
- Thinking visibly off; Charts visibly off; no MXFP4 model loaded or downloaded

Exact patched branch:
1. The user requested `capabilities_load` of `skill/Data Visualizer`, without loading `tool/render_chart` directly.
2. The expanded capability card visibly returned `Auto-loaded tools (callable NOW by name): render_chart` and the full schema.
3. The model preserved the `month,value` CSV header and made one successful `render_chart` call.
4. The app displayed the Monthly Values bar chart and exact final `chart-skill-done` at TTFT 0.73s, 38.0 tok/s, 4 tokens.
5. The model redundantly loaded the same skill twice, but there was no `tool_not_found` and no repeated chart call.

## Honest boundary

A separate natural Charts-off run chose `tool/render_chart` directly, so it bypassed this patch. Its chart succeeded, but its post-tool final was stored as `bonsi` (2 tokens) instead of the requested `bonsai-chart-complete`. A fresh text-only control returned full `bonsai-chart-complete` (4 tokens). Because SQLite stored the same shortened text shown in the UI, that observation is not a UI-only content-delta rendering loss and was not an invalid chart-JSON failure. The post-tool stop/cache path remains a separate PARTIAL Bonsai investigation; this PR does not claim to solve it.

Broader routing, hardware guidance, TurboQuant KV, RAM settings, AppleScript, Sentry, and MXFP4 work are intentionally excluded.