### PR TITLE
fix mcp tool calls failing after invoking a skill via slash command

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -772,7 +772,7 @@ public final class SkillManager {
     /// cannot appear in a tool name, so `use runalyze_mcp_get_activities.`
     /// matches but a substring like `activities` inside a longer name never
     /// does. Sorted output keeps downstream schema composition deterministic.
-    public static func toolNames(
+    public nonisolated static func toolNames(
         referencedIn text: String,
         from candidates: Set<String>
     ) -> [String] {

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -756,6 +756,37 @@ public final class SkillManager {
         return sections.joined(separator: "\n")
     }
 
+    /// Tool names out of `candidates` that `text` mentions as a whole
+    /// identifier token.
+    ///
+    /// A skill's instructions routinely name the exact tools they expect the
+    /// model to call (`runalyze_mcp_get_activities`, …), but the `/skill-name`
+    /// slash path injects those instructions AFTER the turn's tool schema and
+    /// execution scope are frozen — so the model calls a tool it was told
+    /// about and the registry refuses it as not exposed (issue #2145). The
+    /// send path uses this scan to pre-load the mentioned tools into the same
+    /// turn's schema, mirroring what `capabilities_load skill/<name>` already
+    /// does for plugin tool groups.
+    ///
+    /// Matching is token-exact: the text is split on every character that
+    /// cannot appear in a tool name, so `use runalyze_mcp_get_activities.`
+    /// matches but a substring like `activities` inside a longer name never
+    /// does. Sorted output keeps downstream schema composition deterministic.
+    public static func toolNames(
+        referencedIn text: String,
+        from candidates: Set<String>
+    ) -> [String] {
+        guard !candidates.isEmpty, !text.isEmpty else { return [] }
+        // Function-name charset (`[A-Za-z0-9_-]`): everything outside it is a
+        // separator, so surrounding prose, backticks and punctuation fall away.
+        let toolNameCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+        let tokens = Set(
+            text.components(separatedBy: toolNameCharacters.inverted)
+                .filter { !$0.isEmpty }
+        )
+        return candidates.intersection(tokens).sorted()
+    }
+
     private func loadReferenceContents(for skill: Skill, budget: Int = .max) async -> String {
         let textExtensions: Set<String> = [
             "md", "txt", "json", "yaml", "yml", "xml", "html", "css", "js", "ts",

--- a/Packages/OsaurusCore/Tests/Skill/SkillToolReferenceScanTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillToolReferenceScanTests.swift
@@ -1,0 +1,59 @@
+//
+//  SkillToolReferenceScanTests.swift
+//  osaurusTests
+//
+//  Verifies the tool-name scan used to pre-load tools a skill's
+//  instructions reference (issue #2145: a `/skill-name` invocation injected
+//  instructions naming MCP tools that were never exposed to the turn, so
+//  every call failed with tool_not_found).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct SkillToolReferenceScanTests {
+
+    private let candidates: Set<String> = [
+        "runalyze_mcp_get_activities",
+        "runalyze_mcp_get_activity",
+        "web_search",
+        "notion-search",
+    ]
+
+    @Test
+    func findsToolNamesSurroundedByProseAndPunctuation() {
+        let text = """
+            To fetch runs, call `runalyze_mcp_get_activities` with a date.
+            For a single run use runalyze_mcp_get_activity.
+            """
+        #expect(
+            SkillManager.toolNames(referencedIn: text, from: candidates)
+                == ["runalyze_mcp_get_activities", "runalyze_mcp_get_activity"]
+        )
+    }
+
+    @Test
+    func matchesHyphenatedNamesAndSortsOutput() {
+        let text = "Use notion-search first, then web_search as a fallback."
+        #expect(
+            SkillManager.toolNames(referencedIn: text, from: candidates)
+                == ["notion-search", "web_search"]
+        )
+    }
+
+    @Test
+    func doesNotMatchSubstringsOfLongerIdentifiers() {
+        // `web_search` appears only inside a longer identifier; the token
+        // scan must not treat the substring as a mention.
+        let text = "The my_web_search_wrapper helper handles retries."
+        #expect(SkillManager.toolNames(referencedIn: text, from: candidates).isEmpty)
+    }
+
+    @Test
+    func emptyInputsYieldNoMatches() {
+        #expect(SkillManager.toolNames(referencedIn: "", from: candidates).isEmpty)
+        #expect(SkillManager.toolNames(referencedIn: "call web_search", from: []).isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
@@ -1,0 +1,125 @@
+//
+//  ToolScopeGateRecoveryTests.swift
+//  osaurusTests
+//
+//  Pins the execution-scope gate's error contract (#2145). A registered,
+//  enabled dynamic tool the turn simply never exposed must come back as a
+//  RETRYABLE tool_not_found pointing at `capabilities_load`, so the model
+//  can load it and recover instead of apologizing and giving up. A name the
+//  registry does not know keeps the opaque, non-retryable refusal — the
+//  gate must not reveal anything about tools that were deliberately
+//  withheld.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+private final class ScopeProbeTool: OsaurusTool, @unchecked Sendable {
+    let name: String
+    let description = "Test-only scope gate probe."
+    let parameters: JSONValue? = nil
+    private(set) var executions = 0
+
+    init(name: String) { self.name = name }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        executions += 1
+        return ToolEnvelope.success(tool: name, text: "ran")
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct ToolScopeGateRecoveryTests {
+
+    private func envelope(_ result: String) throws -> [String: Any]? {
+        try JSONSerialization.jsonObject(with: result.data(using: .utf8)!) as? [String: Any]
+    }
+
+    @Test
+    func unscopedButLoadableTool_returnsRetryableCapabilitiesLoadHint() async throws {
+        let tool = ScopeProbeTool(name: "test_scope_gate_loadable_probe")
+        ToolRegistry.shared.register(tool)
+        ToolRegistry.shared.setEnabled(true, for: tool.name)
+        defer {
+            ToolRegistry.shared.setEnabled(false, for: tool.name)
+            ToolRegistry.shared.unregister(names: [tool.name])
+        }
+
+        // Scope exposes nothing — the skill-invocation shape from #2145,
+        // where the model calls a real tool it was never shown.
+        let scope = ToolExecutionScope(exposed: [])
+        let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+            try await ToolRegistry.shared.execute(name: tool.name, argumentsJSON: "{}")
+        }
+
+        #expect(tool.executions == 0)
+        let parsed = try envelope(result)
+        #expect(parsed?["ok"] as? Bool == false)
+        #expect(parsed?["kind"] as? String == "tool_not_found")
+        #expect(parsed?["retryable"] as? Bool == true)
+        let message = parsed?["message"] as? String ?? ""
+        #expect(message.contains("capabilities_load"))
+        #expect(message.contains("tool/\(tool.name)"))
+    }
+
+    @Test
+    func unscopedUnknownName_keepsOpaqueNonRetryableRefusal() async throws {
+        let unknown = "test_scope_gate_ghost_\(UUID().uuidString.prefix(8))"
+
+        let scope = ToolExecutionScope(exposed: [])
+        let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+            try await ToolRegistry.shared.execute(name: unknown, argumentsJSON: "{}")
+        }
+
+        let parsed = try envelope(result)
+        #expect(parsed?["ok"] as? Bool == false)
+        #expect(parsed?["kind"] as? String == "tool_not_found")
+        #expect(parsed?["retryable"] as? Bool == false)
+        let message = parsed?["message"] as? String ?? ""
+        #expect(!message.contains("capabilities_load"))
+    }
+
+    @Test
+    func unscopedAgentWithheldTool_keepsOpaqueNonRetryableRefusal() async throws {
+        let tool = ScopeProbeTool(name: "test_scope_gate_withheld_probe")
+        ToolRegistry.shared.register(tool)
+        // Registered but globally disabled: capabilities_load would refuse
+        // it, so the gate must not hint at it.
+        ToolRegistry.shared.setEnabled(false, for: tool.name)
+        defer { ToolRegistry.shared.unregister(names: [tool.name]) }
+
+        let scope = ToolExecutionScope(exposed: [])
+        let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+            try await ToolRegistry.shared.execute(name: tool.name, argumentsJSON: "{}")
+        }
+
+        #expect(tool.executions == 0)
+        let parsed = try envelope(result)
+        #expect(parsed?["retryable"] as? Bool == false)
+        let message = parsed?["message"] as? String ?? ""
+        #expect(!message.contains("capabilities_load"))
+    }
+
+    @Test
+    func scopeActivationMakesTheToolExecutable() async throws {
+        let tool = ScopeProbeTool(name: "test_scope_gate_activated_probe")
+        ToolRegistry.shared.register(tool)
+        ToolRegistry.shared.setEnabled(true, for: tool.name)
+        defer {
+            ToolRegistry.shared.setEnabled(false, for: tool.name)
+            ToolRegistry.shared.unregister(names: [tool.name])
+        }
+
+        let scope = ToolExecutionScope(exposed: [])
+        scope.activate([tool.name])
+        let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+            try await ToolRegistry.shared.execute(name: tool.name, argumentsJSON: "{}")
+        }
+
+        #expect(tool.executions == 1)
+        #expect(!ToolEnvelope.isError(result))
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -745,14 +745,14 @@ public final class ToolRegistry: ObservableObject {
             let loadableCodes: Set<ToolAvailabilityReasonCode> = [
                 .available, .alreadyLoaded, .loadableViaCapabilitiesLoad,
             ]
-            let availability = availability(forTool: name, agentAllowedNames: agentAllowed)
+            let toolAvailability = availability(forTool: name, agentAllowedNames: agentAllowed)
             // The default agent's capabilities_load is gated to the configure
             // write tools, so the hint would only steer it into a rejected
             // load for anything else.
             let loadGateAllows =
                 ChatExecutionContext.currentAgentId != Agent.defaultId
                 || Self.configureWriteToolNames.contains(name)
-            if loadGateAllows, loadableCodes.isSuperset(of: availability.reasonCodes) {
+            if loadGateAllows, loadableCodes.isSuperset(of: toolAvailability.reasonCodes) {
                 return ToolErrorEnvelope(
                     kind: .toolNotFound,
                     reason:

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -728,6 +728,41 @@ public final class ToolRegistry: ObservableObject {
         if let scope = ChatExecutionContext.toolExecutionScope, !scope.permits(name) {
             ToolRegistryLogger.registry.error(
                 "refusing '\(name, privacy: .public)': not exposed to this request")
+            // Distinguish "real tool, just never loaded into this
+            // conversation" from "withheld". A skill's instructions or the
+            // user can name a dynamic tool that was never exposed to the
+            // turn; the old unconditional dead end ("not available in this
+            // conversation", retryable: false) taught small models to
+            // apologize and give up when one `capabilities_load` away from
+            // succeeding (#2145). Only tools `capabilities_load` would
+            // actually grant get the hint — anything unregistered, globally
+            // disabled, or outside this agent's grant keeps the opaque
+            // refusal, so the gate still reveals nothing about tools that
+            // were deliberately withheld.
+            let agentAllowed: Set<String>? = ChatExecutionContext.currentAgentId.flatMap {
+                AgentManager.shared.effectiveEnabledToolNames(for: $0).map(Set.init)
+            }
+            let loadableCodes: Set<ToolAvailabilityReasonCode> = [
+                .available, .alreadyLoaded, .loadableViaCapabilitiesLoad,
+            ]
+            let availability = availability(forTool: name, agentAllowedNames: agentAllowed)
+            // The default agent's capabilities_load is gated to the configure
+            // write tools, so the hint would only steer it into a rejected
+            // load for anything else.
+            let loadGateAllows =
+                ChatExecutionContext.currentAgentId != Agent.defaultId
+                || Self.configureWriteToolNames.contains(name)
+            if loadGateAllows, loadableCodes.isSuperset(of: availability.reasonCodes) {
+                return ToolErrorEnvelope(
+                    kind: .toolNotFound,
+                    reason:
+                        "\(name) exists but is not loaded in this conversation. "
+                        + "Call capabilities_load with ids: [\"tool/\(name)\"] to load it, "
+                        + "then retry this call.",
+                    toolName: name,
+                    retryable: true
+                ).toJSONString()
+            }
             return ToolErrorEnvelope(
                 kind: .toolNotFound,
                 reason: "\(name) is not available in this conversation.",

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4401,6 +4401,37 @@ final class ChatSession: ObservableObject {
                         guard isRunActive(runId) else { return }
                     }
 
+                    // Resolve the pending one-off skill BEFORE composing.
+                    // Skill instructions routinely name the exact tools they
+                    // expect the model to call (MCP / plugin tools), but those
+                    // tools only enter the schema via `capabilities_load` —
+                    // injecting the instructions after the tool schema and
+                    // execution scope were frozen left every such call refused
+                    // as tool_not_found (#2145). Scan the instructions for
+                    // agent-granted dynamic tools and ride them in through
+                    // `additionalToolNames`, the same channel a prior-turn
+                    // `capabilities_load` would use. Consume the pending id
+                    // either way, but never inject in Mode 2 (the request
+                    // must stay bare).
+                    var oneOffSkillSection: (name: String, body: String)?
+                    var skillReferencedTools: LoadedTools = []
+                    if let skillId = pendingOneOffSkillId {
+                        pendingOneOffSkillId = nil
+                        if !isRemoteAgentTarget, let skill = SkillManager.shared.skill(for: skillId) {
+                            let body = await SkillManager.shared.buildFullInstructions(for: skill)
+                            oneOffSkillSection = (skill.name, body)
+                            let granted = AgentManager.shared
+                                .effectiveEnabledToolNames(for: effectiveAgentId)
+                                .map(Set.init)
+                            let dynamicNames = Set(
+                                ToolRegistry.shared.listDynamicTools().map(\.name)
+                            ).filter { granted?.contains($0) ?? true }
+                            skillReferencedTools = LoadedTools(
+                                SkillManager.toolNames(referencedIn: body, from: dynamicNames)
+                            )
+                        }
+                    }
+
                     let context = await SystemPromptComposer.composeChatContext(
                         agentId: effectiveAgentId,
                         executionMode: executionMode,
@@ -4408,7 +4439,8 @@ final class ChatSession: ObservableObject {
                         query: trimmed,
                         messages: priorUserMessages,
                         toolsDisabled: chatCfg.disableTools,
-                        additionalToolNames: cachedSession?.loadedToolNames ?? [],
+                        additionalToolNames: (cachedSession?.loadedToolNames ?? [])
+                            .union(skillReferencedTools),
                         frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
                         frozenManifest: cachedSession?.frozenManifest,
                         frozenSoul: cachedSession?.frozenSoul,
@@ -4443,15 +4475,11 @@ final class ChatSession: ObservableObject {
                         sys = sys.isEmpty ? pluginInstructions : sys + "\n\n" + pluginInstructions
                     }
 
-                    // Inject one-off skill if the user selected one via slash command.
-                    // Consume the pending id either way, but never append in Mode 2
-                    // (the request must stay bare).
-                    if let skillId = pendingOneOffSkillId {
-                        pendingOneOffSkillId = nil
-                        if !isRemoteAgentTarget, let skill = SkillManager.shared.skill(for: skillId) {
-                            let section = await SkillManager.shared.buildFullInstructions(for: skill)
-                            sys += "\n\n## Active Skill: \(skill.name)\n\n\(section)"
-                        }
+                    // Inject the one-off skill the user selected via slash
+                    // command (resolved above, before compose, so the tools it
+                    // references made it into the schema).
+                    if let oneOff = oneOffSkillSection {
+                        sys += "\n\n## Active Skill: \(oneOff.name)\n\n\(oneOff.body)"
                     }
 
                     // FROZEN for the whole run (deferred-schema / KV-prefix
@@ -4487,6 +4515,18 @@ final class ChatSession: ObservableObject {
                             fingerprint: liveFingerprint,
                             manifest: context.enabledManifest,
                             soul: context.soul
+                        )
+                    }
+
+                    // Skill-referenced tools joined this turn's schema above;
+                    // persist them into the session's loaded-tool union (auto
+                    // mode only, mirroring the capabilities_load drain path)
+                    // so the next turn's frozen schema still contains them.
+                    if !skillReferencedTools.isEmpty, !isManualTools, let sid = sessionId {
+                        await SessionToolStateStore.shared.appendLoadedTools(
+                            sessionStateKey(sid),
+                            names: Array(skillReferencedTools),
+                            fallbackAlwaysLoadedNames: context.alwaysLoadedNames
                         )
                     }
 


### PR DESCRIPTION
## Summary

fixes #2145

Invoking a skill with a `/command` injected its instructions into the system prompt after the turn's tool schema and execution scope were already frozen. Skill instructions routinely name the exact MCP or plugin tools they need, so the model would call a real tool it was told about and the registry refused it with a non-retryable `tool_not_found`, leaving small models to apologize and give up.

- Resolve the pending one-off skill before `composeChatContext` and scan its instructions for agent-granted dynamic tool names, riding matches through `additionalToolNames` so they land in both the model-visible schema and the execution scope.
- Persist those names into the session's loaded tool union (auto mode only, mirroring the `capabilities_load` drain path) so the next turn's frozen schema still contains them.
- Add `SkillManager.toolNames(referencedIn:from:)`, a pure-token exact scan over the function-name charset, so substrings of longer identifiers never match.
- Make the scope-gate refusal retryable with an explicit `capabilities_load` hint when the refused tool is registered, enabled, and within the agent's grant, giving models a recovery path when the scan misses or the model names a real but unloaded tool.
- Keep the opaque non-retryable refusal for unregistered, globally disabled, or agent-withheld tools so the gate reveals nothing about deliberately withheld capabilities, and exclude the default agent whose `capabilities_load` is gated.
- Add `SkillToolReferenceScanTests` and `ToolScopeGateRecoveryTests` covering the scan behavior, the retryable hint, the opaque refusal cases, and that scope activation still executes

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
