### PR TITLE
Fix Bonsai DB recovery and SSD prefix reuse

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7d6235316226ba9fe608018f86c463784e48b3d5"
+        "revision" : "f50853514ee00365837be3301c91850ca7ed5877"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -791,6 +791,12 @@ struct ChatCompletionRequest: Codable, Sendable {
     /// required for sliding-window models whose caches cannot be trimmed to
     /// a boundary at store time.
     var warmupPrefill: Bool = false
+    /// Local-only: byte-exact reusable leading system-prompt text from
+    /// `SystemPromptComposer.staticPrefix`. vmlx uses this only as a
+    /// tokenizer-validated SSD-prefix boundary hint after the full prompt has
+    /// already been rendered; it is not decoded from OpenAI JSON and is not
+    /// forwarded to remote providers.
+    var cacheStableSystemPrefix: String? = nil
     /// Local-only: when true, this request's model load must not disturb a model
     /// that is already resident or already loading — the runtime refuses the load
     /// instead of evicting. Set by housekeeping that nobody is waiting on
@@ -849,6 +855,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.remoteAgentProviderId = remoteAgentProviderId
         copy.suppressProgressUI = suppressProgressUI
         copy.warmupPrefill = warmupPrefill
+        copy.cacheStableSystemPrefix = cacheStableSystemPrefix
         // Must be copied with the other local-only flags. Dropping it silently
         // promotes a background request back to interactive — and an interactive
         // request is allowed to evict the model someone is using.
@@ -897,6 +904,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.remoteAgentProviderId = remoteAgentProviderId
         copy.suppressProgressUI = suppressProgressUI
         copy.warmupPrefill = warmupPrefill
+        copy.cacheStableSystemPrefix = cacheStableSystemPrefix
         // Must be copied with the other local-only flags. Dropping it silently
         // promotes a background request back to interactive — and an interactive
         // request is allowed to evict the model someone is using.

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -291,6 +291,12 @@ final class ChatTurn: ObservableObject, Identifiable {
     /// The chat UI uses this to surface a fallback banner suggesting the
     /// user toggle "Disable Thinking" for the next turn.
     var unclosedReasoning: Bool = false
+    /// Authoritative terminal reason supplied by the runtime (`stop`,
+    /// `length`, and provider equivalents). Unlike a token-count equality
+    /// guess, this distinguishes a natural ending from output-cap exhaustion.
+    /// The agent loop uses it to avoid treating a reasoning-only `length`
+    /// completion as a successful final response.
+    var terminalStopReason: String?
 
     /// Osaurus Router billing snapshot captured from the in-stream summary
     /// frame (cost, token counts, status). Persisted so a reloaded chat still

--- a/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
@@ -36,6 +36,9 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
     /// Seconds from request start to first visible token, for latency
     /// reporting. Nil when unknown.
     public var timeToFirstToken: TimeInterval?
+    /// Authoritative runtime finish reason (`stop`, `length`, etc.). Nil for
+    /// legacy turns and providers that do not report one.
+    public var terminalStopReason: String?
     /// OpenAI Responses reasoning item captured for an assistant turn (opaque
     /// `id` + encrypted blob). Re-emitted for chain continuity. Nil for every
     /// non-Responses turn.
@@ -68,6 +71,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         completedAt: Date? = nil,
         generationTokenCount: Int? = nil,
         timeToFirstToken: TimeInterval? = nil,
+        terminalStopReason: String? = nil,
         reasoningItemId: String? = nil,
         reasoningEncrypted: String? = nil,
         routerBilling: RouterBillingSummary? = nil,
@@ -88,6 +92,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         self.completedAt = completedAt
         self.generationTokenCount = generationTokenCount
         self.timeToFirstToken = timeToFirstToken
+        self.terminalStopReason = terminalStopReason
         self.reasoningItemId = reasoningItemId
         self.reasoningEncrypted = reasoningEncrypted
         self.routerBilling = routerBilling
@@ -111,6 +116,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         completedAt = try container.decodeIfPresent(Date.self, forKey: .completedAt)
         generationTokenCount = try container.decodeIfPresent(Int.self, forKey: .generationTokenCount)
         timeToFirstToken = try container.decodeIfPresent(TimeInterval.self, forKey: .timeToFirstToken)
+        terminalStopReason = try container.decodeIfPresent(String.self, forKey: .terminalStopReason)
         reasoningItemId = try container.decodeIfPresent(String.self, forKey: .reasoningItemId)
         reasoningEncrypted = try container.decodeIfPresent(String.self, forKey: .reasoningEncrypted)
         routerBilling = try container.decodeIfPresent(RouterBillingSummary.self, forKey: .routerBilling)
@@ -146,6 +152,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         try container.encodeIfPresent(completedAt, forKey: .completedAt)
         try container.encodeIfPresent(generationTokenCount, forKey: .generationTokenCount)
         try container.encodeIfPresent(timeToFirstToken, forKey: .timeToFirstToken)
+        try container.encodeIfPresent(terminalStopReason, forKey: .terminalStopReason)
         try container.encodeIfPresent(reasoningItemId, forKey: .reasoningItemId)
         try container.encodeIfPresent(reasoningEncrypted, forKey: .reasoningEncrypted)
         try container.encodeIfPresent(routerBilling, forKey: .routerBilling)
@@ -158,7 +165,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         case attachedImages  // legacy key for reading old sessions
         case toolCalls, toolCallId, toolResults, toolCallDurations, thinking
         case thinkingDuration
-        case createdAt, completedAt, generationTokenCount, timeToFirstToken
+        case createdAt, completedAt, generationTokenCount, timeToFirstToken, terminalStopReason
         case reasoningItemId, reasoningEncrypted
         case routerBilling
         case injectedContextPrefix
@@ -186,6 +193,7 @@ extension ChatTurnData {
         self.completedAt = turn.completedAt
         self.generationTokenCount = turn.generationTokenCount
         self.timeToFirstToken = turn.timeToFirstToken
+        self.terminalStopReason = turn.terminalStopReason
         self.reasoningItemId = turn.reasoningItemId
         self.reasoningEncrypted = turn.reasoningEncrypted
         self.routerBilling = turn.routerBilling
@@ -213,6 +221,7 @@ extension ChatTurn {
         self.completedAt = data.completedAt
         self.generationTokenCount = data.generationTokenCount
         self.timeToFirstToken = data.timeToFirstToken
+        self.terminalStopReason = data.terminalStopReason
         self.reasoningItemId = data.reasoningItemId
         self.reasoningEncrypted = data.reasoningEncrypted
         self.routerBilling = data.routerBilling

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2914,6 +2914,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         )
         if !composed.prompt.isEmpty {
             SystemPromptComposer.injectSystemContent(composed.prompt, into: &enriched.messages)
+            enriched.cacheStableSystemPrefix = composed.staticPrefix
         }
         // Session-stable memory injection: when the caller supplies a
         // session_id, previously injected prefixes are replayed onto the
@@ -5542,6 +5543,25 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     model: model,
                     toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls,
                     errorMessage: AgentToolLoop.emptyToolTaskFallback
+                )
+                return
+            }
+            if exitState == .lengthExhausted {
+                hop {
+                    writerBound.value.writeError(AgentToolLoop.lengthExhaustedFallback, context: ctx.value)
+                    writerBound.value.writeEnd(ctx.value)
+                }
+                logSelf.logRequest(
+                    method: "POST",
+                    path: path,
+                    userAgent: logUserAgent,
+                    requestBody: logRequestBody,
+                    responseBody: loggedResponseText.isEmpty ? nil : loggedResponseText,
+                    responseStatus: 200,
+                    startTime: logStartTime,
+                    model: model,
+                    toolCalls: loggedToolCalls.isEmpty ? nil : loggedToolCalls,
+                    errorMessage: AgentToolLoop.lengthExhaustedFallback
                 )
                 return
             }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7d6235316226ba9fe608018f86c463784e48b3d5"
+        "revision" : "f50853514ee00365837be3301c91850ca7ed5877"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -80,9 +80,15 @@ let package = Package(
         // companion state. The Laguna S 2.1 revision adds the released
         // full-KV + rotating-SWA runtime contract, safe fresh-session SSD
         // seeds, growing partial-leaf reuse, and complete TQ window restore.
+        // vmlx-swift#179 additionally recovers Qwen XML plain bracket lists
+        // only for schema-declared array<string> tool arguments and routes
+        // Gemma's decoded thought-channel opener into reasoning. The static
+        // prefix hint revision lets Osaurus's byte-stable system prefix seed
+        // SSD cache boundaries even when mutable DB/tool state changes later
+        // in the same rendered system message.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7d6235316226ba9fe608018f86c463784e48b3d5"
+            revision: "f50853514ee00365837be3301c91850ca7ed5877"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -119,6 +119,41 @@ enum AgentLoopModelStep {
     /// `AgentLoopHooks.emitFallbackText` so the user never sees nothing and
     /// the loop can never spin on a deterministically-empty model.
     case emptyResponse
+    /// The runtime reached the configured output-token limit without a tool
+    /// call. Visible partial content or reasoning may be present, but the
+    /// authoritative terminal reason says generation was incomplete.
+    case lengthExhausted
+
+    /// Classify a naturally completed model step from its rendered channels
+    /// and authoritative terminal stop reason.
+    ///
+    /// A reasoning-only natural `stop` remains final for model families that
+    /// intentionally answer in their reasoning channel. A reasoning-only
+    /// `length` is different: the runtime says the model hit its configured
+    /// cap, so accepting it as success abandons the task.
+    static func classifyTerminal(
+        contentIsBlank: Bool,
+        thinkingIsBlank: Bool,
+        stopReason: String?
+    ) -> Self {
+        if stopReason == "length" {
+            return .lengthExhausted
+        }
+        if contentIsBlank, thinkingIsBlank {
+            return .emptyResponse
+        }
+        return .finalResponse
+    }
+
+    /// Preserve visible partial output, remove only terminal whitespace, and
+    /// append the truthful output-cap notice. A whitespace-only completion
+    /// becomes the notice itself instead of a giant blank bubble.
+    static func contentWithLengthFallback(_ content: String, fallback: String) -> String {
+        guard let lastVisible = content.lastIndex(where: { !$0.isWhitespace }) else {
+            return fallback
+        }
+        return String(content[...lastVisible]) + "\n\n" + fallback
+    }
 }
 
 /// Result of the surface executing a single tool call. The surface has
@@ -599,6 +634,9 @@ enum AgentToolLoop {
         /// Empty-turn recovery exhausted after at least one tool result had
         /// already landed, so the task may be truncated rather than merely blank.
         case emptyResponseExhausted
+        /// The model exhausted the configured output-token budget without an
+        /// executable tool call. Any visible partial text is preserved.
+        case lengthExhausted
     }
 
     struct RunResult: Equatable, Sendable {
@@ -633,6 +671,11 @@ enum AgentToolLoop {
 
     static let emptyToolTaskFallback =
         "The model returned empty output after tool execution. The agent task may be incomplete; retry with less context or continue from the latest tool result."
+
+    static let lengthExhaustedFallback =
+        "The model reached the configured output-token limit before naturally completing an answer or tool call. "
+        + "The agent task is incomplete; increase Max Tokens, disable Thinking for this task, "
+        + "or continue from the latest tool result."
 
     /// The iteration-budget warning staged when the remaining budget
     /// drops to the policy threshold.
@@ -1179,6 +1222,14 @@ enum AgentToolLoop {
                 // a silent dead-end, then end the run.
                 await hooks.emitFallbackText?(Self.emptyTurnFallback)
                 return RunResult(exit: .finalResponse, iterations: iteration)
+
+            case .lengthExhausted:
+                // `stop=length` is authoritative. Do not mislabel a
+                // reasoning-only capped turn as successful task completion,
+                // and do not auto-retry it with a synthetic prompt: a model
+                // already looping in reasoning can consume the cap repeatedly.
+                await hooks.emitFallbackText?(Self.lengthExhaustedFallback)
+                return RunResult(exit: .lengthExhausted, iterations: iteration)
 
             case .toolCalls(let invocations):
                 // A productive turn — reset the empty-turn recovery budget so

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -254,6 +254,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             runAsRemoteAgent: request.runAsRemoteAgent,
             suppressProgressUI: request.suppressProgressUI,
             warmupPrefill: request.warmupPrefill,
+            cacheStableSystemPrefix: request.cacheStableSystemPrefix,
             requestSource: inferenceSource,
             loadIntent: request.backgroundModelLoad ? .background : .interactive
         )

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -929,6 +929,7 @@ public enum AgentLoopEvaluator {
         case .cancelled: return "cancelled"
         case .overBudget: return "overBudget"
         case .emptyResponseExhausted: return "emptyResponseExhausted"
+        case .lengthExhausted: return "lengthExhausted"
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -74,6 +74,10 @@ struct GenerationParameters: Sendable {
     /// history cache boundary before prefill (see
     /// `ChatCompletionRequest.warmupPrefill`).
     let warmupPrefill: Bool
+    /// Runtime-only byte-exact stable leading system prompt. This is not a
+    /// user/API control and is consumed only by local MLX as a validated SSD
+    /// prefix-boundary hint.
+    let cacheStableSystemPrefix: String?
     /// Where the request originated (chat UI, HTTP API, plugin, P2P).
     /// `ModelRuntime` records this per model so chat-window close can
     /// accelerate idle unload of chat-sourced models without touching models
@@ -113,6 +117,7 @@ struct GenerationParameters: Sendable {
         runAsRemoteAgent: Bool = false,
         suppressProgressUI: Bool = false,
         warmupPrefill: Bool = false,
+        cacheStableSystemPrefix: String? = nil,
         requestSource: RequestSource = .httpAPI,
         loadIntent: ModelLoadIntent = .interactive
     ) {
@@ -135,6 +140,7 @@ struct GenerationParameters: Sendable {
         self.runAsRemoteAgent = runAsRemoteAgent
         self.suppressProgressUI = suppressProgressUI
         self.warmupPrefill = warmupPrefill
+        self.cacheStableSystemPrefix = cacheStableSystemPrefix
         self.requestSource = requestSource
         self.loadIntent = loadIntent
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1204,6 +1204,8 @@ struct MLXBatchAdapter {
                 buildRawPrompt: buildRawPrompt,
                 generation: generation,
                 toolChoice: toolChoice,
+                cacheStableSystemPrefix: buildRawPrompt == nil
+                    ? generation.cacheStableSystemPrefix : nil,
                 trace: trace
             )
             await exitPrepGate()
@@ -1500,6 +1502,7 @@ struct MLXBatchAdapter {
         chat: [MLXLMCommon.Chat.Message],
         toolsSpec: [[String: any Sendable]]?,
         additionalContext: [String: any Sendable],
+        cacheStableSystemPrefix: String?,
         processor: any MLXLMCommon.UserInputProcessor
     ) async -> LMInput? {
         let hasMedia = chat.contains {
@@ -1515,7 +1518,8 @@ struct MLXBatchAdapter {
                 chat: probeChat,
                 processing: .init(),
                 tools: toolsSpec,
-                additionalContext: additionalContext
+                additionalContext: additionalContext,
+                cacheStableSystemPrefix: cacheStableSystemPrefix
             )
             guard let prepared = try? await processor.prepare(input: input),
                 !prepared.hasMediaContent
@@ -1758,6 +1762,7 @@ struct MLXBatchAdapter {
         buildRawPrompt: (@Sendable () -> String)? = nil,
         generation: GenerationParameters,
         toolChoice: ToolChoiceOption?,
+        cacheStableSystemPrefix: String?,
         trace: TTFTTrace?
     ) async throws -> PreparedInput {
         // Heap-allocated outbox so the throwing closure can hand a value back
@@ -1839,7 +1844,8 @@ struct MLXBatchAdapter {
                     chat: chat,
                     processing: .init(),
                     tools: toolsSpec,
-                    additionalContext: additionalContext
+                    additionalContext: additionalContext,
+                    cacheStableSystemPrefix: cacheStableSystemPrefix
                 )
 
                 trace?.mark("batch_tokenization_start")
@@ -1859,6 +1865,7 @@ struct MLXBatchAdapter {
                             chat: chat,
                             toolsSpec: toolsSpec,
                             additionalContext: additionalContext,
+                            cacheStableSystemPrefix: cacheStableSystemPrefix,
                             processor: context.processor
                         )
                     {

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1621,6 +1621,14 @@ final class PluginHostContext: @unchecked Sendable {
                     "shared_artifacts": sharedArtifacts,
                 ])
             }
+            if exit == .lengthExhausted {
+                return Self.jsonString([
+                    "error": "output_token_limit",
+                    "message": AgentToolLoop.lengthExhaustedFallback,
+                    "tool_calls_executed": toolCallsExecuted,
+                    "shared_artifacts": sharedArtifacts,
+                ])
+            }
 
             // A successful `complete`/`clarify` intercept ended the run
             // (`.endedBySurface`): build the matching terminal envelope
@@ -2102,6 +2110,16 @@ final class PluginHostContext: @unchecked Sendable {
                 return Self.jsonString([
                     "error": "empty_tool_task_completion",
                     "message": AgentToolLoop.emptyToolTaskFallback,
+                    "tool_calls_executed": toolCallsExecuted,
+                    "shared_artifacts": sharedArtifacts,
+                ])
+            }
+            if exit == .lengthExhausted {
+                emit(Self.chunkPayload(id: cid, delta: [:], finishReason: "length"))
+                persistPartial(lastContent)
+                return Self.jsonString([
+                    "error": "output_token_limit",
+                    "message": AgentToolLoop.lengthExhaustedFallback,
                     "tool_calls_executed": toolCallsExecuted,
                     "shared_artifacts": sharedArtifacts,
                 ])

--- a/Packages/OsaurusCore/Storage/AgentDatabase.swift
+++ b/Packages/OsaurusCore/Storage/AgentDatabase.swift
@@ -287,6 +287,13 @@ public struct AgentExecuteResult: Codable, Sendable, Equatable {
 // MARK: - AgentDatabase
 
 public final class AgentDatabase: @unchecked Sendable {
+    /// Column declarations accepted by the typed database surface. Constraints
+    /// are separate fields and must never be smuggled into the type string.
+    public static let supportedColumnTypes = [
+        "TEXT", "INTEGER", "REAL", "BLOB", "NUMERIC",
+        "BOOLEAN", "DATE", "DATETIME", "JSON",
+    ]
+
     public let agentId: UUID
 
     private static let schemaVersion = 1
@@ -661,6 +668,11 @@ public final class AgentDatabase: @unchecked Sendable {
             // budget ran out). Honoring the declared column preserves the
             // model's intent; SQLite still enforces single-PK rules.
             var columns = columns
+            guard columns.filter(\.primaryKey).count <= 1 else {
+                throw AgentDatabaseError.invalidArgument(
+                    "createTable: declare at most one `primary_key` column"
+                )
+            }
             let hasPK = columns.contains(where: { $0.primaryKey })
             if !hasPK,
                 let idIndex = columns.firstIndex(where: { $0.name.lowercased() == "id" })
@@ -684,10 +696,11 @@ public final class AgentDatabase: @unchecked Sendable {
             for col in columns {
                 try Self.validateIdentifier(col.name)
                 try Self.requireNotReservedColumn(col.name)
-                var def = "\(col.name) \(Self.normalizeType(col.type))"
+                let normalizedType = try Self.normalizeType(col.type)
+                var def = "\(col.name) \(normalizedType)"
                 if col.primaryKey {
                     def += " PRIMARY KEY"
-                    if col.type.uppercased() == "INTEGER" {
+                    if normalizedType == "INTEGER" {
                         // sqlite-only AUTOINCREMENT shorthand on integer PK.
                         def += " AUTOINCREMENT"
                     }
@@ -781,6 +794,7 @@ public final class AgentDatabase: @unchecked Sendable {
         for col in additions {
             try Self.validateIdentifier(col.name)
             try Self.requireNotReservedColumn(col.name)
+            _ = try Self.normalizeType(col.type)
         }
 
         return try inTransaction { _ in
@@ -789,14 +803,14 @@ public final class AgentDatabase: @unchecked Sendable {
             }
             var applied: [String] = []
             for col in additions {
-                var def = "\(col.name) \(Self.normalizeType(col.type))"
+                var def = "\(col.name) \(try Self.normalizeType(col.type))"
                 if !col.nullable {
                     // SQLite rejects NOT NULL ADD COLUMN without a DEFAULT
                     // on a non-empty table (spec §16 Q5). If the caller
                     // didn't supply one, fall back to a type-appropriate
                     // value so the migration always applies cleanly.
                     if col.defaultValue == nil {
-                        def += " NOT NULL DEFAULT \(Self.derivedDefault(forType: col.type))"
+                        def += " NOT NULL DEFAULT \(try Self.derivedDefault(forType: col.type))"
                     } else {
                         def += " NOT NULL"
                     }
@@ -2427,17 +2441,25 @@ public final class AgentDatabase: @unchecked Sendable {
         }
     }
 
-    private static func normalizeType(_ raw: String) -> String {
+    private static func normalizeType(_ raw: String) throws -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty { return "TEXT" }
-        return trimmed.uppercased()
+        let normalized = trimmed.uppercased()
+        guard supportedColumnTypes.contains(normalized) else {
+            throw AgentDatabaseError.invalidArgument(
+                "unsupported column type `\(raw)`. Use one of: "
+                    + supportedColumnTypes.joined(separator: ", ")
+                    + ". Put PRIMARY KEY, AUTOINCREMENT, DEFAULT, and NOT NULL "
+                    + "in their dedicated column fields."
+            )
+        }
+        return normalized
     }
 
     /// Default value used to backfill a `NOT NULL ADD COLUMN` when the
     /// agent didn't supply one and the table has rows (spec §16 Q5).
     /// Picks a benign zero / empty value matching the column's affinity.
-    static func derivedDefault(forType raw: String) -> String {
-        switch normalizeType(raw) {
+    static func derivedDefault(forType raw: String) throws -> String {
+        switch try normalizeType(raw) {
         case "INTEGER", "REAL", "NUMERIC": return "0"
         case "BLOB": return "X''"
         default: return "''"

--- a/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
@@ -177,7 +177,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// stamped newer than this is refused (forward-version fail-fast).
     /// Internal (not private) so migration-repair tests assert "reconciled
     /// to the latest" against the real constant instead of a stale literal.
-    static let latestSchemaVersion = 11
+    static let latestSchemaVersion = 12
 
     private func runMigrations() throws {
         let current = try getSchemaVersion()
@@ -204,6 +204,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         if current < 9 { try runMigrationStep(9, migrateToV9) }
         if current < 10 { try runMigrationStep(10, migrateToV10) }
         if current < 11 { try runMigrationStep(11, migrateToV11) }
+        if current < 12 { try runMigrationStep(12, migrateToV12) }
     }
 
     /// Run one migration body atomically. Called only from `runMigrations`,
@@ -422,6 +423,14 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     private func migrateToV11() throws {
         try addColumnIfMissing("sessions", "pinned", "INTEGER NOT NULL DEFAULT 0")
         try setSchemaVersion(11)
+    }
+
+    /// v12: persist the runtime's authoritative finish reason so a reloaded
+    /// chat keeps distinguishing a natural stop from output-token exhaustion.
+    /// Nullable for legacy turns and providers that do not report a reason.
+    private func migrateToV12() throws {
+        try addColumnIfMissing("turns", "terminal_stop_reason", "TEXT")
+        try setSchemaVersion(12)
     }
 
     // MARK: - Public API: sessions
@@ -1122,6 +1131,9 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         if let ttft = turn.timeToFirstToken {
             hasher.update(data: Data(String(ttft).utf8))
         }
+        if let stopReason = turn.terminalStopReason {
+            hasher.update(data: Data(stopReason.utf8))
+        }
         // Billing can land after the initial empty-turn save (the summary frame
         // often trails the content), so it must be part of the hash or the
         // incremental upsert would skip writing the row.
@@ -1229,8 +1241,8 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             (id, session_id, seq, role, content, attachments,
              tool_calls, tool_call_id, tool_results, thinking, content_hash,
              created_at, completed_at, generation_token_count, time_to_first_token,
-             tool_call_durations, thinking_duration, router_billing)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+             tool_call_durations, thinking_duration, router_billing, terminal_stop_reason)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
         ON CONFLICT(id) DO UPDATE SET
             session_id             = excluded.session_id,
             seq                    = excluded.seq,
@@ -1248,13 +1260,14 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             time_to_first_token    = excluded.time_to_first_token,
             tool_call_durations    = excluded.tool_call_durations,
             thinking_duration      = excluded.thinking_duration,
-            router_billing         = excluded.router_billing
+            router_billing         = excluded.router_billing,
+            terminal_stop_reason   = excluded.terminal_stop_reason
         """
 
     private static let selectTurnsSQL = """
         SELECT id, role, content, attachments, tool_calls, tool_call_id, tool_results, thinking,
                created_at, completed_at, generation_token_count, time_to_first_token,
-               tool_call_durations, thinking_duration, router_billing
+               tool_call_durations, thinking_duration, router_billing, terminal_stop_reason
         FROM turns
         WHERE session_id = ?1
         ORDER BY seq ASC
@@ -1331,6 +1344,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         let routerBilling: RouterBillingSummary? = sqlite3_column_text(stmt, 14)
             .map { String(cString: $0) }
             .flatMap(decodeJSON)
+        let terminalStopReason = sqlite3_column_text(stmt, 15).map { String(cString: $0) }
         return ChatTurnData(
             id: UUID(uuidString: idStr) ?? UUID(),
             role: role,
@@ -1346,6 +1360,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             completedAt: completedAt,
             generationTokenCount: tokenCount,
             timeToFirstToken: timeToFirstToken,
+            terminalStopReason: terminalStopReason,
             routerBilling: routerBilling
         )
     }
@@ -1390,6 +1405,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         bindText(stmt, index: 16, value: turn.toolCallDurations.isEmpty ? nil : encodeJSON(turn.toolCallDurations))
         bindNullableDouble(stmt, index: 17, value: turn.thinkingDuration)
         bindText(stmt, index: 18, value: turn.routerBilling.flatMap(encodeJSON))
+        bindText(stmt, index: 19, value: turn.terminalStopReason)
     }
 
     static func bindNullableDouble(_ stmt: OpaquePointer, index: Int, value: Double?) {

--- a/Packages/OsaurusCore/Subagent/Kinds/BrowserUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/BrowserUseKind.swift
@@ -261,6 +261,11 @@ final class BrowserUseKind: SubagentKind, @unchecked Sendable {
             throw SubagentError.emptyExhausted(
                 "Browser Use returned empty output after tool execution; the task may be incomplete."
             )
+        case .lengthExhausted:
+            throw SubagentError.executionFailed(
+                message: "Browser Use reached its output-token limit before producing a result.",
+                retryable: false
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -441,6 +441,11 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
             throw SubagentError.emptyExhausted(
                 "Subagent '\(targetLabel)' returned empty output after tool execution; the task may be incomplete."
             )
+        case .lengthExhausted:
+            throw SubagentError.executionFailed(
+                message: "Subagent '\(targetLabel)' reached its output-token limit before producing a result.",
+                retryable: false
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -131,6 +131,72 @@ struct AgentToolLoopTests {
         #expect(surface.builtNotices == [[]])
     }
 
+    @Test func reasoningOnlyLengthIsNotClassifiedAsFinalResponse() {
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: true,
+            thinkingIsBlank: false,
+            stopReason: "length"
+        )
+        guard case .lengthExhausted = step else {
+            Issue.record("reasoning-only stop=length must be lengthExhausted")
+            return
+        }
+    }
+
+    @Test func reasoningOnlyNaturalStopRemainsFinalResponse() {
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: true,
+            thinkingIsBlank: false,
+            stopReason: "stop"
+        )
+        guard case .finalResponse = step else {
+            Issue.record("reasoning-only natural stop must preserve existing final behavior")
+            return
+        }
+    }
+
+    @Test func visibleLengthResponseIsIncompleteButPreservedForFallback() {
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: false,
+            thinkingIsBlank: false,
+            stopReason: "length"
+        )
+        guard case .lengthExhausted = step else {
+            Issue.record("authoritative stop=length must remain incomplete")
+            return
+        }
+
+        let rendered = AgentLoopModelStep.contentWithLengthFallback(
+            "Visible partial answer.\n\n\n",
+            fallback: AgentToolLoop.lengthExhaustedFallback
+        )
+        #expect(rendered.hasPrefix("Visible partial answer.\n\n"))
+        #expect(rendered.hasSuffix(AgentToolLoop.lengthExhaustedFallback))
+        #expect(!rendered.contains("\n\n\n"))
+    }
+
+    @Test func whitespaceOnlyLengthResponseCollapsesToFallback() {
+        let rendered = AgentLoopModelStep.contentWithLengthFallback(
+            String(repeating: "\n", count: 1_776),
+            fallback: AgentToolLoop.lengthExhaustedFallback
+        )
+        #expect(rendered == AgentToolLoop.lengthExhaustedFallback)
+    }
+
+    @Test func lengthExhaustionSurfacesIncompleteStateWithoutRetry() async throws {
+        let surface = ScriptedLoopSurface(steps: [.lengthExhausted, .finalResponse])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .lengthExhausted, iterations: 1))
+        #expect(surface.emittedFinalTexts == [AgentToolLoop.lengthExhaustedFallback])
+        #expect(surface.steps.count == 1, "length exhaustion must not silently launch a second generation")
+        #expect(surface.executedCalls.isEmpty)
+    }
+
     @Test func toolCallsExecuteThenFinish() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("file_search", #"{"query":"x"}"#), inv("shell_run", #"{"cmd":"ls"}"#)]),

--- a/Packages/OsaurusCore/Tests/Chat/ChatHistoryDatabaseTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatHistoryDatabaseTests.swift
@@ -56,7 +56,7 @@ struct ChatHistoryDatabaseTests {
     func saveAndLoadSession_roundtripsAllFields() throws {
         let db = try openInMemory()
         let agentId = UUID()
-        let session = makeSession(
+        var session = makeSession(
             agentId: agentId,
             source: .plugin,
             sourcePluginId: "com.example.telegram",
@@ -64,6 +64,7 @@ struct ChatHistoryDatabaseTests {
             dispatchTaskId: UUID(),
             turnCount: 3
         )
+        session.turns[1].terminalStopReason = "length"
         try db.saveSession(session)
 
         let loaded = db.loadSession(id: session.id)
@@ -80,7 +81,21 @@ struct ChatHistoryDatabaseTests {
         #expect(loaded?.turns[0].role == .user)
         #expect(loaded?.turns[0].content == "turn 0")
         #expect(loaded?.turns[1].role == .assistant)
+        #expect(loaded?.turns[1].terminalStopReason == "length")
         #expect(loaded?.turns[2].content == "turn 2")
+    }
+
+    @Test
+    func terminalStopReasonUpdateInvalidatesContentHash() throws {
+        let db = try openInMemory()
+        let id = UUID()
+        var session = makeSession(id: id, turnCount: 2)
+        try db.saveSession(session)
+
+        session.turns[1].terminalStopReason = "length"
+        try db.saveSession(session)
+
+        #expect(db.loadSession(id: id)?.turns[1].terminalStopReason == "length")
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnFinishReasonTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnFinishReasonTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct ChatTurnFinishReasonTests {
+    @Test @MainActor
+    func terminalStopReasonRoundTripsThroughChatTurnData() throws {
+        let turn = ChatTurn(role: .assistant, content: "")
+        turn.thinking = "unfinished reasoning"
+        turn.generationTokenCount = 2_048
+        turn.terminalStopReason = "length"
+
+        let data = ChatTurnData(from: turn)
+        let encoded = try JSONEncoder().encode(data)
+        let decoded = try JSONDecoder().decode(ChatTurnData.self, from: encoded)
+        let restored = ChatTurn(from: decoded)
+
+        #expect(restored.terminalStopReason == "length")
+        #expect(restored.generationTokenCount == 2_048)
+        #expect(restored.thinking == "unfinished reasoning")
+    }
+
+    @Test
+    func legacyTurnWithoutTerminalStopReasonStillDecodes() throws {
+        let legacy = """
+            {
+              "id": "\(UUID().uuidString)",
+              "role": "assistant",
+              "content": "done",
+              "attachments": [],
+              "toolResults": {},
+              "thinking": ""
+            }
+            """
+
+        let decoded = try JSONDecoder().decode(ChatTurnData.self, from: Data(legacy.utf8))
+
+        #expect(decoded.terminalStopReason == nil)
+        #expect(decoded.content == "done")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "df5a4e9ba3b917eff36064f77c3ffddd72c961dd"
+        let expectedRevision = "f50853514ee00365837be3301c91850ca7ed5877"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "7d6235316226ba9fe608018f86c463784e48b3d5"
+        let expectedRevision = "df5a4e9ba3b917eff36064f77c3ffddd72c961dd"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -751,6 +751,13 @@ struct RuntimePolicySourceTests {
         // `1` into `true`) and keeps nested Qwen XML argument marks lossless.
         // vmlx-swift#177 adds the awaited direct-generation cancellation/drain
         // boundary required before Osaurus can admit the next solo request.
+        // vmlx-swift#179 adds schema-bound recovery for Qwen XML
+        // array<string> arguments emitted as plain bracket lists and routes
+        // Gemma's decoded thought-channel opener into the reasoning stream.
+        // The static-prefix cache-hint revision lets Osaurus seed an SSD
+        // boundary from the byte-stable leading system prompt even when a
+        // mutable DB/tool section later changes inside the same rendered
+        // system message.
         //
         // This assertion is a repin tripwire, and it earned its keep: PR #1986
         // shipped titled "(+ vmlx repin)" carrying no repin at all, and the live
@@ -759,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "7d6235316226ba9fe608018f86c463784e48b3d5"
+        let expectedRuntimeHardenedRevision = "f50853514ee00365837be3301c91850ca7ed5877"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -769,7 +776,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the merged vmlx-swift revision with the awaited solo cancellation/drain boundary together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, and static system-prefix SSD cache boundaries together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))
@@ -1139,6 +1146,27 @@ struct RuntimePolicySourceTests {
         #expect(cacheSection.contains("Works with paged RAM cache off"))
         #expect(cacheSection.contains("SSD cache can still restore prefixes"))
         #expect(!cacheSection.contains("Required for cross-request sharing"))
+    }
+
+    @Test("chat-composed static prompt prefix reaches local MLX as a runtime-only cache hint")
+    func chatComposedStaticPromptPrefixReachesLocalMLXCacheHint() throws {
+        let api = try Self.source("Models/API/OpenAIAPI.swift")
+        let chatEngine = try Self.source("Services/Chat/ChatEngine.swift")
+        let chatView = try Self.source("Views/Chat/ChatView.swift")
+        let httpHandler = try Self.source("Networking/HTTPHandler.swift")
+        let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
+
+        #expect(api.contains("var cacheStableSystemPrefix: String? = nil"))
+        #expect(api.contains("copy.cacheStableSystemPrefix = cacheStableSystemPrefix"))
+        #expect(!api.contains("case cacheStableSystemPrefix"))
+        #expect(chatEngine.contains("cacheStableSystemPrefix: request.cacheStableSystemPrefix"))
+        #expect(chatView.contains("req.cacheStableSystemPrefix ="))
+        #expect(chatView.contains("finalReq.cacheStableSystemPrefix ="))
+        #expect(chatView.contains("self.isRemoteAgentTarget ? nil : context.staticPrefix"))
+        #expect(httpHandler.contains("enriched.cacheStableSystemPrefix = composed.staticPrefix"))
+        #expect(adapter.contains("cacheStableSystemPrefix: buildRawPrompt == nil"))
+        #expect(adapter.contains("cacheStableSystemPrefix: cacheStableSystemPrefix"))
+        #expect(!adapter.contains(#""cacheStableSystemPrefix""#))
     }
 
     @Test("Server settings cache changes clear loaded model runtime")

--- a/Packages/OsaurusCore/Tests/Storage/AgentDatabaseTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/AgentDatabaseTests.swift
@@ -669,6 +669,92 @@ struct AgentDatabaseTests {
         #expect(info.rows.contains { $0[1] == .text("id") } == false)
     }
 
+    @Test
+    func createTableRejectsConstraintsEmbeddedInColumnType() throws {
+        let db = try makeDB()
+        do {
+            try db.createTable(
+                name: "water_log",
+                purpose: "reject compound type regression",
+                columns: [
+                    AgentColumnSpec(
+                        name: "id",
+                        type: "INTEGER PRIMARY KEY AUTOINCREMENT",
+                        nullable: false
+                    ),
+                    AgentColumnSpec(name: "ml", type: "INTEGER", nullable: false),
+                ],
+                actor: .agent,
+                runId: nil
+            )
+            Issue.record("compound column type should be rejected before SQL execution")
+        } catch let AgentDatabaseError.invalidArgument(message) {
+            #expect(message.contains("unsupported column type"))
+            #expect(message.contains("PRIMARY KEY"))
+        }
+        #expect(try db.schemaForTable("water_log") == nil)
+    }
+
+    @Test
+    func alterTableRejectsConstraintsEmbeddedInColumnType() throws {
+        let db = try makeDB()
+        try db.createTable(
+            name: "water_log",
+            purpose: "alter-type regression",
+            columns: [AgentColumnSpec(name: "ml", type: "INTEGER", nullable: false)],
+            actor: .agent,
+            runId: nil
+        )
+        do {
+            _ = try db.alterTableAddColumns(
+                name: "water_log",
+                additions: [
+                    AgentColumnSpec(name: "note", type: "TEXT NOT NULL", nullable: false)
+                ],
+                actor: .agent,
+                runId: nil
+            )
+            Issue.record("compound ALTER column type should be rejected before SQL execution")
+        } catch let AgentDatabaseError.invalidArgument(message) {
+            #expect(message.contains("unsupported column type"))
+        }
+        let schema = try #require(try db.schemaForTable("water_log"))
+        #expect(schema.columns.contains(where: { $0.name == "note" }) == false)
+    }
+
+    @Test
+    func typedDatabaseToolSchemasExposeOnlySupportedColumnTypes() throws {
+        func typeEnum(
+            in parameters: JSONValue?,
+            arrayKey: String
+        ) throws -> [String] {
+            guard case .object(let root) = parameters,
+                case .object(let properties)? = root["properties"],
+                case .object(let columns)? = properties[arrayKey],
+                case .object(let items)? = columns["items"],
+                case .object(let itemProperties)? = items["properties"],
+                case .object(let typeProperty)? = itemProperties["type"],
+                case .array(let values)? = typeProperty["enum"]
+            else {
+                Issue.record("missing `\(arrayKey).items.properties.type.enum`")
+                return []
+            }
+            return values.compactMap {
+                guard case .string(let value) = $0 else { return nil }
+                return value
+            }
+        }
+
+        #expect(
+            try typeEnum(in: DBCreateTableTool().parameters, arrayKey: "columns")
+                == AgentDatabase.supportedColumnTypes
+        )
+        #expect(
+            try typeEnum(in: DBAlterTableTool().parameters, arrayKey: "add_columns")
+                == AgentDatabase.supportedColumnTypes
+        )
+    }
+
     // MARK: - Batched soft delete (Database workspace bulk action)
 
     private func seedNotes(_ db: AgentDatabase, count: Int) throws -> [Int64] {

--- a/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
@@ -78,6 +78,7 @@ struct ChatHistoryMigrationRepairTests {
     private static let alterV6 = ["ALTER TABLE turns ADD COLUMN tool_call_durations TEXT"]
     private static let alterV7 = ["ALTER TABLE turns ADD COLUMN thinking_duration REAL"]
     private static let alterV8 = ["ALTER TABLE turns ADD COLUMN router_billing TEXT"]
+    private static let alterV12 = ["ALTER TABLE turns ADD COLUMN terminal_stop_reason TEXT"]
 
     // MARK: - Reporter-exact: v1 stuck, every column except v8 router_billing
 
@@ -141,10 +142,10 @@ struct ChatHistoryMigrationRepairTests {
         }
     }
 
-    // MARK: - v1 stuck, every v2-v8 column already present
+    // MARK: - v1 stuck, every turn-column migration already present
 
     /// A store whose `user_version` is stuck at 1 but already carries every
-    /// column (including v8). Every migration ALTER must be skipped, the
+    /// migrated turn column (including v12). Every migration ALTER must be skipped, the
     /// version reconciled to the latest, and data must still load + save.
     @Test
     func stuckV1WithAllColumnsPresentOpensCleanly() async throws {
@@ -154,7 +155,9 @@ struct ChatHistoryMigrationRepairTests {
             var statements = [Self.createSessionsV1]
             statements += Self.alterV3 + Self.alterV4
             statements.append(Self.createTurnsV1)
-            statements += Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7 + Self.alterV8
+            statements +=
+                Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7
+                + Self.alterV8 + Self.alterV12
             statements += [
                 """
                 INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
@@ -240,7 +243,7 @@ struct ChatHistoryMigrationRepairTests {
     // MARK: - Fresh database
 
     /// Guard against migration regressions: a brand-new (empty) database
-    /// migrates 0 -> 8 cleanly and round-trips a session.
+    /// migrates 0 -> latest cleanly and round-trips a session.
     @Test
     func freshDatabaseMigratesToLatestAndRoundTrips() async throws {
         try await runWithPlaintextRoot {

--- a/Packages/OsaurusCore/Tests/Tool/SchemaValidatorCoercionTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SchemaValidatorCoercionTests.swift
@@ -155,10 +155,18 @@ struct SchemaValidatorCoercionTests {
     }
 
     @Test func booleanAcceptsStringVocabulary() {
-        for s in ["true", "false", "TRUE", "False", "1", "0", "yes", "no", "YES"] {
+        for s in ["true", "false", "TRUE", "False", "1", "0", "yes", "no", "YES", " false "] {
             let r = SchemaValidator.validate(arguments: ["b": s], against: boolSchema)
             #expect(r.isValid, "expected `\(s)` to coerce to bool; got: \(r.errorMessage ?? "?")")
         }
+    }
+
+    @Test func booleanWhitespaceStringCoercesToNativeBool() throws {
+        let coerced = try #require(
+            SchemaValidator.coerceArguments(["b": " false "], against: boolSchema) as? [String: Any]
+        )
+        #expect(coerced["b"] as? Bool == false)
+        #expect(SchemaValidator.validate(arguments: coerced, against: boolSchema).isValid)
     }
 
     @Test func booleanRejectsArbitraryString() {

--- a/Packages/OsaurusCore/Tools/Database/DatabaseTools.swift
+++ b/Packages/OsaurusCore/Tools/Database/DatabaseTools.swift
@@ -271,8 +271,13 @@ final class DBCreateTableTool: OsaurusTool, @unchecked Sendable {
                         "name": .object(["type": .string("string")]),
                         "type": .object([
                             "type": .string("string"),
+                            "enum": .array(
+                                AgentDatabase.supportedColumnTypes.map(JSONValue.string)
+                            ),
                             "description": .string(
-                                "Column type affinity. One of TEXT, INTEGER, REAL, BLOB, NUMERIC."
+                                "Column type only; constraints belong in `nullable`, `default`, "
+                                    + "and `primary_key`. Do not include PRIMARY KEY, "
+                                    + "AUTOINCREMENT, DEFAULT, or NOT NULL here."
                             ),
                         ]),
                         "nullable": .object([
@@ -421,7 +426,12 @@ final class DBAlterTableTool: OsaurusTool, @unchecked Sendable {
                     "type": .string("object"),
                     "properties": .object([
                         "name": .object(["type": .string("string")]),
-                        "type": .object(["type": .string("string")]),
+                        "type": .object([
+                            "type": .string("string"),
+                            "enum": .array(
+                                AgentDatabase.supportedColumnTypes.map(JSONValue.string)
+                            ),
+                        ]),
                         "nullable": .object(["type": .string("boolean")]),
                         "default": .object(["type": .string("string")]),
                     ]),

--- a/Packages/OsaurusCore/Tools/OsaurusTool.swift
+++ b/Packages/OsaurusCore/Tools/OsaurusTool.swift
@@ -366,7 +366,7 @@ public enum ArgumentCoercion {
     public static func bool(_ value: Any?) -> Bool? {
         if let b = value as? Bool { return b }
         if let s = value as? String {
-            switch s.lowercased() {
+            switch s.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
             case "true", "1", "yes": return true
             case "false", "0", "no": return false
             default: return nil

--- a/Packages/OsaurusCore/Tools/SchemaValidator.swift
+++ b/Packages/OsaurusCore/Tools/SchemaValidator.swift
@@ -366,7 +366,7 @@ public struct SchemaValidator {
     private static func isBoolLike(_ value: Any) -> Bool {
         if let n = value as? NSNumber, isObjCBool(n) { return true }
         if let s = value as? String {
-            switch s.lowercased() {
+            switch s.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
             case "true", "false", "1", "0", "yes", "no": return true
             default: return false
             }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3620,6 +3620,7 @@ final class ChatSession: ObservableObject {
                         engineTokensPerSecond = stats.tokensPerSecond
                     }
                     currentTurn.generationTokenCount = stats.tokenCount
+                    currentTurn.terminalStopReason = stats.stopReason
                     // Vmlx tells us the model never closed `</think>` before
                     // EOS / max_tokens. Persist on the turn so the bubble
                     // renderer can surface a one-line banner suggesting
@@ -5337,6 +5338,8 @@ final class ChatSession: ObservableObject {
                             // Mode 1 (plain remote inference via
                             // `/chat/completions`).
                             req.runAsRemoteAgent = self.isRemoteAgentTarget
+                            req.cacheStableSystemPrefix =
+                                self.isRemoteAgentTarget ? nil : context.staticPrefix
                             // Mode 2 routing: target the selected agent's
                             // provider directly (by id), so a stale
                             // `selectedModel` can never redirect the run to a
@@ -5420,19 +5423,11 @@ final class ChatSession: ObservableObject {
                                 // allowance.
                                 if invocations.isEmpty {
                                     transientRetries = 0
-                                    // An empty turn (0-token / EOS-first, no tool
-                                    // call) must not silently end the run as "No
-                                    // visible text was produced": let the driver
-                                    // nudge-and-retry, then fall back to a message.
-                                    // A reasoning-only turn (visible content blank
-                                    // but thinking present) is NOT empty — it's the
-                                    // model's intended answer in the reasoning
-                                    // channel — so require thinking blank too, matching
-                                    // the "No visible text was produced" condition.
-                                    return
-                                        (assistantTurn.contentIsBlank
-                                        && assistantTurn.thinkingIsBlank)
-                                        ? .emptyResponse : .finalResponse
+                                    return AgentLoopModelStep.classifyTerminal(
+                                        contentIsBlank: assistantTurn.contentIsBlank,
+                                        thinkingIsBlank: assistantTurn.thinkingIsBlank,
+                                        stopReason: assistantTurn.terminalStopReason
+                                    )
                                 }
                                 return .toolCalls(invocations)
                             } catch let error as RemoteProviderServiceError {
@@ -5575,7 +5570,15 @@ final class ChatSession: ObservableObject {
                             // malformed call cannot leave a tool card spinning.
                             assistantTurn.pendingToolName = nil
                             assistantTurn.clearPendingToolArgs()
-                            assistantTurn.appendContentAndNotify(text)
+                            if text == AgentToolLoop.lengthExhaustedFallback {
+                                assistantTurn.content =
+                                    AgentLoopModelStep.contentWithLengthFallback(
+                                        assistantTurn.content,
+                                        fallback: text
+                                    )
+                            } else {
+                                assistantTurn.appendContentAndNotify(text)
+                            }
                             self.rebuildVisibleBlocks()
                         }
                     )
@@ -5614,6 +5617,14 @@ final class ChatSession: ObservableObject {
                         rebuildVisibleBlocks()
                     }
 
+                    if runResult.exit == .lengthExhausted {
+                        // The driver already appended a visible, truthful
+                        // incomplete-state message. Mark lifecycle cleanup as
+                        // failed so this capped reasoning-only turn cannot be
+                        // announced or warmed as a completed agent task.
+                        lastStreamError = AgentToolLoop.lengthExhaustedFallback
+                    }
+
                     if runResult.exit == .iterationCapReached && isRunActive(runId) {
                         do {
                             var finalReq = ChatCompletionRequest(
@@ -5641,6 +5652,8 @@ final class ChatSession: ObservableObject {
                             )
                             finalReq.samplingParametersAreImplicit = true
                             finalReq.runAsRemoteAgent = isRemoteAgentTarget
+                            finalReq.cacheStableSystemPrefix =
+                                isRemoteAgentTarget ? nil : context.staticPrefix
                             // Carry the agent provider id on this path too so
                             // the route-by-provider invariant holds for *every*
                             // Mode 2 request — a `runAsRemoteAgent` send with no

--- a/docs/BONSAI_AGENT_DB_FITNESS_LIVE_GATE_2026-07-23.md
+++ b/docs/BONSAI_AGENT_DB_FITNESS_LIVE_GATE_2026-07-23.md
@@ -557,8 +557,8 @@ configuration.
 
 ## 2026-07-23 late emergency: stable system-prefix SSD restore
 
-Status: **PARTIAL — SOURCE AND FOCUSED TESTS PASS; GEMMA AND BONSAI RELEASE
-UI CACHE ROWS RECORDED; TOOL-SUFFIX LIVE ROWS STILL OPEN**
+Status: **VERIFIED LIVE FOR THE SCOPED QWEN/GEMMA EMERGENCY PR — FINAL-PIN
+RELEASE TOOL, FINISH-REASON, REASONING, AND SSD-SUFFIX ROWS RECORDED**
 
 The user-reported cache symptom is that fresh chats and post-tool continuations
 can show `0/N` prefill even though SSD cache is enabled and previous chats
@@ -692,17 +692,74 @@ Qwen-family generations with hybrid/SSM disk restores and no post-output hang.
 It does **not** prove Ornith, Qwen3.5/VL, Laguna, DB-tool dynamic suffix
 recovery, or AppleScript behavior.
 
-Live proof still required before merge-ready:
+### Final-pin Release UI closeout
 
-1. With paged RAM cache Off and SSD On, run a DB/tool workload that first
-   stores the static prompt boundary, then changes the database/schema suffix,
-   then starts a fresh chat or same-tool continuation.
-2. Require log and UI evidence that the second request restores a nonzero SSD
-   prefix boundary and only prefills the divergent suffix. A truthful smaller
-   restore than the full prompt is acceptable; a return to `0/N` is not.
-3. Confirm the request does not hang after final output, the input unlocks,
-   finish reason is persisted, and cache telemetry agrees with the visible
-   prefill/TTFT state.
-4. Record the exact model, Thinking state, token counts, disk hit/miss/store
-   counters, and TQ layer/compression counters. Any TQ counter increment while
-   Settings are not explicitly TurboQuant is a failure.
+Final app and runtime:
+
+- Release product:
+  `/tmp/osaurus-static-prefix-release-derived-f5085351-20260723/Build/Products/Release/osaurus.app`
+- bundle id: `com.dinoki.osaurus.staticprefixprooff50820260723`
+- isolated root:
+  `/private/tmp/osaurus-static-prefix-proof-root-20260723-f5085351-live2`
+- final vMLX pin:
+  `f50853514ee00365837be3301c91850ca7ed5877`
+- vMLX PR #179 is merged at that exact revision. Its current source contains
+  the schema-bound Qwen XML `array<string>` recovery, Gemma thought-channel
+  reasoning routing, and tokenizer-validated static system-prefix boundary.
+- Osaurus PR #2153 carries the hint only through local runtime request
+  plumbing, persists the authoritative terminal stop reason, constrains
+  database column types in the public schema, and does not expose the cache
+  hint through OpenAI JSON or remote requests.
+
+The Release app was operated through the real model picker, chat composer,
+tool cards, and Server Settings UI. No screenshot or binary was added to the
+repository.
+
+Visible effective settings:
+
+- Prefix Cache: On
+- GPU/Paged KV Cache: Off
+- SSD Disk Cache: On
+- cache codec: Engine Selected
+- TurboQuant compressions: `0`
+
+Live tool rows:
+
+| Model and control | Visible result | Persisted/runtime result |
+| --- | --- | --- |
+| `dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`, Thinking Off | one create, one insert, one query; exact row `(21, bonsai-finalpin-twenty-one)`; TTFT `1.12s`; `41.3 tok/s`; input unlocked | nested `columns` and `rows` arguments persisted; terminal reason `stop`; isolated SQLite row matches |
+| `JANGQ-AI/Ornith-1.0-9B-MXFP8`, Thinking Off | one create, one insert, one query; exact row `(31, ornith-finalpin-thirty-one)`; TTFT `0.68s`; `65.3 tok/s`; input unlocked | nested `columns` and `row` arguments persisted; terminal reason `stop`; isolated SQLite row matches |
+| `OsaurusAI/gemma-4-12B-it-MXFP8`, Thinking Off | one create, one insert, one query; exact row `(41, gemma-finalpin-forty-one)`; TTFT `1.25s`; `30.0 tok/s`; input unlocked | typed boolean/number strings were coerced against schema; terminal reason `stop`; isolated SQLite row matches |
+| same Gemma model, fresh chat, Thinking Off | queried the newly created table without mutation; exact row returned; TTFT `8.29s`; `39.8 tok/s`; input unlocked | Disk L2 hits increased `3 -> 4`; terminal reason `stop` |
+| same Gemma model, fresh chat, Thinking On | model-picker control visibly On; separate `Thought for 5.3s` / 294-character reasoning block; one query; exact row; TTFT `8.75s`; `27.1 tok/s`; input unlocked | first assistant step persisted 294 reasoning characters, tool result remained grounded, final terminal reason `stop`; Disk L2 hits increased `4 -> 5` |
+
+Final Server > Settings > Live Activity readout:
+
+- active slots `0`
+- queued `0`
+- engine accepting requests
+- cache-enabled models `1`
+- paged evictions `0`
+- Disk L2 hits / misses / stores `5 / 110 / 22`
+- TurboQuant compressions `0`
+
+The fresh-chat restore is a functional cache pass, not a claimed latency win:
+the second Gemma TTFT was slower despite the hit. The evidence proves that the
+SSD tier is consulted and restores a validated prefix while the DB/tool suffix
+changes, with paged RAM cache disabled. It does not prove every SSD or every
+model will have lower wall-clock TTFT.
+
+The scoped emergency PR is therefore **VERIFIED LIVE** for:
+
+1. Qwen-derived Bonsai and Ornith nested database tool arguments;
+2. Gemma nested tool arguments and schema-bound scalar coercion;
+3. Thinking Off and Gemma Thinking On reasoning/content separation;
+4. post-tool final answer, persisted `stop`, and UI unlock;
+5. SSD stable-prefix reuse across a changed DB suffix with paged RAM off;
+6. TurboQuant remaining off without an explicit user setting.
+
+The broader Russian fitness workflow remains partial at the top of this
+document because scheduler, notification, export, and every other parser family
+were deliberately excluded from this emergency merge. LFM/DSML and the full
+cross-family parser matrix are tracked separately and are not included in PR
+#2153.

--- a/docs/BONSAI_AGENT_DB_FITNESS_LIVE_GATE_2026-07-23.md
+++ b/docs/BONSAI_AGENT_DB_FITNESS_LIVE_GATE_2026-07-23.md
@@ -1,0 +1,708 @@
+# Bonsai Agent DB Fitness Live Gate
+
+Date: 2026-07-23
+
+Status: **PARTIAL — USER EXPORT INSPECTED; FIXED RELEASE LIFECYCLE/CACHE
+EVIDENCE EXISTS; END-TO-END DATABASE/SCHEDULER/EXPORT GATE OPEN**
+
+This checkpoint tracks a user report from Osaurus after the 2026-07-23 update.
+It is deliberately separate from the merged TextEdit/AppleScript PR #2151.
+No screenshot, video, archive, or other binary proof belongs in Git history.
+Local visual artifacts may be inspected during diagnosis, but only sanitized
+text evidence may be committed or posted to GitHub.
+
+## Reported configuration and task
+
+- Model: `OsaurusAI/Bonsai-27b-Ternary-JANG`
+- Thinking: explicitly enabled by the user
+- Export:
+  `/Users/eric/Downloads/Personal Fitness Trainer.zip`
+- Extracted local-only transcript:
+  `/private/tmp/osaurus-fitness-export-20260723.yZ6X4i/За сегодня я съел где-то 1200-1300 кКал и выпил.../chat.md`
+- Prompt:
+
+  > Как мой агент, ты можешь рассчитывать для меня потребление калорий,
+  > напоминать о питье воды, напоминать считать калории без обращения к тебе
+  > в чат напрямую? Ты можешь сам планировать свои запуски и вести меня как
+  > тренер по сжиганию жира? Мне нужна поддержка, напоминания и постоянный
+  > контроль. + расчет физической активности начиная с самых минимальных
+  > занятий, иначе моя нервная система не выдержит и я перестану за всем
+  > следить.
+
+The earlier two turns in the same export were ordinary Russian-language calorie
+questions and received visible text answers. The failure began only when the
+user asked the agent to create persistent tracking and autonomous reminders.
+
+## User-requested end state
+
+The reporter clarified that the intended workflow is:
+
+1. the agent owns a persistent, inspectable table instead of accumulating the
+   tracking history inside chat context;
+2. the table can be exported on demand;
+3. future chats and scheduled runs continue from that database state;
+4. the agent starts itself during the day and sends reminders based on the
+   stored plan;
+5. context growth is bounded because a scheduled run starts fresh and queries
+   the database rather than replaying an indefinitely growing chat.
+
+The current product contract can represent this only when the agent's
+**Database** and **Self-scheduling** abilities are both enabled. Data Keeper
+specifies `db_schema` before schema mutation, `db_upsert`/`db_insert` for
+records, and `db_export` followed by `share_artifact` for a downloadable
+export. Autonomous Scheduler specifies `get_current_time`, one
+`schedule_next_run`, and a self-contained future-run instruction; recurring
+work must schedule its own following run. These are source contracts, not live
+acceptance. The live gate must still prove table creation, record reuse in a
+new chat, export, scheduling, notification, cancellation, and restart.
+
+## Artifact facts
+
+The export contains the following sequence:
+
+1. Bonsai emitted a `db_create_table` call missing the required `name`.
+   vMLX/Chat represented it as the structured
+   `_error:"invalid_tool_arguments"` argument envelope. Osaurus returned
+   `kind:"invalid_args"`, `field:"name"`, `retryable:true`.
+2. Bonsai corrected the arguments and successfully created `daily_log`.
+3. Bonsai immediately called `db_create_table` for `daily_log` again with a
+   different schema. Osaurus truthfully returned
+   `kind:"invalid_args"`, `retryable:false`, and told it to call `db_schema`
+   before evolving the table with `db_alter_table`.
+4. Bonsai successfully created a distinct `activity_log`.
+5. Bonsai attempted to create `daily_log` a third time. Osaurus returned the
+   same non-retryable table-exists failure.
+6. The export ends on an assistant turn recorded as `2048 tok, 25.2 tok/s`
+   with no visible content and no tool call.
+
+The two successful table creations rule out a blanket database-permission or
+tool-execution failure for this transcript. They do not prove that schedules,
+notifications, or later DB operations were authorized or functional because
+the run never reached those steps.
+
+## Current-source trace
+
+Current branch base:
+`25d0175d1e03f019ca26279922b50fdd702ea52e`
+
+1. `DBCreateTableTool` exposes `name`, `purpose`, and `columns` as required
+   schema fields. Its description already says to call `db_schema` first.
+2. `ToolRegistry.invalidToolArgumentsEnvelope` preserves the model/parser
+   error as a typed retryable `invalid_args` result. The first exported
+   missing-name call therefore reached the normal truthful schema-error path.
+3. `AgentTaskState` deliberately excludes `db_*` from deterministic-error
+   replay because repeated database calls can legitimately succeed after state
+   changes. It has no typed transition for a table-exists result and no
+   logical-table-name repeat tracking. Only the generic third identical
+   argument signature can produce an advisory repeat notice.
+4. `StreamingStatsHint` carries `stopReason`, including `length`, alongside
+   token count, rate, and the unclosed-reasoning flag.
+5. `ChatView.processStreamDeltas` reads token count/rate and
+   `unclosedReasoning` from the stats hint but currently discards `stopReason`.
+6. Chat's agent-loop model-step classification explicitly treats a turn with
+   blank visible content but nonblank thinking as `.finalResponse`. It does
+   not distinguish natural stop from `max_tokens`/`length`.
+
+The exported final `2048 tok` reasoning-only turn is therefore consistent with
+this unhandled state: a model can exhaust its output cap entirely in reasoning,
+produce no answer or tool call, and Chat still classifies the task as a clean
+final response. The current-source cache-off reproduction below proves this
+exact state on the exact prompt and local Bonsai bundle.
+
+## Current-source live reproduction
+
+Live app:
+
+- Release product:
+  `/private/tmp/osaurus-bonsai-db-baseline-derived-20260723/Build/Products/Release/osaurus.app`
+- Bundle identifier:
+  `com.dinoki.osaurus.bonsaidbbaseline20260723`
+- Executable SHA-256:
+  `a52d635bdd476e7cf9d3239d0a97a8c710054f8bbafdeef4970091baa60fe166`
+- Isolated root:
+  `/private/tmp/osaurus-bonsai-db-baseline-root-20260723`
+- Osaurus source:
+  `25d0175d1e03f019ca26279922b50fdd702ea52e`
+- vMLX pin:
+  `7d6235316226ba9fe608018f86c463784e48b3d5`
+- Model:
+  `dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`
+- Effective UI controls:
+  Thinking On, maximum output 2,048 tokens, temperature 0.7, paged GPU cache
+  Off. The two runs below differ only in SSD Disk Cache On versus Off and use
+  separate fresh agents/private databases.
+
+### SSD Disk Cache On
+
+The exact Russian prompt completed one healthy interleaved path:
+
+1. visible Russian reasoning;
+2. visible Russian plan;
+3. successful `db_schema`;
+4. a second visible reasoning phase;
+5. a visible Russian final answer.
+
+The UI reported `TTFT 9.68s`, `30 tok/s`, and `814 tokens`. Runtime telemetry
+restored `5383/5496` prompt tokens from disk on the initial step and
+`5491/5618` after the tool result. This proves that Russian input, the database
+tool surface, interleaved reasoning/tool/result/final streaming, and SSD prefix
+restore can all work together in the current app.
+
+On the explicit follow-up asking it to create tables, seed rows, and schedule
+reminders, Bonsai successfully created one database table. Its post-tool
+completion then emitted 2,048 tokens and ended with `stop=length`; persisted
+content contained 5,287 characters, including 1,776 literal newline
+characters. The live bubble expanded into a large blank region while streaming.
+`StreamingDeltaProcessor` appends model deltas verbatim and
+`GenerationEventMapper` forwards vMLX token chunks unchanged, so the blank
+region was not inserted by window sizing or the renderer. Window size only
+made the upstream newline degeneration more conspicuous.
+
+### SSD Disk Cache Off control
+
+Computer Use visibly changed Server > Settings > Cache > SSD Disk Cache to Off
+and saved it. The exact Russian prompt on a fresh agent then showed a fully cold
+`0/5496` prefill with no disk hits or stores, proving that this control changed
+the effective runtime path.
+
+Bonsai emitted this persisted tool call:
+
+```json
+{"ids":"[skill/Autonomous Scheduler, skill/Data Keeper]"}
+```
+
+Osaurus returned:
+
+```json
+{"ok":false,"field":"ids","kind":"invalid_args","message":"Property 'ids' must be an array","retryable":true,"tool":"capabilities_load"}
+```
+
+The next step performed another fully cold `0/5607` prefill, produced exactly
+2,048 tokens and 7,397 reasoning characters, emitted no visible content and no
+tool call, and ended at `stop=length`. The UI unlocked and displayed
+`TTFT 19.29s`, `26.7 tok/s`, `2,048 tokens`, plus the unclosed-thinking warning,
+but the agent loop had classified the reasoning-only capped step as a final
+response and abandoned the requested work.
+
+The cold reproduction rules out SSD cache restore as a necessary cause of the
+failure. The prompt manifest and `capabilities_load` schema both showed `ids`
+as an array, and the enabled-capabilities block included a concrete valid-array
+example. The persisted string value therefore originated in the model/tool
+output path; it was not a validator rewrite of a valid array. The validator's
+typed rejection was correct. The harness defect is what happens next:
+`stop=length` is discarded by Chat UI state and a reasoning-only capped turn is
+accepted as successful finalization.
+
+### Current root-cause split
+
+1. **Model/output contract failure:** Bonsai sometimes emits a stringified
+   pseudo-array for a schema-declared array even when a valid example is in the
+   live prompt.
+2. **Correct validation:** Osaurus rejects that value as retryable
+   `invalid_args`; this is not a permission failure.
+3. **Model recovery failure:** Bonsai loops in reasoning instead of correcting
+   the array and exhausts the explicit 2,048-token output limit.
+4. **Harness finalization failure:** `StreamingStatsHint` carries
+   `stop=length`, but `ChatView` does not retain it and treats the nonblank
+   reasoning channel as `.finalResponse`.
+5. **Separate visible degeneration:** another stochastic branch emits literal
+   newline tokens until the same 2,048-token cap, causing the large blank live
+   bubble.
+
+Russian is not the cause: both earlier exported Russian turns and the healthy
+cache-on current-source turn completed normally. Database permissions are not
+the cause: the export and the current-source run both performed successful
+table creation.
+
+The malformed `capabilities_load` value does pass through vMLX's Qwen XML
+function parser. Bonsai's bundle stamps the Qwen reasoning/tool parsers, and
+its chat template renders `<function=...><parameter=...>` calls. The parser
+correctly attempts JSON conversion for the schema-declared array, but invalid
+JSON such as `[skill/Autonomous Scheduler, skill/Data Keeper]` previously
+remained a scalar string. Osaurus then correctly rejected that scalar against
+the tool schema.
+
+The exact local bundle has no `chat.sampling_defaults` block in
+`jang_config.json`. Its `generation_config.json` declares `do_sample:true`,
+`temperature:1.0`, `top_p:0.95`, `top_k:20`, and EOS id `248046`; it does not
+declare `max_new_tokens`. The baseline app's visible/default-agent temperature
+override was `0.7` and maximum output was `2,048`, so those two user settings
+superseded the corresponding bundle fallback while top-p/top-k/EOS still
+belonged to the bundle/runtime. This means the observed branches are sampled
+behavior under an explicit temperature override, not a deterministic model
+contract. Post-fix proof must record the engine's effective values rather than
+infer them from either file or UI alone.
+
+## Fix branch under test
+
+This section records implementation state, not acceptance:
+
+- vMLX commit:
+  `df5a4e9ba3b917eff36064f77c3ffddd72c961dd`
+- vMLX PR: `osaurus-ai/vmlx-swift#179`
+- vMLX changes:
+  - recover a plain outer-bracketed comma list only when the declared
+    parameter schema is exactly `array<string>`. Valid JSON remains on the
+    existing path. Object arrays, nested collection syntax, quotes, control
+    characters, and ordinary scalar parameters do not enter the recovery.
+  - route Gemma's live-observed decoded `⭕thought\n...<channel|>` opener into
+    the reasoning stream instead of visible content. This is a narrow parser
+    alias, not a forced reasoning close/open or sampler workaround.
+- vMLX source evidence: the existing XML parser selection plus the exact live
+  malformed value, split-delta streaming, valid JSON unchanged, object-array
+  negative control, and nested-syntax negative control passed 13 focused XML
+  parser tests before this pin. The new `df5a4e9...` pin additionally passed
+  `HarmonyParserFocusedTests` (18 tests), including
+  `Gemma4 decoded thought-channel opener routes to reasoning` and the Gemma
+  VLM guard that normalized schemas render in the template while raw schemas
+  remain in `LMInput.toolSchemas`.
+- Osaurus change under test: persist the authoritative terminal stop reason;
+  classify a no-tool `stop=length` turn as incomplete instead of success;
+  propagate that result through Chat, plugin streaming/non-streaming, HTTP
+  streaming, browser/text delegation, and evaluator reporting; collapse
+  terminal whitespace-only output before rendering the incomplete notice; trim
+  whitespace around string boolean tool arguments before schema validation and
+  execution coercion.
+- Osaurus source evidence: focused agent-loop, turn-persistence, and streaming
+  hint suites built and exited zero before this pin. After the `df5a4e9...`
+  repin, `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`,
+  `SchemaValidatorCoercionTests`, and `AgentDatabaseTests` exited zero. This
+  is not live proof.
+- SQLite persistence follow-up: schema v12 adds nullable
+  `turns.terminal_stop_reason`, includes it in the incremental content hash,
+  upsert, select, and row decode. Focused `ChatHistoryDatabase`,
+  `ChatHistoryMigrationRepair`, and `ChatTurnFinishReason` Xcode suites exit
+  zero. App-restart/UI preservation is still open.
+
+## Prior fixed-Release live evidence
+
+These rows are useful diagnostics only after the vMLX repin. They were captured
+before the current `df5a4e9...` vMLX pin and therefore cannot close the current
+acceptance gate.
+
+Isolated fixed build before the current repin:
+
+- product:
+  `/private/tmp/osaurus-bonsai-db-fix-release-derived-20260723/Build/Products/Release/osaurus.app`
+- bundle id: `com.dinoki.osaurus.bonsaidbfix20260723`
+- isolated root:
+  `/private/tmp/osaurus-bonsai-db-fix-root-20260723`
+- Osaurus base: `25d0175d1e03f019ca26279922b50fdd702ea52e`
+  plus the uncommitted scoped patch
+- embedded vMLX: `2dbb39a1e56bf6c5f914e0611ab0002e253fdfae`
+- model: `dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`
+- visibly saved controls: Thinking On, Prefix Cache On, paged GPU cache Off,
+  SSD Disk Cache On, SSM re-derive On
+
+Live Computer Use rows:
+
+1. With Max Tokens visibly saved as 32, a reasoning prompt ended with a
+   distinct reasoning card, the truthful incomplete notice,
+   `TTFT 1.05s`, `43.6 tok/s`, 32 tokens, and the
+   `thinking didn't close` warning. Input unlocked without an automatic retry.
+2. After visibly restoring Max Tokens to 2,048, a same-chat follow-up produced
+   a closed reasoning card plus final answer at `TTFT 0.54s`,
+   `41.3 tok/s`, 535 tokens, with no unclosed warning.
+3. In a fresh chat, the exact Russian prompt restored 5,383 prompt tokens from
+   SSD and prefetched only 113 remaining tokens with paged GPU cache Off. It
+   produced a coherent clarification at `TTFT 0.87s`, `37.3 tok/s`,
+   728 tokens.
+4. The supplied-parameters follow-up emitted a `db_create_table` call whose
+   vMLX parser marked `invalid_tool_arguments`, missing `name`. The next
+   generation restored 5,986 tokens from SSD and prefetched 361 remaining, so
+   the failed tool did not reset KV reuse to zero. That continuation then
+   spent all 2,048 output tokens in unclosed reasoning and ended with the
+   truthful incomplete notice at `TTFT 1.57s`, `22.7 tok/s`; input unlocked.
+
+These rows prove the fixed terminal lifecycle and the failed-tool SSD suffix
+continuation only for that earlier build. They do **not** prove the current
+pin or the requested workflow: no table, schedule, reminder, or export was
+created. Temporary raw tool-envelope tracing used during diagnosis was removed
+from `ChatView.swift` before the current rebuild.
+
+## Current fixed-Release gate still open
+
+The required live acceptance build must embed vMLX
+`df5a4e9ba3b917eff36064f77c3ffddd72c961dd` and visibly prove:
+
+1. Bonsai with Thinking On can complete the Russian database/scheduler task
+   far enough to create the expected tables or, if the model still fails, stops
+   truthfully without hidden success, blank finalization, or a stuck spinner.
+2. A failed tool call does not reset SSD prefix/cache reuse to a cold `0/N`
+   prefill on the next step.
+3. Gemma 4 12B MXFP8 with Thinking On no longer leaks `⭕thought` or
+   `<channel|>` into visible content and the whitespace boolean DB arguments
+   validate when emitted as `" false "`.
+4. A new chat/follow-up with paged GPU cache Off and SSD Disk Cache On shows
+   cross-chat disk restore/partial-prefix behavior in the live UI/cache
+   telemetry.
+5. Input unlocks at stream completion and no turn remains indefinitely queued
+   or spinning after model output has ended.
+
+## Adjacent context-limit UI contract
+
+A current user screenshot shows three apparently conflicting values:
+
+- the chat composer shows approximately `8.6k / 262k`;
+- Settings > Chat shows Context Length `128000`;
+- Settings > Server > Cache exposes a separate per-session window.
+
+Current source assigns them different owners:
+
+1. The composer denominator calls
+   `AgentLoopBudget.resolveContextWindowSync`. For an installed local model it
+   reads model-bundle metadata first. Bonsai's
+   `config.json > text_config.max_position_embeddings` is 262,144, so the
+   displayed 262K is the bundle's nominal local context window.
+2. Settings > Chat labels its 128,000 field “Context window for remote
+   models.” `AgentLoopBudget` uses it only when no fixed Foundation window and
+   no installed-model context metadata are available. It does not override
+   Bonsai's detected 262,144.
+3. Settings > Server > Cache labels the other field “Per-Session Window
+   (tokens)” and binds it to `cache.defaultMaxKVSize`. The live coordinator
+   resolves a blank field through Memory Safety (the default Safe Auto plan
+   currently resolves 65,536); an explicit user value overrides that plan.
+   `longPromptMultiplier` controls when this retained-KV cap engages.
+
+This distinction is source-traced but not yet accepted. The open correctness
+question is whether a nominal 262K request can be admitted while a smaller
+per-session KV window silently rotates away earlier full-attention context. The
+UI must either show the actual effective retained window/threshold or prove
+that the cache cap is only a storage optimization and does not reduce model
+attention. Required live rows: local 262K metadata, remote/unknown 128K
+fallback, Safe Auto resolved KV cap, explicit cache-cap override, and prompt
+behavior below/above the multiplier threshold. Do not relabel or merge these
+values until the vMLX cache implementation and live telemetry agree.
+
+Both fixes remain **PARTIAL** until the exact fixed Release app passes the
+Computer Use matrix below.
+
+## Cross-system regression questions
+
+These are required questions because parser output, loop state, and cache state
+meet at the same model step. A pass in one layer does not imply a pass in the
+others.
+
+### Tool parser and schema boundary
+
+1. Does the exact malformed Bonsai list become two string-array elements when
+   emitted in one chunk and when its XML tags/value are split across stream
+   chunks?
+2. Are already-valid JSON arrays byte-for-byte equivalent in parsed value?
+3. Do `array<object>`, nested arrays, quote-containing values, empty members,
+   unknown functions, ordinary string parameters, and missing required
+   parameters remain on their existing rejection paths?
+4. Can two tool calls in one completion parse independently without the first
+   call's recovery changing the second call?
+5. Do reasoning deltas before and after a tool call remain in the reasoning
+   card, with no XML/protocol markers leaking into visible content?
+6. Is the recovery limited to Qwen XML parsing, leaving Gemma, LFM, DSML, and
+   other parser families unchanged?
+
+### Agent-loop completion and recovery
+
+1. Are natural `stop`, tool-call termination, `length`, cancellation,
+   disconnect, and provider error still distinguishable after persistence and
+   chat reload?
+2. Does reasoning-only `length` show a truthful incomplete state once, unlock
+   input, and avoid an automatic identical retry?
+3. Does visible content followed by newline degeneration trim only terminal
+   whitespace while preserving the visible answer and reporting the output
+   cap honestly?
+4. After missing-field, malformed-array, table-exists, permission-denied, or
+   tool-runtime failures, does the next step receive the exact structured tool
+   result and either correct itself or stop truthfully?
+5. Can a same-chat follow-up continue after each failure without a stuck
+   spinner, queued lease, stale pending tool card, or false completion
+   notification?
+6. Do spawned text/browser agents and plugin/API agent loops return an
+   incomplete/error envelope rather than silently treating the same capped
+   state as success?
+
+### SSD/prefix cache interaction
+
+1. With paged RAM cache Off and SSD cache On, does the initial stable system,
+   tool-schema, agent-memory, and user-prefix region restore from disk on a
+   fresh chat and after app relaunch?
+2. When a failed tool result changes only the suffix, does longest-prefix
+   lookup reuse the earlier matching SSD blocks and prefill only the divergent
+   result/continuation suffix instead of returning to `0/N`?
+3. If several partial candidates exist, does selection use the longest safe
+   match rather than the newest, shortest, or incompatible entry?
+4. Do cache telemetry and visible prefill agree on restored/remaining token
+   counts, TTFT, disk hit/miss/store counters, and queued/prefill/decode/drain
+   transitions?
+5. Does cancellation during prefill/decode drain the lease without storing a
+   poisoned partial suffix, while preserving earlier safe SSD blocks for the
+   next chat?
+6. Do model, tokenizer, template, tool schema, Thinking state, media salt,
+   cache codec, and architecture changes produce intentional misses rather
+   than unsafe cross-configuration hits?
+7. For Bonsai/Ornith/Qwen 3.5 hybrid GDN/SSM models, does a partial SSD KV hit
+   restore or asynchronously re-derive companion recurrent state at the exact
+   matched boundary before decode?
+8. Does the same sequence remain coherent with SSD Off, proving cache is an
+   optimization and not required for correct parser/loop behavior?
+
+### Cross-family and UI controls
+
+1. Does the exact task remain coherent on Bonsai plus one other Qwen-XML model,
+   while a non-Qwen parser control shows no behavior change?
+2. Does explicit Thinking On/Off reach every model step after tool results and
+   every delegated step, rather than only the first manual chat request?
+3. Does resizing the chat during generation change only layout, not persisted
+   deltas, tool cards, stop reason, or terminal whitespace cleanup?
+4. Do the input, Stop button, model picker, Thinking control, and new-chat
+   action return to the correct enabled state after success, tool error,
+   output-cap exhaustion, and cancellation?
+
+### Generation-config ownership and stochastic behavior
+
+1. At model load, are temperature, top-p, top-k, min-p/top-min-p, repetition
+   controls, stop ids/strings, and other supported defaults read from the
+   active bundle's `generation_config.json`/JANG metadata rather than inferred
+   from a display name?
+2. Do user-explicit chat/API overrides win only for that request, while an
+   untouched control uses the exact bundle defaults?
+3. Are the effective values preserved on every post-tool generation, spawned
+   model run, delegated agent step, and automatic follow-up, including the
+   explicit Thinking choice?
+4. Does changing model/config invalidate or salt incompatible cache entries
+   rather than restoring a prefix produced under different template or
+   generation ownership?
+5. Under a deterministic control, do repeated runs produce the same parsed
+   tool structure and terminal state? Under matched bundle-default stochastic
+   sampling, what is the failure rate across repeated fresh runs?
+6. If malformed arrays, duplicate DB creation, newline degeneration, or
+   reasoning-only exhaustion are stochastic, do all failures still recover or
+   terminate truthfully without depending on a lucky sample?
+7. Do logs/telemetry expose the effective request values used by the engine so
+   the UI setting, request DTO, and runtime cannot disagree silently?
+
+No acceptance fix may introduce a hidden sampler override, forced reasoning
+tag, synthetic stop token, or family-name-based clamp. A behavioral difference
+must be traced either to the bundle contract, a user-visible override, or a
+runtime/parser bug.
+
+## Remaining questions and post-fix gates
+
+1. Does retaining `stop=length` prevent a reasoning-only capped turn from
+   finalizing the agent run as success, across Chat UI and the other agent-loop
+   surfaces?
+2. Does one bounded, truthful length continuation recover, or does the model
+   repeat the same reasoning loop? Do not add forced tags, sampler overrides,
+   or family-specific prompt coercion.
+3. Does the model emit a valid visible answer if Thinking is explicitly Off?
+   This is a diagnostic control, not permission to force Thinking Off.
+4. After a successful `db_create_table`, does a structured table-exists result
+   plus `db_schema` preserve tool-result grounding and lead to
+   `db_alter_table`, or does Bonsai repeat creation under matched sampling?
+5. Do a missing-field error, a table-exists error, and a permission denial
+   have distinct continuation behavior?
+6. Does the run terminate, unlock input, and accept a same-chat follow-up after
+   each outcome?
+7. Do scheduler/reminder steps ask for the correct user confirmation and
+   respect the agent's actual schedule mode?
+8. Do the same task and error controls preserve SSD-prefix reuse across
+   post-tool turns without resetting to a cold prompt?
+
+## Acceptance matrix
+
+All rows require a fresh Release-config Osaurus app with a unique bundle id,
+isolated `OSAURUS_TEST_ROOT`, keychain-disabled test profile, exact local model
+bundle under `/Users/eric/models`, and visible Computer Use operation.
+
+| Row | Required evidence | Status |
+| --- | --- | --- |
+| Exact Russian prompt, Thinking On | Visible tool rows, exact args/results, reasoning card, final visible answer, finish reason, TTFT, token/s, input unlocked | PARTIAL — one healthy run; one cache-on newline/length failure; one cache-off malformed-array/length failure |
+| Thinking Off control | Same prompt, explicit picker state, no hidden reasoning, truthful final/tool behavior | OPEN |
+| Malformed `capabilities_load.ids` recovery | Typed invalid-args result followed by corrected array call or truthful incomplete state; never clean-finalize a capped reasoning-only turn | FAILED CURRENT LIVE |
+| Missing `name` recovery | One typed invalid-args result, corrected call, no parser-marker leak | EXPORT-OBSERVED; CURRENT LIVE OPEN |
+| Existing table recovery | `db_schema`/`db_alter_table` or truthful stop; no repeated create loop | FAILED IN EXPORT; CURRENT LIVE OPEN |
+| Schedule/reminder continuation | Correct schedule tools, confirmation, bounded recurrence, final summary | OPEN |
+| Tool error then same-chat follow-up | No hang; history grounded; partial SSD cache restore; input unlocked | PARTIAL — 5,986-token SSD restore and clean unlock proven; task correction failed at output cap |
+| New chat and app restart | Disk L2 partial restore with paged RAM off; coherent answer/tool use | OPEN |
+| Cross-model control | At least one non-Bonsai local family under the same tool schema | OPEN |
+
+### Cross-model reporter-workflow matrix
+
+The reporter's exact usage—not a load-only or single-call prompt—is the
+acceptance workload. Run it first on Bonsai, then with matched UI settings on
+one additional Qwen-XML bundle and one non-Qwen parser family:
+
+1. Russian intake prompt and supplied body parameters;
+2. inspect existing schema before mutation;
+3. create the tracking schema once and seed/query a row;
+4. start a fresh chat and query the same persisted row without replaying the
+   old conversation;
+5. export CSV/JSON and surface the downloadable artifact;
+6. read current time and schedule one approved next run whose instruction is
+   self-contained and reschedules itself for recurrence;
+7. inspect/cancel that run;
+8. inject one malformed/missing argument and prove the typed result is
+   grounded, the next prefill reuses SSD prefix state, and the model either
+   corrects it or stops truthfully;
+9. repeat after app restart with paged RAM cache Off and SSD cache On;
+10. record visible Thinking state, reasoning/content separation, tool rows,
+    terminal reason, TTFT, token/s, restored/remaining prompt tokens, and input
+    unlock.
+
+No family is inferred from another. Bonsai, the Qwen control, and the
+non-Qwen control each remain `OPEN` until their own live rows exist.
+
+No implementation is accepted from source/tests alone. No model-family blame is
+accepted unless matched live controls show the same current harness succeeds
+while the exact Bonsai bundle repeatedly fails under the same effective
+configuration.
+
+## 2026-07-23 late emergency: stable system-prefix SSD restore
+
+Status: **PARTIAL — SOURCE AND FOCUSED TESTS PASS; GEMMA AND BONSAI RELEASE
+UI CACHE ROWS RECORDED; TOOL-SUFFIX LIVE ROWS STILL OPEN**
+
+The user-reported cache symptom is that fresh chats and post-tool continuations
+can show `0/N` prefill even though SSD cache is enabled and previous chats
+already warmed the same Osaurus/tool prompt rail. The current source diagnosis
+is not arbitrary suffix-cache failure. vMLX restores one validated contiguous
+prefix boundary from the candidate set; it does not stitch unrelated SSD
+fragments. The missed reuse occurs because Osaurus renders static system
+instructions plus mutable DB/sandbox/tool state into one system message. When
+the mutable suffix changes after a database or tool event, the full-system
+boundary becomes unsafe even though the leading static bytes remain identical.
+
+The fix under test adds a runtime-only cache hint:
+
+- Osaurus computes the already-existing `SystemPromptComposer.staticPrefix` and
+  attaches it to local MLX requests as `cacheStableSystemPrefix`.
+- The field is local-only: it is not in `ChatCompletionRequest.CodingKeys`, is
+  not exposed to OpenAI JSON, is not forwarded to remote providers, and is not
+  rendered as additional model-visible text.
+- vMLX accepts `UserInput.cacheStableSystemPrefix` and derives an earlier
+  tokenizer boundary by rendering two probe system messages with divergent
+  suffixes, then LCP-validating both probes against the real prompt tokens.
+  This prevents BPE split-point mistakes and avoids trusting raw byte length.
+- LLM, Gemma 4, and Qwen3VL processors pass the hint into
+  `canonicalChatCacheBoundaries`, covering the text path and the main local
+  Gemma/Qwen/VL paths affected by Osaurus chat.
+
+Important non-change: **TurboQuant KV remains opt-in only.** This cache-boundary
+fix must not turn on TurboQuant for any family. Source policy still says
+`engineSelected` resolves to native/fp16 KV and `shouldUseTurboQuantByDefault`
+returns `false`. The only path to TurboQuant KV is a user-visible Settings
+change to `cache.liveKVCodec = turboQuant` with explicit key/value bit widths.
+The live Release proof must inspect the isolated app config and UI state before
+any PR comment claims this is verified.
+
+Current source/test evidence:
+
+- Final Osaurus vMLX pin:
+  `f50853514ee00365837be3301c91850ca7ed5877`
+- Pre-squash vMLX proof commit:
+  `91933aef193cab180b821bad1f4b4cc8ad753107`
+  (`git diff 91933aef..vmlx-origin/main` was empty after PR #179 merged, so
+  the final main pin has the same vMLX source tree as the proof commit)
+- vMLX focused test:
+  `/tmp/vmlx-static-prefix-boundary-tests-20260723.log`
+  (`CanonicalChatCacheBoundariesTests`, including
+  `staticSystemHintAddsEarlierBoundaryInsideMutableSystemMessage`)
+- Osaurus focused source/pin test:
+  `/tmp/osaurus-static-prefix-source-tests-91933aef-rerun-20260723.log`
+  (`RuntimePolicySourceTests/chatComposedStaticPromptPrefixReachesLocalMLXCacheHint`
+  and `vmlxPinIncludesRuntimeHardening`)
+- Osaurus focused DB/tool-loop regression test:
+  `/tmp/osaurus-db-toolloop-static-prefix-91933aef-20260723.log`
+  (`SchemaValidatorCoercionTests`, `AgentDatabaseTests`,
+  `AgentToolLoopTests`, `ChatTurnFinishReasonTests`)
+- Osaurus focused TurboQuant policy regression test:
+  `/tmp/osaurus-tq-default-policy-tests-91933aef-20260723.log`
+  (`MLXBatchAdapterTests/cacheKVModeTagTracksEffectiveCoordinatorPolicy`,
+  `ServerRuntimeSettingsStoreTests/load_repairsLegacyCacheDefaultsWithoutEnablingTurboQuant`,
+  and `ServerRuntimeSettingsStoreTests/loadOrMigrate_buildsFromLegacyOnFirstRun`)
+- Post-merge vMLX main repin source/TQ test:
+  `/tmp/osaurus-source-tq-pin-tests-f5085351-20260723.log`
+  (reran `RuntimePolicySourceTests`, including
+  `vmlxPinIncludesRuntimeHardening` and
+  `chatComposedStaticPromptPrefixReachesLocalMLXCacheHint`, plus the focused
+  TurboQuant default/opt-in rows at final pin
+  `f50853514ee00365837be3301c91850ca7ed5877`)
+
+Release UI evidence recorded:
+
+- Proof app:
+  `/tmp/osaurus-static-prefix-release-derived-91933aef-20260723/Build/Products/Release/osaurus.app`
+- Bundle id:
+  `com.dinoki.osaurus.staticprefixproof20260723`
+- Executable SHA-256:
+  `f110b825de75dfae41e288a6215080e5f1e3ba468f1f25ea1203434e8fc6d9ce`
+- Isolated root:
+  `/private/tmp/osaurus-static-prefix-proof-root-20260723-91933aef-live2`
+- Runtime log:
+  `/tmp/osaurus-static-prefix-live-91933aef-20260723.log`
+- This Release app was built before the vMLX PR #179 squash merge, against
+  `91933aef193cab180b821bad1f4b4cc8ad753107`. The final Osaurus source is
+  pinned to `f50853514ee00365837be3301c91850ca7ed5877`, and the vMLX tree diff
+  between those two revisions is empty. The final pin has source/test proof in
+  `/tmp/osaurus-source-tq-pin-tests-f5085351-20260723.log`; a rebuilt final-pin
+  Release app row would still be required before claiming binary-identical live
+  proof.
+- Live Settings > Server > Cache state:
+  prefix cache On, SSD/block-disk cache On, paged RAM KV cache Off,
+  `liveKVCodec = engine_selected`, `storedKVCodec = auto`, no
+  `turboQuantKeyBits`/`turboQuantValueBits` fields.
+- Live Settings > Server > Live Activity state after the Gemma cache rows:
+  `TurboQuant compressions 0`, `Loaded models 1`, `Cache-enabled models 1`,
+  `Disk L2 hits / misses / stores 3 / 6 / 4`.
+- Gemma 4 12B MXFP8 visible chat rows, with paged RAM KV Off and SSD On:
+  - fresh prompt `Say exactly: cache proof one.` produced
+    `cache proof one.`, TTFT `1.17s`, `26.4 tok/s`, and unlocked input.
+  - new chat prompt `Say exactly: cache proof two.` produced
+    `cache proof two.`, TTFT `0.46s`, `31.9 tok/s`, and unlocked input.
+  - after quitting and relaunching the same isolated app/root, prompt
+    `Say exactly: cache proof after restart.` produced
+    `cache proof after restart.`, TTFT `0.48s`, `32.0 tok/s`, and unlocked
+    input.
+- Log evidence for cross-chat/restart SSD restore includes:
+  - `HIT disk boundary=1725 remaining=4 ... tokens=1729`
+  - `HIT disk boundary=1729 remaining=12 ... tokens=1741`
+  - `HIT disk boundary=1741 remaining=9 ... tokens=1750`
+  - restart row `HIT disk boundary=1725 remaining=4 ... tokens=1729`
+    followed by `HIT disk boundary=1729 remaining=13 ... tokens=1742`
+    and `HIT disk boundary=1742 remaining=10 ... tokens=1752`.
+- Bonsai 27B Ternary JANG CRACK visible chat rows, with the same isolated root,
+  paged RAM KV Off, SSD On, and model-picker Thinking Off:
+  - new chat prompt `Say exactly: bonsai cache proof one.` produced
+    `bonsai cache proof one.`, TTFT `0.62s`, `32.2 tok/s`, and unlocked input.
+  - second new chat prompt `Say exactly: bonsai cache proof two.` produced
+    `bonsai cache proof two.`, TTFT `0.60s`, `32.3 tok/s`, and unlocked input.
+  - log evidence shows hybrid companion-state SSD restores on this Qwen-family
+    route, including `HIT disk boundary=3007 remaining=1 ssm=96 ...`,
+    `HIT disk boundary=3007 remaining=19 ssm=96 ...`, and
+    `HIT disk boundary=3019 remaining=14 ssm=96 ...`.
+  - post-Bonsai Live Activity showed `TurboQuant compressions 0`,
+    `Hybrid caches 1`, `Disk L2 hits / misses / stores 5 / 31 / 8`,
+    and `SSM hits / misses / re-derives 5 / 0 / 0`.
+- The isolated SSD cache directory grew from `4.0G` after Gemma to `7.2G`
+  after Bonsai under
+  `/private/tmp/osaurus-static-prefix-proof-root-20260723-91933aef-live2/cache/kv_v2`.
+
+This live row proves the default path does not enable TurboQuant and that
+Gemma's local Release app path can reuse SSD L2 blocks across new chats and app
+restart. The Bonsai row proves the same app build can complete simple fresh-chat
+Qwen-family generations with hybrid/SSM disk restores and no post-output hang.
+It does **not** prove Ornith, Qwen3.5/VL, Laguna, DB-tool dynamic suffix
+recovery, or AppleScript behavior.
+
+Live proof still required before merge-ready:
+
+1. With paged RAM cache Off and SSD On, run a DB/tool workload that first
+   stores the static prompt boundary, then changes the database/schema suffix,
+   then starts a fresh chat or same-tool continuation.
+2. Require log and UI evidence that the second request restores a nonzero SSD
+   prefix boundary and only prefills the divergent suffix. A truthful smaller
+   restore than the full prompt is acceptable; a return to `0/N` is not.
+3. Confirm the request does not hang after final output, the input unlocks,
+   finish reason is persisted, and cache telemetry agrees with the visible
+   prefill/TTFT state.
+4. Record the exact model, Thinking state, token counts, disk hit/miss/store
+   counters, and TQ layer/compression counters. Any TQ counter increment while
+   Settings are not explicitly TurboQuant is a failure.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7d6235316226ba9fe608018f86c463784e48b3d5"
+        "revision" : "f50853514ee00365837be3301c91850ca7ed5877"
       }
     },
     {


### PR DESCRIPTION
## Problem

The emergency Qwen/Gemma lane had three connected failures:

- Qwen-derived Bonsai/Ornith and Gemma could emit recoverable but schema-sensitive tool arguments, including nested arrays/objects and scalar strings that must be validated/coerced against the declared schema.
- A reasoning-only output-cap completion could be mistaken for a successful final response because Osaurus discarded the runtime terminal reason.
- SSD prefix reuse lost the safe static system-prompt boundary when mutable DB/tool state changed later in the same rendered system message.

## Change

- Pin vMLX to merged PR #179 at `f50853514ee00365837be3301c91850ca7ed5877`:
  - schema-bound Qwen XML `array<string>` recovery;
  - Gemma thought-channel output routed to reasoning;
  - tokenizer-validated static system-prefix cache boundary for LLM, Gemma 4, and Qwen3VL processors.
- Carry `SystemPromptComposer.staticPrefix` as local-only `cacheStableSystemPrefix` runtime data. It is not decoded from OpenAI JSON, sent to remotes, or added to model-visible text.
- Persist the authoritative terminal reason and classify `stop=length` as incomplete instead of successful finalization.
- Constrain DB column types in the tool schema and storage boundary; keep constraints in their dedicated fields.
- Normalize whitespace around schema-declared boolean strings.
- Add focused tests for terminal reason persistence/classification, DB type validation, coercion, and the local cache-hint route.

## Current source and CI

- Base: `25d0175d1e03f019ca26279922b50fdd702ea52e`
- Head: `34f1c94ec3b753e39acc9eb23a9e9640bca2fe85`
- vMLX PR #179 is merged at the exact pinned revision.
- The previous code head passed `test-core`, `test-cli`, `test-packages`, `test-statspack`, `test-evals`, `swiftlint`, `shellcheck`, and release-drafter checks. The final head changes documentation only; its checks are the merge gate.
- `git diff --check` is clean.
- The PR contains no image, video, archive, or other binary proof.

## Final-pin Release UI evidence

Real app, operated through the model picker, chat UI, tool cards, and Server Settings:

- Product: `/tmp/osaurus-static-prefix-release-derived-f5085351-20260723/Build/Products/Release/osaurus.app`
- Bundle: `com.dinoki.osaurus.staticprefixprooff50820260723`
- Isolated root: `/private/tmp/osaurus-static-prefix-proof-root-20260723-f5085351-live2`
- Effective UI settings: Prefix Cache On, SSD Disk Cache On, GPU/Paged KV Off, codec Engine Selected.
- Final Live Activity: active `0`, queued `0`, Disk L2 hits/misses/stores `5 / 110 / 22`, TurboQuant compressions `0`.

Tool rows:

- `dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`, Thinking Off:
  - exactly one create, insert, and query;
  - SQLite and UI both returned `(21, bonsai-finalpin-twenty-one)`;
  - TTFT `1.12s`, `41.3 tok/s`, terminal `stop`, input unlocked.
- `JANGQ-AI/Ornith-1.0-9B-MXFP8`, Thinking Off:
  - exactly one create, insert, and query;
  - SQLite and UI both returned `(31, ornith-finalpin-thirty-one)`;
  - TTFT `0.68s`, `65.3 tok/s`, terminal `stop`, input unlocked.
- `OsaurusAI/gemma-4-12B-it-MXFP8`, Thinking Off:
  - exactly one create, insert, and query;
  - SQLite and UI both returned `(41, gemma-finalpin-forty-one)`;
  - TTFT `1.25s`, `30.0 tok/s`, terminal `stop`, input unlocked.
- Same Gemma model, fresh chat after the DB suffix changed:
  - query returned the exact row and unlocked;
  - Disk L2 hits increased `3 -> 4`;
  - TTFT was `8.29s`, so this is a functional restore pass, not a latency-win claim.
- Same Gemma model, Thinking On:
  - the model picker visibly showed On;
  - UI rendered a separate 294-character `Thought for 5.3s` block, then one query and a visible final answer;
  - terminal `stop`, input unlocked, Disk L2 hits `4 -> 5`.

The persisted tool calls contain the expected nested `columns`, `rows`, and `row` structures; the final turns persist `stop`. The database contents were checked independently rather than trusting model prose.

## Scope boundary

This emergency PR is limited to Qwen-derived Bonsai/Ornith, Gemma, and the shared runtime paths required by those fixes. It does not include the parked LFM/DSML parser work, AppleScript changes, Laguna, scheduler/notification/export completion, or a claim that every model/parser family is verified.

The full text-only gate is in `docs/BONSAI_AGENT_DB_FITNESS_LIVE_GATE_2026-07-23.md`.
