### PR TITLE
fix: honor reasoning toggle across agent tool loops

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "24ce87c5ef812f816a242459aec50e544fd228f4"
+        "revision" : "4b431c6a3f229e2150810b9dea9afe57790ca60b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "24ce87c5ef812f816a242459aec50e544fd228f4"
+        "revision" : "4b431c6a3f229e2150810b9dea9afe57790ca60b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -77,7 +77,7 @@ let package = Package(
         // keeps every unproven cache topology fail-closed.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "24ce87c5ef812f816a242459aec50e544fd228f4"
+            revision: "4b431c6a3f229e2150810b9dea9afe57790ca60b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/AgentReasoningPolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentReasoningPolicy.swift
@@ -1,0 +1,76 @@
+//
+//  AgentReasoningPolicy.swift
+//  osaurus
+//
+//  Resolves the one agent-specific reasoning default Osaurus owns. Ordinary
+//  chat leaves an omitted thinking control to the model bundle. Agent/tool
+//  runs instead choose the direct rail for locally detected toggleable
+//  templates, unless the user or API explicitly chose a mode.
+//
+
+import Foundation
+
+enum AgentReasoningPolicy {
+    /// Return the thinking override an agent/tool request should add, or nil
+    /// when the caller/model contract must remain untouched.
+    ///
+    /// Precedence is deliberate:
+    /// 1. The wire-safe API toggle is an explicit user/client choice.
+    /// 2. The canonical local model option is the same choice before encoding.
+    /// 3. A reasoning-effort control owns the model's reasoning rail.
+    /// 4. Only a truly unspecified agent/tool run receives the direct default.
+    static func defaultEnableThinking(
+        isAgentOrToolRequest: Bool,
+        explicitEnableThinking: Bool?,
+        explicitReasoningEffort: String?,
+        modelOptions: [String: ModelOptionValue],
+        usesReasoningEffortControl: Bool,
+        capability: LocalReasoningCapability.Capability
+    ) -> Bool? {
+        if let explicitEnableThinking {
+            return explicitEnableThinking
+        }
+        if let disableThinking = modelOptions["disableThinking"]?.boolValue {
+            return !disableThinking
+        }
+        if let explicitReasoningEffort,
+            !explicitReasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return nil
+        }
+        if let optionEffort = modelOptions["reasoningEffort"]?.stringValue,
+            !optionEffort.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return nil
+        }
+        // A segmented reasoning-effort rail (DSV4 instruct/reasoning/max,
+        // Hy3, and similar profiles) owns its own default semantics even when
+        // the underlying template also happens to accept `enable_thinking`.
+        // Never collapse that richer contract into the generic boolean rail.
+        guard !usesReasoningEffortControl else { return nil }
+        guard isAgentOrToolRequest, capability.isToggleableThinking else {
+            return nil
+        }
+        return false
+    }
+
+    /// Resolve the state the UI should present for a toggleable local model.
+    /// This deliberately reuses the dispatch policy so an untouched agent
+    /// composer cannot claim the bundle default is active while dispatch will
+    /// select the direct rail. Explicit choices still win; ordinary no-tool
+    /// chat falls back to the bundle's own template default.
+    static func effectiveEnableThinkingForPresentation(
+        isAgentOrToolRequest: Bool,
+        modelOptions: [String: ModelOptionValue],
+        capability: LocalReasoningCapability.Capability
+    ) -> Bool {
+        defaultEnableThinking(
+            isAgentOrToolRequest: isAgentOrToolRequest,
+            explicitEnableThinking: nil,
+            explicitReasoningEffort: nil,
+            modelOptions: modelOptions,
+            usesReasoningEffortControl: false,
+            capability: capability
+        ) ?? capability.defaultThinkingOn
+    }
+}

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -11,6 +11,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
     private let services: [ModelService]
     private let installedModelsProvider: @Sendable () -> [String]
     private let remoteServicesProvider: @Sendable () async -> [ModelService]
+    private let reasoningCapabilityProvider: @Sendable (String) -> LocalReasoningCapability.Capability
+    private let agentModelOptionsProvider:
+        @Sendable (String) async -> [String: ModelOptionValue]?
 
     /// Source of the inference (for logging purposes)
     private var inferenceSource: InferenceSource = .httpAPI
@@ -25,11 +28,25 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 RemoteProviderManager.shared.connectedServices().map { $0 as ModelService }
             }
         },
+        reasoningCapabilityProvider:
+            @escaping @Sendable (String) ->
+            LocalReasoningCapability.Capability = {
+                LocalReasoningCapability.capability(forModelId: $0)
+            },
+        agentModelOptionsProvider:
+            @escaping @Sendable (String) async ->
+            [String: ModelOptionValue]? = { modelId in
+                await MainActor.run {
+                    ModelOptionsStore.shared.loadOptions(for: modelId)
+                }
+            },
         source: InferenceSource = .httpAPI
     ) {
         self.services = services
         self.installedModelsProvider = installedModelsProvider
         self.remoteServicesProvider = remoteServicesProvider
+        self.reasoningCapabilityProvider = reasoningCapabilityProvider
+        self.agentModelOptionsProvider = agentModelOptionsProvider
         self.inferenceSource = source
     }
     /// Errors thrown by `ChatEngine` that carry a classification so the
@@ -127,9 +144,27 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         let repPenalty: Float? = nil
         let seedBits: UInt64? = request.seed.map { UInt64(bitPattern: Int64($0)) }
         let isJSONObject = (request.response_format?.type == "json_object")
+        // Internal UI-owned agent loops (Computer Use, AppleScript, and
+        // delegated text agents) construct fresh requests on every step. They
+        // do not own a composer-local option snapshot, so resolve the same
+        // persisted per-model choice the visible picker writes. Keep this
+        // strictly on `.chatUI` + explicit agent requests: ordinary chat,
+        // OpenAI tool requests, plugins, scheduled work, P2P, and remote-agent
+        // execution must not silently inherit GUI preferences.
+        let requestModelOptions: [String: ModelOptionValue]? =
+            if let explicit = request.modelOptions {
+                explicit
+            } else if inferenceSource == .chatUI,
+                request.isAgentRequest,
+                !request.runAsRemoteAgent
+            {
+                await agentModelOptionsProvider(request.model)
+            } else {
+                nil
+            }
         var modelOptions = Self.normalizedModelOptions(
             for: request.model,
-            requestOptions: request.modelOptions
+            requestOptions: requestModelOptions
         )
         let isHy3 = Hy3ReasoningProfile.matches(modelId: request.model)
         let requestReasoningEffort: String? = {
@@ -140,6 +175,36 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             else { return nil }
             return value
         }()
+
+        // An agent/tool run must not inherit a toggleable template's
+        // reasoning-on default merely because the caller stayed silent. That
+        // made every Ornith tool step spend thousands of hidden tokens before
+        // trivial calls. Detect the contract from the installed bundle rather
+        // than a model-name alias, and preserve every explicit UI/API choice.
+        // A schema paired with OpenAI `tool_choice: none` is an ordinary
+        // no-tool request, not an agent turn. Explicit agent markers still
+        // win because cap finalizers intentionally remove their tool schema.
+        let hasEnabledToolSurface =
+            request.tools?.isEmpty == false
+            && Self.allowsLocalToolDispatch(request.tool_choice)
+        let isAgentOrToolRequest = request.isAgentRequest || hasEnabledToolSurface
+        let usesReasoningEffortControl = ModelProfileRegistry.options(for: request.model)
+            .contains { $0.id == "reasoningEffort" }
+        if !request.runAsRemoteAgent,
+            !isHy3,
+            let agentEnableThinking = AgentReasoningPolicy.defaultEnableThinking(
+                isAgentOrToolRequest: isAgentOrToolRequest,
+                explicitEnableThinking: request.enable_thinking,
+                explicitReasoningEffort: requestReasoningEffort,
+                modelOptions: modelOptions,
+                usesReasoningEffortControl: usesReasoningEffortControl,
+                capability: reasoningCapabilityProvider(request.model)
+            ),
+            request.enable_thinking == nil,
+            modelOptions["disableThinking"] == nil
+        {
+            modelOptions["disableThinking"] = .bool(!agentEnableThinking)
+        }
 
         if isHy3 {
             if let requestReasoningEffort {

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1096,6 +1096,7 @@ final class PluginHostContext: @unchecked Sendable {
         request.enable_thinking = base.enable_thinking
         request.reasoning_effort = base.reasoning_effort
         request.modelOptions = base.modelOptions
+        request.isAgentRequest = base.isAgentRequest || tools?.isEmpty == false
         return request
     }
 
@@ -1262,6 +1263,7 @@ final class PluginHostContext: @unchecked Sendable {
         request.enable_thinking = inference.request.enable_thinking
         request.reasoning_effort = inference.request.reasoning_effort
         request.modelOptions = inference.request.modelOptions
+        request.isAgentRequest = inference.request.isAgentRequest || effectiveTools?.isEmpty == false
         return EnrichedInference(request: request, tools: effectiveTools)
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/AgentReasoningPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentReasoningPolicyTests.swift
@@ -1,0 +1,333 @@
+//
+//  AgentReasoningPolicyTests.swift
+//  osaurusTests
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Agent reasoning policy")
+struct AgentReasoningPolicyTests {
+    private let toggleableDefaultOn = LocalReasoningCapability.Capability(
+        supportsThinking: true,
+        hasEnableThinkingKwarg: true,
+        templateInjectsThinkTag: true,
+        defaultThinkingOn: true
+    )
+    private let toggleableDefaultOff = LocalReasoningCapability.Capability(
+        supportsThinking: true,
+        hasEnableThinkingKwarg: true,
+        templateInjectsThinkTag: false,
+        defaultThinkingOn: false
+    )
+
+    @Test("unset ordinary chat preserves opposite bundle defaults")
+    func ordinaryChatPreservesBundleDefault() {
+        for capability in [toggleableDefaultOn, toggleableDefaultOff] {
+            #expect(
+                AgentReasoningPolicy.defaultEnableThinking(
+                    isAgentOrToolRequest: false,
+                    explicitEnableThinking: nil,
+                    explicitReasoningEffort: nil,
+                    modelOptions: [:],
+                    usesReasoningEffortControl: false,
+                    capability: capability
+                ) == nil
+            )
+        }
+    }
+
+    @Test("unset agent/tool run selects direct rail for any toggleable template")
+    func unsetAgentDefaultsThinkingOff() {
+        for capability in [toggleableDefaultOn, toggleableDefaultOff] {
+            #expect(
+                AgentReasoningPolicy.defaultEnableThinking(
+                    isAgentOrToolRequest: true,
+                    explicitEnableThinking: nil,
+                    explicitReasoningEffort: nil,
+                    modelOptions: [:],
+                    usesReasoningEffortControl: false,
+                    capability: capability
+                ) == false
+            )
+        }
+    }
+
+    @Test("explicit API and UI choices win in both directions")
+    func explicitChoicesWin() {
+        for enabled in [false, true] {
+            #expect(
+                AgentReasoningPolicy.defaultEnableThinking(
+                    isAgentOrToolRequest: true,
+                    explicitEnableThinking: enabled,
+                    explicitReasoningEffort: nil,
+                    modelOptions: [:],
+                    usesReasoningEffortControl: false,
+                    capability: toggleableDefaultOn
+                ) == enabled
+            )
+            #expect(
+                AgentReasoningPolicy.defaultEnableThinking(
+                    isAgentOrToolRequest: true,
+                    explicitEnableThinking: nil,
+                    explicitReasoningEffort: nil,
+                    modelOptions: ["disableThinking": .bool(!enabled)],
+                    usesReasoningEffortControl: false,
+                    capability: toggleableDefaultOn
+                ) == enabled
+            )
+        }
+    }
+
+    @Test("explicit reasoning effort blocks the agent default")
+    func reasoningEffortWins() {
+        #expect(
+            AgentReasoningPolicy.defaultEnableThinking(
+                isAgentOrToolRequest: true,
+                explicitEnableThinking: nil,
+                explicitReasoningEffort: "high",
+                modelOptions: [:],
+                usesReasoningEffortControl: false,
+                capability: toggleableDefaultOn
+            ) == nil
+        )
+        #expect(
+            AgentReasoningPolicy.defaultEnableThinking(
+                isAgentOrToolRequest: true,
+                explicitEnableThinking: nil,
+                explicitReasoningEffort: nil,
+                modelOptions: ["reasoningEffort": .string("max")],
+                usesReasoningEffortControl: false,
+                capability: toggleableDefaultOn
+            ) == nil
+        )
+    }
+
+    @Test("non-toggleable models receive no synthetic kwarg")
+    func nonToggleableIsUntouched() {
+        #expect(
+            AgentReasoningPolicy.defaultEnableThinking(
+                isAgentOrToolRequest: true,
+                explicitEnableThinking: nil,
+                explicitReasoningEffort: nil,
+                modelOptions: [:],
+                usesReasoningEffortControl: false,
+                capability: .none
+            ) == nil
+        )
+    }
+
+    @Test("dedicated reasoning-effort profiles stay off the boolean rail")
+    func reasoningEffortProfileIsUntouched() {
+        #expect(
+            AgentReasoningPolicy.defaultEnableThinking(
+                isAgentOrToolRequest: true,
+                explicitEnableThinking: nil,
+                explicitReasoningEffort: nil,
+                modelOptions: [:],
+                usesReasoningEffortControl: true,
+                capability: toggleableDefaultOn
+            ) == nil
+        )
+    }
+
+    @Test("presentation matches dispatch while preserving ordinary bundle default")
+    func presentationMatchesDispatch() {
+        #expect(
+            AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+                isAgentOrToolRequest: false,
+                modelOptions: [:],
+                capability: toggleableDefaultOn
+            )
+        )
+        #expect(
+            !AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+                isAgentOrToolRequest: true,
+                modelOptions: [:],
+                capability: toggleableDefaultOn
+            )
+        )
+        #expect(
+            AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+                isAgentOrToolRequest: true,
+                modelOptions: ["disableThinking": .bool(false)],
+                capability: toggleableDefaultOn
+            )
+        )
+        #expect(
+            !AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+                isAgentOrToolRequest: true,
+                modelOptions: ["disableThinking": .bool(true)],
+                capability: toggleableDefaultOn
+            )
+        )
+    }
+}
+
+@Suite("Agent reasoning dispatch")
+struct AgentReasoningDispatchTests {
+    private actor Capture {
+        var parameters: GenerationParameters?
+        func set(_ parameters: GenerationParameters) { self.parameters = parameters }
+    }
+
+    private struct CaptureService: ModelService {
+        let capture: Capture
+        let id: String
+        func isAvailable() -> Bool { true }
+        func handles(requestedModel: String?) -> Bool { requestedModel == id }
+        func generateOneShot(
+            messages: [ChatMessage],
+            parameters: GenerationParameters,
+            requestedModel: String?
+        ) async throws -> String {
+            await capture.set(parameters)
+            return "ok"
+        }
+        func streamDeltas(
+            messages: [ChatMessage],
+            parameters: GenerationParameters,
+            requestedModel: String?,
+            stopSequences: [String]
+        ) async throws -> AsyncThrowingStream<String, Error> {
+            await capture.set(parameters)
+            return AsyncThrowingStream { continuation in
+                continuation.yield("ok")
+                continuation.finish()
+            }
+        }
+    }
+
+    private var toggleableDefaultOn: LocalReasoningCapability.Capability {
+        LocalReasoningCapability.Capability(
+            supportsThinking: true,
+            hasEnableThinkingKwarg: true,
+            templateInjectsThinkTag: true,
+            defaultThinkingOn: true
+        )
+    }
+
+    private func request(
+        model: String = "ornith-fixture",
+        tools: [Tool]? = nil,
+        toolChoice: ToolChoiceOption? = nil
+    ) -> ChatCompletionRequest {
+        ChatCompletionRequest(
+            model: model,
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            max_tokens: 32,
+            stream: false,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: tools,
+            tool_choice: toolChoice,
+            session_id: nil
+        )
+    }
+
+    private var fixtureTool: Tool {
+        Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "fixture",
+                description: "fixture",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([:]),
+                ])
+            )
+        )
+    }
+
+    @Test("shared dispatch distinguishes agent, enabled tools, and tool_choice none")
+    func dispatchPolicy() async throws {
+        let capture = Capture()
+        let capability = toggleableDefaultOn
+        let engine = ChatEngine(
+            services: [CaptureService(capture: capture, id: "ornith-fixture")],
+            installedModelsProvider: { [] },
+            reasoningCapabilityProvider: { _ in capability }
+        )
+
+        var ordinary = request()
+        _ = try await engine.completeChat(request: ordinary)
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+
+        ordinary = request(tools: [fixtureTool], toolChoice: ToolChoiceOption.none)
+        _ = try await engine.completeChat(request: ordinary)
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+
+        var agentFinalizer = request()
+        agentFinalizer.isAgentRequest = true
+        _ = try await engine.completeChat(request: agentFinalizer)
+        #expect(await capture.parameters?.modelOptions["disableThinking"]?.boolValue == true)
+
+        let enabledTools = request(tools: [fixtureTool], toolChoice: .auto)
+        _ = try await engine.completeChat(request: enabledTools)
+        #expect(await capture.parameters?.modelOptions["disableThinking"]?.boolValue == true)
+
+        var explicitOn = agentFinalizer
+        explicitOn.enable_thinking = true
+        _ = try await engine.completeChat(request: explicitOn)
+        #expect(await capture.parameters?.modelOptions["disableThinking"]?.boolValue == false)
+
+        var explicitModelOptionOn = agentFinalizer
+        explicitModelOptionOn.modelOptions = ["disableThinking": .bool(false)]
+        _ = try await engine.completeChat(request: explicitModelOptionOn)
+        #expect(await capture.parameters?.modelOptions["disableThinking"]?.boolValue == false)
+
+        var remoteAgent = agentFinalizer
+        remoteAgent.runAsRemoteAgent = true
+        _ = try await engine.completeChat(request: remoteAgent)
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+    }
+
+    @Test("DSV4 agent default stays on its dedicated effort rail")
+    func dsv4DispatchDoesNotSynthesizeBooleanThinking() async throws {
+        let model = "dealign.ai/DeepSeek-V4-Flash-JANG-CRACK"
+        let capture = Capture()
+        let capability = toggleableDefaultOn
+        let engine = ChatEngine(
+            services: [CaptureService(capture: capture, id: model)],
+            installedModelsProvider: { [] },
+            reasoningCapabilityProvider: { _ in capability }
+        )
+
+        var agent = request(model: model)
+        agent.isAgentRequest = true
+        _ = try await engine.completeChat(request: agent)
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+        #expect(await capture.parameters?.modelOptions["reasoningEffort"] == nil)
+    }
+
+    @Test("chat UI agents load persisted model choice without leaking it to ordinary or remote requests")
+    func chatUIAgentLoadsPersistedChoiceOnly() async throws {
+        let capture = Capture()
+        let capability = toggleableDefaultOn
+        let engine = ChatEngine(
+            services: [CaptureService(capture: capture, id: "ornith-fixture")],
+            installedModelsProvider: { [] },
+            reasoningCapabilityProvider: { _ in capability },
+            agentModelOptionsProvider: { _ in ["disableThinking": .bool(false)] },
+            source: .chatUI
+        )
+
+        _ = try await engine.completeChat(request: request())
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+
+        var localAgent = request()
+        localAgent.isAgentRequest = true
+        _ = try await engine.completeChat(request: localAgent)
+        #expect(await capture.parameters?.modelOptions["disableThinking"]?.boolValue == false)
+
+        var remoteAgent = localAgent
+        remoteAgent.runAsRemoteAgent = true
+        _ = try await engine.completeChat(request: remoteAgent)
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "24ce87c5ef812f816a242459aec50e544fd228f4""#))
-        #expect(packageResolved.contains(#""revision" : "24ce87c5ef812f816a242459aec50e544fd228f4""#))
-        #expect(workspaceResolved.contains(#""revision" : "24ce87c5ef812f816a242459aec50e544fd228f4""#))
-        #expect(appResolved.contains(#""revision" : "24ce87c5ef812f816a242459aec50e544fd228f4""#))
+        #expect(packageSwift.contains(#"revision: "4b431c6a3f229e2150810b9dea9afe57790ca60b""#))
+        #expect(packageResolved.contains(#""revision" : "4b431c6a3f229e2150810b9dea9afe57790ca60b""#))
+        #expect(workspaceResolved.contains(#""revision" : "4b431c6a3f229e2150810b9dea9afe57790ca60b""#))
+        #expect(appResolved.contains(#""revision" : "4b431c6a3f229e2150810b9dea9afe57790ca60b""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -698,7 +698,9 @@ struct RuntimePolicySourceTests {
         // cleanup (vmlx-swift#149), and the Nemotron Omni projector,
         // bounded-media-prefill, and safe hybrid media-prefix fixes (#156),
         // plus the paged-cache chain pinning, leaf-first release order, and
-        // bounded hybrid companion-state replay proven in vmlx-swift#161.
+        // bounded hybrid companion-state replay proven in vmlx-swift#161,
+        // followed by recurrent prompt-snapshot detachment and caller-cache
+        // reset after an unverified coordinator miss in vmlx-swift#163.
         //
         // This assertion is a repin tripwire, and it earned its keep: PR #1986
         // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
@@ -707,7 +709,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "24ce87c5ef812f816a242459aec50e544fd228f4"
+        let expectedRuntimeHardenedRevision = "4b431c6a3f229e2150810b9dea9afe57790ca60b"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1543,6 +1543,15 @@ final class ChatSession: ObservableObject {
         return preview
     }
 
+    /// Whether the next local UI send exposes at least one tool and will
+    /// therefore carry the same agent/tool marker consumed by
+    /// `ChatEngine.prepareDispatch`. The composer uses this exact preview
+    /// surface to present the untouched Thinking default truthfully.
+    var appliesAgentReasoningDefault: Bool {
+        guard !isRemoteAgentTarget else { return false }
+        return previewContext()?.tools.isEmpty == false
+    }
+
     /// Compose a fresh welcome/pre-send preview from the current agent /
     /// sandbox / tool / folder / model state. Pure — no caching, no
     /// `objectWillChange`. Single source of truth for the lazy read
@@ -5105,6 +5114,12 @@ final class ChatSession: ObservableObject {
                             req.remoteAgentLogModel =
                                 self.isRemoteAgentTarget
                                 ? self.windowState?.pinnedRemoteAgentEffectiveModel : nil
+                            // Freeze agent semantics for the whole logical run.
+                            // Tool schemas stay present on ordinary iterations,
+                            // but the cap finalizer below intentionally removes
+                            // them; the explicit marker keeps both paths on the
+                            // same reasoning policy.
+                            req.isAgentRequest = !toolSpecs.isEmpty || self.isRemoteAgentTarget
                             turnGenerationControls.apply(to: &req)
                             req.backgroundModelLoad = (self.loadIntent == .background)
                             req.ttftTrace = ttftTrace
@@ -5386,6 +5401,7 @@ final class ChatSession: ObservableObject {
                             finalReq.remoteAgentLogModel =
                                 isRemoteAgentTarget
                                 ? windowState?.pinnedRemoteAgentEffectiveModel : nil
+                            finalReq.isAgentRequest = !toolSpecs.isEmpty || isRemoteAgentTarget
                             turnGenerationControls.apply(to: &finalReq)
                             finalReq.backgroundModelLoad = (loadIntent == .background)
                             finalReq.turnId = assistantTurn.id
@@ -6153,6 +6169,7 @@ struct ChatView: View {
                                 isPrivacyReviewSheetVisible: pendingRedactionReview != nil,
                                 supportsImages: observedSession.selectedModelSupportsImages,
                                 estimatedContextTokens: observedSession.estimatedContextTokens,
+                                appliesAgentReasoningDefault: observedSession.appliesAgentReasoningDefault,
                                 contextBreakdown: observedSession.estimatedContextBreakdown,
                                 sessionSpendMicro: observedSession.sessionRouterSpendMicro,
                                 isRouterBilledSession: observedSession.isOsaurusRouterSession,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -34,6 +34,9 @@ struct FloatingInputCard: View {
     let supportsImages: Bool
     /// Current estimated context token count for the session
     let estimatedContextTokens: Int
+    /// True when the next local send has an enabled tool surface, so an
+    /// untouched toggleable model will use the agent direct-reasoning default.
+    let appliesAgentReasoningDefault: Bool
     /// Per-category breakdown of context token usage
     var contextBreakdown: ContextBreakdown = .zero
     /// Total micro-USD spent on the Osaurus Router this session.
@@ -133,6 +136,7 @@ struct FloatingInputCard: View {
         isPrivacyReviewSheetVisible: Bool = false,
         supportsImages: Bool,
         estimatedContextTokens: Int,
+        appliesAgentReasoningDefault: Bool = false,
         contextBreakdown: ContextBreakdown = .zero,
         sessionSpendMicro: Int = 0,
         isRouterBilledSession: Bool = false,
@@ -175,6 +179,7 @@ struct FloatingInputCard: View {
         self.isPrivacyReviewSheetVisible = isPrivacyReviewSheetVisible
         self.supportsImages = supportsImages
         self.estimatedContextTokens = estimatedContextTokens
+        self.appliesAgentReasoningDefault = appliesAgentReasoningDefault
         self.contextBreakdown = contextBreakdown
         self.sessionSpendMicro = sessionSpendMicro
         self.isRouterBilledSession = isRouterBilledSession
@@ -2227,8 +2232,19 @@ extension FloatingInputCard {
             inlineReasoningSuffix == nil,
             ModelProfileRegistry.profile(for: model)?.thinkingOption != nil
         else { return nil }
-        return ModelProfileRegistry.thinkingEnabled(for: model, values: activeModelOptions)
-            ?? ModelProfileRegistry.thinkingDefaultOn(for: model)
+        return effectiveThinkingEnabled(for: model)
+    }
+
+    /// Keep the chip and picker on the same policy as dispatch. In a local
+    /// tool-capable chat, an untouched toggleable model defaults to direct
+    /// answers; in ordinary no-tool chat, the bundle template still owns the
+    /// default. An explicit persisted UI choice wins in either context.
+    private func effectiveThinkingEnabled(for model: String) -> Bool {
+        AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+            isAgentOrToolRequest: appliesAgentReasoningDefault,
+            modelOptions: activeModelOptions,
+            capability: LocalReasoningCapability.capability(forModelId: model)
+        )
     }
 
     private var selectorRow: some View {
@@ -3121,7 +3137,7 @@ extension FloatingInputCard {
             values: activeModelOptions
         )
         return ModelPickerThinkingControl(
-            isEnabled: explicitEnabled ?? ModelProfileRegistry.thinkingDefaultOn(for: model),
+            isEnabled: effectiveThinkingEnabled(for: model),
             isExplicit: explicitEnabled != nil,
             onSetEnabled: { enabled in
                 // Deferred write for the same reason as the generic option

--- a/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
+++ b/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
@@ -1,10 +1,14 @@
 # Gemma/Bonsai Emergency Proof Ledger
 
-Last updated: 2026-07-19 (America/Los_Angeles)
+Last updated: 2026-07-20 (America/Los_Angeles)
 
-Verdict: **PASS for the narrow schema-1 JANG loader pin; PARTIAL for the
-separate Ornith multi-step semantic-completion defect, which is not changed or
-claimed fixed by this PR.**
+Verdict: **PASS for the narrow Ornith/Qwen-toggleable agent-reasoning policy
+and recurrent-cache cross-hit repair on the exact installed JANG_4M bundle;
+PASS for the historical schema-1 JANG loader and Bonsai paged-chain repairs;
+PARTIAL for the separate Ornith semantic-completion defect and every deferred
+family/cache matrix. The current Release app was operated through the real UI
+across untouched OFF, explicit ON, OFF-after-ON, process restart, and partial
+disk-L2 reuse. No MXFP4 artifact was loaded or used as evidence.**
 
 ## Local model root (hard rule)
 
@@ -18,7 +22,8 @@ Current Ornith fixtures:
 - JANG_4M: `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M`
 - MXFP8: `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-MXFP8`
 
-This branch starts from `origin/main` `504d174ab`. Bonsai structured-chart and
+This emergency branch is rebased on merged `main`
+`08eb8bd8a29f79bef9bdb1dd791fcf6a8c1fea4c`. Bonsai structured-chart and
 hybrid-memory fixes are already on main through PR #2041. Selected Memory
 Safety load admission is already on main through PR #2045. The deferred broad
 automatic-routing/hardware-guidance work in PR #2044 is not part of this
@@ -35,21 +40,294 @@ emergency diff.
 - Record visible output, tool cards, streamed tool assembly, token/s, physical
   footprint, cache topology/counters, and on-disk effects.
 
+## Active Gemma 4 QAT checkpoint gates
+
+The project `AGENTS.md` makes the following required follow-up evidence part of
+this ledger. These rows do not broaden the present emergency diff, and they
+remain PARTIAL until exercised in an exact-head Release Osaurus app through the
+real UI:
+
+- ordinary single-batch chat/server loading starts with paged RAM KV off;
+  paged RAM may only be enabled by an explicit user or regression setting;
+- Gemma 4 JANG_4M and QAT MXFP4 use bundle generation configuration plus the
+  real Osaurus/vMLX parser/tool/streaming path, with no protocol-marker leakage
+  and no prompt, sampler, reasoning-tag, stop-token, or output-cap masking;
+- telemetry names the effective topology exactly. Rotating KV plus disk restore
+  with `turbo_quant_kv_layer_count=0` must not be described as a TurboQuant-KV
+  topology, and prefix/paged/L2/disk-restore counters must agree with behavior;
+- long first-token waits expose runtime prefill/cache/media progress rather
+  than UI timer estimates;
+- every generation row records TTFT/token/s, visible answer and reasoning
+  coherency, no loop or hidden-only answer, and Activity Monitor
+  `phys_footprint`; load-only and report-only admission rows do not pass; and
+- multi-turn plus architecture-specific cache proof is mandatory, including
+  companion state for rotating SWA, hybrid/recurrent state, VL, video, or other
+  path-dependent caches. Raw speed and Gemma 4 audio stay deferred until the
+  correctness checkpoint closes, and BF16/source Gemma bundles are excluded
+  from that checkpoint.
+
 ## Priority and current evidence
 
 | Priority | Row | Status |
 | --- | --- | --- |
-| P0 | Installed JANG schema-1 bundles load | LIVE LOAD PASS on exact JANG_4M; multi-step correctness still fails |
+| P0 | Installed JANG schema-1 bundles load | LIVE LOAD PASS on exact JANG_4M; separate semantic-completion row remains partial |
+| P0 | Untouched Thinking state on agent/tool runs | VERIFIED-SOURCE + VERIFIED-LIVE on exact current Release app: OFF→ON→OFF and restart |
+| P0 | Reasoning-mode cache isolation across same-chat tool turns | VERIFIED-SOURCE + VERIFIED-LIVE: no stale replay after vMLX reset plus detached recurrent snapshots |
 | P0 | Ornith/Qwen post-tool cutoff or partial completion | REPRODUCED AS PARTIAL MUTATION on JANG_4M and MXFP8; exact pre-write cutoff not reproduced |
 | P0 | Bonsai tiny-pool paged-cache eviction and hybrid replay tail | VERIFIED-SOURCE + VERIFIED-LIVE for the cache defect; model semantic-quality controls remain mixed |
 | P0 | PR scope contains no deferred routing/hardware changes | PASS for current pin-only source/test diff plus ledger; repeat on final diff |
-| P0 | Exact pin-only candidate Release UI rerun | PASS for JANG_4M load and plain generation; semantic handbook behavior remains a separate reproduced failure |
+| P0 | Exact pin-only candidate Release UI rerun | PASS for the scoped agent reasoning/cache matrix; semantic handbook behavior remains a separate reproduced failure |
 | P1 | Gemma/Bonsai tool correctness regressions | NOT YET RUN on clean head |
 | P1 | TurboQuant default-off, explicit toggle, persistence, Gemma rotating-SWA topology | NOT YET RUN on clean head |
 | P1 | Qwen 3.5 text/VL hybrid rederive, prefix/L2 disk restore, cache growth in GB | NOT YET RUN on clean head |
 | P1 | Memory Safety warning, setting change, larger-model load, restore refusal | NOT YET RUN on clean head |
 | P1 | Image generation/editing and spawn/delegation RAM admission/notifications | NOT YET RUN on clean head |
+| P1 | MiniMax M2.7 JANGTQ/JANG_K runtime plus native reasoning-mode behavior | DOCUMENTED; SEPARATE LIVE MATRIX OPEN |
+| P1 | DSV4 Flash mixed SWA/HCA/CSA/DSA/MLA prefix/partial/L2 cache behavior | DOCUMENTED; SEPARATE LIVE MATRIX OPEN |
 | P2 | MXFP4 structurally incomplete answer/reasoning/tool-envelope recovery | DOCUMENTED ONLY; no MXFP4 runtime claim and excluded from the emergency diff without a later exact-model reproduction |
+
+## 2026-07-20 Ornith agent reasoning emergency
+
+Status: **VERIFIED-SOURCE + VERIFIED-LIVE for the scoped emergency.** The
+current request policy and both vMLX cache repairs were rebuilt together into
+an isolated Release app and operated through the real model picker, folder,
+tool cards, cache settings, chat history, and process restart. The same chat
+completed OFF→ON→OFF without a stale tool call, and the restarted process
+restored a partial disk prefix before the requested tool call. This does not
+close the separate Ornith semantic-completion defect or any deferred model
+family.
+
+### Reproduced contract
+
+The exact installed bundle
+`/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M` declares
+`text_config.model_type=qwen3_5_text`, 24 linear-attention layers, eight
+full-attention layers, and a Qwen tool/reasoning contract. Its template's only
+direct-rail branch is
+`enable_thinking is defined and enable_thinking is false`; omission therefore
+means thinking ON. Ornith's display id does not match the existing Qwen family
+name path in `MLXBatchAdapter`, so an untouched request reaches the template
+without `enable_thinking` and inherits the reasoning rail.
+
+Osaurus `main` at `846ca9185dfee42a9bf2f741938f0b89a546b8ca`
+already freezes an explicit Thinking choice for every reconstructed ChatView
+tool iteration and cap finalizer. That fix deliberately preserves `nil` for an
+untouched control, so it does not implement the required agent default.
+
+### Required policy
+
+- Ordinary chat plus untouched Thinking: preserve the bundle/template default.
+- Agent or tool run plus untouched Thinking: pass
+  `enable_thinking=false` for every model step and finalizer, but only when the
+  installed bundle exposes a real toggleable reasoning template.
+- Explicit Thinking ON or OFF: the user/API choice wins on every step.
+- Explicit reasoning effort: the effort rail wins; do not synthesize a
+  contradictory boolean.
+- Non-toggleable models, models with a dedicated reasoning-effort control
+  (including DSV4 instruct/reasoning/max and Hy3), and remote agent-owned Mode
+  2 generation receive no synthetic local boolean kwarg.
+- Detect from the local template/config capability, never from `ornith`,
+  `qwen`, or another display-name allowlist.
+
+### Owning-layer fixes
+
+The Osaurus candidate adds a pure `AgentReasoningPolicy` and calls
+it from `ChatEngine.prepareDispatch`, the shared stream/non-stream request
+entry. The policy fires only for `isAgentRequest` or a non-empty tool schema,
+only for `LocalReasoningCapability.isToggleableThinking`, and only when no
+explicit thinking or reasoning-effort control exists. Any model profile that
+owns a segmented `reasoningEffort` rail is excluded even if its underlying
+template also accepts `enable_thinking`. ChatView carries the
+logical agent marker into its tool-less cap finalizer. Plugin iterations copy
+the same marker when their resolved schema is non-empty. Computer Use,
+AppleScript, HTTP agent loops, and delegated subagents already mark their
+requests as agent-driven and therefore converge at the shared entry point.
+Fresh local `.chatUI` requests created by Computer Use, AppleScript, and
+delegated text-agent loops now resolve the persisted per-model picker choice at
+that same entry point when the request does not already carry explicit
+`modelOptions`. This lookup is limited to local `.chatUI` agent requests:
+explicit request options win, and ordinary chat, OpenAI/API tools, plugins,
+scheduled/P2P work, and remote-agent execution do not inherit GUI state.
+An ordinary OpenAI request that supplies schemas with `tool_choice: none`
+remains ordinary chat and preserves the bundle default; an explicit local
+agent marker still wins for a tool-less finalizer.
+
+This is request-policy wiring, not a model-behavior repair: it does not change
+the chat template, prompt text, sampler, output parser, stop/EOS handling,
+reasoning delimiters, tool JSON schema, tool-result history, or content-delta
+assembly.
+
+### Required current-source and live closure
+
+| Gate | Required evidence | Status |
+| --- | --- | --- |
+| Pure precedence tests | ordinary unset, agent unset, explicit ON/OFF, explicit effort, non-toggleable, dedicated effort rail, remote-agent exclusion | PASS: rebased-head `ReasoningTests9.xcresult` reports 64 passed, 0 failed, 0 skipped across policy, dispatch, turn controls, local capability, and profile regressions |
+| Request reconstruction | ChatView normal iterations + finalizer, HTTP agents, plugins, Computer Use, AppleScript, delegated subagents | VERIFIED-SOURCE at shared dispatch and reconstruction sites; local ChatView path VERIFIED-LIVE; other surfaces not separately live-proven by this row |
+| Untouched real-user row | Fresh isolated preferences; real tool calls; zero reasoning on every step; exact tool args/results; final answer; TTFT and tok/s | PASS-LIVE: two exact file reads, zero reasoning deltas on all steps/finalizer, exact `FIX2-OFF-DONE`; TTFT 0.48s, 72.7 tok/s, 6 tokens |
+| Explicit OFF row | Toggle OFF in picker; repeat multi-tool run; zero reasoning on every step and finalizer | PASS-LIVE after ON: two exact requested reads, no extras/reasoning, exact `FIX2-OFF-RETURN-DONE`; TTFT 0.44s, 69.8 tok/s, 8 tokens |
+| Explicit ON row | Toggle ON in picker; structured reasoning present on every intended step without leakage/looping | PASS-LIVE: one exact requested read, visible Thought before and after the tool, exact `FIX2-ON-DONE`; TTFT 0.52s, 70.6 tok/s, 27 tokens |
+| OFF after ON | Toggle back OFF; repeat to prove no stale prompt/cache replay | PASS-LIVE: no stale argument or final-answer replay in the same chat |
+| Settings/user-state truth | Reopen history and restart app; visible mode and effective request behavior agree | PASS-LIVE: reopened persisted chat after process restart; chip remained Off and every restarted step logged zero reasoning deltas |
+| Adjacent behavior | tool error + recovery, auto/required/no-tool, post-tool final answer, content/reasoning delta boundaries, cancellation, retry, spawn/delegation | OPEN |
+| Resource/cache proof | Activity Monitor physical footprint, per-turn token/s, prefix/paged/L2/SSM counters, no cache cross-hit between thinking states | PASS for scoped row: exact PID 84047 was 2.53 GB; rates above; disk partial-prefix hits and quota eviction captured. Broader cache-efficiency/family rows remain PARTIAL |
+
+Current-source safeguard results: the reasoning-delta routing, Chat UI
+reasoning routing, and no-hidden-local-sampler-default guards pass. The broad
+no-forced-behavior guard reports one lexical failure at the untouched
+`CapabilityTools.swift:17` documentation phrase `parser repair`. That line
+predates this branch (blame commit `2d238592cf`) and describes why malformed
+dynamic schemas fail closed; this diff does not modify that file or add a
+parser repair. The guard is therefore not reported as passing and the unrelated
+documentation is not edited merely to silence it.
+
+### Adjacent cache-contamination reproduction and candidate root
+
+The isolated proof app at
+`/private/tmp/osaurus-ornith-reasoning-release-derived/Build/Products/Release/osaurus.app`
+used bundle id `com.dinoki.osaurus.ornithreasoningproof`, isolated files and
+preferences, and the exact JANG_4M fixture. In one OFF turn it read lines 20–22
+and 35–37. After changing the same chat to ON, a prompt requesting only lines
+70–72 first executed the stale lines-20–22 call and only then the requested
+lines-70–72 call. The UI showed two tool cards and Thinking before every model
+step, then ended `ON-CROSS-HIT-DONE` at TTFT 0.36s and 80.7 tok/s. Runtime logs
+recorded the stale and requested argument objects in that order. A fresh-chat
+ON control did not replay the old arguments, which isolates the defect to
+cross-request state rather than tool JSON assembly or content-delta streaming.
+
+vMLX already salts coordinator keys by exact prompt tokens plus
+`reasoning=on|off`, tool choice, media, and effective KV policy. The coordinator
+therefore returned a miss after the mode change. `TokenIterator` nevertheless
+kept a populated caller-owned cache on that miss and treated the numeric cache
+offset as if it proved token-prefix identity. Offset ordering cannot prove that
+the rendered tool/reasoning history is the same; for Ornith/Qwen 3.5 it carried
+old `ArraysCache` recurrent state into the new request. The owning-layer
+fix in `6d5694fff9816e5f2e31444e62158e0970013b26` discards any
+populated unverified cache on a coordinator miss and full-prefills the request;
+verified coordinator hits remain the only reuse path. `NativeMTPTokenIterator`
+receives the same invariant.
+
+The first post-reset probe still exposed a second owning-layer defect:
+`ArraysCache.copy()` and `MambaCache.copy()` used an ellipsis slice, which is a
+view rather than an independent recurrent-state snapshot. Later tool/output
+tokens could therefore mutate a prompt-boundary cache entry stored under an
+earlier prompt hash. vMLX commit
+`4b431c6a3f229e2150810b9dea9afe57790ca60b` creates independent buffers,
+materializes prompt snapshots once, detaches recorded Mamba prefix states, and
+adds mutation-after-snapshot coverage. It does not modify prompt text, model
+templates, samplers, stop/EOS handling, parsers, tool schemas, or output
+streaming.
+
+Focused current-source vMLX evidence at that exact revision:
+
+- `BatchEngineGrowingChatCacheSourceTests`: 17 passed;
+- `CacheCoordinatorTopologyFocusedTests`: 40 passed;
+- `CacheCoordinatorModeKeyIsolationTests`: 9 passed;
+- `swift build --target MLXLMCommon` completed; and
+- `git diff --check` returned clean.
+
+### Exact current Release UI proof
+
+- App:
+  `/private/tmp/osaurus-ornith-cachefix2-release-derived/Build/Products/Release/osaurus.app`
+- Bundle id: `com.dinoki.osaurus.ornithcachefixproof2`
+- Embedded vMLX revision:
+  `4b431c6a3f229e2150810b9dea9afe57790ca60b`
+- Executable SHA-256:
+  `5291afc8309f8a94b7642cbb7da04b326227fd23eafabd94a11047c66c1d7dde`
+- Runtime root:
+  `/private/tmp/osaurus-ornith-cachefix2-proof-root-v1`
+- Exact model:
+  `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M`
+
+The Release build completed successfully, was ad-hoc signed under the isolated
+bundle id, and passed deep strict code-sign verification. Fresh preferences,
+test-root files, and keychain-disabled mode kept it separate from the installed
+app. The real Cache settings UI showed Prefix on, paged RAM/GPU cache off, SSD
+L2 on, codec `Engine Selected` rather than TurboQuant, SSM rederive on, and a
+10 GB disk soft cap.
+
+After the OFF→ON→OFF chat matrix, the app was quit and the same binary/root was
+relaunched. History restored the same chat, working folder, model, and Off
+presentation. A unique prompt then executed exactly one `read_file` for
+`FloatingInputCard.swift:2220-2240`, rendered exactly
+`FIX2-RESTART-L2-DONE`, and showed TTFT 0.65s, 71.9 tok/s, and 9 tokens. Runtime
+traces recorded zero reasoning deltas, a disk partial-prefix hit at
+`boundary=4921 remaining=2481`, the exact requested tool arguments, a later
+disk hit at `boundary=7112 remaining=823`, and no stale calls or finals.
+
+The `ssm=48 fmtV=2 willRestore=false` trace is not a missing companion restore
+for this effective topology. The live cache was 24 `MambaCache` plus eight
+`KVCacheSimple` layers; v2 typed disk payloads restore Mamba state directly,
+while the extra sidecar apply is reserved for legacy format or dynamic
+`ArraysCache` layers that v2 marks skipped. The visible coherent continuation
+and exact tool/final output are live behavior evidence, not a claim that every
+Qwen hybrid representation has now been proven.
+
+Activity Monitor visibly showed the exact restarted process PID 84047 at
+2.53 GB after generation. The disk root reached 9.8 GB with 219 files and 36
+files above 100 MB. Quota traces showed active KV and companion eviction back
+under the 10 GB soft cap. Correctness and quota enforcement passed this scoped
+row, but per-boundary disk amplification/efficiency remains a separate PARTIAL
+follow-up; it is not silently called healthy or changed in this emergency PR.
+
+After adding the shared local `.chatUI` agent-option lookup, this exact app was
+rebuilt in Release, ad-hoc signed, and passed deep strict verification again.
+The existing isolated root and persisted chat were reopened through the real
+sidebar; the model and working folder restored and the visible Thinking chip
+remained Off. A new unique request executed exactly one `read_file` for
+`ChatEngine.swift:144-171`, rendered exactly
+`FIX2-CURRENT-SOURCE-OFF-DONE`, and showed TTFT 1.23s, 68.9 tok/s, and 10
+tokens. The tool card reported 925 ms. Runtime logs recorded zero reasoning
+deltas on the tool step and finalizer, the exact requested arguments, a disk
+partial-prefix hit at `boundary=7734 remaining=943`, the same 24 `MambaCache`
+plus eight `KVCacheSimple` topology, and no stale call or final. Activity
+Monitor visibly showed exact PID 90712 at 2.45 GB after this generation. The
+app then exited cleanly. This live row exercises the main ChatView path on the
+final source; the explicit persisted-choice branches for Computer Use,
+AppleScript, delegation, ordinary-chat exclusion, and remote-agent exclusion
+have current source/test evidence but are still not separately live-proven by
+this row.
+
+The branch was then rebased cleanly onto `main`
+`08eb8bd8a29f79bef9bdb1dd791fcf6a8c1fea4c`, which added unrelated TTS and
+slash-command fixes outside this PR diff. The focused matrix was rerun as
+`ReasoningTests9.xcresult` with 64 passed, 0 failed, and 0 skipped; the same app
+path was rebuilt in Release, re-signed, and passed deep strict verification at
+the final executable hash recorded above. In the reopened real UI, the model,
+folder, chat, and visible Off state restored. A new unique request produced
+exactly one 923 ms `read_file` card for
+`AgentReasoningPolicy.swift:40-55`, exact final
+`FIX2-REBASED-HEAD-OFF-DONE`, TTFT 0.67s, 69.9 tok/s, and 12 tokens. Logs
+recorded exact arguments, zero reasoning deltas on the tool and finalizer
+steps, no stale call/final, and a post-tool disk partial-prefix hit at
+`boundary=8466 remaining=708` with 24 `MambaCache` plus eight
+`KVCacheSimple` layers. Activity Monitor visibly showed exact PID 93334 at
+2.45 GB after generation, and the proof app exited cleanly.
+
+The separate Ornith semantic-completion defect remains separate. A faster
+direct rail does not prove multi-step task completion, success detection, tool
+selection, tool-error honesty, or final-answer correctness.
+
+### Deferred mixed-cache/runtime matrices
+
+These are required follow-up campaigns and must not be described as closed by
+the Ornith reasoning patch:
+
+- MiniMax M2.7 JANGTQ and JANG_K: prove load, coherent multi-turn text and
+  tools, the bundle's own reasoning-mode semantics, explicit mode changes,
+  TTFT/token rate, physical footprint, and prefix/paged/L2 behavior. Do not
+  translate its reasoning contract onto the generic boolean rail unless the
+  exact bundle template/config explicitly owns that kwarg.
+- DSV4 Flash: prove the effective mixed SWA/HCA/CSA/DSA/MLA cache topology,
+  full and partial prefix reuse, paged eviction, disk-L2-only restore, raw
+  prefill fallback, companion-state synchronization/rederivation, coherent
+  tool continuation, TTFT/token rate, and physical footprint. Exercise
+  instruct, reasoning, and max separately; no row may infer one mode from
+  another.
+
+Both matrices require an isolated Release Osaurus app operated through the UI
+with exact local bundle paths and visible cache/resource evidence. Source
+inspection, unit tests, load-only rows, and CLI harness output remain PARTIAL.
 
 ## 2026-07-19 Bonsai paged-cache eviction checkpoint
 

--- a/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
+++ b/docs/GEMMA_BONSAI_EMERGENCY_PROOF_2026-07-15.md
@@ -233,7 +233,7 @@ Focused current-source vMLX evidence at that exact revision:
 - Embedded vMLX revision:
   `4b431c6a3f229e2150810b9dea9afe57790ca60b`
 - Executable SHA-256:
-  `5291afc8309f8a94b7642cbb7da04b326227fd23eafabd94a11047c66c1d7dde`
+  `6975d56bf873d1afe7d76cb039d5011a5b3aa69af4ab8f34775fd9436cfb9e4b`
 - Runtime root:
   `/private/tmp/osaurus-ornith-cachefix2-proof-root-v1`
 - Exact model:
@@ -307,6 +307,34 @@ steps, no stale call/final, and a post-tool disk partial-prefix hit at
 The separate Ornith semantic-completion defect remains separate. A faster
 direct rail does not prove multi-step task completion, success detection, tool
 selection, tool-error honesty, or final-answer correctness.
+
+The first `test-core` run on PR #2105 then caught a real four-surface repin
+inconsistency rather than a flaky runtime test: `Package.swift`, the core
+package resolver, and the top-level workspace resolver named vMLX
+`4b431c6a3f229e2150810b9dea9afe57790ca60b`, while the nested app resolver and
+the image/runtime repin tripwires still named its ancestor `24ce87c...`. The
+nested resolver and both tripwires now name the exact merged vMLX revision;
+the tripwire comment also records the two vMLX #163 cache invariants. Focused
+workspace testing in `PinContractTests2.xcresult` reports 94 passed, 0 failed,
+and 0 skipped across `ImageGenerationBridgeContractTests` and
+`RuntimePolicySourceTests`. The exact Release app above was rebuilt from that
+four-surface pin state, ad-hoc signed, and passed deep strict verification.
+
+The post-repin binary was then relaunched with the isolated root, keychain
+disabled, and `OSU_MODELS_DIR=/Users/eric/models`. Computer Use first exposed
+that reopening the old proof chat restored its old Gemma selection, so that
+chat was not counted as Ornith evidence. A new real-user chat visibly selected
+`Ornith-1.0-9B-JANG_4M`, the repository folder, and Thinking Off. It executed
+exactly one expanded `file_read` card with JSON
+`path=Packages/OsaurusCore/Package.swift`, `start_line=77`, and `end_line=82`;
+the visible result contained the exact vMLX pin, and the final response was
+exactly `FIX2-FINAL-ORNITH-OFF-DONE`. The UI reported TTFT 0.57s, 71.4 tok/s,
+11 tokens, and an 820 ms tool call, with no Thought row or protocol leakage.
+Activity Monitor visibly showed exact PID 99370 at 2.47 GB after generation.
+The proof app then exited cleanly. This is the final-binary current UI smoke;
+the broader explicit ON/OFF/restart matrix above remains the preceding
+functional-source proof, not a claim that all of it was repeated after the
+resolver-only correction.
 
 ### Deferred mixed-cache/runtime matrices
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e2e2dcc84fb1edf6d86debbeecdfb1a73f7aca5c631e06833992b737220ddd91",
+  "originHash" : "a54989b432b7810391896d269c01180dcba2ba9cec506362a9888d25196be468",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "24ce87c5ef812f816a242459aec50e544fd228f4"
+        "revision" : "4b431c6a3f229e2150810b9dea9afe57790ca60b"
       }
     },
     {


### PR DESCRIPTION
## Summary

Fixes the Ornith/Qwen-style agent slowdown where an untouched Thinking control omitted enable_thinking, allowing templates that default to reasoning-on to reason before every tool step. The change is capability-driven, preserves explicit UI/API choices, excludes dedicated reasoning-effort rails and remote agents, and pins the two vMLX recurrent-cache isolation fixes from osaurus-ai/vmlx-swift#163.

## Changes

- Add AgentReasoningPolicy at shared ChatEngine dispatch.
- Preserve ordinary no-tool bundle defaults and OpenAI tool_choice none behavior.
- Default only unspecified local toggleable agent/tool runs to direct mode.
- Carry the agent marker through ChatView cap finalizers and plugin reconstruction.
- Resolve persisted per-model UI choices for fresh local chatUI Computer Use, AppleScript, and delegated-agent requests only. Explicit request options win; ordinary/API/plugin/scheduled/P2P/remote execution does not inherit GUI state.
- Make the visible Thinking chip and picker reflect the effective agent default.
- Pin vMLX 4b431c6a3f229e2150810b9dea9afe57790ca60b, which resets unverified live cache after a coordinator miss and detaches recurrent prompt snapshots.
- Keep all four manifest/resolver surfaces and both existing repin tripwires on that exact vMLX revision.
- No automatic-routing, hardware-guidance, TurboQuant, sampler, parser, chat-template, or model-bundle behavior changes.

## Test Plan and Evidence

Current head: 0278add91, based on main 08eb8bd8a.

- ReasoningTests9.xcresult: 64 passed, 0 failed, 0 skipped across policy/dispatch, turn controls, local reasoning capability, and model profiles.
- The first PR test-core run correctly failed because the nested App resolver and the image/runtime repin tripwires still named ancestor 24ce87c5 while the other three pin surfaces named 4b431c6.
- PinContractTests2.xcresult after correction: 94 passed, 0 failed, 0 skipped across ImageGenerationBridgeContractTests and RuntimePolicySourceTests.
- Release workspace build succeeded with exact vMLX pin. The isolated app was ad-hoc signed and passed codesign deep strict verification.
- App: /private/tmp/osaurus-ornith-cachefix2-release-derived/Build/Products/Release/osaurus.app
- Bundle: com.dinoki.osaurus.ornithcachefixproof2
- Executable SHA-256: 6975d56bf873d1afe7d76cb039d5011a5b3aa69af4ab8f34775fd9436cfb9e4b
- Exact model: /Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M. No MXFP4 model was downloaded or run.

Real UI proof through Computer Use:

- Untouched Off: two exact file calls, zero reasoning on all steps/finalizer, exact FIX2-OFF-DONE; TTFT 0.48s, 72.7 tok/s.
- Explicit On: visible Thought before and after one exact tool call, exact FIX2-ON-DONE; TTFT 0.52s, 70.6 tok/s.
- Off after On: two exact calls, zero reasoning, no stale replay, exact FIX2-OFF-RETURN-DONE; TTFT 0.44s, 69.8 tok/s.
- Restart/L2: restored persisted chat/model/folder/Off state, exact one tool call and final, disk partial hit; TTFT 0.65s, 71.9 tok/s.
- Rebased-head smoke: exact one tool call and final, visible Off, 69.9 tok/s, zero reasoning, disk partial hit, Activity Monitor 2.45 GB.
- Final post-repin binary: Computer Use first exposed that reopening the old proof chat restored its old Gemma selection, so that chat was rejected as Ornith evidence. A new chat explicitly selected Ornith-1.0-9B-JANG_4M from /Users/eric/models, selected the repo folder, and visibly showed Thinking Off. One expanded file_read card showed exact JSON path Packages/OsaurusCore/Package.swift, start_line 77, end_line 82, with visible result containing vMLX 4b431c6. Exact final: FIX2-FINAL-ORNITH-OFF-DONE. UI: TTFT 0.57s, 71.4 tok/s, 11 tokens, tool 820ms, no Thought row or protocol leakage. Activity Monitor showed exact PID 99370 at 2.47 GB. App exited cleanly.

vMLX checks at the pinned revision:

- BatchEngineGrowingChatCacheSourceTests: 17 passed.
- CacheCoordinatorTopologyFocusedTests: 40 passed.
- CacheCoordinatorModeKeyIsolationTests: 9 passed.
- swift build --target MLXLMCommon succeeded.
- vMLX PR #163 is merged at merge commit 364eab42a91664ca92299b9fc1d49f1e15238bbc; the pinned head revision is reachable from it.

Source guards for reasoning-delta routing, Chat UI reasoning routing, and hidden sampler defaults pass. The broad no-forced-behavior script remains red on a pre-existing untouched CapabilityTools.swift documentation phrase containing parser repair; this PR does not modify that file or add parser recovery.

## Scope Audit

The diff contains only reasoning policy/UI/tool-loop wiring, its tests, the exact vMLX pin in four resolver surfaces, two existing repin tripwires, and the proof ledger. It contains no routing guidance, hardware guidance, TurboQuant, sampler, parser, template, or model-bundle changes.

## Remaining Partial Rows

- Computer Use, AppleScript, and delegated-agent explicit persisted-choice branches have source/test evidence but were not separately live-proven in the final row.
- Ornith semantic completion, tool-error honesty, cancellation/retry, and broad family cache/TurboQuant matrices remain partial and are not claimed fixed here.
- Disk quota enforcement worked, but per-boundary L2 amplification/efficiency remains partial.
- GitHub CI on current head must be terminal green before merge; no skipped vMLX job is described as green.

## Checklist

- [x] Focused tests
- [x] Isolated Release build
- [x] Computer Use proof on the correct local JANG_4M model
- [x] Activity Monitor physical footprint
- [x] Exact resolver and diff scope audit
- [x] Proof ledger updated
