### PR TITLE
Fix stream finalization and model-picker thinking control

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
@@ -74,6 +74,41 @@ struct ChatTurnGenerationControlsTests {
         )
     }
 
+    @Test("model picker semantic Thinking toggle maps to request enable_thinking")
+    func modelPickerSemanticToggleMapsToRequestFlag() throws {
+        let modelIds = [
+            "JANGQ-AI/Laguna-S2.1-JANG_2L",
+            "OsaurusAI/Qwen3.6-35B-A3B-MXFP8",
+            "OsaurusAI/Gemma-4-12B-JANG_4M",
+        ]
+
+        for modelId in modelIds {
+            let onOption = try #require(
+                ModelProfileRegistry.thinkingStoredOption(for: modelId, enabled: true)
+            )
+            let offOption = try #require(
+                ModelProfileRegistry.thinkingStoredOption(for: modelId, enabled: false)
+            )
+
+            let onControls = ChatTurnGenerationControls.capture(
+                activeModelOptions: [onOption.id: onOption.value]
+            )
+            let offControls = ChatTurnGenerationControls.capture(
+                activeModelOptions: [offOption.id: offOption.value]
+            )
+
+            var onRequest = request()
+            var offRequest = request()
+            onControls.apply(to: &onRequest)
+            offControls.apply(to: &offRequest)
+
+            #expect(onRequest.enable_thinking == true)
+            #expect(offRequest.enable_thinking == false)
+            #expect(onRequest.modelOptions?[onOption.id] == onOption.value)
+            #expect(offRequest.modelOptions?[offOption.id] == offOption.value)
+        }
+    }
+
     @Test("unset Thinking preserves the bundle default")
     func unsetPreservesBundleDefault() {
         let controls = ChatTurnGenerationControls.capture(

--- a/Packages/OsaurusCore/Tests/Chat/StreamingDeltaProcessorTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/StreamingDeltaProcessorTests.swift
@@ -1,0 +1,39 @@
+//
+//  StreamingDeltaProcessorTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Streaming delta processor")
+@MainActor
+struct StreamingDeltaProcessorTests {
+    @Test("smooth finalize drains a small final tail without waiting for another timer tick")
+    func smoothFinalizeDrainsSmallTail() async {
+        let key = "chatSmoothStreamingEnabled"
+        let previous = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.set(true, forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let turn = ChatTurn(role: .assistant, content: "")
+        var syncCount = 0
+        let processor = StreamingDeltaProcessor(turn: turn) {
+            syncCount += 1
+        }
+
+        processor.receiveDelta("Finished.")
+        await processor.finalize()
+
+        #expect(turn.content == "Finished.")
+        #expect(syncCount >= 1)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1405,6 +1405,7 @@ struct RuntimePolicySourceTests {
     @Test("Thinking control persists semantic thinking state, not raw inverted booleans")
     func thinkingControlPersistsSemanticThinkingState() throws {
         let floatingInput = try Self.source("Views/Chat/FloatingInputCard.swift")
+        let modelPicker = try Self.source("Views/Model/ModelPickerView.swift")
 
         #expect(
             floatingInput.contains("ModelProfileRegistry.thinkingEnabled("),
@@ -1423,12 +1424,20 @@ struct RuntimePolicySourceTests {
             "The Thinking control must not toggle the raw stored bool directly; that reintroduces first-click explicit no-thinking for inverted profiles"
         )
         #expect(
-            floatingInput.contains("thinkingToggleChip(compact: compact)"),
-            "Toggle-only reasoning models must expose a standalone Thinking control in the ordinary chat footer, not only inside the model picker"
+            !floatingInput.contains("thinkingToggleChip"),
+            "The ordinary chat footer must not render a second Thinking toggle; the user-facing switch lives in the model picker's Model Options section"
         )
         #expect(
-            floatingInput.contains("persistThinkingOverride(!isEnabled, for: model)"),
-            "The footer Thinking control must use the same semantic persistence path as the picker"
+            modelPicker.contains("Text(\"Model Options\", bundle: .module)"),
+            "ModelPickerView must visibly label the per-model option section where Thinking is controlled"
+        )
+        #expect(
+            modelPicker.contains("thinkingOptionRow(thinking)"),
+            "The model picker must render the semantic Thinking row in Model Options"
+        )
+        #expect(
+            floatingInput.contains("persistThinkingOverride(enabled, for: model)"),
+            "The picker Thinking control must persist through the semantic registry path"
         )
     }
 

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -185,11 +185,17 @@ final class StreamingDeltaProcessor {
 
         if smoothStreamingEnabled && pendingCount > 0 {
             startPacingTimerIfNeeded()
-            // Block here until `pacingTick` empties the buffer and
-            // resumes us. The processor stays alive for the duration
-            // because the surrounding `send(...)` is awaiting.
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                self.pacingDoneContinuation = continuation
+            // Drain one tick synchronously. Short final tails should not
+            // depend on any future run-loop timer delivery before ChatView can
+            // leave its streaming state.
+            pacingTick()
+            if pendingCount > 0 {
+                // Block here until `pacingTick` empties the buffer and
+                // resumes us. The processor stays alive for the duration
+                // because the surrounding `send(...)` is awaiting.
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    self.pacingDoneContinuation = continuation
+                }
             }
         } else if pendingCount > 0 {
             // Non-smooth path: drain immediately.
@@ -240,6 +246,12 @@ final class StreamingDeltaProcessor {
         pacingTimer = nil
     }
 
+    private func resumePacingDoneIfNeeded() {
+        guard let cont = pacingDoneContinuation else { return }
+        pacingDoneContinuation = nil
+        cont.resume()
+    }
+
     /// Drain a chunk from the head of `deltaBuffer` into the turn + push
     /// one sync. Chunk size adapts to the pending buffer so a giant
     /// response that arrived in one shot still finishes typing out within
@@ -251,10 +263,7 @@ final class StreamingDeltaProcessor {
         if pending == 0 {
             stopPacingTimer()
             // Wake up `finalize()` if it's waiting for the tail to drain.
-            if let cont = pacingDoneContinuation {
-                pacingDoneContinuation = nil
-                cont.resume()
-            }
+            resumePacingDoneIfNeeded()
             return
         }
         let scaled = pending / Self.pacingDrainTicks
@@ -265,6 +274,15 @@ final class StreamingDeltaProcessor {
         // UI re-apply follows the adaptive `syncIntervalMs` cadence. Any
         // residual pending content is synced by `finalize()`.
         syncIfNeeded(now: Date())
+        if pendingCount == 0 {
+            // The last visible chunk was just consumed. Do not require one
+            // more run-loop timer tick to finish the chat run: if that tick is
+            // coalesced or never delivered, ChatView keeps `isStreaming=true`
+            // after the answer is fully visible and the red Stop button never
+            // clears.
+            stopPacingTimer()
+            resumePacingDoneIfNeeded()
+        }
     }
 
     /// Pending (unrevealed) character count. O(1) — replaces the O(n)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2344,7 +2344,6 @@ extension FloatingInputCard {
     /// screen (a remote-agent run, for instance, hides most of them).
     private var visibleToggleChipCount: Int {
         var count = 0
-        if inlineThinkingEnabled != nil { count += 1 }
         if autoSpeakAssistant { count += 1 }
         if !isRemoteAgentRun, !isDefaultConfigAgent, isSandboxAvailable { count += 1 }
         if !isRemoteAgentRun { count += 1 }  // folder or configuration chip
@@ -2356,23 +2355,17 @@ extension FloatingInputCard {
         return count
     }
 
-    /// The interactive toggle chips (Thinking, auto-speak, sandbox, folder,
-    /// clipboard) as one horizontal group. Thinking stays directly available
-    /// in the chat footer as well as in the model picker's options section;
-    /// hiding the only switch in the picker made the active reasoning state
-    /// easy to miss during ordinary chat and agent runs. `compact` drops each
-    /// secondary chip's text label to icon-only unless the chip has live state
-    /// worth spelling out; Thinking stays labeled because an unlabeled brain
-    /// glyph recreates the discoverability regression. `selectorRow` renders
-    /// one rendering of this cluster,
+    /// The interactive toggle chips (auto-speak, sandbox, folder, clipboard)
+    /// as one horizontal group. Thinking is controlled from the model picker
+    /// `Model Options` section and reflected as the brain glyph on the model
+    /// chip, so changing reasoning mode always goes through the model-scoped
+    /// dropdown path. `selectorRow` renders one rendering of this cluster,
     /// choosing `compact` from the measured region width so the row degrades
     /// gracefully as it narrows without re-measuring layout candidates every
     /// frame.
     @ViewBuilder
     private func toggleChipCluster(compact: Bool) -> some View {
         HStack(spacing: 6) {
-            thinkingToggleChip(compact: compact)
-
             if autoSpeakAssistant {
                 autoSpeakToggleChip(compact: compact)
             }
@@ -3184,43 +3177,6 @@ extension FloatingInputCard {
     }
 
     // MARK: - Thinking Toggle
-
-    /// Primary, always-visible reasoning control for toggle-only models. The
-    /// model picker keeps its richer default/reset row, but users should not
-    /// have to open that popover merely to see or change the current mode.
-    @ViewBuilder
-    private func thinkingToggleChip(compact _: Bool) -> some View {
-        if let model = selectedModel, let isEnabled = inlineThinkingEnabled {
-            SelectorChip(isActive: isEnabled) {
-                withAnimation(.spring(response: 0.2, dampingFraction: 0.7)) {
-                    persistThinkingOverride(!isEnabled, for: model)
-                }
-            } content: {
-                HStack(spacing: 5) {
-                    Image(systemName: "brain")
-                        .font(theme.font(size: CGFloat(theme.captionSize) - 1, weight: .semibold))
-                        .foregroundColor(isEnabled ? theme.accentColor : theme.tertiaryText)
-
-                    Text("Thinking", bundle: .module)
-                        .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
-                        .foregroundColor(isEnabled ? theme.secondaryText : theme.tertiaryText)
-                        .lineLimit(1)
-                        .fixedSize()
-                }
-            }
-            .localizedHelp(
-                isEnabled
-                    ? "Thinking is on. Click to turn it off."
-                    : "Thinking is off. Click to turn it on."
-            )
-            .accessibilityLabel(Text("Thinking", bundle: .module))
-            .accessibilityValue(
-                isEnabled
-                    ? Text("On", bundle: .module)
-                    : Text("Off", bundle: .module)
-            )
-        }
-    }
 
     // MARK: - Auto-Speak Toggle
 


### PR DESCRIPTION
## Summary
- Fix smooth streaming finalization so a fully visible final answer cannot remain stuck with the run still active.
- Move the interactive Thinking switch to the model picker `Model Options` path; the footer model chip only reflects the model-scoped state.
- Add focused regressions for smooth-streaming finalize, semantic Thinking request propagation, and the picker-only Thinking UI contract.

## Source trace
- `StreamingDeltaProcessor.finalize()` now drains one pacing tick synchronously and `pacingTick()` resumes the waiting finalizer immediately when the buffer empties.
- `FloatingInputCard` no longer renders `thinkingToggleChip`; the picker `Model Options` path persists Thinking via `ModelProfileRegistry.thinkingStoredOption`.
- `ChatTurnGenerationControls` tests verify semantic model-picker Thinking values map to `enable_thinking=true/false` and propagate into reconstructed requests.

## Verification
- Focused Xcode tests passed on macOS arm64:
  - `OsaurusCoreTests/StreamingDeltaProcessorTests`
  - `OsaurusCoreTests/ChatTurnGenerationControlsTests`
  - `OsaurusCoreTests/RuntimePolicySourceTests/thinkingControlPersistsSemanticThinkingState`
- Release-config app built, ad-hoc signed, and launched under isolated test root:
  - bundle id `com.dinoki.osaurus.emergencyfinalize20260722`
  - `OSAURUS_TEST_ROOT=/private/tmp/osaurus-emergency-finalize-live-root-1915c`
  - `OSU_MODELS_DIR=/Users/eric/models`
- Live UI proof through the app:
  - Gemma 4 12B MXFP8: Thinking On produced a reasoning box and completed; cross-chat repeat completed; L2 disk hits observed.
  - Laguna S 2.1 JANG_2L: Thinking On produced a reasoning box and completed; L2 disk hits observed.
  - Ornith 1.0 9B MXFP8: Thinking Off produced no reasoning box and completed; Thinking On produced a reasoning box and completed; SSM disk hits observed.
  - Qwen3.6 27B MXFP8 CRACK MTP: Thinking Off completed; Thinking On produced a reasoning box and completed; SSM disk hits observed.
  - Bonsai 27b Ternary JANG CRACK: Thinking Off completed; cross-chat repeat completed; Thinking On produced a reasoning box and completed; SSM disk hits and disk-quota eviction observed.

## Notes
- No image/video artifacts are added to this PR.
- This PR does not change model sampler defaults, cache algorithms, parser rules, or vMLX pinning.
