### PR TITLE
Adopt native macOS theme defaults with system accent following

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
+++ b/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
@@ -241,6 +241,79 @@ public struct ThemeColors: Codable, Equatable, Sendable {
     }
 }
 
+// MARK: - System Accent Derivation
+
+extension ThemeColors {
+    /// Returns a copy with the accent-adjacent colors re-derived from
+    /// `accentHex`. Everything else (backgrounds, text, status colors, …)
+    /// is left untouched.
+    ///
+    /// When `accentHex` already matches the stored `accentColor` the
+    /// receiver is returned unchanged, so themes hand-tuned against the
+    /// default accent keep their exact authored values.
+    public func applyingAccent(_ accentHex: String, isDark: Bool) -> ThemeColors {
+        guard let accent = Self.parseHexRGB(accentHex),
+            Self.normalizedHex(accentHex) != Self.normalizedHex(accentColor)
+        else { return self }
+
+        let accentString = Self.formatHexRGB(accent)
+        let white: (Double, Double, Double) = (255, 255, 255)
+        let black: (Double, Double, Double) = (0, 0, 0)
+
+        var derived = self
+        derived.accentColor = accentString
+        derived.focusBorder = accentString
+        derived.cursorColor = accentString
+        derived.accentColorLight = Self.formatHexRGB(Self.blend(accent, toward: white, fraction: 0.4))
+        // Keep the canonical selection alphas (see darkDefault/lightDefault).
+        derived.selectionColor = accentString + (isDark ? "45" : "26")
+        if isDark {
+            // Factors tuned so the default blue accent lands close to the
+            // hand-picked #0a3d70 / #d8e8ff selected-row colors.
+            derived.sidebarSelectedBackground = Self.formatHexRGB(Self.blend(accent, toward: black, fraction: 0.55))
+            derived.infoColor = derived.accentColorLight
+        } else {
+            derived.sidebarSelectedBackground = Self.formatHexRGB(Self.blend(accent, toward: white, fraction: 0.84))
+            derived.infoColor = accentString
+        }
+        return derived
+    }
+
+    private static func normalizedHex(_ hex: String) -> String {
+        let trimmed = hex.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+    }
+
+    private static func parseHexRGB(_ hex: String) -> (Double, Double, Double)? {
+        let body = normalizedHex(hex)
+        guard body.count == 6, body.allSatisfy(\.isHexDigit) else { return nil }
+        var int: UInt64 = 0
+        Scanner(string: body).scanHexInt64(&int)
+        return (Double(int >> 16 & 0xFF), Double(int >> 8 & 0xFF), Double(int & 0xFF))
+    }
+
+    private static func formatHexRGB(_ rgb: (Double, Double, Double)) -> String {
+        String(
+            format: "#%02x%02x%02x",
+            Int(rgb.0.rounded()),
+            Int(rgb.1.rounded()),
+            Int(rgb.2.rounded())
+        )
+    }
+
+    private static func blend(
+        _ from: (Double, Double, Double),
+        toward target: (Double, Double, Double),
+        fraction: Double
+    ) -> (Double, Double, Double) {
+        (
+            from.0 + (target.0 - from.0) * fraction,
+            from.1 + (target.1 - from.1) * fraction,
+            from.2 + (target.2 - from.2) * fraction
+        )
+    }
+}
+
 // MARK: - Theme Background
 
 /// Background configuration for the theme
@@ -674,6 +747,12 @@ public struct CustomTheme: Codable, Equatable, Sendable {
     public var isBuiltIn: Bool
     public var isDark: Bool
 
+    /// When true, accent-adjacent colors are re-derived from the user's
+    /// system accent color (System Settings > Appearance) at theme-build
+    /// time. The stored hex values act as the palette for the default
+    /// (blue) accent. See `ThemeColors.applyingAccent(_:isDark:)`.
+    public var followsSystemAccent: Bool
+
     public init(
         metadata: ThemeMetadata = ThemeMetadata(),
         colors: ThemeColors = ThemeColors(),
@@ -687,7 +766,8 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         codeHighlightTheme: String? = nil,
         library: ThemeLibraryInfo? = nil,
         isBuiltIn: Bool = false,
-        isDark: Bool = true
+        isDark: Bool = true,
+        followsSystemAccent: Bool = false
     ) {
         self.metadata = metadata
         self.colors = colors
@@ -702,6 +782,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         self.library = library
         self.isBuiltIn = isBuiltIn
         self.isDark = isDark
+        self.followsSystemAccent = followsSystemAccent
     }
 
     /// Backward-compatible decoding: new fields fall back to defaults if missing
@@ -720,14 +801,218 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         library = try container.decodeIfPresent(ThemeLibraryInfo.self, forKey: .library)
         isBuiltIn = try container.decode(Bool.self, forKey: .isBuiltIn)
         isDark = try container.decode(Bool.self, forKey: .isDark)
+        followsSystemAccent = try container.decodeIfPresent(Bool.self, forKey: .followsSystemAccent) ?? false
     }
 
-    /// Default dark theme
+    /// Default dark theme — native macOS dark palette (issue #2102)
     public static var darkDefault: CustomTheme {
         CustomTheme(
             metadata: ThemeMetadata(
                 id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
                 name: "Dark",
+                version: "2.0",
+                author: "Osaurus"
+            ),
+            colors: ThemeColors(
+                primaryText: "#f5f5f7",
+                secondaryText: "#d1d1d6",
+                tertiaryText: "#98989d",
+                primaryBackground: "#1c1c1e",
+                secondaryBackground: "#2c2c2e",
+                tertiaryBackground: "#3a3a3c",
+                sidebarBackground: "#252527",
+                sidebarSelectedBackground: "#0a3d70",
+                accentColor: "#0a84ff",
+                accentColorLight: "#64d2ff",
+                primaryBorder: "#38383a",
+                secondaryBorder: "#48484a",
+                focusBorder: "#0a84ff",
+                successColor: "#30d158",
+                warningColor: "#ff9f0a",
+                errorColor: "#ff453a",
+                infoColor: "#64d2ff",
+                cardBackground: "#2c2c2e",
+                cardBorder: "#48484a",
+                buttonBackground: "#3a3a3c",
+                buttonBorder: "#545458",
+                inputBackground: "#2c2c2e",
+                inputBorder: "#545458",
+                glassTintOverlay: "#00000050",
+                codeBlockBackground: "#1c1c1e",
+                shadowColor: "#000000",
+                selectionColor: "#0a84ff45",
+                cursorColor: "#0a84ff",
+                placeholderText: "#8e8e93"
+            ),
+            background: .default,
+            glass: ThemeGlass(
+                enabled: true,
+                sidebarEnabled: true,
+                inputEnabled: false,
+                material: .windowBackground,
+                blurRadius: 20,
+                opacityPrimary: 0.82,
+                opacitySecondary: 0.68,
+                opacityTertiary: 0.5,
+                tintColor: "#000000",
+                tintOpacity: 0.12,
+                edgeLight: "#ffffff30",
+                windowBackingOpacity: 0.94
+            ),
+            typography: ThemeTypography(
+                primaryFont: "SF Pro",
+                monoFont: "SF Mono",
+                titleSize: 26,
+                headingSize: 18,
+                bodySize: 15,
+                captionSize: 12,
+                codeSize: 13
+            ),
+            animationConfig: ThemeAnimation(
+                durationQuick: 0.15,
+                durationMedium: 0.25,
+                durationSlow: 0.35,
+                springResponse: 0.35,
+                springDamping: 0.82
+            ),
+            shadows: ThemeShadows(
+                shadowOpacity: 0.32,
+                cardShadowRadius: 10,
+                cardShadowRadiusHover: 18,
+                cardShadowY: 3,
+                cardShadowYHover: 7
+            ),
+            messages: ThemeMessages(
+                bubbleCornerRadius: 18,
+                userBubbleOpacity: 0.2,
+                assistantBubbleOpacity: 0.95,
+                borderWidth: 0.5,
+                showEdgeLight: true,
+                showInlineAvatar: true,
+                inlineAvatarSize: 24,
+                showAgentName: true,
+                agentNameSize: 13
+            ),
+            borders: ThemeBorders(
+                defaultWidth: 1,
+                cardCornerRadius: 10,
+                inputCornerRadius: 7,
+                borderOpacity: 0.5
+            ),
+            isBuiltIn: true,
+            isDark: true,
+            followsSystemAccent: true
+        )
+    }
+
+    /// Default light theme — native macOS light palette (issue #2102)
+    public static var lightDefault: CustomTheme {
+        CustomTheme(
+            metadata: ThemeMetadata(
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+                name: "Light",
+                version: "2.0",
+                author: "Osaurus"
+            ),
+            colors: ThemeColors(
+                primaryText: "#1d1d1f",
+                secondaryText: "#515154",
+                tertiaryText: "#6e6e73",
+                primaryBackground: "#f5f5f7",
+                secondaryBackground: "#ececf0",
+                tertiaryBackground: "#f9f9fb",
+                sidebarBackground: "#e9e9ed",
+                sidebarSelectedBackground: "#d8e8ff",
+                accentColor: "#007aff",
+                accentColorLight: "#5ac8fa",
+                primaryBorder: "#d1d1d6",
+                secondaryBorder: "#c7c7cc",
+                focusBorder: "#007aff",
+                successColor: "#248a3d",
+                warningColor: "#b26a00",
+                errorColor: "#d70015",
+                infoColor: "#007aff",
+                cardBackground: "#ffffff",
+                cardBorder: "#d1d1d6",
+                buttonBackground: "#f6f6f7",
+                buttonBorder: "#c7c7cc",
+                inputBackground: "#ffffff",
+                inputBorder: "#c7c7cc",
+                glassTintOverlay: "#ffffff70",
+                codeBlockBackground: "#f2f2f7",
+                shadowColor: "#000000",
+                selectionColor: "#007aff26",
+                cursorColor: "#007aff",
+                placeholderText: "#8e8e93"
+            ),
+            background: .default,
+            glass: ThemeGlass(
+                enabled: true,
+                sidebarEnabled: true,
+                inputEnabled: false,
+                material: .windowBackground,
+                blurRadius: 20,
+                opacityPrimary: 0.78,
+                opacitySecondary: 0.62,
+                opacityTertiary: 0.45,
+                tintColor: "#ffffff",
+                tintOpacity: 0.08,
+                edgeLight: "#ffffffcc",
+                windowBackingOpacity: 0.92
+            ),
+            typography: ThemeTypography(
+                primaryFont: "SF Pro",
+                monoFont: "SF Mono",
+                titleSize: 26,
+                headingSize: 18,
+                bodySize: 15,
+                captionSize: 12,
+                codeSize: 13
+            ),
+            animationConfig: ThemeAnimation(
+                durationQuick: 0.15,
+                durationMedium: 0.25,
+                durationSlow: 0.35,
+                springResponse: 0.35,
+                springDamping: 0.82
+            ),
+            shadows: ThemeShadows(
+                shadowOpacity: 0.12,
+                cardShadowRadius: 8,
+                cardShadowRadiusHover: 16,
+                cardShadowY: 2,
+                cardShadowYHover: 6
+            ),
+            messages: ThemeMessages(
+                bubbleCornerRadius: 18,
+                userBubbleOpacity: 0.16,
+                assistantBubbleOpacity: 0.95,
+                borderWidth: 0.5,
+                showEdgeLight: true,
+                showInlineAvatar: true,
+                inlineAvatarSize: 24,
+                showAgentName: true,
+                agentNameSize: 13
+            ),
+            borders: ThemeBorders(
+                defaultWidth: 1,
+                cardCornerRadius: 10,
+                inputCornerRadius: 7,
+                borderOpacity: 0.45
+            ),
+            isBuiltIn: true,
+            isDark: false,
+            followsSystemAccent: true
+        )
+    }
+
+    /// Osaurus Dark — the previous default dark palette, retained as a
+    /// selectable built-in preset after the macOS-native defaults landed.
+    public static var osaurusDarkPreset: CustomTheme {
+        CustomTheme(
+            metadata: ThemeMetadata(
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000007")!,
+                name: "Osaurus Dark",
                 version: "1.1",
                 author: "Osaurus"
             ),
@@ -800,12 +1085,13 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         )
     }
 
-    /// Default light theme
-    public static var lightDefault: CustomTheme {
+    /// Osaurus Light — the previous default light palette, retained as a
+    /// selectable built-in preset after the macOS-native defaults landed.
+    public static var osaurusLightPreset: CustomTheme {
         CustomTheme(
             metadata: ThemeMetadata(
-                id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
-                name: "Light",
+                id: UUID(uuidString: "00000000-0000-0000-0000-000000000008")!,
+                name: "Osaurus Light",
                 version: "1.1",
                 author: "Osaurus"
             ),
@@ -1216,7 +1502,10 @@ public struct CustomTheme: Codable, Equatable, Sendable {
 
     /// All built-in theme presets
     public static var allBuiltInPresets: [CustomTheme] {
-        [.darkDefault, .lightDefault, .neonPreset, .nordPreset, .paperPreset, .terminalPreset]
+        [
+            .darkDefault, .lightDefault, .neonPreset, .nordPreset, .paperPreset, .terminalPreset,
+            .osaurusDarkPreset, .osaurusLightPreset,
+        ]
     }
 }
 

--- a/Packages/OsaurusCore/Models/Theme/SystemAccentColor.swift
+++ b/Packages/OsaurusCore/Models/Theme/SystemAccentColor.swift
@@ -1,0 +1,30 @@
+//
+//  SystemAccentColor.swift
+//  osaurus
+//
+//  Resolves the user's system accent color (System Settings > Appearance)
+//  for themes that opt in via `CustomTheme.followsSystemAccent`.
+//
+
+import AppKit
+
+public enum SystemAccentColor {
+    /// The current system accent color as an sRGB `#rrggbb` hex string,
+    /// resolved under the appearance the theme targets. `controlAccentColor`
+    /// is a dynamic color whose components differ between light and dark
+    /// appearances, so the derived palette must be sampled under the right one.
+    public static func currentAccentHex(isDark: Bool) -> String? {
+        guard let appearance = NSAppearance(named: isDark ? .darkAqua : .aqua) else { return nil }
+
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = NSColor.controlAccentColor.usingColorSpace(.sRGB)
+        }
+        guard let color = resolved else { return nil }
+
+        let r = Int((color.redComponent * 255).rounded())
+        let g = Int((color.greenComponent * 255).rounded())
+        let b = Int((color.blueComponent * 255).rounded())
+        return String(format: "#%02x%02x%02x", r, g, b)
+    }
+}

--- a/Packages/OsaurusCore/Models/Theme/Theme.swift
+++ b/Packages/OsaurusCore/Models/Theme/Theme.swift
@@ -402,6 +402,15 @@ struct CustomizableTheme: ThemeProtocol {
     let fontScale: Double
 
     init(config: CustomTheme, fontScale: Double = ThemeManager.fontScale) {
+        // Substituting here covers every construction site (startup,
+        // appearance resolution, custom apply, per-agent chat themes,
+        // font-scale rebuilds) without touching them individually.
+        var config = config
+        if config.followsSystemAccent,
+            let accentHex = SystemAccentColor.currentAccentHex(isDark: config.isDark)
+        {
+            config.colors = config.colors.applyingAccent(accentHex, isDark: config.isDark)
+        }
         self.config = config
         self.fontScale = fontScale
     }
@@ -673,6 +682,23 @@ public class ThemeManager: ObservableObject {
             object: nil
         )
 
+        // Observe system accent color changes so themes that opt in via
+        // `followsSystemAccent` re-derive their palette live. AppKit posts
+        // the in-process notification when system colors change; the
+        // distributed one covers accent changes made in System Settings.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(systemAccentColorChanged),
+            name: NSColor.systemColorsDidChangeNotification,
+            object: nil
+        )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(systemAccentColorChanged),
+            name: Notification.Name("AppleColorPreferencesChangedNotification"),
+            object: nil
+        )
+
         // Defer the heavy disk work (built-in install + full theme decode)
         // off the *synchronous* launch-critical path. `ThemeConfigurationStore`
         // is `@MainActor` (it guards a static install-cache + UserDefaults), so
@@ -902,6 +928,28 @@ public class ThemeManager: ObservableObject {
         guard appearanceMode == .system, activeCustomTheme == nil else { return }
 
         applyResolvedTheme(for: .system, animated: true)
+        NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
+    }
+
+    @objc private func systemAccentColorChanged() {
+        // Delivered on an arbitrary thread (see `systemAppearanceChanged`);
+        // hop to the main actor before touching @Published theme state.
+        Task { @MainActor [weak self] in
+            self?.applySystemAccentChange()
+        }
+    }
+
+    private func applySystemAccentChange() {
+        if let custom = activeCustomTheme {
+            // Rebuilding `CustomizableTheme` re-runs the accent substitution;
+            // static themes have nothing to re-derive.
+            guard custom.followsSystemAccent else { return }
+            applyCustomTheme(custom, persist: false)
+            return
+        }
+
+        applyResolvedTheme(for: appearanceMode, animated: true)
+        // Notify so per-agent chat windows rebuild their themes too.
         NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
     }
 

--- a/Packages/OsaurusCore/Models/Theme/ThemeConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/Theme/ThemeConfigurationStore.swift
@@ -14,7 +14,9 @@ public enum ThemeConfigurationStore {
     private static let builtInThemeSchemaKey = "builtInThemeSchemaVersion"
     /// Increment this whenever the built-in Dark/Light palette changes so existing
     /// installations receive the updated colors on next launch.
-    private static let currentBuiltInThemeSchema = 5
+    /// Schema 6: canonical Dark/Light switched to the native macOS palettes
+    /// (issue #2102); previous palettes retained as Osaurus Dark/Light presets.
+    private static let currentBuiltInThemeSchema = 6
     private static var builtInThemesInstalled = false
 
     // MARK: - Active Theme

--- a/Packages/OsaurusCore/Tests/Theme/ThemeAppearanceModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeAppearanceModeTests.swift
@@ -17,6 +17,56 @@ struct ThemeAppearanceModeTests {
         #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.nordPreset) == nil)
         #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.paperPreset) == nil)
         #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.terminalPreset) == nil)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.osaurusDarkPreset) == nil)
+        #expect(ThemeManager.appearanceMode(forBuiltInTheme: CustomTheme.osaurusLightPreset) == nil)
+    }
+
+    @Test
+    func builtInPresetIdsAreUnique() {
+        let ids = CustomTheme.allBuiltInPresets.map(\.metadata.id)
+        #expect(Set(ids).count == ids.count)
+        #expect(CustomTheme.allBuiltInPresets.contains { $0.metadata.id == CustomTheme.osaurusDarkPreset.metadata.id })
+        #expect(CustomTheme.allBuiltInPresets.contains { $0.metadata.id == CustomTheme.osaurusLightPreset.metadata.id })
+    }
+
+    @Test
+    func canonicalDefaultsUseNativeMacOSPalettes() {
+        let dark = CustomTheme.darkDefault
+        #expect(dark.metadata.name == "Dark")
+        #expect(dark.colors.primaryBackground == "#1c1c1e")
+        #expect(dark.colors.accentColor == "#0a84ff")
+        #expect(dark.glass.enabled)
+        #expect(dark.glass.sidebarEnabled)
+        #expect(dark.glass.material == .windowBackground)
+        #expect(dark.isDark)
+
+        let light = CustomTheme.lightDefault
+        #expect(light.metadata.name == "Light")
+        #expect(light.colors.primaryBackground == "#f5f5f7")
+        #expect(light.colors.accentColor == "#007aff")
+        #expect(light.glass.enabled)
+        #expect(light.glass.sidebarEnabled)
+        #expect(light.glass.material == .windowBackground)
+        #expect(!light.isDark)
+    }
+
+    @Test
+    func osaurusPresetsRetainLegacyDefaultPalettes() {
+        let dark = CustomTheme.osaurusDarkPreset
+        #expect(dark.metadata.name == "Osaurus Dark")
+        #expect(dark.isBuiltIn)
+        #expect(dark.isDark)
+        #expect(dark.colors.primaryBackground == "#0e1120")
+        #expect(dark.colors.accentColor == "#4a6de0")
+        #expect(!dark.glass.enabled)
+
+        let light = CustomTheme.osaurusLightPreset
+        #expect(light.metadata.name == "Osaurus Light")
+        #expect(light.isBuiltIn)
+        #expect(!light.isDark)
+        #expect(light.colors.primaryBackground == "#ffffea")
+        #expect(light.colors.accentColor == "#214099")
+        #expect(!light.glass.enabled)
     }
 
     @Test
@@ -47,6 +97,14 @@ struct ThemeAppearanceModeTests {
         #expect(neonSelection.appearanceMode == .system)
         #expect(neonSelection.activeTheme?.metadata.id == CustomTheme.neonPreset.metadata.id)
         #expect(!neonSelection.shouldClearActiveTheme)
+
+        let osaurusDarkSelection = ThemeManager.startupSelection(
+            savedActiveTheme: CustomTheme.osaurusDarkPreset,
+            configuredAppearanceMode: .system
+        )
+        #expect(osaurusDarkSelection.appearanceMode == .system)
+        #expect(osaurusDarkSelection.activeTheme?.metadata.id == CustomTheme.osaurusDarkPreset.metadata.id)
+        #expect(!osaurusDarkSelection.shouldClearActiveTheme)
 
         let emptySelection = ThemeManager.startupSelection(
             savedActiveTheme: nil,

--- a/Packages/OsaurusCore/Tests/Theme/ThemeSystemAccentTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeSystemAccentTests.swift
@@ -1,0 +1,108 @@
+//
+//  ThemeSystemAccentTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("System accent following")
+struct ThemeSystemAccentTests {
+    @Test("only the canonical Dark/Light defaults follow the system accent")
+    func canonicalPresetsOptIn() {
+        #expect(CustomTheme.darkDefault.followsSystemAccent)
+        #expect(CustomTheme.lightDefault.followsSystemAccent)
+        #expect(!CustomTheme.neonPreset.followsSystemAccent)
+        #expect(!CustomTheme.nordPreset.followsSystemAccent)
+        #expect(!CustomTheme.paperPreset.followsSystemAccent)
+        #expect(!CustomTheme.terminalPreset.followsSystemAccent)
+        #expect(!CustomTheme.osaurusDarkPreset.followsSystemAccent)
+        #expect(!CustomTheme.osaurusLightPreset.followsSystemAccent)
+    }
+
+    @Test("decoding JSON without the flag defaults to false; round-trip preserves true")
+    func decodingDefaultsAndRoundTrips() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        // Round-trip preserves the flag.
+        let encoded = try encoder.encode(CustomTheme.darkDefault)
+        let roundTripped = try decoder.decode(CustomTheme.self, from: encoded)
+        #expect(roundTripped.followsSystemAccent)
+
+        // A legacy payload without the key decodes to false.
+        var json = try #require(
+            try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        json.removeValue(forKey: "followsSystemAccent")
+        let legacyData = try JSONSerialization.data(withJSONObject: json)
+        let legacy = try decoder.decode(CustomTheme.self, from: legacyData)
+        #expect(!legacy.followsSystemAccent)
+    }
+
+    @Test("applying the stored accent is an identity")
+    func identityWhenAccentMatchesStoredValue() {
+        let dark = CustomTheme.darkDefault.colors
+        #expect(dark.applyingAccent("#0a84ff", isDark: true) == dark)
+        // Case and prefix insensitive.
+        #expect(dark.applyingAccent("0A84FF", isDark: true) == dark)
+
+        let light = CustomTheme.lightDefault.colors
+        #expect(light.applyingAccent("#007aff", isDark: false) == light)
+    }
+
+    @Test("invalid accent input leaves colors unchanged")
+    func invalidAccentIsIgnored() {
+        let colors = CustomTheme.darkDefault.colors
+        #expect(colors.applyingAccent("not-a-color", isDark: true) == colors)
+        #expect(colors.applyingAccent("#fff", isDark: true) == colors)
+    }
+
+    @Test("a new accent rewrites only the accent-adjacent fields")
+    func derivationRewritesAccentAdjacentFieldsOnly() {
+        let purple = "#a550a7"
+        let base = CustomTheme.darkDefault.colors
+        let derived = base.applyingAccent(purple, isDark: true)
+
+        #expect(derived.accentColor == purple)
+        #expect(derived.focusBorder == purple)
+        #expect(derived.cursorColor == purple)
+        #expect(derived.selectionColor == purple + "45")
+        #expect(derived.accentColorLight != base.accentColorLight)
+        #expect(derived.sidebarSelectedBackground != base.sidebarSelectedBackground)
+        #expect(derived.infoColor == derived.accentColorLight)
+
+        // Everything else stays authored.
+        #expect(derived.primaryText == base.primaryText)
+        #expect(derived.secondaryText == base.secondaryText)
+        #expect(derived.primaryBackground == base.primaryBackground)
+        #expect(derived.secondaryBackground == base.secondaryBackground)
+        #expect(derived.sidebarBackground == base.sidebarBackground)
+        #expect(derived.successColor == base.successColor)
+        #expect(derived.warningColor == base.warningColor)
+        #expect(derived.errorColor == base.errorColor)
+        #expect(derived.cardBackground == base.cardBackground)
+        #expect(derived.buttonBackground == base.buttonBackground)
+        #expect(derived.inputBackground == base.inputBackground)
+        #expect(derived.shadowColor == base.shadowColor)
+        #expect(derived.placeholderText == base.placeholderText)
+    }
+
+    @Test("light derivation uses the light selection alpha and accent info color")
+    func lightDerivationUsesLightRules() {
+        let purple = "#a550a7"
+        let base = CustomTheme.lightDefault.colors
+        let derived = base.applyingAccent(purple, isDark: false)
+
+        #expect(derived.selectionColor == purple + "26")
+        #expect(derived.infoColor == purple)
+        // Light selected-row color blends toward white, so it should be
+        // much lighter than the accent itself.
+        #expect(derived.sidebarSelectedBackground != base.sidebarSelectedBackground)
+        #expect(derived.sidebarSelectedBackground.hasPrefix("#"))
+    }
+}

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -26,7 +26,8 @@ This document describes the JSON schema for Osaurus custom themes. Themes can be
   "borders": { ... },
   "library": { ... },
   "isBuiltIn": false,
-  "isDark": true
+  "isDark": true,
+  "followsSystemAccent": false
 }
 ```
 
@@ -34,6 +35,7 @@ This document describes the JSON schema for Osaurus custom themes. Themes can be
 |---|---|---|
 | `isBuiltIn` | Bool | Always set to `false` for custom themes. Forced to `false` on import. |
 | `isDark` | Bool | Whether this is a dark theme. Affects system appearance matching. |
+| `followsSystemAccent` | Bool | Optional, defaults to `false`. When `true`, accent-adjacent colors (`accentColor`, `accentColorLight`, `focusBorder`, `cursorColor`, `selectionColor`, `sidebarSelectedBackground`, `infoColor`) are re-derived from the user's macOS system accent color when the theme is applied. The stored hex values are used as-is when the system accent matches the theme's `accentColor` (the palette authored for the default blue accent). |
 
 `messages`, `borders`, and `library` are optional -- missing `messages` and `borders` fall back to defaults, and missing `library` is treated as a local custom theme.
 


### PR DESCRIPTION
## Summary

- Makes the macOS-native Light/Dark palettes from #2102 the canonical built-in defaults (`Dark`/`Light`, UUIDs unchanged so appearance-mode resolution, saved active-theme normalization, and agent `themeId` references keep working), including glass with the `windowBackground` material and SF Pro/SF Mono typography.
- Retains the previous default palettes as two new built-in presets, `Osaurus Dark` and `Osaurus Light`, and bumps the built-in theme schema to 6 so existing installations pick up both changes on next launch.
- Adds opt-in system accent following: a new `followsSystemAccent` flag (set on the canonical defaults, documented in `docs/THEMES.md`) re-derives accent-adjacent colors (`accentColor`, `accentColorLight`, `focusBorder`, `cursorColor`, `selectionColor`, `sidebarSelectedBackground`, `infoColor`) from `NSColor.controlAccentColor` at theme-build time. When the system accent is the default blue, the authored #2102 palettes are used byte-for-byte. `ThemeManager` observes accent-change notifications and rebuilds live themes, mirroring the existing light/dark handling.

Closes #2102.

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore`
- [x] Theme suites pass (`swift test --filter "Theme"`, 43 tests / 11 suites) including new coverage: preset ID uniqueness, canonical vs retained palette values, appearance-mode mapping, `followsSystemAccent` decoding/round-trip, accent derivation identity and field scope
- [ ] Manual smoke: change accent color in System Settings with the app running and confirm buttons/selection/sidebar update live in both light and dark