### PR TITLE
Fix TextEdit AppleScript state and completion handling

### DIFF
--- a/Packages/OsaurusCore/AppleScript/Knowledge/AppleScriptAppKnowledge.swift
+++ b/Packages/OsaurusCore/AppleScript/Knowledge/AppleScriptAppKnowledge.swift
@@ -105,6 +105,11 @@ public enum AppleScriptAppKnowledge {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !app.isEmpty, wordRange(of: app, in: task) == nil else { return task }
         let grounding = "\nWorking app resolved from the live desktop: \(app). "
+        if mentionsNewDocumentCreation(task) {
+            return task + grounding
+                + "Create one new blank document in that app and leave it editable. "
+                + "Do not type example text, and do not save unless the task explicitly asks."
+        }
         if mentionsWorkingDocument(task) {
             return task + grounding
                 + "Interpret the file/document as that app's front open document. "
@@ -130,6 +135,13 @@ public enum AppleScriptAppKnowledge {
             || mentionsWorkingDocument(task)
     }
 
+    private static func mentionsNewDocumentCreation(_ task: String) -> Bool {
+        task.range(
+            of: #"\b(?:create|make|open)\s+(?:a\s+)?(?:new|blank)\s+(?:plain\s+text\s+)?document\b"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
+    }
+
     private static func mentionsWorkingDocument(_ task: String) -> Bool {
         let lower = task.lowercased()
         return lower.contains("the file") || lower.contains("this file")
@@ -137,6 +149,7 @@ public enum AppleScriptAppKnowledge {
             || lower.contains("current file") || lower.contains("open file")
             || lower.contains("the document") || lower.contains("this document")
             || lower.contains("current document") || lower.contains("open document")
+            || mentionsNewDocumentCreation(task)
     }
 
     // MARK: - Composition

--- a/Packages/OsaurusCore/AppleScript/Knowledge/AppleScriptRecipes.swift
+++ b/Packages/OsaurusCore/AppleScript/Knowledge/AppleScriptRecipes.swift
@@ -46,6 +46,10 @@ public enum AppleScriptRecipeCatalog {
                     + "Never write `... of TextEdit` as though TextEdit were a variable.",
                 "The unsaved/edited-state property is `modified of front document` (boolean). "
                     + "Do not invent `changed of front document`.",
+                "For a blank new document, do not type placeholder/example text. If TextEdit's "
+                    + "standard Open window is frontmost, use System Events to click "
+                    + "`button \"New Document\" of splitter group 1 of window \"Open\"`; otherwise "
+                    + "use `tell application \"TextEdit\" to make new document`.",
                 "When the whole document is the old text, replace it directly: "
                     + "`tell application \"TextEdit\" to set text of front document to \"new text\"`. "
                     + "Do not add a handler, UI keystrokes, formatting, files, or shell commands.",

--- a/Packages/OsaurusCore/AppleScript/Loop/AppleScriptLoop.swift
+++ b/Packages/OsaurusCore/AppleScript/Loop/AppleScriptLoop.swift
@@ -460,6 +460,17 @@ public enum AppleScriptLoop {
         // case one bounded protocol retry; never execute reasoning text or
         // retry a real plain-text explanation.
         var compileEnvelopeRecoveryAttempted = false
+        let requiresBlankTextEditDocument =
+            mode == .automate && blankTextEditDocumentTask(task: task, literals: literals)
+        let blankTextEditDocumentCountBefore: Int?
+        if requiresBlankTextEditDocument {
+            let observation = await runExecutor(textEditDocumentCountScript, .appleScript)
+            blankTextEditDocumentCountBefore = observation.isSuccess
+                ? Int(observation.output?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
+                : nil
+        } else {
+            blankTextEditDocumentCountBefore = nil
+        }
 
         func record(
             intent: EffectClass,
@@ -905,6 +916,15 @@ public enum AppleScriptLoop {
                     step += 1
                     continue
                 }
+                if requiresBlankTextEditDocument {
+                    return terminate(
+                        .failed(
+                            reason:
+                                "TextEdit did not reach a verified blank editable document. "
+                                + "The Open window must be closed and a new document must be frontmost."
+                        )
+                    )
+                }
                 if harness.verifyReadBack, !verifyAttempted, !haveValue, succeeded > 0,
                     shouldVerify(mode: mode, task: task)
                 {
@@ -1109,6 +1129,59 @@ public enum AppleScriptLoop {
                 if consecutiveInvalid >= limits.maxConsecutiveInvalid {
                     return terminate(
                         .failed(reason: "The model kept adding an unrequested TextEdit save operation.")
+                    )
+                }
+                messages.append(
+                    ChatMessage(
+                        role: "tool",
+                        content: reason,
+                        tool_calls: nil,
+                        tool_call_id: call.id
+                    )
+                )
+                lastToolResult = reason
+                step += 1
+                continue
+            }
+
+            // A request for a BLANK TextEdit document authorizes creating the
+            // document, not inventing its contents. Reject model-authored
+            // example/placeholder text before it reaches the confirmation UI.
+            // This is the same user-data boundary as the literal placeholder
+            // contract above, scoped only to the confirmed blank-document task.
+            if !verifying, proposedEffect != .read,
+                let contentOperation = unrequestedBlankTextEditContentOperation(
+                    in: proposedScript,
+                    task: task,
+                    language: language,
+                    literals: literals
+                )
+            {
+                consecutiveInvalid += 1
+                let reason =
+                    "The task requested a blank TextEdit document, but the script added "
+                    + "unrequested content (\(contentOperation)). Create the document without "
+                    + "typing, setting, or inventing any text."
+                feed.emit(
+                    SubagentActivityEvent(
+                        step: step,
+                        kind: .retry,
+                        title: "Unrequested TextEdit content rejected",
+                        detail: reason
+                    )
+                )
+                steps.append(
+                    AppleScriptStepRecord(
+                        n: steps.count + 1,
+                        intent: "unknown",
+                        status: "invalid",
+                        error: reason,
+                        scriptPreview: scriptPreview(proposedScript)
+                    )
+                )
+                if consecutiveInvalid >= limits.maxConsecutiveInvalid {
+                    return terminate(
+                        .failed(reason: "The model kept adding text to a requested blank document.")
                     )
                 }
                 messages.append(
@@ -1557,6 +1630,95 @@ public enum AppleScriptLoop {
                 }
             }
 
+            // `NSAppleScript` success only proves that the script returned; it
+            // does not prove TextEdit left its startup Open window. The live
+            // regression returned success for `make new document` while the
+            // Open panel remained frontmost. For the narrow blank-document
+            // contract, require BOTH a document-count increase and live AX
+            // evidence of an editable front window with the Open panel gone.
+            if execution.isSuccess, requiresBlankTextEditDocument {
+                let uiObservation = await runExecutor(
+                    textEditBlankDocumentUIStateScript,
+                    .appleScript
+                )
+                let countObservation = await runExecutor(
+                    textEditDocumentCountScript,
+                    .appleScript
+                )
+                let uiState = uiObservation.output?.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                )
+                let afterCount = Int(
+                    countObservation.output?.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ) ?? ""
+                )
+                let matched =
+                    uiObservation.isSuccess
+                    && countObservation.isSuccess
+                    && uiState == "editable"
+                    && blankTextEditDocumentCountBefore != nil
+                    && afterCount != nil
+                    && afterCount! > blankTextEditDocumentCountBefore!
+                let mismatch =
+                    "TextEdit postcondition was not met "
+                    + "(ui=\(uiState ?? "unavailable"), "
+                    + "documents=\(afterCount.map(String.init) ?? "unavailable"), "
+                    + "before=\(blankTextEditDocumentCountBefore.map(String.init) ?? "unavailable"))."
+                steps.append(
+                    AppleScriptStepRecord(
+                        n: steps.count + 1,
+                        intent: "read",
+                        status: matched ? "success" : "verification_mismatch",
+                        output: uiState,
+                        error: matched ? nil : mismatch,
+                        scriptPreview: scriptPreview(textEditBlankDocumentUIStateScript)
+                    )
+                )
+                if matched {
+                    lastOutput = "blank editable document"
+                    lastReadOutput = "blank editable document"
+                    feed.emit(
+                        SubagentActivityEvent(
+                            step: step,
+                            kind: .verify,
+                            title: "Verified blank TextEdit document",
+                            detail: "Open window closed; editable document is frontmost.",
+                            success: true
+                        )
+                    )
+                    return terminate(
+                        .done(summary: "Created a blank editable document in TextEdit.")
+                    )
+                }
+
+                feed.emit(
+                    SubagentActivityEvent(
+                        step: step,
+                        kind: .retry,
+                        title: "TextEdit is not ready for editing",
+                        detail: mismatch,
+                        success: false
+                    )
+                )
+                let postconditionResult =
+                    toolResult + "\n" + mismatch
+                    + " Do not type any text. If the standard Open window is still frontmost, "
+                    + "click its New Document button first; otherwise create one new document. "
+                    + "Call run_applescript with only the missing state transition."
+                messages.append(
+                    ChatMessage(
+                        role: "tool",
+                        content: postconditionResult,
+                        tool_calls: nil,
+                        tool_call_id: call.id
+                    )
+                )
+                lastToolResult = postconditionResult
+                step += 1
+                continue
+            }
+
             // Do not ask the helper for a free-form terminal turn between an
             // already-successful mutation and the required OS read-back. Gemma
             // 4 AppleScript bundles can answer that `tool_choice:auto` turn
@@ -1776,6 +1938,38 @@ public enum AppleScriptLoop {
 
     private static let textEditFrontDocumentReadScript =
         #"tell application "TextEdit" to get text of front document"#
+    private static let textEditDocumentCountScript =
+        #"tell application "TextEdit" to count documents"#
+    private static let textEditBlankDocumentUIStateScript = """
+        tell application "System Events"
+            tell process "TextEdit"
+                if exists window "Open" then return "open_panel"
+                if (count of windows) is 0 then return "no_window"
+                if exists text area 1 of scroll area 1 of window 1 then return "editable"
+                return "no_editable_document"
+            end tell
+        end tell
+        """
+
+    static func blankTextEditDocumentTask(
+        task: String,
+        literals: AppleScriptLiterals
+    ) -> Bool {
+        guard literals.isEmpty else { return false }
+        let normalized = task.lowercased()
+        guard normalized.contains("textedit") else { return false }
+        let creationIntent =
+            normalized.range(
+                of: #"\b(?:create|make|open)\s+(?:a\s+)?(?:new|blank)\s+(?:plain\s+text\s+)?document\b"#,
+                options: .regularExpression
+            ) != nil
+        guard creationIntent else { return false }
+        let contentIntent: [String] = [
+            "contain", " with ", "that says", "and type", "and write", "and enter",
+            "and put", "insert ", "add the text", "content:",
+        ]
+        return !contentIntent.contains { normalized.contains($0) }
+    }
 
     private static func exactTextEditReplacementContract(
         task: String,
@@ -2051,13 +2245,48 @@ public enum AppleScriptLoop {
         else { return nil }
 
         let checks: [(pattern: String, label: String)] = [
-            (#"(?im)^\s*save(?:\s|$)"#, "save command"),
+            (#"(?i)\bsave\s+(?:(?:front|current)\s+)?document\b"#, "save command"),
             (#"(?i)\bkeystroke\s+[\"“]s[\"”]\s+using\s+\{[^}]*command\s+down"#, "Command-S"),
             (#"(?i)\bclick\s+(?:menu\s+item|button)\s+[\"“]save[\"”]"#, "Save UI action"),
             (#"(?im)^\s*close\b[^\n]*\bsaving\s+(?:yes|true)\b"#, "close-with-save"),
             (
                 #"(?im)^\s*set\s+[^\n]*\b(?:changed|modified)\b[^\n]*\bto\s+false\b"#,
                 "dirty-state reset"
+            ),
+        ]
+        for check in checks
+        where script.range(of: check.pattern, options: .regularExpression) != nil {
+            return check.label
+        }
+        return nil
+    }
+
+    /// Return the unauthorized content primitive a model added to a request
+    /// that only asked for a blank TextEdit document. Navigation keystrokes
+    /// such as Command-N remain allowed; literal typing and document-text
+    /// assignments do not.
+    static func unrequestedBlankTextEditContentOperation(
+        in script: String,
+        task: String,
+        language: AppleScriptLanguage,
+        literals: AppleScriptLiterals
+    ) -> String? {
+        guard language == .appleScript,
+            blankTextEditDocumentTask(task: task, literals: literals)
+        else { return nil }
+
+        let checks: [(pattern: String, label: String)] = [
+            (
+                #"(?i)\bset\s+(?:the\s+)?(?:text|content|contents|body|thetext|value)\s+of\b[^\n]*\bto\b"#,
+                "document text assignment"
+            ),
+            (
+                #"(?is)\bmake\s+new\s+document\s+with\s+properties\s+\{[^}]*(?:text|content|contents|body|thetext|value)\s*:"#,
+                "document content property"
+            ),
+            (
+                #"(?i)\bkeystroke\s+[\"“](?!n[\"”]\s+using\s+(?:\{[^}]*\bcommand\s+down\b[^}]*\}|\bcommand\s+down\b))[^\"”]+[\"”]"#,
+                "typed text"
             ),
         ]
         for check in checks

--- a/Packages/OsaurusCore/ComputerUse/Recipes/AppRecipe.swift
+++ b/Packages/OsaurusCore/ComputerUse/Recipes/AppRecipe.swift
@@ -162,6 +162,15 @@ public enum AppRecipes {
         matchers: ["textedit"],
         flows: [
             RecipeFlow(
+                name: "Create a blank document",
+                steps: [
+                    "If the standard Open window is visible, click New Document before doing anything else.",
+                    "Verify the Open window closed and an editable text area is visible.",
+                    "Finish with done without typing example or placeholder text.",
+                    "Do not save unless the goal explicitly requests it.",
+                ]
+            ),
+            RecipeFlow(
                 name: "Replace text in an open document",
                 steps: [
                     "Choose the textarea whose visible value contains the old text, using its window label when several documents are open.",

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
@@ -1310,6 +1310,17 @@ struct AppleScriptLoopTests {
         )
         #expect(
             AppleScriptLoop.unrequestedTextEditPersistenceOperation(
+                in: """
+                    tell application "TextEdit"
+                        if modified of front document then save front document
+                    end tell
+                    """,
+                task: "Create a new blank document in TextEdit.",
+                language: .appleScript
+            ) == "save command"
+        )
+        #expect(
+            AppleScriptLoop.unrequestedTextEditPersistenceOperation(
                 in: #"tell application "TextEdit" to set text of front document to {{content}}"#,
                 task: "Replace the TextEdit contents and do not save it.",
                 language: .appleScript
@@ -1325,6 +1336,92 @@ struct AppleScriptLoopTests {
                     """,
                 task: "Replace the TextEdit contents and save the document.",
                 language: .appleScript
+            ) == nil
+        )
+    }
+
+    @Test("blank TextEdit document tasks reject invented content but allow the Open-window transition")
+    func blankTextEditDocumentContentContract() {
+        let task = "Create a new document in TextEdit."
+        let noLiterals = AppleScriptLiterals()
+        #expect(AppleScriptLoop.blankTextEditDocumentTask(task: task, literals: noLiterals))
+        #expect(
+            AppleScriptLoop.unrequestedBlankTextEditContentOperation(
+                in: """
+                    tell application "System Events"
+                        tell process "TextEdit"
+                            keystroke "Hello world"
+                        end tell
+                    end tell
+                    """,
+                task: task,
+                language: .appleScript,
+                literals: noLiterals
+            ) == "typed text"
+        )
+        #expect(
+            AppleScriptLoop.unrequestedBlankTextEditContentOperation(
+                in: #"tell application "TextEdit" to set text of front document to "Hello world""#,
+                task: task,
+                language: .appleScript,
+                literals: noLiterals
+            ) == "document text assignment"
+        )
+        #expect(
+            AppleScriptLoop.unrequestedBlankTextEditContentOperation(
+                in: """
+                    tell application "TextEdit"
+                        make new document
+                        set body of front document to {"This is placeholder text."}
+                    end tell
+                    """,
+                task: task,
+                language: .appleScript,
+                literals: noLiterals
+            ) == "document text assignment"
+        )
+        #expect(
+            AppleScriptLoop.unrequestedBlankTextEditContentOperation(
+                in: """
+                    tell application "System Events"
+                        tell process "TextEdit"
+                            click button "New Document" of splitter group 1 of window "Open"
+                        end tell
+                    end tell
+                    """,
+                task: task,
+                language: .appleScript,
+                literals: noLiterals
+            ) == nil
+        )
+        #expect(
+            AppleScriptLoop.blankTextEditDocumentTask(
+                task: "Create a new TextEdit document with Hello world.",
+                literals: noLiterals
+            ) == false
+        )
+        #expect(
+            AppleScriptLoop.unrequestedBlankTextEditContentOperation(
+                in: """
+                    tell application "System Events"
+                        keystroke "n" using {command down}
+                    end tell
+                    """,
+                task: task,
+                language: .appleScript,
+                literals: noLiterals
+            ) == nil
+        )
+        #expect(
+            AppleScriptLoop.unrequestedBlankTextEditContentOperation(
+                in: """
+                    tell application "System Events"
+                        keystroke "n" using command down
+                    end tell
+                    """,
+                task: task,
+                language: .appleScript,
+                literals: noLiterals
             ) == nil
         )
     }
@@ -1482,6 +1579,137 @@ struct AppleScriptLoopTests {
         #expect(result.failed == 0)
         #expect(await exec.count == 1)
         #expect(await confirm.count == 1)
+    }
+
+    @Test("blank TextEdit creation requires a new editable front document")
+    func blankTextEditCreationRequiresLivePostcondition() async {
+        let feed = SubagentFeed(
+            toolCallId: "t-blank-textedit-postcondition",
+            kindId: "applescript",
+            title: "Create a new document in TextEdit."
+        )
+        let exec = ScriptedExec(results: [
+            successResult("0"),
+            successResult(nil),
+            successResult("open_panel"),
+            successResult("1"),
+            successResult(nil),
+            successResult("editable"),
+            successResult("1"),
+        ])
+        let confirm = ConfirmCounter(approve: true)
+        let seq = ScriptSequencer([
+            call(#"tell application "TextEdit" to make new document"#, id: "dictionary-create"),
+            call(
+                """
+                tell application "System Events"
+                    tell process "TextEdit"
+                        click button "New Document" of splitter group 1 of window "Open"
+                    end tell
+                end tell
+                """,
+                id: "open-window-transition"
+            ),
+        ])
+
+        let result = await AppleScriptLoop.run(
+            task: "Create a new document in TextEdit.",
+            modelId: "applescript-test",
+            feed: feed,
+            interrupt: InterruptToken(),
+            executionMode: .confirmEach,
+            confirm: { _ in await confirm.confirm() },
+            limits: RunLimits(maxSteps: 6),
+            sessionId: "s",
+            mode: .automate,
+            execute: { script, _ in await exec.run(script) },
+            nextScript: { _ in await seq.next() }
+        )
+
+        guard case .done(let summary) = result.outcome else {
+            Issue.record("expected .done, got \(result.outcome)")
+            return
+        }
+        #expect(summary == "Created a blank editable document in TextEdit.")
+        #expect(result.scriptsExecuted == 2)
+        #expect(result.succeeded == 2)
+        #expect(result.failed == 0)
+        #expect(result.lastOutput == "blank editable document")
+        #expect(await confirm.count == 2)
+        #expect(
+            result.steps.contains {
+                $0.status == "verification_mismatch"
+                    && $0.output == "open_panel"
+            }
+        )
+        #expect(
+            feed.currentEvents().contains {
+                $0.title == "Verified blank TextEdit document" && $0.success == true
+            }
+        )
+    }
+
+    @Test("invented blank-document text never reaches approval or execution")
+    func blankTextEditInventedTextIsRejectedBeforeApproval() async {
+        let feed = SubagentFeed(
+            toolCallId: "t-blank-textedit-content",
+            kindId: "applescript",
+            title: "Create a blank document in TextEdit."
+        )
+        let exec = ScriptedExec(results: [
+            successResult("0"),
+            successResult(nil),
+            successResult("editable"),
+            successResult("1"),
+        ])
+        let confirm = ConfirmCounter(approve: true)
+        let seq = ScriptSequencer([
+            call(
+                """
+                tell application "System Events"
+                    tell process "TextEdit"
+                        keystroke "Hello world"
+                    end tell
+                end tell
+                """,
+                id: "invented-content"
+            ),
+            call(
+                """
+                tell application "System Events"
+                    tell process "TextEdit"
+                        click button "New Document" of splitter group 1 of window "Open"
+                    end tell
+                end tell
+                """,
+                id: "blank-document"
+            ),
+        ])
+
+        let result = await AppleScriptLoop.run(
+            task: "Create a blank document in TextEdit.",
+            modelId: "applescript-test",
+            feed: feed,
+            interrupt: InterruptToken(),
+            executionMode: .confirmEach,
+            confirm: { _ in await confirm.confirm() },
+            limits: RunLimits(maxSteps: 6),
+            sessionId: "s",
+            mode: .automate,
+            execute: { script, _ in await exec.run(script) },
+            nextScript: { _ in await seq.next() }
+        )
+
+        #expect(result.outcome.isSuccess)
+        #expect(result.scriptsExecuted == 1)
+        #expect(result.succeeded == 1)
+        #expect(await confirm.count == 1)
+        #expect(
+            result.steps.contains {
+                $0.status == "invalid"
+                    && ($0.error?.contains("unrequested content") ?? false)
+            }
+        )
     }
 
     @Test("a mutating script return is not accepted as exact-content verification")
@@ -3728,6 +3956,13 @@ struct AppleScriptAppKnowledgeTests {
         )
         #expect(documentTask == ["TextEdit"])
 
+        let newDocumentTask = AppleScriptAppKnowledge.detectTargetApps(
+            task: "Create a new document",
+            frontmost: "TextEdit",
+            runningAppNames: ["TextEdit"]
+        )
+        #expect(newDocumentTask == ["TextEdit"])
+
         let unrelatedTask = AppleScriptAppKnowledge.detectTargetApps(
             task: "What is the battery percentage?",
             frontmost: "TextEdit",
@@ -3767,6 +4002,14 @@ struct AppleScriptAppKnowledgeTests {
         #expect(appQuery.contains("Use that app as the frontmost/current/active app"))
         #expect(!appQuery.contains("file/document"))
         #expect(!appQuery.contains("do not save"))
+
+        let newDocument = AppleScriptAppKnowledge.groundingWorkingAppReference(
+            task: "Create a new document",
+            resolvedApp: "TextEdit"
+        )
+        #expect(newDocument.contains("Create one new blank document in that app"))
+        #expect(newDocument.contains("Do not type example text"))
+        #expect(!newDocument.contains("front open document"))
     }
 
     @Test("recipe catalog matches by app name, case-insensitively")

--- a/Packages/OsaurusCore/Tests/ComputerUse/Recipes/AppRecipeTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Recipes/AppRecipeTests.swift
@@ -68,6 +68,9 @@ final class AppRecipeTests: XCTestCase {
         guard let text = AppRecipes.guidanceText(for: "TextEdit") else {
             return XCTFail("expected TextEdit guidance")
         }
+        XCTAssertTrue(text.contains("Create a blank document"))
+        XCTAssertTrue(text.contains("click New Document"))
+        XCTAssertTrue(text.contains("without typing example or placeholder text"))
         XCTAssertTrue(text.contains("Use set_value once"))
         XCTAssertTrue(text.contains("finish with done"))
         XCTAssertTrue(text.contains("Do not save"))

--- a/docs/APPLESCRIPT_TEXTEDIT_LIVE_PROOF_2026_07_23.md
+++ b/docs/APPLESCRIPT_TEXTEDIT_LIVE_PROOF_2026_07_23.md
@@ -1,0 +1,158 @@
+# AppleScript TextEdit state and completion proof — 2026-07-23
+
+## Scope
+
+This checkpoint is intentionally limited to the reported TextEdit/AppleScript
+regressions:
+
+- a blank-document request typed invented/example text;
+- TextEdit's startup Open panel was mistaken for an editable document;
+- a successful mutation was retried or followed by an unrequested save;
+- the helper returned success even when the requested UI postcondition was not
+  present;
+- an informational follow-up was incorrectly treated as a new tool request.
+
+It does not claim to close Sandbox GPU utilization, global screen-context
+freshness, cache-family coverage, or other model-runtime work.
+
+## Source trace
+
+Current branch base: Osaurus `main` at
+`46c0748611a7ac07c400344f191a1e16abb2b74d`.
+
+Workspace vMLX pin:
+`7d6235316226ba9fe608018f86c463784e48b3d5`.
+
+The old loop treated a successful `NSAppleScript` return as sufficient. In a
+live baseline, `make new document` returned successfully while TextEdit still
+showed its standard Open panel, so Osaurus finalized a false success. Small
+AppleScript bundles also generated placeholder text through several distinct
+forms (`text`, document properties, and `body`) and could place `save front
+document` after `then`, outside the old line-start save matcher.
+
+The patch:
+
+- adds explicit TextEdit blank-document recipes for both AppleScript and
+  Computer Use;
+- recognizes only literal-free blank TextEdit creation tasks;
+- rejects unauthorized text/body/content/value assignments and literal
+  keystrokes before confirmation;
+- recognizes inline `save ... document` as an unrequested save when the task
+  did not opt in;
+- accepts both AppleScript Command-N spellings for classification, then leaves
+  syntax validity to the compile check;
+- records the pre-action document count;
+- requires both a larger document count and live Accessibility state
+  `editable` with no Open panel before returning success;
+- feeds a failed postcondition back for a bounded retry instead of silently
+  finalizing.
+
+No sampler override, forced reasoning tag, prompt answer, synthetic completion,
+or hidden save behavior was added.
+
+## Automated evidence
+
+The following targeted macOS suites passed after the final inline-save change:
+
+```text
+OsaurusCoreTests/AppleScriptLoopTests
+OsaurusCoreTests/AppRecipeTests
+OsaurusCoreTests/AppleScriptAppKnowledgeTests
+```
+
+The invocation used the checked-in workspace and the isolated derived-data
+directory:
+
+```text
+xcodebuild -workspace osaurus.xcworkspace \
+  -scheme OsaurusCoreTests -configuration Debug \
+  -destination platform=macOS,arch=arm64 \
+  -derivedDataPath /private/tmp/osaurus-applescript-live-derived-20260723 \
+  -disableAutomaticPackageResolution -skipPackagePluginValidation test \
+  -only-testing:OsaurusCoreTests/AppleScriptLoopTests \
+  -only-testing:OsaurusCoreTests/AppRecipeTests \
+  -only-testing:OsaurusCoreTests/AppleScriptAppKnowledgeTests
+```
+
+`git diff --check` and `swiftc -parse` also passed. Xcode emitted the
+machine's pre-existing out-of-date CoreSimulator warning, but the macOS tests
+executed and exited zero.
+
+## Live UI evidence
+
+All live rows use:
+
+- an isolated Release app with bundle identifier
+  `com.dinoki.osaurus.curootproof202607220512`;
+- `OSAURUS_TEST_ROOT=/private/tmp/osaurus-cu-root-proof-root-20260722-2343`;
+- keychain disabled for the proof app;
+- actual Settings -> Agents -> Assistant -> Abilities -> Subagents ->
+  AppleScript model selection;
+- Confirm Each Script;
+- Computer Use inspection of both the Osaurus approval/final state and the
+  real TextEdit window.
+
+Final Release executable:
+`1035ff23916e7e2f99306423d81d486248e447e0ea94f5465ffbf359ad47f657`.
+
+### Current-source final rows
+
+- Shipped Osaurus AppleScript 8B JANG_6M, blank document: the first proposed
+  script contained no invented text or save, but mistook TextEdit's Open panel
+  for a document and failed before mutation. The bounded retry created one
+  visibly blank editable document. Osaurus then emitted a terminal response;
+  there was no duplicate text, save attempt, or hang. This is a safe recovery,
+  not a one-shot pass.
+- AppleScript 16B A4B JANG_4M, blank document: one approval containing only
+  `make new document`; TextEdit's Open panel closed; one visibly blank,
+  editable and unmodified document appeared; Osaurus emitted a terminal
+  response. No retry, invented text, save, or hang.
+- AppleScript 16B A4B JANG_4M, exact replacement: after `Hello World` was
+  entered as the user, one approval contained one exact text assignment and no
+  save. TextEdit visibly showed `Hello from OracHQ` exactly once and remained
+  Edited. Osaurus emitted a terminal response. No retry or hang.
+- Parent feedback-only message: the model acknowledged the information directly
+  in 0.48 seconds TTFT. It did not call AppleScript, `mac_query`, or a
+  date/time tool.
+
+### Earlier checkpoint rows
+
+- AppleScript 16B A4B JANG_4M, blank document: one safe approval, a visibly
+  blank editable TextEdit window, and terminal Osaurus success. No retry or
+  hang.
+- AppleScript 16B A4B JANG_4M, exact replacement: the user-created text
+  `Hello World` changed exactly once to `Hello from OracHQ`; the approval
+  contained one direct `set text` statement and no save; TextEdit remained
+  edited; Osaurus finalized successfully without retry.
+- Parent feedback-only message: Osaurus acknowledged the message directly in
+  0.60 seconds TTFT and did not call AppleScript, `mac_query`, or a date/time
+  tool.
+- Shipped Osaurus AppleScript 8B JANG_6M: unsafe generated text was rejected
+  before approval until the model produced a safe `make new document`; the
+  resulting document was visibly blank and Osaurus finalized.
+
+### Regressions caught during live proof
+
+- The shipped 8B used `set body ...` to inject canned text, exposing a missing
+  alias in the content guard.
+- The 16B used `keystroke "n" using command down`, exposing a classifier that
+  accepted only the braced Command-N spelling.
+- The shipped 8B used
+  `if modified of front document then save front document`, exposing a
+  line-start-only save matcher. The script was declined and not executed.
+- With a stale frozen screen context naming Warp, the ambiguous phrase
+  `the file` targeted Warp. That action was declined. The explicit TextEdit
+  replacement path passed, but global frozen-context freshness is outside this
+  PR and remains open.
+
+## Final gate status
+
+VERIFIED-LIVE for the narrow TextEdit/AppleScript scope above. The final
+Release binary was ad-hoc signed, passed strict code-sign verification, and was
+operated through the real Osaurus Settings, chat, approval, and TextEdit UI.
+The shipped 8B row retains the explicit one-retry limitation described above.
+
+Global frozen screen-context freshness, Sandbox GPU utilization, and broader
+model/cache-family work remain outside this PR and are not claimed fixed.
+
+No screenshots are added to Git history.


### PR DESCRIPTION
## Summary

- ground generic new-document tasks to the actual frontmost app
- add explicit TextEdit blank-document guidance for AppleScript and Computer Use
- reject invented blank-document content and unrequested TextEdit saves before execution
- require a live TextEdit postcondition (document-count increase, editable UI, no Open panel) before finalizing success
- preserve exact replacement semantics and verify the resulting document text

## Source trace

The old AppleScript loop treated a successful `NSAppleScript` return as task completion. In the live baseline, TextEdit accepted `make new document` while its standard Open panel remained frontmost, so Osaurus reported a false success. Small helper models also produced placeholder text through multiple properties and an inline `if ... then save front document` form that the old line-start save matcher missed.

This patch is narrowly scoped to TextEdit/AppleScript state, content, save, and completion handling. It does not change sampler defaults, reasoning defaults, model runtime/cache behavior, or Sandbox behavior.

## Automated verification

Passed after the final inline-save change:

```text
xcodebuild -workspace osaurus.xcworkspace \
  -scheme OsaurusCoreTests -configuration Debug \
  -destination platform=macOS,arch=arm64 \
  -derivedDataPath /private/tmp/osaurus-applescript-live-derived-20260723 \
  -disableAutomaticPackageResolution -skipPackagePluginValidation test \
  -only-testing:OsaurusCoreTests/AppleScriptLoopTests \
  -only-testing:OsaurusCoreTests/AppRecipeTests \
  -only-testing:OsaurusCoreTests/AppleScriptAppKnowledgeTests
```

`git diff --check` and `swiftc -parse` passed. The final Release app built successfully and passed strict ad-hoc code-sign verification.

## Live Release UI verification

Executable SHA-256:
`1035ff23916e7e2f99306423d81d486248e447e0ea94f5465ffbf359ad47f657`

The isolated Release app was operated through the actual Osaurus Settings, chat, approval, and TextEdit UI with Confirm Each Script enabled.

- AppleScript 16B A4B JANG_4M, blank document: one approval containing only `make new document`; Open panel closed; one blank editable unmodified document appeared; terminal Osaurus response; no retry, invented text, save, or hang.
- AppleScript 16B A4B JANG_4M, replacement: one approval, one exact assignment, no save; `Hello World` became `Hello from OracHQ` exactly once and remained Edited; terminal response; no retry or hang.
- Shipped Osaurus AppleScript 8B JANG_6M, blank document: first script failed before mutation after mistaking the Open panel for a document; bounded retry created one visibly blank editable document; terminal response; no placeholder text, save, duplicate mutation, or hang. This is safe recovery, not a one-shot pass.
- Feedback-only follow-up: direct acknowledgement at 0.48s TTFT; no AppleScript, `mac_query`, or date/time tool call.

## Scope note

Global frozen screen-context freshness, Sandbox GPU utilization, and broader model/cache-family work remain open and are not claimed fixed here. No screenshots or binary artifacts are included.
