### PR TITLE
Reconcile temporary pairing keys after crashes

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -331,6 +331,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // as provider connection, model-picker bundle metadata scans,
         // scheduler DB polling, sandbox registration, or Parakeet/CoreML
         // auto-load can occupy the main actor or accelerator.
+        //
+        // ServerController centrally gates every bind (initial launch,
+        // restart, Settings, status panel, and App Intents) on crash-orphan
+        // reconciliation and readable revocation state.
         let serverStartupTask = Task { @MainActor in
             await serverController.startServer()
         }
@@ -1186,6 +1190,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             return .terminateLater
         }
         isTerminating = true
+        // Stop accepting new temporary pairing credentials as soon as ordered
+        // shutdown begins (before NIO teardown). Cleanup of already-tracked
+        // IDs runs after the server stops so no concurrent mint can race.
+        TemporaryPairedKeyStore.shared.beginShutdown()
 
         // Global watchdog: hard ceiling on the entire quit. Independent of
         // the ordered chain below, so it fires even if a step blocks the
@@ -1268,6 +1276,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             // false)`; the outer deadline is a backstop.
             await runWithDeadline(seconds: 4) {
                 await self.serverController.ensureShutdown()
+            }
+            // Temporary pairing cleanup runs only after the server has stopped
+            // accepting traffic. Failed durable deletes keep IDs tracked for
+            // the next launch — do not depend on willTerminate observer order.
+            await runWithDeadline(seconds: 4) {
+                await TemporaryPairedKeyStore.shared.cleanupTrackedKeysOnShutdownOffMain()
             }
             await runWithDeadline(seconds: 3) {
                 do {

--- a/Packages/OsaurusCore/Identity/APIKeyManager.swift
+++ b/Packages/OsaurusCore/Identity/APIKeyManager.swift
@@ -10,12 +10,47 @@
 import Foundation
 import LocalAuthentication
 
+private enum APIKeyPersistenceError: LocalizedError {
+    case metadataReadFailed
+    case metadataWriteFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .metadataReadFailed:
+            "Could not safely read existing access-key metadata."
+        case .metadataWriteFailed:
+            "Could not persist access-key metadata."
+        }
+    }
+}
+
+/// Result of a security-critical temporary API-key deletion.
+/// Internal only — not part of the public access-key management surface.
+enum TemporaryAPIKeyDeletionResult: Equatable, Sendable {
+    /// Key was absent after a successful metadata load, or was revoked and
+    /// removed with durable revocation + metadata persistence.
+    case succeeded
+    /// Metadata could not be loaded, durable revocation failed, or metadata
+    /// write failed. Callers must retain recovery tracking for this id.
+    case failed
+}
+
+/// Typed access-key metadata Keychain load for security-critical paths.
+private enum APIKeyMetadataLoad: Sendable {
+    case missing
+    case loaded([AccessKeyInfo])
+    case unavailable
+}
+
 public final class APIKeyManager: @unchecked Sendable {
     public static let shared = APIKeyManager()
 
     private let queue = DispatchQueue(label: "com.osaurus.api-keys", attributes: .concurrent)
     private var keys: [AccessKeyInfo] = []
     private var didLoadFromKeychain = false
+    /// Set when a security-critical load observed unavailable/corrupt metadata.
+    /// Prevents treating "could not read" as an empty key list for deletion.
+    private var metadataLoadUnavailable = false
 
     private static let keychainService = "com.osaurus.access-keys"
     private static let keychainAccount = "key-metadata"
@@ -35,7 +70,27 @@ public final class APIKeyManager: @unchecked Sendable {
         expiration: AccessKeyExpiration,
         agentIndex: UInt32? = nil
     ) throws -> (fullKey: String, info: AccessKeyInfo) {
-        ensureLoadedFromKeychain()
+        try generate(label: label, expiration: expiration, agentIndex: agentIndex, keyId: UUID())
+    }
+
+    /// Create a new access key with a caller-chosen metadata id.
+    ///
+    /// Temporary Bonjour pairing uses this after durably registering `keyId` in
+    /// `TemporaryPairedKeyStore`, so a crash between registration and mint
+    /// cannot leave an untracked long-lived credential (only an orphan id that
+    /// launch reconciliation deletes as a no-op).
+    func generate(
+        label: String,
+        expiration: AccessKeyExpiration,
+        agentIndex: UInt32?,
+        keyId: UUID
+    ) throws -> (fullKey: String, info: AccessKeyInfo) {
+        guard ensureLoadedFromKeychain() else {
+            // Never overwrite an inaccessible/corrupt metadata blob with a
+            // list containing only the new key. Temporary pairing depends on
+            // this read succeeding before minting.
+            throw APIKeyPersistenceError.metadataReadFailed
+        }
 
         let context = LAContext()
         context.touchIDAuthenticationAllowableReuseDuration = 300
@@ -85,7 +140,7 @@ public final class APIKeyManager: @unchecked Sendable {
         let fullKey = "osk-v1.\(payloadData.base64urlEncoded).\(signature.hexEncodedString)"
 
         let info = AccessKeyInfo(
-            id: UUID(),
+            id: keyId,
             label: label,
             prefix: String(fullKey.prefix(20)),
             nonce: nonce,
@@ -97,10 +152,22 @@ public final class APIKeyManager: @unchecked Sendable {
             expiresAt: expiration.expirationDate(from: now)
         )
 
-        queue.sync(flags: .barrier) {
+        let didPersist = queue.sync(flags: .barrier) {
+            // Signing / biometric work above can suspend this mutation for
+            // seconds. A reload may discover unavailable/corrupt metadata in
+            // that interval; never append and overwrite that unknown blob
+            // using the stale preflight state.
+            guard didLoadFromKeychain, !metadataLoadUnavailable else {
+                return false
+            }
             keys.append(info)
-            Self.saveToKeychain(keys)
+            guard Self.saveToKeychain(keys) else {
+                keys.removeAll { $0.id == keyId }
+                return false
+            }
+            return true
         }
+        guard didPersist else { throw APIKeyPersistenceError.metadataWriteFailed }
         // A new key (and possibly the first key) must be honored by the live
         // server without a restart.
         APIKeyValidatorEpoch.shared.bump()
@@ -113,7 +180,7 @@ public final class APIKeyManager: @unchecked Sendable {
     /// Revoke an access key by its ID. Adds (address, nonce) to the revocation store
     /// and marks the metadata as revoked.
     public func revoke(id: UUID) {
-        ensureLoadedFromKeychain()
+        guard ensureLoadedFromKeychain() else { return }
 
         queue.sync(flags: .barrier) {
             guard let index = keys.firstIndex(where: { $0.id == id }) else { return }
@@ -127,7 +194,7 @@ public final class APIKeyManager: @unchecked Sendable {
 
     /// Revoke all keys from a given address with counter <= current counter.
     public func revokeAll(forAddress address: OsaurusID) {
-        ensureLoadedFromKeychain()
+        guard ensureLoadedFromKeychain() else { return }
 
         queue.sync(flags: .barrier) {
             let currentCounter = CounterStore.shared.current
@@ -143,17 +210,60 @@ public final class APIKeyManager: @unchecked Sendable {
 
     /// Revoke an access key and remove it from the key list entirely.
     /// Use this for temporary keys that should leave no trace after deletion.
+    ///
+    /// Best-effort: does not report durable write failures. Temporary pairing
+    /// recovery must use `deleteTemporaryKeyChecked(id:)` instead.
     public func delete(id: UUID) {
-        ensureLoadedFromKeychain()
+        _ = deleteTemporaryKeyChecked(id: id)
+    }
 
-        queue.sync(flags: .barrier) {
-            guard let index = keys.firstIndex(where: { $0.id == id }) else { return }
+    /// Security-critical temporary-key deletion used by crash reconciliation.
+    ///
+    /// Returns `.succeeded` only when:
+    /// - access-key metadata was loaded successfully, and
+    /// - the key was already absent, or
+    /// - durable synchronous revocation succeeded and metadata removal persisted.
+    ///
+    /// On `.failed`, callers must retain temporary-pairing tracking so a later
+    /// retry (or next launch) can finish the job. Never clears tracking first.
+    @discardableResult
+    func deleteTemporaryKeyChecked(id: UUID) -> TemporaryAPIKeyDeletionResult {
+        let outcome: TemporaryAPIKeyDeletionResult = queue.sync(flags: .barrier) {
+            switch ensureMetadataReadyForSecurityCriticalMutationLocked() {
+            case .unavailable:
+                return .failed
+            case .ready:
+                break
+            }
+
+            guard let index = keys.firstIndex(where: { $0.id == id }) else {
+                // Missing key after a safe load: track-before-mint orphan or
+                // prior successful delete. Idempotent success.
+                return .succeeded
+            }
+
             let key = keys[index]
-            RevocationStore.shared.revokeKey(address: key.iss, nonce: key.nonce)
+            // Durable revocation MUST succeed before we drop metadata (and
+            // before TemporaryPairedKeyStore clears tracking).
+            guard RevocationStore.shared.revokeKeySynchronously(
+                address: key.iss, nonce: key.nonce)
+            else {
+                return .failed
+            }
+
             keys.remove(at: index)
-            Self.saveToKeychain(keys)
+            guard Self.saveToKeychain(keys) else {
+                // Keep the in-memory entry so a retry can re-attempt the
+                // metadata write; revocation is already durable.
+                keys.insert(key, at: min(index, keys.count))
+                return .failed
+            }
+            return .succeeded
         }
-        APIKeyValidatorEpoch.shared.bump()
+        if outcome == .succeeded {
+            APIKeyValidatorEpoch.shared.bump()
+        }
+        return outcome
     }
 
     // MARK: - List
@@ -215,34 +325,111 @@ public final class APIKeyManager: @unchecked Sendable {
 
     // The access-key metadata blob is read/written through the shared
     // `Keychain` helper.
-    private static func saveToKeychain(_ keys: [AccessKeyInfo]) {
+    @discardableResult
+    private static func saveToKeychain(_ keys: [AccessKeyInfo]) -> Bool {
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            return true
+        }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(keys) else { return }
-        Keychain.write(service: keychainService, account: keychainAccount, data: data)
+        guard let data = try? encoder.encode(keys) else { return false }
+        return Keychain.write(service: keychainService, account: keychainAccount, data: data)
     }
 
-    private static func loadFromKeychain() -> [AccessKeyInfo] {
-        guard let data = Keychain.read(service: keychainService, account: keychainAccount)
-        else { return [] }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return (try? decoder.decode([AccessKeyInfo].self, from: data)) ?? []
+    private static func loadFromKeychainChecked() -> APIKeyMetadataLoad {
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            return .missing
+        }
+        switch Keychain.readResult(service: keychainService, account: keychainAccount) {
+        case .missing:
+            return .missing
+        case .unavailable:
+            return .unavailable
+        case .value(let data):
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            guard let decoded = try? decoder.decode([AccessKeyInfo].self, from: data) else {
+                return .unavailable
+            }
+            return .loaded(decoded)
+        }
     }
 
     /// Force a reload from Keychain.
     public func reload() {
         queue.sync(flags: .barrier) {
-            keys = Self.loadFromKeychain()
-            didLoadFromKeychain = true
+            switch Self.loadFromKeychainChecked() {
+            case .missing:
+                keys = []
+                didLoadFromKeychain = true
+                metadataLoadUnavailable = false
+            case .loaded(let loaded):
+                keys = loaded
+                didLoadFromKeychain = true
+                metadataLoadUnavailable = false
+            case .unavailable:
+                // Do not pretend the store is empty when the read failed.
+                keys = []
+                didLoadFromKeychain = false
+                metadataLoadUnavailable = true
+            }
         }
     }
 
-    private func ensureLoadedFromKeychain() {
+    @discardableResult
+    private func ensureLoadedFromKeychain() -> Bool {
         queue.sync(flags: .barrier) {
-            guard !didLoadFromKeychain else { return }
-            keys = Self.loadFromKeychain()
+            guard !didLoadFromKeychain else { return !metadataLoadUnavailable }
+            switch Self.loadFromKeychainChecked() {
+            case .missing:
+                keys = []
+                didLoadFromKeychain = true
+                metadataLoadUnavailable = false
+                return true
+            case .loaded(let loaded):
+                keys = loaded
+                didLoadFromKeychain = true
+                metadataLoadUnavailable = false
+                return true
+            case .unavailable:
+                // Never let generation overwrite an inaccessible/corrupt
+                // metadata blob as though it were an empty store.
+                keys = []
+                didLoadFromKeychain = false
+                metadataLoadUnavailable = true
+                return false
+            }
+        }
+    }
+
+    private enum SecurityCriticalMetadataAccess {
+        case ready
+        case unavailable
+    }
+
+    /// Must be called under `queue` barrier. Loads metadata when needed and
+    /// refuses security-critical mutation when the Keychain read is unsafe.
+    private func ensureMetadataReadyForSecurityCriticalMutationLocked()
+        -> SecurityCriticalMetadataAccess
+    {
+        if didLoadFromKeychain {
+            return metadataLoadUnavailable ? .unavailable : .ready
+        }
+        switch Self.loadFromKeychainChecked() {
+        case .missing:
+            keys = []
             didLoadFromKeychain = true
+            metadataLoadUnavailable = false
+            return .ready
+        case .loaded(let loaded):
+            keys = loaded
+            didLoadFromKeychain = true
+            metadataLoadUnavailable = false
+            return .ready
+        case .unavailable:
+            metadataLoadUnavailable = true
+            // Leave didLoadFromKeychain false so a later retry can re-read.
+            return .unavailable
         }
     }
 }

--- a/Packages/OsaurusCore/Identity/RevocationStore.swift
+++ b/Packages/OsaurusCore/Identity/RevocationStore.swift
@@ -14,24 +14,82 @@ public final class RevocationStore: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.osaurus.revocations", attributes: .concurrent)
     private var revokedKeys: Set<String> = []
     private var counterThresholds: [String: UInt64] = [:]
+    /// False when the durable blob could not be read or decoded. Checked
+    /// mutations must not overwrite unknown revocation state.
+    private var persistenceAvailable = true
 
     private static let keychainService = "com.osaurus.revocations"
     private static let keychainAccount = "revocation-data"
 
     private init() {
-        load()
+        persistenceAvailable = loadChecked()
     }
 
     // MARK: - Individual Revocation
 
     /// Revoke a specific access key identified by its signer address and nonce.
+    ///
+    /// Best-effort: updates in-memory state immediately and schedules a
+    /// background Keychain write. Prefer `revokeKeySynchronously` when a
+    /// security-critical caller must know the durable write succeeded before
+    /// clearing recovery state.
     public func revokeKey(address: OsaurusID, nonce: String) {
         let key = RevocationSnapshot.revocationKey(address: address, nonce: nonce)
         queue.sync(flags: .barrier) {
             revokedKeys.insert(key)
-            save()
+            saveInBackground()
         }
         APIKeyValidatorEpoch.shared.bump()
+    }
+
+    /// Security-critical revocation: insert `(address, nonce)` and persist
+    /// synchronously. Returns `false` when the durable write fails; in that
+    /// case in-memory state is rolled back so a process that thinks the key is
+    /// still live cannot clear tracking as if revocation succeeded.
+    @discardableResult
+    func revokeKeySynchronously(address: OsaurusID, nonce: String) -> Bool {
+        let key = RevocationSnapshot.revocationKey(address: address, nonce: nonce)
+        let didPersist = queue.sync(flags: .barrier) { () -> Bool in
+            if !persistenceAvailable {
+                persistenceAvailable = loadChecked()
+            }
+            guard persistenceAvailable else { return false }
+            let alreadyPresent = revokedKeys.contains(key)
+            revokedKeys.insert(key)
+            guard saveSynchronously() else {
+                persistenceAvailable = false
+                if !alreadyPresent {
+                    revokedKeys.remove(key)
+                }
+                return false
+            }
+            return true
+        }
+        if didPersist {
+            APIKeyValidatorEpoch.shared.bump()
+        }
+        return didPersist
+    }
+
+    /// Re-establish that the durable revocation blob was read successfully.
+    /// Server startup uses this even when there are no temporary IDs to clean:
+    /// an unavailable/corrupt revocation set must never be treated as empty.
+    func ensurePersistenceAvailableSynchronously() -> Bool {
+        queue.sync(flags: .barrier) {
+            if !persistenceAvailable {
+                persistenceAvailable = loadChecked()
+            }
+            guard persistenceAvailable else { return false }
+            // Always checkpoint current state through the ordered writer.
+            // `loadChecked` merges rather than replaces, so revocations made
+            // while Keychain was unavailable become durable before server
+            // readiness is granted.
+            guard saveSynchronously() else {
+                persistenceAvailable = false
+                return false
+            }
+            return true
+        }
     }
 
     // MARK: - Bulk Revocation
@@ -42,7 +100,7 @@ public final class RevocationStore: @unchecked Sendable {
         queue.sync(flags: .barrier) {
             let existing = counterThresholds[normalized] ?? 0
             counterThresholds[normalized] = max(existing, counter)
-            save()
+            saveInBackground()
         }
         APIKeyValidatorEpoch.shared.bump()
     }
@@ -79,7 +137,9 @@ public final class RevocationStore: @unchecked Sendable {
     }
 
     // The revocation blob is read/written through the shared `Keychain` helper.
-    private func save() {
+    /// Best-effort background persistence used by non-critical revoke paths.
+    private func saveInBackground() {
+        guard persistenceAvailable else { return }
         let model = StorageModel(
             revokedKeys: Array(revokedKeys),
             counterThresholds: counterThresholds
@@ -89,19 +149,78 @@ public final class RevocationStore: @unchecked Sendable {
             service: Self.keychainService, account: Self.keychainAccount, data: data)
     }
 
-    private func load() {
-        guard let data = Keychain.read(service: Self.keychainService, account: Self.keychainAccount),
-            let model = try? JSONDecoder().decode(StorageModel.self, from: data)
-        else { return }
+    /// Synchronous checked write for security-critical revocation. Returns
+    /// `false` when encoding or Keychain persistence fails.
+    @discardableResult
+    private func saveSynchronously() -> Bool {
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            return true
+        }
+        let model = StorageModel(
+            revokedKeys: Array(revokedKeys),
+            counterThresholds: counterThresholds
+        )
+        guard let data = try? JSONEncoder().encode(model) else { return false }
+        return Keychain.writeAfterPendingWrites(
+            service: Self.keychainService, account: Self.keychainAccount, data: data)
+    }
 
-        revokedKeys = Set(model.revokedKeys)
-        counterThresholds = model.counterThresholds
+    /// Load without collapsing a missing item and an inaccessible/corrupt
+    /// item. Revocations are monotonic: recovered durable state is merged
+    /// into current memory rather than replacing revokes accumulated while
+    /// persistence was unavailable. Caller must hold the barrier queue
+    /// (except during init).
+    private func loadChecked() -> Bool {
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            return true
+        }
+        switch Keychain.readResult(
+            service: Self.keychainService,
+            account: Self.keychainAccount
+        ) {
+        case .missing:
+            return true
+        case .unavailable:
+            return false
+        case .value(let data):
+            guard let model = try? JSONDecoder().decode(StorageModel.self, from: data) else {
+                return false
+            }
+            let merged = Self.mergeForRecovery(
+                currentRevokedKeys: revokedKeys,
+                currentThresholds: counterThresholds,
+                loadedRevokedKeys: Set(model.revokedKeys),
+                loadedThresholds: model.counterThresholds
+            )
+            revokedKeys = merged.revokedKeys
+            counterThresholds = merged.counterThresholds
+            return true
+        }
+    }
+
+    /// Pure seam for the monotonic recovery contract.
+    static func mergeForRecovery(
+        currentRevokedKeys: Set<String>,
+        currentThresholds: [String: UInt64],
+        loadedRevokedKeys: Set<String>,
+        loadedThresholds: [String: UInt64]
+    ) -> (revokedKeys: Set<String>, counterThresholds: [String: UInt64]) {
+        var revoked = currentRevokedKeys
+        revoked.formUnion(loadedRevokedKeys)
+        var thresholds = currentThresholds
+        for (address, loaded) in loadedThresholds {
+            thresholds[address] = max(thresholds[address] ?? 0, loaded)
+        }
+        return (revoked, thresholds)
     }
 
     /// Force reload from Keychain.
     public func reload() {
         queue.sync(flags: .barrier) {
-            load()
+            persistenceAvailable = loadChecked()
+            if persistenceAvailable, !saveSynchronously() {
+                persistenceAvailable = false
+            }
         }
     }
 }

--- a/Packages/OsaurusCore/Identity/TemporaryPairedKeyStore.swift
+++ b/Packages/OsaurusCore/Identity/TemporaryPairedKeyStore.swift
@@ -3,31 +3,298 @@
 //  osaurus
 //
 //  Tracks API keys generated for temporary (non-permanent) Bonjour pairings.
-//  On app termination, all tracked keys are revoked and removed from APIKeyManager
-//  so they cannot be reused in future sessions.
+//
+//  Contract:
+//  - Temporary pairing credentials are session-scoped: they must not survive
+//    force-quit / crash as ordinary durable keys.
+//  - Tracking records are persisted synchronously to Keychain *before* the
+//    corresponding API key is minted, so a crash cannot create an untracked
+//    long-lived credential.
+//  - On the next launch, any still-tracked IDs are deleted via a checked path
+//    that durably revokes before clearing tracking. Missing keys are OK;
+//    unavailable/corrupt tracking or failed durable revocation refuses a safe
+//    reconciliation result so the HTTP server does not bind.
+//  - Graceful shutdown rejects new registrations, stops the NIO server first,
+//    then cleans tracked keys. Failed deletes keep their IDs tracked.
 //
 
-import AppKit
 import Foundation
 
-public final class TemporaryPairedKeyStore: @unchecked Sendable {
-    public static let shared = TemporaryPairedKeyStore()
+// MARK: - Tracking load result
 
-    private let queue = DispatchQueue(label: "com.osaurus.temporary-paired-keys")
-    private var keyIds: [UUID] = []
+/// Keychain (or test) load of temporary-pairing tracking IDs.
+/// Distinguishes a true empty store from a read that cannot establish a safe state.
+enum TemporaryPairedKeyTrackingLoad: Equatable, Sendable {
+    /// No durable tracking item exists — treat as empty.
+    case missing
+    /// Tracking payload decoded successfully (may be empty).
+    case loaded([UUID])
+    /// Denied, transient, or corrupt — do not erase recovery state or start
+    /// the server as if reconciliation succeeded.
+    case unavailableOrCorrupt
+}
 
-    private init() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(applicationWillTerminate),
-            name: NSApplication.willTerminateNotification,
-            object: nil
+/// Outcome of launch reconciliation. Server bind must only proceed on `.ready`.
+enum TemporaryPairedKeyReconciliationOutcome: Equatable, Sendable {
+    case ready
+    case failed(String)
+}
+
+// MARK: - Persistence seam
+
+/// Durable store for temporary-pairing key identifiers only (never secrets).
+/// Synchronous writes are required so registration cannot return before the
+/// crash-recovery record is on disk/Keychain.
+protocol TemporaryPairedKeyPersisting: Sendable {
+    func load() -> TemporaryPairedKeyTrackingLoad
+    /// Persist the full set of tracked IDs. Returns `false` when the durable
+    /// write fails so callers can refuse to mint an untracked credential.
+    func save(_ ids: [UUID]) -> Bool
+}
+
+/// Default Keychain-backed persistence. Uses the same protected store class as
+/// access-key metadata / revocations (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`).
+struct KeychainTemporaryPairedKeyPersistence: TemporaryPairedKeyPersisting {
+    static let keychainService = "com.osaurus.temporary-paired-keys"
+    static let keychainAccount = "key-ids"
+
+    init() {}
+
+    func load() -> TemporaryPairedKeyTrackingLoad {
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            // Hermetic / keychain-disabled launches: no cross-process recovery.
+            return .missing
+        }
+        switch Keychain.readResult(
+            service: Self.keychainService,
+            account: Self.keychainAccount
+        ) {
+        case .missing:
+            return .missing
+        case .unavailable:
+            return .unavailableOrCorrupt
+        case .value(let data):
+            guard let ids = Self.decode(data) else {
+                return .unavailableOrCorrupt
+            }
+            return .loaded(ids)
+        }
+    }
+
+    func save(_ ids: [UUID]) -> Bool {
+        // Keychain-disabled process (live-proof / hermetic tests): keep callers
+        // unblocked for in-session tracking, but do not touch the login Keychain.
+        // Crash-recovery across process restarts is intentionally unavailable
+        // in that mode.
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            return true
+        }
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(StorageModel(ids: ids.map(\.uuidString))) else {
+            return false
+        }
+        // Synchronous write: register() must not return before the durable
+        // record exists, or a crash can leave an untracked API key.
+        return Keychain.write(
+            service: Self.keychainService,
+            account: Self.keychainAccount,
+            data: data
         )
     }
 
-    public func register(keyId: UUID) {
-        queue.sync(flags: .barrier) {
-            keyIds.append(keyId)
+    /// Decode tracking metadata. Returns `nil` for corrupt payloads so the
+    /// store can fail closed without treating garbage as live key IDs.
+    static func decode(_ data: Data) -> [UUID]? {
+        guard let model = try? JSONDecoder().decode(StorageModel.self, from: data) else {
+            return nil
+        }
+        var ids: [UUID] = []
+        ids.reserveCapacity(model.ids.count)
+        for raw in model.ids {
+            guard let id = UUID(uuidString: raw) else {
+                // Stale/corrupt entry — drop the whole payload rather than
+                // partially applying unknown identifiers.
+                return nil
+            }
+            ids.append(id)
+        }
+        return ids
+    }
+
+    private struct StorageModel: Codable {
+        var ids: [String]
+    }
+}
+
+// MARK: - Key deletion seam
+
+/// Deletes access-key metadata for a tracked temporary id.
+/// Returns `true` only when durable revocation/deletion succeeded (or the key
+/// was already absent after a safe metadata load). Callers must retain tracking
+/// when this returns `false`.
+protocol TemporaryPairedKeyDeleting: Sendable {
+    func deleteTemporaryKey(id: UUID) -> Bool
+    /// Establish that revocation persistence is readable before server bind,
+    /// including the empty-tracking case.
+    func isRevocationPersistenceReady() -> Bool
+}
+
+extension TemporaryPairedKeyDeleting {
+    func isRevocationPersistenceReady() -> Bool { true }
+}
+
+struct APIKeyManagerTemporaryPairedKeyDeleter: TemporaryPairedKeyDeleting {
+    init() {}
+
+    func deleteTemporaryKey(id: UUID) -> Bool {
+        APIKeyManager.shared.deleteTemporaryKeyChecked(id: id) == .succeeded
+    }
+
+    func isRevocationPersistenceReady() -> Bool {
+        RevocationStore.shared.ensurePersistenceAvailableSynchronously()
+    }
+}
+
+// MARK: - Store
+
+public final class TemporaryPairedKeyStore: @unchecked Sendable {
+    public static let shared = TemporaryPairedKeyStore(reconcileOnInit: false)
+
+    /// Access the lazy shared store and reconcile it on a utility queue. This
+    /// keeps the shared instance's initial Keychain load off `MainActor` too;
+    /// calling an instance async helper from the main actor would initialize
+    /// `shared` before that helper had a chance to dispatch.
+    static func reconcileSharedBeforeServerStart()
+        async -> TemporaryPairedKeyReconciliationOutcome
+    {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: shared.ensureLaunchReconciliation())
+            }
+        }
+    }
+
+    private let queue = DispatchQueue(label: "com.osaurus.temporary-paired-keys")
+    private let persistence: any TemporaryPairedKeyPersisting
+    private let keyDeleter: any TemporaryPairedKeyDeleting
+    /// In-memory mirror of durable tracking. Mutations always persist first
+    /// (for register) or only clear IDs after durable deletion succeeds.
+    private var keyIds: Set<UUID> = []
+    /// IDs registered by an in-flight pairing request whose mint has not yet
+    /// completed. Shutdown cleanup must retain these IDs rather than treating
+    /// their not-yet-created metadata as an idempotent missing key.
+    private var activeMintIds: Set<UUID> = []
+    /// False when the durable tracking load was denied/corrupt — reconciliation
+    /// cannot establish a safe state and must not erase recovery records.
+    private var trackingAvailable: Bool = true
+    /// Immediate shutdown latch. It is deliberately separate from `queue`:
+    /// Cmd-Q must not park the main actor behind a slow Keychain write.
+    private let shutdownRequested = AtomicBool(false)
+    /// Cached successful launch reconciliation only. Failures remain retriable.
+    private var didSuccessfullyReconcile = false
+
+    init(
+        persistence: (any TemporaryPairedKeyPersisting)? = nil,
+        keyDeleter: (any TemporaryPairedKeyDeleting)? = nil,
+        reconcileOnInit: Bool = true
+    ) {
+        self.persistence = persistence ?? KeychainTemporaryPairedKeyPersistence()
+        self.keyDeleter = keyDeleter ?? APIKeyManagerTemporaryPairedKeyDeleter()
+
+        // Load durable IDs before optional launch reconciliation so a crash
+        // recovery path can delete the associated API keys before the server
+        // accepts traffic that would treat them as ordinary durable keys.
+        switch self.persistence.load() {
+        case .missing:
+            self.keyIds = []
+            self.trackingAvailable = true
+        case .loaded(let ids):
+            self.keyIds = Set(ids)
+            self.trackingAvailable = true
+        case .unavailableOrCorrupt:
+            self.keyIds = []
+            self.trackingAvailable = false
+        }
+
+        if reconcileOnInit {
+            _ = ensureLaunchReconciliation()
+        }
+    }
+
+    // MARK: - Registration (crash-consistent ordering)
+
+    /// Durably record that `keyId` is a session-temporary pairing credential.
+    ///
+    /// Callers that mint temporary keys MUST:
+    /// 1. Allocate a `UUID`
+    /// 2. Call `register` and refuse minting if this returns `false`
+    /// 3. Pass that same id into `APIKeyManager.generate(..., keyId:)`
+    /// 4. Call `unregister` if key creation fails after a successful register
+    ///
+    /// Ordering is intentional: a crash between (2) and (3) leaves only an
+    /// orphan tracking record, which launch reconciliation deletes as a no-op
+    /// key delete. A crash after (3) leaves a tracked credential that the next
+    /// launch revokes. Never mint first and register second.
+    ///
+    /// Returns `false` when tracking is unavailable, shutdown has begun, or the
+    /// durable write fails — callers must not mint in those cases.
+    @discardableResult
+    public func register(keyId: UUID) -> Bool {
+        guard !shutdownRequested.load() else { return false }
+        return queue.sync {
+            guard trackingAvailable, !shutdownRequested.load() else { return false }
+            // Duplicate / concurrent register of the same id is a no-op success
+            // once durable — do not corrupt the set or fail the second caller.
+            if keyIds.contains(keyId) {
+                return true
+            }
+            var next = keyIds
+            next.insert(keyId)
+            // Persist *before* updating in-memory state so a failed write never
+            // claims tracking that is not recoverable after a crash.
+            guard persistence.save(Self.sortedIds(next)) else {
+                return false
+            }
+            keyIds = next
+            // Shutdown may have begun while persistence was blocked. The
+            // durable recovery pointer is retained for cleanup, but the caller
+            // is refused permission to mint.
+            guard !shutdownRequested.load() else {
+                return false
+            }
+            activeMintIds.insert(keyId)
+            return true
+        }
+    }
+
+    /// Mark the mint attempt complete and report whether its credential may
+    /// be returned to the caller. If shutdown began while biometric/signing
+    /// work was in flight, the caller must delete the new key and fail the
+    /// pairing response; durable tracking remains until that delete succeeds.
+    func finishMint(keyId: UUID) -> Bool {
+        queue.sync {
+            activeMintIds.remove(keyId)
+            return trackingAvailable && !shutdownRequested.load() && keyIds.contains(keyId)
+        }
+    }
+
+    /// Drop a tracking record after a failed key mint, or after the key has
+    /// already been deleted with a checked success. Idempotent for missing ids.
+    ///
+    /// Do **not** call this after a failed durable delete — retain tracking so
+    /// the next launch can finish revocation.
+    func unregister(keyId: UUID) {
+        queue.sync {
+            guard trackingAvailable, keyIds.contains(keyId) else { return }
+            var next = keyIds
+            next.remove(keyId)
+            // Best-effort durable clear. Even if save fails, drop the in-memory
+            // entry so the current session does not keep treating the id as live
+            // after a mint rollback; a stale durable entry only causes an
+            // idempotent delete on relaunch.
+            _ = persistence.save(Self.sortedIds(next))
+            keyIds = next
+            activeMintIds.remove(keyId)
         }
     }
 
@@ -35,10 +302,147 @@ public final class TemporaryPairedKeyStore: @unchecked Sendable {
         queue.sync { keyIds.contains(id) }
     }
 
-    @objc private func applicationWillTerminate() {
-        let ids = queue.sync { keyIds }
-        for id in ids {
-            APIKeyManager.shared.delete(id: id)
+    /// Snapshot of currently tracked temporary key ids (tests / diagnostics).
+    func trackedKeyIds() -> Set<UUID> {
+        queue.sync { keyIds }
+    }
+
+    /// Whether durable tracking is available for this process (tests / diagnostics).
+    func isTrackingAvailable() -> Bool {
+        queue.sync { trackingAvailable }
+    }
+
+    /// Nonblocking lifecycle check used after suspension points in server
+    /// startup so a `.ready` result cannot resume into a bind after Cmd-Q.
+    func isShutdownRequested() -> Bool {
+        shutdownRequested.load()
+    }
+
+    // MARK: - Launch reconciliation
+
+    /// Delete API keys for every durable temporary-pairing id, retaining any
+    /// IDs whose durable revocation/deletion failed. Safe to call repeatedly.
+    /// Permanent keys are never touched because they are never registered here.
+    @discardableResult
+    func reconcileCrashOrphans() -> TemporaryPairedKeyReconciliationOutcome {
+        ensureLaunchReconciliation()
+    }
+
+    /// Ensures launch reconciliation has run successfully once for the shared
+    /// process store. Failures remain retriable. Used from app bootstrap so
+    /// orphan cleanup happens before the HTTP server accepts traffic.
+    @discardableResult
+    func ensureLaunchReconciliation() -> TemporaryPairedKeyReconciliationOutcome {
+        queue.sync {
+            guard !shutdownRequested.load() else {
+                return .failed("temporary pairing lifecycle is shutting down")
+            }
+            if didSuccessfullyReconcile {
+                return .ready
+            }
+            guard trackingAvailable else {
+                return .failed(
+                    "temporary pairing tracking is unavailable or corrupt; refusing unsafe reconciliation"
+                )
+            }
+            return cleanupTrackedKeysLocked(markSuccessfulReconcile: true)
         }
+    }
+
+    /// Run launch reconciliation off the main actor so Keychain I/O does not
+    /// stall UI, while still completing before the caller binds the server.
+    func ensureLaunchReconciliationOffMain() async -> TemporaryPairedKeyReconciliationOutcome {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: self.ensureLaunchReconciliation())
+            }
+        }
+    }
+
+    // MARK: - Graceful shutdown
+
+    /// Reject new temporary registrations for the remainder of the process.
+    /// Call when ordered app shutdown begins (before or as the server stops).
+    func beginShutdown() {
+        shutdownRequested.store(true)
+    }
+
+    /// After the NIO server has stopped accepting traffic, attempt durable
+    /// deletion of every tracked temporary key. IDs whose deletion fails remain
+    /// tracked for the next launch. Does not depend on `willTerminate` ordering.
+    func cleanupTrackedKeysOnShutdown() {
+        shutdownRequested.store(true)
+        queue.sync {
+            guard trackingAvailable else { return }
+            _ = cleanupTrackedKeysLocked(markSuccessfulReconcile: false)
+        }
+    }
+
+    /// Keep synchronous Keychain revocation and tracking writes out of the
+    /// ordered shutdown task's main-actor executor.
+    func cleanupTrackedKeysOnShutdownOffMain() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.cleanupTrackedKeysOnShutdown()
+                continuation.resume()
+            }
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Shared cleanup for launch reconciliation and ordered shutdown.
+    /// Caller must hold `queue`. Only removes IDs whose checked delete succeeds
+    /// and whose remaining set can be persisted.
+    private func cleanupTrackedKeysLocked(markSuccessfulReconcile: Bool)
+        -> TemporaryPairedKeyReconciliationOutcome
+    {
+        guard keyDeleter.isRevocationPersistenceReady() else {
+            return .failed(
+                "revocation persistence is unavailable or corrupt; refusing unsafe reconciliation"
+            )
+        }
+        let original = keyIds
+        guard !original.isEmpty else {
+            if markSuccessfulReconcile {
+                didSuccessfullyReconcile = true
+            }
+            return .ready
+        }
+
+        // An in-flight request may have registered before shutdown but not
+        // minted metadata yet. Keep that recovery pointer; deleting a
+        // currently-missing key and clearing its ID would let the request mint
+        // an untracked token after cleanup.
+        var failed = activeMintIds.intersection(original)
+        for id in original.subtracting(activeMintIds) {
+            if !keyDeleter.deleteTemporaryKey(id: id) {
+                failed.insert(id)
+            }
+        }
+
+        // Persist the residual set (failed only). If that write fails, keep
+        // the original in-memory tracking so no recovery ID is lost.
+        if persistence.save(Self.sortedIds(failed)) {
+            keyIds = failed
+        } else {
+            // Deletes that already succeeded are idempotent on retry.
+            return .failed("could not persist temporary pairing tracking after cleanup")
+        }
+
+        if !failed.isEmpty {
+            return .failed(
+                "could not durably revoke \(failed.count) temporary pairing key(s); retaining tracking"
+            )
+        }
+
+        if markSuccessfulReconcile {
+            didSuccessfullyReconcile = true
+        }
+        return .ready
+    }
+
+    private static func sortedIds(_ ids: Set<UUID>) -> [UUID] {
+        ids.sorted { $0.uuidString < $1.uuidString }
     }
 }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -3972,13 +3972,46 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
             let expiration: AccessKeyExpiration = isPermanent ? .never : .days90
-            guard
-                let (fullKey, keyInfo) = try? APIKeyManager.shared.generate(
+            // Temporary pairings must durably track the metadata id *before*
+            // minting so a crash cannot leave an untracked long-lived key.
+            // Permanent keys skip tracking entirely.
+            let preassignedKeyId: UUID?
+            if isPermanent {
+                preassignedKeyId = nil
+            } else {
+                let pendingId = UUID()
+                guard TemporaryPairedKeyStore.shared.register(keyId: pendingId) else {
+                    reply(
+                        status: .internalServerError,
+                        body: #"{"error":"Failed to track temporary access key"}"#,
+                        code: 500
+                    )
+                    return
+                }
+                preassignedKeyId = pendingId
+            }
+
+            let generated: (fullKey: String, info: AccessKeyInfo)?
+            if let keyId = preassignedKeyId {
+                generated = try? APIKeyManager.shared.generate(
+                    label: label,
+                    expiration: expiration,
+                    agentIndex: agentIndex,
+                    keyId: keyId
+                )
+            } else {
+                generated = try? APIKeyManager.shared.generate(
                     label: label,
                     expiration: expiration,
                     agentIndex: agentIndex
                 )
-            else {
+            }
+            guard let (fullKey, keyInfo) = generated else {
+                // Roll back the durable tracking record so a failed mint does
+                // not leave a stale id that launch would try to delete forever.
+                if let keyId = preassignedKeyId {
+                    TemporaryPairedKeyStore.shared.unregister(keyId: keyId)
+                }
                 reply(
                     status: .internalServerError,
                     body: #"{"error":"Failed to generate access key"}"#,
@@ -3986,10 +4019,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 )
                 return
             }
-
-            // Temporary keys are revoked and removed from the key list on app exit.
-            if !isPermanent {
-                TemporaryPairedKeyStore.shared.register(keyId: keyInfo.id)
+            if let keyId = preassignedKeyId,
+                !TemporaryPairedKeyStore.shared.finishMint(keyId: keyId)
+            {
+                // Shutdown began while biometric/signing work was in flight.
+                // Do not return a newly minted credential after cleanup took
+                // its snapshot. Clear tracking only after checked deletion;
+                // otherwise the next launch retains the recovery pointer.
+                if APIKeyManager.shared.deleteTemporaryKeyChecked(id: keyId) == .succeeded {
+                    TemporaryPairedKeyStore.shared.unregister(keyId: keyId)
+                }
+                reply(
+                    status: .serviceUnavailable,
+                    body: #"{"error":"Pairing interrupted by server shutdown"}"#,
+                    code: 503
+                )
+                return
             }
 
             // 4b. Sign a server-identity attestation over the challenge nonce
@@ -4028,7 +4073,17 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         info: PairingKeyEnvelope.info(agentAddress: agentAddress, nonce: req.nonce)
                     )
                 else {
-                    APIKeyManager.shared.revoke(id: keyInfo.id)
+                    // Fail closed: drop the minted credential. Temporary keys
+                    // were tracked before mint — only clear tracking after a
+                    // checked durable delete succeeds. On failure, retain the
+                    // tracking ID so launch reconciliation can finish the job.
+                    if isPermanent {
+                        APIKeyManager.shared.revoke(id: keyInfo.id)
+                    } else if APIKeyManager.shared.deleteTemporaryKeyChecked(id: keyInfo.id)
+                        == .succeeded
+                    {
+                        TemporaryPairedKeyStore.shared.unregister(keyId: keyInfo.id)
+                    }
                     reply(status: .badRequest, body: #"{"error":"Invalid encryption key"}"#, code: 400)
                     return
                 }

--- a/Packages/OsaurusCore/Networking/OsaurusServer.swift
+++ b/Packages/OsaurusCore/Networking/OsaurusServer.swift
@@ -54,6 +54,8 @@ public actor OsaurusServer: Sendable {
 
     private var group: MultiThreadedEventLoopGroup?
     private var channel: Channel?
+    /// Invalidates a suspended bind when stop wins the lifecycle race.
+    private var lifecycleGeneration: UInt64 = 0
 
     public init() {}
 
@@ -70,9 +72,14 @@ public actor OsaurusServer: Sendable {
         serverConfiguration: ServerConfiguration = .default
     ) async throws {
         guard group == nil, channel == nil else { return }
+        lifecycleGeneration &+= 1
+        let startGeneration = lifecycleGeneration
 
         let threads = ProcessInfo.processInfo.activeProcessorCount
         let group = MultiThreadedEventLoopGroup(numberOfThreads: threads)
+        // Root before bind. `bootstrap.bind(...).get()` suspends; without this,
+        // stop/quit cannot observe or shut down the in-progress event loop.
+        self.group = group
 
         let validatorSnapshot = LazyAPIKeyValidatorSnapshot {
             Self.buildValidator(agentIndex: config.agentIndex)
@@ -115,9 +122,21 @@ public actor OsaurusServer: Sendable {
             .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 16)
             .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
 
-        let ch = try await bootstrap.bind(host: config.host, port: config.port).get()
-        self.group = group
-        self.channel = ch
+        do {
+            let ch = try await bootstrap.bind(host: config.host, port: config.port).get()
+            guard lifecycleGeneration == startGeneration, self.group === group else {
+                _ = try? await ch.close()
+                throw CancellationError()
+            }
+            self.channel = ch
+        } catch {
+            // If this start still owns the lifecycle, release its group. When
+            // stop already advanced the generation, it owns that cleanup.
+            if lifecycleGeneration == startGeneration {
+                _ = await stop(gracefully: false)
+            }
+            throw error
+        }
         print("[Osaurus] OsaurusServer started on http://\(config.host):\(config.port)")
     }
 
@@ -131,6 +150,7 @@ public actor OsaurusServer: Sendable {
     ///   trips NIO's `EventLoopGroup is still running` precondition at exit).
     @discardableResult
     public func stop(gracefully: Bool = true) async -> Bool {
+        lifecycleGeneration &+= 1
         if let ch = self.channel {
             _ = try? await ch.close()
             self.channel = nil

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -13,6 +13,14 @@ import NIOCore
 import NIOHTTP1
 import NIOPosix
 
+private enum ServerControllerLifecycleError: LocalizedError {
+    case previousServerStillStopping
+
+    var errorDescription: String? {
+        "The previous server is still stopping; retry after its event loop finishes."
+    }
+}
+
 /// Main controller responsible for managing the server lifecycle
 @MainActor
 final class ServerController: ObservableObject {
@@ -50,6 +58,9 @@ final class ServerController: ObservableObject {
     private var serverChannel: Channel?
     private var serverActor: OsaurusServer?
     private var agentsCancellable: AnyCancellable?
+    /// Main-actor latch set before the first startup suspension point.
+    /// Prevents Settings, App Intents, and launch tasks from racing two binds.
+    private var isStartInFlight = false
 
     /// Flipped once `applicationDidFinishLaunching` finishes its server
     /// wiring. The Bonjour-expose Combine sink consults this so it never
@@ -105,7 +116,30 @@ final class ServerController: ObservableObject {
 
     /// Starts the server with current configuration
     func startServer() async {
-        guard !isRunning else { return }
+        guard !isRunning, !isStartInFlight else { return }
+        isStartInFlight = true
+        defer { isStartInFlight = false }
+
+        let reconciliation =
+            await TemporaryPairedKeyStore.reconcileSharedBeforeServerStart()
+        guard case .ready = reconciliation else {
+            let reason: String
+            if case .failed(let failureReason) = reconciliation {
+                reason = failureReason
+            } else {
+                reason = "unknown temporary pairing reconciliation failure"
+            }
+            lastErrorMessage =
+                "Server start refused: temporary pairing security state is unavailable (\(reason))."
+            serverHealth = .error(lastErrorMessage!)
+            print("[Osaurus] \(lastErrorMessage!)")
+            return
+        }
+        guard !TemporaryPairedKeyStore.shared.isShutdownRequested() else {
+            lastErrorMessage = "Server start refused because application shutdown has begun."
+            serverHealth = .stopped
+            return
+        }
         guard configuration.isValidPort else {
             lastErrorMessage = "Invalid port: \(configuration.port). Port must be between 1 and 65535."
             serverHealth = .error(lastErrorMessage!)
@@ -125,11 +159,23 @@ final class ServerController: ObservableObject {
             try await stopServerIfNeeded()
 
             let server = OsaurusServer()
+            // Root the actor before the bind suspension so stop/quit paths can
+            // observe an in-progress start. A post-bind shutdown check below
+            // closes it if stop raced before the actor acquired its channel.
+            self.serverActor = server
             try await server.start(
                 .init(host: bindHost, port: configuration.port, trustLoopback: !configuration.exposeToNetwork),
                 serverConfiguration: self.configuration
             )
-            self.serverActor = server
+            guard !TemporaryPairedKeyStore.shared.isShutdownRequested() else {
+                let completed = await server.stop(gracefully: false)
+                if completed, self.serverActor === server {
+                    self.serverActor = nil
+                }
+                isRunning = false
+                serverHealth = .stopped
+                return
+            }
 
             // Update state
             isRunning = true
@@ -160,6 +206,13 @@ final class ServerController: ObservableObject {
             }
             RelayTunnelManager.shared.reconnectIfNeeded(port: configuration.port)
         } catch {
+            if TemporaryPairedKeyStore.shared.isShutdownRequested() {
+                // The quit path owns teardown/rooting. In particular, retain
+                // an actor whose event loop exceeded the bounded stop budget.
+                isRunning = false
+                serverHealth = .stopped
+                return
+            }
             handleServerError(error)
             await cleanupRuntime()
         }
@@ -189,8 +242,14 @@ final class ServerController: ObservableObject {
 
         // Stop the actor-backed server if present
         if let server = serverActor {
-            await server.stop(gracefully: true)
-            serverActor = nil
+            let completed = await server.stop(gracefully: true)
+            if completed {
+                serverActor = nil
+            } else {
+                print(
+                    "[Osaurus] NIO group is still draining; retaining serverActor until a later stop"
+                )
+            }
         }
 
         localNetworkAddress = "127.0.0.1"
@@ -421,6 +480,9 @@ final class ServerController: ObservableObject {
     private func stopServerIfNeeded() async throws {
         if serverActor != nil || serverChannel != nil || eventLoopGroup != nil {
             await stopServer()
+        }
+        guard serverActor == nil else {
+            throw ServerControllerLifecycleError.previousServerStillStopping
         }
     }
 

--- a/Packages/OsaurusCore/Services/Keychain/Keychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/Keychain.swift
@@ -9,6 +9,20 @@
 import Foundation
 import Security
 
+/// Distinguishes an absent Keychain item from a denied/transient/corrupt read.
+///
+/// Existing `Keychain.read` callers still collapse non-values to `nil`; security-
+/// critical paths that must not treat "could not read" as "empty" use this.
+enum KeychainReadResult: Equatable, Sendable {
+    /// No generic-password item exists for the query.
+    case missing
+    /// Item exists and its value was returned.
+    case value(Data)
+    /// Item may exist but the read failed (auth UI required, locked, transient
+    /// error, unexpected payload type, etc.). Must not be treated as empty.
+    case unavailable
+}
+
 /// Generic-password CRUD used by every secret store in the app.
 ///
 /// Reads run with `kSecUseAuthenticationUISkip` plus a non-interactive
@@ -75,11 +89,66 @@ enum Keychain {
     static func writeInBackground(
         service: String,
         account: String,
-        data: Data,
-        accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        data: Data
     ) {
+        _ = performOrderedWrite(waitUntilFinished: false) {
+            write(service: service, account: account, data: data)
+        }
+    }
+
+    /// Perform a checked write behind every previously-enqueued background
+    /// write. Security-critical callers use this instead of calling `write`
+    /// directly so an older fire-and-forget snapshot cannot land afterward
+    /// and roll durable state back.
+    @discardableResult
+    static func writeAfterPendingWrites(
+        service: String,
+        account: String,
+        data: Data
+    ) -> Bool {
+        performOrderedWrite(waitUntilFinished: true) {
+            write(service: service, account: account, data: data)
+        }
+    }
+
+    /// Internal deterministic seam for proving ordering without touching the
+    /// login Keychain. All queued writes share the same serial executor.
+    @discardableResult
+    static func performOrderedWrite(
+        waitUntilFinished: Bool,
+        operation: @escaping @Sendable () -> Bool
+    ) -> Bool {
+        if waitUntilFinished {
+            return writeQueue.sync(execute: operation)
+        }
         writeQueue.async {
-            _ = write(service: service, account: account, data: data, accessible: accessible)
+            _ = operation()
+        }
+        return true
+    }
+
+    /// Read (`service`, `account`) with an explicit missing vs unavailable result.
+    static func readResult(
+        service: String,
+        account: String,
+        accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> KeychainReadResult {
+        var query = baseQuery(service: service, account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        query[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data else { return .unavailable }
+            return .value(data)
+        case errSecItemNotFound:
+            return .missing
+        default:
+            return .unavailable
         }
     }
 
@@ -90,17 +159,12 @@ enum Keychain {
         account: String,
         accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
     ) -> Data? {
-        var query = baseQuery(service: service, account: account)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-        query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
-        query[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
-
-        var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-            let data = result as? Data
-        else { return nil }
-        return data
+        if case .value(let data) = readResult(
+            service: service, account: account, accessible: accessible)
+        {
+            return data
+        }
+        return nil
     }
 
     /// Delete (`service`, `account`).

--- a/Packages/OsaurusCore/Tests/Identity/TemporaryPairedKeyStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Identity/TemporaryPairedKeyStoreTests.swift
@@ -1,0 +1,815 @@
+//
+//  TemporaryPairedKeyStoreTests.swift
+//  OsaurusCoreTests
+//
+//  Crash-safe temporary Bonjour pairing tracking.
+//  Uses in-memory persistence / recording deleters so tests never touch the
+//  login Keychain or raise biometric prompts.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Test seams
+
+private final class InMemoryTemporaryPairedKeyPersistence:
+    TemporaryPairedKeyPersisting, @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var stored: [UUID]
+    private var shouldFailNextSave: Bool
+    private var loadResultOverride: TemporaryPairedKeyTrackingLoad?
+
+    init(
+        initial: [UUID] = [],
+        failNextSave: Bool = false,
+        loadResult: TemporaryPairedKeyTrackingLoad? = nil
+    ) {
+        self.stored = initial
+        self.shouldFailNextSave = failNextSave
+        self.loadResultOverride = loadResult
+    }
+
+    func load() -> TemporaryPairedKeyTrackingLoad {
+        lock.withLock {
+            if let loadResultOverride {
+                return loadResultOverride
+            }
+            return .loaded(stored)
+        }
+    }
+
+    func save(_ ids: [UUID]) -> Bool {
+        lock.withLock {
+            if shouldFailNextSave {
+                shouldFailNextSave = false
+                return false
+            }
+            stored = ids
+            return true
+        }
+    }
+
+    func snapshot() -> [UUID] {
+        lock.withLock { stored }
+    }
+
+    func setFailNextSave(_ value: Bool) {
+        lock.withLock { shouldFailNextSave = value }
+    }
+}
+
+private final class RecordingTemporaryPairedKeyDeleter:
+    TemporaryPairedKeyDeleting, @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var recordedIds: [UUID] = []
+    private var failingIds: Set<UUID>
+    private var failAll: Bool
+    private var revocationPersistenceReady: Bool
+    private let onDelete: (@Sendable (UUID) -> Void)?
+
+    init(
+        failingIds: Set<UUID> = [],
+        failAll: Bool = false,
+        revocationPersistenceReady: Bool = true,
+        onDelete: (@Sendable (UUID) -> Void)? = nil
+    ) {
+        self.failingIds = failingIds
+        self.failAll = failAll
+        self.revocationPersistenceReady = revocationPersistenceReady
+        self.onDelete = onDelete
+    }
+
+    var deletedIds: [UUID] {
+        lock.withLock { recordedIds }
+    }
+
+    func setFailingIds(_ ids: Set<UUID>) {
+        lock.withLock { failingIds = ids }
+    }
+
+    func setFailAll(_ value: Bool) {
+        lock.withLock { failAll = value }
+    }
+
+    func deleteTemporaryKey(id: UUID) -> Bool {
+        let shouldFail = lock.withLock {
+            recordedIds.append(id)
+            return failAll || failingIds.contains(id)
+        }
+        guard !shouldFail else { return false }
+        onDelete?(id)
+        return true
+    }
+
+    func isRevocationPersistenceReady() -> Bool {
+        lock.withLock { revocationPersistenceReady }
+    }
+}
+
+private final class BlockingTemporaryPairedKeyPersistence:
+    TemporaryPairedKeyPersisting, @unchecked Sendable
+{
+    let saveStarted = DispatchSemaphore(value: 0)
+    let releaseSave = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var stored: [UUID] = []
+
+    func load() -> TemporaryPairedKeyTrackingLoad { .loaded([]) }
+
+    func save(_ ids: [UUID]) -> Bool {
+        saveStarted.signal()
+        _ = releaseSave.wait(timeout: .now() + 2)
+        lock.withLock { stored = ids }
+        return true
+    }
+
+    func snapshot() -> [UUID] {
+        lock.withLock { stored }
+    }
+}
+
+/// Thread-safe key set so `@Sendable` delete hooks can mutate safely.
+private final class KeySet: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: Set<UUID>
+
+    init(_ values: Set<UUID>) {
+        self.values = values
+    }
+
+    func remove(_ id: UUID) {
+        lock.lock()
+        values.remove(id)
+        lock.unlock()
+    }
+
+    func contains(_ id: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return values.contains(id)
+    }
+
+    func snapshot() -> Set<UUID> {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+private final class LockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func set(_ newValue: Value) {
+        lock.withLock { value = newValue }
+    }
+
+    func mutate(_ body: (inout Value) -> Void) {
+        lock.withLock { body(&value) }
+    }
+
+    func snapshot() -> Value {
+        lock.withLock { value }
+    }
+}
+
+@Suite("TemporaryPairedKeyStore crash-safe reconciliation")
+struct TemporaryPairedKeyStoreTests {
+
+    // MARK: - Durable registration
+
+    @Test("registration durably records an ID that survives a new store instance")
+    func registrationPersistsAcrossRelaunchSimulation() {
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        let id = UUID()
+
+        #expect(store.register(keyId: id))
+        #expect(store.isTemporary(id: id))
+        #expect(persistence.snapshot() == [id])
+
+        // Simulate process relaunch with the same durable backend but without
+        // auto-reconcile so we can assert the tracking record itself survived.
+        let relaunched = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        #expect(relaunched.isTemporary(id: id))
+        #expect(relaunched.trackedKeyIds() == [id])
+    }
+
+    // MARK: - Graceful shutdown cleanup
+
+    @Test("shutdown cleanup deletes the API key and clears tracking on success")
+    func shutdownCleanupDeletesKeyAndTracking() {
+        let tempId = UUID()
+        let permanentId = UUID()
+        let remainingKeys = KeySet([tempId, permanentId])
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let deleter = RecordingTemporaryPairedKeyDeleter { id in
+            remainingKeys.remove(id)
+        }
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        #expect(store.register(keyId: tempId))
+        #expect(store.finishMint(keyId: tempId))
+        store.beginShutdown()
+        store.cleanupTrackedKeysOnShutdown()
+
+        #expect(deleter.deletedIds == [tempId])
+        #expect(!remainingKeys.contains(tempId))
+        #expect(remainingKeys.contains(permanentId), "permanent keys must never be deleted")
+        #expect(store.trackedKeyIds().isEmpty)
+        #expect(persistence.snapshot().isEmpty)
+        #expect(!store.isTemporary(id: tempId))
+    }
+
+    // MARK: - Crash orphan reconciliation
+
+    @Test("a newly initialized store reconciles crash-orphaned temporary keys")
+    func relaunchReconcilesCrashOrphans() {
+        let orphanId = UUID()
+        let permanentId = UUID()
+        let remainingKeys = KeySet([orphanId, permanentId])
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [orphanId])
+        let deleter = RecordingTemporaryPairedKeyDeleter { id in
+            remainingKeys.remove(id)
+        }
+
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: true
+        )
+
+        #expect(deleter.deletedIds == [orphanId])
+        #expect(!remainingKeys.contains(orphanId))
+        #expect(remainingKeys.contains(permanentId))
+        #expect(store.trackedKeyIds().isEmpty)
+        #expect(persistence.snapshot().isEmpty)
+        #expect(!store.isTemporary(id: orphanId))
+    }
+
+    // MARK: - Durable revocation / metadata failure retains tracking
+
+    @Test("durable revocation failure retains tracking and does not clear the id")
+    func durableRevocationFailureRetainsTracking() {
+        let id = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [id])
+        let deleter = RecordingTemporaryPairedKeyDeleter(failAll: true)
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        let outcome = store.ensureLaunchReconciliation()
+        #expect(outcome != .ready)
+        if case .failed(let reason) = outcome {
+            #expect(reason.contains("durably revoke"))
+        } else {
+            Issue.record("expected failed outcome")
+        }
+        #expect(deleter.deletedIds == [id])
+        #expect(store.trackedKeyIds() == [id])
+        #expect(persistence.snapshot() == [id])
+    }
+
+    @Test("API metadata / delete failure retains tracking (same checked seam)")
+    func apiMetadataFailureRetainsTracking() {
+        // The production deleter maps API metadata load failure and revocation
+        // failure onto deleteTemporaryKey -> false. This seam proves the store
+        // never clears tracking when the checked delete reports failure.
+        let id = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let deleter = RecordingTemporaryPairedKeyDeleter(failingIds: [id])
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+        #expect(store.register(keyId: id))
+        #expect(store.finishMint(keyId: id))
+
+        store.cleanupTrackedKeysOnShutdown()
+
+        #expect(deleter.deletedIds == [id])
+        #expect(store.trackedKeyIds() == [id])
+        #expect(persistence.snapshot() == [id])
+        #expect(store.isTemporary(id: id))
+    }
+
+    // MARK: - Unavailable / corrupt tracking blocks reconciliation
+
+    @Test("unavailable or corrupt tracking blocks reconciliation and erases nothing")
+    func unavailableTrackingBlocksReconciliation() {
+        let persistence = InMemoryTemporaryPairedKeyPersistence(
+            loadResult: .unavailableOrCorrupt
+        )
+        let deleter = RecordingTemporaryPairedKeyDeleter()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        #expect(!store.isTrackingAvailable())
+        let outcome = store.ensureLaunchReconciliation()
+        #expect(outcome != .ready)
+        if case .failed(let reason) = outcome {
+            #expect(reason.contains("unavailable or corrupt"))
+        } else {
+            Issue.record("expected failed outcome")
+        }
+        #expect(deleter.deletedIds.isEmpty)
+        #expect(store.trackedKeyIds().isEmpty)
+        // Must not have written an empty recovery record over unknown state.
+        #expect(persistence.snapshot().isEmpty)
+        #expect(!store.register(keyId: UUID()))
+    }
+
+    @Test("unavailable revocation persistence blocks even with empty tracking")
+    func unavailableRevocationPersistenceBlocksEmptyReconciliation() {
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let deleter = RecordingTemporaryPairedKeyDeleter(
+            revocationPersistenceReady: false
+        )
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        let outcome = store.ensureLaunchReconciliation()
+        #expect(outcome != .ready)
+        if case .failed(let reason) = outcome {
+            #expect(reason.contains("revocation persistence"))
+        } else {
+            Issue.record("expected failed outcome")
+        }
+        #expect(deleter.deletedIds.isEmpty)
+        #expect(persistence.snapshot().isEmpty)
+    }
+
+    @Test("corrupt tracking payloads decode as nil (fail closed)")
+    func corruptPayloadsAreRejected() throws {
+        let corrupt = Data("not-json".utf8)
+        #expect(KeychainTemporaryPairedKeyPersistence.decode(corrupt) == nil)
+
+        let partialCorrupt = try JSONEncoder().encode(["ids": ["not-a-uuid", UUID().uuidString]])
+        #expect(KeychainTemporaryPairedKeyPersistence.decode(partialCorrupt) == nil)
+
+        #expect(KeychainTemporaryPairedKeyPersistence.decode(Data("{\"ids\":[]}".utf8)) == [])
+        let goodId = UUID()
+        let good = try JSONEncoder().encode(["ids": [goodId.uuidString]])
+        #expect(KeychainTemporaryPairedKeyPersistence.decode(good) == [goodId])
+    }
+
+    @Test("revocation recovery preserves pending revokes and maximum thresholds")
+    func revocationRecoveryIsMonotonic() {
+        let merged = RevocationStore.mergeForRecovery(
+            currentRevokedKeys: ["pending"],
+            currentThresholds: ["agent-a": 8, "agent-b": 2],
+            loadedRevokedKeys: ["durable"],
+            loadedThresholds: ["agent-a": 3, "agent-b": 9, "agent-c": 4]
+        )
+        #expect(merged.revokedKeys == ["pending", "durable"])
+        #expect(
+            merged.counterThresholds
+                == ["agent-a": 8, "agent-b": 9, "agent-c": 4]
+        )
+    }
+
+    // MARK: - Shutdown rejects new registrations
+
+    @Test("shutdown rejects new temporary registrations")
+    func shutdownRejectsNewRegistrations() {
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        let before = UUID()
+        #expect(store.register(keyId: before))
+
+        store.beginShutdown()
+
+        let after = UUID()
+        #expect(!store.register(keyId: after))
+        #expect(store.trackedKeyIds() == [before])
+        #expect(!store.isTemporary(id: after))
+        #expect(persistence.snapshot() == [before])
+    }
+
+    @Test("shutdown latch does not wait behind blocked persistence")
+    func shutdownLatchDoesNotBlockMainThread() {
+        let persistence = BlockingTemporaryPairedKeyPersistence()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        let id = UUID()
+        let registrationFinished = DispatchSemaphore(value: 0)
+        let shutdownFinished = DispatchSemaphore(value: 0)
+        let registrationResult = LockedValue<Bool?>(nil)
+
+        DispatchQueue.global().async {
+            let result = store.register(keyId: id)
+            registrationResult.set(result)
+            registrationFinished.signal()
+        }
+        #expect(persistence.saveStarted.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global().async {
+            store.beginShutdown()
+            shutdownFinished.signal()
+        }
+        #expect(
+            shutdownFinished.wait(timeout: .now() + 0.25) == .success,
+            "beginShutdown must not wait for Keychain persistence"
+        )
+
+        persistence.releaseSave.signal()
+        #expect(registrationFinished.wait(timeout: .now() + 1) == .success)
+        #expect(registrationResult.snapshot() == false)
+        // The durable pointer remains recoverable even though minting was
+        // refused after shutdown won the race.
+        #expect(persistence.snapshot() == [id])
+    }
+
+    @Test("shutdown retains a registered key while its mint is in flight")
+    func shutdownRetainsInFlightMintTracking() {
+        let id = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let deleter = RecordingTemporaryPairedKeyDeleter()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        #expect(store.register(keyId: id))
+        store.beginShutdown()
+        store.cleanupTrackedKeysOnShutdown()
+
+        #expect(deleter.deletedIds.isEmpty)
+        #expect(store.trackedKeyIds() == [id])
+        #expect(persistence.snapshot() == [id])
+        #expect(!store.finishMint(keyId: id))
+    }
+
+    // MARK: - Retry clears only succeeded IDs
+
+    @Test("retry success clears only IDs whose durable delete succeeded")
+    func retrySuccessClearsOnlySucceededIds() {
+        let okId = UUID()
+        let failId = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [okId, failId])
+        let deleter = RecordingTemporaryPairedKeyDeleter(failingIds: [failId])
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        let first = store.ensureLaunchReconciliation()
+        #expect(first != .ready)
+        #expect(store.trackedKeyIds() == [failId])
+        #expect(Set(persistence.snapshot()) == [failId])
+        #expect(Set(deleter.deletedIds) == [okId, failId])
+
+        // Second pass: previously-failed id now succeeds.
+        deleter.setFailingIds([])
+        let second = store.ensureLaunchReconciliation()
+        #expect(second == .ready)
+        #expect(store.trackedKeyIds().isEmpty)
+        #expect(persistence.snapshot().isEmpty)
+        #expect(deleter.deletedIds.filter { $0 == failId }.count == 2)
+    }
+
+    // MARK: - Idempotent missing-key cleanup
+
+    @Test("missing-key cleanup is idempotent when checked delete succeeds")
+    func missingKeyCleanupIsIdempotent() {
+        let missingId = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [missingId])
+        // Deleter returns true (API path: safe load + absent key => succeeded).
+        let deleter = RecordingTemporaryPairedKeyDeleter()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: true
+        )
+        #expect(deleter.deletedIds == [missingId])
+        #expect(persistence.snapshot().isEmpty)
+
+        #expect(store.ensureLaunchReconciliation() == .ready)
+        store.cleanupTrackedKeysOnShutdown()
+        #expect(deleter.deletedIds == [missingId])
+        #expect(store.trackedKeyIds().isEmpty)
+    }
+
+    // MARK: - Permanent keys untouched
+
+    @Test("permanent keys are never deleted by temporary reconciliation")
+    func permanentKeysNeverDeleted() {
+        let permanentA = UUID()
+        let permanentB = UUID()
+        let remainingKeys = KeySet([permanentA, permanentB])
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [])
+        let deleter = RecordingTemporaryPairedKeyDeleter { id in
+            remainingKeys.remove(id)
+        }
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: true
+        )
+
+        #expect(store.ensureLaunchReconciliation() == .ready)
+        store.beginShutdown()
+        store.cleanupTrackedKeysOnShutdown()
+
+        #expect(deleter.deletedIds.isEmpty)
+        #expect(remainingKeys.snapshot() == [permanentA, permanentB])
+    }
+
+    // MARK: - Ordering / rollback
+
+    @Test("persistence failure refuses registration so no untracked credential is implied")
+    func persistenceFailureBlocksRegistration() {
+        let persistence = InMemoryTemporaryPairedKeyPersistence(failNextSave: true)
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        let id = UUID()
+
+        #expect(!store.register(keyId: id))
+        #expect(!store.isTemporary(id: id))
+        #expect(persistence.snapshot().isEmpty)
+    }
+
+    @Test("key-creation failure unregisters the durable tracking record")
+    func keyCreationFailureRollsBackTracking() {
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        let id = UUID()
+
+        #expect(store.register(keyId: id))
+        #expect(persistence.snapshot() == [id])
+
+        store.unregister(keyId: id)
+
+        #expect(!store.isTemporary(id: id))
+        #expect(persistence.snapshot().isEmpty)
+        store.unregister(keyId: id)
+        #expect(persistence.snapshot().isEmpty)
+    }
+
+    @Test("track-before-create ordering: orphan tracking without a key cleans up safely")
+    func trackBeforeCreateOrphanIsSafeOnRelaunch() {
+        let pendingId = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [pendingId])
+        let deleter = RecordingTemporaryPairedKeyDeleter()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: true
+        )
+
+        #expect(deleter.deletedIds == [pendingId])
+        #expect(store.trackedKeyIds().isEmpty)
+        #expect(persistence.snapshot().isEmpty)
+    }
+
+    // MARK: - Source ordering (reconcile-before-bind / cleanup-after-server-stop)
+
+    @Test("production wiring: track-before-mint, reconcile-before-bind, cleanup-after-stop")
+    func productionWiringPreservesCrashOrdering() throws {
+        let coreRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Identity
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // OsaurusCore
+
+        let handler = try String(
+            contentsOf: coreRoot.appendingPathComponent("Networking/HTTPHandler.swift"),
+            encoding: .utf8
+        )
+        let pairStart = try #require(handler.range(of: "private func handlePairEndpoint("))
+        let pairEnd = try #require(
+            handler.range(
+                of: "private func handlePairInviteEndpoint(",
+                range: pairStart.upperBound ..< handler.endIndex
+            )
+        )
+        let pairBody = handler[pairStart.lowerBound ..< pairEnd.lowerBound]
+        let register = try #require(pairBody.range(of: ".register(keyId: pendingId)"))
+        let mint = try #require(
+            pairBody.range(
+                of: "keyId: keyId",
+                range: register.upperBound ..< pairBody.endIndex
+            )
+        )
+        #expect(register.lowerBound < mint.lowerBound)
+        #expect(pairBody.contains(".unregister(keyId: keyId)"))
+        // Permanent path must not register temporary tracking.
+        #expect(pairBody.contains("if isPermanent"))
+        #expect(pairBody.contains("preassignedKeyId = nil"))
+
+        let appDelegate = try String(
+            contentsOf: coreRoot.appendingPathComponent("AppDelegate.swift"),
+            encoding: .utf8
+        )
+        let serverController = try String(
+            contentsOf: coreRoot.appendingPathComponent("Networking/ServerController.swift"),
+            encoding: .utf8
+        )
+        let osaurusServer = try String(
+            contentsOf: coreRoot.appendingPathComponent("Networking/OsaurusServer.swift"),
+            encoding: .utf8
+        )
+        let reconcile = try #require(
+            serverController.range(
+                of: "TemporaryPairedKeyStore.reconcileSharedBeforeServerStart()"
+            )
+        )
+        let serverStart = try #require(serverController.range(of: "try await server.start("))
+        #expect(reconcile.lowerBound < serverStart.lowerBound)
+        #expect(serverController.contains("Server start refused"))
+        #expect(serverController.contains("guard case .ready = reconciliation"))
+        #expect(serverController.contains("guard !isRunning, !isStartInFlight"))
+        #expect(serverController.contains("self.serverActor = server"))
+        #expect(serverController.contains("isShutdownRequested()"))
+        #expect(osaurusServer.contains("self.group = group"))
+        #expect(osaurusServer.contains("lifecycleGeneration == startGeneration"))
+
+        let ensureShutdown = try #require(
+            appDelegate.range(of: "await self.serverController.ensureShutdown()")
+        )
+        let cleanup = try #require(
+            appDelegate.range(
+                of: "TemporaryPairedKeyStore.shared.cleanupTrackedKeysOnShutdownOffMain()",
+                range: ensureShutdown.upperBound ..< appDelegate.endIndex
+            )
+        )
+        #expect(ensureShutdown.lowerBound < cleanup.lowerBound)
+        #expect(appDelegate.contains("TemporaryPairedKeyStore.shared.beginShutdown()"))
+        // Must not rely on willTerminate observer for temporary-key cleanup.
+        #expect(!appDelegate.contains("willTerminateNotification"))
+
+        let storeSource = try String(
+            contentsOf: coreRoot.appendingPathComponent("Identity/TemporaryPairedKeyStore.swift"),
+            encoding: .utf8
+        )
+        #expect(!storeSource.contains("willTerminateNotification"))
+        #expect(!storeSource.contains("NSApplication.willTerminateNotification"))
+
+        let keyManager = try String(
+            contentsOf: coreRoot.appendingPathComponent("Identity/APIKeyManager.swift"),
+            encoding: .utf8
+        )
+        #expect(keyManager.contains("deleteTemporaryKeyChecked"))
+        #expect(keyManager.contains("revokeKeySynchronously"))
+        #expect(keyManager.contains("guard Self.saveToKeychain(keys) else"))
+        #expect(keyManager.contains("guard didLoadFromKeychain, !metadataLoadUnavailable else"))
+        #expect(keyManager.contains("throw APIKeyPersistenceError.metadataReadFailed"))
+        #expect(keyManager.contains("throw APIKeyPersistenceError.metadataWriteFailed"))
+
+        let revocation = try String(
+            contentsOf: coreRoot.appendingPathComponent("Identity/RevocationStore.swift"),
+            encoding: .utf8
+        )
+        #expect(revocation.contains("func revokeKeySynchronously"))
+        #expect(revocation.contains("saveSynchronously"))
+        #expect(revocation.contains("Keychain.writeAfterPendingWrites"))
+        #expect(revocation.contains("guard persistenceAvailable else { return false }"))
+        #expect(revocation.contains("Self.mergeForRecovery"))
+        // Best-effort public path remains background; checked path is sync.
+        #expect(revocation.contains("saveInBackground"))
+    }
+
+    @Test("checked Keychain writes wait behind older background snapshots")
+    func keychainWriteQueuePreservesMonotonicOrder() {
+        let firstStarted = DispatchSemaphore(value: 0)
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let checkedFinished = DispatchSemaphore(value: 0)
+        let order = LockedValue<[String]>([])
+
+        Keychain.performOrderedWrite(waitUntilFinished: false) {
+            firstStarted.signal()
+            _ = releaseFirst.wait(timeout: .now() + 2)
+            order.mutate { $0.append("older-background") }
+            return true
+        }
+        #expect(firstStarted.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global().async {
+            _ = Keychain.performOrderedWrite(waitUntilFinished: true) {
+                order.mutate { $0.append("checked") }
+                return true
+            }
+            checkedFinished.signal()
+        }
+        #expect(
+            checkedFinished.wait(timeout: .now() + 0.1) == .timedOut,
+            "checked write must wait for the earlier snapshot"
+        )
+        releaseFirst.signal()
+        #expect(checkedFinished.wait(timeout: .now() + 1) == .success)
+        #expect(order.snapshot() == ["older-background", "checked"])
+    }
+
+    // MARK: - Concurrency
+
+    @Test("concurrent and duplicate registration does not corrupt tracking")
+    func concurrentAndDuplicateRegistrationIsSafe() async {
+        let persistence = InMemoryTemporaryPairedKeyPersistence()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+
+        let sharedId = UUID()
+        let uniqueCount = 40
+        let uniqueIds = (0..<uniqueCount).map { _ in UUID() }
+
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<uniqueCount {
+                group.addTask { store.register(keyId: sharedId) }
+            }
+            for id in uniqueIds {
+                group.addTask { store.register(keyId: id) }
+            }
+            var successes = 0
+            for await ok in group where ok {
+                successes += 1
+            }
+            #expect(successes == uniqueCount + uniqueCount)
+        }
+
+        let tracked = store.trackedKeyIds()
+        #expect(tracked.contains(sharedId))
+        #expect(tracked.count == uniqueCount + 1)
+        #expect(Set(persistence.snapshot()) == tracked)
+
+        #expect(store.register(keyId: sharedId))
+        #expect(store.trackedKeyIds().count == uniqueCount + 1)
+    }
+
+    // MARK: - Off-main reconciliation seam
+
+    @Test("off-main reconciliation returns the same outcome as the sync path")
+    func offMainReconciliationMatchesSyncPath() async {
+        let id = UUID()
+        let persistence = InMemoryTemporaryPairedKeyPersistence(initial: [id])
+        let deleter = RecordingTemporaryPairedKeyDeleter()
+        let store = TemporaryPairedKeyStore(
+            persistence: persistence,
+            keyDeleter: deleter,
+            reconcileOnInit: false
+        )
+
+        let outcome = await store.ensureLaunchReconciliationOffMain()
+        #expect(outcome == .ready)
+        #expect(store.trackedKeyIds().isEmpty)
+        #expect(deleter.deletedIds == [id])
+    }
+
+    @Test("a cached successful reconciliation is invalidated by shutdown")
+    func shutdownPreventsLaterServerReadiness() {
+        let store = TemporaryPairedKeyStore(
+            persistence: InMemoryTemporaryPairedKeyPersistence(),
+            keyDeleter: RecordingTemporaryPairedKeyDeleter(),
+            reconcileOnInit: false
+        )
+        #expect(store.ensureLaunchReconciliation() == .ready)
+        store.beginShutdown()
+        #expect(store.ensureLaunchReconciliation() != .ready)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -325,8 +325,10 @@ struct RuntimePolicySourceTests {
         #expect(!chatSessions.contains("prewarmCurrentKeyOffCooperativeExecutor()"))
 
         let apiKeys = try Self.source("Identity/APIKeyManager.swift")
-        // The metadata blob now loads through the shared non-interactive store.
-        #expect(apiKeys.contains("Keychain.read("))
+        // The metadata blob now uses the shared non-interactive store's typed
+        // read so security-critical callers can distinguish missing data from
+        // a denied or transient Keychain failure.
+        #expect(apiKeys.contains("Keychain.readResult("))
         #expect(apiKeys.contains("private init() {}"))
         #expect(apiKeys.contains("private func ensureLoadedFromKeychain()"))
         #expect(!apiKeys.contains("private init() {\n        keys = Self.loadFromKeychain()"))


### PR DESCRIPTION
## Summary

Make temporary Bonjour pairing credentials genuinely session-scoped across crashes, failed Keychain reads/writes, concurrent mints, and ordered app shutdown.

This PR changes the lifecycle from “delete what is still in memory when the app quits” to a crash-consistent protocol:

```text
persist recovery ID → mint credential → serve it
         ↓ crash
reconcile ID → durably revoke → remove metadata → clear recovery ID
```

The HTTP server binds only after that recovery state and the revocation store are known to be safe.

## Why

Temporary pairing keys were tracked only in process memory. A crash, force-quit, or incomplete shutdown could therefore leave an ordinary durable API credential in Keychain. Several failure modes made a simple “persist the IDs” patch insufficient:

- a crash between key creation and tracking could create an untracked credential;
- an unreadable/corrupt Keychain blob could be mistaken for an empty store;
- a revocation write could fail while tracking was still cleared;
- an older queued revocation snapshot could overwrite a newer checked write;
- a mint could still be in flight while shutdown cleanup ran;
- alternate server start/restart paths could bypass launch-only reconciliation; and
- a suspended bind could race shutdown or a second start.

## Design and ordering

### 1. Track before mint

Temporary pairing allocates the metadata UUID first and persists it in a dedicated Keychain record before any biometric/signing work begins. Minting uses that same UUID.

- Tracking write fails: do not mint.
- Mint fails: remove the recovery ID.
- Crash before mint: next launch performs an idempotent missing-key cleanup.
- Crash after mint: next launch finds and revokes the credential.

### 2. Revoke before forgetting

Cleanup uses a checked API-key deletion path:

1. safely load API-key metadata;
2. durably revoke the signer/nonce;
3. persist metadata removal; and
4. only then clear the temporary recovery ID.

Any failed or ambiguous step retains the ID for retry. Missing metadata counts as success only after a safe metadata load.

### 3. Distinguish missing from unavailable

Keychain reads now expose typed outcomes for security-critical callers:

- missing;
- value;
- unavailable.

Unavailable or corrupt temporary tracking, API metadata, or revocation state fails closed. A generation that passed preflight also rechecks metadata availability inside its final mutation barrier, covering a reload failure during biometric/signing work.

### 4. Keep revocation state monotonic

All background and checked revocation writes share one ordered Keychain queue. A checked write waits behind older snapshots, so stale state cannot land afterward.

If persistence was unavailable, in-memory revokes and counter thresholds are merged with recovered durable state using set union / maximum threshold semantics. The merged state is synchronously checkpointed before server readiness is granted.

### 5. Serialize server lifecycle

`ServerController.startServer` is the central gate for launch, Settings, status-panel, App Intent, and restart paths.

- An in-flight latch prevents concurrent binds.
- Shutdown is checked before and after bind suspension.
- The server actor is rooted before the bind.
- `OsaurusServer` roots its event-loop group before suspension and invalidates a stale bind with a lifecycle generation.
- A group that exceeds the bounded stop budget remains rooted and blocks replacement instead of being deinitialized while still running.

### 6. Order shutdown around active mints

Cmd-Q sets a nonblocking atomic shutdown latch before NIO teardown. New registrations fail immediately without waiting behind Keychain I/O. Cleanup runs after the server stops accepting traffic.

Registered-but-still-minting IDs remain tracked. If signing finishes after shutdown wins, the new credential is checked-deleted and never returned to the peer.

## Failure behavior

When reconciliation cannot prove a safe state, the server stays stopped and publishes an actionable health error. No recovery record is overwritten with an assumed empty set, and failed deletions remain retryable on the next start or launch.

Permanent API keys are never placed in the temporary tracking store and are not selected for this cleanup.

## Tests

Added 23 focused tests covering:

- durable track-before-mint ordering and relaunch simulation;
- crash-orphan cleanup and idempotent missing-key cleanup;
- failed revocation, metadata, and tracking persistence;
- unavailable/corrupt tracking and empty-tracking revocation readiness;
- monotonic revocation union / threshold recovery;
- stale background write ordering versus checked writes;
- concurrent and duplicate registration;
- shutdown rejection without blocking behind persistence;
- registered-but-in-flight mint retention;
- retry behavior that clears only successful IDs;
- permanent-key isolation;
- central reconcile-before-bind / cleanup-after-stop wiring; and
- cached readiness invalidation after shutdown.

Local result:

```text
OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
OSAURUS_TEST_ROOT=/tmp/osaurus-pairing-audit \
swift test --package-path Packages/OsaurusCore \
  --filter TemporaryPairedKeyStoreTests

✓ 23 tests in 1 suite passed
✓ git diff --check
```

## Review guide

This is intentionally one PR because the safety claim depends on the full ordering chain. Reviewing one layer without the others can produce a false sense of durability.

Suggested order:

1. `TemporaryPairedKeyStore` — state machine and failure retention.
2. `HTTPHandler` — register/mint/finish/delete ordering.
3. `APIKeyManager` and `RevocationStore` — checked durable deletion.
4. `Keychain` — ordered checked/background writes.
5. `ServerController`, `OsaurusServer`, and `AppDelegate` — bind and shutdown lifecycle.

The tests use in-memory seams and keychain-disabled mode. CI should remain the final full build/regression gate; a manual crash/force-quit pairing smoke test is still valuable before release promotion.
