### PR TITLE
Pin paged cache eviction fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
+        "revision" : "24ce87c5ef812f816a242459aec50e544fd228f4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
+        "revision" : "24ce87c5ef812f816a242459aec50e544fd228f4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -77,7 +77,7 @@ let package = Package(
         // keeps every unproven cache topology fail-closed.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
+            revision: "24ce87c5ef812f816a242459aec50e544fd228f4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
-        #expect(packageResolved.contains(#""revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
-        #expect(workspaceResolved.contains(#""revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
-        #expect(appResolved.contains(#""revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6""#))
+        #expect(packageSwift.contains(#"revision: "24ce87c5ef812f816a242459aec50e544fd228f4""#))
+        #expect(packageResolved.contains(#""revision" : "24ce87c5ef812f816a242459aec50e544fd228f4""#))
+        #expect(workspaceResolved.contains(#""revision" : "24ce87c5ef812f816a242459aec50e544fd228f4""#))
+        #expect(appResolved.contains(#""revision" : "24ce87c5ef812f816a242459aec50e544fd228f4""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -696,7 +696,9 @@ struct RuntimePolicySourceTests {
         // Now also carries native schema-2 affine1 JANG loading and Metal
         // execution, Qwen3-VL tool-schema preservation, bounded media-cache
         // cleanup (vmlx-swift#149), and the Nemotron Omni projector,
-        // bounded-media-prefill, and safe hybrid media-prefix fixes (#156).
+        // bounded-media-prefill, and safe hybrid media-prefix fixes (#156),
+        // plus the paged-cache chain pinning, leaf-first release order, and
+        // bounded hybrid companion-state replay proven in vmlx-swift#161.
         //
         // This assertion is a repin tripwire, and it earned its keep: PR #1986
         // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
@@ -705,7 +707,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
+        let expectedRuntimeHardenedRevision = "24ce87c5ef812f816a242459aec50e544fd228f4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1116,6 +1116,8 @@ struct RuntimePolicySourceTests {
         #expect(concurrency.contains("Concurrent Sessions"))
         #expect(concurrency.contains("Continuous Batching"))
         #expect(concurrency.contains("Prompt Prefill Chunk Size"))
+        #expect(concurrency.contains(
+            "draft.concurrency.maxConcurrentSequences != nil || clamped != 1"))
     }
 
     @Test("Tools settings panel separates wired parser overrides from planned host bridges")

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift
@@ -108,6 +108,13 @@ struct ConcurrencySection: View {
         let trimmed = maxConcurrentText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let parsed = Int(trimmed), parsed > 0 else { return }
         let clamped = min(parsed, 32)
+
+        // `nil` is the persisted engine-default state and resolves to one
+        // session in this control. Merely materializing the lazily-rendered
+        // section must not turn that equivalent display value into an edit.
+        guard draft.concurrency.maxConcurrentSequences != nil || clamped != 1 else {
+            return
+        }
         if draft.concurrency.maxConcurrentSequences != clamped {
             draft.concurrency.maxConcurrentSequences = clamped
         }

--- a/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
+++ b/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
@@ -1,6 +1,6 @@
 # Gemma/Bonsai Emergency Proof Ledger
 
-Last updated: 2026-07-16 (America/Los_Angeles)
+Last updated: 2026-07-19 (America/Los_Angeles)
 
 Verdict: **PASS for the narrow schema-1 JANG loader pin; PARTIAL for the
 separate Ornith multi-step semantic-completion defect, which is not changed or
@@ -41,6 +41,7 @@ emergency diff.
 | --- | --- | --- |
 | P0 | Installed JANG schema-1 bundles load | LIVE LOAD PASS on exact JANG_4M; multi-step correctness still fails |
 | P0 | Ornith/Qwen post-tool cutoff or partial completion | REPRODUCED AS PARTIAL MUTATION on JANG_4M and MXFP8; exact pre-write cutoff not reproduced |
+| P0 | Bonsai tiny-pool paged-cache eviction and hybrid replay tail | VERIFIED-SOURCE + VERIFIED-LIVE for the cache defect; model semantic-quality controls remain mixed |
 | P0 | PR scope contains no deferred routing/hardware changes | PASS for current pin-only source/test diff plus ledger; repeat on final diff |
 | P0 | Exact pin-only candidate Release UI rerun | PASS for JANG_4M load and plain generation; semantic handbook behavior remains a separate reproduced failure |
 | P1 | Gemma/Bonsai tool correctness regressions | NOT YET RUN on clean head |
@@ -49,6 +50,127 @@ emergency diff.
 | P1 | Memory Safety warning, setting change, larger-model load, restore refusal | NOT YET RUN on clean head |
 | P1 | Image generation/editing and spawn/delegation RAM admission/notifications | NOT YET RUN on clean head |
 | P2 | MXFP4 structurally incomplete answer/reasoning/tool-envelope recovery | DOCUMENTED ONLY; no MXFP4 runtime claim and excluded from the emergency diff without a later exact-model reproduction |
+
+## 2026-07-19 Bonsai paged-cache eviction checkpoint
+
+Status: **VERIFIED-SOURCE + VERIFIED-LIVE for the paged-chain eviction fix;
+PARTIAL for Bonsai answer quality.** This checkpoint used only
+`/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`. No MXFP4 bundle
+was loaded, downloaded, or used as evidence.
+
+### Owning-layer source fix
+
+The pre-fix tiny-pool trace showed that `PagedCacheManager.storeTokenSequence`
+released each block immediately after inserting it. With only two blocks, the
+pool could recycle a parent while constructing its child, leaving an orphan
+leaf that could not satisfy the root-to-leaf prefix walk. Fetch release also
+ran root-to-leaf, making the indispensable root the oldest eviction target.
+Hybrid SSM replay independently captured every automatic paged boundary even
+when the configured pool could retain only one useful boundary.
+
+vMLX commit `24ce87c5ef812f816a242459aec50e544fd228f4`:
+
+- pins the complete block chain until storage finishes;
+- re-pins an existing free chain member before constructing descendants;
+- releases stored and fetched chains leaf-to-root; and
+- caps automatic hybrid companion boundaries to usable paged capacity while
+  retaining exact, prompt-minus-one, history, and explicit boundaries.
+
+The diff changes only `PagedCacheManager`, `CacheCoordinator`, `SSMReDerive`,
+and their tests. It does not change chat templates, prompts, thinking tags,
+reasoning closers, sampler defaults, stop/EOS behavior, token limits, tool
+schemas, content-delta assembly, or model routing.
+
+Focused current-source proof passed 109 selected vMLX cache tests: 21 XCTest
+cases plus 88 Swift Testing cases covering paged eviction, disk L2, SSM
+companion state, TurboQuant transitions, and multi-turn behavior. The Osaurus
+pin resolves the same vMLX revision from the manifest and all three lockfiles.
+
+### Exact isolated Release app
+
+- App:
+  `/private/tmp/osaurus-cache-campaign-patched-derived/Build/Products/Release/osaurus.app`
+- Proof bundle id: `com.dinoki.osaurus.cachecampaignpatchedproof`
+- Compiled Osaurus source: `8730a66b8065cce59d5cbcaa654880e554f914e5`
+- Embedded vMLX source: `24ce87c5ef812f816a242459aec50e544fd228f4`
+- Executable SHA-256:
+  `52354ba594599a296e41f131caab27661c54eaae98488c67a56f5e3e1823b90c`
+- Runtime root:
+  `/private/tmp/osaurus-cache-campaign-patched-live-20260719-2132`
+
+The app was built Release-optimized, ad-hoc signed, verified with
+`codesign --verify --deep --strict`, launched keychain-free against the
+isolated root, and operated through the actual UI. Settings visibly remained
+`All changes saved` when Cache was opened without an edit. The UI then saved
+Prefix on, Paged on, two maximum blocks, SSD L2 on, TurboQuant 4/4, and SSM
+rederive on; persisted JSON matched those values and did not materialize the
+untouched effective-one concurrent-session default.
+
+### Paged on plus explicit TurboQuant 4/4
+
+Thinking was explicitly turned off in the real model picker. The first visible
+turn produced four coherent numbered sentences with no reasoning or tool call:
+TTFT 2.69 seconds, 45.3 tok/s, 79 tokens. The second visible turn produced one
+coherent sentence with no reasoning or tool call at TTFT 1.40 seconds and 18.6
+tok/s, but it used label `1.` instead of the requested `5.` and gave a generic
+LRU explanation. That instruction/semantic row is failed rather than hidden.
+
+After the second turn the admin endpoint reported:
+
+- paged hits 4, misses 6, one eviction, two total blocks, one free block;
+- SSD L2 hits 4, misses 12, stores 12;
+- SSM companion hits 4 and rederives 6;
+- effective KV mode `turbo(4,4)`;
+- exactly 16 `KVCacheSimple` layers converted to TurboQuant and all 48 Mamba
+  layers retained as native Mamba companion state; and
+- a transition from 16 KV + 48 Mamba to 16 TQ-KV + 48 Mamba, with no blanket
+  encoding of the Mamba layers.
+
+The prompt-boundary trace reduced the roughly 2,923-token warmup capture from
+every 16-token boundary to `[16, 2920, 2922, 2923]`. A coarse UI observation
+bounded the first post-answer maintenance tail below 18.3 seconds, versus the
+pre-fix 41.04-second diagnostic; this is an improvement bound, not a precise
+tail benchmark. Activity Monitor visibly reported the exact proof process at
+2.49 GB after the two turns.
+
+### Paged off, SSD-only restart and partial reuse
+
+The real Settings UI turned Paged off while keeping Prefix, SSD L2,
+TurboQuant 4/4, and SSM rederive on, then saved successfully. After terminating
+and relaunching only the isolated proof app:
+
+- warmup restored an exact 2,923-token disk boundary with zero remaining;
+- the user turn restored the same 2,923-token boundary with 36 tokens
+  remaining;
+- fresh-process counters reached SSD L2 hits 3 and SSM companion hits 3 while
+  paged hits/misses both remained zero;
+- the real user request triggered the delayed live transition of exactly 16
+  normal KV layers to TQ-KV while leaving 48 Mamba layers native;
+- visible telemetry was TTFT 1.16 seconds, 44.0 tok/s, 185 tokens, with no
+  reasoning, tool call, protocol leakage, stream cutoff, or loop; and
+- Activity Monitor visibly reported 2.27 GB for the restarted proof process.
+
+The answer's explanation of SSD controller behavior was factually poor. The
+identical prompt was therefore repeated after restoring the UI default codec
+and restarting into effective `fp16`; it remained factually poor at TTFT 0.74
+seconds and 50.0 tok/s. The FP16 endpoint showed 16 native KV + 48 Mamba,
+TurboQuant transition `null`, paged off, and SSD on. This matched control
+isolates the misconception to the model's answer quality rather than TQ cache
+encoding or delta streaming. No prompt coercion or decoder guard is added.
+
+The proof SSD directory reached 6.9 GB with 17 top-level cache payloads during
+the complete native/TQ sequence. TQ and native cache keys remained isolated:
+after returning to engine-selected FP16, the first 2,923-token FP16 warmup was
+a disk miss rather than consuming the TQ entry.
+
+### Honest boundary
+
+The cache corruption/eviction path is fixed and live-proven on the exact
+Bonsai JANG 1-bit bundle. Bonsai's strict instruction following and factual
+quality are mixed and are not repaired by this change. The vMLX fork's GitHub
+workflow is hard-gated to `ml-explore/mlx-swift`, so all fork jobs are skipped;
+the 109-test local Xcode/Swift run is the executable engine evidence. Osaurus
+CI must be green on the final four-pin source state before merge.
 
 ## Current-source trace
 

--- a/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
+++ b/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
@@ -106,6 +106,39 @@ Prefix on, Paged on, two maximum blocks, SSD L2 on, TurboQuant 4/4, and SSM
 rederive on; persisted JSON matched those values and did not materialize the
 untouched effective-one concurrent-session default.
 
+Final rebased-head recheck after the pin-tripwire correction:
+
+- Osaurus source: `1bbac6d38` (rebased onto `1cbeeb044`)
+- Embedded vMLX source: `24ce87c5ef812f816a242459aec50e544fd228f4`
+- Isolated bundle id: `com.dinoki.osaurus.cachecampaignpatchedproof`
+- Release executable SHA-256:
+  `aee9c802642fbf3c8e7ccfce44565c1defd4824e38edc488af900fd57a343b8e`
+- Xcode Release build: `BUILD SUCCEEDED`; the app passed strict deep ad-hoc
+  code-sign verification.
+- Focused current-source Osaurus suites passed 94 tests with zero failures or
+  skips: `RuntimePolicySourceTests` and
+  `ImageGenerationBridgeContractTests`.
+- In the real Settings UI, opening Cache left the footer at
+  `All changes saved`. Visible effective settings were Prefix on, Paged off,
+  SSD L2 on, Engine Selected/TurboQuant off, and SSM rederive on.
+- The exact Bonsai model remained selected with Thinking visibly off. Its
+  first smoke answer was streamed without a loop, tool call, reasoning, or
+  protocol leakage at TTFT 1.06 seconds and 54.0 tok/s, but it failed the
+  requested two-sentence constraint and gave an imprecise explanation. This
+  row is a semantic failure, not a pass.
+- A visible correction turn produced two numbered sentences at TTFT 1.10
+  seconds and 52.5 tok/s, again without a loop, tool call, reasoning, or
+  protocol leakage. The admin snapshot recorded five SSD L2 hits and five SSM
+  companion hits, paged disabled, effective FP16, 16 ordinary KV layers plus
+  48 native Mamba layers, and zero TurboQuant layers. Activity Monitor showed
+  the exact proof process at 2.30 GB.
+
+The final-head recheck therefore confirms the source pin, default-off paged and
+TurboQuant policy, settings persistence, disk/SSM partial reuse, streaming,
+multi-turn correction, speed, and low physical footprint. It does not promote
+the failed first-answer instruction/semantic row, and no prompt, parser,
+sampler, hidden continuation, or forced-output guard was added for it.
+
 ### Paged on plus explicit TurboQuant 4/4
 
 Thinking was explicitly turned off in the real model picker. The first visible

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3852026f9fe052abe9e158ae915fa8ad3d7577c6"
+        "revision" : "24ce87c5ef812f816a242459aec50e544fd228f4"
       }
     },
     {


### PR DESCRIPTION
## Scope

This PR contains only the current Bonsai/paged-cache lane:

- pin vMLX PR #161 / `24ce87c5ef812f816a242459aec50e544fd228f4` in the manifest and all three lockfiles
- prevent opening the lazy Concurrency settings section from materializing `nil` (effective one session) as an unsaved explicit `1`
- update the two exact-pin source tripwires
- record the source and live proof, including failed model-quality rows

It does not include model routing, hardware guidance, MXFP4 changes, prompt/template changes, sampler overrides, forced reasoning tags/closers, synthetic output, hidden continuation, or output limits.

## Source trace and fix

vMLX stored paged blocks while releasing each parent before descendants were complete. Tiny pools could recycle the parent and leave an unusable orphan leaf. Fetch release also made roots oldest. Hybrid SSM replay derived automatic boundaries beyond the configured pool's usable capacity.

vMLX #161 pins the full store chain, re-pins reused members, releases leaf-to-root, and bounds automatic companion boundaries by usable paged capacity while preserving exact, prompt-minus-one, history, and explicit boundaries.

Osaurus's settings fix keeps `maxConcurrentSequences == nil` when the lazily rendered field merely displays the effective default `1`, so opening Settings no longer creates a false dirty state.

## Current-source proof

- Rebased Osaurus head before this proof-ledger-only commit: `1bbac6d38`
- Final branch head: `c0ba8655f`
- vMLX: 109 selected cache/TurboQuant/disk/SSM/paged/multi-turn tests, zero failures
- Osaurus: 94 tests in `RuntimePolicySourceTests` and `ImageGenerationBridgeContractTests`, zero failures, zero skips
- `git diff --check`: passed
- Final diff versus current `origin/main`: 8 files only (four pin surfaces, settings source/test, pin tripwire, proof ledger)

## Exact Release app

- Bundle id: `com.dinoki.osaurus.cachecampaignpatchedproof`
- Embedded vMLX: `24ce87c5ef812f816a242459aec50e544fd228f4`
- Final-head executable SHA-256 before ad-hoc signing: `edd28ce6925050def246340fbe91d48014f6caee6e18bd2e4350d4b0870cdb3f`
- Final-head executable SHA-256 after ad-hoc signing: `4426ca8e8a7427911507d39bbb06b6bd81e346eafb9e0a3f9bdd09a1ca75669a`
- Xcode Release build: `BUILD SUCCEEDED`
- strict deep ad-hoc code-sign verification: passed
- isolated app root; production app and preferences untouched

## Actual UI evidence

Real model: `/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`. Thinking was visibly off. No MXFP4 bundle was downloaded or tested.

Settings through the real UI:

- opening Server → Settings → Cache left the footer at `All changes saved`
- visible defaults: Prefix on, Paged off, SSD L2 on, Engine Selected/TurboQuant off, SSM rederive on
- explicit paged/TQ test: Prefix on, Paged on, max blocks 2, SSD L2 on, TQ 4/4, SSM on

Paged + TQ live rows:

- paged hits 4, misses 6, evictions 1, total blocks 2, free 1
- disk hits 4, misses 12, stores 12; SSM hits 4, rederives 6
- exact transition: 16 KV → 16 TQ-KV; all 48 Mamba layers remained native
- prompt boundaries `[16, 2920, 2922, 2923]`
- visible 2.69 s TTFT / 45.3 tok/s and 1.40 s / 18.6 tok/s rows
- Activity Monitor 2.49 GB
- first post-answer maintenance observed below 18.3 s versus pre-fix 41.04 s; coarse bound only

Paged-off SSD-only restart:

- exact 2,923-token disk restore, then partial restore with 36 tokens remaining
- disk hits 3 and SSM hits 3; paged hits/misses zero
- exact 16 TQ-KV + 48 native Mamba after generation
- visible 1.16 s TTFT / 44.0 tok/s; Activity Monitor 2.27 GB

Final rebased-head UI smoke:

- Cache still showed `All changes saved` and the default-off Paged/TurboQuant policy
- disk and SSM partial hits reached 5 each; paged stayed off; effective FP16 topology was 16 KV + 48 Mamba with zero TQ layers
- first answer: 1.06 s TTFT / 54.0 tok/s / 40 tokens, no loop/tool/reasoning/protocol leakage, but failed the requested two-sentence constraint and was imprecise
- visible correction turn: two numbered sentences, 1.10 s / 52.5 tok/s / 55 tokens, no loop/tool/reasoning/protocol leakage
- Activity Monitor exact process: 2.30 GB

The documentation-only final head `c0ba8655f` was then rebuilt and launched
again rather than assumed equivalent. The exact signed binary visibly kept
Bonsai selected and Thinking off. An ungrounded question about the unpublished
source change produced the wrong answer (`roots`), which is retained as a
hallucination row rather than used as runtime evidence. A fair two-item control
then correctly returned `17 + 25 = 42` and `apple` on separate lines at 1.09 s
TTFT and 36.0 tok/s, without tools, reasoning, looping, or protocol leakage.
Activity Monitor showed the exact final process at 2.31 GB. Its fresh admin
snapshot showed disk/SSM hits 4 each, paged off, FP16, 16 KV + 48 Mamba, and
zero TurboQuant layers.

The final launch also resolved the automatic disk-L2 ceiling to 3,354,793,984
bytes because the volume had only about 17 GiB free. That is the existing
host-aware 25%-of-free-disk policy in `ModelRuntime`, not a change in this PR;
the cache remained enabled and continued recording partial disk/SSM hits.

The semantic failures are intentionally retained and keep broad Bonsai answer quality partial. No fake output-behavior guard was added.

Related engine PR: osaurus-ai/vmlx-swift#161

## Merge gate

The narrow source/live gate is complete. This PR remains pending the fresh GitHub CI run for the rebased head; it must not merge if that run fails.
