### PR TITLE
Attach SSD cache before publishing loaded models

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b87cdd6b2a9f05f600461e41b239b7197151d9ff"
+        "revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b87cdd6b2a9f05f600461e41b239b7197151d9ff"
+        "revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
         // companion state.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b87cdd6b2a9f05f600461e41b239b7197151d9ff"
+            revision: "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -366,19 +366,6 @@ final class ChatWarmupController: ObservableObject {
         guard !Task.isCancelled else { return }
         guard shouldAttemptWarmup(session: session) else { return }
 
-        // Never warm up over a load already in flight: under strict
-        // single-model residency this warm-up's own load would cancel the
-        // in-flight one (an explicit API request, or another window), and
-        // its prefill can be torn down mid-encode by the reciprocal
-        // eviction — a Metal command-buffer abort, not a graceful skip.
-        if await ModelRuntime.shared.hasLoadInFlight() {
-            state = .cold
-            debugLog(
-                "[ChatWarmup] skipped model=\(payload.model): another model load is in flight"
-            )
-            return
-        }
-
         // Speculative warm-ups must not evict. Loading a non-resident model
         // under strict single-model residency evicts whoever IS resident —
         // observed live as a launch-time warm-up for the restored UI
@@ -388,7 +375,13 @@ final class ChatWarmupController: ObservableObject {
         //
         // Resolved ONCE here and threaded down, so the early gate below and the
         // load intent in `runWarmupGeneration` can never disagree about whether
-        // this warm-up carries the user's intent.
+        // this warm-up carries the user's intent. Do not preflight the
+        // runtime's load-in-flight state here: that snapshot is stale after
+        // the actor hop and made a new chat permanently skip its static-prefix
+        // warm-up while the same model was still finishing a cancelled prior
+        // warm-up. The background load intent below is the atomic gate: it
+        // coalesces a same-model load and refuses a conflicting load before it
+        // can evict or cancel anything.
         let userIntent = consumeUserIntent(for: payload.model)
 
         if !userIntent,
@@ -405,7 +398,11 @@ final class ChatWarmupController: ObservableObject {
         let id = UUID()
         let task = Task { @MainActor in
             await runWarmupGeneration(
-                session: session, payload: payload, id: id, userIntent: userIntent)
+                session: session,
+                payload: payload,
+                id: id,
+                userIntent: userIntent
+            )
         }
         inFlightWarmup = task
         inFlightWarmupID = id
@@ -481,7 +478,7 @@ final class ChatWarmupController: ObservableObject {
         defer { WarmupProgressHub.shared.finish(model: payload.model) }
         do {
             let stream = try await engine.streamChat(request: request)
-            for try await _ in stream { /* discard warm-up output */ }
+            for try await _ in stream { /* discard warm-up output */  }
             // Stale-writer guard: a reset() (chat cleared / agent switched)
             // during the generation dropped this warm-up's claim; its result
             // must not resurrect a warm dot for a payload that no longer

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -738,10 +738,6 @@ public actor ModelRuntime {
         currentModelName = name
         Memory.cacheLimit = mlxCacheLimit()
 
-        // Enable multi-tier KV caching via vmlx-swift's CacheCoordinator.
-        // Cache tier config is entirely osaurus-internal — not user-visible.
-        await installCacheCoordinator(on: holder)
-
         // Native-MTP bundles historically ran their FIRST request in plain
         // autoregressive mode (the registry's cold-warmup rule), so the one
         // request most users judge a model by silently lost the speculative
@@ -2268,7 +2264,7 @@ public actor ModelRuntime {
             genLog.info(
                 "loadContainer: task loaded model=\(name, privacy: .public) loadID=\(loadID, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public) isVLM=\(isVLM, privacy: .public)"
             )
-            return SessionHolder(
+            let holder = SessionHolder(
                 name: name,
                 container: container,
                 weightsSizeBytes: loadFootprintBytes,
@@ -2282,6 +2278,18 @@ public actor ModelRuntime {
                         physicalMemory: ProcessInfo.processInfo.physicalMemory
                     )
             )
+
+            // Install the cache coordinator before the coalesced load task
+            // returns its holder. `finishLoadedContainer` publishes the holder
+            // in `modelCache` and is actor-reentrant across its post-load MTP
+            // warm-up; installing there let a rapid UI send observe a loaded
+            // model whose BatchEngine still had no coordinator. The request
+            // then generated coherently but could neither fetch nor store its
+            // SSD prefix. Keeping this inside the single shared load task makes
+            // "load complete" mean the configured prefix/paged/L2 policy is
+            // already attached for every waiter.
+            await Self.installCacheCoordinator(on: holder)
+            return holder
         }
 
         loadingTasks[name] = LoadingTaskRecord(id: loadID, task: task)
@@ -2693,7 +2701,8 @@ public actor ModelRuntime {
             let entries = try? fm.contentsOfDirectory(
                 at: directory,
                 includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey],
-                options: [.skipsHiddenFiles])
+                options: [.skipsHiddenFiles]
+            )
         else {
             // Unreadable bundle: fall back to a value that never matches a previous
             // load, so we take a cold prefill rather than risk a wrong-weights hit.
@@ -2797,10 +2806,10 @@ public actor ModelRuntime {
     }
 
     /// Installs the cache coordinator on a freshly-loaded holder.
-    private func installCacheCoordinator(on holder: SessionHolder) async {
+    private nonisolated static func installCacheCoordinator(on holder: SessionHolder) async {
         let cacheTopology = await holder.container.cacheTopologySnapshot()
         holder.cacheTopology = cacheTopology
-        let cacheConfig = Self.buildCacheCoordinatorConfig(
+        let cacheConfig = buildCacheCoordinatorConfig(
             modelName: holder.name,
             weightsFingerprint: holder.weightsFingerprint,
             cacheTopology: cacheTopology

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -275,6 +275,7 @@ struct ChatWarmupControllerRequestTests {
         #expect(engine.lastRequest?.modelOptions?["disableThinking"] == .bool(true))
         #expect(engine.lastRequest?.suppressProgressUI == true)
         #expect(engine.lastRequest?.warmupPrefill == true)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "b87cdd6b2a9f05f600461e41b239b7197151d9ff""#))
-        #expect(packageResolved.contains(#""revision" : "b87cdd6b2a9f05f600461e41b239b7197151d9ff""#))
-        #expect(workspaceResolved.contains(#""revision" : "b87cdd6b2a9f05f600461e41b239b7197151d9ff""#))
-        #expect(appResolved.contains(#""revision" : "b87cdd6b2a9f05f600461e41b239b7197151d9ff""#))
+        #expect(packageSwift.contains(#"revision: "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
+        #expect(packageResolved.contains(#""revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
+        #expect(workspaceResolved.contains(#""revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
+        #expect(appResolved.contains(#""revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -92,6 +92,18 @@ struct RuntimePolicySourceTests {
         }
     }
 
+    @Test("chat warm-up uses atomic background load intent instead of a stale load probe")
+    func chatWarmupDoesNotSkipSameModelLoadInFlight() throws {
+        let warmup = try Self.source("Services/Chat/ChatWarmupController.swift")
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+
+        #expect(!warmup.contains("ModelRuntime.shared.hasLoadInFlight()"))
+        #expect(warmup.contains("request.backgroundModelLoad = !userIntent"))
+        #expect(runtime.contains("Diagnostics only. Do **not** gate a load on this"))
+        #expect(runtime.contains("if let existingRecord = loadingTasks[name]"))
+        #expect(runtime.contains("refuseBackgroundLoadIfItWouldDisturb"))
+    }
+
     @Test("Makefile builds through workspace resolver mirrors")
     func makefileUsesWorkspaceResolver() throws {
         let source = try Self.source("../../Makefile")
@@ -740,7 +752,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "b87cdd6b2a9f05f600461e41b239b7197151d9ff"
+        let expectedRuntimeHardenedRevision = "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -1152,8 +1164,11 @@ struct RuntimePolicySourceTests {
         #expect(concurrency.contains("Concurrent Sessions"))
         #expect(concurrency.contains("Continuous Batching"))
         #expect(concurrency.contains("Prompt Prefill Chunk Size"))
-        #expect(concurrency.contains(
-            "draft.concurrency.maxConcurrentSequences != nil || clamped != 1"))
+        #expect(
+            concurrency.contains(
+                "draft.concurrency.maxConcurrentSequences != nil || clamped != 1"
+            )
+        )
     }
 
     @Test("Tools settings panel separates wired parser overrides from planned host bridges")
@@ -1926,7 +1941,10 @@ struct RuntimePolicySourceTests {
         let serverBind = try #require(launchBody.range(of: "await serverStartupTask.value"))
         let keychainBranch = try #require(launchBody.range(of: "if keychainDisabledTestMode {"))
         let safeModeBranch = try #require(
-            launchBody.range(of: "} else if !shouldLoadPluginsAtStartup {", range: keychainBranch.upperBound ..< launchBody.endIndex)
+            launchBody.range(
+                of: "} else if !shouldLoadPluginsAtStartup {",
+                range: keychainBranch.upperBound ..< launchBody.endIndex
+            )
         )
         let keychainStartupComplete = try #require(
             launchBody.range(of: startupCompleteCall, range: keychainBranch.upperBound ..< safeModeBranch.lowerBound)
@@ -1934,7 +1952,10 @@ struct RuntimePolicySourceTests {
         let runningCheck = try #require(launchBody.range(of: "if serverController.isRunning {"))
         let completionHook = try #require(launchBody.range(of: "completeFirstSuccessfulServerStart()"))
         let handledStartupErrorComplete = try #require(
-            launchBody.range(of: "LaunchGuard.markStartupComplete()", range: completionHook.upperBound ..< launchBody.endIndex)
+            launchBody.range(
+                of: "LaunchGuard.markStartupComplete()",
+                range: completionHook.upperBound ..< launchBody.endIndex
+            )
         )
         let isRunningSink = try #require(observerBody.range(of: "serverController.$isRunning"))
         let runningObserverHook = try #require(
@@ -2244,6 +2265,49 @@ struct RuntimePolicySourceTests {
         #expect(
             health.contains("\"automatic_memory_limits_disabled\":")
                 && health.contains("f.automaticMemoryLimitsDisabled")
+        )
+    }
+
+    @Test("coalesced model load installs cache policy before publishing its holder")
+    func modelLoadInstallsCacheCoordinatorBeforePublication() throws {
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+        let taskStart = try #require(
+            runtime.range(of: "let task = Task<SessionHolder, Error>")
+        )
+        let taskEnd = try #require(
+            runtime.range(
+                of: "loadingTasks[name] = LoadingTaskRecord",
+                range: taskStart.upperBound ..< runtime.endIndex
+            )
+        )
+        let taskBody = String(runtime[taskStart.lowerBound ..< taskEnd.lowerBound])
+        let install = try #require(
+            taskBody.range(of: "await Self.installCacheCoordinator(on: holder)")
+        )
+        let returnHolder = try #require(
+            taskBody.range(of: "return holder", range: install.upperBound ..< taskBody.endIndex)
+        )
+
+        #expect(install.lowerBound < returnHolder.lowerBound)
+        #expect(
+            runtime.contains(
+                "private nonisolated static func installCacheCoordinator(on holder: SessionHolder) async"
+            )
+        )
+
+        let finishStart = try #require(
+            runtime.range(of: "private func finishLoadedContainer(")
+        )
+        let finishEnd = try #require(
+            runtime.range(
+                of: "/// Unload `name`",
+                range: finishStart.upperBound ..< runtime.endIndex
+            )
+        )
+        let finishBody = String(runtime[finishStart.lowerBound ..< finishEnd.lowerBound])
+        #expect(
+            !finishBody.contains("installCacheCoordinator"),
+            "Actor-reentrant post-load finalization must not publish a holder before its cache coordinator is attached."
         )
     }
 
@@ -2644,7 +2708,11 @@ struct RuntimePolicySourceTests {
     func residentSameModelTurnsDoNotFlashModelLoadingUI() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
 
-        #expect(runtime.contains("let shouldReportModelLoad = modelCache[modelName] == nil && !parameters.suppressProgressUI"))
+        #expect(
+            runtime.contains(
+                "let shouldReportModelLoad = modelCache[modelName] == nil && !parameters.suppressProgressUI"
+            )
+        )
         #expect(
             runtime.contains(
                 "if shouldReportModelLoad {\n            InferenceProgressManager.shared.modelLoadWillStartAsync()"

--- a/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
+++ b/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
@@ -356,3 +356,76 @@ hot-to-SSD fallback, explicit TurboQuant On, corruption recovery, cache-key
 configuration invalidation, or Activity Monitor physical-footprint limits.
 TurboQuant remained Off/default-native throughout and no TurboQuant topology
 claim is made.
+
+## 2026-07-21 physical-footprint budget and pre-publication cache proof
+
+Status: **VERIFIED-LIVE for Qwen 3.6 27B JANG_4M CRACK and Gemma 4 12B it
+MXFP8 with native SSD cache, paged RAM Off, and TurboQuant Off; PARTIAL for all
+other families and cache modes.**
+
+This follow-up fixes two independent ways that an enabled SSD cache could
+behave like a cold cache:
+
+1. vMLX's store admission compared cache bytes only with MLX active bytes. A
+   memory-mapped model can have a low MLX-active count while the process already
+   has a large physical footprint, so the admission calculation understated
+   occupancy. vMLX revision
+   `a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7` now budgets stores from Darwin
+   `task_vm_info.phys_footprint`, using MLX active bytes only as a failure
+   fallback. The trace records `source=phys_footprint` or
+   `source=mlx_active_fallback` instead of making the source implicit.
+2. Osaurus published a loaded `SessionHolder` before its cache coordinator was
+   installed. A user who sent immediately after model selection could generate
+   a coherent response through a `BatchEngine` that had no prefix/paged/L2
+   coordinator, producing no SSD fetch or store at all. The single coalesced
+   load task now installs the coordinator before returning the holder to any
+   waiter. New-chat warmup also relies on the atomic background-load intent
+   instead of a stale `hasLoadInFlight()` preflight snapshot.
+
+The exact ad-hoc-signed Release app was
+`/private/tmp/Osaurus Cache Publication Proof 20260721-0854.app`, bundle id
+`com.dinoki.osaurus.physfootprintproof2`, executable SHA-256
+`be5ec47406c0647368bf23e87d19cef0e31b096476583f680ad937e432132896`, and
+isolated root
+`/private/tmp/osaurus-cache-publication-proof-root-20260721-0854`. The first
+process trace is
+`/private/tmp/osaurus-cache-publication-proof-20260721-0854.log`; the complete
+quit/relaunch trace is
+`/private/tmp/osaurus-cache-publication-restart-proof-20260721-0859.log`.
+Computer Use visibly confirmed Prefix Cache On, GPU/Paged Cache Off, SSD Disk
+Cache On, Codec Engine Selected, SSM Re-derive On, Safe Auto memory safety, and
+Thinking Off.
+
+Observed real-UI rows:
+
+- **Qwen 3.6 27B JANG_4M CRACK, rapid model-select/send:** immediately after
+  selecting the model, a new chat and send were issued while the UI still said
+  Warming up. The visible response was exactly `QWEN36-PUBLICATION`, TTFT 1.26
+  seconds, 23.4 tok/s, and 8 tokens. The first request missed 2,993 tokens, then
+  persisted 2,993 and the stable 2,990 boundary under
+  `source=phys_footprint`. Later partial requests restored 2,993/3,017 and
+  3,010/3,026 tokens with the hybrid topology reported as 48 `MambaCache` plus
+  16 `KVCacheSimple` layers and 96 recurrent companion states.
+- **Qwen complete-process restart:** after Cmd-Q and relaunch with the same
+  isolated root, startup warmup restored SSD boundary 2,990 of 2,993 tokens.
+  The first visible request returned exactly `QWEN36-RESTART`, TTFT 0.86
+  seconds, 22.9 tok/s, and 8 tokens; it restored boundary 2,993 with 82 novel
+  suffix tokens and subsequently restored boundary 3,068 with 16 remaining.
+  The macOS `footprint` sample reported 15 GiB current and 17 GiB peak physical
+  footprint for the first proof process.
+- **Gemma 4 12B it MXFP8 fresh chat after the same process restart:** changing
+  the existing Qwen conversation to Gemma correctly missed because the rendered
+  1,911-token prefix differed. Creating a real new chat then restored the prior
+  Gemma SSD boundary 1,630 of 1,633 tokens. Its visible request returned exactly
+  `GEMMA4-RESTART`, TTFT 0.63 seconds, 27.4 tok/s, and 10 tokens; it restored
+  boundary 1,633 of 1,740 tokens, then 1,740 of 1,751. Telemetry reported 40
+  `RotatingKVCache` layers and 8 `KVCacheSimple` layers.
+
+The cache index contained complete Qwen KV/companion records at boundaries
+2,990, 2,993, 3,010, 3,017, 3,023, 3,025, and 3,026 plus Gemma records at
+1,630 and 1,633. The Qwen companion payloads held 96 recurrent states. These
+rows establish persisted partial reuse and coherent warmup/request behavior for
+the two named native-cache bundles only. They do not establish Qwen VL/media
+salt, Bonsai, Ornith, LFM, MiniMax, DSV4, Nemotron, explicit paged-RAM On
+hot-to-SSD fallback, explicit TurboQuant On, cache corruption recovery, or
+configuration-change invalidation.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b87cdd6b2a9f05f600461e41b239b7197151d9ff"
+        "revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
       }
     },
     {


### PR DESCRIPTION
## Root causes

Two independent races made enabled SSD caching behave like a cold cache:

1. `ChatWarmupController` sampled `hasLoadInFlight()` before asking the runtime to load. That actor-hop snapshot could become stale and permanently skip a new-chat warmup while a cancelled same-model warmup was still finishing.
2. `ModelRuntime` returned and published a loaded `SessionHolder` before installing its vMLX cache coordinator. A rapid real UI send could therefore generate coherently but have no prefix/paged/L2 fetch or store path attached.

The pinned vMLX dependency also includes merged PR #172, which admits stores using Darwin `task_vm_info.phys_footprint` instead of treating MLX allocator accounting as process occupancy.

## Change

- Remove the stale warmup load probe; use the existing atomic background model-load intent to coalesce the same model and refuse conflicting speculative loads.
- Install the cache coordinator inside the single coalesced model-load task before it returns the holder to any waiter.
- Pin all four SwiftPM resolution points to exact live-tested vMLX commit `a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7` (merged through vMLX main commit `294d536df2f47ba5d323b0caf88dd1efaeea36e2`; both commits have identical trees).
- Add source contracts for both ordering guarantees and document exact Release-app proof.

No AppleScript, parser, reasoning, TurboQuant, paged-cache, media, routing, or model-family behavior is changed in this PR.

## Local verification

- Strict Swift format on all changed Swift files: pass.
- `git diff --check`: pass.
- Focused Xcode tests exited 0:
  - `ChatWarmupControllerRequestTests`
  - `ChatWarmupControllerModelSwitchTests`
  - `RuntimePolicySourceTests`
  - `ImageGenerationBridgeContractTests`
- Exact ad-hoc-signed Release app built successfully before the final formatting-only source wraps and documentation update.

## Live Computer Use proof

Exact artifact:
- `/private/tmp/Osaurus Cache Publication Proof 20260721-0854.app`
- bundle id `com.dinoki.osaurus.physfootprintproof2`
- executable SHA-256 `be5ec47406c0647368bf23e87d19cef0e31b096476583f680ad937e432132896`
- isolated root `/private/tmp/osaurus-cache-publication-proof-root-20260721-0854`
- traces `/private/tmp/osaurus-cache-publication-proof-20260721-0854.log` and `/private/tmp/osaurus-cache-publication-restart-proof-20260721-0859.log`

Computer Use visibly confirmed Prefix On, Paged/GPU Cache Off, SSD On, Engine Selected codec (TurboQuant Off), SSM Re-derive On, Safe Auto, and Thinking Off.

Qwen3.6 27B JANG_4M CRACK:
- immediate model-select/new-chat/send while Warming up returned exact `QWEN36-PUBLICATION`, TTFT 1.26s, 23.4 tok/s, 8 tokens.
- first 2,993-token miss stored under `source=phys_footprint`; later requests restored partial SSD boundaries with 48 `MambaCache`, 16 `KVCacheSimple`, and 96 companion states.
- after complete Cmd-Q/relaunch with the same root, warmup restored 2,990/2,993; the visible response was exact `QWEN36-RESTART`, TTFT 0.86s, 22.9 tok/s, 8 tokens.

Gemma 4 12B it MXFP8:
- after the same restart, a real new chat restored SSD boundary 1,630/1,633.
- visible response was exact `GEMMA4-RESTART`, TTFT 0.63s, 27.4 tok/s, 10 tokens.
- request restored 1,633/1,740 then 1,740/1,751; topology was 40 `RotatingKVCache` plus 8 `KVCacheSimple` layers.

## Proof boundary

Verified-live only for these two native-SSD bundles with paged RAM and TurboQuant off. Qwen VL/media, Bonsai, Ornith, LFM, MiniMax, DSV4, Nemotron, paged-On hot-to-SSD fallback, TurboQuant-On, corruption recovery, and configuration invalidation remain partial and are not claimed by this PR.