### PR TITLE
Correct Gemma QAT cache settings and TQ telemetry

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a26c7ecec950f18e3d07c8402fbd8c80f40ac764"
+        "revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
+        "revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -296,10 +296,9 @@ public enum ServerRuntimeSettingsStore {
         }
         if shouldRepairLegacyCacheDefaults(normalized.cache) {
             // Keep companion-cache repair independent from the live KV codec.
-            // Engine-selected is the default policy now, but ModelRuntime
-            // only resolves it to TurboQuant for proven full-KV rows and
-            // leaves hybrid/rotating/CCA/DSV4 rows on fp16 unless explicitly
-            // overridden.
+            // Engine-selected is the default policy and resolves to native
+            // KV. TurboQuant remains available only through an explicit
+            // user-selected codec with explicit bit widths.
             normalized.cache.enableSSMReDerive = true
             writeCacheDefaultsMigrationMarker()
         }
@@ -474,10 +473,8 @@ public enum ServerRuntimeSettingsStore {
         // Cache: seed the engine-owned topology with automatic policy.
         // Prefix, block-disk L2, and SSM rederive are on by default; paged
         // RAM KV is opt-in because it only helps materially for multibatch
-        // workloads. Engine-selected live KV is resolved by ModelRuntime per
-        // model family/topology: proven full-KV rows get TurboQuant, while
-        // hybrid/rotating/CCA/DSV4 rows stay native/fp16 unless explicitly
-        // overridden.
+        // workloads. Engine-selected live KV stays native/fp16 for every
+        // family. TurboQuant remains an explicit user opt-in with bit widths.
         settings.cache = VMLXServerCacheSettings(
             prefix: VMLXPrefixCacheSettings(
                 enabled: true,

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -858,6 +858,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let lastMemorySafetyLoadDecision =
                 await ModelRuntime.shared.lastMemorySafetyLoadDecisionSnapshot()
             let batchDiagnostics = await MLXBatchAdapter.snapshotDiagnostics()
+            let turboQuantTransitions =
+                await MLXBatchAdapter.turboQuantCacheTransitionsSnapshot()
             let lastEffectiveGenerationSettings =
                 await MLXBatchAdapter.lastEffectiveGenerationSettingsSnapshot()
             var aggregate: [String: Int] = [
@@ -932,28 +934,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     cacheTopology: summary.cacheTopology
                 )
                 if let topology = summary.cacheTopology {
-                    row["cache_topology"] =
-                        [
-                            "layer_count": topology.layerCount,
-                            "kv_layer_count": topology.kvLayerCount,
-                            "chunked_kv_layer_count": topology.chunkedKVLayerCount,
-                            "quantized_kv_layer_count": topology.quantizedKVLayerCount,
-                            "turbo_quant_kv_layer_count": topology.turboQuantKVLayerCount,
-                            "compilable_kv_layer_count": topology.compilableKVLayerCount,
-                            "compilable_turbo_quant_kv_layer_count": topology.compilableTurboQuantKVLayerCount,
-                            "rotating_kv_layer_count": topology.rotatingKVLayerCount,
-                            "compilable_rotating_kv_layer_count": topology.compilableRotatingKVLayerCount,
-                            "rotating_wrapper_layer_count": topology.rotatingWrapperLayerCount,
-                            "hybrid_pool_layer_count": topology.hybridPoolLayerCount,
-                            "mamba_layer_count": topology.mambaLayerCount,
-                            "compilable_mamba_layer_count": topology.compilableMambaLayerCount,
-                            "arrays_layer_count": topology.arraysLayerCount,
-                            "zaya_cca_layer_count": topology.zayaCCALayerCount,
-                            "cache_list_layer_count": topology.cacheListLayerCount,
-                            "requires_ssm_companion_state": topology.requiresSSMCompanionState,
-                            "requires_disk_backed_restore": topology.requiresDiskBackedCoordinatorRestore,
-                            "tags": topology.topologyTags,
-                        ] as [String: Any]
+                    row["cache_topology"] = Self.cacheTopologyJSONObject(topology)
+                }
+                if let transition = turboQuantTransitions[summary.name] {
+                    row["last_turboquant_cache_transition"] =
+                        Self.turboQuantCacheTransitionJSONObject(transition)
+                } else {
+                    row["last_turboquant_cache_transition"] = NSNull()
                 }
 
                 var paged: [String: Any] = ["enabled": stats.pagedEnabled]
@@ -8986,6 +8973,43 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         // cancellation, but a merely-slow one stops doing work sooner.
         if first == nil { work.cancel() }
         return first
+    }
+
+    static func cacheTopologyJSONObject(
+        _ topology: ModelCacheTopologySnapshot
+    ) -> [String: Any] {
+        [
+            "layer_count": topology.layerCount,
+            "kv_layer_count": topology.kvLayerCount,
+            "chunked_kv_layer_count": topology.chunkedKVLayerCount,
+            "quantized_kv_layer_count": topology.quantizedKVLayerCount,
+            "turbo_quant_kv_layer_count": topology.turboQuantKVLayerCount,
+            "compilable_kv_layer_count": topology.compilableKVLayerCount,
+            "compilable_turbo_quant_kv_layer_count": topology.compilableTurboQuantKVLayerCount,
+            "rotating_kv_layer_count": topology.rotatingKVLayerCount,
+            "compilable_rotating_kv_layer_count": topology.compilableRotatingKVLayerCount,
+            "rotating_wrapper_layer_count": topology.rotatingWrapperLayerCount,
+            "hybrid_pool_layer_count": topology.hybridPoolLayerCount,
+            "mamba_layer_count": topology.mambaLayerCount,
+            "compilable_mamba_layer_count": topology.compilableMambaLayerCount,
+            "arrays_layer_count": topology.arraysLayerCount,
+            "zaya_cca_layer_count": topology.zayaCCALayerCount,
+            "cache_list_layer_count": topology.cacheListLayerCount,
+            "requires_ssm_companion_state": topology.requiresSSMCompanionState,
+            "requires_disk_backed_restore": topology.requiresDiskBackedCoordinatorRestore,
+            "tags": topology.topologyTags,
+        ] as [String: Any]
+    }
+
+    static func turboQuantCacheTransitionJSONObject(
+        _ transition: TurboQuantCacheTransitionSnapshot
+    ) -> [String: Any] {
+        [
+            "converted_turbo_quant_kv_layer_count":
+                transition.convertedTurboQuantKVLayerCount,
+            "before": cacheTopologyJSONObject(transition.before),
+            "after": cacheTopologyJSONObject(transition.after),
+        ] as [String: Any]
     }
 
     /// Shape the `/health` `batch_diagnostics` block from a snapshot.

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a26c7ecec950f18e3d07c8402fbd8c80f40ac764"
+        "revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
+        "revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -69,7 +69,7 @@ let package = Package(
         // before/after each real TurboQuant transition.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
+            revision: "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -62,10 +62,14 @@ let package = Package(
         // carries #149: native schema-2 affine1 JANG loading and Metal kernels,
         // Qwen3-VL tool-schema preservation, and bounded media-cache cleanup.
         // Also carries #153: fail-closed support for historical schema-1 JANG
-        // affine manifests.
+        // affine manifests. Also carries #93: Gemma4 model registrations no
+        // longer inject the stale `<end_of_turn>` token into extraEOSTokens;
+        // bundle generation_config.json remains the stop-token authority. The
+        // PR #154 proof revision also reports the exact cache-layer topology
+        // before/after each real TurboQuant transition.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a26c7ecec950f18e3d07c8402fbd8c80f40ac764"
+            revision: "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2644,9 +2644,8 @@ public actor ModelRuntime {
         // shipped default) therefore resolves to native fp16 KV for every
         // model.
         //
-        // vMLX's settings resolve `.engineSelected -> .turboQuant()`, so this
-        // runtime gate is the single point that decides whether engine-
-        // selected actually turns TurboQuant on. Previously it returned true
+        // This host gate and the pinned vMLX settings default both resolve
+        // engine-selected to native KV. Previously this gate returned true
         // for full-KV families (MiniMax) and for any topology with KV layers
         // and no rotating/hybrid layers — which silently force-enabled
         // TurboQuant on multiple families. TurboQuant's per-step

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -44,6 +44,16 @@ struct MLXBatchAdapter {
         await Registry.shared.snapshotDiagnostics()
     }
 
+    /// Exact live cache-class transitions keyed by the model name used to
+    /// create each BatchEngine. Unlike the aggregate compression counter,
+    /// these snapshots prove how many layers converted and which mixed-cache
+    /// layers remained native.
+    static func turboQuantCacheTransitionsSnapshot() async
+        -> [String: TurboQuantCacheTransitionSnapshot]
+    {
+        await Registry.shared.turboQuantCacheTransitionsSnapshot()
+    }
+
     static func lastEffectiveGenerationSettingsSnapshot() async -> [String: EffectiveGenerationSettings] {
         await Registry.shared.lastEffectiveGenerationSettingsSnapshot()
     }
@@ -413,6 +423,19 @@ struct MLXBatchAdapter {
 
         func lastEffectiveGenerationSettingsSnapshot() -> [String: EffectiveGenerationSettings] {
             lastEffectiveGenerationSettings
+        }
+
+        func turboQuantCacheTransitionsSnapshot() async
+            -> [String: TurboQuantCacheTransitionSnapshot]
+        {
+            let entries = await coalescer.resolvedEntries()
+            var result: [String: TurboQuantCacheTransitionSnapshot] = [:]
+            for (modelName, engine) in entries {
+                if let transition = await engine.lastTurboQuantCacheTransitionForDiagnostics {
+                    result[modelName] = transition
+                }
+            }
+            return result
         }
 
         /// Aggregate live BatchEngine diagnostics across every resolved

--- a/Packages/OsaurusCore/Services/ModelRuntime/TaskCoalescer.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/TaskCoalescer.swift
@@ -289,4 +289,12 @@ public actor TaskCoalescer<Value: Sendable> {
     public func resolvedValues() -> [Value] {
         Array(values.values)
     }
+
+    /// Returns the currently-resolved key/value pairs. Read-only diagnostic
+    /// helper for per-model runtime telemetry; the actor snapshots the map so
+    /// callers never enumerate it concurrently with mutation.
+    public func resolvedEntries() -> [(key: String, value: Value)] {
+        values.map { (key: $0.key, value: $0.value) }
+            .sorted { $0.key < $1.key }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Networking/TurboQuantCacheTransitionShapingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/TurboQuantCacheTransitionShapingTests.swift
@@ -1,0 +1,37 @@
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("TurboQuant cache transition admin telemetry")
+struct TurboQuantCacheTransitionShapingTests {
+    @Test("admin JSON reports exact mixed Gemma before and after topology")
+    func mixedGemmaTransition() throws {
+        let transition = TurboQuantCacheTransitionSnapshot(
+            before: ModelCacheTopologySnapshot(
+                layerCount: 48,
+                kvLayerCount: 8,
+                rotatingKVLayerCount: 40
+            ),
+            after: ModelCacheTopologySnapshot(
+                layerCount: 48,
+                turboQuantKVLayerCount: 8,
+                rotatingKVLayerCount: 40
+            )
+        )
+
+        let object = HTTPHandler.turboQuantCacheTransitionJSONObject(transition)
+        let before = try #require(object["before"] as? [String: Any])
+        let after = try #require(object["after"] as? [String: Any])
+
+        #expect(object["converted_turbo_quant_kv_layer_count"] as? Int == 8)
+        #expect(before["layer_count"] as? Int == 48)
+        #expect(before["kv_layer_count"] as? Int == 8)
+        #expect(before["turbo_quant_kv_layer_count"] as? Int == 0)
+        #expect(before["rotating_kv_layer_count"] as? Int == 40)
+        #expect(after["layer_count"] as? Int == 48)
+        #expect(after["kv_layer_count"] as? Int == 0)
+        #expect(after["turbo_quant_kv_layer_count"] as? Int == 8)
+        #expect(after["rotating_kv_layer_count"] as? Int == 40)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "a26c7ecec950f18e3d07c8402fbd8c80f40ac764""#))
-        #expect(packageResolved.contains(#""revision" : "a26c7ecec950f18e3d07c8402fbd8c80f40ac764""#))
-        #expect(workspaceResolved.contains(#""revision" : "a26c7ecec950f18e3d07c8402fbd8c80f40ac764""#))
-        #expect(appResolved.contains(#""revision" : "a26c7ecec950f18e3d07c8402fbd8c80f40ac764""#))
+        #expect(packageSwift.contains(#"revision: "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
+        #expect(packageResolved.contains(#""revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
+        #expect(workspaceResolved.contains(#""revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
+        #expect(appResolved.contains(#""revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
-        #expect(packageResolved.contains(#""revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
-        #expect(workspaceResolved.contains(#""revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
-        #expect(appResolved.contains(#""revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd""#))
+        #expect(packageSwift.contains(#"revision: "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
+        #expect(packageResolved.contains(#""revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
+        #expect(workspaceResolved.contains(#""revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
+        #expect(appResolved.contains(#""revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -704,7 +704,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
+        let expectedRuntimeHardenedRevision = "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -704,7 +704,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "a26c7ecec950f18e3d07c8402fbd8c80f40ac764"
+        let expectedRuntimeHardenedRevision = "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -989,7 +989,7 @@ struct RuntimePolicySourceTests {
         )
         #expect(
             store.contains("liveKVCodec: .engineSelected"),
-            "ServerRuntimeSettingsStore.migratedFromLegacy must use engine-selected live KV so proven full-KV rows default to TurboQuant"
+            "ServerRuntimeSettingsStore.migratedFromLegacy must preserve the engine-selected native-KV default"
         )
         #expect(
             store.contains("pagedKV: VMLXPagedKVCacheSettings(\n                enabled: false"),
@@ -1004,8 +1004,8 @@ struct RuntimePolicySourceTests {
             "Legacy cache migration must not overwrite explicit existing live-KV choices"
         )
         #expect(
-            store.contains("Engine-selected live KV is resolved by ModelRuntime per"),
-            "ServerRuntimeSettingsStore must document that engine-selected is topology-gated by ModelRuntime"
+            store.contains("Engine-selected live KV stays native/fp16 for every"),
+            "ServerRuntimeSettingsStore must document that engine-selected keeps TurboQuant off by default"
         )
         #expect(
             store.contains("shouldRepairLegacyCacheDefaults"),
@@ -1074,8 +1074,11 @@ struct RuntimePolicySourceTests {
         #expect(!adapter.contains("prefixMisses += diskStats.misses"))
 
         let cacheSection = try Self.source("Views/Settings/ServerSettings/CacheSection.swift")
+        #expect(cacheSection.contains(#"isOn: $draft.cache.blockDisk.enabled"#))
         #expect(cacheSection.contains(#"value: $draft.cache.blockDisk.directory"#))
-        #expect(cacheSection.contains(#"value: $draft.cache.legacyDisk.directory"#))
+        #expect(!cacheSection.contains(#"isOn: $draft.cache.legacyDisk.enabled"#))
+        #expect(!cacheSection.contains(#"value: $draft.cache.legacyDisk.directory"#))
+        #expect(cacheSection.contains("Works with paged RAM cache off"))
     }
 
     @Test("Server settings cache changes clear loaded model runtime")

--- a/Packages/OsaurusCore/Tests/Service/TaskCoalescerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/TaskCoalescerTests.swift
@@ -92,6 +92,21 @@ struct TaskCoalescerTests {
         #expect(v1 === v2 && v2 === v3)
     }
 
+    @Test("resolvedEntries preserves model keys for per-engine diagnostics")
+    func resolvedEntriesPreserveKeys() async {
+        let coalescer = TaskCoalescer<Sentinel>()
+        let factoryA = SlowFactory(sleepMs: 1)
+        let factoryB = SlowFactory(sleepMs: 1)
+        let a = await coalescer.value(for: "model-a") { await factoryA.make() }
+        let b = await coalescer.value(for: "model-b") { await factoryB.make() }
+
+        let entries = await coalescer.resolvedEntries()
+
+        #expect(entries.map(\.key) == ["model-a", "model-b"])
+        #expect(entries[0].value === a)
+        #expect(entries[1].value === b)
+    }
+
     @Test("remove() drains an in-flight creation and returns the resolved value")
     func remove_drainsInFlight() async {
         let coalescer = TaskCoalescer<Sentinel>()

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift
@@ -57,7 +57,7 @@ struct CacheSection: View {
 
             SettingsDivider()
 
-            SettingsSubsection(label: "Disk Spillover") {
+            SettingsSubsection(label: "SSD Cache (L2)") {
                 diskCacheControls
             }
 
@@ -109,49 +109,27 @@ struct CacheSection: View {
 
     // MARK: - Subviews
 
-    @ViewBuilder
     private var diskCacheControls: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if draft.cache.pagedKV.enabled {
-                SettingsToggle(
-                    title: L("Disk Cache"),
-                    description:
-                        "Spill paged blocks to disk so cache survives restarts and shares across processes.",
-                    isOn: $draft.cache.blockDisk.enabled
-                )
-                OptionalDoubleField(
-                    label: "Disk Cache Size (GB)",
-                    placeholder: "Blank = engine default (10 GB)",
-                    help: "Soft cap before older entries are evicted.",
-                    value: $draft.cache.blockDisk.maxSizeGB,
-                    format: "%.1f"
-                )
-                OptionalStringField(
-                    label: "Disk Cache Directory",
-                    placeholder: "Blank = Osaurus default cache directory",
-                    help: "Absolute path or ~/... path for persisted block-cache entries.",
-                    value: $draft.cache.blockDisk.directory
-                )
-            } else {
-                SettingsToggle(
-                    title: L("Legacy Disk Cache"),
-                    description: "Used when the GPU paged cache is off.",
-                    isOn: $draft.cache.legacyDisk.enabled
-                )
-                OptionalDoubleField(
-                    label: "Disk Cache Size (GB)",
-                    placeholder: "Blank = engine default (10 GB)",
-                    help: "Soft cap before older entries are evicted.",
-                    value: $draft.cache.legacyDisk.maxSizeGB,
-                    format: "%.1f"
-                )
-                OptionalStringField(
-                    label: "Legacy Disk Cache Directory",
-                    placeholder: "Blank = Osaurus default cache directory",
-                    help: "Absolute path or ~/... path for legacy disk-cache entries.",
-                    value: $draft.cache.legacyDisk.directory
-                )
-            }
+            SettingsToggle(
+                title: L("Disk Cache"),
+                description:
+                    "Persist reusable cache blocks on SSD. Works with paged RAM cache off and restores the longest matching prefix after restart; turn off to disable disk reuse.",
+                isOn: $draft.cache.blockDisk.enabled
+            )
+            OptionalDoubleField(
+                label: "Disk Cache Size (GB)",
+                placeholder: "Blank = engine default (10 GB)",
+                help: "Soft cap before older entries are evicted.",
+                value: $draft.cache.blockDisk.maxSizeGB,
+                format: "%.1f"
+            )
+            OptionalStringField(
+                label: "Disk Cache Directory",
+                placeholder: "Blank = Osaurus default cache directory",
+                help: "Absolute path or ~/... path for persisted block-cache entries.",
+                value: $draft.cache.blockDisk.directory
+            )
         }
     }
 

--- a/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
+++ b/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
@@ -11,7 +11,7 @@ not part of this checkpoint.
 ## Scoped changes
 
 - Pin all four Osaurus SwiftPM resolution points to vMLX
-  `86f8634d85fdbf228f2981645f1d3b0a7fb1dacd`.
+  `bbc0b20d7dd46445c9ff3d76be7caf329310a338`.
 - Keep paged RAM cache off by default.
 - Keep engine-selected TurboQuant KV off by default. An explicit user
   TurboQuant selection with explicit bit widths remains available.
@@ -30,7 +30,7 @@ MLXPress, Bonsai, or automatic model-routing implementation is changed here.
 
 | Gate | Evidence | Status |
 |---|---|---|
-| Four-pin equality | Manifest, package resolution, app workspace resolution, and root workspace resolution all name `86f8634d...` | VERIFIED-SOURCE |
+| Four-pin equality | Manifest, package resolution, app workspace resolution, and root workspace resolution all name `bbc0b20d...` | VERIFIED-SOURCE |
 | Default cache policy | Focused persistence/default tests show prefix on, paged off, block-disk L2 on, legacy disk off, engine-selected codec retained; vMLX resolves that codec to native KV | VERIFIED-SOURCE |
 | Explicit Off | vMLX focused regression preserves block-disk Off with prefix on and paged off through memory-safety resolution | VERIFIED-SOURCE |
 | Explicit TurboQuant | Osaurus policy test resolves explicit bit widths to `turbo(k,v)` while engine-selected remains native | VERIFIED-SOURCE |

--- a/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
+++ b/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
@@ -1,0 +1,82 @@
+# Gemma 4 QAT cache checkpoint — 2026-07-19
+
+Status: **PARTIAL — source contracts and the prior pinned Release app are
+verified; the current Osaurus pin/settings patch still needs an isolated
+Release rebuild and live UI repeat before merge.**
+
+This checkpoint uses only the locally installed Gemma 4 12B MXFP8 and
+JANG_4M bundles under `~/models`. MXFP4 is not a substitute artifact and is
+not part of this checkpoint.
+
+## Scoped changes
+
+- Pin all four Osaurus SwiftPM resolution points to vMLX
+  `86f8634d85fdbf228f2981645f1d3b0a7fb1dacd`.
+- Keep paged RAM cache off by default.
+- Keep engine-selected TurboQuant KV off by default. An explicit user
+  TurboQuant selection with explicit bit widths remains available.
+- Keep block-disk SSD L2 on by default even when paged RAM cache is off.
+  Bind the visible Settings toggle to block-disk L2, not the deprecated
+  legacy disk cache, and preserve explicit user Off through memory-safety
+  resolution.
+- Expose the exact last TurboQuant cache-class transition per loaded model in
+  `/admin/cache-stats` so the app can distinguish 8 converted full-attention
+  KV layers from 40 preserved rotating SWA layers.
+
+No parser, tool schema, content-delta streaming, AppleScript, Sentry,
+MLXPress, Bonsai, or automatic model-routing implementation is changed here.
+
+## Current evidence
+
+| Gate | Evidence | Status |
+|---|---|---|
+| Four-pin equality | Manifest, package resolution, app workspace resolution, and root workspace resolution all name `86f8634d...` | VERIFIED-SOURCE |
+| Default cache policy | Focused persistence/default tests show prefix on, paged off, block-disk L2 on, legacy disk off, engine-selected codec retained; vMLX resolves that codec to native KV | VERIFIED-SOURCE |
+| Explicit Off | vMLX focused regression preserves block-disk Off with prefix on and paged off through memory-safety resolution | VERIFIED-SOURCE |
+| Explicit TurboQuant | Osaurus policy test resolves explicit bit widths to `turbo(k,v)` while engine-selected remains native | VERIFIED-SOURCE |
+| Exact transition telemetry | vMLX transition suite 3/3 plus Osaurus admin JSON shaping 1/1 report 48 layers before/after, 8 KV to 8 TQ, 40 rotating preserved | VERIFIED-SOURCE |
+| Prior JANG_4M native/TQ UI | Exact visible codes, 39.1/41.4 tok/s native and 34.3/32.5 tok/s TQ; cold/partial SSD hits; exact 8-to-8/40 transition | VERIFIED-LIVE on prior pin `718522bc` |
+| Prior MXFP8 native/TQ UI | Exact visible codes, 32.0/31.7 tok/s native and 28.1/26.1 tok/s TQ; cold/partial SSD hits; exact 8-to-8/40 transition | VERIFIED-LIVE on prior pin `718522bc` |
+| Current pin UI | Fresh isolated Release app, visible settings toggles, endpoint counters, coherent restart continuation, tok/s, and Activity Monitor footprint | OPEN |
+
+## Current-build live matrix
+
+- Fresh isolated bundle ID, preferences root, files root, and SSD cache root.
+- Settings defaults visibly show paged RAM off, engine-selected/native cache,
+  and SSD L2 on.
+- Endpoint agrees: paged false, block-disk true, legacy disk false, native
+  live codec, null TurboQuant transition before explicit opt-in.
+- Turn SSD L2 off in Settings, save, restart/load, and prove zero disk
+  hits/stores plus no new cache artifacts in the isolated root.
+- Turn SSD L2 back on, save, restart/load, generate a unique sentinel, quit,
+  relaunch, and prove full and partial longest-prefix disk hits with coherent
+  exact continuation while paged stays off.
+- Enable explicit TurboQuant 4/4 and prove the live transition converts only
+  8 full-attention KV layers while preserving all 40 rotating SWA layers.
+- Return to Native and prove transition null/TQ-layer count zero.
+- Exercise the visible RAM-safety refusal and No Automatic Limits override on
+  the next real load, then restore Safe Auto.
+- Inspect the exact proof process and executable path in Activity Monitor and
+  record physical footprint, TTFT, tok/s, visible answer, and no loop/marker
+  leakage.
+
+Gemma's rotating cache topology is paged-incompatible in the pinned runtime.
+An explicit paged request must therefore report its effective state truthfully
+instead of fabricating paged hits. SSD L2 restore remains independently usable
+with paged RAM off.
+
+## Wider cache campaign retained after this checkpoint
+
+- Qwen 3.5/3.5 VL, Ornith, Bonsai, Nemotron, and other hybrid SSM/GDN/GLA
+  families: TurboQuant off/on, partial SSD-only reuse, typed companion-state
+  sync/async rederive, VL media salt, multi-turn coherence, TTFT/tok/s, and
+  physical footprint.
+- LFM and MiniMax M2.7: TurboQuant off/on, paged eviction where supported,
+  partial SSD reuse, multi-turn coherence, TTFT/tok/s, and footprint.
+- DSV4/ZAYA/MiniMax-M3 native composite-cache exceptions remain separate and
+  must not be inferred from Gemma proof.
+- JANGTQ/MXTQ weight correctness remains separate from TurboQuant KV-cache
+  encoding.
+
+No row is merge-ready from a setting value, source inspection, or aggregate
+counter alone. Current-build UI and matching runtime telemetry are mandatory.

--- a/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
+++ b/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
@@ -1,8 +1,11 @@
 # Gemma 4 QAT cache checkpoint — 2026-07-19
 
-Status: **PARTIAL — source contracts and the prior pinned Release app are
-verified; the current Osaurus pin/settings patch still needs an isolated
-Release rebuild and live UI repeat before merge.**
+Status: **PARTIAL — the exact current Osaurus branch and vMLX
+`bbc0b20d7dd46445c9ff3d76be7caf329310a338` are live-proven in an isolated
+Release app for the core Gemma 4 12B JANG_4M/MXFP8 cache and settings rows.
+The 31B RAM-limit override control works, but its Activity Monitor Memory
+column exceeded the bundle's on-disk size, so low-footprint readiness remains
+failed and the PR is not yet described as release-ready.**
 
 This checkpoint uses only the locally installed Gemma 4 12B MXFP8 and
 JANG_4M bundles under `~/models`. MXFP4 is not a substitute artifact and is
@@ -22,6 +25,11 @@ not part of this checkpoint.
 - Expose the exact last TurboQuant cache-class transition per loaded model in
   `/admin/cache-stats` so the app can distinguish 8 converted full-attention
   KV layers from 40 preserved rotating SWA layers.
+- Preserve the vMLX type-selective contract: explicit TQ converts only real
+  `KVCacheSimple` full-attention layers. Rotating, DeepseekV4, Mamba,
+  Arrays/CCA, and composite companion caches remain native; a hybrid prefix
+  hit without matching companion state must be rejected and rederived rather
+  than blanket-encoded or reported as reusable.
 
 No parser, tool schema, content-delta streaming, AppleScript, Sentry,
 MLXPress, Bonsai, or automatic model-routing implementation is changed here.
@@ -35,30 +43,34 @@ MLXPress, Bonsai, or automatic model-routing implementation is changed here.
 | Explicit Off | vMLX focused regression preserves block-disk Off with prefix on and paged off through memory-safety resolution | VERIFIED-SOURCE |
 | Explicit TurboQuant | Osaurus policy test resolves explicit bit widths to `turbo(k,v)` while engine-selected remains native | VERIFIED-SOURCE |
 | Exact transition telemetry | vMLX transition suite 3/3 plus Osaurus admin JSON shaping 1/1 report 48 layers before/after, 8 KV to 8 TQ, 40 rotating preserved | VERIFIED-SOURCE |
-| Prior JANG_4M native/TQ UI | Exact visible codes, 39.1/41.4 tok/s native and 34.3/32.5 tok/s TQ; cold/partial SSD hits; exact 8-to-8/40 transition | VERIFIED-LIVE on prior pin `718522bc` |
-| Prior MXFP8 native/TQ UI | Exact visible codes, 32.0/31.7 tok/s native and 28.1/26.1 tok/s TQ; cold/partial SSD hits; exact 8-to-8/40 transition | VERIFIED-LIVE on prior pin `718522bc` |
-| Current pin UI | Fresh isolated Release app, visible settings toggles, endpoint counters, coherent restart continuation, tok/s, and Activity Monitor footprint | OPEN |
+| Current Release artifact | `/private/tmp/osaurus-gemma4-bbc0-release-derived/Build/Products/Release/osaurus.app`; isolated bundle id `com.dinoki.osaurus.gemma4proofbbc0`; executable SHA-256 `7b26f98a6d3ae9ddec53357972abebed93829b81ce62b51cb04d4c8392651943`; exact vMLX pin `bbc0b20d...` | VERIFIED-LIVE |
+| Current settings defaults | Fresh UI and restored-final UI visibly showed prefix on, paged off, SSD L2 on, Codec Engine Selected, SSM rederive on, Safe Auto, MLXPress off. Endpoint agreed: native fp16, paged false, disk true, TQ transition null | VERIFIED-LIVE |
+| Current explicit SSD Off | Settings saved SSD Off; visible `DISK-OFF-CURRENT-2846` at 41.4 tok/s; endpoint block disk false and all disk/paged counters zero | VERIFIED-LIVE |
+| Current JANG_4M native/TQ UI | Native `NATIVE-COLD-6724` 36.8 tok/s; partial `NATIVE-PARTIAL-9381` 41.7 tok/s; TQ eight CACHE lines 55.2 tok/s; restart RESTORE lines 52.8 tok/s; exact 8-to-8/40 transition | VERIFIED-LIVE |
+| Current MXFP8 native/TQ UI | Native `MXFP8-NATIVE-COLD-7412` 31.9 tok/s; TQ eight lines 38.0 tok/s; restart/partial RESTORE lines 36.7 tok/s; restored-default `MXFP8-DEFAULT-RESTORED-9021` 32.0 tok/s; exact 8-to-8/40 transition | VERIFIED-LIVE |
+| Current SSD-only restart/partial reuse | JANG after restart: disk hits 2/misses 11/stores 3; MXFP8 after restart: hits 2/misses 13/stores 3. Paged hits/misses stayed zero; both changed-prefix outputs remained coherent | VERIFIED-LIVE |
+| Current paged incompatibility truth | Explicit UI paged On on Gemma yielded requested true but effective `paged_cache.enabled=false`, `is_paged_incompatible=true`, zero paged hits/misses; SSD remained active | VERIFIED-LIVE |
+| Current RAM refusal/override | Strict custom 10% visibly refused the 31B JANG_4M at a 12.8 GiB budget. No Automatic Limits then loaded the same model and emitted `RAM-OVERRIDE-3179` at 12.2 tok/s. Endpoint: automatic limits disabled, estimated working set 30.9 GiB, allowed true. Safe Auto restored | VERIFIED-LIVE for control behavior |
+| Current Activity Monitor footprint | Exact proof executable: 31B main Memory 28.37 GB; inspector Real 19.30 GB, Private 996 MB. Bundle is 25G on disk (25,926,564 KiB), so the main Memory column fails the low-footprint gate | FAILED-LIVE |
 
 ## Current-build live matrix
 
-- Fresh isolated bundle ID, preferences root, files root, and SSD cache root.
-- Settings defaults visibly show paged RAM off, engine-selected/native cache,
-  and SSD L2 on.
-- Endpoint agrees: paged false, block-disk true, legacy disk false, native
-  live codec, null TurboQuant transition before explicit opt-in.
-- Turn SSD L2 off in Settings, save, restart/load, and prove zero disk
-  hits/stores plus no new cache artifacts in the isolated root.
-- Turn SSD L2 back on, save, restart/load, generate a unique sentinel, quit,
-  relaunch, and prove full and partial longest-prefix disk hits with coherent
-  exact continuation while paged stays off.
-- Enable explicit TurboQuant 4/4 and prove the live transition converts only
-  8 full-attention KV layers while preserving all 40 rotating SWA layers.
-- Return to Native and prove transition null/TQ-layer count zero.
-- Exercise the visible RAM-safety refusal and No Automatic Limits override on
-  the next real load, then restore Safe Auto.
-- Inspect the exact proof process and executable path in Activity Monitor and
-  record physical footprint, TTFT, tok/s, visible answer, and no loop/marker
-  leakage.
+| Row | Result |
+|---|---|
+| Isolated artifact and exact pin | VERIFIED-LIVE |
+| Fresh/restored defaults | VERIFIED-LIVE |
+| Explicit SSD Off | VERIFIED-LIVE |
+| SSD on with paged off | VERIFIED-LIVE on JANG_4M and MXFP8 |
+| Full/partial fresh-process L2 reuse | VERIFIED-LIVE on JANG_4M and MXFP8 |
+| Selective TQ4/4 mixed-SWA conversion | VERIFIED-LIVE on JANG_4M and MXFP8 |
+| Return to Engine Selected/native | VERIFIED-LIVE |
+| Strict refusal and No-Limits next-load override | VERIFIED-LIVE |
+| 31B low Activity Monitor footprint | FAILED-LIVE |
+| Long rotating-window sentinel | OPEN |
+| Ten-turn coherence | OPEN |
+| Tool/parser continuation with TQ off/on | OPEN |
+| Stream/non-stream protocol parity | OPEN |
+| Cancel/preload cleanup | OPEN |
 
 Gemma's rotating cache topology is paged-incompatible in the pinned runtime.
 An explicit paged request must therefore report its effective state truthfully
@@ -68,15 +80,27 @@ with paged RAM off.
 ## Wider cache campaign retained after this checkpoint
 
 - Qwen 3.5/3.5 VL, Ornith, Bonsai, Nemotron, and other hybrid SSM/GDN/GLA
-  families: TurboQuant off/on, partial SSD-only reuse, typed companion-state
-  sync/async rederive, VL media salt, multi-turn coherence, TTFT/tok/s, and
-  physical footprint.
+  families: TurboQuant off/on for eligible full-attention KV only, partial
+  SSD-only reuse, typed native companion-state synchronization/rederive, VL
+  media salt, multi-turn coherence, TTFT/tok/s, and physical footprint.
+  Detached async rederive is not accepted as a replacement for safe
+  prompt-boundary synchronization.
 - LFM and MiniMax M2.7: TurboQuant off/on, paged eviction where supported,
   partial SSD reuse, multi-turn coherence, TTFT/tok/s, and footprint.
-- DSV4/ZAYA/MiniMax-M3 native composite-cache exceptions remain separate and
-  must not be inferred from Gemma proof.
+- DSV4 Flash and OpenPangu must remain hard-excluded from TurboQuant KV even
+  under explicit user opt-in until their typed native cache paths have
+  separate source and live proof. DSV4/ZAYA/MiniMax-M3 composite-cache
+  behavior must not be inferred from Gemma.
 - JANGTQ/MXTQ weight correctness remains separate from TurboQuant KV-cache
   encoding.
 
 No row is merge-ready from a setting value, source inspection, or aggregate
 counter alone. Current-build UI and matching runtime telemetry are mandatory.
+
+## Current-source focused tests
+
+With the Xcode 26 toolchain selected, 5/5 focused Osaurus assertions passed:
+admin JSON mixed-topology shaping, all four exact vMLX pin checks, legacy
+settings repair without enabling TQ, per-engine resolved-key diagnostics, and
+the shared image-bridge contract's pin-only assertion. The latter contains no
+image-runtime behavior change in this diff.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a26c7ecec950f18e3d07c8402fbd8c80f40ac764"
+        "revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "86f8634d85fdbf228f2981645f1d3b0a7fb1dacd"
+        "revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
       }
     },
     {


### PR DESCRIPTION
## Scope

- pin all four Osaurus SwiftPM resolution points to vMLX `bbc0b20d7dd46445c9ff3d76be7caf329310a338`
- keep paged RAM KV off by default
- keep Engine Selected/native KV as the default; TurboQuant remains explicit opt-in
- bind Settings `SSD Cache (L2)` to the real block-disk cache independently of paged RAM and preserve explicit Off
- expose exact per-model TurboQuant before/after cache topology in `/admin/cache-stats`
- snapshot resolved BatchEngine keys read-only so per-model diagnostics remain correctly attributed

No parser, tool schema, content-delta streaming, AppleScript, Sentry, MLXPress, Bonsai, automatic-routing, or image-runtime behavior is changed. The image bridge test change only updates its existing four-pin assertion.

## Current source verification

- Xcode 26 toolchain focused Osaurus assertions: 5/5 passed
  - mixed Gemma admin JSON shaping
  - exact four-pin source contract
  - legacy settings repair without enabling TQ
  - per-engine resolved-key diagnostics
  - shared image-bridge pin assertion
- exact pinned vMLX focused assertions: 8/8 passed
- Release app build succeeded
- `git diff --check`: passed
- branch is 0 commits behind current `main`

## Current live verification

Exact artifact: `/private/tmp/osaurus-gemma4-bbc0-release-derived/Build/Products/Release/osaurus.app`, isolated bundle ID `com.dinoki.osaurus.gemma4proofbbc0`, executable SHA-256 `7b26f98a6d3ae9ddec53357972abebed93829b81ce62b51cb04d4c8392651943`.

- fresh and restored UI defaults visibly showed Safe Auto, prefix on, paged off, SSD L2 on, Engine Selected/native, SSM rederive on, MLXPress off
- JANG_4M native 36.8 tok/s; partial 41.7; TQ warm 55.2; TQ restart 52.8
- MXFP8 native 31.9 tok/s; TQ 38.0; TQ restart 36.7; restored native 32.0
- both TQ rows reported exactly 8 full-attention KV layers converted to 8 TQ while all 40 rotating SWA layers remained native
- both formats showed process-restart partial SSD hits with paged hits/misses at zero
- explicit SSD Off saved through the UI and produced zero disk/paged counters
- explicit paged On reported requested true but effective false/incompatible true on Gemma
- Strict custom 10% refused the 31B bundle before load; No Automatic Limits then allowed the next load; Safe Auto was restored

## Honest remaining gate

PARTIAL, not release-ready: the exact 31B proof process showed 28.37 GB in Activity Monitor's main Memory column versus a 25G on-disk bundle, so the low-footprint gate is FAILED-LIVE. Long rotating-window, ten-turn, tool/parser, stream/non-stream protocol, and cancellation rows remain open and are listed in the committed checkpoint.
