### PR TITLE
Fix tool finalization and SSD cache warmup

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+        "revision" : "7d6235316226ba9fe608018f86c463784e48b3d5"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -668,7 +668,9 @@ struct NemotronThinkingProfile: ModelProfile {
 /// whose chat template (`laguna_glm_thinking_v5/chat_template.jinja`)
 /// reads an `enable_thinking` Jinja kwarg. Osaurus exposes the native switch
 /// while leaving absent values absent so the shipped template/runtime defaults
-/// remain authoritative.
+/// remain authoritative. Laguna S 2.1 serving defaults thinking ON through
+/// `default_chat_template_kwargs.enable_thinking=true`, so the display default
+/// is the inverted stored form `disableThinking=false`.
 ///
 /// Match is `laguna` substring lower-cased; covers any future Laguna
 /// variant (e.g. Laguna-S, Laguna-M) without a registry edit. There is
@@ -686,12 +688,12 @@ struct LagunaThinkingProfile: ModelProfile {
             id: "disableThinking",
             label: L("Disable Thinking"),
             icon: "brain.head.profile",
-            kind: .toggle(default: true)
+            kind: .toggle(default: false)
         )
     ]
 
     static let defaults: [String: ModelOptionValue] = [
-        "disableThinking": .bool(true)
+        "disableThinking": .bool(false)
     ]
 
     static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+        "revision" : "7d6235316226ba9fe608018f86c463784e48b3d5"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
         // seeds, growing partial-leaf reuse, and complete TQ window restore.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+            revision: "7d6235316226ba9fe608018f86c463784e48b3d5"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -201,10 +201,17 @@ extension ChatSession: ChatWarmupSessionContext {
     }
 
     func handleWarmupAfterRunCompleted(wasCancelled: Bool, hadError: Bool) {
+        let hadToolActivity = turns.contains { turn in
+            turn.role == .tool
+                || !(turn.toolCalls?.isEmpty ?? true)
+                || !turn.toolResults.isEmpty
+                || turn.hasRemoteToolActivity
+        }
         warmupController.handleRunCompleted(
             session: self,
             wasCancelled: wasCancelled,
-            hadError: hadError
+            hadError: hadError,
+            hadToolActivity: hadToolActivity
         )
     }
 

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -290,19 +290,24 @@ final class ChatWarmupController: ObservableObject {
         }
     }
 
-    /// Re-warm the completed transcript only after a natural, successful run.
-    /// A user Stop intentionally abandons the active prompt; warming that
-    /// abandoned (often very large) turn immediately starts a second hidden
-    /// prefill after the UI has returned to idle. Besides wasting work, that
-    /// hidden generation owns the solo-generation lease and makes the next
-    /// chat appear permanently queued. Errors are excluded for the same
-    /// reason: the failed prompt is not a stable checkpoint to precompute.
+    /// Re-warm the completed transcript only after a natural, successful
+    /// plain-chat run. A user Stop intentionally abandons the active prompt;
+    /// warming that abandoned (often very large) turn immediately starts a
+    /// second hidden prefill after the UI has returned to idle. Besides
+    /// wasting work, that hidden generation owns the solo-generation lease and
+    /// makes the next chat appear permanently queued. Errors are excluded for
+    /// the same reason: the failed prompt is not a stable checkpoint to
+    /// precompute. Tool transcripts are also excluded: the real tool-loop
+    /// turns already store SSD-L2 blocks, while the post-success hidden
+    /// completed-transcript warm-up can cold-prefill a large tool history and
+    /// block the next visible user turn.
     func handleRunCompleted(
         session: ChatWarmupSessionContext,
         wasCancelled: Bool,
-        hadError: Bool
+        hadError: Bool,
+        hadToolActivity: Bool = false
     ) {
-        guard !wasCancelled, !hadError else {
+        guard !wasCancelled, !hadError, !hadToolActivity else {
             cancelScheduledWarmup()
             return
         }

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -92,7 +92,16 @@ enum LocalReasoningCapability {
             return .none
         }
         if let template = readChatTemplate(at: dir) {
-            return analyze(template: template)
+            let analyzed = analyze(template: template)
+            if let metadataDefault = readTemplateDefaultThinkingOn(at: dir) {
+                return Capability(
+                    supportsThinking: analyzed.supportsThinking,
+                    hasEnableThinkingKwarg: analyzed.hasEnableThinkingKwarg,
+                    templateInjectsThinkTag: analyzed.templateInjectsThinkTag,
+                    defaultThinkingOn: metadataDefault
+                )
+            }
+            return analyzed
         }
         // Fallback for JANG bundles that ship no chat template (DSV4-Flash
         // ships `encoding/encoding_dsv4.py` instead; the JANG converter
@@ -261,8 +270,51 @@ enum LocalReasoningCapability {
             supportsThinking: true,
             hasEnableThinkingKwarg: false,
             templateInjectsThinkTag: false,
-            defaultThinkingOn: false
+            defaultThinkingOn: jangReasoningDefaultThinkingOn(reasoning) ?? false
         )
+    }
+
+    /// Bundle metadata can override the Jinja fallback for omitted kwargs. Laguna
+    /// S 2.1 is the concrete case: its sidecar template says
+    /// `enable_thinking | default(false)`, but generation_config and
+    /// jang_config both stamp the serving default as thinking-on. The UI should
+    /// present that effective default, and request construction should still
+    /// send nothing until the user/API makes an explicit choice.
+    private static func readTemplateDefaultThinkingOn(at dir: URL) -> Bool? {
+        if let data = readSmallConfigFile(dir.appendingPathComponent("generation_config.json")),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let defaults = root["default_chat_template_kwargs"] as? [String: Any],
+            let enableThinking = defaults["enable_thinking"] as? Bool
+        {
+            return enableThinking
+        }
+
+        let jangURL = dir.appendingPathComponent("jang_config.json")
+        guard let data = readSmallConfigFile(jangURL),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let chat = root["chat"] as? [String: Any],
+            let reasoning = chat["reasoning"] as? [String: Any]
+        else {
+            return nil
+        }
+        return jangReasoningDefaultThinkingOn(reasoning)
+    }
+
+    private static func jangReasoningDefaultThinkingOn(_ reasoning: [String: Any]) -> Bool? {
+        if let enabled = reasoning["default_enabled"] as? Bool {
+            return enabled
+        }
+        if let mode = reasoning["default_mode"] as? String {
+            switch mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "think", "thinking", "reason", "reasoning", "high", "max":
+                return true
+            case "chat", "direct", "none", "no_think", "nothink", "off":
+                return false
+            default:
+                break
+            }
+        }
+        return nil
     }
 
     static func readChatTemplate(at dir: URL) -> String? {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3296,17 +3296,14 @@ public actor ModelRuntime {
         )
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
-            // Chat UI streaming should execute a parsed tool call as soon as
-            // the model finishes the step. We surface the tool hints
-            // immediately, then keep draining ONLY to forward the step's
-            // end-of-generation `.completionInfo` (decode/prefill tok/s + token
-            // count) before finishing-by-throw — otherwise a step that ends in
-            // a tool call (the common agentic case) drops its decode stats,
-            // which is why tool-call turns historically reported 0 completion
-            // tokens / no tok/s in both the OpenAI `usage` and the eval
-            // telemetry. Post-tool model text is still suppressed (never
-            // yielded once a tool is pending), preserving the no-leak intent.
-            var pendingTool: ServiceToolInvocation?
+            // Chat UI streaming must dispatch a parsed local tool call as soon
+            // as vmlx emits `.toolInvocation`. A trailing `.completionInfo`
+            // is useful telemetry, but it is not part of the executable tool
+            // contract: the parser has already closed the envelope and built
+            // canonical JSON. Waiting for stats lets a model/runtime stream
+            // that never reaches EOS leave the UI stuck with a complete-looking
+            // tool row and no actual dispatch. Finish-by-throw immediately and
+            // let `onTermination` cancel the now-unneeded decode tail.
             do {
                 for try await ev in events {
                     if case .completionInfo(
@@ -3325,14 +3322,6 @@ public actor ModelRuntime {
                                 prefillTokensPerSecond: promptTokensPerSecond
                             )
                         )
-                        // End-of-generation stats are the terminal event. If a
-                        // tool call is pending, the stats have now been
-                        // forwarded — finish-by-throw so the consumer dispatches
-                        // the tool, with the decode telemetry already delivered.
-                        if let tool = pendingTool {
-                            continuation.finish(throwing: tool)
-                            return
-                        }
                         continue
                     }
 
@@ -3342,56 +3331,46 @@ public actor ModelRuntime {
                     }
                     switch ev {
                     case .tokens(let s):
-                        // Suppress model text once a tool call is pending so the
-                        // pseudo-tool prose never leaks to the UI/consumer.
-                        if pendingTool == nil, !s.isEmpty { continuation.yield(s) }
+                        if !s.isEmpty { continuation.yield(s) }
                     case .reasoning(let s):
-                        if pendingTool == nil, !s.isEmpty {
+                        if !s.isEmpty {
                             continuation.yield(StreamingReasoningHint.encode(s))
                         }
                     case .prefillProgress(let progress):
-                        if pendingTool == nil {
-                            continuation.yield(StreamingPrefillProgressHint.encode(progress))
-                        }
+                        continuation.yield(StreamingPrefillProgressHint.encode(progress))
                     case .toolCallProgress(let envelopeDelta):
                         // Live preview of the tool-call envelope as it is
                         // written. Emitted before the committed
-                        // `.toolInvocation`, so `pendingTool` is still nil here.
+                        // `.toolInvocation`.
                         // Encoded behind the `\u{FFFE}` sentinel so it never
                         // reaches the visible token stream or the OpenAI wire —
                         // only the native ChatView decodes it, to keep the
                         // tool-call card alive instead of showing a frozen
                         // spinner during a long file-write call.
-                        if pendingTool == nil, !envelopeDelta.isEmpty {
+                        if !envelopeDelta.isEmpty {
                             continuation.yield(
                                 StreamingToolCallProgressHint.encode(envelopeDelta)
                             )
                         }
                     case .toolInvocation(let name, let argsJSON):
-                        // Surface the first tool call's hints immediately, then
-                        // keep draining for its trailing `.completionInfo`
-                        // before throwing (see comment above). Arity is
-                        // unchanged: only the first tool is dispatched per step.
-                        if pendingTool == nil {
-                            continuation.yield(StreamingToolHint.encode(name))
-                            continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
-                            pendingTool = ServiceToolInvocation(
-                                toolName: name,
-                                jsonArguments: argsJSON
-                            )
-                        }
+                        // Surface the first parsed tool call and terminate this
+                        // generation step immediately. The stream termination
+                        // cancels any remaining decode tail, so post-tool prose
+                        // cannot leak and the chat loop can execute the tool
+                        // without waiting for an optional stats/EOS event.
+                        continuation.yield(StreamingToolHint.encode(name))
+                        continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
+                        let tool = ServiceToolInvocation(
+                            toolName: name,
+                            jsonArguments: argsJSON
+                        )
+                        continuation.finish(throwing: tool)
+                        return
                     case .completionInfo:
                         continue
                     }
                 }
-                // Stream ended (natural EOS). If the generator never emitted a
-                // trailing `.completionInfo` after the tool call, throw now so
-                // the tool is still dispatched (just without decode stats).
-                if let tool = pendingTool {
-                    continuation.finish(throwing: tool)
-                } else {
-                    continuation.finish()
-                }
+                continuation.finish()
             } catch {
                 if Task.isCancelled {
                     continuation.finish()

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -316,6 +316,114 @@ struct ChatWarmupControllerCompletedRunTests {
         #expect(controller.state == .cold)
     }
 
+    @Test("errored run does not launch a hidden transcript warm-up")
+    func erroredRunDoesNotWarm() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [
+                ChatMessage(role: "system", content: "sys"),
+                ChatMessage(role: "user", content: "needs a tool"),
+                ChatMessage(
+                    role: "assistant",
+                    content: "",
+                    tool_calls: [
+                        ToolCall(
+                            id: "call_failed",
+                            type: "function",
+                            function: ToolCallFunction(
+                                name: "unstable_tool",
+                                arguments: #"{"bad":true}"#
+                            )
+                        )
+                    ],
+                    tool_call_id: nil
+                ),
+                ChatMessage(
+                    role: "tool",
+                    content: ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message: "bad input",
+                        tool: "unstable_tool"
+                    ),
+                    tool_calls: nil,
+                    tool_call_id: "call_failed"
+                ),
+            ],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|errored-tool-run"
+        )
+
+        let controller = ChatWarmupController()
+        controller.handleRunCompleted(
+            session: session,
+            wasCancelled: false,
+            hadError: true
+        )
+
+        try? await Task.sleep(for: .milliseconds(650))
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 0)
+        #expect(controller.state == .cold)
+    }
+
+    @Test("successful tool run does not launch a hidden transcript warm-up")
+    func successfulToolRunDoesNotWarmCompletedTranscript() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [
+                ChatMessage(role: "system", content: "sys"),
+                ChatMessage(role: "user", content: "read a file"),
+                ChatMessage(
+                    role: "assistant",
+                    content: "",
+                    tool_calls: [
+                        ToolCall(
+                            id: "call_ok",
+                            type: "function",
+                            function: ToolCallFunction(
+                                name: "read_file",
+                                arguments: #"{"path":"README.md"}"#
+                            )
+                        )
+                    ],
+                    tool_call_id: nil
+                ),
+                ChatMessage(
+                    role: "tool",
+                    content: ToolEnvelope.success(tool: "read_file", text: "ok"),
+                    tool_calls: nil,
+                    tool_call_id: "call_ok"
+                ),
+                ChatMessage(role: "assistant", content: "Done."),
+            ],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|successful-tool-run"
+        )
+
+        let controller = ChatWarmupController()
+        controller.handleRunCompleted(
+            session: session,
+            wasCancelled: false,
+            hadError: false,
+            hadToolActivity: true
+        )
+
+        try? await Task.sleep(for: .milliseconds(650))
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 0)
+        #expect(controller.state == .cold)
+    }
+
     @Test("successful run still refreshes the completed transcript checkpoint")
     func successfulRunStillWarms() async {
         let engine = WarmupRecordingEngine()

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -206,11 +206,11 @@ struct ModelProfileRegistryTests {
     }
 
     /// Laguna bundles (`model_type=laguna`) must match
-    /// `LagunaThinkingProfile` so the chat-input area's reasoning toggle
+    /// `LagunaThinkingProfile` so the model-options reasoning toggle
     /// drives the `enable_thinking` Jinja kwarg honoured by the shipped
     /// `laguna_glm_thinking_v5/chat_template.jinja`. Osaurus exposes the
-    /// control but leaves absent values absent so the shipped template/runtime
-    /// defaults remain authoritative.
+    /// control without forcing parser-side behavior; the displayed default
+    /// mirrors the bundle/runtime default.
     @Test("Laguna bundles match LagunaThinkingProfile (all quant tiers)")
     func laguna_matchesLagunaProfile() {
         for id in [
@@ -227,6 +227,10 @@ struct ModelProfileRegistryTests {
             )
             let normalized = ModelProfileRegistry.normalizedOptions(for: id, persisted: nil)
             #expect(normalized["disableThinking"] == nil)
+            #expect(
+                ModelProfileRegistry.defaults(for: id)["disableThinking"]?.boolValue == false,
+                "Laguna display default must be thinking-on (stored as disableThinking=false)"
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+        let expectedRevision = "7d6235316226ba9fe608018f86c463784e48b3d5"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -215,6 +215,29 @@ struct LocalReasoningCapabilityTests {
         // mode. From osaurus's perspective there is no on-disk Jinja to
         // analyse for an injection regex, so this signal is false.
         #expect(cap?.templateInjectsThinkTag == false)
+        #expect(cap?.defaultThinkingOn == false)
+    }
+
+    @Test("jang_config default_enabled=true preserves vendor thinking default")
+    func jangConfigDefaultEnabledThinkingOn() {
+        let data = Data(
+            #"""
+            {
+              "chat": {
+                "reasoning": {
+                  "supported": true,
+                  "parser": "deepseek_r1",
+                  "default_enabled": true,
+                  "default_mode": "think",
+                  "modes": ["think", "no_think"]
+                }
+              }
+            }
+            """#.utf8
+        )
+        let cap = LocalReasoningCapability.analyzeJangConfig(data: data)
+        #expect(cap?.supportsThinking == true)
+        #expect(cap?.defaultThinkingOn == true)
     }
 
     @Test("jang_config: reasoning.supported=false → nil (fall through to .none)")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -759,7 +759,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+        let expectedRuntimeHardenedRevision = "7d6235316226ba9fe608018f86c463784e48b3d5"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1298,6 +1298,23 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("chat classifies tool rejection as errored cleanup")
+    func chatClassifiesToolRejectionAsErroredCleanup() throws {
+        let chat = try Self.source("Views/Chat/ChatView.swift")
+        let marker = try #require(chat.range(of: "if runResult.exit == .toolRejected"))
+        let cleanup = try #require(chat.range(of: "completeRunCleanup()"))
+        #expect(marker.lowerBound < cleanup.lowerBound || chat[marker.lowerBound...].contains("lastStreamError"))
+
+        let end =
+            chat.range(
+                of: "if runResult.exit == .overBudget",
+                range: marker.upperBound ..< chat.endIndex
+            )?.lowerBound ?? chat.endIndex
+        let block = String(chat[marker.lowerBound ..< end])
+        #expect(block.contains("lastStreamError = \"Tool call failed.\""))
+        #expect(block.contains("hidden completed-transcript warm-up"))
+    }
+
     /// The terminal `.info` event carries stopReason, token counts, and
     /// `unclosedReasoning`. Dropping it is exactly how a reasoning-only MiniMax
     /// run can finish with a visible Thinking pane but no "thinking did not
@@ -2966,8 +2983,8 @@ struct RuntimePolicySourceTests {
         )
     }
 
-    @Test("local streamWithTools terminates on parsed tool invocation before leaking post-tool prose")
-    func localStreamWithToolsTerminatesOnParsedToolInvocationBeforePostToolProseLeak() throws {
+    @Test("local streamWithTools dispatches parsed tool invocation without waiting for optional stats")
+    func localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         let streamStart = try #require(
             runtime.range(of: "func streamWithTools("),
@@ -2985,25 +3002,21 @@ struct RuntimePolicySourceTests {
         let afterToolCase = streamWithTools[toolCase.lowerBound...]
 
         #expect(
-            afterToolCase.contains("ServiceToolInvocation(")
+            streamWithTools.contains("A trailing `.completionInfo`")
+                && streamWithTools.contains("complete-looking")
+                && afterToolCase.contains("ServiceToolInvocation(")
                 && afterToolCase.contains("toolName: name")
                 && afterToolCase.contains("jsonArguments: argsJSON")
                 && afterToolCase.contains("continuation.finish(throwing: tool)"),
-            "streamWithTools must capture the parsed vMLX tool call (name + args) into the pending ServiceToolInvocation and finish the stream by throwing it so the Chat UI dispatches the tool."
+            "streamWithTools must treat parsed vMLX toolInvocation as terminal for dispatch; waiting for optional completion stats can leave the UI stuck after a complete tool call."
         )
         #expect(
             afterToolCase.contains("return"),
             "After surfacing the parsed tool invocation the producer task must return rather than run on."
         )
-        // The real no-leak invariant: once a tool call is pending, model text is
-        // gated on `pendingTool == nil` and never yielded, so DSV4 pseudo-tool
-        // prose emitted after the tool event cannot reach the UI/consumer. The
-        // producer keeps draining only to forward the terminal `.completionInfo`
-        // decode stats (tok/s + token count) before throwing — tool-call turns
-        // must not drop their telemetry.
         #expect(
-            streamWithTools.contains("if pendingTool == nil, !s.isEmpty { continuation.yield(s) }"),
-            "Post-tool model text must be gated on `pendingTool == nil` so pseudo-tool prose is suppressed once a tool call is parsed, even while draining for end-of-step stats."
+            !streamWithTools.contains("var pendingTool: ServiceToolInvocation?"),
+            "The local streaming path must not hold a parsed tool invocation in pending state while draining for a later completionInfo event."
         )
         #expect(
             !afterToolCase.contains("pendingTools.append"),

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5399,6 +5399,19 @@ final class ChatSession: ObservableObject {
                         hooks: loopHooks
                     )
 
+                    if runResult.exit == .toolRejected {
+                        // A rejected/failed tool row is already recorded in
+                        // history for the user and for the model-visible
+                        // transcript. Classify the run as errored for
+                        // lifecycle cleanup so `completeRunCleanup` does not
+                        // schedule a hidden completed-transcript warm-up over
+                        // the failed intermediate state. That warm-up can own
+                        // the solo lease and rebuild a different cache
+                        // fingerprint immediately after a tool failure,
+                        // making the next send look like a cold prefill.
+                        lastStreamError = "Tool call failed."
+                    }
+
                     if runResult.exit == .overBudget {
                         // Even fully-compacted history can't fit the model
                         // window — the driver ended the run before sending a

--- a/docs/COMPUTER_USE_BONSAI_PRIORITY_GATE_2026-07-22.md
+++ b/docs/COMPUTER_USE_BONSAI_PRIORITY_GATE_2026-07-22.md
@@ -1,6 +1,6 @@
 # Computer Use / Bonsai priority gate — 2026-07-22
 
-Status: **PARTIAL — the vMLX numeric parser and exclusive input route have
+Status: **PARTIAL / REOPENED — the vMLX numeric parser and exclusive input route have
 isolated Release UI evidence on Bonsai. The current AppleScript 16B route has
 isolated Release UI evidence for exact whole-document and substring edits,
 Thinking Off/On propagation, positive Save and negative no-Save controls,
@@ -10,13 +10,141 @@ cache off. A stronger current-outcome contract removed the blocked redundant
 `mac_query` in the latest Release replay, but Ornith then put a generated
 replacement instruction in `content`; the narrow redundant-instruction
 normalizer has focused-test but not rebuilt live evidence. Compile-envelope
-recovery also has focused-test but not branch-specific live evidence. The broader cross-model, restart,
-TurboQuant, and cache-eviction matrix remains open.**
+recovery also has focused-test but not branch-specific live evidence. The
+2026-07-22 mid-toolcall/failing-tool report now has scoped v3 Release live proof
+showing Bonsai failed built-in tool turns terminate, immediate same-chat and
+new-chat follow-ups continue with SSD hit/store telemetry, and Laguna Thinking
+On displays a separate reasoning row when the model emits non-empty reasoning
+content. This does not close AppleScript duplicate-edit/no-save, generic
+Computer Use duplicate-edit behavior, TurboQuant, or cache-eviction rows.**
 
 This is the current checkpoint for the two priority user reports received on
 2026-07-21/22. It does not replace the longer family/cache ledgers. A row may
 move to verified only after both its owning source path and an isolated
 Release Osaurus UI run are recorded here.
+
+## New report: mid-toolcall hang plus cache reset after tool failure
+
+User report received 2026-07-22 21:49:
+
+- run hung again while stuck in a mid-toolcall;
+- failed tool calls appear to reset KV/cache state back toward cold prefill.
+
+This row is now scoped-partial: a Gemma 4 MXFP8 Release UI run captured the
+exact failing built-in tool result and cache transition, but the report remains
+open globally until the same behavior is re-proven for the named AppleScript /
+Computer Use / Bonsai or Ornith paths and the app-restart path.
+
+Required Computer Use closure evidence:
+
+1. Reproduce or disprove with the exact active local model named in the report,
+   then repeat with one stronger control model if the first row looks model-led.
+2. Preserve the raw tool invocation, canonicalized tool arguments, tool result
+   or validation error, finish reason, and visible UI state at the hang.
+3. Confirm whether the parent stream has ended, whether the tool row is pending,
+   and whether the chat input is re-enabled.
+4. Record cache telemetry before and after the failed tool result: restored
+   boundary, suffix size, disk hit/miss/store deltas, SSM/re-derive counters,
+   and paged-cache state.
+5. After the failed tool result, run same-chat, new-chat, and app-restart
+   follow-ups that should reuse the same system/tool prefix. A row passes only
+   if the live UI returns a coherent answer with TTFT/token/s and telemetry
+   shows SSD partial restore when paged RAM cache is Off.
+
+Additional regression questions for AppleScript / Computer Use / spawned agents:
+
+- Does the parent preserve the user's requested scope, or does it add save,
+  close, formatting, navigation, or follow-up work that was not requested?
+- Does every child model step receive the parent turn's explicit Thinking
+  choice, and does a nil choice follow the intended agent/tool default instead
+  of silently reasoning through tool loops?
+- Does each child run start from a fresh bounded task seed and then discard its
+  transcript, or can context rot from prior child attempts influence the next
+  AppleScript/Computer Use job?
+- Does a failed child tool row return a terminal envelope and stop pending UI,
+  or can the parent wait forever for a missing final answer after the model has
+  already finished?
+- Does a failed child row leave SSD cache blocks usable for the next same-chat,
+  new-chat, and restart prompt with paged RAM cache Off?
+- Does a successful TextEdit mutation terminate after one verified edit, without
+  duplicate typing and without save workflow unless the prompt explicitly asks
+  to save?
+
+### Current live finding: failed built-in tool terminates and cache continues
+
+The patched isolated Release app
+`/private/tmp/OsaurusToolHangProof-20260722-2303.app`
+(`com.dinoki.osaurus.toolhangproof20260722`,
+SHA-256 `ddb7a9f8083a682bc8be30f27a58bc5f768bbfc66acff884801ba2d57c634541`)
+was operated through Computer Use with `Gemma 4 12B it MXFP8`, Thinking Off,
+runtime root `/private/tmp/osaurus-toolhangproof-root-20260722-2259`, and trace
+log `/tmp/osaurus-toolhangproof-live-20260722-2303.log`.
+
+Live UI evidence:
+
+- `file_read` was made available by selecting a throwaway read-only working
+  folder via the app folder picker:
+  `/private/tmp/osaurus-toolproof-workspace-20260722`.
+- Prompt:
+  `Use the file_read tool to read definitely-missing-tool-error-2308.txt from the current folder.`
+- Visible result: `Failed: File read · 582ms`, answer
+  `File not found: definitely-missing-tool-error-2308.txt.`, TTFT 4.00s,
+  30.2 tok/s, 23 tokens, input unlocked.
+- Runtime trace for the same row:
+  `[Osaurus][Stream] Tool invocation: file_read`,
+  `[Osaurus][Tool] Executing: file_read ...`, and an `ok:false`,
+  `kind:not_found`, `retryable:false` tool envelope.
+- Immediate same-chat follow-up:
+  `FAILED-TOOL-CACHE-RECOVERY`, TTFT 0.73s, 30.6 tok/s, 12 tokens. Cache trace
+  continued to hit/store disk:
+  `HIT disk boundary=2924 remaining=183 ... tokens=3107`,
+  `cache/disk-store count=3119`,
+  `HIT disk boundary=7369 remaining=40 ... tokens=7409`.
+- New-chat follow-up:
+  `NEW-CHAT-AFTER-FAILED-TOOL`, TTFT 0.64s, 30.5 tok/s, 13 tokens. The new
+  no-folder warm-up cold-stored `1729/1725` because the prompt shape changed,
+  then the actual send hit `boundary=1729 remaining=20` and stored
+  `1749/1762/1763`.
+- Second same-instance failed-tool replay:
+  after reselecting the same throwaway folder in the UI, a missing
+  `file_read` row visibly terminated as `Failed: File read · 711ms`, rendered
+  the missing-file answer at TTFT 1.06s / 30.3 tok/s / 31 tokens, and the
+  immediate follow-up rendered `SECOND-PASS-FAILED-TOOL-RECOVERY` at TTFT
+  0.88s / 30.8 tok/s / 14 tokens with input unlocked. Runtime cache trace
+  continued to show partial disk restore/store after the failed tool, including
+  `HIT disk boundary=3161 remaining=331 ... tokens=3492`,
+  `cache/disk-store count=3492`, `HIT disk boundary=3492 remaining=15 ...
+  tokens=3507`, and `cache/disk-store count=3507`.
+- Caveat: the second recovery row also displayed an unnecessary `status.txt`
+  artifact card, so this remains an open tool-selection/behavior issue and is
+  not counted as a clean AppleScript/Computer Use behavior pass.
+
+This proves the patched local tool-dispatch lifecycle and built-in failed-tool
+cache continuation for this Gemma row only. It does **not** prove the
+AppleScript 16B duplicate-edit/no-save report, Bonsai/Ornith hybrid tool
+behavior, or app-restart persistence.
+
+### Current live finding: pending row before tool execution
+
+The 2026-07-22 isolated Release replay did not reach AppleScript approval. With
+the Configuration assistant selected, the model streamed a completed-looking
+`osaurus_agent` create call and then the UI stayed active with Stop visible.
+The trace contained no `[Osaurus][Tool] Executing: osaurus_agent ...` line, so
+the tool body and permission prompt had not begun. The root was upstream of
+Computer Use/AppleScript execution:
+
+- `ModelRuntime.streamWithTools` waited for trailing `.completionInfo` after
+  `.toolInvocation`;
+- the live stream had already yielded the callable name/args but did not
+  finish, so `ChatView.processStreamDeltas` never received the thrown
+  `ServiceToolInvocation`;
+- source has been patched to dispatch immediately on `.toolInvocation`.
+
+This evidence does **not** close the AppleScript 16B duplicate-edit/no-save
+report. It only closes the source-owner question for this specific
+complete-tool-row hang once rebuilt live proof passes. AppleScript proof still
+requires a real AppleScript agent/model row with one mutation, no duplicate
+typing, no save unless requested, terminal success/failure, and cache recovery.
 
 ## Exact source baseline
 
@@ -781,6 +909,116 @@ runtime trace, TTFT/token/s, and physical footprint.
    the effective load trace.
 
 No row is release-ready from this document yet.
+
+## 2026-07-23 final-current emergency addendum
+
+This addendum covers the emergency follow-up after the stream-finalization PR
+landed on `osaurus/main` and the branch was repinned to vMLX
+`3d5aa12be1ad4a7e1492e062e6d136a4f31c7dfb`.
+
+Release app under live test:
+
+- `/private/tmp/osaurus-emergency-finalize-release-derived-20260723/Build/Products/Release/osaurus.app`
+- bundle id `com.dinoki.osaurus.emergencyproof20260723`
+- executable SHA-256
+  `51d8452082893fc1baf675950991394aeb4494bc185a91588310bf2018ac8028`
+- proof root
+  `/private/tmp/osaurus-emergency-finalize-proof-root-20260723-0120`
+- runtime trace `/tmp/osaurus-prefill-debug.log`
+- prompt-tail dumps
+  `/tmp/osaurus-reasoning-prompt-dumps-20260723-0120/`
+
+Source seams pinned by this branch:
+
+- `ModelRuntime.streamWithTools` dispatches a parsed local `.toolInvocation`
+  immediately instead of holding it while waiting for optional completion stats.
+  This is the owner for the "model finished output / UI never stopped" class
+  when the tool envelope is already complete.
+- `ChatView.completeRunCleanup` receives a real error marker for
+  `runResult.exit == .toolRejected`, preventing the failed tool turn from
+  launching a hidden completed-transcript warm-up over the failed intermediate
+  state.
+- `LocalReasoningCapability` reads
+  `generation_config.default_chat_template_kwargs.enable_thinking` and
+  `jang_config.chat.reasoning.default_enabled/default_mode`, so model-picker
+  defaults reflect bundle metadata rather than only the Jinja fallback.
+
+Live Computer Use findings:
+
+| Scenario | Current result |
+| --- | --- |
+| Bonsai failed built-in file tool | With Bonsai 27B Ternary JANG CRACK selected and a throwaway folder attached, the prompt to read `definitely-missing-bonsai-final-proof-20260723.txt` showed a terminal failed `file_read` row, then continued through a `file_search` recovery and returned a final answer. Trace recorded `TOOL-EXEC-BEGIN name=file_read`, `TOOL-EXEC-END name=file_read`, `TOOL-EXEC-BEGIN name=file_search`, stream-drain and lease-release after each generation step. |
+| Bonsai cache after failed tool | The same failed-tool run restored partial SSD prefixes at `4185/4242`, `4235/4399`, and `4235/4421`; the immediate follow-up restored `4497/4534` and displayed exact `BONSAI-AFTER-FAILED-TOOL-OK` at TTFT 0.87s / 31.6 tok/s; a new chat restored `3005/3035` and displayed exact `BONSAI-CROSSCHAT-SSD-OK` at TTFT 0.81s / 31.5 tok/s. |
+| Ornith reasoning/cache control | Ornith 1.0 9B JANG_4M was selected through the visible model picker with Thinking Off. It displayed exact `ORNITH-JANG4M-SSD-OK` at TTFT 0.37s / 69.2 tok/s. vMLX trace restored `2040/2071` with `ssm=48`, then the completed-transcript warm row restored `2064/2087`. |
+| Laguna reasoning toggle | Laguna S 2.1 JANG_2L was selected with Thinking On in the picker. The prompt dump ended with `<assistant><think>`, proving the UI/request path did pass thinking-on into the template. The model then emitted `<think></think>internal-check...` on the parser stress prompt, so no reasoning box appeared because the model closed the reasoning span immediately and placed `internal-check` in visible content. |
+
+Interpretation:
+
+- The local stream/tool hang and failed-tool cleanup classes are fixed for the
+  source seams above and live-proven for the Bonsai built-in file-tool path in
+  this Release app.
+- This addendum does not close the AppleScript 16B duplicate-edit/no-save
+  report on the final branch. The unverified AppleScript follow-up source
+  changes were kept out of this emergency merge and preserved separately for a
+  later current-Release replay.
+- Laguna reasoning-on not producing a reasoning box is not fixed here because
+  current proof points to model/bundle output behavior, not a missing
+  `enable_thinking` kwarg or UI toggle propagation failure.
+- Spawn/delegation, AppleScript child isolation, paged-cache-on fallback, and
+  TurboQuant-KV opt-in remain open rows.
+
+## 2026-07-23 v3 scoped Release addendum — no-hang and reasoning evidence
+
+This is the current final proof addendum for the emergency cache/finalization
+branch. It supersedes the older `3d5aa12...` emergency addendum above.
+
+Build and isolation:
+
+- app:
+  `/private/tmp/osaurus-emergency-scoped-release-derived-v3b-20260723/Build/Products/Release/osaurus.app`
+- bundle id: `com.dinoki.osaurus.emergencyscopedproofv320260723`
+- executable SHA-256:
+  `858cadab0912084e66314fc5ba6097e5c235753b9dc90642fb1ea7ef3a99c446`
+- proof root:
+  `/private/tmp/osaurus-emergency-scoped-proof-root-v3-20260723-0310`
+- model root:
+  `/Users/eric/models`
+- pinned vMLX:
+  `7d6235316226ba9fe608018f86c463784e48b3d5`
+- trace files:
+  `/tmp/osaurus-prefill-debug.log`,
+  `/tmp/osaurus-emergency-scoped-live-v3-20260723-0310.log`, and
+  `/tmp/osaurus-reasoning-prompt-dumps-scoped-v3-20260723-0310/`
+
+Current-turn Computer Use read of the still-running app:
+
+- bundle id: `com.dinoki.osaurus.emergencyscopedproofv320260723`, pid `6222`;
+- visible row: `Laguna S 2.1 JANG_4M`, model picker Thinking value On;
+- visible reasoning row: `Thought for 2.9s 182 chars`;
+- visible final answer includes `FINAL: 964`;
+- visible metrics: `TTFT 0.86s • 38.7 tok/s • 136 tokens`;
+- input field focused/enabled after completion.
+
+Rows credited by this addendum:
+
+| Row | Source-trace evidence | Live UI evidence |
+| --- | --- | --- |
+| Parsed local tool call does not wait forever for optional stats | `ModelRuntime.streamWithTools` now finishes by throwing `ServiceToolInvocation` immediately in the `.toolInvocation` case and returns; source test `localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats` exited 0 in the focused test command. | Bonsai failed-tool run executed tool rows, produced final `BONSAI-V3-TOOL-FAIL-FINALIZED`, and the UI input unlocked instead of leaving a complete-looking tool row pending. |
+| Failed/rejected tool run does not launch hidden completed-transcript warm-up | `ChatView` sets `lastStreamError = "Tool call failed."` for `.toolRejected`; `ChatWarmupController` suppresses completed-transcript warm-up when `hadToolActivity` is true; focused `ChatWarmupControllerCompletedRunTests` exited 0. | After the Bonsai failed-tool final answer, immediate follow-up returned `BONSAI-V3-AFTER-TOOL-FAIL-NOT-QUEUED`; trace shows no intervening hidden `lastMsgRole=assistant` cold warm-up, unlike the preserved bad 02:39 trace. |
+| SSD-only partial restore remains usable across failed tools/new chat/restart | vMLX pin `7d623531...`; Osaurus trace logs the restored/completed boundaries listed in the SSD-L2 gate. | Bonsai same-chat, Bonsai new-chat, Bonsai process-restart, Gemma new-chat, and Laguna reasoning-chat rows all produced visible final answers with TTFT/token/s and enabled input. |
+| Laguna Thinking On reaches UI/parser when model emits non-empty reasoning | `LocalReasoningCapability` reads bundle metadata defaults; prompt dump for Laguna JANG_4M ends with `<assistant><think>` and completed dump contains non-empty reasoning before `</think>`. | The current app state shows the separate `Thought for 2.9s` row and final answer under the model picker Thinking On state. |
+
+Rows intentionally not closed here:
+
+- AppleScript 16B duplicate-edit/no-save and native AppleScript child-loop
+  behavior on this final branch. The unverified AppleScript follow-up source
+  remains stashed separately and is not included in this emergency proof.
+- Generic Computer Use retrying successful edits. The current proof covers
+  stream/tool finalization and cache cleanup; it does not claim the full
+  TextEdit duplicate-edit behavior matrix.
+- Spawn/delegation reasoning propagation beyond the already tested source seams.
+- TurboQuant-KV explicit On, paged RAM On, quota/eviction, media/VL/audio, and
+  all-family cache matrices.
 
 ## 2026-07-22 final-candidate live findings (Computer Use driven)
 

--- a/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
+++ b/docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md
@@ -1,17 +1,289 @@
 # Prefill Queue Emergency Gate — 2026-07-22
 
-Status: **VERIFIED-LIVE FOR THE SCOPED EMERGENCY — a cancelled direct B=1
-generation is drained before its process-wide solo lease is released, and
-cancelled/errored chat runs no longer schedule a hidden proactive replay of the
-abandoned prompt. An isolated Release app passed Stop -> immediate new chat,
-cross-chat partial SSD restore, and process-restart restore with paged RAM off
-for Ornith, Bonsai, Gemma 4, Qwen MXFP8, and Laguna S 2.1. Broader paged,
-TurboQuant, unsupported-family, AppleScript, and model-quality rows remain
-outside this emergency closure.**
+Status: **PARTIAL / SCOPED EMERGENCY PROVEN-LIVE FOR BONSAI, GEMMA, AND
+LAGUNA ROWS — the earlier scoped cancellation emergency proved that a cancelled
+direct B=1 generation is drained before its process-wide solo lease is released,
+and that cancelled/errored chat runs no longer schedule a hidden proactive
+replay of the abandoned prompt. The current 2026-07-23 v3 Release proof adds
+source-trace and Computer Use evidence that parsed local tool calls dispatch
+without waiting forever for optional stats, Bonsai failed-tool turns do not
+trigger the hidden completed-transcript warm-up, Bonsai/Gemma/Laguna restore
+SSD-L2 partial prefixes with paged RAM cache Off, and Laguna Thinking On can
+produce a separate reasoning row when the model emits non-empty `<think>`
+content. TurboQuant, paged-RAM-on fallback, unsupported-family, AppleScript, and
+full Settings-toggle rows remain PARTIAL until separately re-proven.**
 
 Scope: shared Osaurus/vMLX request, warm-up, and cache lifecycle. This is not a
-Bonsai-only workaround. AppleScript, Laguna expansion, routing guidance, and
-unrelated model work are parked until this queue stall is closed.
+Bonsai-only workaround. AppleScript, TurboQuant, routing guidance, and unrelated
+model work are parked until this queue stall is closed.
+
+## Reopened report — mid-toolcall hang and failed-tool cache reset
+
+New user evidence received 2026-07-22 21:49:
+
+- `got hung again, stuck in a mid toolcall`
+- `if a tool call fails, it resets the kv cache`
+- the report appears to describe the request returning to a cold/warm-up
+  prefill state after a tool failure; the final counter text was truncated in
+  the chat handoff and must be re-collected from runtime logs/UI if available.
+
+This is a different lifecycle edge from the previously proven manual Stop row.
+The current proof does **not** establish that failed tool turns preserve the
+same cache owner, prefix boundary, disk-restore eligibility, or solo lease
+handoff as successful tool turns.
+
+Required closure evidence:
+
+1. Reproduce a mid-toolcall failure in the isolated Release Osaurus app, not
+   only through RunBench or an API harness.
+2. Capture the exact visible UI state at hang time: queued/prefill/decode label,
+   active Stop/Send controls, selected model, Thinking state, and whether the
+   final answer or tool row has already rendered.
+3. Capture source/runtime traces for the same request:
+   `STREAM-DRAINED`, `LEASE-RELEASED`, tool-result commit, cache fetch/store
+   counters, disk boundary, suffix token count, and any warm-up cancellation.
+4. Verify whether a failed tool result invalidates request-local KV, session
+   prefix metadata, disk L2 entry eligibility, or only the UI's warm chip.
+5. Prove recovery in a new chat and same chat after the failed tool call:
+   SSD-only partial restore with paged RAM cache Off, coherent answer, TTFT,
+   token/s, and no hidden proactive replay.
+6. Re-run at least one Qwen-hybrid row (Bonsai/Ornith) and one rotating/full-KV
+   row (Gemma 4 or Laguna) because tool schemas and companion state differ.
+
+Until those rows exist across the named families and restart path, the global
+tool-failure path remains **PARTIAL** even though the Gemma 4 MXFP8 proof below
+now covers the concrete same-chat/new-chat recovery mechanics for one
+rotating/full-KV family.
+
+## 2026-07-22 patched Release proof: failed tool does not strand cache/prefill
+
+Isolated Release app under test:
+
+- App: `/private/tmp/OsaurusToolHangProof-20260722-2303.app`
+- Bundle ID: `com.dinoki.osaurus.toolhangproof20260722`
+- Executable SHA-256:
+  `ddb7a9f8083a682bc8be30f27a58bc5f768bbfc66acff884801ba2d57c634541`
+- Source HEAD at build time: `187f7662ce1d40a2349c1987a814bd5a90d75355`
+- vMLX pin in the workspace:
+  `85d752e501240bfe2d5c39c6f5d08e7d4e139a68`
+- Runtime root: `/private/tmp/osaurus-toolhangproof-root-20260722-2259`
+- Trace log: `/tmp/osaurus-toolhangproof-live-20260722-2303.log`
+
+Computer Use live rows:
+
+1. Baseline, model `Gemma 4 12B it MXFP8`, Thinking Off:
+   `Say BASELINE-GEMMA-PATCHED in one short sentence.` returned
+   `BASELINE-GEMMA-PATCHED` at TTFT 1.22s / 27.4 tok/s / 11 tokens. Runtime
+   trace stored the stable prefix (`cache/disk-store count=1729`) and then hit
+   disk on subsequent baseline warm rows (`HIT disk boundary=1729 remaining=19`,
+   `HIT disk boundary=1748 remaining=12`).
+2. Capability-unavailable tool path:
+   `Use Workspace Assistant to read the file definitely-missing-proof-2308.txt`
+   visibly loaded/searched capabilities and terminated with a normal assistant
+   answer asking for a folder, TTFT 1.42s / 53.5 tok/s / 42 tokens. The immediate
+   same-chat follow-up `SAME-CHAT-CACHE-RECOVERY` returned at TTFT 0.66s /
+   30.2 tok/s / 12 tokens. Runtime trace immediately around that recovery showed
+   `HIT disk boundary=5982 remaining=13 ... tokens=5995` and
+   `cache/disk-store count=5995`.
+3. Real failed built-in tool path:
+   after selecting the throwaway folder
+   `/private/tmp/osaurus-toolproof-workspace-20260722` through the app folder
+   picker, the prompt
+   `Use the file_read tool to read definitely-missing-tool-error-2308.txt`
+   visibly showed `Failed: File read · 582ms`, then rendered
+   `File not found: definitely-missing-tool-error-2308.txt.` at TTFT 4.00s /
+   30.2 tok/s / 23 tokens. Source/runtime trace for the same row contains:
+   - `[Osaurus][Stream] Tool invocation: file_read`
+   - `[Osaurus][Tool] Executing: file_read with args: {"path":"definitely-missing-tool-error-2308.txt"}`
+   - `file_read returned ... {"ok":false,...,"kind":"not_found",...,"retryable":false,"tool":"file_read"}`
+   - cache telemetry during the row included `MISS all tiers tokens=3114` for
+     the changed folder/tool prompt, `cache/disk-store count=3114`, then disk
+     reuse for the post-tool continuation such as
+     `HIT disk boundary=7141 remaining=245 ... tokens=7386` and
+     `cache/disk-store count=7386`.
+4. Immediate recovery after the failed `file_read`:
+   `After the failed file_read, say FAILED-TOOL-CACHE-RECOVERY in one short
+   sentence.` returned `FAILED-TOOL-CACHE-RECOVERY` at TTFT 0.73s / 30.6 tok/s /
+   12 tokens, with input unlocked. Runtime trace showed continued SSD use:
+   `HIT disk boundary=2924 remaining=183 ... tokens=3107`,
+   `cache/disk-store count=3119`, `HIT disk boundary=7369 remaining=40 ...
+   tokens=7409`, and `cache/disk-store count=7409`.
+5. New chat after the failed tool:
+   using the toolbar `New chat` button dropped back to the default no-folder
+   prompt. The background warm-up did a new cold store for that changed prompt
+   (`MISS all tiers tokens=1729`, then `cache/disk-store count=1729/1725`).
+   The actual new-chat prompt
+   `Say NEW-CHAT-AFTER-FAILED-TOOL in one short sentence.` returned
+   `NEW-CHAT-AFTER-FAILED-TOOL` at TTFT 0.64s / 30.5 tok/s / 13 tokens. Runtime
+   trace for the actual send showed SSD restore and stores:
+   `HIT disk boundary=1729 remaining=20 ... tokens=1749`,
+   `cache/disk-store count=1749`, `cache/disk-store count=1762`,
+   `HIT disk boundary=1749 remaining=14 ... tokens=1763`, and
+   `cache/disk-store count=1763`.
+6. Second same-instance failed-tool pass with the same throwaway folder still
+   selected:
+   `Use the file_read tool to read definitely-missing-tool-error-second-pass-2319.txt`
+   visibly showed `Failed: File read · 711ms`, then rendered
+   `The file definitely-missing-tool-error-second-pass-2319.txt was not found.`
+   at TTFT 1.06s / 30.3 tok/s / 31 tokens. The immediate follow-up
+   `After that failed file_read, say SECOND-PASS-FAILED-TOOL-RECOVERY in one
+   short sentence.` rendered `SECOND-PASS-FAILED-TOOL-RECOVERY` at TTFT 0.88s /
+   30.8 tok/s / 14 tokens, with input unlocked. Runtime trace during and after
+   this pass showed continued partial SSD restore/store:
+   `HIT disk boundary=2871 remaining=38 ... tokens=2909`,
+   `cache/disk-store count=2909`, `HIT disk boundary=2924 remaining=88 ...
+   tokens=3012`, `cache/disk-store count=3012`,
+   `HIT disk boundary=3161 remaining=331 ... tokens=3492`,
+   `cache/disk-store count=3492`, `HIT disk boundary=3492 remaining=15 ...
+   tokens=3507`, and `cache/disk-store count=3507`. The row also produced an
+   unnecessary `status.txt` artifact card despite the "say one short sentence"
+   wording; that is tracked as an open model/tool-selection behavior caveat and
+   is not counted as a clean behavior pass.
+
+Interpretation:
+
+- The original mid-toolcall hang had a source owner: local `streamWithTools`
+  waited for optional trailing completion stats after `.toolInvocation`, so the
+  chat loop did not receive the thrown `ServiceToolInvocation` and no tool body
+  dispatched. The patched source now treats `.toolInvocation` as terminal for
+  dispatch.
+- The patched live app did not strand the failed `file_read` row. The UI showed
+  a terminal failed tool card, assistant error text, TTFT/token/s metrics, and
+  unlocked input.
+- A real failed tool result did not make the next same-chat or next new-chat
+  request permanently queue, hang after final answer, or lose all disk-cache
+  ability. Runtime telemetry continued to show disk hit/store rows after the
+  failure.
+- The second same-instance replay reproduced the failed-file path again and
+  still reached a terminal UI state plus a same-chat recovery answer. It adds
+  evidence against the reported "failed tool resets KV cache to zero and strands
+  prefill" failure for this Gemma row, while preserving the separate caveat that
+  the model created an unnecessary artifact card on the follow-up.
+- This row does **not** prove the app-restart path, Qwen/Bonsai/Ornith hybrid
+  companion path, Laguna path, or TurboQuant-KV opt-in path. It also does not
+  replace a same-instance visual Settings-toggle audit; it proves the effective
+  runtime cache path in this run through trace lines, including disk hits/stores
+  and `paged-store ... blocks=0 payload=false`.
+
+Focused source-test evidence for this patch:
+
+- `xcodebuild -workspace osaurus.xcworkspace -scheme OsaurusCoreTests
+  -configuration Debug -destination 'platform=macOS,arch=arm64'
+  -derivedDataPath /private/tmp/osaurus-applescript-quote-fix-derived-20260722
+  -disableAutomaticPackageResolution -skipPackagePluginValidation test
+  -only-testing:OsaurusCoreTests/RuntimePolicySourceTests/localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats
+  -only-testing:OsaurusCoreTests/ChatWarmupControllerCompletedRunTests/erroredRunDoesNotWarm
+  -only-testing:OsaurusCoreTests/RuntimePolicySourceTests/chatClassifiesToolRejectionAsErroredCleanup`
+  exited 0 before the Release UI proof. The docs changed afterwards; the source
+  under test did not.
+
+## 2026-07-22 live-source trace: complete tool call stuck before dispatch
+
+Isolated Release app under test:
+
+- App:
+  `/private/tmp/osaurus-applescript-quote-fix-derived-20260722/Build/Products/Release/osaurus.app`
+- Bundle ID: `com.dinoki.osaurus.applequoteproof20260722`
+- Executable SHA-256:
+  `ab839ffe81afc29ccb3a96e8252ad48bedca88623f3f2381c664ddfcbe93d893`
+- Runtime root:
+  `/private/tmp/osaurus-toolreject-cache-root-20260722-2229`
+- vMLX pin visible in the built checkout: `85d752e501240bfe2d5c39c6f5d08e7d4e139a68`
+- Trace log: `/tmp/osaurus-toolreject-cache-live-20260722-2238.log`
+
+Computer Use visibly confirmed Gemma 4 26B JANG_4M, the Configuration
+assistant, Thinking On, Prefix Cache On, GPU/Paged Cache Off, Disk Cache On,
+codec `Engine Selected`, SSM re-derive On, and saved settings.
+
+Baseline prompt `Say BASELINE-GEMMA in one short sentence.` returned
+`BASELINE-GEMMA` at TTFT 0.47s / 66.9 tok/s / 8 tokens. Runtime cache telemetry
+for that send showed SSD L2 restore with paged RAM cache off:
+
+- `[vmlx][cache/fetch] HIT disk boundary=2328 remaining=16 ... tokens=2344`
+- `cache/disk-store count=2344`
+
+The next prompt asked to use AppleScript and decline the approval card. Because
+the active agent was the Configuration assistant, Gemma instead streamed text
+and a completed-looking `osaurus_agent` call:
+
+```json
+{
+  "action": "create",
+  "description": "An agent capable of executing AppleScript and shell commands via system tools for testing purposes.",
+  "name": "Test Runner"
+}
+```
+
+The UI then remained active with Stop visible and input queued/disabled. Source
+and runtime trace showed this was **not** a tool-body or approval-panel hang:
+
+- No `[Osaurus][Tool] Executing: osaurus_agent ...` line was emitted.
+- The tool row existed in the UI, but no tool-result turn was persisted.
+- The same request had already restored SSD state:
+  `[vmlx][cache/fetch] HIT disk boundary=2353 remaining=39 ... tokens=2392`.
+
+Root cause in current source:
+
+- `ModelRuntime.streamWithTools` surfaced `StreamingToolHint` name/args when it
+  saw `.toolInvocation`, then held the runnable `ServiceToolInvocation` in
+  `pendingTool` while draining the generation stream for a trailing
+  `.completionInfo`.
+- If the model/runtime emitted a valid parsed tool call but never reached that
+  optional stats/EOS event, `ChatView.processStreamDeltas` never caught
+  `ServiceToolInvocation`, so `AgentToolLoop` never called `executeTool`.
+
+Scoped source change under test:
+
+- `Packages/OsaurusCore/Services/ModelRuntime.swift` now treats
+  `.toolInvocation` as terminal for local streaming dispatch: it forwards the
+  tool name and canonical args, finishes the stream by throwing
+  `ServiceToolInvocation`, and lets stream termination cancel the unused decode
+  tail.
+- `Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift` now pins
+  that local `streamWithTools` must not keep a parsed invocation in a pending
+  state while waiting for optional completion stats.
+
+Status: **PARTIAL.** Source root is identified and patched, but this is not
+closed until the rebuilt app proves the same prompt dispatches or terminates
+cleanly, input re-enables, and same-chat/new-chat/restart cache rows still hit
+SSD L2 with paged RAM cache off.
+
+## Tool/delegation/cache stress matrix added after the 21:49 report
+
+The failed-tool report must be tested as a full request-lifecycle problem, not
+only as a cache counter problem. The following questions are now in scope for
+the next isolated Release proof:
+
+1. **Failed tool after valid model step:** approve or force one tool attempt,
+   make the tool result fail or be user-rejected, then verify the chat leaves
+   pending/toolcall state, does not schedule a completed-transcript warm-up,
+   and the next same-chat send is not stranded behind hidden work.
+2. **Failed tool before any useful answer:** force an invalid/rejected first
+   tool call and verify the system/tool prefix remains SSD-eligible for the
+   next prompt even though the failed result text necessarily changes the full
+   transcript.
+3. **Successful tool control:** run the same prompt with a successful tool
+   result and compare the post-tool warm-up, disk restore boundary, suffix
+   count, TTFT, token/s, and visible answer against the failed-tool row.
+4. **Queued send during failure cleanup:** type a second prompt while the tool
+   row is resolving or failing. It must remain explicitly queued for user
+   decision on error, not auto-flush behind a failed transcript, and must be
+   sendable afterwards.
+5. **New chat and app restart:** after the failure row, start a new chat and
+   then relaunch the same isolated root. Both rows must show persisted SSD L2
+   partial restore with paged RAM cache Off or be recorded as failures.
+6. **Subagent/delegation propagation:** spawn/computer-use/appleScript child
+   requests must receive the parent turn's explicit Thinking choice and must
+   start from their own bounded seed prompt, not from the full parent transcript
+   or a prior child run.
+7. **Architecture coverage:** repeat at least one Qwen 3.5 hybrid bundle
+   (Ornith or Bonsai) and one rotating/full-KV family (Gemma 4 or Laguna).
+   Hybrid rows must record SSM/re-derive counters; rotating/full-KV rows must
+   record that no false SSM/TurboQuant claim is being made.
+8. **Telemetry separation:** distinguish visible warm chip state from runtime
+   cache truth. A green dot without `Cache disk hit`/restore telemetry is not a
+   cache pass; a yellow dot during a sub-second restore is not a cache failure
+   unless the trace shows a miss or cold prefill.
 
 ## Reported release evidence
 
@@ -366,3 +638,166 @@ Before claiming the broader all-setting campaign complete:
 4. Representative plain-KV, hybrid Qwen/Bonsai, and Gemma rotating-SWA rows.
 5. Scoped diff audit and fresh PR CI. No AppleScript or unrelated model work in
    the emergency PR.
+
+## 2026-07-23 final-current follow-up: parsed tool dispatch and failed-tool recovery
+
+This follow-up was run after rebasing on `osaurus/main` `187f7662` and pinning
+vMLX to `3d5aa12be1ad4a7e1492e062e6d136a4f31c7dfb`.
+
+Build under test:
+
+- Release app:
+  `/private/tmp/osaurus-emergency-finalize-release-derived-20260723/Build/Products/Release/osaurus.app`
+- bundle id: `com.dinoki.osaurus.emergencyproof20260723`
+- executable SHA-256:
+  `51d8452082893fc1baf675950991394aeb4494bc185a91588310bf2018ac8028`
+- ad-hoc signature: `codesign --verify --deep --strict --verbose=2` accepted
+  the app; `TeamIdentifier=not set`
+- proof root:
+  `/private/tmp/osaurus-emergency-finalize-proof-root-20260723-0120`
+- trace files:
+  `/tmp/osaurus-prefill-debug.log`,
+  `/tmp/osaurus-emergency-finalize-live-20260723-0120.log`, and
+  `/tmp/osaurus-reasoning-prompt-dumps-20260723-0120/`
+
+Source trace for the final diff:
+
+- `Packages/OsaurusCore/Services/ModelRuntime.swift` treats
+  `.toolInvocation` as terminal for local tool dispatch, yields the committed
+  tool name/arguments, finishes by throwing `ServiceToolInvocation`, and cancels
+  the unused decode tail instead of waiting for optional `.completionInfo`.
+- `Packages/OsaurusCore/Views/Chat/ChatView.swift` classifies
+  `runResult.exit == .toolRejected` as an errored cleanup path so a failed tool
+  row does not schedule a hidden completed-transcript warm-up over the failed
+  intermediate prompt.
+- Focused source tests pinned both seams:
+  `RuntimePolicySourceTests/localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats`,
+  `RuntimePolicySourceTests/chatClassifiesToolRejectionAsErroredCleanup`, and
+  `ChatWarmupControllerCompletedRunTests/erroredRunDoesNotWarm`.
+
+Computer Use live proof from the same Release app:
+
+| Row | Visible result | Runtime/cache evidence |
+| --- | --- | --- |
+| Gemma 4 12B it MXFP8, Thinking Off | exact `GEMMA-SSD-FINAL-OK`, TTFT 1.31s, 27.7 tok/s, input unlocked | prompt restored `1729/1749`, then stats `promptTps=2144.5`, `genTokens=12`, `genTps=27.7`, and disk L2 advanced from 0 to 1 hit with stores 2 -> 4 |
+| Bonsai 27B Ternary JANG CRACK, failed `file_read` | visible `Failed: File read`, final answer returned, no stuck Stop state | first step restored `4185/4242`, emitted `TOOL-EXEC-BEGIN name=file_read`, then the post-tool continuation restored `4235/4399`; follow-up file search restored `4235/4421`; final stats `genTokens=86`, `genTps=31.0`; stream drained and lease released after each step |
+| Bonsai same-chat recovery after the failed tool | exact `BONSAI-AFTER-FAILED-TOOL-OK`, TTFT 0.87s, 31.6 tok/s, input unlocked | next request restored `4497/4534`; stats `promptTps=15245.8`, `genTokens=13`, `genTps=31.6`; disk L2 hits advanced 4 -> 5 |
+| Bonsai new chat after failed tool | exact `BONSAI-CROSSCHAT-SSD-OK`, TTFT 0.81s, 31.5 tok/s, input unlocked | new no-folder warm-up cold-stored the changed prompt shape, then actual send restored `3005/3035`; stats `promptTps=10291.9`, `genTokens=12`, `genTps=31.5`; disk L2 hits advanced 6 -> 7 |
+| Ornith 1.0 9B JANG_4M, Thinking Off | exact `ORNITH-JANG4M-SSD-OK`, TTFT 0.37s, 69.2 tok/s, input unlocked | user send restored `2040/2071` with `ssm=48` in vMLX trace; Osaurus trace recorded `promptTps=17644.9`, `genTokens=11`, `genTps=69.2`; the follow-up warm row restored `2064/2087` |
+| Laguna S 2.1 JANG_2L, Thinking On | coherent answer and unlocked input, but no reasoning box | source and prompt-dump evidence shows the rendered prompt ended with `<assistant><think>`, so the UI/request path did send thinking-on; the model then immediately emitted `</think>` and placed `internal-check` in visible content on the parser stress prompt |
+
+Interpretation:
+
+- The previously observed "complete-looking tool row but no execution" owner is
+  closed for the local streaming path on this build: a parsed `.toolInvocation`
+  now dispatches immediately and the UI no longer waits for optional stats/EOS
+  before tool execution.
+- A real failed built-in tool result did not reset the cache into an unusable
+  state in the Bonsai hybrid row. The failed-tool continuation, same-chat
+  follow-up, and new-chat follow-up all restored partial SSD prefixes with
+  paged RAM cache off and produced visible terminal answers.
+- Laguna's missing reasoning box is not proven to be an Osaurus toggle/parser
+  miss. The prompt tail contained `<assistant><think>`, and the next prompt
+  dump contained `<assistant><think></think>internal-check...`; this is current
+  model/bundle decode behavior. No app-side forced-thinking or hidden parser
+  nudge was added.
+- This evidence does not close TurboQuant-KV, paged-RAM-on fallback, full
+  all-model cache matrix, or AppleScript duplicate-edit/no-save rows.
+
+## 2026-07-23 v3 scoped Release proof — current source of truth
+
+This supersedes the older `3d5aa12...` addendum above for the emergency merge
+candidate. It does not erase that history; it records the current app/pin that
+was actually live-operated for the final scoped rows.
+
+Build under test:
+
+- Release app:
+  `/private/tmp/osaurus-emergency-scoped-release-derived-v3b-20260723/Build/Products/Release/osaurus.app`
+- bundle id: `com.dinoki.osaurus.emergencyscopedproofv320260723`
+- executable SHA-256 after ad-hoc signing:
+  `858cadab0912084e66314fc5ba6097e5c235753b9dc90642fb1ea7ef3a99c446`
+- `codesign --verify --deep --strict --verbose=2` accepted the app;
+  `TeamIdentifier=not set`
+- proof root:
+  `/private/tmp/osaurus-emergency-scoped-proof-root-v3-20260723-0310`
+- pinned vMLX:
+  `7d6235316226ba9fe608018f86c463784e48b3d5`
+- trace files:
+  `/tmp/osaurus-prefill-debug.log`,
+  `/tmp/osaurus-emergency-scoped-live-v3-20260723-0310.log`, and
+  `/tmp/osaurus-reasoning-prompt-dumps-scoped-v3-20260723-0310/`
+- current live process at proof time:
+  pid `6222`, same bundle id, same proof root, and open cache files under
+  `/private/tmp/osaurus-emergency-scoped-proof-root-v3-20260723-0310/cache/kv_v2`
+
+Current source seams:
+
+- `ModelRuntime.streamWithTools` treats parsed local `.toolInvocation` as
+  terminal for dispatch: it yields the tool name/args, throws
+  `ServiceToolInvocation`, and returns instead of holding a pending tool while
+  waiting for optional completion stats.
+- `ChatView` marks `runResult.exit == .toolRejected` as `lastStreamError =
+  "Tool call failed."`, so failed/rejected tool runs do not enter the normal
+  successful-run cleanup path.
+- `ChatWarmupController.handleRunCompleted` now accepts `hadToolActivity`; the
+  session computes that from tool turns/calls/results/remote tool activity and
+  suppresses hidden completed-transcript warm-up for tool-loop transcripts.
+- `LocalReasoningCapability` reads bundle metadata
+  `generation_config.default_chat_template_kwargs.enable_thinking` and
+  `jang_config.chat.reasoning.default_enabled/default_mode` before presenting
+  effective local Thinking defaults.
+
+Focused source verification on this source tree:
+
+```sh
+git diff --check
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -quiet \
+  -workspace osaurus.xcworkspace \
+  -scheme OsaurusCoreTests \
+  -configuration Debug \
+  -destination 'platform=macOS,arch=arm64' \
+  -derivedDataPath /private/tmp/osaurus-emergency-finalize-derived-20260723 \
+  -skipPackagePluginValidation \
+  -parallel-testing-enabled NO \
+  test \
+  -only-testing:OsaurusCoreTests/RuntimePolicySourceTests/localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats \
+  -only-testing:OsaurusCoreTests/ChatWarmupControllerCompletedRunTests \
+  -only-testing:OsaurusCoreTests/RuntimePolicySourceTests/chatClassifiesToolRejectionAsErroredCleanup \
+  -only-testing:OsaurusCoreTests/LocalReasoningCapabilityTests \
+  -only-testing:OsaurusCoreTests/ModelProfileRegistryTests
+```
+
+The command exited 0. This is focused source verification only, not a full
+Osaurus test-suite claim.
+
+Computer Use live rows from the same v3 Release app:
+
+| Scenario | Visible UI result | Runtime/cache evidence |
+| --- | --- | --- |
+| Cache Settings | Settings -> Server -> Cache visibly saved Prefix Cache On, GPU/Paged KV Off, SSD/L2 Disk Cache On, SSM rederive On, and "All changes saved." | The rows below are SSD-only/paged-off rows; no paged RAM hit is being counted. |
+| Bonsai failed multi-tool path | `Bonsai 27b Ternary JANG CRACK`, Thinking Off. A missing-file/tool prompt produced failed tool rows and then exact `BONSAI-V3-TOOL-FAIL-FINALIZED`, TTFT 0.96s, 31.9 tok/s, 14 tokens, input unlocked. | Initial warm stored `3008`; user prompt restored `3005/3077`; tool-loop continuations restored `3070/3124`, `3117/3817`, `3810/4051`, `4044/4101`, `4094/4451`, and `4444/4498`; disk L2 hits advanced 0 -> 7. |
+| Bonsai same-chat after failed tools | Immediate follow-up returned exact `BONSAI-V3-AFTER-TOOL-FAIL-NOT-QUEUED`, TTFT 2.73s, 32.0 tok/s, 18 tokens, input unlocked. | There was no hidden `lastMsgRole=assistant` warm-up between the final tool answer and this follow-up. The follow-up request was `lastMsgRole=user` and restored `3070/4518`; disk L2 hits advanced 7 -> 8. |
+| Bonsai new chat | Toolbar `+` new chat, same model/settings. Prompt returned exact `BONSAI-V3-NEW-CHAT-SSD-PARTIAL`, TTFT 0.93s, 32.0 tok/s, 16 tokens. | New-chat warm prefix restored `3007/3008`; user prompt restored `3007/3035`; disk L2 hits advanced 8 -> 10. |
+| Bonsai process restart | Same signed app relaunched against the same isolated proof root. Prompt returned exact `BONSAI-V3-RESTART-SSD-PARTIAL`, TTFT 0.86s, 33.1 tok/s, 15 tokens. | In the fresh process, first warm prefix restored `3007/3008` from disk with `diskL2Hits=0 -> 1`; user prompt restored `3007/3034`, then hits advanced 1 -> 2. |
+| Gemma 4 MXFP8 | Switched in UI to `Gemma 4 12B it MXFP8`, Thinking Off, new chat. Prompt returned exact `GEMMA-V3-NEW-CHAT-SSD-PARTIAL`, TTFT 0.82s, 29.6 tok/s, 18 tokens. | Earlier cold warm stored `1729`; fresh-chat warm prefix restored `1725/1729`; visible prompt restored `1729/1751`; post-success warm row restored `1751/1770`. |
+| Laguna S 2.1 JANG_4M reasoning | UI model picker selected `Laguna S 2.1 JANG_4M`; Thinking value On. The non-trivial arithmetic prompt showed a separate `Thought for 2.9s` row and final answer with `FINAL: 964`; TTFT 0.86s, 38.7 tok/s, 136 tokens, input unlocked. | Prompt dump ended with `<assistant><think>` and the completed dump contained non-empty reasoning before `</think>` followed by the visible answer. Cache trace restored fresh-chat warm prefix `1670/1673`, then user prompt `1673/1706`, with disk L2 hits advancing 4 -> 5. |
+
+Negative/source-trace comparison:
+
+- The older bad pattern is preserved in `/tmp/osaurus-prefill-debug.log` lines
+  around 2374-2382: after a Bonsai tool run, Osaurus launched a hidden
+  `lastMsgRole=assistant` warm-up that cold-prefilled `0/8467` and took
+  15.7s of prompt work before the next visible turn.
+- The v3 Bonsai failed-tool run has no such hidden assistant warm-up between
+  the final tool answer and the immediate user follow-up. The next request is a
+  visible `lastMsgRole=user` send with partial SSD restore.
+
+Current conclusion for this emergency row:
+
+- Source and live evidence cover the local stream finalization bug, failed-tool
+  cleanup classification, suppression of hidden tool-transcript warm-up, and
+  SSD-only partial restore for the Bonsai/Gemma/Laguna rows above.
+- The rows remain scoped. They do not close AppleScript duplicate-edit/no-save,
+  generic Computer Use retries, TurboQuant-KV opt-in, paged-RAM-on fallback,
+  full all-model media/cache topology, or external-user hardware variance.

--- a/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026-07-21.md
+++ b/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026-07-21.md
@@ -2,13 +2,159 @@
 
 ## Status
 
-`VERIFIED-LIVE — EMERGENCY N-1 FIX; BROADER CACHE MATRIX PARTIAL`
+`PARTIAL / SCOPED BONSAI-GEMMA-LAGUNA SSD-L2 PARTIAL RESTORE PROVEN-LIVE ON
+THE 2026-07-23 V3 RELEASE APP; BROADER CACHE MATRIX PARTIAL`
 
 This gate covers the report that a model becomes responsive in one chat but a
 new chat appears to prefill from zero while paged RAM cache is Off and Disk L2
 is On. Aggregate counters are supporting evidence only. A row is credited only
 when a request trace identifies the tier, matched boundary, remaining suffix,
 companion-state behavior, TTFT, token/s, and a coherent visible answer.
+
+## New open failure mode: failed tool call appears to reset KV/cache state
+
+User report received 2026-07-22 21:49 says a run hung inside a mid-toolcall and
+that, when a tool call fails, the warm KV/cache state appears to reset back to
+the cold prefill path. The report is not yet paired with a complete trace, so
+the exact owner is open.
+
+Working hypotheses to test, without assuming a fix:
+
+- the tool-failure turn may be clearing request-local KV/session prefix state
+  when only the tool continuation should be invalidated;
+- the failed tool result may be changing the canonical prompt/tool schema
+  enough to miss the previously stored SSD prefix;
+- an error path may skip disk store or companion-state re-derive metadata while
+  still updating the visible chat/session state;
+- a lease/stream cleanup path may leave a stale active owner, making the next
+  request show cold queued/prefill even when disk entries exist;
+- UI warm-state projection may be reset even if runtime disk entries remain
+  valid, which must be separated from a real cache miss.
+
+Required proof rows before closure:
+
+1. Force a deterministic failing tool call in the live Osaurus app, with Prefix
+   On, paged RAM cache Off, Disk L2 On, and trace flags enabled.
+2. Immediately send a same-session follow-up that should share the same
+   system/tool prefix. Record disk boundary, suffix tokens, TTFT, token/s,
+   visible answer, and whether the chip shows warm versus cold.
+3. Start a new chat and repeat the same prompt. Record whether SSD partial
+   restore uses the already stored system/tool prefix.
+4. Quit/relaunch against the same test root and repeat the prompt to prove the
+   cache is truly persisted, not only resident in process memory.
+5. Compare at least one successful-tool row with one failed-tool row on the
+   same model and same settings.
+6. Run the comparison on at least:
+   - one Qwen 3.5 hybrid family bundle such as Ornith or Bonsai;
+   - one rotating/full-KV family such as Gemma 4 or Laguna.
+
+Until these rows exist across the named families and restart path, SSD partial
+restore is not globally verified for tool-failure recovery. The Gemma 4 MXFP8
+row below now proves the failed built-in `file_read` path does not globally
+poison SSD cache fetch/store inside the same app process.
+
+### 2026-07-22 patched failed-tool cache-retention proof
+
+Isolated Release app:
+
+- App: `/private/tmp/OsaurusToolHangProof-20260722-2303.app`
+- Bundle ID: `com.dinoki.osaurus.toolhangproof20260722`
+- Executable SHA-256:
+  `ddb7a9f8083a682bc8be30f27a58bc5f768bbfc66acff884801ba2d57c634541`
+- Source HEAD: `187f7662ce1d40a2349c1987a814bd5a90d75355`
+- vMLX pin: `85d752e501240bfe2d5c39c6f5d08e7d4e139a68`
+- Runtime root: `/private/tmp/osaurus-toolhangproof-root-20260722-2259`
+- Trace log: `/tmp/osaurus-toolhangproof-live-20260722-2303.log`
+
+Live UI model row: `Gemma 4 12B it MXFP8`, Thinking Off. The run did not use
+image evidence in git; the proof is the Computer Use accessibility transcript
+plus the runtime trace above.
+
+Observed sequence:
+
+| Step | Visible UI result | Cache trace result |
+| --- | --- | --- |
+| Baseline | `BASELINE-GEMMA-PATCHED`, TTFT 1.22s, 27.4 tok/s, 11 tokens | initial `MISS all tiers tokens=1729`, then stores `1729/1725`; later baseline warm rows hit `boundary=1729 remaining=19` and `boundary=1748 remaining=12` |
+| Capability-unavailable tool path | loaded/searched capabilities, answered that folder tools were unavailable, TTFT 1.42s, 53.5 tok/s, 42 tokens | context continued to store/hit disk; immediate recovery hit `boundary=5982 remaining=13 ... tokens=5995` |
+| Same-chat recovery after capability failure | `SAME-CHAT-CACHE-RECOVERY`, TTFT 0.66s, 30.2 tok/s, 12 tokens | `cache/disk-store count=5995` after the disk hit |
+| Real failed built-in tool | `Failed: File read · 582ms`; answer `File not found: definitely-missing-tool-error-2308.txt.`, TTFT 4.00s, 30.2 tok/s, 23 tokens | trace shows `Tool invocation: file_read`, `Executing: file_read`, and an `ok:false kind:not_found retryable:false` tool envelope; changed folder/tool prompt first missed/stored `3114`, then the post-tool continuation reused disk `boundary=7141 remaining=245 ... tokens=7386` |
+| Same-chat recovery after real failed tool | `FAILED-TOOL-CACHE-RECOVERY`, TTFT 0.73s, 30.6 tok/s, 12 tokens | disk hits/stores continued: `boundary=2924 remaining=183 ... tokens=3107`, `cache/disk-store count=3119`, `boundary=7369 remaining=40 ... tokens=7409`, `cache/disk-store count=7409` |
+| New chat after failed tool | `NEW-CHAT-AFTER-FAILED-TOOL`, TTFT 0.64s, 30.5 tok/s, 13 tokens | new no-folder warm-up first cold-stored `1729/1725` because the folder/tool prompt changed; the actual new-chat send hit `boundary=1729 remaining=20 ... tokens=1749`, stored `1749/1762`, then hit `boundary=1749 remaining=14 ... tokens=1763` |
+| Second same-instance failed tool | `Failed: File read · 711ms`; answer `The file definitely-missing-tool-error-second-pass-2319.txt was not found.`, TTFT 1.06s, 30.3 tok/s, 31 tokens | with the same throwaway folder still selected, the row and its immediate follow-up continued to hit/store disk: `boundary=2871 remaining=38 ... tokens=2909`, `store count=2909`; `boundary=2924 remaining=88 ... tokens=3012`, `store count=3012`; follow-up `boundary=3161 remaining=331 ... tokens=3492`, `store count=3492`; then `boundary=3492 remaining=15 ... tokens=3507`, `store count=3507` |
+| Second same-chat recovery caveat | `SECOND-PASS-FAILED-TOOL-RECOVERY`, TTFT 0.88s, 30.8 tok/s, 14 tokens, input unlocked | recovery proves the failed tool did not strand this live Gemma session, but the UI also displayed an unnecessary `status.txt` artifact card; that behavior is not counted as a clean tool-selection pass |
+
+Interpretation:
+
+- The user-visible `Prefill 0/3114` frame was reproduced during the real
+  missing-file row and advanced to completion. It did not become a permanent
+  `Queued 0/N` hang.
+- The failed `file_read` result did not clear all SSD eligibility or block the
+  next request. Both same-chat and new-chat follow-ups produced visible coherent
+  answers with TTFT/token/s and runtime disk hit/store evidence.
+- A second same-instance failed `file_read` replay also completed and was
+  followed by continued disk partial restore/store. This narrows the failure
+  report away from a universal "failed tool clears all KV/SSD cache" explanation
+  for Gemma 4 MXFP8, but still leaves Qwen/Bonsai/Ornith hybrid, Laguna,
+  app-restart, and TurboQuant opt-in rows open.
+- The no-folder new chat did a cold store before the actual send because the
+  prompt shape changed when the throwaway folder context was removed. That row
+  must not be misreported as proof that every new chat always starts with a disk
+  hit; it proves the failed tool did not poison the default prompt path and that
+  the subsequent send reused the just-stored SSD prefix.
+- Still open: same-root app restart, Qwen 3.5 hybrid rows, Laguna row,
+  TurboQuant-KV opt-in rows, quota/eviction pressure rows, and a visual
+  Settings-toggle audit in this exact app instance.
+
+### 2026-07-22 cache observation during the streamed-tool hang
+
+An isolated Release app live run reproduced a complete-looking tool row that
+never dispatched. The cache trace for that same stuck request showed SSD L2 was
+not absent:
+
+- Baseline send: disk hit restored boundary 2,328 with 16 remaining prompt
+  tokens, then stored 2,344.
+- Pre-hang tool-call send: disk hit restored boundary 2,353 with 39 remaining
+  prompt tokens, then stored 2,392.
+- Paged RAM cache was visibly Off in Settings; the stored payload had no paged
+  blocks and used the runtime's disk/companion state path.
+
+This narrows the reopened failure: the visible hang was not caused by the
+stable system/tool prefix failing to restore from SSD before generation. The
+patched owner is local streaming finalization: Osaurus waited for optional
+trailing completion stats after vMLX had already emitted `.toolInvocation`, so
+the tool call was never thrown to the chat loop and the failed-tool cleanup path
+could not run.
+
+Status remains **PARTIAL** until the rebuilt app proves:
+
+1. parsed local tool calls dispatch/terminate without waiting forever;
+2. a failed/rejected tool result does not trigger hidden completed-transcript
+   warm-up;
+3. same-chat, new-chat, and post-relaunch prompts still restore partial SSD
+   blocks with paged RAM cache Off.
+
+### Cache questions that must be answered by the next harness/UI run
+
+- Does a failed tool result alter only the suffix of the prompt, or does it
+  also invalidate the stable system/tool prefix entry that should remain
+  reusable across chats and restarts?
+- Does Osaurus attempt to warm the failed intermediate transcript as though it
+  were a successful checkpoint? If yes, that hidden warm-up can own the same
+  solo slot and make the next visible send look cold or permanently queued.
+- Do tool schemas, loaded-tool manifests, frozen soul/system prompt text,
+  folder/sandbox mode, and Thinking options produce the same fingerprint in
+  warm-up and real-send paths?
+- When paged RAM cache is Off, can the next same-chat send, a fresh chat, and
+  a post-relaunch chat still restore the shared prefix directly from SSD L2?
+- For hybrid models, does the restored disk boundary include the required
+  companion-state/re-derive behavior instead of falsely restoring an unsafe
+  full boundary?
+- For subagents and delegated runs, does the child prompt start from a stable
+  child seed so its own system/tool prefix can be cached, or does it inherit
+  enough parent context to make every child request a one-off miss?
+- If a tool call is rejected by policy or by the user, is queued follow-up input
+  intentionally left for user action instead of being auto-flushed behind a
+  failed transcript?
 
 ## Root cause and scoped change
 
@@ -114,3 +260,98 @@ the row even if the cache counter increments.
 TurboQuant-KV On is a separate opt-in matrix. JANGTQ weights are not
 TurboQuant KV encoding. This emergency merge keeps the default policy unchanged
 and does not claim TurboQuant coverage.
+
+## 2026-07-23 final-current SSD-only partial-restore addendum
+
+The final-current Osaurus follow-up used the Release app
+`/private/tmp/osaurus-emergency-finalize-release-derived-20260723/Build/Products/Release/osaurus.app`
+with bundle id `com.dinoki.osaurus.emergencyproof20260723`, executable
+SHA-256 `51d8452082893fc1baf675950991394aeb4494bc185a91588310bf2018ac8028`,
+and pinned vMLX `3d5aa12be1ad4a7e1492e062e6d136a4f31c7dfb`.
+The app was operated through the visible UI with model selection and
+Thinking-state controls in the picker. Settings had Prefix Cache On, GPU/Paged
+Cache Off, Disk Cache On, cache codec Engine Selected, and SSM Re-derive On.
+Evidence lives in `/tmp/osaurus-prefill-debug.log`,
+`/tmp/osaurus-emergency-finalize-live-20260723-0120.log`, and
+`/tmp/osaurus-reasoning-prompt-dumps-20260723-0120/`; no screenshot artifacts
+are committed for this addendum.
+
+Representative SSD-only rows on this final pin:
+
+| Family | Scenario | SSD/cache evidence | Visible outcome |
+| --- | --- | --- | --- |
+| Gemma 4 MXFP8 rotating/full-attention | same-chat warmed send after startup store | restored `1729/1749`; post-answer warm row restored `1749/1762`; disk L2 hits advanced 0 -> 2 | exact `GEMMA-SSD-FINAL-OK`, TTFT 1.31s, 27.7 tok/s |
+| Bonsai Qwen 3.5 hybrid | failed `file_read` and tool-result continuation | required-tool step restored `4185/4242`; tool-result continuation restored `4235/4399`; file-search continuation restored `4235/4421`; disk L2 hits advanced through the failed tool | visible failed tool card and terminal answer; no stuck queued/stop state |
+| Bonsai Qwen 3.5 hybrid | same-chat after failed tool | restored `4497/4534`; disk L2 hits advanced 4 -> 5 | exact `BONSAI-AFTER-FAILED-TOOL-OK`, TTFT 0.87s, 31.6 tok/s |
+| Bonsai Qwen 3.5 hybrid | new chat after failed tool | changed no-folder warm-up cold-stored a new prompt shape, then actual send restored `3005/3035`; disk L2 hits advanced 6 -> 7 | exact `BONSAI-CROSSCHAT-SSD-OK`, TTFT 0.81s, 31.5 tok/s |
+| Ornith Qwen 3.5 hybrid JANG_4M | same-chat warmed send | vMLX trace restored `2040/2071` with `ssm=48`; next warm row restored `2064/2087` | exact `ORNITH-JANG4M-SSD-OK`, TTFT 0.37s, 69.2 tok/s |
+| Laguna S 2.1 mixed full/rotating | post-relaunch same-root send | after relaunch, vMLX restored `1673/1732` from disk; later user prompt restored `1866/1915`; disk L2 hits advanced 0 -> 3 in the new process | coherent train answer at 47.0 tok/s, then parser stress output at 45.3 tok/s; no request hang |
+
+Notes:
+
+- The Bonsai failed-tool row is the current strongest evidence against the
+  report that a failed tool universally resets KV/cache to zero. It does not
+  prove every tool family or AppleScript child path.
+- The new no-folder chat intentionally changed the tool/folder prompt identity.
+  The cold warm-up for that changed prompt is not a cache failure; the actual
+  following send restored the newly stored SSD prefix.
+- The Laguna app-restart row proves the disk-backed path survives process
+  restart for the mixed full/rotating cache topology on this pin. Its missing
+  reasoning box is documented separately as model/bundle behavior because the
+  rendered prompt did contain `<assistant><think>`.
+- TurboQuant-KV remains default Off and unproven in this addendum. Paged RAM
+  cache remains Off in the rows above; paged-hot-to-SSD-warm fallback is still
+  an open matrix row.
+
+## 2026-07-23 v3 scoped SSD-L2 proof — current source of truth
+
+Current app/pin:
+
+- app:
+  `/private/tmp/osaurus-emergency-scoped-release-derived-v3b-20260723/Build/Products/Release/osaurus.app`
+- bundle id: `com.dinoki.osaurus.emergencyscopedproofv320260723`
+- SHA-256:
+  `858cadab0912084e66314fc5ba6097e5c235753b9dc90642fb1ea7ef3a99c446`
+- proof root:
+  `/private/tmp/osaurus-emergency-scoped-proof-root-v3-20260723-0310`
+- pinned vMLX:
+  `7d6235316226ba9fe608018f86c463784e48b3d5`
+- runtime trace:
+  `/tmp/osaurus-prefill-debug.log`
+
+The current v3 Computer Use proof ran with Prefix Cache On, GPU/Paged KV Off,
+SSD/L2 Disk Cache On, and SSM rederive On. These rows therefore count only the
+disk-backed partial restore path, not paged RAM cache.
+
+| Family | Scenario | SSD-L2 evidence | Visible outcome |
+| --- | --- | --- | --- |
+| Bonsai Qwen 3.5 hybrid | tool-failure run with multiple failed tool rows | cold warm stored `3008`; user prompt restored `3005/3077`; successive tool continuations restored `3070/3124`, `3117/3817`, `3810/4051`, `4044/4101`, `4094/4451`, and `4444/4498`; disk L2 hits advanced 0 -> 7 | exact `BONSAI-V3-TOOL-FAIL-FINALIZED`, TTFT 0.96s, 31.9 tok/s, input unlocked |
+| Bonsai Qwen 3.5 hybrid | same-chat follow-up after failed tools | no hidden assistant warm-up between final answer and follow-up; follow-up restored `3070/4518`; disk L2 hits advanced 7 -> 8 | exact `BONSAI-V3-AFTER-TOOL-FAIL-NOT-QUEUED`, TTFT 2.73s, 32.0 tok/s |
+| Bonsai Qwen 3.5 hybrid | new chat | new-chat warm prefix restored `3007/3008`; visible prompt restored `3007/3035`; disk L2 hits advanced 8 -> 10 | exact `BONSAI-V3-NEW-CHAT-SSD-PARTIAL`, TTFT 0.93s, 32.0 tok/s |
+| Bonsai Qwen 3.5 hybrid | process restart, same proof root | fresh process warm prefix restored `3007/3008` from disk; visible prompt restored `3007/3034`; disk L2 hits advanced 0 -> 2 in the new process | exact `BONSAI-V3-RESTART-SSD-PARTIAL`, TTFT 0.86s, 33.1 tok/s |
+| Gemma 4 MXFP8 rotating/full-attention | new chat after earlier cold store | earlier cold warm stored `1729`; fresh-chat warm prefix restored `1725/1729`; visible prompt restored `1729/1751`; post-success warm restored `1751/1770` | exact `GEMMA-V3-NEW-CHAT-SSD-PARTIAL`, TTFT 0.82s, 29.6 tok/s |
+| Laguna S 2.1 mixed full/rotating | Thinking-On arithmetic prompt | fresh-chat warm prefix restored `1670/1673`; visible prompt restored `1673/1706`; post-success warm restored `1842/1846`; disk L2 hits advanced through 6 | separate reasoning row plus `FINAL: 964`, TTFT 0.86s, 38.7 tok/s |
+
+Interpretation for the user report:
+
+- A new chat or app restart can still show a short prefill stage because the
+  suffix after the restored SSD boundary must be processed. The pass condition
+  is not "no prefill frames"; it is an identified disk boundary, small remaining
+  suffix, coherent output, and no permanent queued/hung state.
+- The v3 Bonsai rows specifically address the report where a failed tool seemed
+  to reset cache state: failed tool continuations, same-chat follow-up, new
+  chat, and same-root process restart all hit SSD partial prefixes with paged
+  RAM cache Off.
+- The v3 Gemma row addresses a rotating/full-attention family with the same
+  SSD-only user setting.
+- The v3 Laguna row addresses mixed full/rotating cache plus reasoning-parser
+  output, but it is not a TurboQuant-KV or media/VL row.
+
+Still open:
+
+- TurboQuant-KV explicit On proof and cache-size growth;
+- paged RAM cache On as hot tier with SSD as warm fallback;
+- quota/eviction pressure;
+- media/VL/audio companion-cache rows;
+- AppleScript/Computer Use child-loop behavior and duplicate-edit/no-save;
+- broader model matrix beyond the scoped Bonsai/Gemma/Laguna slices.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a54989b432b7810391896d269c01180dcba2ba9cec506362a9888d25196be468",
+  "originHash" : "0e46463cc1fdb73bcbf28f394619b4f470b0107a0d6ca9243db58ca1ae5d5ebb",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "85d752e501240bfe2d5c39c6f5d08e7d4e139a68"
+        "revision" : "7d6235316226ba9fe608018f86c463784e48b3d5"
       }
     },
     {


### PR DESCRIPTION
## Summary

Scoped emergency fix for the local tool/finalization + SSD-L2 warmup regression path:

- pin vMLX Swift to `7d6235316226ba9fe608018f86c463784e48b3d5`
- dispatch parsed local `.toolInvocation` immediately instead of waiting for optional trailing `.completionInfo`
- classify rejected/failed tool loops as errored cleanup so they do not schedule hidden completed-transcript warmups
- suppress completed-transcript warmup after successful tool-loop transcripts; the real tool-loop turns already store SSD-L2 blocks
- read bundle metadata defaults for local reasoning capability, including `default_chat_template_kwargs.enable_thinking` and `jang_config.chat.reasoning.default_enabled/default_mode`
- set Laguna display default to Thinking On to match the Laguna S 2.1 metadata contract
- add focused tests and update text-only proof ledgers

## Source-trace evidence

Current source seams:

- `Packages/OsaurusCore/Services/ModelRuntime.swift`: `.toolInvocation` yields tool name/args, throws `ServiceToolInvocation`, and returns immediately.
- `Packages/OsaurusCore/Views/Chat/ChatView.swift`: `.toolRejected` sets `lastStreamError = "Tool call failed."` before cleanup.
- `Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift`: `handleRunCompleted(... hadToolActivity:)` suppresses hidden completed-transcript warmups for tool transcripts.
- `Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift`: detects tool activity from tool role/calls/results/remote tool activity.
- `Packages/OsaurusCore/Services/LocalReasoningCapability.swift`: reads generation/jang metadata defaults for reasoning.
- `Packages/OsaurusCore/Models/Configuration/ModelOptions.swift`: Laguna default is Thinking On (`disableThinking=false`).

Focused local command exited 0:

```sh
git diff --check
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -quiet \
  -workspace osaurus.xcworkspace \
  -scheme OsaurusCoreTests \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  -derivedDataPath /private/tmp/osaurus-emergency-finalize-derived-20260723 \
  -skipPackagePluginValidation \
  -parallel-testing-enabled NO \
  test \
  -only-testing:OsaurusCoreTests/RuntimePolicySourceTests/localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats \
  -only-testing:OsaurusCoreTests/ChatWarmupControllerCompletedRunTests \
  -only-testing:OsaurusCoreTests/RuntimePolicySourceTests/chatClassifiesToolRejectionAsErroredCleanup \
  -only-testing:OsaurusCoreTests/LocalReasoningCapabilityTests \
  -only-testing:OsaurusCoreTests/ModelProfileRegistryTests
```

This is focused verification, not a full-suite claim.

## Live verification evidence

A Release-config Osaurus app was built, ad-hoc signed, launched with an isolated bundle id/root, and operated through the visible UI.

- app: `/private/tmp/osaurus-emergency-scoped-release-derived-v3b-20260723/Build/Products/Release/osaurus.app`
- bundle id: `com.dinoki.osaurus.emergencyscopedproofv320260723`
- executable SHA-256: `858cadab0912084e66314fc5ba6097e5c235753b9dc90642fb1ea7ef3a99c446`
- proof root: `/private/tmp/osaurus-emergency-scoped-proof-root-v3-20260723-0310`
- trace: `/tmp/osaurus-prefill-debug.log`
- prompt dumps: `/tmp/osaurus-reasoning-prompt-dumps-scoped-v3-20260723-0310/`
- UI settings: Prefix Cache On, GPU/Paged KV Off, SSD/L2 Disk Cache On, SSM rederive On

Live rows:

- Bonsai 27B Ternary JANG CRACK, Thinking Off: failed tool path produced terminal final `BONSAI-V3-TOOL-FAIL-FINALIZED`, TTFT 0.96s, 31.9 tok/s; trace restored SSD partials through the tool loop (`3005/3077`, then `3070/3124`, `3117/3817`, `3810/4051`, `4044/4101`, `4094/4451`, `4444/4498`).
- Bonsai same-chat follow-up after failed tools: exact `BONSAI-V3-AFTER-TOOL-FAIL-NOT-QUEUED`, TTFT 2.73s, 32.0 tok/s; trace shows no hidden assistant warmup between final tool answer and user follow-up.
- Bonsai new chat: exact `BONSAI-V3-NEW-CHAT-SSD-PARTIAL`, TTFT 0.93s, 32.0 tok/s; trace restored `3007/3008` warm prefix and `3007/3035` visible prompt.
- Bonsai process restart, same proof root: exact `BONSAI-V3-RESTART-SSD-PARTIAL`, TTFT 0.86s, 33.1 tok/s; fresh process restored `3007/3008` and `3007/3034` from disk.
- Gemma 4 12B MXFP8, Thinking Off: exact `GEMMA-V3-NEW-CHAT-SSD-PARTIAL`, TTFT 0.82s, 29.6 tok/s; trace restored `1725/1729`, then `1729/1751`, then `1751/1770`.
- Laguna S 2.1 JANG_4M, Thinking On: visible separate `Thought for 2.9s` row and final `FINAL: 964`, TTFT 0.86s, 38.7 tok/s; prompt dump contains non-empty `<think>...</think>` reasoning and trace restores `1670/1673`, `1673/1706`, and `1842/1846`.

The old bad trace is also preserved in the same prefill log around the earlier Bonsai row where a hidden `lastMsgRole=assistant` warmup cold-prefilled `0/8467` after a tool run. The v3 row does not repeat that pattern.

## Not claimed by this PR

- no TurboQuant-KV explicit On proof
- no paged-RAM-cache On hot-tier fallback proof
- no AppleScript duplicate-edit/no-save closure on this branch
- no generic Computer Use duplicate-edit closure
- no full all-model/media/cache matrix closure
- no full local suite or release-readiness claim until PR CI completes

## Docs

Text-only proof docs were updated:

- `docs/PREFILL_QUEUE_EMERGENCY_GATE_2026_07_22.md`
- `docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026-07-21.md`
- `docs/COMPUTER_USE_BONSAI_PRIORITY_GATE_2026-07-22.md`

No images or videos are included in this PR.
