### PR TITLE
Preserve visible generation telemetry across chat warmups

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -151,6 +151,12 @@ struct MLXBatchAdapter {
         runtimeDefaults: VMLXServerGenerationDefaults,
         maxBatchSize: Int
     ) async {
+        // `last_effective_generation` is user/API request telemetry. Chat
+        // prefill warm-ups deliberately submit `temperature=0, maxTokens=1`
+        // after a visible turn; letting that housekeeping request overwrite
+        // the row makes the admin endpoint describe the warm-up instead of
+        // the generation the user just observed.
+        guard shouldRecordAsLastEffectiveGeneration(generation) else { return }
         let modelDefaults = LocalGenerationDefaults.defaults(forModelId: modelName)
         let effective = Self.effectiveGenerationSettings(
             modelName: modelName,
@@ -164,6 +170,12 @@ struct MLXBatchAdapter {
             modelName: modelName,
             settings: effective
         )
+    }
+
+    static func shouldRecordAsLastEffectiveGeneration(
+        _ generation: GenerationParameters
+    ) -> Bool {
+        !generation.warmupPrefill
     }
 
     static func effectiveDraftStrategy(
@@ -1229,10 +1241,12 @@ struct MLXBatchAdapter {
             cacheTopology: cacheTopology,
             stage: "submitted_to_batch_engine"
         )
-        await Registry.shared.recordEffectiveGenerationSettings(
-            modelName: modelName,
-            settings: effective
-        )
+        if Self.shouldRecordAsLastEffectiveGeneration(generation) {
+            await Registry.shared.recordEffectiveGenerationSettings(
+                modelName: modelName,
+                settings: effective
+            )
+        }
         var mlxParams = ModelRuntime.makeGenerateParameters(
             temperature: effective.temperature,
             maxTokens: effective.maxTokens,

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -230,6 +230,22 @@ struct MLXBatchAdapterTests {
         #expect(!effective.compiledBatchDecode)
     }
 
+    @Test func lastEffectiveGenerationTelemetry_excludesChatPrefillWarmups() {
+        let visibleRequest = GenerationParameters(
+            temperature: nil,
+            maxTokens: 256,
+            maxTokensExplicit: false
+        )
+        let prefillWarmup = GenerationParameters(
+            temperature: 0,
+            maxTokens: 1,
+            warmupPrefill: true
+        )
+
+        #expect(MLXBatchAdapter.shouldRecordAsLastEffectiveGeneration(visibleRequest))
+        #expect(!MLXBatchAdapter.shouldRecordAsLastEffectiveGeneration(prefillWarmup))
+    }
+
     @Test func effectiveGenerationSettings_preservesNemotronUltraBundleDefaultsWithoutInventingTopK() {
         let generation = GenerationParameters(
             temperature: nil,


### PR DESCRIPTION
## Summary

- Keep `last_effective_generation` attached to the last visible user or API generation.
- Exclude internal `warmupPrefill` requests at both the pending and submitted telemetry record sites.
- Add a focused Swift Testing regression for visible requests versus one-token chat-prefill warmups.

## Root cause

`ChatWarmupController` creates the automatic post-turn prefill request with `temperature=0`, `maxTokens=1`, and `warmupPrefill=true`. Both `MLXBatchAdapter.recordPendingEffectiveGenerationSettings` and the submitted-to-batch-engine recorder previously accepted that housekeeping request, so `/admin/cache-stats` described the discarded warmup instead of the generation the user had just observed.

The fix changes telemetry ownership only. It does not change model routing, templates, parsers, tool schemas, cache topology, generation defaults, sampler values, or the warmup itself.

## Current source and live proof

- Base was current `origin/main` at `9b0331fd40186f88c776d62756e4f9853c54b131`; branch diff is 2 files, +34/-4.
- Release workspace build completed for isolated bundle id `com.dinoki.osaurus.gemma4telemetryproof`.
- Ad-hoc signed executable SHA-256: `fc49aba748ef4c0388ddfbcbc2458663efd0b0e6b190a7de1cd77a72fa18a76b`.
- Fresh isolated preferences visibly showed Prefix On, GPU/paged Off, Disk L2 On, Codec Engine Selected, SSM rederive On, and Thinking Off.
- Exact local model selected in the real UI: `OsaurusAI--gemma-4-12B-it-qat-JANG_4M`; no MXFP4 model was loaded.
- Plain UI turn visibly emitted exactly `USER-VISIBLE-TELEMETRY-7319`; TTFT 1.27 s, 38.8 tok/s, 16 tokens.
- Agent-loop UI turn called built-in `web_search` exactly once and visibly emitted exactly `TOOL-TELEMETRY-8842`; TTFT 2.02 s, 33.1 tok/s, 14 tokens.
- Runtime logs then recorded a sentinel-only chat warmup. After it completed, `/admin/cache-stats` still reported the visible bundle-owned settings: `max_tokens=16384`, `temperature=1`, `top_k=64`, `top_p=0.95`, instead of the old warmup values `1/0`.
- Exact enumerated test passed 1/1: `OsaurusCoreTests/MLXBatchAdapterTests/lastEffectiveGenerationTelemetry_excludesChatPrefillWarmups()`.
- `git diff --check` is clean.

## Honest remaining gates

This PR closes only generation-telemetry ownership. The broader Gemma checkpoint remains PARTIAL: the strict 12B physical-footprint gate failed at 9.48 GB, assigned non-search required-tool and tool-error recovery rows remain open, Thinking On produced no visible reasoning block, and the wider API/cancel matrix is not complete.
