### PR TITLE
nudge model to continue when run ends with unchecked todo items

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1062,6 +1062,20 @@ enum AgentToolLoop {
         "[System Notice] Your todo list still has \(pending) unchecked item\(pending == 1 ? "" : "s") and has not been updated recently. If you finished any, re-send the full list with those boxes checked now; if the plan changed, rewrite the list."
     }
 
+    /// Bounded number of times a text-only final response is bounced back
+    /// to the model while the session todo list still has unchecked items.
+    /// Small local models routinely narrate the next step in plain text
+    /// instead of calling a tool; without this guard the run ends with the
+    /// checklist abandoned (issue #2133).
+    static let maxPendingTodoContinuations = 2
+
+    /// Transient nudge staged when the model tried to end the run with
+    /// unchecked todo items remaining. Rides the same notice channel as the
+    /// staleness nudge — never persisted into history.
+    static func pendingTodoContinuationNotice(pending: Int) -> String {
+        "[System Notice] Your todo list still has \(pending) unchecked item\(pending == 1 ? "" : "s"). Do not stop here: continue with the next unchecked item using tool calls. If everything is actually done, re-send the full list with all boxes checked, then finish."
+    }
+
     // Capability schemas loaded mid-run are delivered append-only in the
     // `capabilities_load` tool *result* (see
     // `CapabilitiesLoadTool.loadedSchemaBlock`), never by rewriting the frozen
@@ -1151,6 +1165,10 @@ enum AgentToolLoop {
         // productive turn; bounds the nudge-and-retry recovery so the loop
         // can never spin on a deterministically-empty model.
         var consecutiveEmptyTurns = 0
+        // Text-only final responses bounced back because unchecked todo
+        // items remained. Bounded so a model that insists on stopping can
+        // still end the run.
+        var pendingTodoContinuations = 0
         // Last iteration that carried a `todo` call (0 = run start), for
         // the staleness check below.
         var lastTodoIteration = 0
@@ -1191,6 +1209,24 @@ enum AgentToolLoop {
             let step = try await hooks.modelStep(input.messages, iteration)
             switch step {
             case .finalResponse:
+                // The model tried to finish with plain text while the
+                // session todo list still has unchecked items. Weak local
+                // models often narrate the next step instead of calling a
+                // tool; bounce the turn back with a continuation nudge a
+                // bounded number of times before accepting the stop.
+                if let pendingTodoCount = hooks.pendingTodoCount,
+                    pendingTodoContinuations < Self.maxPendingTodoContinuations
+                {
+                    let pending = await pendingTodoCount()
+                    if pending > 0 {
+                        pendingTodoContinuations += 1
+                        pendingTodoNotice = Self.pendingTodoContinuationNotice(pending: pending)
+                        // Re-arm the staleness window so the two nudges
+                        // don't stack on the same iteration.
+                        lastTodoIteration = iteration
+                        continue
+                    }
+                }
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .retryWithoutCharge:
@@ -1232,9 +1268,11 @@ enum AgentToolLoop {
                 return RunResult(exit: .lengthExhausted, iterations: iteration)
 
             case .toolCalls(let invocations):
-                // A productive turn — reset the empty-turn recovery budget so
-                // a later unrelated empty turn gets its own fresh allowance.
+                // A productive turn — reset the recovery budgets so a later
+                // unrelated empty turn or premature stop gets its own fresh
+                // allowance.
                 consecutiveEmptyTurns = 0
+                pendingTodoContinuations = 0
 
                 // A desktop subagent already completed successfully, and the
                 // very next model step emitted only a malformed repeat of that

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -1703,9 +1703,9 @@ struct AgentLoopTodoStalenessTests {
             state: AgentTaskState(),
             hooks: surface.makeHooks()
         )
-        let needle = "[System Notice] Your todo list"
+        let staleness = AgentToolLoop.todoStalenessNotice(pending: 1)
         for notices in surface.builtNotices {
-            #expect(!notices.contains(where: { $0.hasPrefix(needle) }))
+            #expect(!notices.contains(staleness))
         }
     }
 
@@ -1724,6 +1724,70 @@ struct AgentLoopTodoStalenessTests {
         for notices in surface.builtNotices {
             #expect(!notices.contains(where: { $0.hasPrefix(needle) }))
         }
+    }
+}
+
+// MARK: - Pending-todo continuation on premature final response
+
+@MainActor
+struct AgentLoopPendingTodoContinuationTests {
+
+    /// A text-only final response with unchecked todo items is bounced
+    /// back with a continuation nudge instead of ending the run
+    /// (issue #2133), bounded by `maxPendingTodoContinuations`.
+    @Test func prematureFinalResponseIsNudgedThenAccepted() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .finalResponse, .finalResponse, .finalResponse,
+        ])
+        surface.pendingTodos = 2
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        // Two nudged retries, then the third stop is accepted.
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 3))
+        let expected = AgentToolLoop.pendingTodoContinuationNotice(pending: 2)
+        #expect(surface.builtNotices.count == 3)
+        #expect(surface.builtNotices[0] == [])
+        #expect(surface.builtNotices[1].contains(expected))
+        #expect(surface.builtNotices[2].contains(expected))
+    }
+
+    /// A productive tool turn after a nudge refreshes the continuation
+    /// allowance for a later premature stop.
+    @Test func toolTurnResetsContinuationAllowance() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .finalResponse,
+            .toolCalls([inv("alpha")]),
+            .finalResponse, .finalResponse, .finalResponse,
+        ])
+        surface.pendingTodos = 1
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        // Nudge, tool turn (reset), then two fresh nudges, then accepted.
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
+        let expected = AgentToolLoop.pendingTodoContinuationNotice(pending: 1)
+        let nudgedBuilds = surface.builtNotices.filter { $0.contains(expected) }
+        #expect(nudgedBuilds.count == 3)
+        #expect(surface.executedCalls.map(\.name) == ["alpha"])
+    }
+
+    /// No unchecked items (or no todo hook at all) → the first final
+    /// response ends the run exactly as before.
+    @Test func finalResponseWithNoPendingItemsEndsImmediately() async throws {
+        let surface = ScriptedLoopSurface(steps: [.finalResponse])
+        surface.pendingTodos = 0
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
+        #expect(surface.builtNotices == [[]])
     }
 }
 


### PR DESCRIPTION
## Summary

closes #2133

  - the agent loop ended on any text-only final response even when the session todo still had unchecked items 
  - now the loop bounces a premature stop back with a transient system notice telling the model to continue with the next unchecked item or check the boxes and finish
  - bounded at 2 consecutive nudges so a model that insists on stopping still ends the run, and a productive tool turn resets the allowance
  - adds tests for the nudge-then-accept bound, allowance reset, and unchanged behavior with no pending items

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+



## eval verification

- ran `AgentLoop`, `AgentLoopFrontier`, and `CacheProof` suites on main (baseline) and this branch with `mlx-community/Qwen3.5-9B-MLX-4bit`
- `CacheProof` passed 8/8 on both branches, so the KV prefix cache concern is cleared by the live cache gates, not just theory
- measured worst case for the new user role nudge on a Qwen template: partial re-prefill of about 500 tokens (13 percent of the prompt, roughly 30 to 40 ms at logged prefill speeds), never a reset to 0
- the continuation nudge fired 24 times across the fix branch suites and flipped `no-clarify-when-default-obvious` from fail to pass
- 4 diff regressions were inspected and are sampling variance: in 3 of them no todo list was ever created so the changed code path never executed, and the agent loop runner samples at model default temperature
- the hard todo cases that still fail (`todo-discipline-multistep`, `long-horizon-project`, `multi-file-refactor-with-todo`) fail identically on both branches for pre-existing model quality reasons
