### PR TITLE
Wire Nemotron Audex 2B and 30B audio models

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8d111cc773598230c81735c36eabc920db8374c5"
+        "revision" : "58553de7d29ea3881b8a54048cff815aa6c55ab9"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f2b184841e98d969e46dec83109f27cd7bb57357"
+        "revision" : "6de24bbaf1164948692a869531100bc845c9bbf6"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6de24bbaf1164948692a869531100bc845c9bbf6"
+        "revision" : "8d111cc773598230c81735c36eabc920db8374c5"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -135,6 +135,16 @@ enum ModelFamilyNames {
             || matches(#"(^|/)nemotron[\-_]omni($|[\-_/\.0-9])"#, in: lower)
     }
 
+    /// NVIDIA Nemotron-Labs-Audex audio-input/text-output checkpoints. Keep
+    /// this separate from `isNemotronThinkingFamily`: several legacy media
+    /// guards deliberately treat non-Omni Nemotron thinking models as text
+    /// only, while Audex must remain routed through the VLM/audio processor.
+    static func isAudexFamily(_ modelId: String) -> Bool {
+        let lower = modelId.lowercased()
+        return lower.contains("nemotron-labs-audex")
+            || lower.contains("nemotron_labs_audex")
+    }
+
     /// Nemotron bundles whose native template exposes an `enable_thinking`
     /// switch. Keep this broader than Omni media support but narrower than all
     /// historical Nemotron lineages.

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -16,8 +16,8 @@
 //   - Per-family video support is config-parametric. Mistral 3 / 3.5
 //     have a vision_config but no video preprocessor. Qwen 3 VL hardcodes
 //     `targetFPS=2` in the model class.
-//   - Audio support today is exclusively Nemotron-3-Nano-Omni — gated by
-//     the `config_omni.json` sidecar.
+//   - Nemotron-3-Nano-Omni is gated by `config_omni.json`; Audex is a
+//     distinct audio-in/text-out family and must not inherit image/video.
 //
 //  The matrix here mirrors `vmlx-swift/Libraries/MLXLMCommon/
 //  BatchEngine/MEDIA-MODEL-MATRIX.md`. Keep them in sync — when vmlx
@@ -123,6 +123,12 @@ public enum ModelMediaCapabilities {
             supportsAudio: false
         )
 
+        public static let audioOnly = Capabilities(
+            supportsImage: false,
+            supportsVideo: false,
+            supportsAudio: true
+        )
+
         public static let omni = Capabilities(
             supportsImage: true,
             supportsVideo: true,
@@ -159,8 +165,14 @@ public enum ModelMediaCapabilities {
     public static func from(modelId: String) -> Capabilities {
         let lower = modelId.lowercased()
 
-        // Nemotron-3-Nano-Omni / Nemotron-Omni-Nano — only family with
-        // native audio today.
+        // NVIDIA Nemotron-Labs-Audex: native audio-in/text-out. This is
+        // intentionally audio-only, not Nemotron Omni (no image/video path).
+        if lower.contains("nemotron-labs-audex") || lower.contains("nemotron_labs_audex") {
+            return .audioOnly
+        }
+
+        // Nemotron-3-Nano-Omni / Nemotron-Omni-Nano — native audio plus
+        // image/video (unlike audio-only Audex above).
         // Matches:
         //   OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4 / -JANGTQ4 / -JANGTQ
         //   nemotron-3-nano-omni-* (case-folded picker form)
@@ -271,6 +283,13 @@ public enum ModelMediaCapabilities {
         }
 
         let detected = from(modelId: modelId)
+        // A known media family is authoritative. In particular, Audex is a
+        // VLM-factory model because it splices audio embeddings, but that must
+        // not let the generic `isVLM` image fallback widen `.audioOnly` into
+        // image + audio support.
+        if detected != .textOnly {
+            return detected
+        }
         if detected == .textOnly,
             ModelFamilyNames.isNemotronThinkingFamily(modelId),
             !ModelFamilyNames.isNemotronOmniFamily(modelId)
@@ -368,8 +387,12 @@ public enum ModelMediaCapabilities {
         let modelType = (json["model_type"] as? String)?.lowercased() ?? ""
         let hasVisionConfig = json["vision_config"] != nil
 
+        if modelType == "nemotron_dense_audex" {
+            return .audioOnly
+        }
+
         // No vision config → not even image-capable. (Audio without
-        // vision is only the omni path, already handled above.)
+        // vision is Audex, handled above.)
         guard hasVisionConfig else {
             return .textOnly
         }

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -163,13 +163,13 @@ public enum ModelMediaCapabilities {
     /// video accept slots. After load, `from(directory:modelId:)`
     /// can refine via the bundle's `config_omni.json` sidecar.
     public static func from(modelId: String) -> Capabilities {
-        let lower = modelId.lowercased()
-
         // NVIDIA Nemotron-Labs-Audex: native audio-in/text-out. This is
         // intentionally audio-only, not Nemotron Omni (no image/video path).
-        if lower.contains("nemotron-labs-audex") || lower.contains("nemotron_labs_audex") {
+        if ModelFamilyNames.isAudexFamily(modelId) {
             return .audioOnly
         }
+
+        let lower = modelId.lowercased()
 
         // Nemotron-3-Nano-Omni / Nemotron-Omni-Nano — native audio plus
         // image/video (unlike audio-only Audex above).
@@ -387,7 +387,7 @@ public enum ModelMediaCapabilities {
         let modelType = (json["model_type"] as? String)?.lowercased() ?? ""
         let hasVisionConfig = json["vision_config"] != nil
 
-        if modelType == "nemotron_dense_audex" {
+        if ["nemotron_dense_audex", "nemotron_h_audex"].contains(modelType) {
             return .audioOnly
         }
 

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -629,12 +629,13 @@ struct QwenThinkingProfile: ModelProfile {
     static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)
 }
 
-// MARK: - Nemotron-3 Thinking Profile
+// MARK: - Nemotron Thinking Profile
 
-/// Nemotron-3 reasoning models — `model_type=nemotron_h` hybrid
-/// Mamba+Attn+MoE bundles whose chat template reads an `enable_thinking`
-/// kwarg. Osaurus exposes the toggle but does not synthesize a reasoning mode:
-/// absent values must let the model bundle/runtime decide.
+/// Nemotron-3 reasoning and Nemotron-Labs-Audex models whose chat templates
+/// read an `enable_thinking` kwarg. Audex remains a distinct audio-only media
+/// family; matching it here only exposes the explicit template toggle.
+/// Osaurus does not synthesize a reasoning mode: absent values still let the
+/// model bundle/runtime decide.
 ///
 /// Match excludes `coder` variants (none ship today, but mirroring
 /// `QwenThinkingProfile`'s shape for consistency if NVIDIA publishes one).
@@ -643,7 +644,10 @@ struct NemotronThinkingProfile: ModelProfile {
 
     static func matches(modelId: String) -> Bool {
         let lower = modelId.lowercased()
-        return ModelFamilyNames.isNemotronThinkingFamily(modelId) && !lower.contains("coder")
+        return
+            (ModelFamilyNames.isNemotronThinkingFamily(modelId)
+            || ModelFamilyNames.isAudexFamily(modelId))
+            && !lower.contains("coder")
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -71,6 +71,10 @@ enum VLMDetection {
                 return true
             }
             guard let json = readConfigJSON(at: directory) else { return false }
+            let modelType = (json["model_type"] as? String)?.lowercased()
+            if modelType == "nemotron_dense_audex" || modelType == "nemotron_h_audex" {
+                return true
+            }
             return json["vision_config"] != nil
         }
     }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8d111cc773598230c81735c36eabc920db8374c5"
+        "revision" : "58553de7d29ea3881b8a54048cff815aa6c55ab9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f2b184841e98d969e46dec83109f27cd7bb57357"
+        "revision" : "6de24bbaf1164948692a869531100bc845c9bbf6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6de24bbaf1164948692a869531100bc845c9bbf6"
+        "revision" : "8d111cc773598230c81735c36eabc920db8374c5"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -79,7 +79,7 @@ let package = Package(
         // audio-input/text-output runtimes.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8d111cc773598230c81735c36eabc920db8374c5"
+            revision: "58553de7d29ea3881b8a54048cff815aa6c55ab9"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -75,10 +75,11 @@ let package = Package(
         // follow-up separates typed-disk persistence from paged compatibility,
         // restores recurrent companions at the exact matched boundary, and
         // keeps every unproven cache topology fail-closed. The pinned revision
-        // adds the native Nemotron-Labs-Audex-2B audio-input/text-output runtime.
+        // adds the native Nemotron-Labs-Audex 2B and 30B-A3B
+        // audio-input/text-output runtimes.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6de24bbaf1164948692a869531100bc845c9bbf6"
+            revision: "8d111cc773598230c81735c36eabc920db8374c5"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -74,10 +74,11 @@ let package = Package(
         // enables safe image/audio hybrid-prefix restore. The paged-cache
         // follow-up separates typed-disk persistence from paged compatibility,
         // restores recurrent companions at the exact matched boundary, and
-        // keeps every unproven cache topology fail-closed.
+        // keeps every unproven cache topology fail-closed. The pinned revision
+        // adds the native Nemotron-Labs-Audex-2B audio-input/text-output runtime.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f2b184841e98d969e46dec83109f27cd7bb57357"
+            revision: "6de24bbaf1164948692a869531100bc845c9bbf6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Model/MLXModelTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MLXModelTests.swift
@@ -77,6 +77,33 @@ struct MLXModelTests {
         #expect(!model.isVLM)
     }
 
+    @Test(
+        "Downloaded Audex model types retain multimodal runtime identity",
+        arguments: ["nemotron_dense_audex", "nemotron_h_audex"]
+    )
+    func downloadedAudexModelTypeIsVLM(modelType: String) async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let model = MLXModel(
+            id: "local/runtime-bundle",
+            name: "runtime-bundle",
+            description: "",
+            downloadURL: "https://example.com/repo",
+            rootDirectory: tempDir
+        )
+        let dir = model.localDirectory
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data(#"{"model_type":"\#(modelType)"}"#.utf8)
+            .write(to: dir.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: dir.appendingPathComponent("tokenizer.json"))
+        try Data([0x00]).write(to: dir.appendingPathComponent("model.safetensors"))
+
+        #expect(model.isDownloaded)
+        #expect(model.isVLM)
+    }
+
     @Test func isDownloaded_falseWhenMissingConfig() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -31,6 +31,7 @@ struct ModelMediaCapabilitiesMCDCTests {
         for modelId in [
             "nvidia/Nemotron-Labs-Audex-2B",
             "Nemotron-Labs-Audex-2B-4bit-vMLX",
+            "OsaurusAI/Nemotron-Labs-Audex-30B-A3B-6bit",
             "nemotron_labs_audex_local",
         ] {
             let cap = ModelMediaCapabilities.from(modelId: modelId)

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -5,6 +5,7 @@
 // must independently flip its flag based on regex/substring matching.
 //
 // Decision tree from the implementation:
+//   D0: contains `nemotron-labs-audex`                        → .audioOnly
 //   D1: matches `nemotron-3-nano-omni|nemotron_h_omni`        → .omni
 //   D2: matches `qwen[2-3](\.\d+|_\d+)?[-_]?vl`               → .imageVideo
 //   D3: matches `qwen3\.[5-6].*[-_]vl|holo3.*[-_]vl`          → .imageVideo
@@ -24,6 +25,21 @@ import Testing
 
 @Suite("ModelMediaCapabilities — MC/DC coverage")
 struct ModelMediaCapabilitiesMCDCTests {
+
+    @Test("D0: Audex advertises audio without image or video")
+    func d0_audexAudioOnly() {
+        for modelId in [
+            "nvidia/Nemotron-Labs-Audex-2B",
+            "Nemotron-Labs-Audex-2B-4bit-vMLX",
+            "nemotron_labs_audex_local",
+        ] {
+            let cap = ModelMediaCapabilities.from(modelId: modelId)
+            #expect(cap == .audioOnly)
+            #expect(cap.supportsAudio)
+            #expect(!cap.supportsImage)
+            #expect(!cap.supportsVideo)
+        }
+    }
 
     // MARK: - D1: Nemotron-3 omni (audio + video + image)
 
@@ -378,6 +394,13 @@ struct ModelMediaCapabilitiesMCDCTests {
                 modelId: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
                 fallbackSupportsImages: false
             ) == .omni
+        )
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "nvidia/Nemotron-Labs-Audex-2B",
+                fallbackSupportsImages: true
+            ) == .audioOnly,
+            "generic VLM fallback must not add image support to known audio-only Audex"
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
@@ -142,6 +142,18 @@ struct ModelPickerItemChatCapabilityTests {
         #expect(localLooksLikeEmbedding.isLikelyChatCapable)
     }
 
+    @Test func audexVLMFactoryIdentityDoesNotAdvertiseImages() {
+        let audex = ModelPickerItem(
+            id: "nvidia/Nemotron-Labs-Audex-2B",
+            displayName: "Nemotron-Labs-Audex-2B",
+            source: .local,
+            isVLM: true
+        )
+
+        #expect(!ChatSession.modelSupportsImages(modelId: audex.id, pickerItems: [audex]))
+        #expect(ModelMediaCapabilities.from(modelId: audex.id) == .audioOnly)
+    }
+
     @Test func localEmbeddingModelsAreNotChatCapable() {
         // An embedding bundle imported from the HF cache (e.g.
         // minishlab/potion-base-4M downloaded by the memory feature) is not

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -183,6 +183,26 @@ struct ModelProfileRegistryTests {
         }
     }
 
+    @Test("Audex exposes the explicit Nemotron thinking toggle without changing media identity")
+    func audexMatchesNemotronProfileWithoutThinkingFamilyMediaFallback() {
+        for id in [
+            "OsaurusAI/Nemotron-Labs-Audex-2B-4bit",
+            "OsaurusAI/Nemotron-Labs-Audex-30B-A3B-8bit",
+            "nemotron_labs_audex_local",
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            #expect(profile?.displayName == NemotronThinkingProfile.displayName)
+            #expect(ModelFamilyNames.isAudexFamily(id))
+            #expect(!ModelFamilyNames.isNemotronThinkingFamily(id))
+            #expect(ModelMediaCapabilities.from(modelId: id) == .audioOnly)
+            #expect(
+                ModelProfileRegistry.normalizedOptions(for: id, persisted: nil)[
+                    "disableThinking"
+                ] == nil
+            )
+        }
+    }
+
     /// Older "Nemotron-Cascade-2" / "Nemotron-Hyper" bundles use a different
     /// model-type lineage (deprecated NeMo style) and shouldn't accidentally
     /// pick up the new profile. Locks the matcher specificity to `nemotron-3`.

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -2080,6 +2080,39 @@ struct MLXBatchAdapterTests {
         }
     }
 
+    @Test func additionalContext_honorsExplicitAudexInstructAndThinkingModes() {
+        for modelName in [
+            "OsaurusAI/Nemotron-Labs-Audex-2B-4bit",
+            "OsaurusAI/Nemotron-Labs-Audex-30B-A3B-6bit",
+        ] {
+            let unspecified = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(temperature: nil, maxTokens: 16),
+                modelName: modelName
+            )
+            #expect(unspecified["enable_thinking"] == nil)
+
+            let instruct = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["disableThinking": .bool(true)]
+                ),
+                modelName: modelName
+            )
+            #expect(instruct["enable_thinking"] as? Bool == false)
+
+            let thinking = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["disableThinking": .bool(false)]
+                ),
+                modelName: modelName
+            )
+            #expect(thinking["enable_thinking"] as? Bool == true)
+        }
+    }
+
     /// MiniMax M2/M2.7 bundles are reasoning-capable. Live post-tool proof on
     /// `minimax-m2.7-jang_k-crack` showed the omitted-template-default path can
     /// spend the whole response in hidden reasoning after a tool result. Keep

--- a/Packages/OsaurusCore/Tests/Service/MultiTurnFamilyMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MultiTurnFamilyMatrixTests.swift
@@ -196,6 +196,18 @@ struct CapabilityFromDirectoryTests {
         #expect(cap == .omni, "config_omni.json must resolve to omni")
     }
 
+    @Test func audexModelTypeIsAudioOnlyWithoutVisionConfig() throws {
+        let dir = try makeBundle(
+            modelType: "nemotron_dense_audex",
+            hasVisionConfig: false,
+            hasOmniSidecar: false
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let cap = ModelMediaCapabilities.from(directory: dir, modelId: "local-audex")
+        #expect(cap == .audioOnly)
+    }
+
     /// Vision config + video-capable model_type → imageVideo.
     @Test(arguments: [
         "qwen2_vl", "qwen2_5_vl", "qwen3_vl",

--- a/Packages/OsaurusCore/Tests/Service/MultiTurnFamilyMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MultiTurnFamilyMatrixTests.swift
@@ -196,9 +196,10 @@ struct CapabilityFromDirectoryTests {
         #expect(cap == .omni, "config_omni.json must resolve to omni")
     }
 
-    @Test func audexModelTypeIsAudioOnlyWithoutVisionConfig() throws {
+    @Test(arguments: ["nemotron_dense_audex", "nemotron_h_audex"])
+    func audexModelTypeIsAudioOnlyWithoutVisionConfig(modelType: String) throws {
         let dir = try makeBundle(
-            modelType: "nemotron_dense_audex",
+            modelType: modelType,
             hasVisionConfig: false,
             hasOmniSidecar: false
         )

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1180,7 +1180,10 @@ final class ChatSession: ObservableObject {
     /// model rejects the image part with a visible provider error.
     static func modelSupportsImages(modelId: String, pickerItems: [ModelPickerItem]) -> Bool {
         if modelId.lowercased() == "foundation" { return false }
-        if ModelMediaCapabilities.from(modelId: modelId).supportsImage { return true }
+        let declaredCapabilities = ModelMediaCapabilities.from(modelId: modelId)
+        if declaredCapabilities != .textOnly {
+            return declaredCapabilities.supportsImage
+        }
         guard let option = pickerItems.first(where: { $0.id == modelId }) else { return false }
         // Image-edit models accept image input (osaurus image-edit feature).
         if option.imageCapabilities?.imageEdit == true { return true }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8d111cc773598230c81735c36eabc920db8374c5"
+        "revision" : "58553de7d29ea3881b8a54048cff815aa6c55ab9"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f2b184841e98d969e46dec83109f27cd7bb57357"
+        "revision" : "6de24bbaf1164948692a869531100bc845c9bbf6"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6de24bbaf1164948692a869531100bc845c9bbf6"
+        "revision" : "8d111cc773598230c81735c36eabc920db8374c5"
       }
     },
     {


### PR DESCRIPTION
## Summary

Wires NVIDIA Nemotron-Labs Audex 2B and 30B-A3B into Osaurus/Dinoki as audio-input/text-output models and pins the companion runtime PR exactly.

- Detects repository names containing `nemotron-labs-audex` or `nemotron_labs_audex`.
- Detects downloaded bundle types `nemotron_dense_audex` and `nemotron_h_audex` as multimodal runtime identities.
- Advertises audio only; Audex VLM identity cannot widen picker support to image/video.
- Exposes the model template's explicit thinking toggle without injecting a default.
- Maps `disableThinking=true` to `enable_thinking=false`, `false` to `true`, and keeps the key absent when the user has not chosen a value.
- Covers both model types in directory detection, media-capability, profile, adapter, and multi-turn matrix tests.

## Exact dependency

All four dependency surfaces pin vMLX revision:

`58553de7d29ea3881b8a54048cff815aa6c55ab9`

- `Packages/OsaurusCore/Package.swift`
- `Packages/OsaurusCore/Package.resolved`
- `osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- `App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`

Companion runtime PR: https://github.com/osaurus-ai/vmlx-swift/pull/168

## Public models

- https://huggingface.co/OsaurusAI/Nemotron-Labs-Audex-2B-4bit
- https://huggingface.co/OsaurusAI/Nemotron-Labs-Audex-2B-6bit
- https://huggingface.co/OsaurusAI/Nemotron-Labs-Audex-2B-8bit
- https://huggingface.co/OsaurusAI/Nemotron-Labs-Audex-30B-A3B-4bit
- https://huggingface.co/OsaurusAI/Nemotron-Labs-Audex-30B-A3B-6bit
- https://huggingface.co/OsaurusAI/Nemotron-Labs-Audex-30B-A3B-8bit

Every repository is public and passed a complete post-upload filename/size/SHA-256 comparison against the locally live-tested bundle.

## Dinoki request contract

- Accept audio attachments and text; reject image/video before inference.
- Route through the normal VLM/audio processor.
- Map OpenAI-compatible `input_audio` or `audio_url` content to `Chat.Message.audios`.
- Do not inject literal sound/embedding markers; the processor owns placeholder expansion.
- Use batch size 1.
- Preserve bundle sampler defaults unless the user explicitly overrides them.
- For the currently proven path, send the user's explicit instruct selection as `enable_thinking=false`.
- Do not advertise output audio, TTS, text-to-audio, or speech-to-speech from these input-audio quants.

## Verification

The current exact-pin package run resolved vMLX at the revision above and passed 180 tests in 9 affected suites. The companion runtime has live audio plus three-turn evidence for all six quant tiers, including normal stops, visible semantic output, token/s, sampled physical footprint, and no marker leakage.

## Proof boundary

Overall status is PARTIAL. Omitted/default thinking failed representative 2B and 30B rows with unclosed reasoning and zero visible output. Packaged-app attachment flow, live OpenAI endpoint audio, prefix/paged/L2 counters, fresh-process restore, and 30B Mamba companion-state restore remain unproven. No forced-close, hidden sampler, prompt-coercion, or output-rewrite workaround is included.

