### PR TITLE
Pin ZAYA cache fix and enable Nemotron Omni multimodal routing

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
+        "revision" : "4634af5151ffd71262d180e32962939dd8b2263f"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -59,11 +59,17 @@ enum VLMDetection {
     }
 
     /// Check if a downloaded model at the given directory is a VLM.
-    /// Uses vision_config key presence in config.json as the definitive signal,
-    /// disambiguating model types registered in both LLM and VLM factories
-    /// (e.g. gemma4 has both text-only and vision variants).
+    /// Mirrors vMLX's factory dispatch: Nemotron Omni bundles are identified by
+    /// `config_omni.json` because their primary `config.json` deliberately
+    /// describes only the inner text decoder (`model_type: nemotron_h`). Other
+    /// families use `vision_config` presence to disambiguate model types
+    /// registered in both LLM and VLM factories (for example Gemma4).
     static func isVLM(at directory: URL) -> Bool {
         cachedVerdict("dir:\(directory.path)") {
+            let omniSidecar = directory.appendingPathComponent("config_omni.json")
+            if FileManager.default.fileExists(atPath: omniSidecar.path) {
+                return true
+            }
             guard let json = readConfigJSON(at: directory) else { return false }
             return json["vision_config"] != nil
         }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6fb106582a3681ed33e6e186165327a0069ff785"
+        "revision" : "4634af5151ffd71262d180e32962939dd8b2263f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "41434e8bab2d30c0c9c2eb746104621caf40fdcc"
+        "revision" : "6fb106582a3681ed33e6e186165327a0069ff785"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
+        "revision" : "41434e8bab2d30c0c9c2eb746104621caf40fdcc"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -69,10 +69,12 @@ let package = Package(
         // before/after each real TurboQuant transition. The ZAYA cache proof
         // revision adds real-attention-only TQ ownership, native CCA companion
         // restore, atomic typed L2 records, and a proven four-bit floor for
-        // TQ-native ZAYA disk boundaries.
+        // TQ-native ZAYA disk boundaries. The Nemotron Omni revision also
+        // aligns the RADIO/projector contract, bounds media prefill, and
+        // enables safe image/audio hybrid-prefix restore.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6fb106582a3681ed33e6e186165327a0069ff785"
+            revision: "4634af5151ffd71262d180e32962939dd8b2263f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -66,10 +66,13 @@ let package = Package(
         // longer inject the stale `<end_of_turn>` token into extraEOSTokens;
         // bundle generation_config.json remains the stop-token authority. The
         // PR #154 proof revision also reports the exact cache-layer topology
-        // before/after each real TurboQuant transition.
+        // before/after each real TurboQuant transition. The ZAYA cache proof
+        // revision adds real-attention-only TQ ownership, native CCA companion
+        // restore, atomic typed L2 records, and a proven four-bit floor for
+        // TQ-native ZAYA disk boundaries.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
+            revision: "41434e8bab2d30c0c9c2eb746104621caf40fdcc"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -72,7 +72,7 @@ let package = Package(
         // TQ-native ZAYA disk boundaries.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "41434e8bab2d30c0c9c2eb746104621caf40fdcc"
+            revision: "6fb106582a3681ed33e6e186165327a0069ff785"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
@@ -86,6 +86,28 @@ import Testing
         #expect(!VLMDetection.isVLM(at: tmp))
     }
 
+    /// Nemotron Omni's outer multimodal contract lives in config_omni.json;
+    /// config.json intentionally remains the inner text decoder config. The
+    /// picker detector must make the same sidecar decision as vMLX's
+    /// VLMModelFactory or an installed Omni bundle is displayed/routed as a
+    /// text model even though the runtime loads NemotronHOmni.
+    @Test func isVLMAtDirectory_trueForNemotronOmniSidecar() throws {
+        let tmp = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try writeConfig(
+            at: tmp,
+            json: #"{"model_type": "nemotron_h", "_jang_modality": "text"}"#
+        )
+        try #"{"model_type": "NemotronH_Nano_Omni_Reasoning_V3"}"#
+            .write(
+                to: tmp.appendingPathComponent("config_omni.json"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        #expect(VLMDetection.isVLM(at: tmp))
+    }
+
     @Test func isVLMAtDirectory_falseWhenConfigMissing() {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
-        #expect(packageResolved.contains(#""revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
-        #expect(workspaceResolved.contains(#""revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
-        #expect(appResolved.contains(#""revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338""#))
+        #expect(packageSwift.contains(#"revision: "4634af5151ffd71262d180e32962939dd8b2263f""#))
+        #expect(packageResolved.contains(#""revision" : "4634af5151ffd71262d180e32962939dd8b2263f""#))
+        #expect(workspaceResolved.contains(#""revision" : "4634af5151ffd71262d180e32962939dd8b2263f""#))
+        #expect(appResolved.contains(#""revision" : "4634af5151ffd71262d180e32962939dd8b2263f""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -694,8 +694,9 @@ struct RuntimePolicySourceTests {
         // resolver read, so it moved nothing.
         //
         // Now also carries native schema-2 affine1 JANG loading and Metal
-        // execution, Qwen3-VL tool-schema preservation, and bounded media-cache
-        // cleanup (vmlx-swift#149).
+        // execution, Qwen3-VL tool-schema preservation, bounded media-cache
+        // cleanup (vmlx-swift#149), and the Nemotron Omni projector,
+        // bounded-media-prefill, and safe hybrid media-prefix fixes (#156).
         //
         // This assertion is a repin tripwire, and it earned its keep: PR #1986
         // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
@@ -704,7 +705,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
+        let expectedRuntimeHardenedRevision = "4634af5151ffd71262d180e32962939dd8b2263f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -712,7 +713,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift revision proven for the native affine1 JANG, Qwen3-VL tool-schema, and bounded media-cache checkpoint. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift revision proven for the native affine1 JANG, Qwen3-VL tool-schema, bounded media-cache, and Nemotron Omni multimodal checkpoints. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026_07_19.md
+++ b/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026_07_19.md
@@ -1,0 +1,61 @@
+# Nemotron Omni Multimodal Checkpoint — 2026-07-19
+
+Status: **PARTIAL — source and focused boundary tests pass; rebuilt-app live
+multimodal acceptance is still required.**
+
+Exact proof model:
+
+`/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ4-CRACK`
+
+This checkpoint does not use or make claims about MXFP4.
+
+## App-side root cause
+
+Nemotron Omni keeps the text decoder contract in `config.json` and the outer
+multimodal contract in `config_omni.json`. `VLMDetection.isVLM(at:)` inspected
+only `config.json` for `vision_config`, so the installed bundle could be
+filtered/routed as text-only in Osaurus even though vMLX's factory supports its
+RADIO vision, temporal video, and Parakeet audio towers.
+
+The detector now treats a present `config_omni.json` sidecar as multimodal,
+matching the vMLX factory boundary. Other families retain the existing
+`vision_config` rule.
+
+## Exact engine pin
+
+OsaurusCore and both checked-in package resolutions point to vMLX commit:
+
+`6fb106582a3681ed33e6e186165327a0069ff785`
+
+That engine commit fixes the Nemotron vision projector and RADIO normalization,
+removes the hidden media-only prompt/Thinking override, and adds strict
+multimodal regression coverage. Its detailed direct-model matrix is in
+`docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md` in vmlx-swift.
+
+## Current-source evidence
+
+`/tmp/osaurus_nemotron_focused_tests2_20260719.log`:
+
+- `VLMDetectionTests/isVLMAtDirectory_trueForNemotronOmniSidecar()` passed.
+- Existing text-ZAYA, ZAYA-VL, Qwen-VL, DiffusionGemma, missing-config, and
+  malformed-config detector rows passed, guarding adjacent routing behavior.
+- `MultimodalContentPartTests` passed for image/audio/video content decoding,
+  video forwarding, WAV-to-samples, container materialization, all-role media,
+  and MP4 extension preservation.
+- Two live-audio registry freshness tests were skipped by their existing
+  environment preconditions; they are not counted as passes.
+
+## Remaining live acceptance
+
+- Build and ad-hoc sign the isolated Release app with a non-production bundle
+  identifier and `OSAURUS_TEST_ROOT`.
+- In the UI, inspect and record the effective Multimodal, Thinking, RAM safety,
+  prefix, paged, L2 disk, SSM re-derive, and TurboQuant-KV controls.
+- Load the exact JANGTQ4 bundle through the model picker.
+- Exercise image, video, audio, mixed media, multi-turn recall, same/different
+  media cache isolation, post-media text, and Thinking off/on.
+- Record visible TTFT/token rate and Activity Monitor physical footprint plus
+  exact runtime cache telemetry. JANGTQ weight format must not be reported as
+  TurboQuant KV encoding.
+- Keep the row PARTIAL if video Thinking-on still length-stops. Do not force
+  Thinking off or inject a prompt to manufacture a pass.

--- a/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026_07_19.md
+++ b/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026_07_19.md
@@ -1,7 +1,8 @@
 # Nemotron Omni Multimodal Checkpoint — 2026-07-19
 
-Status: **PARTIAL — source and focused boundary tests pass; rebuilt-app live
-multimodal acceptance is still required.**
+Status: **PARTIAL — the rebuilt isolated Release app now passes the default
+image, audio, video, mixed-media, restart/L2, and multi-turn transport rows.
+Video with Thinking enabled and 4/4 TurboQuant-KV video accuracy remain open.**
 
 Exact proof model:
 
@@ -23,14 +24,25 @@ matching the vMLX factory boundary. Other families retain the existing
 
 ## Exact engine pin
 
-OsaurusCore and both checked-in package resolutions point to vMLX commit:
+OsaurusCore and all three checked-in package resolutions point to vMLX commit:
 
-`6fb106582a3681ed33e6e186165327a0069ff785`
+`4634af5151ffd71262d180e32962939dd8b2263f`
 
 That engine commit fixes the Nemotron vision projector and RADIO normalization,
-removes the hidden media-only prompt/Thinking override, and adds strict
+removes the hidden media-only prompt/Thinking override, bounds multimodal Mamba
+prefill, enables safe image/audio hybrid-prefix capture, and adds strict
 multimodal regression coverage. Its detailed direct-model matrix is in
 `docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md` in vmlx-swift.
+
+## Pre-patch live reproduction
+
+The isolated Release app at the former `6fb10658` pin selected the exact model
+through the UI with Thinking visibly off. It correctly described a two-region
+image at 115.1 tok/s and recalled it in a text-only follow-up at 55.4 tok/s, but
+reached a 76 GiB physical-footprint peak and visibly re-prefilled `0/4729` on
+the follow-up. The isolated cache database contained full 4433/4577 and
+4729/4758 boundaries but no reusable stripped media prefix. This proves the
+old failure; it does not verify the newly pinned build.
 
 ## Current-source evidence
 
@@ -45,17 +57,79 @@ multimodal regression coverage. Its detailed direct-model matrix is in
 - Two live-audio registry freshness tests were skipped by their existing
   environment preconditions; they are not counted as passes.
 
-## Remaining live acceptance
+## Current isolated Release-app proof
 
-- Build and ad-hoc sign the isolated Release app with a non-production bundle
-  identifier and `OSAURUS_TEST_ROOT`.
-- In the UI, inspect and record the effective Multimodal, Thinking, RAM safety,
-  prefix, paged, L2 disk, SSM re-derive, and TurboQuant-KV controls.
-- Load the exact JANGTQ4 bundle through the model picker.
-- Exercise image, video, audio, mixed media, multi-turn recall, same/different
-  media cache isolation, post-media text, and Thinking off/on.
-- Record visible TTFT/token rate and Activity Monitor physical footprint plus
-  exact runtime cache telemetry. JANGTQ weight format must not be reported as
-  TurboQuant KV encoding.
-- Keep the row PARTIAL if video Thinking-on still length-stops. Do not force
-  Thinking off or inject a prompt to manufacture a pass.
+The exact `4634af5151ffd71262d180e32962939dd8b2263f` pin was built in Release at
+`/tmp/osaurus-nemotron-proof-dd-4634/Build/Products/Release/osaurus.app`,
+ad-hoc signed, and launched as the non-production bundle
+`com.dinoki.osaurus.nemotron4634proof` with
+`OSAURUS_TEST_ROOT=/tmp/osaurus-nemotron-ui-proof-20260719-4634`. The model was
+selected from `/Users/eric/models` through the real model picker. The UI
+identified it as `Nemotron Omni Nano JANGTQ4 CRACK`, VLM, Vision + Language,
+and JANGTQ4. No MXFP4 bundle was loaded.
+
+The real Server settings showed and persisted:
+
+- Prefix cache on, paged RAM cache off, SSD L2 on, SSM re-derive on.
+- Live KV codec `Engine Selected` by default. The fresh post-test restart
+  reported effective KV mode `fp16`, six KV layers, 23 Mamba layers, zero
+  TurboQuant-KV layers, disk-backed restore required, and paged cache off.
+- RAM safety `safe_auto`, slider 2, 70% load budget, one concurrent request,
+  and a 65,536-token KV cap. The exact external bundle had no catalog size
+  estimate, so this run did not display the low-RAM override warning and does
+  not prove that separate warning/override UI.
+- Thinking was changed through the real toolbar control. The persisted model
+  option encoded `disableThinking=true` for the off rows and
+  `disableThinking=false` for the on rows.
+
+Visible/default-cache rows recorded in the isolated chat database at
+`/tmp/osaurus-nemotron-ui-proof-20260719-4634/chat-history/history.sqlite`:
+
+| Row | Result |
+|---|---|
+| Image, Thinking off | Correct yellow upper half / blue lower half; TTFT 6.46s, 103.4 tok/s, 32 tokens. |
+| Image follow-up, no attachment | Correct recall; TTFT 0.95s, 103.2 tok/s, 16 tokens. |
+| App restart + L2-only image recall | Correct without reattaching; TTFT 1.17s, 102.6 tok/s, 13 tokens. Fresh-process telemetry reported four disk-L2 hits and four SSM-companion hits while paged/prefix counters remained zero for this paged-incompatible hybrid topology. |
+| Audio, controlled transcript | Correctly returned `The verification phrase is "Silver Comet 42."`; TTFT 1.05s, 101.3 tok/s, 13 tokens. The preceding attempt made an unsolicited but schema-valid `share_artifact` call, so automatic tool choice is still a separate user-visible caveat rather than an audio-transport pass. |
+| Image + audio | Correctly reported yellow over blue and `silver comet 42`; TTFT 5.53s, 101.4 tok/s, 27 tokens. |
+| Video, Thinking off | Correctly recognized the SMPTE bars and changing timecode/frame label; TTFT 12.20s, 109.3 tok/s, 198 tokens. It estimated the final frame as 140 rather than the fixture's late-frame value near 148, so fine numerical video accuracy is not claimed. |
+| Thinking already on, fresh mixed-media chat | Correct one-time image/audio answer; TTFT 5.56s, 101.8 tok/s, 32 tokens, followed by a correct no-attachment turn at 0.95s and 101.9 tok/s. |
+| Off-to-on transition follow-up | One run repeated the correct sentence three times. A fresh Thinking-on chat did not reproduce it. This remains PARTIAL; no forced closer, sampler override, or output post-processing was added. |
+
+`vmmap -summary` measured 17.6-17.9 GiB physical footprint and a 20.3 GiB
+peak during the current app matrix, replacing the pre-patch 76 GiB peak.
+
+## Explicit TurboQuant-KV toggle proof
+
+TurboQuant-KV was enabled by a real user path in Server -> Settings -> Cache
+with explicit 4-bit keys and 4-bit values, then the app was restarted. This is
+independent of the model's JANGTQ4 weight format. Runtime telemetry reported:
+
+- effective mode `turbo(4,4)`;
+- exactly six ordinary KV layers converted to six TurboQuant-KV layers while
+  all 23 Mamba layers remained Mamba companion state;
+- three TurboQuant compressions, four disk-L2 hits, four SSM-companion hits,
+  zero paged hits, and a 20.3 GiB physical-footprint peak.
+
+The mixed image/audio answer remained correct at 6.71s TTFT and 21.3 tok/s;
+its no-attachment follow-up was correct at 0.97s and 68.3 tok/s. Video remained
+coherent and recognized SMPTE bars, but the same-prompt A/B materially degraded
+quantitative accuracy: 4/4 TurboQuant described the five-second clip as five
+minutes / 24 frames, whereas the restored FP16-cache run tracked the counter to
+about 140 at 11.91s TTFT and 110.6 tok/s. The 4/4 hybrid-video row is therefore
+PARTIAL, not a quality pass. The UI was restored to `Engine Selected`, saved,
+and a fresh restart confirmed `fp16`, zero TurboQuant-KV layers, and paged cache
+off.
+
+## Remaining limits
+
+- Video with Thinking enabled still length-stops in the deterministic direct
+  engine matrix. Do not force Thinking off or inject a prompt to hide it.
+- Repeat the off-to-on transition row to distinguish stochastic repetition
+  from transition/cache state.
+- The automatic `share_artifact` selection on one transcript-only request is
+  a tool-choice issue, not a multimodal decoder/transport failure.
+- 4/4 TurboQuant-KV works structurally for this hybrid topology, including
+  disk and SSM companion reuse, but its video-detail accuracy is not accepted.
+- Low-RAM warning override behavior remains unverified because this external
+  model had no size estimate and the warning did not appear.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6fb106582a3681ed33e6e186165327a0069ff785"
+        "revision" : "4634af5151ffd71262d180e32962939dd8b2263f"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "39d96d6abd98bc653081336ec6b19b78a09d138c4a4131ad7dd5cd6ed264de5c",
+  "originHash" : "8d2ab45cd3ecdf2f71c069ef0919a0c0731224d9554a0f8bbbb6862238299a2e",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bbc0b20d7dd46445c9ff3d76be7caf329310a338"
+        "revision" : "6fb106582a3681ed33e6e186165327a0069ff785"
       }
     },
     {


### PR DESCRIPTION
## Summary

This PR pins the exact vMLX revision containing the scoped ZAYA selective-cache and Nemotron Omni multimodal fixes. It also recognizes Nemotron Omni bundles whose outer media contract is in config_omni.json while config.json describes the inner nemotron_h text decoder.

The change is model-specific. It does not include broader automatic routing or hardware-guidance work.

## Changes

- [x] Behavior change
- [ ] UI layout change
- [ ] Refactor / chore
- [x] Tests
- [x] Docs

## Test plan and evidence

Exact non-MXFP4 model: /Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ4-CRACK.

- Exact vMLX pin 4634af5151ffd71262d180e32962939dd8b2263f is identical in Package.swift and all three checked-in Package.resolved files.
- VLMDetection recognizes config_omni.json; adjacent ZAYA, Qwen-VL, DiffusionGemma, missing-config, and malformed-config rows remain covered.
- Focused Osaurus source suites passed 109 tests in 3 suites, including the four-surface revision tripwire.
- Release app: /tmp/osaurus-nemotron-proof-dd-4634/Build/Products/Release/osaurus.app.
- Isolated bundle/root: com.dinoki.osaurus.nemotron4634proof and /tmp/osaurus-nemotron-ui-proof-20260719-4634.
- Real UI default settings: Prefix on, Paged RAM off, SSD L2 on, SSM re-derive on, Engine Selected KV codec.
- Correct image and follow-up at 103.4 / 103.2 tok/s.
- Correct restart/L2 recall at 102.6 tok/s with disk-L2 and SSM-companion hits.
- Correct audio transcript at 101.3 tok/s.
- Correct image + audio at 101.4 tok/s.
- SMPTE video recognition at 109.3 tok/s.
- Correct fresh Thinking-on mixed media and follow-up at 101.8 / 101.9 tok/s.
- Current physical footprint 17.6-17.9 GiB, 20.3 GiB peak versus 76 GiB pre-patch.

The real Settings UI also proved selective 4/4 TurboQuant-KV wiring: 6 KV layers converted, 23 Mamba layers preserved, disk/SSM hits present, paged hits zero. Mixed media remained coherent, but same-prompt quantitative video accuracy degraded, so TQ video remains PARTIAL. The app was restored to Engine Selected and a fresh restart confirmed fp16, zero TQ-KV layers, and paged cache off.

Known limits are explicit in the checkpoint: video Thinking-on length stop, one non-reproduced off-to-on repetition, one unsolicited valid share_artifact choice, and 4/4 TQ video-detail accuracy.

## Checklist

- [x] I added/updated tests where reasonable
- [x] I updated docs
- [x] I verified the isolated Release app visually on macOS
- [ ] Required CI complete
- [ ] Ready to merge