### PR TITLE
fix streaming error on deepseek and other openai compatible providers

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -1094,8 +1094,17 @@ struct DeltaContent: Codable, Sendable {
 /// Streaming choice
 struct StreamChoice: Codable, Sendable {
     let index: Int
-    let delta: DeltaContent
+    /// Optional on decode: OpenAI-compatible providers (DeepSeek among them)
+    /// omit `delta` on the final finish/usage chunk. Osaurus's own stream
+    /// writers always populate it.
+    let delta: DeltaContent?
     let finish_reason: String?
+
+    init(index: Int, delta: DeltaContent, finish_reason: String?) {
+        self.index = index
+        self.delta = delta
+        self.finish_reason = finish_reason
+    }
 }
 
 /// Chat completion chunk for streaming

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1690,16 +1690,27 @@ public actor RemoteProviderService: ToolCapableService {
                 )
             }
         } catch {
-            let phase =
-                state.accumulatedToolCalls.isEmpty
-                ? "" : " while receiving tool arguments"
+            // Fatal only while tool arguments are accumulating: an undecodable
+            // event there can hide truncated arguments, and dispatching a
+            // partial call is worse than failing the turn. Outside that window
+            // an unrecognized chunk shape (e.g. a delta-less finish or
+            // keep-alive frame from an OpenAI-compatible provider) is skipped,
+            // matching pre-0.22.8 behavior; the finish boundary still closes
+            // the stream normally.
+            guard !state.accumulatedToolCalls.isEmpty else {
+                print(
+                    "[Osaurus] Warning: Skipping unparseable provider SSE event: "
+                        + "\(error.localizedDescription) (\(jsonData.count) bytes)"
+                )
+                return .continue
+            }
             print(
-                "[Osaurus] Failed to parse provider SSE event\(phase): "
+                "[Osaurus] Failed to parse provider SSE event while receiving tool arguments: "
                     + "\(error.localizedDescription) (\(jsonData.count) bytes)"
             )
             return .finishWithError(
                 RemoteProviderServiceError.streamingError(
-                    "Provider emitted an invalid streaming event\(phase) "
+                    "Provider emitted an invalid streaming event while receiving tool arguments "
                         + "(\(jsonData.count) bytes). The response may have been truncated in transit."
                 )
             )

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -522,6 +522,64 @@ struct OpenAICompatibleStreamParserTests {
         #expect(visible == ["answer"])
     }
 
+    @Test func parser_strictDecodesFinishChunkWithoutDelta() throws {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        let finishChunk =
+            #"{"id":"c1","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":"stop"}]}"#
+
+        let outcome = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(finishChunk.utf8),
+            options: .strict,
+            state: &state,
+            yield: { _ in }
+        )
+        guard case .continue = outcome else {
+            Issue.record("Expected delta-less finish chunk to decode and continue, got \(outcome)")
+            return
+        }
+        #expect(state.lastFinishReason == "stop")
+    }
+
+    @Test func service_skipsUnparseableChunkOutsideToolArguments() {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        let unknownShape = #"{"unexpected":"frame","payload":[1,2,3]}"#
+
+        let outcome = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(unknownShape.utf8),
+            providerType: .openaiLegacy,
+            state: &state,
+            yield: { _ in }
+        )
+        guard case .continue = outcome else {
+            Issue.record("Expected unknown chunk shape to be skipped, got \(outcome)")
+            return
+        }
+    }
+
+    @Test func service_failsUnparseableChunkWhileReceivingToolArguments() {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        let toolStart =
+            #"{"id":"c1","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"file_write","arguments":"{\"pa"}}]}}]}"#
+        _ = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(toolStart.utf8),
+            providerType: .openaiLegacy,
+            state: &state,
+            yield: { _ in }
+        )
+
+        let outcome = RemoteProviderService.handleStreamEvent(
+            jsonData: Data(#"{"unexpected":"frame"}"#.utf8),
+            providerType: .openaiLegacy,
+            state: &state,
+            yield: { _ in }
+        )
+        guard case .finishWithError(let error) = outcome else {
+            Issue.record("Expected unparseable chunk mid-arguments to fail, got \(outcome)")
+            return
+        }
+        #expect(error.localizedDescription.contains("while receiving tool arguments"))
+    }
+
     private func dispatchEvents(
         from parser: inout OpenAICompatibleStreamFramer.SSELineParser,
         options: OpenAICompatibleStreamFramer.Options

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -559,7 +559,7 @@ struct OpenAICompatibleStreamParserTests {
     @Test func service_failsUnparseableChunkWhileReceivingToolArguments() {
         var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
         let toolStart =
-            #"{"id":"c1","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"file_write","arguments":"{\"pa"}}]}}]}"#
+            #"{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"file_write","arguments":"{\"pa"}}]}}]}"#
         _ = RemoteProviderService.handleStreamEvent(
             jsonData: Data(toolStart.utf8),
             providerType: .openaiLegacy,


### PR DESCRIPTION
## Summary

fixes #2148

- 0.22.8 made every SSE parse failure fatal, so DeepSeek's end-of-turn chunk (which omits `delta` on the finish frame) aborted each turn with "Provider emitted an invalid streaming event"
- make `StreamChoice.delta` optional on decode so delta-less finish chunks parse properly and preserve `finish_reason`. Osaurus's own stream writers still always populate it
- skip unparseable chunks outside tool-call accumulation (matching pre-0.22.8 behavior) instead of failing the stream, the `[DONE]` boundary still closes it normally
- keep the fatal path from #2108 when a chunk fails to parse while tool arguments are accumulating, along with the empty-args quarantine and the output-limit guards, so truncated tool calls still cannot dispatch as `{}`
- add tests covering the delta-less finish chunk, skipping unknown chunk shapes outside tool calls, and still failing on unparseable chunks mid-arguments

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
