### PR TITLE
Fix launch-time SSD prefix cache misses

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -1531,7 +1531,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             // Keep plugin and repository work off the initial bind path;
             // crashes here are handled by the plugin loading marker.
             Task { @MainActor in
-                await PluginManager.shared.loadAll()
+                await PluginManager.shared.ensurePromptCatalogReady()
             }
             PluginRepositoryService.shared.startBackgroundRefresh()
         }

--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -133,6 +133,12 @@ final class PluginManager {
     /// calls from overwriting and deallocating each other's host contexts.
     private var activeReloadTask: Task<Void, Never>?
 
+    /// True while PluginManager, ToolRegistry, and SkillManager expose one
+    /// complete catalog snapshot. A reload clears it until registry mutation
+    /// finishes. Prompt composition uses this readiness boundary so a
+    /// persisted KV prefix can never depend on launch/reload task timing.
+    private var isPromptCatalogReady = false
+
     private init() {}
 
     /// Returns the load error for a specific plugin, if any
@@ -181,6 +187,19 @@ final class PluginManager {
 
     // MARK: - Loading
 
+    /// Wait for the process's initial plugin catalog snapshot without turning
+    /// every prompt into a rescan. Concurrent launch/warmup/send callers join
+    /// the same `activeReloadTask`; later install/uninstall paths still call
+    /// `loadAll()` directly to refresh the catalog.
+    func ensurePromptCatalogReady() async {
+        if isPromptCatalogReady { return }
+        if let task = activeReloadTask {
+            await task.value
+            return
+        }
+        await loadAll()
+    }
+
     /// Result of heavy plugin scanning performed on a background thread.
     private struct PluginScanResult: @unchecked Sendable {
         let allURLs: [URL]
@@ -204,6 +223,7 @@ final class PluginManager {
             }
         }
 
+        isPromptCatalogReady = false
         let task = Task {
             await _loadAll(forceReload: forceReload)
         }
@@ -338,6 +358,11 @@ final class PluginManager {
         }
 
         observeTunnelStatus()
+        // Every model-facing tool/skill registry mutation is complete here.
+        // Publish readiness before first-delivery callbacks: a plugin is
+        // allowed to invoke host inference from a callback, and making that
+        // nested request await its own active reload task would deadlock.
+        isPromptCatalogReady = true
         // Per-plugin first-delivery sweep, each step bracketed by the
         // `.currently_loading` marker. A SIGABRT inside the plugin's
         // `on_config_changed` (e.g. misaligned ABI mirror calling

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2903,6 +2903,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         // `effectiveToolsDisabled` does not read it, so it must be folded
         // in here (the app chat path does the same via `chatCfg.disableTools`).
         let globalToolsDisabled = await MainActor.run { ChatConfigurationStore.load().disableTools }
+        await PluginManager.shared.ensurePromptCatalogReady()
         let composed = await SystemPromptComposer.composeChatContext(
             agentId: agentUUID,
             executionMode: executionMode,

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -21,6 +21,12 @@ extension ChatSession: ChatWarmupSessionContext {
         let effectiveAgentId = agentId ?? Agent.defaultId
         let executionMode = await prepareChatExecutionMode(agentId: effectiveAgentId)
 
+        // The plugin catalog is part of the static system/tool prefix. Wait
+        // for its one-time launch snapshot before warming, otherwise the same
+        // installed plugins can render a different prefix across process
+        // restarts and bypass an otherwise valid disk-L2 cache entry.
+        await PluginManager.shared.ensurePromptCatalogReady()
+
         let liveToolMode = AgentManager.shared.effectiveToolSelectionMode(for: effectiveAgentId)
         let liveFingerprint = SessionToolState.fingerprint(
             executionMode: executionMode,

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -1464,7 +1464,9 @@ public struct SystemPromptComposer: Sendable {
 
     /// Friendly plugin name for the manifest. Native plugins carry a
     /// `name` in their manifest; MCP / sandbox-plugin groups don't, so we
-    /// fall back to the raw group id.
+    /// fall back to the raw group id. Production prompt entry points wait for
+    /// `PluginManager.ensurePromptCatalogReady()` before reaching here, so
+    /// launch scheduling cannot alternate between the two representations.
     @MainActor
     private static func pluginDisplayName(for pluginId: String) -> String {
         if let loaded = PluginManager.shared.loadedPlugin(for: pluginId),

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -969,6 +969,7 @@ final class PluginHostContext: @unchecked Sendable {
             )
             cachedSession = await SessionToolStateStore.shared.get(sid)
         }
+        await PluginManager.shared.ensurePromptCatalogReady()
         let composed = await SystemPromptComposer.composeChatContext(
             agentId: agentId,
             executionMode: execMode,

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -61,6 +61,37 @@ struct RuntimePolicySourceTests {
         }
     }
 
+    @Test("production prompt entry points wait for the initial plugin catalog")
+    func promptCompositionWaitsForPluginCatalog() throws {
+        let manager = try Self.source("Managers/Plugin/PluginManager.swift")
+        #expect(manager.contains("private var isPromptCatalogReady = false"))
+        #expect(manager.contains("func ensurePromptCatalogReady() async"))
+        #expect(manager.contains("if let task = activeReloadTask"))
+        #expect(manager.contains("isPromptCatalogReady = true"))
+
+        for path in [
+            "Services/Chat/ChatSessionWarmup.swift",
+            "Views/Chat/ChatView.swift",
+            "Networking/HTTPHandler.swift",
+            "Services/Plugin/PluginHostAPI.swift",
+        ] {
+            let source = try Self.source(path)
+            let readiness = try #require(
+                source.range(of: "await PluginManager.shared.ensurePromptCatalogReady()")
+            )
+            let compose = try #require(
+                source.range(
+                    of: "SystemPromptComposer.composeChatContext",
+                    range: readiness.upperBound ..< source.endIndex
+                )
+            )
+            #expect(
+                readiness.lowerBound < compose.lowerBound,
+                "\(path) must await plugin readiness before composing a cacheable prompt"
+            )
+        }
+    }
+
     @Test("Makefile builds through workspace resolver mirrors")
     func makefileUsesWorkspaceResolver() throws {
         let source = try Self.source("../../Makefile")
@@ -1917,7 +1948,9 @@ struct RuntimePolicySourceTests {
             successfulStartBody.range(of: "guard !hasCompletedFirstServerStartWork else { return }")
         )
         let startupComplete = try #require(successfulStartBody.range(of: startupCompleteCall))
-        let pluginLoad = try #require(successfulStartBody.range(of: "await PluginManager.shared.loadAll()"))
+        let pluginLoad = try #require(
+            successfulStartBody.range(of: "await PluginManager.shared.ensurePromptCatalogReady()")
+        )
         let pluginRepositoryRefresh = try #require(
             successfulStartBody.range(of: "PluginRepositoryService.shared.startBackgroundRefresh()")
         )

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4229,6 +4229,15 @@ final class ChatSession: ObservableObject {
                         self.isScreenContextFrozen = true
                     }
 
+                    // Keep the first real send byte-identical to warmup and
+                    // restart restore: plugin tools/skills are part of the
+                    // static prompt and must come from a completed catalog
+                    // snapshot, not launch-task timing.
+                    if !isRemoteAgentTarget {
+                        await PluginManager.shared.ensurePromptCatalogReady()
+                        guard isRunActive(runId) else { return }
+                    }
+
                     let context = await SystemPromptComposer.composeChatContext(
                         agentId: effectiveAgentId,
                         executionMode: executionMode,

--- a/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
+++ b/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
@@ -65,6 +65,76 @@ TurboQuant Off, but no current-version default is promoted solely from this
 document; it must be observed in the development Release app and confirmed by
 the next request's effective counters.
 
+#### Launch-time prompt-catalog stability (2026-07-21)
+
+Status: **VERIFIED-LIVE for Gemma 4 12B MXFP8, Ornith 9B MXFP8, and Bonsai
+27B 1-bit JANG native-SSD text rows; PARTIAL for every other topology and
+setting row.** A current-main Release app reproduced a distinct
+reason that an otherwise valid SSD checkpoint can miss on restart: plugin
+loading raced model warmup. The first process composed a 650-token static
+prefix whose capability manifest named `plugin/osaurus.browser` as `Browser`;
+after restart, warmup ran before that plugin manifest was loaded and composed
+652 tokens naming the same capability `osaurus.browser`. The static-prefix
+hash changed from `098112c4c4d65328` to `dc3b73b7d7b77196`, so vMLX correctly
+reported `MISS all tiers` and performed full prefill. This was a prompt-identity
+race above the cache engine, not an SSD lookup failure.
+
+The candidate makes initial warmup, local UI send, enriched HTTP agent
+requests, and plugin-host inference await one completed plugin/tool/skill
+catalog snapshot before composing the static prompt. It does not force a raw
+plugin ID or otherwise change the established user-visible prompt contract.
+On the same isolated root that reproduced the miss, the patched Release app
+returned to the 650-token prefix/hash and restored SSD boundary 1,643 with
+only three warmup tokens remaining. A real UI request returned exact
+`GEMMA12-RESTART-HIT` at TTFT 0.65 seconds and 32.0 tok/s; its 1,747-token
+prompt restored boundary 1,646 with 101 suffix tokens remaining. Settings
+visibly showed Prefix and SSD On, paged GPU cache Off, Codec Engine Selected,
+SSM re-derive On, and `All changes saved`.
+
+The clean-profile gate used the ad-hoc-signed Release app
+`/private/tmp/Osaurus Cache Catalog Fresh Proof 20260721.app`, bundle id
+`com.dinoki.osaurus.cachecatalogfreshproof20260721`, executable SHA-256
+`d43ce37c923bacc6e169e713f87654bffebf75a38dc53a60469480682fc23efd`,
+isolated root
+`/private/tmp/osaurus-cache-catalog-fresh-proof-root-20260721-0636`, and exact
+resolved vMLX revision
+`b87cdd6b2a9f05f600461e41b239b7197151d9ff`. Before launch the root was empty
+and the custom bundle had no UserDefaults domain. Onboarding, Browser plugin
+installation, model selection, new-chat creation, and every quit/relaunch were
+performed in the real UI. Settings visibly showed Prefix Cache On, Disk Cache
+On, GPU/Paged Cache Off, Codec Engine Selected, SSM re-derive On, and `All
+changes saved`; Thinking remained visibly Off for all three models.
+
+Observed clean-profile rows:
+
+- **Gemma 4 12B it MXFP8 (40 rotating + 8 full KV layers):** cold warmup
+  persisted the 1,643-token stable boundary. A new chat restored 1,643 of
+  1,646 warmup tokens, then returned exact `FRESH-GEMMA-NEWCHAT` at TTFT 0.61s
+  and 32.4 tok/s. Full app restart again restored 1,643/1,646 and returned
+  exact `FRESH-GEMMA-RESTART` at TTFT 0.61s and 32.4 tok/s. The initial cold
+  answer was coherent but omitted a requested final period, so it is not
+  counted as exact-instruction proof.
+- **Ornith 1.0 9B MXFP8 / Qwen 3.5 hybrid (24 Mamba/GDN + 8 full KV
+  layers):** the one-time Gemma-to-Ornith model switch and first Ornith-only
+  chat were cold as expected. The next new chat restored SSD boundary 1,743
+  of 1,746 with all 48 recurrent companion arrays and returned exact
+  `ORNITH-NEWCHAT` at TTFT 0.35s and 52.0 tok/s. Full app restart restored the
+  same partial KV/companion checkpoint and returned exact `ORNITH-RESTART` at
+  TTFT 0.36s and 51.8 tok/s.
+- **Bonsai 27B 1-bit JANG CRACK / Qwen 3.5 hybrid (48 Mamba/GDN + 16 full KV
+  layers):** the second Bonsai-only chat restored SSD boundary 3,795 of 3,798
+  with all 96 recurrent companion arrays and returned exact
+  `BONSAI-NEWCHAT` at TTFT 0.84s and 36.6 tok/s. Full app restart restored the
+  same checkpoint and returned exact `BONSAI-RESTART` at TTFT 0.85s and 36.7
+  tok/s. The 10 GiB quota evicted complete KV/companion records during later
+  writes; a subsequent new chat still restored 3,795/3,798 and both current
+  KV/SSM entries were reported as already validated.
+
+These rows do not generalize to base Qwen 3.5, Qwen VL/media salt, Gemma VL,
+LFM, MiniMax, Nemotron, DSV4, explicit paged RAM On, explicit TurboQuant On,
+corruption recovery, or configuration-change invalidation. TurboQuant stayed
+Off/default-native throughout; no TurboQuant topology claim is made.
+
 Current Ornith evidence from the isolated Release app
 `com.dinoki.osaurus.applescriptemergency20260720` (SHA-256
 `114fbe282e9e2872abe88ca8c991da6ebc1b7c9e19f0ef5029bd94c54511fd9b`)


### PR DESCRIPTION
## Root cause

Osaurus could warm a model before the installed plugin catalog finished loading. The same Browser capability therefore rendered as `Browser` on one launch and the raw `osaurus.browser` id on another. That changed the static prompt from 650 to 652 tokens (hash `098112c4c4d65328` to `dc3b73b7d7b77196`), so vMLX correctly rejected the prior disk-L2 checkpoint and performed a cold prefill.

This is a prompt-identity race above the cache engine, not a missing-model, quantization, or SSD lookup workaround.

## Changes

- Add one `PluginManager.ensurePromptCatalogReady()` readiness boundary shared by concurrent launch, warmup, send, HTTP-agent, and plugin-host inference paths.
- Publish readiness only after PluginManager, ToolRegistry, and SkillManager mutations finish, but before plugin first-delivery callbacks so callback-triggered inference cannot self-deadlock.
- Preserve friendly plugin display names; no prompt rewrite, sampler override, reasoning coercion, or cache-default change.
- Add a source contract covering all production prompt-composition entry points.
- Record the exact source and live proof plus the unproven matrix boundaries in the cache/runtime policy document.

## Source/build verification

- Base/current `main`: `cee858bc84ccf49cdab1d05dcdcbfb83eed520de`
- Resolved vMLX: `b87cdd6b2a9f05f600461e41b239b7197151d9ff`
- Isolated Release app: `/private/tmp/Osaurus Cache Catalog Fresh Proof 20260721.app`
- Bundle id: `com.dinoki.osaurus.cachecatalogfreshproof20260721`
- Executable SHA-256: `d43ce37c923bacc6e169e713f87654bffebf75a38dc53a60469480682fc23efd`
- `codesign --verify --deep --strict`: passed
- `git diff --check`: passed; exactly 9 intended Osaurus files, no vMLX pin change
- Focused workspace tests passed: `EnabledCapabilitiesManifestTests`, `RuntimePolicySourceTests`, `ChatWarmupControllerTests`

## Live Release UI verification

All onboarding, Browser installation, model selection, new-chat creation, settings changes, prompts, and quit/relaunch operations were performed in the real Release app through Computer Use on an empty isolated root. The UI visibly showed Prefix Cache On, Disk Cache On, GPU/Paged Cache Off, Codec Engine Selected, SSM re-derive On, `All changes saved`, and Thinking Off.

- Gemma 4 12B it MXFP8: new chat restored disk boundary 1,643/1,646 and returned exact `FRESH-GEMMA-NEWCHAT`, TTFT 0.61s, 32.4 tok/s. Full app restart restored the same boundary and returned exact `FRESH-GEMMA-RESTART`, TTFT 0.61s, 32.4 tok/s.
- Ornith 1.0 9B MXFP8 / Qwen 3.5 hybrid: new chat restored 1,743/1,746 plus all 48 recurrent companion arrays and returned exact `ORNITH-NEWCHAT`, TTFT 0.35s, 52.0 tok/s. Full restart restored the same checkpoint and returned exact `ORNITH-RESTART`, TTFT 0.36s, 51.8 tok/s.
- Bonsai 27B 1-bit JANG CRACK / Qwen 3.5 hybrid: new chat restored 3,795/3,798 plus all 96 recurrent companion arrays and returned exact `BONSAI-NEWCHAT`, TTFT 0.84s, 36.6 tok/s. Full restart restored the same checkpoint and returned exact `BONSAI-RESTART`, TTFT 0.85s, 36.7 tok/s. Under the visible 10 GiB SSD quota, complete older KV/companion records were evicted and the current partial checkpoint still restored.

No MXFP4 model was loaded or used.

## Explicitly not claimed by this PR

The named native-SSD text rows are verified live. Base Qwen 3.5, Qwen VL/media-salt reuse, Gemma VL, LFM, MiniMax, Nemotron, DSV4, paged-RAM On, TurboQuant On, corruption recovery, configuration invalidation, RAM-safety/delegation, and the broader AppleScript matrix remain PARTIAL and are not hidden behind this emergency fix. TurboQuant remained Off/default-native throughout.
