### PR TITLE
Fix release job: reuse sentry-cli installed by the dSYM step

### DIFF
--- a/scripts/build/sentry_release.sh
+++ b/scripts/build/sentry_release.sh
@@ -43,10 +43,15 @@ fi
 BUNDLE_ID="com.dinoki.osaurus"
 RELEASE="${BUNDLE_ID}@${VERSION}+${VERSION}"
 
-# Install a pinned sentry-cli (no sudo) if it isn't already on PATH — the
-# dSYM step usually ran first and left one installed.
+# Reuse the pinned sentry-cli the dSYM step installed, or install one (no
+# sudo). The dSYM step's `export PATH` does NOT survive into this workflow
+# step, so PATH alone can't find it — and re-running the installer against a
+# populated INSTALL_DIR hard-fails with "sentry-cli is already installed".
+INSTALL_DIR="${RUNNER_TEMP:-/tmp}/sentry-cli-bin"
+if [[ -x "${INSTALL_DIR}/sentry-cli" ]]; then
+  export PATH="${INSTALL_DIR}:${PATH}"
+fi
 if ! command -v sentry-cli >/dev/null 2>&1; then
-  INSTALL_DIR="${RUNNER_TEMP:-/tmp}/sentry-cli-bin"
   mkdir -p "${INSTALL_DIR}"
   echo "Installing sentry-cli ${SENTRY_CLI_VERSION} into ${INSTALL_DIR} ..."
   curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="${INSTALL_DIR}" SENTRY_CLI_VERSION="${SENTRY_CLI_VERSION}" bash

--- a/scripts/build/upload_dsyms_sentry.sh
+++ b/scripts/build/upload_dsyms_sentry.sh
@@ -46,10 +46,15 @@ if [[ ${#SOURCES[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# Install a pinned sentry-cli into a temp dir (no sudo) if it isn't already on
-# PATH. The official installer honors INSTALL_DIR + SENTRY_CLI_VERSION.
+# Reuse a previously installed pinned sentry-cli, or install one into a temp
+# dir (no sudo). PATH exports don't survive across workflow steps, so check
+# the install dir directly — the installer hard-fails ("sentry-cli is already
+# installed") when rerun against a populated INSTALL_DIR.
+INSTALL_DIR="${RUNNER_TEMP:-/tmp}/sentry-cli-bin"
+if [[ -x "${INSTALL_DIR}/sentry-cli" ]]; then
+  export PATH="${INSTALL_DIR}:${PATH}"
+fi
 if ! command -v sentry-cli >/dev/null 2>&1; then
-  INSTALL_DIR="${RUNNER_TEMP:-/tmp}/sentry-cli-bin"
   mkdir -p "${INSTALL_DIR}"
   echo "Installing sentry-cli ${SENTRY_CLI_VERSION} into ${INSTALL_DIR} ..."
   curl -sL https://sentry.io/get-cli/ | INSTALL_DIR="${INSTALL_DIR}" SENTRY_CLI_VERSION="${SENTRY_CLI_VERSION}" bash


### PR DESCRIPTION
## Summary

- Fixes the failed release run https://github.com/osaurus-ai/osaurus/actions/runs/29714223396: `sentry_release.sh` runs in a separate workflow step from `upload_dsyms_sentry.sh`, so the dSYM step's `export PATH` for its freshly installed sentry-cli doesn't survive. The release step's `command -v sentry-cli` then missed the binary, re-ran the official installer against the already-populated `${RUNNER_TEMP}/sentry-cli-bin`, and the installer's hard "sentry-cli is already installed" error (it refuses to overwrite) failed the release step.
- Both scripts now put an existing `${RUNNER_TEMP}/sentry-cli-bin` on PATH before deciding whether to install, so the second step reuses the pinned binary the first step installed and the installer only ever runs against an empty dir.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Simulated the failing scenario locally (populated `${RUNNER_TEMP}/sentry-cli-bin`, empty PATH): the new guard reuses the existing binary instead of re-invoking the installer
- [ ] Re-run the release workflow after merge to confirm the Sentry release step completes