### PR TITLE
Continue cap-truncated file_read to the end of the file

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -988,15 +988,40 @@ struct FileReadTool: OsaurusTool {
             return ToolEnvelope.success(tool: name, text: "(empty file)")
         }
 
-        // If truncated, inform the model and suggest using line ranges
-        if outputTruncated || lastLineIncluded < validEnd {
+        let renderedTruncated = outputTruncated || lastLineIncluded < validEnd
+        // Exact continuation boundary when the RENDERED character cap cut the
+        // output (issue #2098: a 13.9KB source file whose gutters pushed the
+        // render past the cap read "complete" to the model, which reviewed
+        // 426 of 499 lines as if it had the whole file). Only offered when:
+        //   - the whole file was loaded (a raw byte-capped read cannot reach
+        //     unloaded bytes by line number, so a line continuation would lie);
+        //   - progress past `validStart` was made (a single line longer than
+        //     the cap can never advance — re-reading the same start would loop).
+        // The continuation never extends past the caller's requested range end.
+        let continuationStart: Int? = {
+            guard renderedTruncated, content.rawRead?.truncatedByByteLimit != true else {
+                return nil
+            }
+            let next = partialLine ?? (lastLineIncluded + 1)
+            guard next > validStart, next <= validEnd else { return nil }
+            return next
+        }()
+
+        // If truncated, inform the model and name the exact next range
+        if renderedTruncated {
             let totalLabel = Self.lineCountLabel(lines.count, rawRead: content.rawRead)
+            let rangeHint: String
+            if let continuationStart {
+                rangeHint = "continue with start_line=\(continuationStart), end_line=\(validEnd)"
+            } else {
+                rangeHint = "use start_line/end_line for specific ranges"
+            }
             if let partialLine {
                 output +=
-                    "\n... (truncated mid-line: line \(partialLine) is only PARTIALLY shown; complete lines end at \(lastLineIncluded) of \(totalLabel) — use start_line/end_line for specific ranges)"
+                    "\n... (truncated mid-line: line \(partialLine) is only PARTIALLY shown; complete lines end at \(lastLineIncluded) of \(totalLabel) — \(rangeHint))"
             } else {
                 output +=
-                    "\n... (truncated at \(lastLineIncluded) of \(totalLabel) lines — use start_line/end_line for specific ranges)"
+                    "\n... (truncated at \(lastLineIncluded) of \(totalLabel) lines — \(rangeHint))"
             }
         }
         if let rawRead = content.rawRead, rawRead.truncatedByByteLimit {
@@ -1032,9 +1057,16 @@ struct FileReadTool: OsaurusTool {
             "end_line": lastLineIncluded,
             "total_lines": lines.count,
             "total_lines_exact": content.rawRead?.truncatedByByteLimit != true,
-            "truncated": outputTruncated || lastLineIncluded < validEnd
-                || content.rawRead?.truncatedByByteLimit == true,
+            "truncated": renderedTruncated || content.rawRead?.truncatedByByteLimit == true,
         ]
+        // Machine-readable continuation: the exact `start_line`/`end_line`
+        // pair that resumes this read where the rendered cap cut it. The
+        // harness (`AgentTaskState`) turns these into a next-step notice so
+        // a truncated read becomes a continuation action, not a silent gap.
+        if let continuationStart {
+            result["next_start_line"] = continuationStart
+            result["next_end_line"] = validEnd
+        }
         // The numbered gutter cannot express whether the file's last line is
         // terminated — a byte-exact reconstruction (backup copies, `equals`
         // contracts) needs to know if a final `\n` belongs at the end

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -33,6 +33,12 @@ public enum ToolResultClass: Equatable, Sendable {
     case partialListing
     /// File content (`kind: "file"`).
     case fileContent
+    /// File content whose RENDERED output was cut by the character cap
+    /// and which carries an exact continuation range (`next_start_line`
+    /// / `next_end_line`). Distinct from `.fileContent` so the harness
+    /// can stage a continuation notice instead of letting the model
+    /// review a truncated file as if it were complete (issue #2098).
+    case partialFileContent(path: String, nextStartLine: Int, nextEndLine: Int)
     /// A referenced path does not exist (`kind: "not_found"`).
     case notFound
     /// Any other failure envelope.
@@ -448,11 +454,14 @@ public final class AgentTaskState {
         case .emptyListing, .populatedListing, .partialListing:
             consecutiveListingsWithoutRead += 1
             lastListing = parseListing(result)
-        case .fileContent:
+        case .fileContent, .partialFileContent:
+            // A partial read is still a successful descent into a file —
+            // progress for the wandering counter; its continuation steer is
+            // handled by `nextStepBias`, not here.
             consecutiveListingsWithoutRead = 0
         case .notFound, .error, .nativeImageGeneration, .other:
             break
-        }  // nativeImageGeneration carries associated values; matched without binding
+        }  // associated-value cases matched without binding
 
         // Mark a successful read-like result as fresh (with its exact
         // envelope) so a re-issue replays it until a write invalidates it.
@@ -554,6 +563,12 @@ public final class AgentTaskState {
                 + "without `source_paths` again (that produces a brand-new unrelated image, not an "
                 + "edit of this one). Only if no such follow-up was requested should you give a brief "
                 + "final confirmation. Do not narrate the edit as the final answer instead of calling the tool."
+        case .partialFileContent(let path, let nextStart, let nextEnd):
+            // Reactive by nature — the read is observed incomplete. Without
+            // this steer, models treated the truncated render as the whole
+            // file and reviewed 426 of 499 lines as complete (issue #2098).
+            return
+                "The `file_read` of `\(path)` was truncated by the output cap — you have only seen part of the requested range. Before drawing conclusions about the whole file, call `file_read` again with {\"path\": \"\(path)\", \"start_line\": \(nextStart), \"end_line\": \(nextEnd)} to read the rest."
         case .fileContent, .error, .other:
             return nil
         }
@@ -583,6 +598,24 @@ public final class AgentTaskState {
             if payload["truncated"] as? Bool == true { return .partialListing }
             return .populatedListing
         case "file":
+            // A rendered-cap truncation with an exact continuation range is
+            // its own state: the tool read the whole file but the model only
+            // saw a prefix, and `next_start_line`/`next_end_line` say exactly
+            // how to resume. Raw byte-capped reads (`raw_bytes_truncated`)
+            // deliberately carry no continuation fields — a line-ranged
+            // re-read cannot reach bytes that were never loaded — so they
+            // stay plain `.fileContent` and keep the tool's own split-the-
+            // file guidance.
+            if payload["truncated"] as? Bool == true,
+                let nextStart = payload["next_start_line"] as? Int,
+                let nextEnd = payload["next_end_line"] as? Int
+            {
+                return .partialFileContent(
+                    path: payload["path"] as? String ?? "",
+                    nextStartLine: nextStart,
+                    nextEndLine: nextEnd
+                )
+            }
             return .fileContent
         case "native_image_generation_job":
             let paths = nativeImagePaths(from: payload)

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -28,6 +28,20 @@ struct AgentTaskStateTests {
         )
     }
 
+    private func partialFileEnvelope(path: String, nextStart: Int, nextEnd: Int) -> String {
+        ToolEnvelope.success(
+            tool: "file_read",
+            result: [
+                "kind": "file",
+                "text": "Lines 1-\(nextStart - 1) of \(nextEnd):\n...",
+                "path": path,
+                "truncated": true,
+                "next_start_line": nextStart,
+                "next_end_line": nextEnd,
+            ]
+        )
+    }
+
     private func listingEnvelope(
         path: String,
         entries: [(name: String, path: String, dir: Bool)],
@@ -69,6 +83,34 @@ struct AgentTaskStateTests {
 
     @Test func classify_fileContent() {
         #expect(AgentTaskState.classify(fileContentEnvelope(path: "a.txt")) == .fileContent)
+    }
+
+    /// Issue #2098: a rendered-cap-truncated read carrying an exact
+    /// continuation range classifies as its own state so the harness can
+    /// stage a continuation notice instead of treating it as complete.
+    @Test func classify_partialFileContent() {
+        let env = partialFileEnvelope(path: "BeatStrip.ino", nextStart: 427, nextEnd: 499)
+        #expect(
+            AgentTaskState.classify(env)
+                == .partialFileContent(path: "BeatStrip.ino", nextStartLine: 427, nextEndLine: 499)
+        )
+    }
+
+    /// A raw byte-capped read reports `truncated: true` but deliberately
+    /// carries NO continuation fields (line numbers can't reach unloaded
+    /// bytes) — it must stay plain `.fileContent`, never a continuation.
+    @Test func classify_byteCappedFileWithoutContinuationStaysFileContent() {
+        let env = ToolEnvelope.success(
+            tool: "file_read",
+            result: [
+                "kind": "file",
+                "text": "Lines 1-90000 of at least 90000 scanned:\n...",
+                "path": "huge.csv",
+                "truncated": true,
+                "raw_bytes_truncated": true,
+            ]
+        )
+        #expect(AgentTaskState.classify(env) == .fileContent)
     }
 
     @Test func classify_notFound() {
@@ -305,6 +347,73 @@ struct AgentTaskStateTests {
             argsJSON: #"{"path":"a.txt"}"#,
             result: fileContentEnvelope(path: "a.txt")
         )
+        #expect(state.nextStepBias() == nil)
+    }
+
+    /// Issue #2098: a rendered-cap-truncated read stages a continuation
+    /// notice naming the exact path and `start_line`/`end_line` to resume
+    /// with, so the model reads the rest instead of reviewing a prefix as
+    /// if it were the whole file.
+    @Test func bias_partialFileReadStagesExactContinuation() {
+        let state = AgentTaskState()
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"BeatStrip.ino"}"#,
+            result: partialFileEnvelope(path: "BeatStrip.ino", nextStart: 427, nextEnd: 499)
+        )
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("BeatStrip.ino"))
+        #expect(bias.contains(#""start_line": 427"#))
+        #expect(bias.contains(#""end_line": 499"#))
+    }
+
+    /// The disabled-bias validation gate covers the continuation notice too.
+    @Test func bias_partialFileReadSilentWhenBiasDisabled() {
+        let state = AgentTaskState(biasEnabled: false)
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"BeatStrip.ino"}"#,
+            result: partialFileEnvelope(path: "BeatStrip.ino", nextStart: 427, nextEnd: 499)
+        )
+        #expect(state.nextStepBias() == nil)
+    }
+
+    /// A byte-capped read (`truncated: true` but no continuation fields)
+    /// must not receive a line-continuation steer that could not work.
+    @Test func bias_byteCappedReadGetsNoContinuationSteer() {
+        let state = AgentTaskState()
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"huge.csv"}"#,
+            result: ToolEnvelope.success(
+                tool: "file_read",
+                result: [
+                    "kind": "file",
+                    "text": "...",
+                    "path": "huge.csv",
+                    "truncated": true,
+                    "raw_bytes_truncated": true,
+                ]
+            )
+        )
+        #expect(state.nextStepBias() == nil)
+    }
+
+    /// A partial read is still a successful descent into a file: it resets
+    /// the wandering (listings-without-read) counter like a complete read.
+    @Test func bias_partialFileReadResetsWanderingCounter() {
+        let state = AgentTaskState()
+        let listing = listingEnvelope(path: ".", entries: [("a.txt", "a.txt", false)])
+        state.record(name: "file_read", argsJSON: #"{"path":"."}"#, result: listing)
+        state.record(name: "file_read", argsJSON: #"{"path":"x"}"#, result: listing)
+        #expect(state.nextStepBias()?.contains("result.entries") == true)
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"big.ino"}"#,
+            result: partialFileEnvelope(path: "big.ino", nextStart: 400, nextEnd: 499)
+        )
+        // One fresh listing after the reset is below the reactive threshold.
+        state.record(name: "file_read", argsJSON: #"{"path":"y"}"#, result: listing)
         #expect(state.nextStepBias() == nil)
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -318,6 +318,72 @@ struct AgentToolLoopTests {
         #expect(surface.batchOutcomes[1].first?.wasDeduped == true)
     }
 
+    /// Issue #2098: a `file_read` whose rendered output was cut by the
+    /// character cap carries `next_start_line`/`next_end_line`; the loop
+    /// must stage a continuation notice for the NEXT model step naming the
+    /// exact path and resume range, so the model reads the rest instead of
+    /// reviewing the visible prefix as the whole file.
+    @Test func partialFileReadStagesContinuationNoticeForNextStep() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("file_read", #"{"path":"BeatStrip.ino"}"#)]),
+            .finalResponse,
+        ])
+        surface.toolResults["file_read"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "file_read",
+                result: [
+                    "kind": "file",
+                    "text": "Lines 1-426 of 499:\n...",
+                    "path": "BeatStrip.ino",
+                    "truncated": true,
+                    "next_start_line": 427,
+                    "next_end_line": 499,
+                ]
+            )
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.builtNotices.count == 2)
+        let notice = try #require(surface.builtNotices[1].first)
+        #expect(notice.hasPrefix("[System Notice] "))
+        #expect(notice.contains("BeatStrip.ino"))
+        #expect(notice.contains(#""start_line": 427"#))
+        #expect(notice.contains(#""end_line": 499"#))
+    }
+
+    /// A COMPLETE file read must not stage any continuation notice — the
+    /// steer is reserved for reads observed truncated by the output cap.
+    @Test func completeFileReadStagesNoContinuationNotice() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("file_read", #"{"path":"small.txt"}"#)]),
+            .finalResponse,
+        ])
+        surface.toolResults["file_read"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "file_read",
+                result: [
+                    "kind": "file",
+                    "text": "     1|hello\n",
+                    "path": "small.txt",
+                    "truncated": false,
+                ]
+            )
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.builtNotices == [[], []])
+    }
+
     @Test func dedupeNoticeSuppressedForHeadlessPolicy() async throws {
         let args = #"{"path":"notes.txt"}"#
         let envelope = ToolEnvelope.success(

--- a/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
@@ -174,6 +174,69 @@ struct FolderToolsResilienceTests {
         #expect(payload["partial_line"] as? Int == 1)
         #expect(payload["truncated"] as? Bool == true)
         #expect(payload["raw_bytes_truncated"] as? Bool == false)
+        // No continuation offer: re-reading from the same start line cannot
+        // advance past a single line longer than the cap — advertising one
+        // would send the model into a same-args loop.
+        #expect(payload["next_start_line"] == nil)
+        #expect(payload["next_end_line"] == nil)
+    }
+
+    /// Issue #2098 regression: a ~14KB, 499-line source file is fully read
+    /// from disk, but the line-number gutters push the RENDERED output past
+    /// the 15K character cap, so the model only sees a prefix (~line 426).
+    /// The payload must report truthful truncation plus an exact
+    /// continuation range, and the suggested second ranged read must reach
+    /// the end of the file.
+    @Test func fileRead_renderedCapTruncationCarriesExactContinuation() async throws {
+        let root = tmpRoot()
+        // 498 content lines with unicode (the reporter's file had unicode
+        // characters) + a final sentinel line. ~28 chars/line ≈ 14K chars,
+        // rendered at +8 chars/line of gutter ≈ 18K > the 15K cap.
+        var lines = (1 ... 498).map { String(format: "línea %03d — carga de la tira", $0) }
+        lines.append("FINAL_SENTINEL_LINE_499 ✓")
+        let content = lines.joined(separator: "\n")
+        let path = root.appendingPathComponent("BeatStrip.ino")
+        try content.write(to: path, atomically: true, encoding: .utf8)
+
+        let tool = FileReadTool(rootPath: root)
+        let first = try await tool.execute(argumentsJSON: #"{"path": "BeatStrip.ino"}"#)
+        #expect(ToolEnvelope.isSuccess(first))
+        let payload = try #require(EnvelopeAssertions.successPayload(first))
+
+        // The whole file was loaded — only the render was cut.
+        #expect(payload["raw_bytes_truncated"] as? Bool == false)
+        #expect(payload["total_lines"] as? Int == 499)
+        #expect(payload["total_lines_exact"] as? Bool == true)
+        #expect(payload["truncated"] as? Bool == true)
+
+        // Exact, range-safe continuation boundary.
+        let nextStart = try #require(payload["next_start_line"] as? Int)
+        let nextEnd = try #require(payload["next_end_line"] as? Int)
+        #expect(nextEnd == 499)
+        let endLine = try #require(payload["end_line"] as? Int)
+        if let partial = payload["partial_line"] as? Int {
+            #expect(nextStart == partial)
+        } else {
+            #expect(nextStart == endLine + 1)
+        }
+        // The truncation notice names the exact next range, not just a
+        // generic "use start_line/end_line" hint.
+        let text = try #require(payload["text"] as? String)
+        #expect(text.contains("start_line=\(nextStart), end_line=\(nextEnd)"))
+        #expect(text.contains("FINAL_SENTINEL_LINE_499") == false)
+
+        // The suggested continuation read reaches the end of the file.
+        let second = try await tool.execute(
+            argumentsJSON:
+                #"{"path": "BeatStrip.ino", "start_line": \#(nextStart), "end_line": \#(nextEnd)}"#
+        )
+        #expect(ToolEnvelope.isSuccess(second))
+        let secondPayload = try #require(EnvelopeAssertions.successPayload(second))
+        #expect(secondPayload["truncated"] as? Bool == false)
+        #expect(secondPayload["end_line"] as? Int == 499)
+        #expect(secondPayload["next_start_line"] == nil)
+        let secondText = try #require(secondPayload["text"] as? String)
+        #expect(secondText.contains("FINAL_SENTINEL_LINE_499"))
     }
 
     /// Raw text / CSV reads are part of the prompt-building hot path. A
@@ -204,6 +267,10 @@ struct FolderToolsResilienceTests {
         #expect(payload["total_lines_exact"] as? Bool == false)
         #expect(payload["truncated"] as? Bool == true)
         #expect(text.contains("raw read capped at 5 MiB"))
+        // A byte-capped read must NOT advertise a line continuation: line
+        // numbers cannot reach bytes that were never loaded.
+        #expect(payload["next_start_line"] == nil)
+        #expect(payload["next_end_line"] == nil)
     }
 
     /// The success payload carries a single line-numbered `text` field — no


### PR DESCRIPTION
## Summary

Fixes #2098.

`file_read` fully reads a file from disk, but the rendered output cap (`ToolOutputCaps.fileRead == 15_000` chars) also counts the seven-character line-number gutters — so a ~14KB / 499-line source file renders past the cap and cuts near line 426. The result honestly said `truncated: true`, but nothing turned that into an action, so models (Gemma 4 12B, Qwen3.6 27B per the report) reviewed the visible prefix as if it were the whole file.

- **`FileReadTool`** now emits an exact machine-readable continuation range (`next_start_line` / `next_end_line`) when the rendered cap cuts the output, and the truncation notice names it (`continue with start_line=427, end_line=499`). The continuation is range-safe (never past an explicit `end_line`) and deliberately withheld where it could not work: byte-capped raw reads (`raw_bytes_truncated`, line numbers can't reach unloaded bytes) and a single line longer than the cap (re-reading the same start would loop). The 15K context-safety cap itself is unchanged.
- **`AgentTaskState`** classifies such results as a new `partialFileContent` state and stages a next-step notice with the exact path + resume range; the existing `AgentToolLoop` notice channel delivers it on the next model step. Complete reads and byte-capped reads are unchanged, and a partial read still resets the wandering counter like any successful read.

## Test plan

- [x] Issue-shaped regression in `FolderToolsResilienceTests`: ~14KB, 499-line unicode file → full raw read, truthful rendered truncation, exact continuation boundary, and the suggested second ranged read reaches the final-line sentinel.
- [x] `AgentTaskStateTests`: partial-read classification + exact continuation notice; byte-capped and complete reads get no steer; bias-disabled gate stays silent; wandering counter resets.
- [x] `AgentToolLoopTests`: the loop stages the `[System Notice]` continuation (exact path, `start_line`, `end_line`) for the next model step; complete reads stage nothing.
- [x] Targeted suites pass (`FolderToolsResilienceTests`, `AgentTaskStateTests`, `AgentToolLoopTests`, `HarnessStabilityFixesTests`, `FileReadWorkbookTests`, `FileReadDocumentFormatsTests`, `UnifiedFileToolParamsTests`) + `swift build`.
- [x] Live agent-loop proof (issue-shaped eval case): PASS on `OsaurusAI/Ornith-1.0-9B-MXFP8` — first `file_read` truncated, continuation notice fired, second ranged read reached line 499, final answer contained the sentinel. Exit `finalResponse`, 2 tool calls / 3 iterations, decode 12.2 tok/s, TTFT 101ms, prefill 293 tok/s, peak RAM 3104MB.
- [ ] Live proof on the reported models is BLOCKED locally: the `gemma-4-12B-it-MXFP8` (5/13 shards, no tokenizer) and `Qwen3.6-27B-MXFP8-MTP` (2/29 shards) bundles on this machine are incomplete and cannot load. The fix is harness-level (tool payload + loop notice), but per-family behavior on those two models is unproven until the bundles are restored.
- [ ] Full `make test` suite not run per instruction; run once before merge if desired.