### PR TITLE
Pin Bonsai hybrid cache replay and disk quota fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0975201e745a1774fda1e78d1bc99b5bd1c668c6"
+        "revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0975201e745a1774fda1e78d1bc99b5bd1c668c6"
+        "revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -77,7 +77,7 @@ let package = Package(
         // keeps every unproven cache topology fail-closed.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0975201e745a1774fda1e78d1bc99b5bd1c668c6"
+            revision: "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "0975201e745a1774fda1e78d1bc99b5bd1c668c6""#))
-        #expect(packageResolved.contains(#""revision" : "0975201e745a1774fda1e78d1bc99b5bd1c668c6""#))
-        #expect(workspaceResolved.contains(#""revision" : "0975201e745a1774fda1e78d1bc99b5bd1c668c6""#))
-        #expect(appResolved.contains(#""revision" : "0975201e745a1774fda1e78d1bc99b5bd1c668c6""#))
+        #expect(packageSwift.contains(#"revision: "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
+        #expect(packageResolved.contains(#""revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
+        #expect(workspaceResolved.contains(#""revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
+        #expect(appResolved.contains(#""revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -705,7 +705,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "0975201e745a1774fda1e78d1bc99b5bd1c668c6"
+        let expectedRuntimeHardenedRevision = "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8d2ab45cd3ecdf2f71c069ef0919a0c0731224d9554a0f8bbbb6862238299a2e",
+  "originHash" : "e2e2dcc84fb1edf6d86debbeecdfb1a73f7aca5c631e06833992b737220ddd91",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0975201e745a1774fda1e78d1bc99b5bd1c668c6"
+        "revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
       }
     },
     {


### PR DESCRIPTION
## Scope

Pins Osaurus to vMLX merge commit `3852026f9fe052abe9e158ae915fa8ad3d7577c6` from osaurus-ai/vmlx-swift#160.

This PR changes only:

- `Packages/OsaurusCore/Package.swift`
- `Packages/OsaurusCore/Package.resolved`
- `osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- `App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- `Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift`
- `Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift`

The diff is 6 files and 10 insertions/10 deletions: four exact vMLX pin surfaces plus two tests that require those surfaces to remain on the same proven revision. It contains no Osaurus runtime/model behavior code.

The already-merged Osaurus Gemma/Bonsai app fixes remain on main in #2085, #2090, and #2091. This PR does not change model routing, hardware guidance, AppleScript/ZAYA, Sentry, Nemotron, sampling, prompts, reasoning delimiters, or output handling. No MXFP4 bundle was used.

## Owning-layer fixes in vMLX #160

- Resets Qwen 3.5 retained VL/position state before independent hybrid SSM replay, while preserving continuous cache state for later chunks.
- Shares the hybrid prompt-state replay path across cache stores and prevents transient replay state from being persisted as independent disk entries.
- Links SSM companion sidecars to their KV payload hash and enforces one combined disk quota across KV and companion payloads, including legacy/orphan cleanup.
- Adds focused coverage for replay parity, partial disk reuse, paired eviction, orphan cleanup, and quota accounting.
- Adds no model-output guard, forced reasoning tag/closer, prompt coercion, sampler override, repetition penalty, or length cap.

## Source and test evidence

- vMLX PR #160 is merged at `3852026f9fe052abe9e158ae915fa8ad3d7577c6`.
- Xcode 26.6 / Swift 6.3.3: `SSMReDeriveParityTests` 8/8 passed.
- Swift Testing filters for `DiskCache`, `SSMStateCache`, and `BatchEngine`: 33/33 passed.
- The first Osaurus CI run exposed two additional stale lock files and two exact-revision test constants. Its XCTest portion ran 311 tests with 8 skipped and 0 failures; the only Swift Testing failures were the four pin-consistency expectations. All four pin surfaces and both contracts now use `3852026f...`.
- After rebasing onto Osaurus main `1904e0ac...` (#2094), focused `ImageGenerationBridgeContractTests` and full `RuntimePolicySourceTests` passed from the workspace. This includes the vMLX pin, semantic Thinking-state, and no-hidden-reasoning-default contracts.
- Fresh Osaurus Release build resolved the remote vMLX checkout to exactly `3852026f...`.
- Exact Osaurus head used for the current proof: `59e0e69dda5efafffb8c83d4d6c155643c108328`.
- Signed isolated app bundle: `com.dinoki.osaurus.bonsaipin385proof`; binary SHA-256 `01363135a86c3b4f52efbca67d6ff10602fe597fad65125c73c53d3c9ab5578f`.
- All 8 exact-head checks completed successfully: `test-core` (23m07s), `test-evals` (10m37s), `test-statspack` (8m53s), `test-cli`, `test-packages`, `swiftlint`, `shellcheck`, and Release Drafter.
- Squash-merged to Osaurus main as `e51c804cf6edf194a77650f518161738e30f1f09` on 2026-07-20. A post-merge fetch confirmed the same six-file diff and `3852026f...` in all four production pin surfaces plus both exact-pin contracts.

## Live UI verification

Used the exact local bundle `/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK` in the freshly built Release Osaurus app. The app used an isolated storage root and a fresh bundle identifier, so onboarding, model discovery, and settings were exercised as a new user.

- Storage UI: changed the external model folder to `/Users/eric/models`, clicked Rescan, and saw 68 external models found; Bonsai became the selected model.
- Server > Settings > Cache visibly showed Prefix Cache on, paged/GPU cache off, SSD L2 on, Codec Engine Selected, and SSM re-derive on.
- Clean-bundle Thinking-on control produced a visible reasoning block. After toggling the actual brain control off, the next response had no reasoning block. This distinguishes real UI state from prompt text.
- Thinking-off multi-turn recall: `Spring, summer, fall, and winter follow that order, and the arithmetic result from the prior turn was 46.` TTFT 0.87 s, 65.7 tok/s, 25 tokens.
- After quitting and relaunching the app, the same conversation recalled coherently: `Spring, summer, fall, and winter appear in that order, and the arithmetic result calculated here is 46.` TTFT 1.03 s, 36.4 tok/s, 24 tokens.
- During post-restart prefill the UI visibly showed `Prefill 3048/3279`.
- Exact post-restart cache trace: `HIT disk boundary=3048 remaining=231 ssm=96 fmtV=2 tokens=3279`.
- Post-restart API telemetry: 16 KV layers + 48 Mamba layers, effective KV mode FP16, TurboQuant KV layers 0, disk-L2 hits 3, SSM companion hits 3, paged hits 0.
- Fresh Activity Monitor identified the live Release app PID 56621 at 2.28 GB.
- Disk integrity after the run: 8,433,273,860 KV bytes + 1,726,010,346 companion bytes = 10,159,284,206 bytes under the 10 GiB cap; 22 companion manifests and 22 payloads; missing linked KV payloads = 0.

Current-head visual rerun after #2094 moved Thinking into the model picker:

- Opened the selected Bonsai row in the model picker and visually confirmed `MODEL OPTIONS > Thinking` was off; the main selected-model control also reported `Thinking ... Value: Off`.
- Re-opened Server > Settings > Cache in the exact app and visually confirmed Prefix Cache on, paged/GPU cache off, SSD L2 on, Codec `Engine Selected`, and SSM re-derive on.
- Turn 1: `Spring, summer, fall, and winter appear in that order, and the arithmetic result from this conversation is 17 + 29 = 46.` TTFT 1.04 s, 60.6 tok/s, 33 tokens.
- Turn 2: `Winter, fall, summer, and spring in that order, and 46 minus 12 equals 34.` TTFT 1.08 s, 36.3 tok/s, 25 tokens.
- Both responses were one sentence, coherent, tool-free, and had no reasoning or protocol-marker leakage.
- The UI visibly showed partial prefill (`2923/3160` then `3194/3439`). Matching traces were `HIT disk boundary=2923 remaining=237 ssm=96` and `HIT disk boundary=3194 remaining=245 ssm=96`.
- Post-turn health reported disk-L2 hits 5, SSM-companion hits 5, and TurboQuant compressions 0. Quota telemetry showed KV and linked companion entries evicted together; orphan cleanup counters stayed zero.
- Activity Monitor visually showed the exact Release app PID 82072 at 2.30 GB; `vmmap` reported 2.3 GB current physical footprint and 3.9 GB peak.
- Current cache directory size was 10,697,744,384 bytes under the 10,737,418,240-byte cap, and all companion manifests referenced an existing KV payload (`missing_linked_kv=0`).

## Transparent limitations

- Explicit TurboQuant 4/4 was exercised in the earlier isolated Release candidate and was coherent with correct 16 TQ KV + 48 Mamba topology and disk/SSM hits, but its second partial-cache turn measured 17.0 tok/s versus 54.7-65.7 tok/s on Engine Selected. TurboQuant remains default-off and that performance is not promoted as resolved by this pin.
- The larger cross-family cache/TurboQuant, AppleScript/ZAYA, Sentry, JANGTQ, DSV4, and Nemotron multimodal campaign remains separate. None of those issues are claimed fixed here.
