### PR TITLE
Redact secret tool arguments across agent surfaces

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5384,23 +5384,27 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                                 )
                             }
                         }
+                        // History + host logs use the recorded (secret-safe)
+                        // argument view; ToolRegistry.execute still saw the
+                        // original via the batch executor above.
                         assistantToolCalls.append(
-                            ToolCall(
+                            SecretArgumentScrubber.recordedToolCall(
                                 id: outcome.callId,
-                                type: "function",
-                                function: ToolCallFunction(
-                                    name: outcome.invocation.toolName,
-                                    arguments: outcome.invocation.jsonArguments
-                                )
+                                invocation: outcome.invocation
                             )
                         )
                         toolResultsByCallId.append((outcome.callId, outcome.result))
-                        // Host-only: full tool detail (args + result). The peer
-                        // still sees only the sanitized SSE trace emitted above.
+                        // Host-only tool detail (args + result). Args are the
+                        // recorded view so sandbox_secret_set values never
+                        // re-enter Insights / agent-run logs. The peer still
+                        // sees only the sanitized SSE trace emitted above.
                         loggedToolCalls.append(
                             ToolCallLog(
                                 name: outcome.invocation.toolName,
-                                arguments: outcome.invocation.jsonArguments,
+                                arguments: SecretArgumentScrubber.recordedArguments(
+                                    toolName: outcome.invocation.toolName,
+                                    argumentsJSON: outcome.invocation.jsonArguments
+                                ),
                                 result: outcome.result,
                                 isError: outcome.wasError
                             )

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -463,7 +463,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
     static func serializeResponseForLog(_ response: ChatCompletionResponse) -> String? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(response),
+        let recorded = SecretArgumentScrubber.recordedResponse(response)
+        guard let data = try? encoder.encode(recorded),
             let s = String(data: data, encoding: .utf8)
         else { return nil }
         return s
@@ -516,11 +517,15 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         toolInvocation: (name: String, args: String)?
     ) -> String? {
         if let (name, args) = toolInvocation {
+            let recordedArgs = SecretArgumentScrubber.recordedArguments(
+                toolName: name,
+                argumentsJSON: args
+            )
             // Try to embed `args` as a parsed JSON object so the UI can
             // pretty-print it; fall back to a string if it isn't valid JSON.
             let argsValue: Any =
-                (args.data(using: .utf8)
-                    .flatMap { try? JSONSerialization.jsonObject(with: $0) }) ?? args
+                (recordedArgs.data(using: .utf8)
+                    .flatMap { try? JSONSerialization.jsonObject(with: $0) }) ?? recordedArgs
             let envelope: [String: Any] = [
                 "tool_calls": [["name": name, "arguments": argsValue]]
             ]
@@ -534,6 +539,28 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             }
         }
         return accumulated.isEmpty ? nil : accumulated
+    }
+
+    /// Raw provider responses can contain model-emitted secret arguments.
+    /// Omit that diagnostic snapshot for secret-setting calls; the structured
+    /// response and tool-call log remain available in redacted form.
+    static func wireResponseBodyForLog(
+        _ body: Data?,
+        parsedToolNames: [String],
+        secretToolWasExposed: Bool
+    ) -> Data? {
+        guard let body, !body.isEmpty else { return nil }
+        // Fail closed when the request exposed the secret-setting capability:
+        // malformed provider output may defeat invocation parsing while still
+        // leaving raw secret material in the captured response. Also inspect
+        // every parsed invocation because a batch may place the secret call
+        // after an ordinary tool.
+        guard !secretToolWasExposed,
+            !parsedToolNames.contains(where: SecretArgumentScrubber.isSecretSetToolName(_:))
+        else {
+            return nil
+        }
+        return body
     }
 
     private static func canonicalToolArgumentsJSON(
@@ -713,7 +740,13 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 temperature: temperature,
                 maxTokens: maxTokens,
                 toolCalls: invocations.map {
-                    ToolCallLog(name: $0.toolName, arguments: $0.jsonArguments)
+                    ToolCallLog(
+                        name: $0.toolName,
+                        arguments: SecretArgumentScrubber.recordedArguments(
+                            toolName: $0.toolName,
+                            argumentsJSON: $0.jsonArguments
+                        )
+                    )
                 },
                 finishReason: .toolCalls,
                 requestBody: requestBodyJSON,
@@ -811,6 +844,10 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             // Capture the request body up-front so the producer task does not
             // need to retain `request` (a non-Sendable in Swift 6 strict mode).
             let requestBodyJSON = source == .chatUI ? Self.serializeRequestForLog(request) : nil
+            let secretToolWasExposed =
+                request.tools?.contains {
+                    SecretArgumentScrubber.isSecretSetToolName($0.function.name)
+                } ?? false
             // `turnId` is a Sendable UUID, so capturing it (unlike `request`)
             // is safe for the detached producer — correlates the log back to
             // the chat assistant turn for the per-message Insights button.
@@ -829,7 +866,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 requestBodyJSON: requestBodyJSON,
                 connection: remoteConn?.info,
                 logPath: remoteConn?.path,
-                wireProbe: wireProbe
+                wireProbe: wireProbe,
+                secretToolWasExposed: secretToolWasExposed
             )
 
         case .none:
@@ -962,7 +1000,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         requestBodyJSON: String? = nil,
         connection: RequestConnectionInfo? = nil,
         logPath: String? = nil,
-        wireProbe: WireTransportProbe? = nil
+        wireProbe: WireTransportProbe? = nil,
+        secretToolWasExposed: Bool = false
     ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
 
@@ -1031,6 +1070,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             var finishReason: InferenceLog.FinishReason = .stop
             var errorMsg: String? = nil
             var toolInvocation: (name: String, args: String)? = nil
+            var parsedToolNames: [String] = []
             var lastDeltaTime = startTime
             // Accumulate the streamed assistant text so the Insights Response
             // tab can show what was produced. Only retained when logging is
@@ -1182,6 +1222,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 }
             } catch let invs as ServiceToolInvocations {
                 print("[Osaurus][Stream] Tool invocations (batch): count=\(invs.invocations.count)")
+                parsedToolNames = invs.invocations.map(\.toolName)
                 if let first = invs.invocations.first {
                     toolInvocation = (first.toolName, first.jsonArguments)
                 }
@@ -1189,6 +1230,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 continuation.finish(throwing: invs)
             } catch let inv as ServiceToolInvocation {
                 print("[Osaurus][Stream] Tool invocation: \(inv.toolName)")
+                parsedToolNames = [inv.toolName]
                 toolInvocation = (inv.toolName, inv.jsonArguments)
                 finishReason = .toolCalls
                 continuation.finish(throwing: inv)
@@ -1208,7 +1250,17 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             // Log the completed inference (only for Chat UI - HTTP requests are logged by HTTPHandler)
             if source == .chatUI {
                 let durationMs = Date().timeIntervalSince(startTime) * 1000
-                let toolCallsLog = toolInvocation.map { [ToolCallLog(name: $0.name, arguments: $0.args)] }
+                let toolCallsLog = toolInvocation.map {
+                    [
+                        ToolCallLog(
+                            name: $0.name,
+                            arguments: SecretArgumentScrubber.recordedArguments(
+                                toolName: $0.name,
+                                argumentsJSON: $0.args
+                            )
+                        )
+                    ]
+                }
 
                 // Snapshot the real wire bytes (post-scrub request + raw
                 // pre-unscrub response) so the Insights "Server" toggle shows
@@ -1236,7 +1288,11 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         toolInvocation: toolInvocation
                     ),
                     wireRequestBody: wireSnapshot?.request,
-                    wireResponseBody: (wireSnapshot?.response).flatMap { $0.isEmpty ? nil : $0 },
+                    wireResponseBody: Self.wireResponseBodyForLog(
+                        wireSnapshot?.response,
+                        parsedToolNames: parsedToolNames,
+                        secretToolWasExposed: secretToolWasExposed
+                    ),
                     connection: connection,
                     path: logPath ?? "/chat/completions"
                 )

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1527,11 +1527,17 @@ final class PluginHostContext: @unchecked Sendable {
                         // The non-streaming path appends the full assistant
                         // message (with all tool_calls) once; the per-call
                         // hooks then append only the tool-result messages.
+                        // Recorded history gets the secret-safe argument view
+                        // so sandbox_secret_set values never re-enter the
+                        // multi-turn context; execution still uses the raw
+                        // invocations built from the model's original args.
                         // The iteration cap is owned by the DRIVER (same
                         // taxonomy as the HTTP surface): the final
                         // iteration's calls still execute, then the loop
                         // exits `.iterationCapReached`.
-                        messages.append(choice.message)
+                        messages.append(
+                            SecretArgumentScrubber.recordedAssistantMessage(choice.message)
+                        )
                         return .toolCalls(
                             calls.map {
                                 ServiceToolInvocation(
@@ -1968,12 +1974,17 @@ final class PluginHostContext: @unchecked Sendable {
                 },
                 willProcessCall: { inv, callId in
                     // Surface the tool call to the plugin before the dedupe
-                    // check, exactly as the historical batch processor did.
+                    // check. Streamed argument material uses the recorded
+                    // (secret-safe) view; execution still sees raw args.
+                    let recordedArgs = SecretArgumentScrubber.recordedArguments(
+                        toolName: inv.toolName,
+                        argumentsJSON: inv.jsonArguments
+                    )
                     let tcDelta: [String: Any] = [
                         "tool_calls": [
                             [
                                 "id": callId,
-                                "function": ["name": inv.toolName, "arguments": inv.jsonArguments],
+                                "function": ["name": inv.toolName, "arguments": recordedArgs],
                             ]
                         ]
                     ]
@@ -1983,7 +1994,8 @@ final class PluginHostContext: @unchecked Sendable {
                     // Dedupe a still-fresh re-read: replay the exact held
                     // envelope instead of re-running the read. Still pair an
                     // assistant tool_call message with the tool result so
-                    // history stays valid.
+                    // history stays valid. Arguments on the recorded
+                    // assistant message are the secret-safe view.
                     emit(
                         Self.chunkPayload(
                             id: cid,
@@ -1995,13 +2007,9 @@ final class PluginHostContext: @unchecked Sendable {
                             role: "assistant",
                             content: lastContent.isEmpty ? nil : lastContent,
                             tool_calls: [
-                                ToolCall(
+                                SecretArgumentScrubber.recordedToolCall(
                                     id: callId,
-                                    type: "function",
-                                    function: ToolCallFunction(
-                                        name: inv.toolName,
-                                        arguments: inv.jsonArguments
-                                    )
+                                    invocation: inv
                                 )
                             ],
                             tool_call_id: nil
@@ -2174,6 +2182,11 @@ final class PluginHostContext: @unchecked Sendable {
 
     /// Execute one tool call, post-process the result, and produce the
     /// assistant + tool ChatMessages to append to the running history.
+    ///
+    /// Execution receives the original `argumentsJSON`. The assistant
+    /// tool-call message that re-enters multi-turn history uses the
+    /// recorded (secret-safe) argument view so `sandbox_secret_set`
+    /// values never ride the next model step or plugin-visible material.
     /// The tool schema is intentionally NOT mutated here — see the
     /// deferred-schema policy in `postProcessToolResult`.
     private static func processToolCall(
@@ -2183,6 +2196,7 @@ final class PluginHostContext: @unchecked Sendable {
         priorAssistantContent: String,
         prep: PreparedInference
     ) async -> ToolCallProcessing {
+        // Execution seam: original arguments, including any secret value.
         var result = await Self.executeToolCall(
             name: toolName,
             argumentsJSON: argumentsJSON,
@@ -2196,10 +2210,15 @@ final class PluginHostContext: @unchecked Sendable {
         )
         result = postProcessed.result
 
+        // Recording seam: secret-safe args for history / model re-feed.
+        let material = ToolCallArgumentMaterial.split(
+            toolName: toolName,
+            argumentsJSON: argumentsJSON
+        )
         let toolCall = ToolCall(
             id: callId,
             type: "function",
-            function: ToolCallFunction(name: toolName, arguments: argumentsJSON)
+            function: ToolCallFunction(name: toolName, arguments: material.forRecording)
         )
         let assistantMessage = ChatMessage(
             role: "assistant",

--- a/Packages/OsaurusCore/Tests/Service/ToolExecutionScopeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ToolExecutionScopeTests.swift
@@ -100,17 +100,28 @@ struct ToolExecutionScopeWiringTests {
         let src = try Self.source("Tools/ToolRegistry.swift")
 
         guard
-            let strip = src.range(of: #"if toolsByName[name] == nil, name.hasPrefix("tool/")"#),
-            let check = src.range(of: "ChatExecutionContext.toolExecutionScope")
+            let execute = src.range(
+                of: "func execute(\n        name rawName: String,"
+            )
         else {
-            Issue.record("could not locate the normalization or the check")
+            Issue.record("could not locate ToolRegistry.execute")
+            return
+        }
+        let executeBody = src[execute.lowerBound...]
+        guard
+            let normalization = executeBody.range(
+                of: "let name = resolvedRegisteredName(for: rawName)"
+            ),
+            let check = executeBody.range(of: "ChatExecutionContext.toolExecutionScope")
+        else {
+            Issue.record("could not locate the normalization or the exposure check")
             return
         }
 
         // Checking the RAW name would let the model bypass the whole allowlist by prefixing a
         // name it was never given: `tool/sandbox_exec` normalizes to `sandbox_exec` afterwards.
         #expect(
-            strip.lowerBound < check.lowerBound,
+            normalization.lowerBound < check.lowerBound,
             "the allowlist must be checked on the NORMALIZED name, or `tool/` walks straight past it"
         )
     }

--- a/Packages/OsaurusCore/Tests/Tool/SecretContainmentTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SecretContainmentTests.swift
@@ -5,9 +5,10 @@
 //  Pins the two secret-containment layers added by the round-2 audit:
 //   - `SecretScrubber`: known secret VALUES are redacted from exec
 //     stdout/stderr before they reach the model's context.
-//   - `SecretArgumentScrubber`: the direct-`value` path of
-//     `sandbox_secret_set` never persists the secret in the recorded
-//     tool-call arguments.
+//   - `SecretArgumentScrubber` / `ToolCallArgumentMaterial`: the direct-
+//     `value` path of `sandbox_secret_set` reaches the execution seam
+//     intact, but never re-enters recorded / model-visible / plugin-
+//     visible tool-call material.
 //
 
 import Foundation
@@ -61,15 +62,19 @@ struct SecretScrubberTests {
 
 struct SecretArgumentScrubberTests {
 
+    private let secret = "sk-live-secret-xyz-containment"
+    private var secretSetArgs: String {
+        """
+        {"key":"API_KEY","description":"d","instructions":"i","value":"\(secret)"}
+        """
+    }
+
     @Test func valueIsRedactedForSandboxSecretSet() throws {
-        let args = """
-            {"key":"API_KEY","description":"d","instructions":"i","value":"sk-live-12345"}
-            """
         let scrubbed = SecretArgumentScrubber.scrubForPersistence(
             toolName: "sandbox_secret_set",
-            argumentsJSON: args
+            argumentsJSON: secretSetArgs
         )
-        #expect(!scrubbed.contains("sk-live-12345"))
+        #expect(!scrubbed.contains(secret))
 
         let dict =
             try JSONSerialization.jsonObject(with: Data(scrubbed.utf8)) as? [String: Any]
@@ -85,6 +90,7 @@ struct SecretArgumentScrubberTests {
             toolName: "file_write",
             argumentsJSON: args
         )
+        // Byte-equivalent for every tool other than sandbox_secret_set.
         #expect(scrubbed == args)
     }
 
@@ -98,7 +104,8 @@ struct SecretArgumentScrubberTests {
     }
 
     @Test func alreadyRedactedArgsAreStable() {
-        let args = #"{"key":"API_KEY","value":"[REDACTED]"}"#
+        let args =
+            #"{"key":"API_KEY","description":"d","instructions":"i","value":"[REDACTED]"}"#
         let scrubbed = SecretArgumentScrubber.scrubForPersistence(
             toolName: "sandbox_secret_set",
             argumentsJSON: args
@@ -106,13 +113,319 @@ struct SecretArgumentScrubberTests {
         #expect(scrubbed == args)
     }
 
-    @Test func malformedArgumentsPassThrough() {
-        let args = "not json at all"
-        let scrubbed = SecretArgumentScrubber.scrubForPersistence(
+    @Test func unknownNestedFieldsFailClosed() {
+        // `additionalProperties` is false. An unknown field can carry a
+        // second secret copy even when the top-level value is redacted.
+        let args = """
+            {"key":"API_KEY","description":"d","instructions":"i","value":"\(secret)","meta":{"value":"nested-lookalike","note":"keep"}}
+            """
+        let scrubbed = SecretArgumentScrubber.recordedArguments(
             toolName: "sandbox_secret_set",
             argumentsJSON: args
         )
-        #expect(scrubbed == args)
+        #expect(!scrubbed.contains(secret))
+        #expect(!scrubbed.contains("nested-lookalike"))
+        #expect(scrubbed == SecretArgumentScrubber.failClosedArgumentsJSON)
+    }
+
+    @Test func malformedSecretSetJSONFailsClosedAndNeverEmitsOriginal() {
+        // Truncated / non-JSON payloads may still contain the secret as
+        // raw text. Fail closed rather than echoing the original input.
+        let malformed = #"{"key":"API_KEY","value":"\#(secret)"#
+        let scrubbed = SecretArgumentScrubber.scrubForPersistence(
+            toolName: "sandbox_secret_set",
+            argumentsJSON: malformed
+        )
+        #expect(scrubbed != malformed)
+        #expect(!scrubbed.contains(secret))
+        #expect(scrubbed.contains("[REDACTED]"))
+        #expect(scrubbed == SecretArgumentScrubber.failClosedArgumentsJSON)
+    }
+
+    @Test func nonObjectJSONFailsClosed() {
+        let arrayPayload = #"[{"value":"\#(secret)"}]"#
+        let scrubbed = SecretArgumentScrubber.recordedArguments(
+            toolName: "sandbox_secret_set",
+            argumentsJSON: arrayPayload
+        )
+        #expect(!scrubbed.contains(secret))
+        #expect(scrubbed == SecretArgumentScrubber.failClosedArgumentsJSON)
+    }
+
+    @Test func nonStringValueIsRedacted() throws {
+        let args =
+            #"{"key":"API_KEY","description":"d","instructions":"i","value":{"token":"nested-secret-blob"}}"#
+        let scrubbed = SecretArgumentScrubber.recordedArguments(
+            toolName: "sandbox_secret_set",
+            argumentsJSON: args
+        )
+        #expect(!scrubbed.contains("nested-secret-blob"))
+        #expect(scrubbed == SecretArgumentScrubber.failClosedArgumentsJSON)
+    }
+
+    @Test func directSecretDuplicatedInAllowedSiblingFieldsIsRedactedEverywhere() {
+        let args =
+            #"{"key":"API_\#(secret)","description":"credential \#(secret)","instructions":"paste \#(secret)","value":"\#(secret)"}"#
+        let scrubbed = SecretArgumentScrubber.recordedArguments(
+            toolName: "sandbox_secret_set",
+            argumentsJSON: args
+        )
+        #expect(!scrubbed.contains(secret))
+        #expect(scrubbed.components(separatedBy: "[REDACTED]").count == 5)
+    }
+
+    @Test func capabilityAliasIsRedacted() {
+        let scrubbed = SecretArgumentScrubber.recordedArguments(
+            toolName: "tool/sandbox_secret_set",
+            argumentsJSON: secretSetArgs
+        )
+        #expect(!scrubbed.contains(secret))
+        #expect(scrubbed.contains("[REDACTED]"))
+    }
+
+    @Test func splitKeepsSecretOnExecutionViewOnly() {
+        let material = ToolCallArgumentMaterial.split(
+            toolName: "sandbox_secret_set",
+            argumentsJSON: secretSetArgs
+        )
+        // Execution seam must still see the real secret.
+        #expect(material.forExecution == secretSetArgs)
+        #expect(material.forExecution.contains(secret))
+        // Recording seam must never reintroduce it.
+        #expect(!material.forRecording.contains(secret))
+        #expect(material.forRecording.contains("[REDACTED]"))
+    }
+
+    @Test func recordedToolCallUsesSecretSafeArguments() {
+        let inv = ServiceToolInvocation(
+            toolName: "sandbox_secret_set",
+            jsonArguments: secretSetArgs,
+            toolCallId: "call_secret_1"
+        )
+        let call = SecretArgumentScrubber.recordedToolCall(id: "call_secret_1", invocation: inv)
+        #expect(call.function.name == "sandbox_secret_set")
+        #expect(!call.function.arguments.contains(secret))
+        #expect(call.function.arguments.contains("[REDACTED]"))
+        // Original invocation is unchanged for ToolRegistry.execute.
+        #expect(inv.jsonArguments.contains(secret))
+    }
+
+    @Test func recordedAssistantMessageScrubsSecretSetOnly() {
+        let secretCall = ToolCall(
+            id: "call_1",
+            type: "function",
+            function: ToolCallFunction(name: "sandbox_secret_set", arguments: secretSetArgs)
+        )
+        let otherArgs = #"{"path":"/tmp/notes.txt","value":"not-a-secret-field"}"#
+        let otherCall = ToolCall(
+            id: "call_2",
+            type: "function",
+            function: ToolCallFunction(name: "file_write", arguments: otherArgs)
+        )
+        let message = ChatMessage(
+            role: "assistant",
+            content: nil,
+            tool_calls: [secretCall, otherCall],
+            tool_call_id: nil
+        )
+        let recorded = SecretArgumentScrubber.recordedAssistantMessage(message)
+        let calls = recorded.tool_calls ?? []
+        #expect(calls.count == 2)
+        #expect(!calls[0].function.arguments.contains(secret))
+        #expect(calls[0].function.arguments.contains("[REDACTED]"))
+        // Unrelated tool keeps exact argument text.
+        #expect(calls[1].function.arguments == otherArgs)
+    }
+
+    @Test func completionAndInsightsHelpersNeverReemitSecretArguments() throws {
+        let aliasCall = ToolCall(
+            id: "call_alias",
+            type: "function",
+            function: ToolCallFunction(
+                name: "tool/sandbox_secret_set",
+                arguments: secretSetArgs
+            )
+        )
+        let response = ChatCompletionResponse(
+            id: "response-secret",
+            created: 1,
+            model: "test",
+            choices: [
+                ChatChoice(
+                    index: 0,
+                    message: ChatMessage(
+                        role: "assistant",
+                        content: nil,
+                        tool_calls: [aliasCall],
+                        tool_call_id: nil
+                    ),
+                    finish_reason: "tool_calls"
+                )
+            ],
+            usage: Usage(prompt_tokens: 1, completion_tokens: 0, total_tokens: 1)
+        )
+
+        let serialized = try #require(ChatEngine.serializeResponseForLog(response))
+        #expect(!serialized.contains(secret))
+        #expect(serialized.contains("[REDACTED]"))
+
+        let streamed = try #require(
+            ChatEngine.streamResponseBody(
+                accumulated: "",
+                toolInvocation: ("tool/sandbox_secret_set", secretSetArgs)
+            )
+        )
+        #expect(!streamed.contains(secret))
+        #expect(streamed.contains("[REDACTED]"))
+
+        #expect(
+            ChatEngine.wireResponseBodyForLog(
+                Data(#"{"arguments":"raw-secret"}"#.utf8),
+                parsedToolNames: ["tool/sandbox_secret_set"],
+                secretToolWasExposed: false
+            ) == nil
+        )
+        // Batch parsing must inspect every call, not just the first.
+        #expect(
+            ChatEngine.wireResponseBodyForLog(
+                Data(#"{"arguments":"raw-secret"}"#.utf8),
+                parsedToolNames: ["file_read", "sandbox_secret_set"],
+                secretToolWasExposed: false
+            ) == nil
+        )
+        // Even malformed output that never yields a parsed invocation is
+        // unsafe when the request exposed the secret-setting capability.
+        #expect(
+            ChatEngine.wireResponseBodyForLog(
+                Data(#"{"malformed":"raw-secret""#.utf8),
+                parsedToolNames: [],
+                secretToolWasExposed: true
+            ) == nil
+        )
+        #expect(
+            ChatEngine.wireResponseBodyForLog(
+                Data(#"{"content":"safe"}"#.utf8),
+                parsedToolNames: ["file_read"],
+                secretToolWasExposed: false
+            ) == Data(#"{"content":"safe"}"#.utf8)
+        )
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct SecretAliasPermissionTests {
+    private struct AliasGateFixture: OsaurusTool {
+        let name = "secret_alias_permission_fixture"
+        let description = "Permission alias regression fixture"
+        let parameters: JSONValue? = .object(["type": .string("object")])
+
+        func execute(argumentsJSON: String) async throws -> String {
+            ToolEnvelope.success(tool: name, text: "should not execute")
+        }
+    }
+
+    @Test func capabilityAliasUsesCanonicalPermissionPolicy() async {
+        let registry = ToolRegistry.shared
+        let fixture = AliasGateFixture()
+        registry.registerPluginTool(fixture)
+        registry.setPolicy(.deny, for: fixture.name)
+        defer {
+            registry.clearPolicy(for: fixture.name)
+            registry.unregister(names: [fixture.name])
+        }
+
+        do {
+            try await registry.resolvePermissionGate(
+                name: "tool/\(fixture.name)",
+                argumentsJSON: "{}"
+            )
+            Issue.record("Capability alias bypassed the canonical tool's deny policy")
+        } catch {
+            let nsError = error as NSError
+            #expect(nsError.code == 6)
+            #expect(nsError.localizedDescription.contains(fixture.name))
+        }
+    }
+}
+
+/// Pins the production call sites, not hand-built copies of them. The pure
+/// scrubber tests above prove the transformation; these checks fail if a
+/// surface later bypasses it and records raw `jsonArguments` again.
+struct SecretArgumentSurfaceWiringTests {
+    private func source(_ relativePath: String) throws -> String {
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Tool
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // OsaurusCore
+        return try String(
+            contentsOf: coreRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    @Test func chatHTTPRegistryAndPluginSurfacesUseRecordedArguments() throws {
+        let chat = try source("Views/Chat/ChatView.swift")
+        #expect(chat.contains("SecretArgumentScrubber.recordedToolCall("))
+        #expect(chat.contains("let recordedArgs = SecretArgumentScrubber.recordedArguments("))
+
+        let http = try source("Networking/HTTPHandler.swift")
+        #expect(http.contains("SecretArgumentScrubber.recordedToolCall("))
+        #expect(http.contains("arguments: SecretArgumentScrubber.recordedArguments("))
+
+        let registry = try source("Tools/ToolRegistry.swift")
+        #expect(registry.contains("let approvalArgumentsJSON = SecretArgumentScrubber.recordedArguments("))
+        #expect(registry.contains("let safeArguments = SecretArgumentScrubber.recordedArguments("))
+
+        let plugin = try source("Services/Plugin/PluginHostAPI.swift")
+        #expect(plugin.contains("SecretArgumentScrubber.recordedAssistantMessage("))
+        #expect(plugin.contains("let recordedArgs = SecretArgumentScrubber.recordedArguments("))
+        #expect(plugin.contains("SecretArgumentScrubber.recordedToolCall("))
+        #expect(plugin.contains("let material = ToolCallArgumentMaterial.split("))
+    }
+}
+
+/// End-to-end execution seam: the real secret reaches the tool body while
+/// the recorded view stays redacted.
+struct SecretArgumentExecutionSeamTests {
+
+    @Test func realSecretReachesExecutionWhileRecordingIsRedacted() async throws {
+        let secret = "tok-exec-seam-roundtrip-77"
+        let argsDict: [String: Any] = [
+            "key": "EVAL_API_TOKEN",
+            "description": "d",
+            "instructions": "i",
+            "value": secret,
+        ]
+        let argsJSON = String(
+            data: try JSONSerialization.data(withJSONObject: argsDict),
+            encoding: .utf8
+        )!
+        let material = ToolCallArgumentMaterial.split(
+            toolName: "sandbox_secret_set",
+            argumentsJSON: argsJSON
+        )
+        #expect(material.forExecution.contains(secret))
+        #expect(!material.forRecording.contains(secret))
+        #expect(material.forRecording.contains("[REDACTED]"))
+
+        try await AgentSecretsKeychain._withInMemoryStoreForTesting {
+            let agentId = UUID()
+            let tool = SandboxSecretSetTool(agentId: agentId.uuidString)
+            // Execution seam receives the unredacted payload.
+            let result = try await tool.execute(argumentsJSON: material.forExecution)
+            let payload =
+                try JSONSerialization.jsonObject(with: Data(result.utf8)) as! [String: Any]
+            #expect(payload["ok"] as? Bool == true)
+            let stored = payload["result"] as? [String: Any]
+            #expect(stored?["stored"] as? Bool == true)
+            // Keychain (in-memory under this harness) holds the real secret.
+            #expect(
+                AgentSecretsKeychain.getSecret(id: "EVAL_API_TOKEN", agentId: agentId) == secret
+            )
+            // Recorded material still must not contain it.
+            #expect(!material.forRecording.contains(secret))
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Tools/SandboxSecretTools.swift
+++ b/Packages/OsaurusCore/Tools/SandboxSecretTools.swift
@@ -235,30 +235,118 @@ enum SecretToolResult {
 
 // MARK: - Persisted-Argument Scrubbing
 
+/// Execution vs recording views of one tool-call argument payload.
+///
+/// The direct `value` path of `sandbox_secret_set` must reach
+/// `ToolRegistry.execute` intact so Keychain can store the secret, but the
+/// same JSON must never re-enter model-visible history, plugin SSE,
+/// persistence, or host tool-call logs. Surfaces that need both forms call
+/// `split` so the execution/recording boundary is explicit and hard to invert.
+struct ToolCallArgumentMaterial: Sendable, Equatable {
+    /// Byte-identical arguments for execution and permission gates.
+    let forExecution: String
+    /// Arguments safe for history, model re-feed, SSE deltas, and logs.
+    let forRecording: String
+
+    /// Build both views from the raw model-emitted arguments.
+    static func split(toolName: String, argumentsJSON: String) -> ToolCallArgumentMaterial {
+        ToolCallArgumentMaterial(
+            forExecution: argumentsJSON,
+            forRecording: SecretArgumentScrubber.recordedArguments(
+                toolName: toolName,
+                argumentsJSON: argumentsJSON
+            )
+        )
+    }
+}
+
 /// Scrubs the secret `value` out of `sandbox_secret_set` tool-call
-/// arguments before they land in chat history / persistence.
+/// arguments before they land in recorded / model-visible / plugin-visible
+/// material.
 ///
 /// The direct-`value` path stores the secret in Keychain correctly, but
 /// the model's tool-call arguments would otherwise ride along in every
 /// later context window and in the persisted session file — defeating
 /// the Keychain. Execution always sees the original arguments; only the
-/// RECORDED copy is scrubbed.
+/// RECORDED copy is scrubbed. Scrubbing fails closed: malformed or
+/// non-serializable `sandbox_secret_set` payloads never re-emit the
+/// original input.
 public enum SecretArgumentScrubber {
     static let redactedPlaceholder = "[REDACTED]"
+    private static let allowedSecretSetKeys: Set<String> = [
+        "key", "description", "instructions", "value",
+    ]
+
+    /// Fail-closed stub used when `sandbox_secret_set` arguments cannot be
+    /// parsed or re-serialized without risk of re-emitting a secret.
+    static let failClosedArgumentsJSON = #"{"value":"[REDACTED]"}"#
+
+    /// Arguments JSON safe for recorded/model-visible/persisted surfaces.
+    /// Non-`sandbox_secret_set` tools return the input byte-for-byte.
+    static func recordedArguments(toolName: String, argumentsJSON: String) -> String {
+        scrubForPersistence(toolName: toolName, argumentsJSON: argumentsJSON)
+    }
 
     /// Returns scrubbed arguments JSON for `sandbox_secret_set` calls
-    /// that carry a non-empty `value`; every other input is returned
-    /// unchanged.
+    /// that carry a secret-bearing `value`; every other *tool* returns its
+    /// input unchanged. For `sandbox_secret_set` itself, unparseable or
+    /// non-serializable payloads fail closed rather than echoing the
+    /// original text (which may still contain a secret).
     public static func scrubForPersistence(toolName: String, argumentsJSON: String) -> String {
-        guard toolName == "sandbox_secret_set",
-            let data = argumentsJSON.data(using: .utf8),
-            var args = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-            let value = args["value"] as? String,
-            !value.isEmpty,
-            value != redactedPlaceholder
-        else { return argumentsJSON }
+        let recordedName = ToolRegistry.deferredToolAliasTarget(toolName) ?? toolName
+        guard recordedName == "sandbox_secret_set" else { return argumentsJSON }
 
-        args["value"] = redactedPlaceholder
+        // Malformed / non-object JSON may still embed a secret as raw text.
+        // Never re-emit the original payload for this tool.
+        guard let data = argumentsJSON.data(using: .utf8),
+            var args = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else {
+            return failClosedArgumentsJSON
+        }
+
+        // The tool schema forbids unknown fields and requires these three
+        // strings. Preserve only structurally valid prompt/direct-call
+        // payloads; malformed objects can hide a second copy of the secret
+        // under an ignored nested or extra field.
+        guard Set(args.keys).isSubset(of: allowedSecretSetKeys),
+            args["key"] is String,
+            args["description"] is String,
+            args["instructions"] is String
+        else {
+            return failClosedArgumentsJSON
+        }
+
+        guard let rawValue = args["value"] else {
+            // Valid prompt path (no direct value) — leave byte-identical.
+            return argumentsJSON
+        }
+
+        if let value = rawValue as? String {
+            // Empty / already-redacted values need no rewrite.
+            guard !value.isEmpty, value != redactedPlaceholder else {
+                return argumentsJSON
+            }
+            // The model can duplicate the direct secret into another
+            // schema-valid string field. Redacting only `value` would then
+            // preserve the same credential in recorded history. Replace the
+            // exact known value everywhere in the retained object before
+            // serializing it.
+            for key in ["key", "description", "instructions"] {
+                if let string = args[key] as? String {
+                    args[key] = string.replacingOccurrences(
+                        of: value,
+                        with: redactedPlaceholder
+                    )
+                }
+            }
+            args["value"] = redactedPlaceholder
+        } else {
+            // A non-string `value` is outside the tool contract. We do not
+            // have a trustworthy scalar to scrub from sibling fields, so
+            // retain none of them.
+            return failClosedArgumentsJSON
+        }
+
         guard
             let scrubbed = try? JSONSerialization.data(
                 withJSONObject: args,
@@ -267,11 +355,106 @@ public enum SecretArgumentScrubber {
             let json = String(data: scrubbed, encoding: .utf8)
         else {
             // Re-serialization should never fail for a dict we just
-            // parsed; if it somehow does, fail CLOSED (drop the args
-            // entirely) rather than persisting the secret.
-            return "{\"value\":\"\(redactedPlaceholder)\"}"
+            // parsed; if it somehow does, fail CLOSED rather than
+            // persisting the secret.
+            return failClosedArgumentsJSON
         }
         return json
+    }
+
+    /// Whether a raw or capability-style tool name identifies the
+    /// secret-setting tool. Used to omit raw provider wire snapshots that
+    /// cannot be safely rewritten without changing their protocol shape.
+    static func isSecretSetToolName(_ toolName: String) -> Bool {
+        (ToolRegistry.deferredToolAliasTarget(toolName) ?? toolName) == "sandbox_secret_set"
+    }
+
+    /// Build a history/SSE-safe `ToolCall` from an execution invocation.
+    /// Use this whenever a surface materializes tool-call args into
+    /// history, plugin deltas, or logs; pass `invocation.jsonArguments`
+    /// unchanged to `ToolRegistry.execute`.
+    ///
+    /// Package-internal: takes `ServiceToolInvocation`, which is not part of
+    /// the public module surface.
+    static func recordedToolCall(
+        id: String,
+        invocation: ServiceToolInvocation
+    ) -> ToolCall {
+        ToolCall(
+            id: id,
+            type: "function",
+            function: ToolCallFunction(
+                name: invocation.toolName,
+                arguments: recordedArguments(
+                    toolName: invocation.toolName,
+                    argumentsJSON: invocation.jsonArguments
+                )
+            ),
+            geminiThoughtSignature: invocation.geminiThoughtSignature
+        )
+    }
+
+    /// Scrub every tool-call argument on an assistant message before it
+    /// enters multi-turn history. Used by the plugin non-stream path,
+    /// which appends the model's full `choice.message` (including raw
+    /// `tool_calls`) in one shot.
+    ///
+    /// Package-internal: takes `ChatMessage`, which is not part of the
+    /// public module surface.
+    static func recordedAssistantMessage(_ message: ChatMessage) -> ChatMessage {
+        guard let calls = message.tool_calls, !calls.isEmpty else { return message }
+        let scrubbed = calls.map { call in
+            ToolCall(
+                id: call.id,
+                type: call.type,
+                function: ToolCallFunction(
+                    name: call.function.name,
+                    arguments: recordedArguments(
+                        toolName: call.function.name,
+                        argumentsJSON: call.function.arguments
+                    )
+                ),
+                geminiThoughtSignature: call.geminiThoughtSignature
+            )
+        }
+        // Preserve identity when nothing secret-bearing was present so
+        // unrelated tools keep their exact argument text.
+        if zip(calls, scrubbed).allSatisfy({ $0.function.arguments == $1.function.arguments }) {
+            return message
+        }
+        return ChatMessage(
+            role: message.role,
+            content: message.content,
+            contentParts: message.contentParts,
+            localAudioSamples: message.localAudioSamples,
+            tool_calls: scrubbed,
+            tool_call_id: message.tool_call_id,
+            reasoning_content: message.reasoning_content,
+            reasoning_item_id: message.reasoning_item_id,
+            reasoning_encrypted: message.reasoning_encrypted
+        )
+    }
+
+    /// Copy a completion response for persistence while preserving transport
+    /// metadata and redacting only assistant tool-call arguments.
+    static func recordedResponse(_ response: ChatCompletionResponse) -> ChatCompletionResponse {
+        var recorded = ChatCompletionResponse(
+            id: response.id,
+            created: response.created,
+            model: response.model,
+            choices: response.choices.map {
+                ChatChoice(
+                    index: $0.index,
+                    message: recordedAssistantMessage($0.message),
+                    finish_reason: $0.finish_reason
+                )
+            },
+            usage: response.usage,
+            system_fingerprint: response.system_fingerprint
+        )
+        recorded.object = response.object
+        recorded.prefix_hash = response.prefix_hash
+        return recorded
     }
 }
 

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -540,7 +540,8 @@ public final class ToolRegistry: ObservableObject {
     /// Used by parallel tool batches: approvals resolve serially in model
     /// order first, then the approved set executes concurrently with
     /// `execute(..., permissionGateResolved: true)`.
-    func resolvePermissionGate(name: String, argumentsJSON: String) async throws {
+    func resolvePermissionGate(name rawName: String, argumentsJSON: String) async throws {
+        let name = resolvedRegisteredName(for: rawName)
         // External-surface deny happens BEFORE the gate so a denied tool
         // can never pop an approval prompt from an external request.
         if Self.isDeniedForCurrentSurface(name) {
@@ -557,10 +558,35 @@ public final class ToolRegistry: ObservableObject {
         try await runPermissionGate(tool: tool, name: name, argumentsJSON: argumentsJSON)
     }
 
+    /// Parse the capability-manifest alias syntax shared by permission
+    /// resolution, execution, and secret-recording classification.
+    nonisolated static func deferredToolAliasTarget(_ rawName: String) -> String? {
+        guard rawName.hasPrefix("tool/") else { return nil }
+        let target = String(rawName.dropFirst("tool/".count))
+        return target.isEmpty ? nil : target
+    }
+
+    /// Resolve an alias only when the raw name is not itself registered and
+    /// the bare target is. This preserves the (unusual but valid) possibility
+    /// of a plugin whose literal registered name starts with `tool/`.
+    private func resolvedRegisteredName(for rawName: String) -> String {
+        guard toolsByName[rawName] == nil,
+            let target = Self.deferredToolAliasTarget(rawName),
+            toolsByName[target] != nil
+        else {
+            return rawName
+        }
+        return target
+    }
+
     /// The permission gate shared by `execute` and `resolvePermissionGate`:
     /// system-permission prompts, the per-tool ask/deny/auto policy
     /// (including the user approval prompt), and `.auto` grant backfill.
     private func runPermissionGate(tool: OsaurusTool, name: String, argumentsJSON: String) async throws {
+        let approvalArgumentsJSON = SecretArgumentScrubber.recordedArguments(
+            toolName: name,
+            argumentsJSON: argumentsJSON
+        )
         if let permissioned = tool as? PermissionedTool {
             let requirements = permissioned.requirements
 
@@ -617,7 +643,7 @@ public final class ToolRegistry: ObservableObject {
                     approved = await ToolPermissionPromptService.requestApproval(
                         toolName: name,
                         description: tool.description,
-                        argumentsJSON: argumentsJSON
+                        argumentsJSON: approvalArgumentsJSON
                     )
                 }
                 if !approved {
@@ -665,7 +691,7 @@ public final class ToolRegistry: ObservableObject {
                     approved = await ToolPermissionPromptService.requestApproval(
                         toolName: name,
                         description: tool.description,
-                        argumentsJSON: argumentsJSON
+                        argumentsJSON: approvalArgumentsJSON
                     )
                 }
                 if !approved {
@@ -703,11 +729,7 @@ public final class ToolRegistry: ObservableObject {
         // Resolve to the model's real intent by stripping a `tool/` prefix when
         // the bare name isn't registered but the stripped one is, mirroring the
         // `tool/` handling in CapabilityTools.resolve.
-        var name = rawName
-        if toolsByName[name] == nil, name.hasPrefix("tool/") {
-            let stripped = String(name.dropFirst("tool/".count))
-            if toolsByName[stripped] != nil { name = stripped }
-        }
+        let name = resolvedRegisteredName(for: rawName)
 
         // A tool this request never exposed must not run, however convincingly the model asks
         // for it.
@@ -838,7 +860,11 @@ public final class ToolRegistry: ObservableObject {
                 // the tool name alone can't. Single-lined and truncated to
                 // bound log size and avoid dumping large tool payloads (file
                 // contents, shell scripts) verbatim into /tmp.
-                let flat = effectiveArgumentsJSON.replacingOccurrences(of: "\n", with: " ")
+                let safeArguments = SecretArgumentScrubber.recordedArguments(
+                    toolName: name,
+                    argumentsJSON: effectiveArgumentsJSON
+                )
+                let flat = safeArguments.replacingOccurrences(of: "\n", with: " ")
                 let argsForLog = flat.count > 200 ? String(flat.prefix(200)) + "…" : flat
                 PrefillDebugLog.shared.log("       TOOL-EXEC-BEGIN name=\(name) args=\(argsForLog)")
             }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4927,10 +4927,16 @@ final class ChatSession: ObservableObject {
                         callId: String
                     ) async -> AgentLoopToolExecution {
                         do {
-                            // Log tool execution start
-                            let truncatedArgs = inv.jsonArguments.prefix(200)
+                            // Never print a direct secret-set value to the
+                            // process log. Execution below still receives the
+                            // original arguments.
+                            let recordedArgs = SecretArgumentScrubber.recordedArguments(
+                                toolName: inv.toolName,
+                                argumentsJSON: inv.jsonArguments
+                            )
+                            let truncatedArgs = recordedArgs.prefix(200)
                             print(
-                                "[Osaurus][Tool] Executing: \(inv.toolName) with args: \(truncatedArgs)\(inv.jsonArguments.count > 200 ? "..." : "")"
+                                "[Osaurus][Tool] Executing: \(inv.toolName) with args: \(truncatedArgs)\(recordedArgs.count > 200 ? "..." : "")"
                             )
 
                             if executionMode.usesSandboxTools {
@@ -5458,20 +5464,11 @@ final class ChatSession: ObservableObject {
                             }
                         },
                         willProcessCall: { inv, callId in
-                            // The RECORDED copy of the args is scrubbed
-                            // (sandbox_secret_set `value` → [REDACTED]);
-                            // execution still sees the original `inv`.
-                            let call = ToolCall(
+                            // Recorded history uses the secret-safe view;
+                            // execution still receives the original `inv`.
+                            let call = SecretArgumentScrubber.recordedToolCall(
                                 id: callId,
-                                type: "function",
-                                function: ToolCallFunction(
-                                    name: inv.toolName,
-                                    arguments: SecretArgumentScrubber.scrubForPersistence(
-                                        toolName: inv.toolName,
-                                        argumentsJSON: inv.jsonArguments
-                                    )
-                                ),
-                                geminiThoughtSignature: inv.geminiThoughtSignature
+                                invocation: inv
                             )
                             assistantTurn.pendingToolName = nil
                             assistantTurn.clearPendingToolArgs()

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -519,7 +519,7 @@ The prompt path keeps secret values out of the conversation history and LLM cont
 Storing a secret is only half the problem — the other half is keeping its **value** out of the model context and the persisted transcript afterwards:
 
 - **Output scrubbing.** Agent secrets are injected into the exec environment, so `echo $KEY` would otherwise land the value in the model's context. `SecretScrubber` rewrites every known secret value in `sandbox_exec` stdout/stderr, background-job log tails, and sandbox-plugin tool output to `[REDACTED:<ENV_KEY>]` before the result is enveloped. Longer values scrub first (substring-safe); values under 6 characters are exempt to avoid false positives on ordinary output.
-- **Argument scrubbing.** When the agent uses the direct `value` path of `sandbox_secret_set`, the *recorded* copy of the tool-call arguments is rewritten (`value` → `[REDACTED]`) before it is persisted into chat history; execution still sees the original. The prompt path never carries the value through the model at all and remains the recommended flow — the tool description steers models toward it.
+- **Argument scrubbing.** When the agent uses the direct `value` path of `sandbox_secret_set`, the *recorded* copy of the tool-call arguments is rewritten (`value` → `[REDACTED]`) before it re-enters chat history, HTTP agent-run history, plugin complete/complete_stream history, or plugin streamed tool-call argument material; execution still sees the original. Malformed secret-set arguments fail closed rather than echoing the raw input. The prompt path never carries the value through the model at all and remains the recommended flow — the tool description steers models toward it.
 
 ---
 


### PR DESCRIPTION
## Summary

Keep direct `sandbox_secret_set` values available at the execution seam while removing them from every recorded, persisted, model-visible, plugin-visible, approval, and diagnostic surface.

## Why

The direct-value form of `sandbox_secret_set` is useful when an agent already holds a credential, but its raw tool arguments were reused after execution:

- in chat and agent-run history;
- in plugin events and SSE deltas;
- in approval prompts and debug logs;
- in Insights request/response/tool-call records; and
- in remote provider wire snapshots.

That allowed a value successfully moved into Keychain to be copied back into session history and later model context. Capability-style names such as `tool/sandbox_secret_set` also took a separate permission-resolution path, which made consistent policy and redaction harder to guarantee.

## Implementation

- Introduce an explicit two-view argument boundary:
  - execution receives the original arguments;
  - recording receives a fail-closed, secret-safe representation.
- Canonicalize registered `tool/...` aliases once for both permission checks and execution.
- Scrub `sandbox_secret_set` arguments across Chat, HTTP agent runs, plugins, approval UI, debug logs, and Insights.
- Preserve valid prompt-only calls byte-for-byte.
- For direct values, redact the exact value from every schema-valid sibling string as well as the `value` field.
- Reject malformed, unknown-field, nested, non-object, and non-string secret payloads to a minimal redacted object instead of re-emitting uncertain input.
- Omit raw provider response snapshots whenever the request exposed the secret-setting capability or any invocation in a parsed batch used it. This also covers malformed output that never becomes a parsed invocation.
- Keep unrelated tools byte-identical through the recording helper.

## Security invariants

1. `ToolRegistry.execute` still receives the unmodified secret.
2. The stored Keychain value remains usable by sandbox execution.
3. No post-execution argument/history/logging surface receives that value.
4. Alias spelling cannot bypass the canonical permission policy.
5. Ambiguous secret-tool payloads fail closed.

## Tests

Added and ran focused coverage for:

- direct-value execution versus recorded arguments;
- alias permission-policy enforcement;
- malformed, nested, unknown, non-object, and non-string payloads;
- a secret duplicated into `key`, `description`, and `instructions`;
- Chat, HTTP, registry, plugin, and Insights wiring;
- a secret call appearing second in a tool batch;
- a secret capability exposed in the request when provider output cannot be parsed;
- existing secret stdout/stderr scrubbing and Keychain store-honesty behavior.

Local result:

```text
swift test --package-path Packages/OsaurusCore \
  --filter 'SecretArgumentScrubberTests|SecretAliasPermissionTests|SecretArgumentExecutionSeamTests|SecretArgumentSurfaceWiringTests|SecretScrubberTests|SecretSetStoreHonestyTests|ToolExecutionScopeWiringTests'

✓ 27 tests in 7 suites passed
✓ git diff --check
```

The repository version at this base commit does not include the documented `evals-pr-evidence` Make target, so the normal CI `test-evals` lane is the available agent-loop regression gate for this PR.

## Review guide

The highest-value review points are:

- `SecretArgumentScrubber.scrubForPersistence` for fail-closed behavior;
- `ToolRegistry` for alias normalization and approval/execution parity;
- `ChatEngine.wireResponseBodyForLog` for batch and malformed-response handling; and
- each call site’s separation between execution arguments and recorded arguments.
