### PR TITLE
Fix Gemma cache telemetry and Bonsai chart parsing

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -928,15 +928,20 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 row["cache_enabled"] = true
                 row["is_hybrid"] = stats.isHybrid
                 row["is_paged_incompatible"] = stats.isPagedIncompatible
+                let turboQuantTransition = turboQuantTransitions[summary.name]
+                let effectiveCacheTopology = Self.effectiveCacheTopology(
+                    baseline: summary.cacheTopology,
+                    turboQuantTransition: turboQuantTransition
+                )
                 row["effective_kv_mode"] = ModelRuntime.cacheKVModeTag(
                     for: ServerRuntimeSettingsStore.snapshot().cache,
                     modelName: summary.name,
-                    cacheTopology: summary.cacheTopology
+                    cacheTopology: effectiveCacheTopology
                 )
-                if let topology = summary.cacheTopology {
+                if let topology = effectiveCacheTopology {
                     row["cache_topology"] = Self.cacheTopologyJSONObject(topology)
                 }
-                if let transition = turboQuantTransitions[summary.name] {
+                if let transition = turboQuantTransition {
                     row["last_turboquant_cache_transition"] =
                         Self.turboQuantCacheTransitionJSONObject(transition)
                 } else {
@@ -972,12 +977,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
                 let ssm = stats.ssmStats
                 let companionKinds =
-                    summary.cacheTopology?.topologyTags.filter {
+                    effectiveCacheTopology?.topologyTags.filter {
                         $0.hasPrefix("companion=")
                     } ?? []
                 let hasSSMCompanion = companionKinds.contains("companion=ssm")
                 let hasZayaCCACompanion =
-                    (summary.cacheTopology?.zayaCCALayerCount ?? 0) > 0
+                    (effectiveCacheTopology?.zayaCCALayerCount ?? 0) > 0
                 if hasZayaCCACompanion, let diskStats = stats.diskStats {
                     row["zaya_cca_disk_payload_restore"] =
                         [
@@ -8999,6 +9004,17 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             "requires_disk_backed_restore": topology.requiresDiskBackedCoordinatorRestore,
             "tags": topology.topologyTags,
         ] as [String: Any]
+    }
+
+    /// The container snapshot describes the model's baseline cache shape.
+    /// Request-local TurboQuant conversion happens inside BatchEngine, so the
+    /// admin surface must prefer the transition's post-conversion snapshot or
+    /// it reports FP16 KV layers while the live cache is actually quantized.
+    static func effectiveCacheTopology(
+        baseline: ModelCacheTopologySnapshot?,
+        turboQuantTransition: TurboQuantCacheTransitionSnapshot?
+    ) -> ModelCacheTopologySnapshot? {
+        turboQuantTransition?.after ?? baseline
     }
 
     static func turboQuantCacheTransitionJSONObject(

--- a/Packages/OsaurusCore/Tests/Networking/TurboQuantCacheTransitionShapingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/TurboQuantCacheTransitionShapingTests.swift
@@ -34,4 +34,41 @@ struct TurboQuantCacheTransitionShapingTests {
         #expect(after["turbo_quant_kv_layer_count"] as? Int == 8)
         #expect(after["rotating_kv_layer_count"] as? Int == 40)
     }
+
+    @Test("admin effective topology prefers the live post-conversion cache")
+    func effectiveTopologyPrefersTransitionAfter() throws {
+        let baseline = ModelCacheTopologySnapshot(
+            layerCount: 48,
+            kvLayerCount: 8,
+            rotatingKVLayerCount: 40
+        )
+        let transition = TurboQuantCacheTransitionSnapshot(
+            before: baseline,
+            after: ModelCacheTopologySnapshot(
+                layerCount: 48,
+                turboQuantKVLayerCount: 8,
+                rotatingKVLayerCount: 40
+            )
+        )
+
+        let effective = try #require(
+            HTTPHandler.effectiveCacheTopology(
+                baseline: baseline,
+                turboQuantTransition: transition
+            )
+        )
+        #expect(effective.kvLayerCount == 0)
+        #expect(effective.turboQuantKVLayerCount == 8)
+        #expect(effective.rotatingKVLayerCount == 40)
+
+        let unchanged = try #require(
+            HTTPHandler.effectiveCacheTopology(
+                baseline: baseline,
+                turboQuantTransition: nil
+            )
+        )
+        #expect(unchanged.kvLayerCount == 8)
+        #expect(unchanged.turboQuantKVLayerCount == 0)
+        #expect(unchanged.rotatingKVLayerCount == 40)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Tool/RenderChartToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/RenderChartToolTests.swift
@@ -191,6 +191,65 @@ struct RenderChartToolTests {
         #expect(marker.contains("\"name\":\"Revenue\""))
     }
 
+    @Test func explicitCSVLabelRecoversObservedBonsaiTabDelimitedPayload() async throws {
+        let result = try await RenderChartTool().execute(
+            argumentsJSON: #"""
+                {
+                  "chartType": "bar",
+                  "data": "month\trevenue\nJanuary\t10\nFebruary\t18\nMarch\t13\nApril\t24",
+                  "format": "csv",
+                  "series": "revenue",
+                  "title": "Monthly Revenue",
+                  "xColumn": "month"
+                }
+                """#
+        )
+
+        #expect(ToolEnvelope.isSuccess(result))
+        let payload = try #require(ToolEnvelope.successPayload(result) as? [String: Any])
+        let marker = try #require(payload["text"] as? String)
+        #expect(marker.contains("\"categories\":[\"January\",\"February\",\"March\",\"April\"]"))
+        #expect(marker.contains("\"name\":\"revenue\""))
+        #expect(marker.contains("\"data\":[10,18,13,24]"))
+    }
+
+    @Test func explicitTSVLabelRecoversUnambiguousCommaDelimitedPayload() async throws {
+        let result = try await RenderChartTool().execute(
+            argumentsJSON: #"""
+                {
+                  "chartType": "line",
+                  "data": "month,revenue\nJanuary,10\nFebruary,18",
+                  "format": "tsv",
+                  "series": ["revenue"],
+                  "xColumn": "month"
+                }
+                """#
+        )
+
+        #expect(ToolEnvelope.isSuccess(result))
+        let payload = try #require(ToolEnvelope.successPayload(result) as? [String: Any])
+        let marker = try #require(payload["text"] as? String)
+        #expect(marker.contains("\"categories\":[\"January\",\"February\"]"))
+        #expect(marker.contains("\"data\":[10,18]"))
+    }
+
+    @Test func mixedDelimiterPayloadDoesNotBypassStrictColumnValidation() async throws {
+        let result = try await RenderChartTool().execute(
+            argumentsJSON: #"""
+                {
+                  "chartType": "bar",
+                  "data": "month\trevenue\nJanuary,10\nFebruary\t18",
+                  "format": "csv",
+                  "series": ["revenue"],
+                  "xColumn": "month"
+                }
+                """#
+        )
+
+        #expect(!ToolEnvelope.isSuccess(result))
+        #expect(result.contains("Column(s) not found"))
+    }
+
     @Test func textualHeaderWithMisspelledSeriesStillFails() async throws {
         let result = try await RenderChartTool().execute(
             argumentsJSON: #"""

--- a/Packages/OsaurusCore/Tools/RenderChartTool.swift
+++ b/Packages/OsaurusCore/Tools/RenderChartTool.swift
@@ -203,11 +203,15 @@ struct RenderChartTool: OsaurusTool {
             )
         }
 
-        let format =
+        let declaredFormat =
             (args["format"] as? String)?.lowercased()
             ?? (args["dataFormat"] as? String)?.lowercased()
             ?? referencedEntry?.format
             ?? "csv"
+        let format = Self.reconciledDelimitedFormat(
+            suppliedRaw,
+            declaredFormat: declaredFormat
+        )
         let raw = Self.unwrapQuotedDelimitedPayload(suppliedRaw, format: format)
         let title = args["title"] as? String
         let tipSuffix = args["tooltipSuffix"] as? String
@@ -826,6 +830,46 @@ struct RenderChartTool: OsaurusTool {
             return raw
         }
         return candidate
+    }
+
+    /// Reconcile an explicit CSV/TSV label with the payload's unambiguous
+    /// delimiter shape. Local models can preserve every byte of an attached
+    /// table while changing commas to tabs without changing `format` from
+    /// `csv` (or vice versa). Treat that as transport metadata drift only
+    /// when the declared delimiter produces one column and the alternate
+    /// delimiter produces a stable multi-column table across every sampled
+    /// row. Ambiguous, mixed, JSON, and ordinary one-column data remain on
+    /// the declared path and keep the strict column validation below.
+    private static func reconciledDelimitedFormat(
+        _ raw: String,
+        declaredFormat: String
+    ) -> String {
+        guard declaredFormat == "csv" || declaredFormat == "tsv" else {
+            return declaredFormat
+        }
+
+        let declaredSeparator = declaredFormat == "csv" ? "," : "\t"
+        let alternateSeparator = declaredFormat == "csv" ? "\t" : ","
+        let lines = raw.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .prefix(16)
+        guard !lines.isEmpty else { return declaredFormat }
+
+        let declaredCounts = lines.map {
+            $0.components(separatedBy: declaredSeparator).count
+        }
+        guard declaredCounts.allSatisfy({ $0 == 1 }) else { return declaredFormat }
+
+        let alternateCounts = lines.map {
+            $0.components(separatedBy: alternateSeparator).count
+        }
+        guard let columnCount = alternateCounts.first,
+            columnCount > 1,
+            alternateCounts.allSatisfy({ $0 == columnCount })
+        else { return declaredFormat }
+
+        return declaredFormat == "csv" ? "tsv" : "csv"
     }
 
     private static func chartSpec(from result: String) -> ChartSpec? {

--- a/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
+++ b/docs/GEMMA4_QAT_CACHE_CHECKPOINT_2026_07_19.md
@@ -1,6 +1,86 @@
 # Gemma 4 QAT cache checkpoint — 2026-07-19
 
-Status: **PARTIAL — the exact current Osaurus branch and vMLX
+## Current-main Gemma/Bonsai follow-up
+
+Status: **PARTIAL overall; VERIFIED-LIVE for the narrow Gemma effective-cache
+telemetry and Bonsai first-call chart rows described here.** The wider model,
+RAM, cache-family, multimodal, AppleScript, Sentry, and protocol matrix remains
+open and is not made release-ready by this follow-up.
+
+Current source base is Osaurus `12396f7309e533f572098ddd8810c6229e3ebcb5`
+with vMLX `0975201e745a1774fda1e78d1bc99b5bd1c668c6`. The isolated
+Release artifact is
+`/private/tmp/osaurus-main-gemma-bonsai-derived-20260719/Build/Products/Release/osaurus.app`,
+bundle id `com.dinoki.osaurus.gemmabonsaimainproof`, executable SHA-256
+`a341c6cd58e60f1cda3b675f0b764a287be976284f811cc69587d6f5726fd600`,
+and runtime root
+`/private/tmp/osaurus-main-gemma-bonsai-runtime-20260719-d`. The live process
+environment was read back and matched that root with test keychain access
+disabled. No MXFP4 bundle was loaded or used as evidence.
+
+### Narrow source trace
+
+- `HTTPHandler` now derives the admin `cache_topology`, effective KV-mode tag,
+  and companion-cache checks from `last_turboquant_cache_transition.after`
+  when present, with the container topology as the fallback. The container
+  snapshot is the load-time shape; Gemma's request-local BatchEngine
+  conversion is the live shape. Reporting the former after conversion produced
+  the contradictory 8-FP16-KV/40-rotating top-level topology beside an
+  8-TurboQuant-KV/40-rotating transition.
+- `RenderChartTool` reconciles only an explicit CSV/TSV label whose declared
+  delimiter yields one column for every sampled nonempty row while the other
+  delimiter yields a stable multi-column table for every row. Ambiguous,
+  mixed-delimiter, JSON, and ordinary strict-column failures retain the
+  declared parsing path. This changes data-format metadata handling, not model
+  output, prompts, templates, sampling, content-delta streaming, or tool-call
+  JSON assembly.
+
+### Current Release UI evidence
+
+| Row | Exact live evidence | Status |
+|---|---|---|
+| Real-user model discovery | Settings -> Storage changed the external model folder through the macOS picker from `~/.cache/huggingface/hub` to `/Users/eric/models`; the visible count changed from 5 to 68 and the exact local targets became selectable without copying them | VERIFIED-LIVE |
+| Cache defaults | Server -> Settings -> Cache visibly showed Prefix on, GPU/Paged KV off, SSD Disk Cache on, Codec `Engine Selected`, Stored KV Codec `Auto`, and SSM re-derive on | VERIFIED-LIVE |
+| Gemma explicit TQ topology | Exact `/Users/eric/models/OsaurusAI/OsaurusAI--gemma-4-12B-it-qat-JANG_4M`; UI-selected TQ4/4 produced five coherent sentinel bullets at 59.3 tok/s, a coherent two-sentence follow-up at 64.8 tok/s, and a same-root restart answer at 63.3 tok/s | VERIFIED-LIVE |
+| Gemma telemetry | Top-level admin topology and transition-after both reported 48 layers = 8 TurboQuant KV + 40 rotating KV, zero plain KV; `effective_kv_mode=turbo(4,4)`, paged false, disk enabled, MLXPress disabled | VERIFIED-LIVE |
+| Gemma SSD restart | Before restart the row recorded disk hits 3, misses 10, stores 5; after relaunch, the identical prompt had TTFT 0.72s and fresh-process counters hits 2, misses 7, stores 3 with paged still false | VERIFIED-LIVE |
+| Bonsai ordinary attached CSV | Exact `/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`, Charts on, `disableThinking:true`; the first and only `render_chart` call emitted tab-delimited `month/revenue` data while declaring `dataFormat:"csv"`. It returned `ok:true`, rendered four bars, and the model returned exact `chart-skill-done` at TTFT 0.71s and 36.1 tok/s | VERIFIED-LIVE |
+| Bonsai reasoning toggle | UI gray/off persisted `disableThinking:true`; a fresh exact-output turn returned `BONSAI-NOTHINK-907` at TTFT 1.01s and 37.3 tok/s. SQLite recorded zero reasoning characters. The final chart call and post-tool answer also recorded zero reasoning characters | VERIFIED-LIVE |
+| Bonsai adversarial no-retry | A separate real-UI prompt required literal TSV data labeled CSV and forbade retry. One call returned `ok:true`, three parsed points, an inline chart card, and exact `adversarial-chart-done` | VERIFIED-LIVE |
+| Bonsai current footprint | Activity Monitor visibly showed the exact proof process `Osaurus`, PID 87295, at 2.47 GB after the chart runs. A separate macOS `footprint` read reported 2,527 MB current and 5,587 MB peak; only the 2.47 GB current row is Activity Monitor visual evidence | VERIFIED-LIVE current; peak is direct telemetry |
+
+The current focused Xcode invocation exited zero for both
+`TurboQuantCacheTransitionShapingTests` cases and the complete
+`RenderChartToolTests` suite. That includes the observed CSV-label/TSV-data
+case, the reverse unambiguous case, and strict mixed-delimiter and misspelled-
+column failures.
+
+The pre-change captured Bonsai call was valid JSON and reached
+`render_chart`; its arguments contained TSV rows with `format:"csv"`, so the
+strict CSV parser exposed one header named `month\trevenue` and returned
+`Column(s) not found`. The model then retried with comma CSV successfully.
+That trace rules out content-delta truncation and malformed tool-call JSON for
+this chart failure.
+
+### Retained concerns and non-claims
+
+- The Gemma L2 directory grew from 2.7 GB to 3.9 GB across the tested sequence.
+  The in-memory TQ codec and Stored KV Codec `Auto` are separate controls; this
+  row does **not** prove that SSD blocks are TurboQuant-compressed. Disk growth
+  and eviction remain OPEN.
+- The first Gemma multi-turn run also created an unsolicited markdown artifact
+  before returning the requested answer. The requested answer was coherent,
+  but that semantic over-action is not fixed or hidden here.
+- Bonsai thinking-on runs were retained as diagnostics. The later verified-off
+  runs show the toggle contract works; no output-stripping or forced closer was
+  added.
+- No broad automatic routing, hardware guidance, RAM-safety, multimodal,
+  AppleScript, JANGTQ weight, DSV4/OpenPangu, or other model-family change is
+  included in this narrow diff.
+
+## Historical bbc0 checkpoint
+
+Historical status: **PARTIAL — the exact then-current Osaurus branch and vMLX
 `bbc0b20d7dd46445c9ff3d76be7caf329310a338` are live-proven in an isolated
 Release app for the core Gemma 4 12B JANG_4M/MXFP8 cache and settings rows.
 The 31B RAM-limit override control works, but its Activity Monitor Memory


### PR DESCRIPTION
## Scope\n\n- Report the live post-conversion Gemma cache topology from the request-local TurboQuant transition instead of the load-time baseline.\n- Reconcile only unambiguous CSV/TSV delimiter-label drift in render_chart.\n- Add focused recovery and strict-regression tests.\n- Record exact current-main Release UI evidence.\n\nNo prompt/template coercion, sampler override, output closer, content-delta rewrite, automatic routing, hardware guidance, RAM policy, MXFP4, MLXPress, or other model-family implementation is changed.\n\n## Root causes\n\nGemma cache conversion occurs in BatchEngine per request. The admin endpoint serialized the container baseline, so it could report 8 plain KV plus 40 rotating layers beside a transition proving 8 TurboQuant KV plus 40 rotating layers. The endpoint now prefers transition.after, with the baseline as fallback.\n\nThe reproduced Bonsai chart call was valid tool JSON. Its data contained tab-delimited rows while format was csv, so strict CSV parsing produced a single header named month\trevenue and rejected the requested columns. The model retried with commas. The tool now switches CSV/TSV interpretation only when the declared separator produces one column on every sampled row and the alternate separator produces a stable multi-column table on every row. Mixed and ambiguous input stays strict.\n\n## Focused tests\n\nCurrent Xcode invocation exited zero for:\n\n- TurboQuantCacheTransitionShapingTests, including transition.after preference and baseline fallback.\n- Complete RenderChartToolTests, including the observed Bonsai mismatch, reverse unambiguous mismatch, mixed-delimiter rejection, and misspelled-column rejection.\n\n## Exact Release UI proof\n\nSource base: 12396f7309e533f572098ddd8810c6229e3ebcb5\nvMLX: 0975201e745a1774fda1e78d1bc99b5bd1c668c6\nBundle id: com.dinoki.osaurus.gemmabonsaimainproof\nExecutable SHA-256: a341c6cd58e60f1cda3b675f0b764a287be976284f811cc69587d6f5726fd600\nIsolated runtime root: /private/tmp/osaurus-main-gemma-bonsai-runtime-20260719-d\n\nReal-user setup was operated visually: Settings Storage selected /Users/eric/models through the macOS picker; exact local Gemma JANG_4M and Bonsai 1-bit models were selected; Charts was on; Prefix on; Paged RAM off; SSD L2 on; Codec Engine Selected by default; SSM rederive on.\n\nGemma JANG_4M with explicit TQ4/4 produced coherent sentinel output, coherent follow-up, and coherent same-root restart output. Current telemetry reported 48 layers as 8 TurboQuant KV plus 40 rotating, zero plain KV, matching transition.after. Speeds were 59.3, 64.8, and 63.3 tok/s; restart TTFT was 0.72s. Paged remained false and disk counters showed fresh-process hits.\n\nBonsai final Thinking-off attached-CSV run emitted one render_chart call with literal tab-delimited data and dataFormat csv. It returned ok:true on the first call, rendered all four bars, and returned exact chart-skill-done. SQLite recorded zero reasoning characters. Final-response TTFT was 0.71s at 36.1 tok/s. A separate no-retry adversarial UI run exercised the same mismatch and also succeeded first-call.\n\nActivity Monitor visibly showed exact proof PID 87295 at 2.47 GB after the Bonsai chart runs. macOS footprint separately reported 2,527 MB current and 5,587 MB peak.\n\n## Open and non-claims\n\n- Gemma SSD cache grew from 2.7 GB to 3.9 GB during the sequence. Stored KV Codec was Auto; this PR does not claim disk blocks are TurboQuant-compressed. Disk growth/eviction remains open.\n- A Gemma run created an unsolicited markdown artifact before the requested answer. That semantic over-action is not fixed here.\n- The broader model/cache/multimodal/AppleScript/Sentry/RAM/protocol matrix remains partial.\n- No MXFP4 model was loaded or used as evidence.