### PR TITLE
Drain cancelled prefill before the next chat

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c59024a1b4b1314bf98ce962f99e1ffaaebfc247"
+        "revision" : "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c59024a1b4b1314bf98ce962f99e1ffaaebfc247"
+        "revision" : "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
         // seeds, growing partial-leaf reuse, and complete TQ window restore.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "c59024a1b4b1314bf98ce962f99e1ffaaebfc247"
+            revision: "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -200,8 +200,12 @@ extension ChatSession: ChatWarmupSessionContext {
         warmupController.scheduleWarmup(session: self)
     }
 
-    func handleWarmupAfterRunCompleted() {
-        warmupController.scheduleWarmup(session: self)
+    func handleWarmupAfterRunCompleted(wasCancelled: Bool, hadError: Bool) {
+        warmupController.handleRunCompleted(
+            session: self,
+            wasCancelled: wasCancelled,
+            hadError: hadError
+        )
     }
 
     func invalidateWarmupAfterContextShapeChange() {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -290,6 +290,25 @@ final class ChatWarmupController: ObservableObject {
         }
     }
 
+    /// Re-warm the completed transcript only after a natural, successful run.
+    /// A user Stop intentionally abandons the active prompt; warming that
+    /// abandoned (often very large) turn immediately starts a second hidden
+    /// prefill after the UI has returned to idle. Besides wasting work, that
+    /// hidden generation owns the solo-generation lease and makes the next
+    /// chat appear permanently queued. Errors are excluded for the same
+    /// reason: the failed prompt is not a stable checkpoint to precompute.
+    func handleRunCompleted(
+        session: ChatWarmupSessionContext,
+        wasCancelled: Bool,
+        hadError: Bool
+    ) {
+        guard !wasCancelled, !hadError else {
+            cancelScheduledWarmup()
+            return
+        }
+        scheduleWarmup(session: session)
+    }
+
     /// True when a send must run the async pre-send handshake first
     /// (model switch settling or a warm-up generation in flight).
     /// When false, sends can dispatch synchronously — preserving the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -472,7 +472,21 @@ public actor ModelRuntime {
         // Live voice runs inside the chat UI, so its residency is chat-scoped.
         lastUseSource[holder.name] = .chatUI
         await ModelLease.shared.acquire(holder.name)
-        let soloLease = await MLXBatchAdapter.Registry.shared.acquireSoloLease(for: holder.name)
+        guard
+            let soloLease = await MLXBatchAdapter.Registry.shared.acquireSoloLease(
+                for: holder.name
+            )
+        else {
+            await ModelLease.shared.release(holder.name)
+            await scheduleIdleResidency(for: holder.name)
+            return LiveVoiceAudioPreencodeResult(
+                status: .failed,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: "Cancelled before audio encoding started"
+            )
+        }
 
         final class OutBox: @unchecked Sendable {
             var result: LiveVoiceAudioPreencodeResult?

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -268,7 +268,11 @@ struct MLXBatchAdapter {
     /// encoders are not safe to drive concurrently across solo engines.
     actor SoloGenerationGate {
         private var busy = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private struct Waiter {
+            let id: UUID
+            let continuation: CheckedContinuation<Bool, Never>
+        }
+        private var waiters: [Waiter] = []
 
         struct Lease: @unchecked Sendable {
             fileprivate let gate: SoloGenerationGate
@@ -278,23 +282,39 @@ struct MLXBatchAdapter {
             }
         }
 
-        func acquire(modelName: String) async -> Lease {
+        func acquire(modelName: String) async -> Lease? {
+            guard !Task.isCancelled else { return nil }
             if !busy {
                 busy = true
                 return Lease(gate: self)
             }
 
-            await withCheckedContinuation { continuation in
-                waiters.append(continuation)
+            let id = UUID()
+            let acquired = await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    if Task.isCancelled {
+                        continuation.resume(returning: false)
+                    } else {
+                        waiters.append(Waiter(id: id, continuation: continuation))
+                    }
+                }
+            } onCancel: {
+                Task { await self.cancelWaiter(id) }
             }
-            return Lease(gate: self)
+            return acquired ? Lease(gate: self) : nil
+        }
+
+        private func cancelWaiter(_ id: UUID) {
+            guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+            let waiter = waiters.remove(at: index)
+            waiter.continuation.resume(returning: false)
         }
 
         private func release() {
             guard busy else { return }
             if !waiters.isEmpty {
                 let next = waiters.removeFirst()
-                next.resume()
+                next.continuation.resume(returning: true)
             } else {
                 busy = false
             }
@@ -574,7 +594,7 @@ struct MLXBatchAdapter {
             }
         }
 
-        func acquireSoloLease(for modelName: String) async -> SoloGenerationGate.Lease {
+        func acquireSoloLease(for modelName: String) async -> SoloGenerationGate.Lease? {
             await soloGate.acquire(modelName: modelName)
         }
 
@@ -1125,10 +1145,12 @@ struct MLXBatchAdapter {
         PrefillDebugLog.shared.log(
             "==GEN GENERATE-ENTER model=\(modelName) maxBatch=\(maxBatchSize)"
         )
-        let soloLease =
-            maxBatchSize == 1
-            ? await Registry.shared.acquireSoloLease(for: modelName)
-            : nil
+        let soloLease: SoloGenerationGate.Lease?
+        if maxBatchSize == 1 {
+            soloLease = await Registry.shared.acquireSoloLease(for: modelName)
+        } else {
+            soloLease = nil
+        }
         if Task.isCancelled {
             if let soloLease { await soloLease.release() }
             throw CancellationError()
@@ -1343,12 +1365,11 @@ struct MLXBatchAdapter {
         // reasoning + tool-call extraction handled inside vmlx. We re-wrap
         // it so we can attach a producer `Task` for cancellation.
         //
-        // Important: vmlx emits terminal `.info` before it performs the
-        // post-generation disk-cache store and then finishes its stream. The
-        // solo lease must be held until the upstream stream is actually done;
-        // releasing it at `.info` lets the next solo request enter
-        // `prepareInput` while the previous request is still materializing
-        // cache tensors on Metal.
+        // Important: the solo lease is held until the upstream stream is
+        // actually done. Current vmlx emits terminal `.info` after its
+        // post-generation disk-cache store, but stream completion remains the
+        // ownership boundary; relying on an event's relative order would let
+        // future producer cleanup overlap the next request's `prepareInput`.
         trace?.mark("batch_submit")
         CrashReportingService.recordBreadcrumb(
             category: "inference.generate",
@@ -1385,12 +1406,17 @@ struct MLXBatchAdapter {
                     }
                 }
             } onCancel: {
-                // The upstream stream is bound to a single request inside
-                // the engine; cancelling the consumer task closes it
-                // cooperatively (engine emits a final `.info(.cancelled)`
-                // and finishes the stream). Do not finish the wrapper from
-                // here; the operation body gets the chance to drain and
-                // forward that terminal `.info` event first.
+                // Breaking a wrapping AsyncStream's consumer is not itself an
+                // awaited drain boundary. Cancel the direct B=1 producer now;
+                // the operation body awaits the same idempotent drain below
+                // before it releases the process-wide solo/Metal gates.
+                guard soloLease != nil else { return }
+                Task {
+                    await engine.cancelActiveSoloGenerationAndWait()
+                }
+            }
+            if Task.isCancelled, soloLease != nil {
+                await engine.cancelActiveSoloGenerationAndWait()
             }
             // The upstream loop has fully drained (success or cancellation).
             // Finish the wrapper and release the solo lease *inline* —

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -279,6 +279,74 @@ struct ChatWarmupControllerRequestTests {
     }
 }
 
+@Suite("ChatWarmupController completed-run policy")
+@MainActor
+struct ChatWarmupControllerCompletedRunTests {
+
+    @Test("stopped run does not launch a hidden transcript warm-up")
+    func stoppedRunDoesNotWarm() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [
+                ChatMessage(role: "system", content: "sys"),
+                ChatMessage(
+                    role: "user",
+                    content: String(repeating: "cancelled prompt ", count: 2_000)
+                ),
+            ],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|cancelled-run"
+        )
+
+        let controller = ChatWarmupController()
+        controller.handleRunCompleted(
+            session: session,
+            wasCancelled: true,
+            hadError: false
+        )
+
+        try? await Task.sleep(for: .milliseconds(650))
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 0)
+        #expect(controller.state == .cold)
+    }
+
+    @Test("successful run still refreshes the completed transcript checkpoint")
+    func successfulRunStillWarms() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|successful-run"
+        )
+
+        let controller = ChatWarmupController()
+        controller.handleRunCompleted(
+            session: session,
+            wasCancelled: false,
+            hadError: false
+        )
+
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+    }
+}
+
 @Suite("ChatWarmupController runtime residency")
 @MainActor
 struct ChatWarmupControllerRuntimeResidencyTests {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,10 +74,11 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        #expect(packageSwift.contains(#"revision: "c59024a1b4b1314bf98ce962f99e1ffaaebfc247""#))
-        #expect(packageResolved.contains(#""revision" : "c59024a1b4b1314bf98ce962f99e1ffaaebfc247""#))
-        #expect(workspaceResolved.contains(#""revision" : "c59024a1b4b1314bf98ce962f99e1ffaaebfc247""#))
-        #expect(appResolved.contains(#""revision" : "c59024a1b4b1314bf98ce962f99e1ffaaebfc247""#))
+        let expectedRevision = "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+        #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
+        #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
+        #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))
+        #expect(appResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(service.contains("import vMLXFlux"))
         #expect(service.contains("await MetalGate.shared.enterImageGeneration()"))
         #expect(service.contains("await MetalGate.shared.exitImageGeneration()"))

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1280,7 +1280,7 @@ struct MLXBatchAdapterTests {
         }
 
         let gate = MLXBatchAdapter.SoloGenerationGate()
-        let first = await gate.acquire(modelName: "minimax-m2.7-jangtq")
+        let first = try #require(await gate.acquire(modelName: "minimax-m2.7-jangtq"))
         let secondAcquired = Flag()
         let second = Task {
             let lease = await gate.acquire(modelName: "minimax-m2.7-jangtq")
@@ -1295,7 +1295,7 @@ struct MLXBatchAdapterTests {
         )
 
         await first.release()
-        let secondLease = await second.value
+        let secondLease = try #require(await second.value)
         #expect(secondAcquired.get())
         await secondLease.release()
     }
@@ -1319,7 +1319,7 @@ struct MLXBatchAdapterTests {
         }
 
         let gate = MLXBatchAdapter.SoloGenerationGate()
-        let first = await gate.acquire(modelName: "minimax-m2.7-jangtq")
+        let first = try #require(await gate.acquire(modelName: "minimax-m2.7-jangtq"))
         let secondAcquired = Flag()
         let second = Task {
             let lease = await gate.acquire(modelName: "qwen3.5-30b-a3b-jangtq")
@@ -1334,9 +1334,28 @@ struct MLXBatchAdapterTests {
         )
 
         await first.release()
-        let secondLease = await second.value
+        let secondLease = try #require(await second.value)
         #expect(secondAcquired.get())
         await secondLease.release()
+    }
+
+    @Test func soloGenerationGate_removesCancelledWaiterWithoutTakingLease() async throws {
+        let gate = MLXBatchAdapter.SoloGenerationGate()
+        let first = try #require(await gate.acquire(modelName: "bonsai"))
+
+        let cancelled = Task {
+            await gate.acquire(modelName: "ornith")
+        }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        cancelled.cancel()
+        #expect(await cancelled.value == nil)
+
+        let next = Task {
+            await gate.acquire(modelName: "gemma-4")
+        }
+        await first.release()
+        let nextLease = try #require(await next.value)
+        await nextLease.release()
     }
 
     @Test func additionalContext_mapsDisableThinkingToEnableThinkingKwarg() {

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -586,6 +586,7 @@ struct RuntimePolicySourceTests {
     @Test("vmlx pin uses consolidated package with runtime hardening")
     func vmlxPinIncludesRuntimeHardening() throws {
         let manifest = try Self.source("Package.swift")
+        let coreResolved = try Self.source("Package.resolved")
         let workspaceResolved = try Self.source(
             "../../osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved"
         )
@@ -748,6 +749,8 @@ struct RuntimePolicySourceTests {
         // vmlx-swift#175 preserves integer-valued JSON tool arguments as
         // integers across the Foundation bridge (instead of silently turning
         // `1` into `true`) and keeps nested Qwen XML argument marks lossless.
+        // vmlx-swift#177 adds the awaited direct-generation cancellation/drain
+        // boundary required before Osaurus can admit the next solo request.
         //
         // This assertion is a repin tripwire, and it earned its keep: PR #1986
         // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
@@ -756,15 +759,17 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "c59024a1b4b1314bf98ce962f99e1ffaaebfc247"
+        let expectedRuntimeHardenedRevision = "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
+        let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
+        #expect(manifestRevision == coreResolvedRevision)
         #expect(manifestRevision == workspaceRevision)
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the merged vmlx-swift revision proven for lossless integer/nested tool arguments together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the merged vmlx-swift revision with the awaited solo cancellation/drain boundary together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))
@@ -1256,10 +1261,10 @@ struct RuntimePolicySourceTests {
     /// With the default `maxBatchSize == 1`, vmlx can use its solo
     /// TokenIterator-backed fast path. Osaurus must not let a second solo
     /// request run prompt tokenization / `MLXArray.asArray(...)` while that
-    /// decode is still active. vmlx emits `.info` before its post-generation
-    /// cache store finishes, so Osaurus also must not release the solo lease
-    /// at `.info`; otherwise a second request can enter `prepareInput` while
-    /// the first one is still materializing safetensors cache tensors on Metal.
+    /// decode is still active. Osaurus must release the solo lease only after
+    /// the upstream stream completes, never from one event's relative order;
+    /// otherwise a second request can enter `prepareInput` while the first one
+    /// is still draining GPU or cache work.
     @Test("MLXBatchAdapter gates solo generation and propagates stream cancellation")
     func mlxBatchAdapterGatesSoloGenerationAndCancelsProducer() throws {
         let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
@@ -1286,6 +1291,10 @@ struct RuntimePolicySourceTests {
             adapter.contains("continuation.onTermination = { @Sendable _ in")
                 && adapter.contains("producerTask.cancel()"),
             "adapter stream termination must cancel the producer so UI Stop reaches vmlx's upstream AsyncStream termination handler"
+        )
+        #expect(
+            adapter.contains("await engine.cancelActiveSoloGenerationAndWait()"),
+            "adapter cancellation must explicitly cancel and await the underlying vmlx solo producer before releasing its gate"
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3014,7 +3014,10 @@ final class ChatSession: ObservableObject {
             flushQueuedSendIfEligible()
         }
         suppressQueuedSendFlushForCurrentRun = false
-        handleWarmupAfterRunCompleted()
+        handleWarmupAfterRunCompleted(
+            wasCancelled: stopRequested,
+            hadError: lastStreamError != nil
+        )
     }
 
     /// A stopped (or errored) run can leave an assistant tool call that never

--- a/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
+++ b/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
@@ -1,10 +1,13 @@
 # Prefill Queue Emergency Gate — 2026-07-22
 
-Status: **PARTIAL — current main reproduces a Stop/New Chat cancellation stall.
-SSD partial restore works on completed turns, but a cancelled wrapped solo
-stream can leave the underlying vMLX producer running and the process-wide solo
-lease occupied. The cancellation/drain fix is source-implemented below and is
-not merge-ready until the named Release-app matrix passes.**
+Status: **VERIFIED-LIVE FOR THE SCOPED EMERGENCY — a cancelled direct B=1
+generation is drained before its process-wide solo lease is released, and
+cancelled/errored chat runs no longer schedule a hidden proactive replay of the
+abandoned prompt. An isolated Release app passed Stop -> immediate new chat,
+cross-chat partial SSD restore, and process-restart restore with paged RAM off
+for Ornith, Bonsai, Gemma 4, Qwen MXFP8, and Laguna S 2.1. Broader paged,
+TurboQuant, unsupported-family, AppleScript, and model-quality rows remain
+outside this emergency closure.**
 
 Scope: shared Osaurus/vMLX request, warm-up, and cache lifecycle. This is not a
 Bonsai-only workaround. AppleScript, Laguna expansion, routing guidance, and
@@ -122,8 +125,65 @@ The follow-up policy repair is intentionally lifecycle-scoped: successful
 runs still schedule the completed-transcript checkpoint, while user-cancelled
 or errored runs cancel scheduled warm-up instead of replaying abandoned work.
 Focused tests prove both sides of that decision, alongside the full
-`MLXBatchAdapterTests` suite. The exact rebuilt Release app still has to prove
-Stop -> new chat through the visible UI before this row can pass.
+`MLXBatchAdapterTests` suite. The exact rebuilt Release app proof is recorded
+below.
+
+## Cancellation/drain Release proof — scoped PR head
+
+Exact candidate:
+
+- Osaurus source: `933186a2b317c293f34f11892e22ba83df2ea4be`
+- vMLX pin: merged PR #177,
+  `85d752e501240bfe2d5c39c6f5d08e7d4e139a68`
+- App: `/private/tmp/Osaurus Prefill Queue Drain 933186a2 20260722.app`
+- Bundle ID: `com.dinoki.osaurus.prefillqueueproof20260722`
+- Executable SHA-256:
+  `a9b5b6ad061733bdf8276adfbdf200328b19032cc290d36ff5363f7f03ef4aa9`
+- Isolated root:
+  `/private/tmp/osaurus-prefill-queue-drain-root-20260722-1309`
+
+Computer Use visibly confirmed Prefix Cache On, GPU/Paged Cache Off, Disk
+Cache On, Engine-selected codec, SSM re-derive On, and saved settings. No new
+image file was added to the repository for this proof.
+
+Live rows:
+
+- **Ornith 1.0 9B JANG_4M:** a 17,490-token prompt restored 1,778 tokens;
+  Stop drained/released in 1.514 seconds. No hidden 17k replay followed. A new
+  chat returned `ORNITH-AFTER-CANCEL` at 0.31s TTFT/68.3 tok/s after restoring
+  1,778/1,802. Relaunch against the same root restored 1,772/1,773 from disk
+  before any user turn.
+- **Bonsai 27B Ternary JANG CRACK:** an 18,068-token prompt restored 1,552
+  tokens; Stop drained/released in 2.041 seconds and did not replay. A new-chat
+  user turn restored 2,100/2,126, returned `BONSAI-AFTER-CANCEL` at 0.66s
+  TTFT/32.2 tok/s, and changed the chip from warming to warm.
+- **Gemma 4 12B QAT JANG_4M:** a 14,618-token mixed full-attention/rotating-SWA
+  prompt restored 1,708 tokens; Stop drained/released in 2.213 seconds. The
+  next new-chat turn restored 1,731/1,749 and returned
+  `GEMMA-AFTER-CANCEL` at 0.52s TTFT/31.9 tok/s.
+- **Qwen3.6 35B A3B MXFP8 CRACK MTP:** a 15,940-token hybrid prompt restored
+  1,623 tokens; Stop drained/released in 2.061 seconds. A natural new-chat
+  control restored 2,172/2,205 and answered coherently at 0.55s TTFT/77.5
+  tok/s. A second full app process restored 2,172/2,173 in 77ms from SSD and
+  showed the warm indicator. An exact-phrase agent prompt separately
+  over-selected tools and left empty content; that is retained as a model/tool
+  finalization issue, not hidden as a cache pass.
+- **Laguna S 2.1 JANG_2L:** after a full app restart, startup restored
+  1,644/1,647 from SSD with `KVCacheSimple:12 + RotatingKVCache:36`, paged
+  blocks zero. An 86,557-token prompt restored 1,647 tokens; Stop drained and
+  released in 5.410 seconds. No 86k replay followed. A user turn sent while
+  the new-chat indicator was still warming restored 1,647/1,677 and completed
+  in 0.91 seconds; the immediate same-chat control restored 1,691/1,708 and
+  returned `Four.` at 0.73s TTFT/39.6 tok/s. Laguna Thinking On rendered the
+  exact prompt tail `<assistant><think>`; the model elected to emit an
+  immediate `</think>` and therefore stored zero reasoning characters on
+  those turns. This is bundle decode behavior, not a missing UI/template flag,
+  and no forced-thinking workaround was added.
+
+Across all cancellation rows, the current trace contains a matching
+`STREAM-DRAINED` and `LEASE-RELEASED`; cancelled prompts have no subsequent
+same-length proactive warm-up. Successful turns still produce the expected
+small completed-transcript warm-up and partial SSD store.
 
 ## Current-main isolated Release evidence
 
@@ -272,7 +332,7 @@ visible UI. CLI tests may diagnose but cannot close a row.
 | Same chat, second turn | Leaves Queued; enters prefill/decode; coherent answer; TTFT | PASS — Bonsai, Gemma |
 | New chat, same model | SSD counters before/after; restored tokens; remaining prefill; TTFT | PASS — Bonsai |
 | Send while background warm-up owns load | One load owner; foreground request cannot starve | PASS — Bonsai |
-| Stop/cancel then send | Cancelled slot/producer exits; next request starts | FAIL on merged main — reproduced 15,109-token Bonsai prefill owner leak; fix awaiting rebuilt Release proof |
+| Stop/cancel then send | Cancelled slot/producer exits; next request starts | PASS — isolated Release UI rows for Ornith, Bonsai, Gemma 4, Qwen MXFP8, and Laguna; every cancelled stream drained/released, no abandoned long prompt replayed, and the immediate new-chat request left queued and completed |
 | Switch model and return | Old engine lifecycle completes; returned model starts | PARTIAL — forward switches passed; return-to-prior not rerun |
 | Quit/relaunch and send | Disk L2 restore is attached before request publication | PASS — Bonsai folded hybrid restore |
 | Paged RAM cache off, SSD on | Default user path; partial/exact disk hit truth | PASS — Bonsai, Gemma |
@@ -288,12 +348,13 @@ visible UI. CLI tests may diagnose but cannot close a row.
 
 ## Release gate
 
-The reported Bonsai queue stall belongs to the shipped build and did not
-reproduce permanently on current main. The distinct LFM tool-schema bypass is
-current and justifies a narrow vMLX follow-up plus Osaurus pin PR because the
-rebuilt Release app now proves the before/after fetch delta. It must not be
-conflated with the already-merged Bonsai/Gemma repair series or described as
-closing unsupported/incoherent family rows.
+The shipped-build symptom had two current owners under real interruption: the
+wrapped direct-generation producer was not awaited through cancellation, and
+chat cleanup unconditionally scheduled a proactive warm-up for the abandoned
+prompt. The scoped vMLX drain API plus Osaurus lifecycle policy repair close
+those owners in the exact Release app. The distinct LFM tool-schema bypass was
+already handled by the earlier narrow vMLX/Osaurus pin and is not reimplemented
+here. None of this closes unsupported/incoherent family rows.
 
 Before claiming the broader all-setting campaign complete:
 

--- a/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
+++ b/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
@@ -1,10 +1,10 @@
 # Prefill Queue Emergency Gate — 2026-07-22
 
-Status: **PARTIAL — the released queue symptom predates current main; a distinct
-current-main LFM disk-restore bypass is fixed and live-proven on the exact
-merged vMLX pin in the isolated Release app. Bonsai/Qwen-hybrid and Gemma 4
-rotating-SWA representatives also pass that exact-pin cache gate, while the
-complete all-family/all-setting matrix is not closed.**
+Status: **PARTIAL — current main reproduces a Stop/New Chat cancellation stall.
+SSD partial restore works on completed turns, but a cancelled wrapped solo
+stream can leave the underlying vMLX producer running and the process-wide solo
+lease occupied. The cancellation/drain fix is source-implemented below and is
+not merge-ready until the named Release-app matrix passes.**
 
 Scope: shared Osaurus/vMLX request, warm-up, and cache lifecycle. This is not a
 Bonsai-only workaround. AppleScript, Laguna expansion, routing guidance, and
@@ -62,6 +62,51 @@ model unloading, SSD restore, cancellation, or UI progress projection.
   that warm-up to finish so the just-materialized SSD prefix can be reused. This
   can display the warm-up's queued/prefill phase in the foreground assistant row.
   Current-main live timing below did not strand the wait.
+
+## Current-main cancellation reproduction — 2026-07-22 follow-up
+
+The earlier current-main proof did not exercise the reported interruption hard
+enough and must not be treated as closure. A fresh isolated Release build of
+Osaurus `24af4289ff8338de9bd8796ae6fce3517d96ee4f`, pinned to vMLX
+`c59024a1b4b1314bf98ce962f99e1ffaaebfc247`, reproduced the failure with
+Bonsai 27B Ternary JANG through the real chat UI:
+
+- Prefix Cache On, GPU/Paged Cache Off, Disk Cache On, codec Engine Selected,
+  SSM Re-derive On, and Thinking Off were visibly active.
+- Completed new-chat turns did use SSD state: examples restored `3612/4067`,
+  `4060/5163`, and `3282/3283` prompt tokens.
+- A unique 15,109-token prompt restored its cached 3,282-token static prefix and
+  entered live prefill. Starting a new chat while that run was active left the
+  old runtime request alive after the chat UI had moved on.
+- The trace reached `STEP-PREFILL complete 15109/15109` but emitted no matching
+  `STREAM-DRAINED` or `LEASE-RELEASED`. At 97 seconds after the interruption,
+  the app process was still active at about 84% CPU and the next local send was
+  blocked by the old owner.
+
+Source owner:
+
+1. `MLXBatchAdapter.generate` wraps `BatchEngine.generate` in another
+   `AsyncStream` and owns the process-wide solo lease.
+2. Cancelling the chat cancels the wrapper producer, but its loop previously
+   kept iterating the upstream stream while merely dropping non-info events.
+3. Because the upstream iterator never terminated, vMLX's stream termination
+   handler never cancelled its direct B=1 generation task. Osaurus therefore
+   could not reach its lease-release code.
+4. Repeated new-chat warm-ups can also leave cancelled tasks in
+   `SoloGenerationGate`'s FIFO because its continuations were not
+   cancellation-aware.
+
+Scoped repair under test:
+
+- vMLX adds an awaited, idempotent direct-generation cancellation/drain
+  boundary. It cancels the producer, waits for its GPU/cache work to exit, and
+  clears the same solo id before a serving layer admits the next request.
+- Osaurus invokes that boundary immediately when the wrapping stream is
+  cancelled and again before releasing its solo/Metal leases.
+- The Osaurus solo FIFO removes cancelled waiters instead of letting abandoned
+  warm-ups acquire and hand off the lease later.
+- No sampler, prompt, parser, model-family, cache-boundary, paged-cache default,
+  or TurboQuant setting is changed. No new image artifact is part of this fix.
 
 ## Current-main isolated Release evidence
 
@@ -210,7 +255,7 @@ visible UI. CLI tests may diagnose but cannot close a row.
 | Same chat, second turn | Leaves Queued; enters prefill/decode; coherent answer; TTFT | PASS — Bonsai, Gemma |
 | New chat, same model | SSD counters before/after; restored tokens; remaining prefill; TTFT | PASS — Bonsai |
 | Send while background warm-up owns load | One load owner; foreground request cannot starve | PASS — Bonsai |
-| Stop/cancel then send | Cancelled slot/producer exits; next request starts | PARTIAL — stop recovered, immediate post-cancel send not isolated |
+| Stop/cancel then send | Cancelled slot/producer exits; next request starts | FAIL on merged main — reproduced 15,109-token Bonsai prefill owner leak; fix awaiting rebuilt Release proof |
 | Switch model and return | Old engine lifecycle completes; returned model starts | PARTIAL — forward switches passed; return-to-prior not rerun |
 | Quit/relaunch and send | Disk L2 restore is attached before request publication | PASS — Bonsai folded hybrid restore |
 | Paged RAM cache off, SSD on | Default user path; partial/exact disk hit truth | PASS — Bonsai, Gemma |

--- a/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
+++ b/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
@@ -108,6 +108,23 @@ Scoped repair under test:
 - No sampler, prompt, parser, model-family, cache-boundary, paged-cache default,
   or TurboQuant setting is changed. No new image artifact is part of this fix.
 
+The first exact-pin Release rerun caught a second owner before merge. With
+Ornith 1.0 9B JANG_4M selected, the UI visibly entered prefill at
+`1778/17485`; Stop drained and released the cancelled engine in 1.293 seconds.
+However, `completeRunCleanup()` then unconditionally scheduled a proactive
+warm-up over the abandoned 17k-token user turn. That hidden request began 585
+ms later, owned the same solo lease for another 7.555 seconds, and made the UI
+look idle while the next chat would still have to wait. This is the reported
+"third session stays queued" shape even though the original producer drain is
+now bounded.
+
+The follow-up policy repair is intentionally lifecycle-scoped: successful
+runs still schedule the completed-transcript checkpoint, while user-cancelled
+or errored runs cancel scheduled warm-up instead of replaying abandoned work.
+Focused tests prove both sides of that decision, alongside the full
+`MLXBatchAdapterTests` suite. The exact rebuilt Release app still has to prove
+Stop -> new chat through the visible UI before this row can pass.
+
 ## Current-main isolated Release evidence
 
 App:

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c59024a1b4b1314bf98ce962f99e1ffaaebfc247"
+        "revision" : "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
       }
     },
     {


### PR DESCRIPTION
## Emergency scope

Fixes the released Stop/New Chat failure mode where a cancelled local request can leave the direct B=1 vMLX producer and Osaurus solo gate occupied, causing later chats to remain at `Queued 0/N`.

## Root cause

`MLXBatchAdapter` wraps vMLX generation in a second `AsyncStream`. Cancelling the wrapper did not provide an awaited cancellation boundary for the upstream direct-generation task, and canceled FIFO waiters could survive in `SoloGenerationGate`. SSD partial restore was observed on completed turns; the emergency defect is request ownership/drain, not a global cache disable.

## Change

- pin merged vMLX PR #177 (`85d752e501240bfe2d5c39c6f5d08e7d4e139a68`) in all four package surfaces
- explicitly cancel and drain direct solo generation before releasing Osaurus solo/Metal ownership
- remove canceled solo-gate waiters instead of letting them later acquire the model
- preserve terminal completion info while suppressing canceled non-terminal deltas
- make live-voice preencode handle cancellation before solo acquisition
- update the emergency gate doc with the hard current-main reproduction and source owner

No cache policy, paged-cache default, TurboQuant setting, model parser, reasoning default, sampler, or prompt behavior is changed. No image artifact is added.

## Current evidence

- vMLX cancel/drain/new-generation regression: passed (0.241s)
- existing vMLX solo consumer-cancellation + shutdown-drain regressions: passed
- Osaurus `MLXBatchAdapterTests`, including canceled-waiter regression: passed
- focused RuntimePolicy source gates for pin parity, explicit upstream drain, and terminal-info preservation: passed
- exact Release build and four-family live Computer Use matrix: **running; PR remains PARTIAL until posted**