### PR TITLE
Report MCP tool envelope failures

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9971,9 +9971,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         try await ToolRegistry.shared.execute(name: toolName, argumentsJSON: argsJSON)
                     }
                 }
+                // MCP transport stays HTTP 200; tool-level failure is signaled
+                // via isError when the body is a non-throwing ToolEnvelope.failure
+                // (or legacy error shape). Compute once for response + log.
+                let isError = ToolEnvelope.isError(result)
                 let payload: [String: Any] = [
                     "content": [["type": "text", "text": result]],
-                    "isError": false,
+                    "isError": isError,
                 ]
                 let d =
                     (try? JSONSerialization.data(withJSONObject: payload, options: .osaurusCanonical))
@@ -9995,7 +9999,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     arguments: argsJSON,
                     result: result,
                     durationMs: Date().timeIntervalSince(toolCallStartTime) * 1000,
-                    isError: false
+                    isError: isError
                 )
                 logSelf.logRequest(
                     method: "POST",

--- a/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/MCPHTTPHandlerTests.swift
@@ -473,6 +473,98 @@ struct MCPHTTPHandlerTests {
             #expect(isError == true)
         }
     }
+
+    /// Non-throwing `ToolEnvelope.failure` must surface as MCP `isError: true`
+    /// while keeping HTTP 200 transport semantics. Also proves the request log
+    /// reuses the same error flag.
+    @Test func mcp_call_failure_envelope_sets_isError_true_and_logs_it() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            ToolRegistry.shared.register(FailureEnvelopeTool())
+            ToolRegistry.shared.setEnabled(true, for: FailureEnvelopeTool.nameStatic)
+            defer { ToolRegistry.shared.unregister(names: [FailureEnvelopeTool.nameStatic]) }
+
+            let server = try await startTestServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, resp) = try await postMCPCall(
+                host: server.host,
+                port: server.port,
+                name: FailureEnvelopeTool.nameStatic,
+                arguments: ["marker": FailureEnvelopeTool.marker]
+            )
+            let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            #expect(status == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["isError"] as? Bool == true)
+            let content = try #require(json["content"] as? [[String: Any]])
+            let text = try #require(content.first?["text"] as? String)
+            #expect(ToolEnvelope.isError(text))
+            #expect(text.contains(FailureEnvelopeTool.failureMessage))
+            #expect(text.contains(#""ok":false"#) || text.contains(#""ok": false"#))
+
+            let log = await findMCPCallLog(
+                toolName: FailureEnvelopeTool.nameStatic,
+                marker: FailureEnvelopeTool.marker
+            )
+            let found = try #require(log, "expected Insights log for failure-envelope MCP call")
+            #expect(found.statusCode == 200)
+            let toolCall = try #require(found.toolCalls?.first { $0.name == FailureEnvelopeTool.nameStatic })
+            #expect(toolCall.isError == true)
+            #expect(toolCall.result?.contains(FailureEnvelopeTool.failureMessage) == true)
+        }
+    }
+
+    /// Tool bodies that throw are folded into a failure envelope by the
+    /// registry; MCP must still report `isError: true` at HTTP 200.
+    @Test func mcp_call_thrown_tool_error_sets_isError_true() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            ToolRegistry.shared.register(ThrowingProbeTool())
+            ToolRegistry.shared.setEnabled(true, for: ThrowingProbeTool.nameStatic)
+            defer { ToolRegistry.shared.unregister(names: [ThrowingProbeTool.nameStatic]) }
+
+            let server = try await startTestServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, resp) = try await postMCPCall(
+                host: server.host,
+                port: server.port,
+                name: ThrowingProbeTool.nameStatic,
+                arguments: ["marker": ThrowingProbeTool.marker]
+            )
+            let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            #expect(status == 200)
+
+            let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            #expect(json["isError"] as? Bool == true)
+            let content = try #require(json["content"] as? [[String: Any]])
+            let text = try #require(content.first?["text"] as? String)
+            #expect(ToolEnvelope.isError(text))
+            #expect(text.contains(ThrowingProbeTool.errorMessage))
+
+            let log = await findMCPCallLog(
+                toolName: ThrowingProbeTool.nameStatic,
+                marker: ThrowingProbeTool.marker
+            )
+            let found = try #require(log, "expected Insights log for thrown-tool MCP call")
+            let toolCall = try #require(found.toolCalls?.first { $0.name == ThrowingProbeTool.nameStatic })
+            #expect(toolCall.isError == true)
+        }
+    }
 }
 
 // MARK: - Test tool
@@ -510,6 +602,79 @@ private struct ExternalSurfaceProbeTool: OsaurusTool {
     func execute(argumentsJSON: String) async throws -> String {
         ChatExecutionContext.isExternalSurface ? "external" : "internal"
     }
+}
+
+/// Returns a non-throwing `ToolEnvelope.failure` for MCP isError regression.
+private struct FailureEnvelopeTool: OsaurusTool {
+    static let nameStatic = "mcp_envelope_failure_probe"
+    static let marker = "envelope-failure-marker"
+    static let failureMessage = "intentional envelope failure for MCP isError proof"
+    let name: String = FailureEnvelopeTool.nameStatic
+    let description: String = "Returns a non-throwing ToolEnvelope.failure"
+    let parameters: JSONValue? = nil
+
+    func execute(argumentsJSON: String) async throws -> String {
+        ToolEnvelope.failure(
+            kind: .executionError,
+            message: FailureEnvelopeTool.failureMessage,
+            tool: name
+        )
+    }
+}
+
+/// Throws so the registry folds the error into a failure envelope.
+private struct ThrowingProbeTool: OsaurusTool {
+    static let nameStatic = "mcp_envelope_throw_probe"
+    static let marker = "envelope-throw-marker"
+    static let errorMessage = "intentional throw for MCP isError proof"
+    let name: String = ThrowingProbeTool.nameStatic
+    let description: String = "Throws from the tool body"
+    let parameters: JSONValue? = nil
+
+    func execute(argumentsJSON: String) async throws -> String {
+        throw NSError(
+            domain: "MCPHTTPHandlerTests",
+            code: 42,
+            userInfo: [NSLocalizedDescriptionKey: ThrowingProbeTool.errorMessage]
+        )
+    }
+}
+
+// MARK: - MCP call helpers
+
+private func postMCPCall(
+    host: String,
+    port: Int,
+    name: String,
+    arguments: [String: Any]
+) async throws -> (Data, URLResponse) {
+    var request = URLRequest(url: URL(string: "http://\(host):\(port)/mcp/call")!)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.authenticate()
+    let bodyObj: [String: Any] = [
+        "name": name,
+        "arguments": arguments,
+    ]
+    request.httpBody = try JSONSerialization.data(withJSONObject: bodyObj)
+    return try await URLSession.shared.data(for: request)
+}
+
+/// Polls Insights for the exact `/mcp/call` row created by this test.
+private func findMCPCallLog(toolName: String, marker: String) async -> RequestLog? {
+    for _ in 0 ..< 40 {
+        let match = await MainActor.run {
+            InsightsService.shared.logs.first { log in
+                log.path == "/mcp/call"
+                    && log.toolCalls?.contains(where: {
+                        $0.name == toolName && $0.arguments.contains(marker)
+                    }) == true
+            }
+        }
+        if let match { return match }
+        try? await Task.sleep(nanoseconds: 25_000_000)
+    }
+    return nil
 }
 
 // MARK: - Test server bootstrap


### PR DESCRIPTION
## Summary

Make `/mcp/call` report tool-level failures through the MCP `isError` field while preserving the existing HTTP 200 transport contract.

## Why

`ToolRegistry.execute` can return a structured `ToolEnvelope.failure` without throwing. The MCP handler previously hard-coded `isError: false` for every non-throwing result, so clients could interpret a failed tool execution as success. The Insights entry repeated the same incorrect flag.

This was especially confusing for callers that correctly separated transport success from tool execution success: the response body contained `"ok": false`, but the MCP metadata said the opposite.

## Implementation

- Classify the returned tool envelope once with `ToolEnvelope.isError`.
- Reuse that value for both the MCP response and the Insights `ToolCallLog`.
- Keep the endpoint status at HTTP 200, as required by the existing MCP transport behavior.
- Leave thrown routing/auth/lookup failures on their existing error paths.

## Tests

Added focused coverage for both ways a tool-level failure reaches the handler:

- A tool returns `ToolEnvelope.failure` directly.
- A tool body throws and the registry folds the error into a failure envelope.

Both tests assert HTTP 200, MCP `isError: true`, a structured failure body, and matching Insights metadata.

Validated locally:

```text
swift test --package-path Packages/OsaurusCore \
  --filter MCPHTTPHandlerTests.mcp_call_failure_envelope_sets_isError_true_and_logs_it
✓ 1 test passed

swift test --package-path Packages/OsaurusCore \
  --filter MCPHTTPHandlerTests.mcp_call_thrown_tool_error_sets_isError_true
✓ 1 test passed

swiftlint lint --reporter emoji
✓ completed with 0 serious violations (repository baseline warnings remain)

git diff --check
✓
```

The broader `MCPHTTPHandlerTests` lane compiled successfully but the test process hit the existing MLX default-metallib environment failure in an unrelated cache-stats test. The two new cases were then run directly and passed.

## Review notes

The response and log intentionally share one computed flag so they cannot drift. This PR does not change the existing lightweight `ToolEnvelope.isError` classifier or any MCP wire shape beyond correcting `isError`.
