### PR TITLE
Restore SSD warmup prefixes across new chats

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
+        "revision" : "feb35555900398dc638c82a3e13e98f8b1adbf41"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -14,6 +14,22 @@ enum PrefillProgressStage: String, Codable, Sendable, Equatable {
     case cacheRestore
     case prefill
     case complete
+
+    /// Short, user-facing title for the runtime stage. Keeping cache lookup
+    /// and restore distinct from transformer prefill prevents an initial
+    /// `.cacheLookup(0/N)` event from being presented as a cold `Prefill 0/N`.
+    var localizedDisplayTitle: String {
+        switch self {
+        case .queued:
+            return L("Queued")
+        case .cacheLookup:
+            return L("Checking cache")
+        case .cacheRestore:
+            return L("Restored")
+        case .prefill, .complete:
+            return L("Prefill")
+        }
+    }
 }
 
 struct PrefillProgressState: Codable, Sendable, Equatable {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
+        "revision" : "feb35555900398dc638c82a3e13e98f8b1adbf41"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
         // companion state.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
+            revision: "feb35555900398dc638c82a3e13e98f8b1adbf41"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -34392,6 +34392,41 @@
         }
       }
     },
+    "Checking cache" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache wird geprüft"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시 확인 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка кэша"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在檢查快取"
+          }
+        }
+      }
+    },
     "Checking a secret in sandbox" : {
       "localizations" : {
         "de" : {
@@ -141211,6 +141246,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將僅影響視圖的設置恢復爲推薦默認值（不影響已保存配置）"
+          }
+        }
+      }
+    },
+    "Restored" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederhergestellt"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복원됨"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Восстановлено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已恢复"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已恢復"
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,10 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
-        #expect(packageResolved.contains(#""revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
-        #expect(workspaceResolved.contains(#""revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
-        #expect(appResolved.contains(#""revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7""#))
+        #expect(packageSwift.contains(#"revision: "feb35555900398dc638c82a3e13e98f8b1adbf41""#))
+        #expect(packageResolved.contains(#""revision" : "feb35555900398dc638c82a3e13e98f8b1adbf41""#))
+        #expect(workspaceResolved.contains(#""revision" : "feb35555900398dc638c82a3e13e98f8b1adbf41""#))
+        #expect(appResolved.contains(#""revision" : "feb35555900398dc638c82a3e13e98f8b1adbf41""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
@@ -16,6 +16,14 @@ import Testing
 @MainActor
 struct InferenceProgressManagerTests {
 
+    @Test func progressStageTitlesDistinguishCacheWorkFromPrefill() {
+        #expect(PrefillProgressStage.queued.localizedDisplayTitle == L("Queued"))
+        #expect(PrefillProgressStage.cacheLookup.localizedDisplayTitle == L("Checking cache"))
+        #expect(PrefillProgressStage.cacheRestore.localizedDisplayTitle == L("Restored"))
+        #expect(PrefillProgressStage.prefill.localizedDisplayTitle == L("Prefill"))
+        #expect(PrefillProgressStage.complete.localizedDisplayTitle == L("Prefill"))
+    }
+
     // Each test creates an isolated InferenceProgressManager via _testMake() so
     // tests don't share state with the global .shared singleton.
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -752,7 +752,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
+        let expectedRuntimeHardenedRevision = "feb35555900398dc638c82a3e13e98f8b1adbf41"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -1128,6 +1128,8 @@ struct RuntimePolicySourceTests {
         #expect(!cacheSection.contains(#"isOn: $draft.cache.legacyDisk.enabled"#))
         #expect(!cacheSection.contains(#"value: $draft.cache.legacyDisk.directory"#))
         #expect(cacheSection.contains("Works with paged RAM cache off"))
+        #expect(cacheSection.contains("SSD cache can still restore prefixes"))
+        #expect(!cacheSection.contains("Required for cross-request sharing"))
     }
 
     @Test("Server settings cache changes clear loaded model runtime")

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -285,9 +285,11 @@ final class NativeTypingIndicatorView: NSView {
     private func updatePrefillBadge(_ progress: PrefillProgressState?) {
         guard let progress, progress.totalUnitCount > 0 else {
             prefillBadge.isHidden = true
+            prefillTitleLabel.stringValue = L("Prefill")
             prefillCountLabel.stringValue = ""
             return
         }
+        prefillTitleLabel.stringValue = progress.stage.localizedDisplayTitle
         prefillCountLabel.stringValue = "\(progress.completedUnitCount)/\(progress.totalUnitCount)"
         prefillBadge.isHidden = false
         // The counter lives inside the RAM stack, so make sure that stack is

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift
@@ -35,7 +35,7 @@ struct CacheSection: View {
                     SettingsToggle(
                         title: L("Enable GPU Cache"),
                         description:
-                            "Block-based KV cache held in GPU memory. Required for cross-request sharing.",
+                            "Optional hot tier held in GPU memory. SSD cache can still restore prefixes across requests when this is off.",
                         isOn: $draft.cache.pagedKV.enabled
                     )
 
@@ -114,7 +114,7 @@ struct CacheSection: View {
             SettingsToggle(
                 title: L("Disk Cache"),
                 description:
-                    "Persist reusable cache blocks on SSD. Works with paged RAM cache off and restores the longest matching prefix after restart; turn off to disable disk reuse.",
+                    "Persist content-addressed prompt checkpoints on SSD. Works with paged RAM cache off and restores the longest matching prefix after restart; turn off to disable disk reuse.",
                 isOn: $draft.cache.blockDisk.enabled
             )
             OptionalDoubleField(
@@ -127,7 +127,7 @@ struct CacheSection: View {
             OptionalStringField(
                 label: "Disk Cache Directory",
                 placeholder: "Blank = Osaurus default cache directory",
-                help: "Absolute path or ~/... path for persisted block-cache entries.",
+                help: "Absolute path or ~/... path for persisted disk-cache entries.",
                 value: $draft.cache.blockDisk.directory
             )
         }

--- a/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026-07-21.md
+++ b/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026-07-21.md
@@ -1,0 +1,116 @@
+# SSD L2 new-chat partial-restore gate — 2026-07-21
+
+## Status
+
+`VERIFIED-LIVE — EMERGENCY N-1 FIX; BROADER CACHE MATRIX PARTIAL`
+
+This gate covers the report that a model becomes responsive in one chat but a
+new chat appears to prefill from zero while paged RAM cache is Off and Disk L2
+is On. Aggregate counters are supporting evidence only. A row is credited only
+when a request trace identifies the tier, matched boundary, remaining suffix,
+companion-state behavior, TTFT, token/s, and a coherent visible answer.
+
+## Root cause and scoped change
+
+Qwen 3.5-family templates such as Bonsai and Ornith can require a user message
+before they render. vMLX derives their stable system/tool prefix by intersecting
+two divergent synthetic user renders with the real request; synthetic content
+is never sent to the model or admitted to the stored stable prefix.
+
+Path-dependent hybrid restores deliberately reject an exact disk boundary.
+The GDN/Mamba/CCA state must be restored at N-1 and the final token re-fed.
+The previous stable-prefix writer stored N, so the first brand-new chat missed,
+did a cold prefill, and only then created a usable shorter snapshot for later
+chats. vMLX `feb35555900398dc638c82a3e13e98f8b1adbf41` stores the
+processor-proven stable checkpoint at N-1 for disk-backed hybrid topologies and
+keeps that safe seed in the preferred lookup set even after the bounded disk
+index contains more than 128 larger historical entries.
+
+Dense/full-KV and rotating-SWA topologies retain their existing boundary
+policy. ZAYA CCA remains explicit: its typed v2 payload owns CCA state and does
+not require a separate recurrent sidecar.
+
+Osaurus also labels runtime cache lookup/restore stages separately from actual
+transformer prefill. An initial cache lookup event is no longer displayed as a
+cold `Prefill 0/N`.
+
+## Source/test evidence
+
+- vMLX PR #173, head `feb35555`.
+- `HybridStripBoundaryPrefillTests`: 8/8, including first-new-chat N-1 restore.
+- canonical/coordinator matrix: 19/19.
+- topology and growing-chat source suites: 59/59.
+- updated BatchEngine growing-chat source suite: 17/17.
+- Osaurus consumes the same revision in all four package-pin surfaces.
+
+These checks are not live app proof.
+
+## Current `feb35555` Release-app proof
+
+The freshly built app at
+`/private/tmp/osaurus-ssd-warm-prefill-release-derived-20260721/Build/Products/Release/osaurus.app`
+was ad-hoc signed as `com.dinoki.osaurus.ssdwarmfeb355proof20260721`.
+Its executable SHA-256 was
+`488b2ce7106cb8e85bb3f27e69d4db7941abb6f977bc3174e09131169d22a3ea`,
+and the resolved vMLX checkout was exactly
+`feb35555900398dc638c82a3e13e98f8b1adbf41`.
+
+Computer Use visibly confirmed Prefix On, GPU/paged cache Off, Disk Cache On,
+codec `Engine Selected`, SSM re-derive On, and Thinking Off. Disk Cache was
+turned Off and saved for the negative control, then restored On and saved
+before the Gemma/Bonsai rows.
+
+| Model / scenario | Cache trace | Visible UI result |
+| --- | --- | --- |
+| Qwen AgentWorld 35B A3B MXFP8, first new chat | disk boundary 2,992; one token remaining; 60 recurrent states | warm-up first delta 0.36 s; `Au`, TTFT 0.51 s, 49.0 tok/s |
+| Same Qwen bundle after quit/relaunch | disk boundary 2,992; one token remaining; 60 recurrent states | warm-up first delta 0.21 s; `Au`, TTFT 0.49 s, 47.8 tok/s |
+| Same Qwen request, Disk Cache Off | `MISS all tiers`; true UI prefill visibly reached `1024/3010` | `Au`, TTFT 1.89 s, 47.9 tok/s |
+| Gemma 4 12B QAT JANG_4M, later new chat | disk boundary 1,629; four tokens remaining; `ssm=-1` | warm-up 0.28 s; `Au`, TTFT 0.41 s, 35.3 tok/s |
+| Bonsai 27B Ternary JANG, later new chat | disk boundary 2,922; one token remaining; 96 recurrent states | warm-up 0.20 s; prior `Au`, TTFT 0.50 s, 30.7 tok/s |
+
+The emergency first-new-chat/restart defect is verified on current source.
+Intervening quota pressure, paged-hot-to-SSD fallback, TurboQuant opt-in,
+media salts, and the remaining model-family matrix stay explicitly partial.
+
+## Prior live diagnostic evidence
+
+An isolated Release app at the earlier `c21cf7b0` pin was operated through the
+UI with Bonsai Ternary JANG, Thinking Off, Prefix On, paged RAM Off, Disk L2 On,
+and TurboQuant not enabled. A disk hit restored boundary 3,808 with seven
+tokens remaining and produced `Au` at TTFT 0.37 s and 30.6 tok/s. Turning Disk
+L2 Off in Settings and saving caused the same prompt to miss all tiers and take
+TTFT 5.23 s at 30.3 tok/s. This proves SSD-only restore materially affects
+latency, but it does not prove the new N-1 first-new-chat change.
+
+## Current-source acceptance matrix
+
+The original acceptance checklist now stands as follows:
+
+1. **PASS:** settings visibly saved with Prefix On, paged RAM Off, Disk L2 On,
+   default non-forced codec, and SSM re-derive On.
+2. **PASS:** Qwen 3.5 MXFP8 cold store, first-new-chat N-1 restore, coherent
+   answer, and quit/relaunch persistence.
+3. **PARTIAL:** Gemma 4 QAT JANG_4M rotating-SWA/full-attention restore is
+   proven across a new chat without false SSM/TurboQuant claims; its separate
+   app-restart row remains open.
+4. **PASS:** Bonsai Ternary JANG disk-only partial hit, coherent answer, TTFT,
+   token/s, and recurrent companion restore.
+5. **PASS:** Disk L2 Off produced request-local misses and slower true prefill;
+   Disk L2 was restored On and saved afterward.
+6. **PARTIAL:** the miss visibly showed runtime `Prefill 1024/3010`, and source
+   tests distinguish `Checking cache` and `Restored`; the sub-second hit stages
+   were too brief to capture as separate live frames.
+7. **PARTIAL:** quit/relaunch persistence is proven for Qwen; broader
+   intervening-pressure and non-adjacent eviction rows remain open.
+8. **PARTIAL:** earlier diagnostic telemetry showed quota eviction, but this
+   current Release run did not force a fresh quota eviction.
+
+For every model row capture the full visible response, TTFT, token/s, matched
+and total tokens, suffix size, disk hit/miss/store deltas, effective cache
+topology, and companion restore/re-derive counters. Any stale text, reasoning
+drift, loop, protocol marker leak, hidden-only answer, or length-cap stop fails
+the row even if the cache counter increments.
+
+TurboQuant-KV On is a separate opt-in matrix. JANGTQ weights are not
+TurboQuant KV encoding. This emergency merge keeps the default policy unchanged
+and does not claim TurboQuant coverage.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7"
+        "revision" : "feb35555900398dc638c82a3e13e98f8b1adbf41"
       }
     },
     {


### PR DESCRIPTION
Emergency cache-only integration of vMLX PR 173.

Scope:
- pin all four package surfaces to merged functional revision feb35555
- label cache lookup and restore stages separately from true transformer prefill
- clarify that GPU paged cache is an optional hot tier and SSD restore works with paged cache off
- add focused source contracts and current live proof ledger

Local verification:
- InferenceProgressManagerTests
- RuntimePolicySourceTests
- ImageGenerationBridgeContractTests
- Release workspace build
- git diff --check

Live isolated Release proof:
- bundle com.dinoki.osaurus.ssdwarmfeb355proof20260721
- executable SHA-256 488b2ce7106cb8e85bb3f27e69d4db7941abb6f977bc3174e09131169d22a3ea
- Qwen MXFP8 first-new-chat and restart restore one-token hybrid seed with 60 companion states
- Gemma 4 QAT JANG_4M rotating disk restore
- Bonsai Ternary one-token hybrid seed with 96 companion states
- Disk Cache Off control visibly performs true prefill and is slower
- Disk Cache restored On before exit

No AppleScript, Laguna, model-routing, TurboQuant, or unrelated runtime changes are included. Broader cache-family rows remain partial in the proof document.