### PR TITLE
Fix truncated remote tool arguments

### DIFF
--- a/Packages/OsaurusCore/Models/API/AnthropicAPI.swift
+++ b/Packages/OsaurusCore/Models/API/AnthropicAPI.swift
@@ -308,6 +308,9 @@ struct AnthropicTool: Codable, Sendable {
     let name: String
     let description: String?
     let input_schema: JSONValue?
+    /// Anthropic's GA per-tool opt-in for streaming argument values as they
+    /// are generated instead of buffering each complete value server-side.
+    let eager_input_streaming: Bool?
 }
 
 /// Tool choice specification
@@ -544,11 +547,11 @@ struct ContentBlockStartEvent: Codable, Sendable {
             let name: String
             let input: [String: AnyCodableValue]
 
-            init(id: String, name: String) {
+            init(id: String, name: String, input: [String: AnyCodableValue] = [:]) {
                 self.type = "tool_use"
                 self.id = id
                 self.name = name
-                self.input = [:]
+                self.input = input
             }
         }
 
@@ -577,7 +580,12 @@ struct ContentBlockStartEvent: Codable, Sendable {
             case "tool_use":
                 let id = try container.decode(String.self, forKey: .id)
                 let name = try container.decode(String.self, forKey: .name)
-                self = .toolUse(ToolUseBlockStart(id: id, name: name))
+                let input =
+                    try container.decodeIfPresent(
+                        [String: AnyCodableValue].self,
+                        forKey: .input
+                    ) ?? [:]
+                self = .toolUse(ToolUseBlockStart(id: id, name: name, input: input))
             case "thinking":
                 self = .thinking(ThinkingBlockStart())
             default:

--- a/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
@@ -311,7 +311,14 @@ struct OpenAICompatibleToolCallAccumulator {
 
     static func validateToolCallJSON(_ json: String) -> ValidatedToolCallJSON {
         let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return ValidatedToolCallJSON(json: "{}", wasRepaired: false) }
+        // Providers represent a real no-argument call as the explicit JSON
+        // object `{}`. A named slot that reaches finish with zero argument
+        // bytes instead means its argument event was buffered, dropped, or
+        // truncated. Mark it repaired so dispatch quarantines the call instead
+        // of inventing `{}` and producing a misleading schema error.
+        guard !trimmed.isEmpty else {
+            return ValidatedToolCallJSON(json: "{}", wasRepaired: true)
+        }
 
         if let data = trimmed.data(using: .utf8),
             (try? JSONSerialization.jsonObject(with: data)) != nil
@@ -415,7 +422,8 @@ struct OpenAICompatibleToolCallAccumulator {
         )
         return RemoteProviderServiceError.streamingError(
             "Stream ended before tool call '\(toolName)' arguments were complete "
-                + "(finish marker: \(finishMarker)). The provider closed the connection "
+                + "(finish marker: \(finishMarker); \(argsSummary)). "
+                + "The provider closed the connection "
                 + "mid-argument; retry the request."
         )
     }
@@ -639,6 +647,14 @@ struct OpenAICompatibleStreamParser {
                 return .finishWithError(
                     RemoteProviderServiceError.streamingError(
                         "Provider reached the output token limit before emitting visible text, reasoning, or a tool call (finish_reason=length). Increase max_tokens or reduce the prompt/tool context."
+                    )
+                )
+            }
+            if finishReason == "length", !state.accumulatedToolCalls.isEmpty {
+                return .finishWithError(
+                    RemoteProviderService.outputLimitToolCallError(
+                        from: state.accumulatedToolCalls,
+                        finishMarker: "finish_reason=length"
                     )
                 )
             }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1475,6 +1475,28 @@ public actor RemoteProviderService: ToolCapableService {
         )
     }
 
+    /// A provider output cap is never a valid tool-call finish. Arguments can
+    /// be syntactically valid at the cut point (or still completely buffered
+    /// upstream), so JSON repair alone cannot identify this truncation.
+    static func outputLimitToolCallError(
+        from accumulated: [Int: StreamingState.ToolSlot],
+        finishMarker: String
+    ) -> RemoteProviderServiceError {
+        let calls = accumulated.values.filter { $0.name != nil }
+        let names = calls.compactMap(\.name).joined(separator: "', '")
+        let receivedBytes = calls.reduce(0) { $0 + $1.args.utf8.count }
+        let label = names.isEmpty ? "tool call" : "tool call '\(names)'"
+        print(
+            "[Osaurus] Discarding output-limited \(label): "
+                + "received \(receivedBytes) argument bytes (\(finishMarker))"
+        )
+        return .streamingError(
+            "Provider reached the output token limit while generating \(label) "
+                + "arguments (\(finishMarker), received \(receivedBytes) bytes). "
+                + "Increase the agent's Max Tokens setting and retry."
+        )
+    }
+
     /// Process one fully-framed SSE event payload. Returns `true` when the
     /// outer loop should terminate (event signalled finish, tool call, or
     /// error), `false` to keep iterating. Inlined into `_streamRemote`'s
@@ -1660,8 +1682,19 @@ public actor RemoteProviderService: ToolCapableService {
                 )
             }
         } catch {
-            print("[Osaurus] Warning: Failed to parse SSE chunk: \(error.localizedDescription)")
-            return .continue
+            let phase =
+                state.accumulatedToolCalls.isEmpty
+                ? "" : " while receiving tool arguments"
+            print(
+                "[Osaurus] Failed to parse provider SSE event\(phase): "
+                    + "\(error.localizedDescription) (\(jsonData.count) bytes)"
+            )
+            return .finishWithError(
+                RemoteProviderServiceError.streamingError(
+                    "Provider emitted an invalid streaming event\(phase) "
+                        + "(\(jsonData.count) bytes). The response may have been truncated in transit."
+                )
+            )
         }
     }
 
@@ -1712,7 +1745,11 @@ public actor RemoteProviderService: ToolCapableService {
         providerType: RemoteProviderType,
         parameters: GenerationParameters
     ) -> Int? {
-        if providerType == .osaurusRouter {
+        // Router upstreams and Anthropic's Messages API both require an
+        // explicit output cap. Preserve ChatEngine's resolved implicit budget
+        // for them instead of falling through to a smaller transport-local
+        // fallback (Anthropic previously dropped 16K to 4K).
+        if providerType == .osaurusRouter || providerType == .anthropic {
             return parameters.maxTokens
         }
         return parameters.maxTokensExplicit ? parameters.maxTokens : nil
@@ -1817,9 +1854,7 @@ public actor RemoteProviderService: ToolCapableService {
         state: inout StreamingState,
         yield: (String) -> Void
     ) throws -> StreamEventOutcome {
-        guard let event = try? state.decoder.decode(AnthropicSSEEvent.self, from: jsonData) else {
-            return .continue
-        }
+        let event = try state.decoder.decode(AnthropicSSEEvent.self, from: jsonData)
 
         switch event.type {
         case "message_start":
@@ -1827,31 +1862,28 @@ public actor RemoteProviderService: ToolCapableService {
             // usage split. Log the cache read/write counts so the win from the
             // top-level `cache_control` in `toAnthropicRequest()` is observable
             // per turn (cache reads bill 0.1x input; writes 1.25x).
-            if let startEvent = try? state.decoder.decode(MessageStartEvent.self, from: jsonData) {
-                let usage = startEvent.message.usage
-                debugLog(
-                    "[Cache][Anthropic] input=\(usage.input_tokens)"
-                        + " cacheRead=\(usage.cache_read_input_tokens ?? 0)"
-                        + " cacheWrite=\(usage.cache_creation_input_tokens ?? 0)"
+            let startEvent = try state.decoder.decode(MessageStartEvent.self, from: jsonData)
+            let usage = startEvent.message.usage
+            debugLog(
+                "[Cache][Anthropic] input=\(usage.input_tokens)"
+                    + " cacheRead=\(usage.cache_read_input_tokens ?? 0)"
+                    + " cacheWrite=\(usage.cache_creation_input_tokens ?? 0)"
+            )
+            // Seed provider usage with the prompt side; `message_delta`
+            // fills in the completion side. Without this capture the
+            // Anthropic path never emitted a `StreamingStatsHint`, so
+            // completion tokens fell back to estimates and the provider's
+            // stop reason never reached the HTTP `finish_reason`.
+            state.captureProviderUsage(
+                Usage(
+                    prompt_tokens: usage.input_tokens,
+                    completion_tokens: 0,
+                    total_tokens: usage.input_tokens
                 )
-                // Seed provider usage with the prompt side; `message_delta`
-                // fills in the completion side. Without this capture the
-                // Anthropic path never emitted a `StreamingStatsHint`, so
-                // completion tokens fell back to estimates and the provider's
-                // stop reason never reached the HTTP `finish_reason`.
-                state.captureProviderUsage(
-                    Usage(
-                        prompt_tokens: usage.input_tokens,
-                        completion_tokens: 0,
-                        total_tokens: usage.input_tokens
-                    )
-                )
-            }
+            )
 
         case "content_block_delta":
-            guard
-                let deltaEvent = try? state.decoder.decode(ContentBlockDeltaEvent.self, from: jsonData)
-            else { return .continue }
+            let deltaEvent = try state.decoder.decode(ContentBlockDeltaEvent.self, from: jsonData)
             if case .textDelta(let textDelta) = deltaEvent.delta {
                 let (truncated, hitStop) = applyStopSequences(
                     textDelta.text,
@@ -1872,35 +1904,47 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "content_block_start":
-            guard
-                let startEvent = try? state.decoder.decode(ContentBlockStartEvent.self, from: jsonData)
-            else { return .continue }
+            let startEvent = try state.decoder.decode(ContentBlockStartEvent.self, from: jsonData)
             if case .toolUse(let toolBlock) = startEvent.content_block {
                 let idx = startEvent.index
+                let initialArgs: String
+                if toolBlock.input.isEmpty {
+                    initialArgs = ""
+                } else {
+                    let input = toolBlock.input.mapValues(\.value)
+                    let data = try JSONSerialization.data(
+                        withJSONObject: input,
+                        options: .osaurusCanonical
+                    )
+                    initialArgs = String(decoding: data, as: UTF8.self)
+                }
                 state.accumulatedToolCalls[idx] = (
-                    id: toolBlock.id, name: toolBlock.name, args: "", thoughtSignature: nil
+                    id: toolBlock.id,
+                    name: toolBlock.name,
+                    args: initialArgs,
+                    thoughtSignature: nil
                 )
                 print("[Osaurus] Anthropic tool call detected: index=\(idx), name=\(toolBlock.name)")
                 yield(StreamingToolHint.encode(toolBlock.name))
+                if !initialArgs.isEmpty {
+                    yield(StreamingToolHint.encodeArgs(initialArgs))
+                }
             }
 
         case "message_delta":
-            if let deltaEvent = try? state.decoder.decode(MessageDeltaEvent.self, from: jsonData) {
-                // Complete the usage pair started at `message_start` so
-                // `dispatchFinal` emits a stats hint with the REAL output
-                // token count (Anthropic reports it on this event).
-                let promptTokens = state.providerUsage?.prompt_tokens ?? 0
-                state.captureProviderUsage(
-                    Usage(
-                        prompt_tokens: promptTokens,
-                        completion_tokens: deltaEvent.usage.output_tokens,
-                        total_tokens: promptTokens + deltaEvent.usage.output_tokens
-                    )
+            let deltaEvent = try state.decoder.decode(MessageDeltaEvent.self, from: jsonData)
+            // Complete the usage pair started at `message_start` so
+            // `dispatchFinal` emits a stats hint with the REAL output
+            // token count (Anthropic reports it on this event).
+            let promptTokens = state.providerUsage?.prompt_tokens ?? 0
+            state.captureProviderUsage(
+                Usage(
+                    prompt_tokens: promptTokens,
+                    completion_tokens: deltaEvent.usage.output_tokens,
+                    total_tokens: promptTokens + deltaEvent.usage.output_tokens
                 )
-            }
-            if let deltaEvent = try? state.decoder.decode(MessageDeltaEvent.self, from: jsonData),
-                let stopReason = deltaEvent.delta.stop_reason
-            {
+            )
+            if let stopReason = deltaEvent.delta.stop_reason {
                 // Normalize the Anthropic stop vocabulary to the OpenAI
                 // `finish_reason` contract every downstream consumer expects
                 // (`InferenceLog.FinishReason`, the HTTP chat writer, the
@@ -1940,6 +1984,14 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "message_stop":
+            if state.lastFinishReason == "length", !state.accumulatedToolCalls.isEmpty {
+                return .finishWithError(
+                    outputLimitToolCallError(
+                        from: state.accumulatedToolCalls,
+                        finishMarker: "anthropic stop_reason=max_tokens"
+                    )
+                )
+            }
             switch resolveAccumulatedToolCall(
                 from: state.accumulatedToolCalls,
                 finishMarker: "anthropic message_stop"
@@ -2187,6 +2239,16 @@ public actor RemoteProviderService: ToolCapableService {
                     stopReason: state.lastFinishReason
                 )
             )
+        }
+
+        if state.lastFinishReason == "length", !state.accumulatedToolCalls.isEmpty {
+            continuation.finish(
+                throwing: outputLimitToolCallError(
+                    from: state.accumulatedToolCalls,
+                    finishMarker: finishMarker
+                )
+            )
+            return
         }
 
         switch resolveAccumulatedToolCall(
@@ -4361,7 +4423,11 @@ struct RemoteChatRequest: Encodable {
                 AnthropicTool(
                     name: tool.function.name,
                     description: tool.function.description,
-                    input_schema: tool.function.parameters ?? emptySchema
+                    input_schema: tool.function.parameters ?? emptySchema,
+                    // GA Anthropic contract: stream large parameter values as
+                    // generated so file-write calls do not sit entirely in an
+                    // upstream buffer until the value closes.
+                    eager_input_streaming: stream ? true : nil
                 )
             }
         }

--- a/Packages/OsaurusCore/Tests/Model/AnthropicAPITests.swift
+++ b/Packages/OsaurusCore/Tests/Model/AnthropicAPITests.swift
@@ -319,6 +319,32 @@ struct AnthropicAPITests {
         #expect(delta["text"] as? String == "Hello")
     }
 
+    @Test func decodeToolUseBlockStartPreservesPopulatedInput() throws {
+        let json = """
+            {
+              "type": "content_block_start",
+              "index": 0,
+              "content_block": {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "file_write",
+                "input": {"path": "probe.txt", "content": "hello"}
+              }
+            }
+            """
+
+        let event = try JSONDecoder().decode(
+            ContentBlockStartEvent.self,
+            from: Data(json.utf8)
+        )
+        guard case .toolUse(let tool) = event.content_block else {
+            Issue.record("Expected tool_use content block")
+            return
+        }
+        #expect(tool.input["path"]?.value as? String == "probe.txt")
+        #expect(tool.input["content"]?.value as? String == "hello")
+    }
+
     @Test func encodeMessageDeltaEvent() throws {
         let event = MessageDeltaEvent(stopReason: "end_turn", outputTokens: 50)
 

--- a/Packages/OsaurusCore/Tests/Networking/SSELineParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/SSELineParserTests.swift
@@ -128,6 +128,25 @@ struct SSELineParserTests {
         #expect(expected == ["data: a", "data: b", "data: c", "", "", "data: {\"x\":\"y\"}"])
     }
 
+    @Test(arguments: [7_996, 9_000, 16_000])
+    func splitter_reassemblesLargeSingleLineAcross4KBChunks(payloadBytes: Int) {
+        let value = String(repeating: "x", count: payloadBytes)
+        let wire = Data(("data: {\"value\":\"" + value + "\"}\n\n").utf8)
+        var parser = RemoteProviderService.SSELineParser()
+
+        var offset = 0
+        while offset < wire.count {
+            let end = min(offset + 4_096, wire.count)
+            parser.append(wire.subdata(in: offset ..< end))
+            offset = end
+        }
+
+        let lines = drain(&parser)
+        #expect(lines.count == 2)
+        #expect(lines.last == "")
+        #expect(lines.first == "data: {\"value\":\"" + value + "\"}")
+    }
+
     // MARK: - processSSELine (field parser)
 
     @Test func fieldParser_handlesDataWithSpace() {

--- a/Packages/OsaurusCore/Tests/Provider/AnthropicStreamFinishReasonTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/AnthropicStreamFinishReasonTests.swift
@@ -131,4 +131,127 @@ struct AnthropicStreamFinishReasonTests {
         continuation.finish()
         _ = stream
     }
+
+    @Test(arguments: [7_996, 9_000, 16_000])
+    func largeInputJSONDelta_preservesAllToolArguments(contentBytes: Int) throws {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        var yielded: [String] = []
+        let arguments = #"{"path":"probe.txt","content":""#
+            + String(repeating: "x", count: contentBytes)
+            + #""}"#
+
+        let start =
+            #"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_large","name":"file_write","input":{}}}"#
+        _ = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(start.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+
+        let deltaObject: [String: Any] = [
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": [
+                "type": "input_json_delta",
+                "partial_json": arguments,
+            ],
+        ]
+        let deltaData = try JSONSerialization.data(withJSONObject: deltaObject)
+        let delta = RemoteProviderService.handleStreamEvent(
+            jsonData: deltaData,
+            providerType: .anthropic,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+        guard case .continue = delta else {
+            Issue.record("Expected large Anthropic delta to continue, got \(delta)")
+            return
+        }
+
+        let finishReason =
+            #"{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":100}}"#
+        _ = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(finishReason.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+        let stop = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(#"{"type":"message_stop"}"#.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+
+        guard case .finishWithToolCall(let invocations) = stop,
+            let invocation = invocations.first
+        else {
+            Issue.record("Expected complete Anthropic tool call, got \(stop)")
+            return
+        }
+        #expect(invocation.jsonArguments == arguments)
+        #expect(yielded.compactMap { StreamingToolHint.decodeArgs($0) }.joined() == arguments)
+    }
+
+    @Test func maxTokensWithPendingToolCallIsTruncationError() {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        let start =
+            #"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"file_write","input":{}}}"#
+        _ = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(start.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { _ in }
+        )
+        let limit =
+            #"{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":4096}}"#
+        _ = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(limit.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { _ in }
+        )
+
+        let stop = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(#"{"type":"message_stop"}"#.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { _ in }
+        )
+
+        guard case .finishWithError(let error) = stop else {
+            Issue.record("Expected max_tokens tool call to fail, got \(stop)")
+            return
+        }
+        #expect(error.localizedDescription.contains("output token limit"))
+        #expect(error.localizedDescription.contains("received 0 bytes"))
+    }
+
+    @Test func malformedInputJSONDeltaIsNotSilentlyDropped() {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        let start =
+            #"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"file_write","input":{}}}"#
+        _ = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(start.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { _ in }
+        )
+        let malformed =
+            #"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":123}}"#
+        let outcome = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(malformed.utf8),
+            providerType: .anthropic,
+            state: &state,
+            yield: { _ in }
+        )
+
+        guard case .finishWithError(let error) = outcome else {
+            Issue.record("Expected malformed tool delta to fail, got \(outcome)")
+            return
+        }
+        #expect(error.localizedDescription.contains("invalid streaming event"))
+        #expect(error.localizedDescription.contains("while receiving tool arguments"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -108,6 +108,113 @@ struct OpenAICompatibleStreamParserTests {
         #expect(yielded.compactMap { StreamingToolHint.decodeArgs($0) }.joined() == #"{"path":"a.html","content":"x"}"#)
     }
 
+    @Test(arguments: [7_996, 9_000, 16_000])
+    func parser_preservesLargeSingleEventToolArguments(contentBytes: Int) throws {
+        let arguments = #"{"path":"probe.txt","content":""#
+            + String(repeating: "x", count: contentBytes)
+            + #""}"#
+        let event: [String: Any] = [
+            "id": "chatcmpl-large",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "m",
+            "choices": [
+                [
+                    "index": 0,
+                    "delta": [
+                        "tool_calls": [
+                            [
+                                "index": 0,
+                                "id": "call_large",
+                                "type": "function",
+                                "function": [
+                                    "name": "file_write",
+                                    "arguments": arguments,
+                                ],
+                            ]
+                        ]
+                    ],
+                    "finish_reason": NSNull(),
+                ]
+            ],
+        ]
+        let eventData = try JSONSerialization.data(withJSONObject: event)
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+
+        let delta = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: eventData,
+            options: .routerCompatible,
+            state: &state,
+            yield: { _ in }
+        )
+        guard case .continue = delta else {
+            Issue.record("Expected large argument event to continue, got \(delta)")
+            return
+        }
+
+        let finish = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(#"{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#.utf8),
+            options: .routerCompatible,
+            state: &state,
+            yield: { _ in }
+        )
+        guard case .finishWithToolCall(let invocations) = finish,
+            let invocation = invocations.first
+        else {
+            Issue.record("Expected large tool call to finish, got \(finish)")
+            return
+        }
+        #expect(invocation.jsonArguments == arguments)
+        #expect(invocation.jsonArguments.utf8.count > contentBytes)
+    }
+
+    @Test func parser_doesNotDispatchNamedToolSlotWithNoArgumentBytes() {
+        let accumulated: [Int: RemoteProviderService.StreamingState.ToolSlot] = [
+            0: (
+                id: "call_empty",
+                name: "file_write",
+                args: "",
+                thoughtSignature: nil
+            )
+        ]
+
+        let result = OpenAICompatibleToolCallAccumulator.resolveAccumulatedToolCall(
+            from: accumulated,
+            finishMarker: "tool_calls"
+        )
+
+        guard case .truncated(let error) = result else {
+            Issue.record("Expected blank accumulated arguments to be quarantined, got \(result)")
+            return
+        }
+        #expect(error.localizedDescription.contains("received 0 bytes"))
+    }
+
+    @Test func parser_lengthFinishRejectsEvenSyntacticallyCompletePendingTool() throws {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        let start =
+            #"{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"file_write","arguments":"{}"}}]},"finish_reason":null}]}"#
+        _ = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(start.utf8),
+            options: .routerCompatible,
+            state: &state,
+            yield: { _ in }
+        )
+
+        let finish = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(#"{"choices":[{"index":0,"delta":{},"finish_reason":"length"}]}"#.utf8),
+            options: .routerCompatible,
+            state: &state,
+            yield: { _ in }
+        )
+
+        guard case .finishWithError(let error) = finish else {
+            Issue.record("Expected output-limited tool call to fail, got \(finish)")
+            return
+        }
+        #expect(error.localizedDescription.contains("output token limit"))
+    }
+
     @Test func parser_preservesParallelToolCallIndices() throws {
         var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: true)
         let env = #""id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"m""#

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -249,6 +249,43 @@ struct RemoteChatRequestEncodingTests {
         )
     }
 
+    @Test func anthropicImplicitMaxTokens_forwardsResolvedChatBudget() {
+        let params = GenerationParameters(
+            temperature: nil,
+            maxTokens: 16_384,
+            maxTokensExplicit: false
+        )
+
+        #expect(
+            RemoteProviderService.remoteChatMaxTokens(
+                providerType: .anthropic,
+                parameters: params
+            ) == 16_384
+        )
+    }
+
+    @Test func anthropicStreamingToolsEnableEagerInputStreaming() throws {
+        let streaming = Self.makeRequest(
+            model: "claude-fable-5",
+            maxTokens: 16_384,
+            tools: [Self.weatherTool],
+            stream: true
+        ).toAnthropicRequest()
+        let buffered = Self.makeRequest(
+            model: "claude-fable-5",
+            maxTokens: 16_384,
+            tools: [Self.weatherTool],
+            stream: false
+        ).toAnthropicRequest()
+        let streamingWire = try Self.encodeAsDictionary(streaming)
+        let wireTools = try #require(streamingWire["tools"] as? [[String: Any]])
+
+        #expect(streaming.max_tokens == 16_384)
+        #expect(streaming.tools?.first?.eager_input_streaming == true)
+        #expect(wireTools.first?["eager_input_streaming"] as? Bool == true)
+        #expect(buffered.tools?.first?.eager_input_streaming == nil)
+    }
+
     @Test func openResponsesRequest_defaultSingleUserMessage_usesTextShorthand() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
         let responsesRequest = request.toOpenResponsesRequest()
@@ -3040,14 +3077,15 @@ struct RemoteChatRequestEncodingTests {
         reasoningEffort: String? = nil,
         tools: [Tool]? = nil,
         thinking: ThinkingConfig? = nil,
-        messages: [ChatMessage] = [ChatMessage(role: "user", content: "hi")]
+        messages: [ChatMessage] = [ChatMessage(role: "user", content: "hi")],
+        stream: Bool = false
     ) -> RemoteChatRequest {
         RemoteChatRequest(
             model: model,
             messages: messages,
             temperature: 0.7,
             max_completion_tokens: maxTokens,
-            stream: false,
+            stream: stream,
             top_p: nil,
             frequency_penalty: nil,
             presence_penalty: nil,
@@ -3155,6 +3193,14 @@ struct RemoteChatRequestEncodingTests {
     )
 
     private static func encodeAsDictionary(_ request: RemoteChatRequest) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(request)
+        guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DecodeAsDictionaryError.notAnObject
+        }
+        return obj
+    }
+
+    private static func encodeAsDictionary(_ request: AnthropicMessagesRequest) throws -> [String: Any] {
         let data = try JSONEncoder().encode(request)
         guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw DecodeAsDictionaryError.notAnObject


### PR DESCRIPTION
## Summary
- preserve 8–16 KB OpenAI-compatible and Anthropic tool arguments across SSE framing and dispatch
- reject empty, malformed, and output-limited tool calls with actionable streaming errors instead of executing invented `{}` arguments
- enable Anthropic eager input streaming and forward the resolved 16,384-token implicit output budget

Closes #2104

## Test plan
- [x] Targeted provider/networking suites: 196 tests passed
- [x] Remote request encoding suite: 128 tests passed
- [x] `git diff --check`
- [ ] Full `make test`: issue-specific suites passed; the repository-wide run hit expected keychain-disabled failures plus unrelated timeout/flaky suites and terminated after ~150 seconds
- [ ] Full build skipped as requested