### PR TITLE
plugin lifecycle config resolution

### DIFF
--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -917,7 +917,11 @@ final class ExternalPlugin: @unchecked Sendable {
                 // DIFFERENT plugin's context, or none at all — giving the
                 // dying plugin values it never wrote (or nil where it always
                 // saw a value), which some plugins dereference and crash on.
-                PluginHostContext.withTLSScope(pluginId: self.id, agentId: nil) {
+                // `lifecycle: true`: teardown has no chat-bound agent, so
+                // without it `config_get` returns nil here and plugins that
+                // read credentials in `destroy` (final webhook delete, ...)
+                // dereference the unexpected NULL and crash.
+                PluginHostContext.withTLSScope(pluginId: self.id, agentId: nil, lifecycle: true) {
                     self.api.destroy?(self.ctx)
                 }
                 continuation.resume()
@@ -1274,7 +1278,11 @@ final class ExternalPlugin: @unchecked Sendable {
         agentId: UUID?
     ) {
         guard !self.isShutDown.withLock({ $0 }) else { return }
-        PluginHostContext.withTLSScope(pluginId: pluginId, agentId: agentId) {
+        // `lifecycle: true`: config delivery is host-initiated; when
+        // `agentId` is nil, `config_get` inside `on_config_changed` must
+        // resolve the Default agent's namespace rather than return nil —
+        // plugins guard on that value and abort when it vanishes.
+        PluginHostContext.withTLSScope(pluginId: pluginId, agentId: agentId, lifecycle: true) {
             for (key, value) in filtered {
                 key.withCString { keyPtr in
                     value.withCString { valuePtr in

--- a/Packages/OsaurusCore/Services/CrashReportingService.swift
+++ b/Packages/OsaurusCore/Services/CrashReportingService.swift
@@ -212,6 +212,14 @@ public final class CrashReportingService {
             // Scope: crashes + app hangs. Watchdog termination is not
             // available on macOS; everything performance-related is off.
             options.enableCrashHandler = true
+            // SwiftUI/AppKit runs the app with abort-on-NSException, so an
+            // exception thrown during view layout dies inside
+            // `+[NSApplication _crashOnException:]` and the crash handler
+            // only sees the resulting mach EXC_BREAKPOINT — the exception
+            // name and reason never reach the event. This macOS-only option
+            // installs an NSUncaughtExceptionHandler so those reports carry
+            // the actual exception message instead of an opaque subcode.
+            options.enableUncaughtNSExceptionReporting = true
             options.enableAppHangTracking = true
             // The SDK's 2s default fires on transient, non-fully-blocking
             // stalls — a few dropped frames during heavy SwiftUI updates or

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -227,6 +227,19 @@ final class PluginHostContext: @unchecked Sendable {
         return id == Agent.defaultId ? nil : id
     }
 
+    /// Agent namespace for `config_get` / `config_set` / `config_delete`.
+    /// Same as `resolvedAgentIdOrNil`, except inside a host-driven
+    /// lifecycle scope (`destroy`, config delivery) where a nil agent
+    /// resolves to the Default agent's namespace: plugins routinely call
+    /// `config_get("api_key")` from teardown and `on_config_changed`
+    /// bodies and dereference the result without a nil check, so the
+    /// anonymous-read lockout must not apply to callbacks the host
+    /// itself initiates.
+    var resolvedConfigAgentId: UUID? {
+        if let id = resolvedAgentIdOrNil { return id }
+        return Self.isLifecycleScope() ? Agent.defaultId : nil
+    }
+
     /// Deterministic synthetic UUID used as the bucket key for per-agent rate
     /// limiting when the current invocation has no chat-bound agent context.
     /// Distinct from `Agent.defaultId` so anonymous plugin traffic doesn't
@@ -291,7 +304,9 @@ final class PluginHostContext: @unchecked Sendable {
         // Anonymous reads (no chat-bound agent) must not silently fall back
         // to the Default agent's secret namespace. Warn-once and return nil
         // so the plugin reads no value rather than the Default agent's.
-        guard let agentId = resolvedAgentIdOrNil else {
+        // Host-driven lifecycle callbacks are exempt — see
+        // `resolvedConfigAgentId`.
+        guard let agentId = resolvedConfigAgentId else {
             Self.warnNoAgentContextOnce(pluginId: pluginId, op: "config_get")
             return nil
         }
@@ -325,7 +340,9 @@ final class PluginHostContext: @unchecked Sendable {
         }
         // Anonymous writes (no chat-bound agent) must not silently land in
         // the Default agent's secret namespace. No-op + warn-once instead.
-        guard let agentId = resolvedAgentIdOrNil else {
+        // Host-driven lifecycle callbacks are exempt — see
+        // `resolvedConfigAgentId`.
+        guard let agentId = resolvedConfigAgentId else {
             Self.warnNoAgentContextOnce(pluginId: pluginId, op: "config_set")
             return
         }
@@ -334,7 +351,7 @@ final class PluginHostContext: @unchecked Sendable {
     }
 
     func configDelete(key: String) {
-        guard let agentId = resolvedAgentIdOrNil else {
+        guard let agentId = resolvedConfigAgentId else {
             Self.warnNoAgentContextOnce(pluginId: pluginId, op: "config_delete")
             return
         }
@@ -3426,6 +3443,15 @@ extension PluginHostContext {
     /// different agents on the same invokeQueue resolve the correct agent.
     private static let agentTlsKey: String = "ai.osaurus.plugin.agent"
 
+    /// Thread-local marker set around host-driven lifecycle callbacks
+    /// (`destroy`, config delivery). Inside such a scope, config reads
+    /// with no chat-bound agent resolve against the Default agent's
+    /// namespace instead of returning nil — plugin teardown and
+    /// `on_config_changed` bodies routinely call `config_get` and
+    /// crash on an unexpected nil. The anonymous-path lockout (no
+    /// Default-agent fallback) still applies everywhere else.
+    private static let lifecycleTlsKey: String = "ai.osaurus.plugin.lifecycle"
+
     /// Best-effort fallback for plugin-spawned background threads that don't
     /// have TLS set. Protected by `fallbackLock` to avoid data races under
     /// concurrent execution. TLS (option 1) is the authoritative mechanism.
@@ -3458,16 +3484,27 @@ extension PluginHostContext {
         Thread.current.threadDictionary[agentTlsKey] as? UUID
     }
 
+    static func isLifecycleScope() -> Bool {
+        (Thread.current.threadDictionary[lifecycleTlsKey] as? Bool) == true
+    }
+
     /// Run `body` with the plugin TLS slots set to `pluginId` and
     /// `agentId`, then clear them on exit (success or throw). Collapses
     /// the set / defer-clear pattern repeated by `dispatchPluginCall`,
     /// `notifyConfigBatch`, and `notifyTaskEvent` in `ExternalPlugin`.
-    static func withTLSScope<R>(pluginId: String, agentId: UUID?, _ body: () -> R) -> R {
+    /// `lifecycle: true` marks the scope as a host-driven lifecycle
+    /// callback (see `lifecycleTlsKey`) so nil-agent config reads fall
+    /// back to the Default agent's namespace instead of returning nil.
+    static func withTLSScope<R>(
+        pluginId: String, agentId: UUID?, lifecycle: Bool = false, _ body: () -> R
+    ) -> R {
         setActivePlugin(pluginId)
         if let agentId { setActiveAgent(agentId) }
+        if lifecycle { Thread.current.threadDictionary[lifecycleTlsKey] = true }
         defer {
             clearActivePlugin()
             clearActiveAgent()
+            if lifecycle { Thread.current.threadDictionary.removeObject(forKey: lifecycleTlsKey) }
         }
         return body()
     }


### PR DESCRIPTION
## Summary

This addresses the two actionable crash families in the current production release, plus a reporting gap that keeps the third one undiagnosable.

### Plugin lifecycle crashes

- Production crash reports show two related fatal crashes in the plugin host: a null dereference inside a plugin's `destroy` while it reads `api_key`, and a plugin abort during `on_config_changed` complaining no agent id is resolvable.
- Root cause is the anonymous-read lockout in `PluginHostContext.configGet`: with no chat-bound agent it returns nil instead of falling back to the Default agent namespace, and plugins that read credentials from teardown or `on_config_changed` bodies dereference the unexpected NULL and crash.
- The lockout is correct for anonymous plugin paths but must not apply to callbacks the host itself initiates.
- Adds a thread-local lifecycle scope set via `withTLSScope(pluginId:agentId:lifecycle:)`; inside it, `config_get`, `config_set`, and `config_delete` with no chat-bound agent resolve against the Default agent namespace via a new `resolvedConfigAgentId`.
- Only two call sites opt in: the `destroy` call in `ExternalPlugin.shutdown` and `runConfigDelivery`.
- Every other path keeps the existing behavior; anonymous plugin code still cannot read the Default agent's secrets.

### Uncaught NSException reporting

- The highest-volume unresolved crash group is an Objective-C exception thrown during AppKit layout that kills the app via `+[NSApplication _crashOnException:]`, reported by multiple users across regions and device models.
- The crash handler only sees the resulting Mach `EXC_BREAKPOINT`, so every report arrives without the exception name or reason and the group is undiagnosable.
- Enables `enableUncaughtNSExceptionReporting` in `CrashReportingService`, a macOS-only Sentry-Cocoa option (supported by the pinned 9.15.0) that installs an uncaught exception handler so these reports carry the actual exception message.

## Test plan

- Run the plugin test suites; `AgentLifecycleConfigResolutionTests` asserts the anonymous lockout and should be unaffected since those tests never set the lifecycle flag.
- Load a plugin that reads config in `destroy` (final webhook delete) and quit the app, confirm no crash and the credential resolves.
- Push a config change with no agent bound and confirm `on_config_changed` receives readable config.
- In a debug build, throw a test `NSException` on the main thread and confirm the captured event includes the exception name and reason.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
