### PR TITLE
Preserve explicit Thinking mode across agent tool turns

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/ChatTurnGenerationControls.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatTurnGenerationControls.swift
@@ -1,0 +1,42 @@
+//
+//  ChatTurnGenerationControls.swift
+//  osaurus
+//
+//  Freezes prompt-affecting UI model controls for one logical chat turn.
+//  Agent loops rebuild ChatCompletionRequest for every model step, so the
+//  explicit Thinking choice must be copied to every reconstruction in both
+//  its local runtime representation (`modelOptions`) and its wire-safe API
+//  representation (`enable_thinking`).
+//
+
+import Foundation
+
+struct ChatTurnGenerationControls: Sendable, Equatable {
+    let modelOptions: [String: ModelOptionValue]?
+    let enableThinking: Bool?
+
+    static func capture(
+        activeModelOptions: [String: ModelOptionValue]
+    ) -> ChatTurnGenerationControls {
+        let options = activeModelOptions.isEmpty ? nil : activeModelOptions
+
+        // Only an explicit toggle becomes an API override. An absent value
+        // remains nil so the bundle's chat-template default still owns fresh
+        // models. `disableThinking` is the canonical stored option for every
+        // current Thinking profile, including dynamically discovered local
+        // profiles such as Ornith. Translate it directly instead of resolving
+        // the model profile again on the send path; dynamic profile discovery
+        // can touch the local model catalog and must not add synchronous TTFT.
+        let enableThinking = options?["disableThinking"]?.boolValue.map { !$0 }
+
+        return ChatTurnGenerationControls(
+            modelOptions: options,
+            enableThinking: enableThinking
+        )
+    }
+
+    func apply(to request: inout ChatCompletionRequest) {
+        request.modelOptions = modelOptions
+        request.enable_thinking = enableThinking
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
@@ -1,0 +1,101 @@
+//
+//  ChatTurnGenerationControlsTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Chat turn generation controls")
+struct ChatTurnGenerationControlsTests {
+    private func request() -> ChatCompletionRequest {
+        ChatCompletionRequest(
+            model: "JANGQ-AI/Ornith-1.0-9B-JANG_4M",
+            messages: [ChatMessage(role: "user", content: "Use three tools")],
+            temperature: nil,
+            max_tokens: 64,
+            stream: true,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+    }
+
+    @Test("explicit Thinking off reaches every reconstructed tool-loop request")
+    func explicitOffPropagatesAcrossIterations() throws {
+        let controls = ChatTurnGenerationControls.capture(
+            activeModelOptions: ["disableThinking": .bool(true)]
+        )
+
+        var requests = [request(), request(), request(), request()]
+        for index in requests.indices {
+            controls.apply(to: &requests[index])
+        }
+
+        #expect(controls.enableThinking == false)
+        #expect(requests.allSatisfy { $0.enable_thinking == false })
+        #expect(
+            requests.allSatisfy {
+                $0.modelOptions?["disableThinking"]?.boolValue == true
+            }
+        )
+
+        let encoded = try JSONEncoder().encode(requests[0])
+        let json = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        #expect(json["enable_thinking"] as? Bool == false)
+    }
+
+    @Test("explicit Thinking on reaches every reconstructed tool-loop request")
+    func explicitOnPropagatesAcrossIterations() {
+        let controls = ChatTurnGenerationControls.capture(
+            activeModelOptions: ["disableThinking": .bool(false)]
+        )
+
+        var requests = [request(), request(), request()]
+        for index in requests.indices {
+            controls.apply(to: &requests[index])
+        }
+
+        #expect(controls.enableThinking == true)
+        #expect(requests.allSatisfy { $0.enable_thinking == true })
+        #expect(
+            requests.allSatisfy {
+                $0.modelOptions?["disableThinking"]?.boolValue == false
+            }
+        )
+    }
+
+    @Test("unset Thinking preserves the bundle default")
+    func unsetPreservesBundleDefault() {
+        let controls = ChatTurnGenerationControls.capture(
+            activeModelOptions: [:]
+        )
+        var request = request()
+        controls.apply(to: &request)
+
+        #expect(controls.enableThinking == nil)
+        #expect(request.enable_thinking == nil)
+        #expect(request.modelOptions == nil)
+    }
+
+    @Test("non-thinking model options do not synthesize a Thinking override")
+    func unrelatedOptionsDoNotSynthesizeThinking() {
+        let controls = ChatTurnGenerationControls.capture(
+            activeModelOptions: ["customFlag": .string("kept")]
+        )
+        var request = request()
+        controls.apply(to: &request)
+
+        #expect(request.enable_thinking == nil)
+        #expect(request.modelOptions?["customFlag"]?.stringValue == "kept")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2678,6 +2678,18 @@ struct RuntimePolicySourceTests {
             chatView.contains("finalReq.samplingParametersAreImplicit = true"),
             "Tool-budget wrap-up calls use the same implicit-sampling contract as normal UI turns."
         )
+        #expect(
+            chatView.contains("let turnGenerationControls = ChatTurnGenerationControls.capture("),
+            "Chat UI must freeze prompt-affecting model controls once at send time instead of rereading mutable UI state between tool iterations."
+        )
+        #expect(
+            chatView.contains("turnGenerationControls.apply(to: &req)"),
+            "Every normal agent-loop reconstruction must carry the turn's explicit Thinking choice."
+        )
+        #expect(
+            chatView.contains("turnGenerationControls.apply(to: &finalReq)"),
+            "The post-budget finalizer must carry the same explicit Thinking choice as the tool loop it closes."
+        )
     }
 
     @Test("Tools settings renders runtime-managed folder and sandbox tools")

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4058,6 +4058,14 @@ final class ChatSession: ObservableObject {
         // detached task) couldn't tell what agent they belonged to.
         let turnAgentId = agentId ?? Agent.defaultId
         let imageSettings = imageComposerSettings
+        // Freeze prompt-affecting model controls at send time. Every model
+        // step in the agent loop reconstructs its request; reading the live UI
+        // dictionary inside that loop can change the prompt halfway through a
+        // run, and carrying only local-only `modelOptions` drops the explicit
+        // Thinking choice on any wire-encoded continuation.
+        let turnGenerationControls = ChatTurnGenerationControls.capture(
+            activeModelOptions: activeModelOptions
+        )
 
         currentTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -5097,8 +5105,7 @@ final class ChatSession: ObservableObject {
                             req.remoteAgentLogModel =
                                 self.isRemoteAgentTarget
                                 ? self.windowState?.pinnedRemoteAgentEffectiveModel : nil
-                            req.modelOptions =
-                                self.activeModelOptions.isEmpty ? nil : self.activeModelOptions
+                            turnGenerationControls.apply(to: &req)
                             req.backgroundModelLoad = (self.loadIntent == .background)
                             req.ttftTrace = ttftTrace
                             // Correlate the Insights log this send produces back to the
@@ -5379,7 +5386,7 @@ final class ChatSession: ObservableObject {
                             finalReq.remoteAgentLogModel =
                                 isRemoteAgentTarget
                                 ? windowState?.pinnedRemoteAgentEffectiveModel : nil
-                            finalReq.modelOptions = activeModelOptions.isEmpty ? nil : activeModelOptions
+                            turnGenerationControls.apply(to: &finalReq)
                             finalReq.backgroundModelLoad = (loadIntent == .background)
                             finalReq.turnId = assistantTurn.id
                             // Distinct logical step (the post-cap summarizing


### PR DESCRIPTION
## Scope

This is a four-file emergency hardening for the Chat UI agent loop only.

- Freeze prompt-affecting model options once at user send time.
- Apply the same options to every reconstructed agent request and the iteration-cap finalizer.
- Emit the official Codable `enable_thinking` field alongside local `modelOptions`.
- Preserve `nil` when the user has not made an explicit choice, so the bundle template remains authoritative.

No Gemma, cache, Sentry, AppleScript/Zaya, routing, sampler, template, or model-bundle changes are included.

## Source finding and claim boundary

Exact model bundle: `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M`.

Its template gates non-thinking mode on an explicit false value:

`{% if enable_thinking is defined and enable_thinking is false %}`

Therefore an absent kwarg means Thinking ON for Ornith. Osaurus 0.22.5 and current main already detect that default for the UI, and the pre-change ChatView copied local `activeModelOptions` into each ordinary loop request and finalizer. I did not reproduce the reported current-main condition where explicit OFF is lost only after a tool call. This PR is a contract hardening: it freezes the explicit per-turn state and also carries it in the official wire-safe field. It is not presented as proof that the existing local path dropped the toggle.

This evidence points away from content-delta streaming or tool JSON schema as the cause of the hidden-reasoning slowdown. The observed speed difference follows the template/UI Thinking state.

## Tests

Current result bundles from the candidate source:

- `/private/tmp/osaurus-ornith-thinking-focused-6.xcresult`: 4 passed, 0 failed.
- `/private/tmp/osaurus-ornith-thinking-source-6.xcresult`: 92 passed, 0 failed.
- Release app build completed from base `5202bfe95a8905043251a3a58f1ec4a9a026a305` plus commit `73cedec3f`.
- Candidate app is ad-hoc signed and `codesign --verify --deep --strict` succeeds.
- Bundle ID: `com.dinoki.osaurus.orniththinkingproof`.
- CDHash: `4b582bf516c29bab2215b9557a65aaba4543ee54`.

## Live Computer Use proof

Candidate: `/private/tmp/Osaurus-Ornith-Thinking-Propagation.app`

Fresh isolated root: `/private/tmp/osaurus-ornith-thinking-live-root-20260720`

The exact Ornith JANG_4M model was selected through Settings after adding `/Users/eric/models` as an External Model Source. The toggle was operated in the actual model picker. The isolated preference file independently recorded `disableThinking=true` for OFF and `disableThinking=false` for ON.

Repeated identical multi-call Todo prompt:

| State | Session | Model steps | Persisted thinking | Visible result |
|---|---|---:|---:|---|
| explicit OFF | `EDB961F5-D04E-4478-8BF1-8887F2249177` | 4 | 0 chars on all 4 | no Thinking blocks |
| explicit ON | `B1AA50BA-C431-42EF-88E1-D362646F26E3` | 4 | 348, 255, 292, 628 chars | four Thinking blocks; final row 0.27s TTFT, 58.0 tok/s, 190 tokens |
| explicit OFF again | `BB5CF0A9-8A34-4115-8972-BDA3680F7821` | 4 | 0 chars on all 4 | no Thinking blocks; final text row 0.40s TTFT, 90.2 tok/s, 57 tokens |

This proves the candidate honors OFF -> ON -> OFF on every observed model/tool iteration through the real UI. It does not prove a before/after repair of current main because current-main source already propagated the local option.

## Adjacent failure kept visible

The model did not satisfy the Todo semantics in any run: final state was 1/3, 0/3, and 1/3 respectively instead of completing alpha and beta. One run also falsely summarized completion. That is a separate tool-selection/argument correctness defect; this PR does not mask it with a prompt, sampler, parser, or close-token guard.

The first OFF run ended tool-only and exposed no tok/s metric. The repeated OFF run did expose 90.2 tok/s. No throughput claim is made beyond those visible rows.