### PR TITLE
Preserve SSD warmup across chat lifecycle transitions

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
+        "revision" : "7545ba66bf1060694ca4516cdf18768fef4b7c47"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7545ba66bf1060694ca4516cdf18768fef4b7c47"
+        "revision" : "da2872b07c33bd138f3217eb1760385b8cda259a"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f50853514ee00365837be3301c91850ca7ed5877"
+        "revision" : "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
+        "revision" : "7545ba66bf1060694ca4516cdf18768fef4b7c47"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7545ba66bf1060694ca4516cdf18768fef4b7c47"
+        "revision" : "da2872b07c33bd138f3217eb1760385b8cda259a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f50853514ee00365837be3301c91850ca7ed5877"
+        "revision" : "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -94,7 +94,7 @@ let package = Package(
         // chat's warm-start checkpoint.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
+            revision: "7545ba66bf1060694ca4516cdf18768fef4b7c47"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -85,10 +85,16 @@ let package = Package(
         // Gemma's decoded thought-channel opener into reasoning. The static
         // prefix hint revision lets Osaurus's byte-stable system prefix seed
         // SSD cache boundaries even when mutable DB/tool state changes later
-        // in the same rendered system message.
+        // in the same rendered system message. The disk-recency revision
+        // refreshes accepted KV + recurrent companion groups on restore so
+        // combined-quota eviction preserves genuinely hot SSD prefixes. The
+        // stable-checkpoint follow-up also refreshes the existing canonical
+        // system/tool seed when a longer compatible disk entry serves a
+        // growing turn, preventing tool-loop snapshots from evicting the next
+        // chat's warm-start checkpoint.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f50853514ee00365837be3301c91850ca7ed5877"
+            revision: "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -94,7 +94,7 @@ let package = Package(
         // chat's warm-start checkpoint.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7545ba66bf1060694ca4516cdf18768fef4b7c47"
+            revision: "da2872b07c33bd138f3217eb1760385b8cda259a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -67,6 +67,14 @@ final class ChatWarmupController: ObservableObject {
             await ModelRuntime.shared.projectedLoadFeasibility(for: model)
         }
 
+    /// Resident-model preflight (test seam; production queries the shared
+    /// runtime). This actor hop is a cancellation boundary: a reset may cancel
+    /// the scheduled warm-up while the runtime answers, so callers must
+    /// re-check cancellation and session eligibility after awaiting it.
+    var hasResidentModelOther: @MainActor (String) async -> Bool = { model in
+        await ModelRuntime.shared.hasResidentModelOther(than: model)
+    }
+
     @Published private(set) var state: WarmState = .cold
 
     /// True when the UI should render the green "warm" dot.
@@ -86,11 +94,23 @@ final class ChatWarmupController: ObservableObject {
     /// consecutive switches serialize instead of interleaving unloads.
     private var activeModelSwitch: Task<Void, Never>?
     private var activeModelSwitchID: UUID?
+    /// Cancelled work from a previous chat/reset that may still own a model
+    /// residency or generation lease while it unwinds. This stays separate
+    /// from the current chat's switch and warm-up slots so new work can be
+    /// scheduled, but runtime-touching paths drain it before proceeding.
+    private var retiringWork: Task<Void, Never>?
+    private var retiringWorkID: UUID?
     /// Monotonic counter bumped by every switch-affecting entry point
     /// (selection change, reset). Handlers that suspend re-check it
     /// afterwards so a stale resume can't cancel or restore state installed
     /// by a newer event.
     private var switchEpoch: UInt64 = 0
+
+    #if DEBUG
+        /// Deterministic lifecycle tests retain the outgoing scheduled task
+        /// across reset so they can await its actual cancellation unwind.
+        var scheduledWarmupTaskForTests: Task<Void, Never>? { scheduleTask }
+    #endif
 
     /// True once the owning window began teardown. `session.stop()` during
     /// window close runs the normal run-completed cleanup, which schedules a
@@ -102,6 +122,7 @@ final class ChatWarmupController: ObservableObject {
         scheduleTask?.cancel()
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
+        retiringWork?.cancel()
     }
 
     /// Permanently stop this controller: cancel pending and in-flight warm-up
@@ -117,11 +138,29 @@ final class ChatWarmupController: ObservableObject {
         scheduleTask?.cancel()
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
+
+        let previousRetiringWork = retiringWork
+        let retiringSwitch = activeModelSwitch
+        let retiringWarmup = inFlightWarmup
+        if retiringSwitch != nil || retiringWarmup != nil {
+            let id = UUID()
+            retiringWorkID = id
+            retiringWork = Task { @MainActor [weak self] in
+                await previousRetiringWork?.value
+                await retiringSwitch?.value
+                await retiringWarmup?.value
+                guard let self, self.retiringWorkID == id else { return }
+                self.retiringWork = nil
+                self.retiringWorkID = nil
+            }
+        }
+
         scheduleTask = nil
         activeModelSwitch = nil
         activeModelSwitchID = nil
         inFlightWarmup = nil
         inFlightWarmupID = nil
+        userIntentWarmupModel = nil
         warmedFingerprint = nil
         state = .cold
     }
@@ -235,6 +274,7 @@ final class ChatWarmupController: ObservableObject {
         state = .warming
 
         let switchID = UUID()
+        let retiringWork = retiringWork
         let previousSwitch = activeModelSwitch
         activeModelSwitchID = switchID
         activeModelSwitch = Task { @MainActor in
@@ -253,6 +293,7 @@ final class ChatWarmupController: ObservableObject {
             // never interleave, then wait for the cancelled warm-up to
             // actually unwind — its generation lease would otherwise make
             // the runtime skip (not defer) the old model's unload.
+            await retiringWork?.value
             await previousSwitch?.value
             await staleWarmup?.value
             guard !Task.isCancelled else { return }
@@ -274,6 +315,12 @@ final class ChatWarmupController: ObservableObject {
     /// after a switch generates against a clean residency state.
     func awaitActiveModelSwitch() async {
         await activeModelSwitch?.value
+    }
+
+    /// Drain cancellation-ignoring lease owners from the previous chat before
+    /// a new switch, warm-up, or real send touches the shared runtime.
+    func awaitRetiringWork() async {
+        await retiringWork?.value
     }
 
     // MARK: - Warm-up
@@ -330,7 +377,7 @@ final class ChatWarmupController: ObservableObject {
     /// When false, sends can dispatch synchronously — preserving the
     /// "user turn is appended synchronously inside send()" contract.
     var needsPreSendHandshake: Bool {
-        activeModelSwitch != nil || inFlightWarmup != nil
+        retiringWork != nil || activeModelSwitch != nil || inFlightWarmup != nil
     }
 
     /// Drop a scheduled-but-not-started warm-up so it can't fire mid-run.
@@ -389,6 +436,10 @@ final class ChatWarmupController: ObservableObject {
     private func performWarmup(session: ChatWarmupSessionContext) async {
         guard shouldAttemptWarmup(session: session) else { return }
 
+        await retiringWork?.value
+        guard !Task.isCancelled else { return }
+        guard shouldAttemptWarmup(session: session) else { return }
+
         // Coalesce: let any in-flight warm-up finish first, then decide
         // whether its result already covers the current payload.
         if let inflight = inFlightWarmup {
@@ -439,16 +490,22 @@ final class ChatWarmupController: ObservableObject {
         // warm-up. The background load intent below is the atomic gate: it
         // coalesces a same-model load and refuses a conflicting load before it
         // can evict or cancel anything.
+        // Consume the one-shot pick grant before any further suspension. If a
+        // real send cancels this warm-up, the grant must not survive for a
+        // later speculative re-warm and regain permission to evict a model.
         let userIntent = consumeUserIntent(for: payload.model)
+        if !userIntent {
+            let hasOtherResidentModel = await hasResidentModelOther(payload.model)
+            guard !Task.isCancelled else { return }
+            guard shouldAttemptWarmup(session: session) else { return }
 
-        if !userIntent,
-            await ModelRuntime.shared.hasResidentModelOther(than: payload.model)
-        {
-            state = .cold
-            debugLog(
-                "[ChatWarmup] skipped model=\(payload.model): a different model is resident and this warm-up lacks user intent"
-            )
-            return
+            if hasOtherResidentModel {
+                state = .cold
+                debugLog(
+                    "[ChatWarmup] skipped model=\(payload.model): a different model is resident and this warm-up lacks user intent"
+                )
+                return
+            }
         }
 
         state = .warming

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -238,6 +238,17 @@ final class ChatWarmupController: ObservableObject {
         let previousSwitch = activeModelSwitch
         activeModelSwitchID = switchID
         activeModelSwitch = Task { @MainActor in
+            // A user Stop can cancel this switch while `performSwitch` (or an
+            // older switch/warm-up awaited below) is suspended. Always retire
+            // our tracked task when it eventually unwinds; otherwise
+            // `needsPreSendHandshake` stays true forever and the next send
+            // appears permanently queued.
+            defer {
+                if self.activeModelSwitchID == switchID {
+                    self.activeModelSwitch = nil
+                    self.activeModelSwitchID = nil
+                }
+            }
             // Serialize with a still-running earlier switch so evictions
             // never interleave, then wait for the cancelled warm-up to
             // actually unwind — its generation lease would otherwise make
@@ -326,6 +337,28 @@ final class ChatWarmupController: ObservableObject {
     func cancelScheduledWarmup() {
         scheduleTask?.cancel()
         scheduleTask = nil
+    }
+
+    /// Cancel speculative work owned by a user-stopped pre-send handshake.
+    ///
+    /// Keep active switch / warm-up tasks tracked until they actually unwind:
+    /// the next send must await their residency and generation leases rather
+    /// than racing work that ignored cooperative cancellation. `switchEpoch`
+    /// prevents a suspended switch from scheduling a hidden warm-up when it
+    /// resumes after Stop.
+    func cancelPendingWorkForUserStop() {
+        let hadPendingWork =
+            scheduleTask != nil || activeModelSwitch != nil || inFlightWarmup != nil
+        guard hadPendingWork else { return }
+
+        switchEpoch &+= 1
+        scheduleTask?.cancel()
+        scheduleTask = nil
+        activeModelSwitch?.cancel()
+        inFlightWarmup?.cancel()
+        userIntentWarmupModel = nil
+        warmedFingerprint = nil
+        state = .cold
     }
 
     /// Wait for an in-flight warm-up generation to finish. Called before a
@@ -503,6 +536,11 @@ final class ChatWarmupController: ObservableObject {
         do {
             let stream = try await engine.streamChat(request: request)
             for try await _ in stream { /* discard warm-up output */  }
+            // Some engines finish normally even after the consumer task was
+            // cancelled. A user Stop must not let that late completion
+            // resurrect the green warm claim for an abandoned pre-send
+            // handshake.
+            guard !Task.isCancelled else { return }
             // Stale-writer guard: a reset() (chat cleared / agent switched)
             // during the generation dropped this warm-up's claim; its result
             // must not resurrect a warm dot for a payload that no longer

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -12,9 +12,23 @@ struct ChatSessionStopTests {
         session: ChatSession,
         gate: IgnoringCancellationHandshakeGate
     ) async throws {
-        session.warmupController.handleModelSelectionChange(
+        try await beginSuspendedPreSendHandshake(
             session: session,
-            to: "handshake-test-model",
+            gate: gate,
+            warmupSession: session,
+            model: "handshake-test-model"
+        )
+    }
+
+    private func beginSuspendedPreSendHandshake(
+        session: ChatSession,
+        gate: IgnoringCancellationHandshakeGate,
+        warmupSession: any ChatWarmupSessionContext,
+        model: String
+    ) async throws {
+        session.warmupController.handleModelSelectionChange(
+            session: warmupSession,
+            to: model,
             performSwitch: { _ in await gate.wait() }
         )
         try await waitUntilAsync(timeout: Self.asyncTimeout) {
@@ -101,25 +115,53 @@ struct ChatSessionStopTests {
     @Test
     func stop_invalidatesSuspendedPreSendHandshakeWithoutLaunchingCapturedTurn() async throws {
         try await ChatHistoryTestStorage.run {
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.warmModelsOnLoad = true
+            ChatConfigurationStore.save(chatConfig)
+
             let session = ChatSession()
             let gate = IgnoringCancellationHandshakeGate()
             let engine = PreSendHandshakeRecordingEngine()
             session.chatEngineFactory = { _ in engine }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+            let warmupSession = IncomingWarmupSession(engine: engine)
+            try await beginSuspendedPreSendHandshake(
+                session: session,
+                gate: gate,
+                warmupSession: warmupSession,
+                model: "incoming-warmup-model"
+            )
 
             session.send("keep this stopped turn")
             #expect(session.turns.map(\.content) == ["keep this stopped turn"])
 
             session.stop()
-            // Keep the test focused on the outer ChatSession task rather than
-            // allowing the completed switch to schedule a speculative warm-up.
-            session.warmupController.reset()
             await gate.release()
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                !session.warmupController.needsPreSendHandshake
+            }
+            // Give the zero-debounce task the stale switch used to schedule a
+            // chance to run. Counting only regular requests would miss this
+            // hidden post-Stop warm-up.
             try await Task.sleep(for: .milliseconds(250))
 
             #expect(session.isStreaming == false)
             #expect(session.turns.map(\.content) == ["keep this stopped turn"])
             #expect(await engine.regularRequestCount == 0)
+            #expect(await engine.warmupRequestCount == 0)
+
+            session.send("fresh turn after stopped handshake")
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await engine.regularRequestCount == 1
+            }
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                session.isSendActiveForComposer == false
+            }
+
+            #expect(
+                session.turns.filter { $0.role == .user }.map(\.content)
+                    == ["keep this stopped turn", "fresh turn after stopped handshake"]
+            )
+            #expect(await engine.regularRequestCount == 1)
         }
     }
 
@@ -175,6 +217,58 @@ struct ChatSessionStopTests {
 
             #expect(session.turns.isEmpty)
             #expect(await incomingEngine.requestCount == 1)
+        }
+    }
+
+    @Test
+    func stoppedPreSendWarmupCannotResurrectWarmStateAfterIgnoringCancellation() async throws {
+        try await ChatHistoryTestStorage.run {
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.warmModelsOnLoad = true
+            ChatConfigurationStore.save(chatConfig)
+
+            let session = ChatSession()
+            let controller = session.warmupController
+            controller.projectedLoadFeasibility = { _ in nil }
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = CancellationIgnoringWarmupEngine(gate: gate)
+            let warmupSession = IncomingWarmupSession(engine: engine)
+            let regularEngine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in regularEngine }
+
+            controller.scheduleWarmup(session: warmupSession, debounce: .zero)
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                let started = await gate.started
+                let requestCount = await engine.requestCount
+                return started && requestCount == 1
+            }
+            #expect(controller.needsPreSendHandshake)
+
+            session.send("stop this turn while warm-up streamChat is suspended")
+            #expect(session.isSendActiveForComposer)
+            session.stop()
+            #expect(controller.state == .cold)
+
+            // The engine's streamChat is deliberately suspended on a checked
+            // continuation, so cancelling the consumer cannot unwind it. The
+            // controller must retain the cancelled task until the engine
+            // actually releases its generation lease.
+            try await Task.sleep(for: .milliseconds(100))
+            #expect(controller.needsPreSendHandshake)
+            #expect(await engine.requestCount == 1)
+            #expect(await regularEngine.regularRequestCount == 0)
+
+            await gate.release()
+
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                !controller.needsPreSendHandshake
+            }
+            try await Task.sleep(for: .milliseconds(250))
+
+            #expect(controller.state == .cold)
+            #expect(await engine.requestCount == 1)
+            #expect(await regularEngine.regularRequestCount == 0)
+            #expect(session.isSendActiveForComposer == false)
         }
     }
 
@@ -405,9 +499,12 @@ private actor IgnoringCancellationHandshakeGate {
 
 private actor PreSendHandshakeRecordingEngine: ChatEngineProtocol {
     private(set) var regularRequestCount = 0
+    private(set) var warmupRequestCount = 0
 
     func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
-        if request.warmupPrefill != true {
+        if request.warmupPrefill == true {
+            warmupRequestCount += 1
+        } else {
             regularRequestCount += 1
         }
         return AsyncThrowingStream { continuation in
@@ -427,9 +524,9 @@ private final class IncomingWarmupSession: ChatWarmupSessionContext {
     let selectedModelIsLocal = true
     let isRemoteAgentTarget = false
     let isStreaming = false
-    private let engine: IncomingWarmupRecordingEngine
+    private let engine: any ChatEngineProtocol
 
-    init(engine: IncomingWarmupRecordingEngine) {
+    init(engine: any ChatEngineProtocol) {
         self.engine = engine
     }
 
@@ -446,6 +543,28 @@ private final class IncomingWarmupSession: ChatWarmupSessionContext {
     }
 
     func makeWarmupEngine() -> ChatEngineProtocol { engine }
+}
+
+private actor CancellationIgnoringWarmupEngine: ChatEngineProtocol {
+    private let gate: IgnoringCancellationHandshakeGate
+    private(set) var requestCount = 0
+
+    init(gate: IgnoringCancellationHandshakeGate) {
+        self.gate = gate
+    }
+
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        requestCount += 1
+        // `withCheckedContinuation` does not unwind merely because the caller
+        // task is cancelled. This models an engine setup / stream-drain boundary
+        // that holds its generation lease until the runtime itself returns.
+        await gate.wait()
+        return AsyncThrowingStream { $0.finish() }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionStopTests", code: 7)
+    }
 }
 
 private actor IncomingWarmupRecordingEngine: ChatEngineProtocol {

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -273,6 +273,62 @@ struct ChatSessionStopTests {
     }
 
     @Test
+    func resetRetainsCancelledWarmupAsDrainBarrierForImmediateFollowUp() async throws {
+        try await ChatHistoryTestStorage.run {
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.warmModelsOnLoad = true
+            ChatConfigurationStore.save(chatConfig)
+
+            let session = ChatSession()
+            let controller = session.warmupController
+            controller.projectedLoadFeasibility = { _ in nil }
+            let gate = IgnoringCancellationHandshakeGate()
+            let warmupEngine = CancellationIgnoringWarmupEngine(gate: gate)
+            let warmupSession = IncomingWarmupSession(engine: warmupEngine)
+            let regularEngine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in regularEngine }
+            session.forceChatEngineRouteForTests = true
+
+            controller.scheduleWarmup(session: warmupSession, debounce: .zero)
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                let started = await gate.started
+                let requestCount = await warmupEngine.requestCount
+                return started && requestCount == 1
+            }
+
+            session.send("outgoing turn waiting on warm-up")
+            #expect(session.isSendActiveForComposer)
+            session.stop()
+            session.reset()
+
+            // New Chat must not detach the cancelled warm-up from the
+            // controller while its engine still owns the generation lease.
+            #expect(controller.needsPreSendHandshake)
+
+            session.send("fresh new-chat follow-up")
+            #expect(session.isSendActiveForComposer)
+            try await Task.sleep(for: .milliseconds(100))
+
+            #expect(await warmupEngine.requestCount == 1)
+            #expect(await regularEngine.regularRequestCount == 0)
+
+            await gate.release()
+
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                session.isSendActiveForComposer == false
+            }
+
+            #expect(!controller.needsPreSendHandshake)
+            #expect(
+                session.turns.filter { $0.role == .user }.map(\.content)
+                    == ["fresh new-chat follow-up"]
+            )
+            #expect(await warmupEngine.requestCount == 1)
+            #expect(await regularEngine.regularRequestCount == 1)
+        }
+    }
+
+    @Test
     func sessionLoad_doesNotAppendTurnCapturedByPreviousHandshake() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -8,6 +8,21 @@ import Testing
 struct ChatSessionStopTests {
     private static let asyncTimeout: Duration = .seconds(10)
 
+    private func beginSuspendedPreSendHandshake(
+        session: ChatSession,
+        gate: IgnoringCancellationHandshakeGate
+    ) async throws {
+        session.warmupController.handleModelSelectionChange(
+            session: session,
+            to: "handshake-test-model",
+            performSwitch: { _ in await gate.wait() }
+        )
+        try await waitUntilAsync(timeout: Self.asyncTimeout) {
+            await gate.started
+                && session.warmupController.needsPreSendHandshake
+        }
+    }
+
     @Test
     func stop_trimsTrailingEmptyAssistantPlaceholder() async throws {
         try await ChatHistoryTestStorage.run {
@@ -84,6 +99,219 @@ struct ChatSessionStopTests {
     }
 
     @Test
+    func stop_invalidatesSuspendedPreSendHandshakeWithoutLaunchingCapturedTurn() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("keep this stopped turn")
+            #expect(session.turns.map(\.content) == ["keep this stopped turn"])
+
+            session.stop()
+            // Keep the test focused on the outer ChatSession task rather than
+            // allowing the completed switch to schedule a speculative warm-up.
+            session.warmupController.reset()
+            await gate.release()
+            try await Task.sleep(for: .milliseconds(250))
+
+            #expect(session.isStreaming == false)
+            #expect(session.turns.map(\.content) == ["keep this stopped turn"])
+            #expect(await engine.regularRequestCount == 0)
+        }
+    }
+
+    @Test
+    func reset_doesNotResurrectTurnCapturedBySuspendedPreSendHandshake() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("old chat turn")
+            #expect(session.turns.map(\.content) == ["old chat turn"])
+
+            session.reset()
+            await gate.release()
+            try await Task.sleep(for: .milliseconds(250))
+
+            #expect(session.turns.isEmpty)
+            #expect(session.sessionId == nil)
+            #expect(session.isStreaming == false)
+            #expect(await engine.regularRequestCount == 0)
+        }
+    }
+
+    @Test
+    func reset_incomingWarmupSurvivesCancelledPreviousHandshake() async throws {
+        try await ChatHistoryTestStorage.run {
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.warmModelsOnLoad = true
+            ChatConfigurationStore.save(chatConfig)
+
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            session.chatEngineFactory = { _ in PreSendHandshakeRecordingEngine() }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("old chat turn")
+            session.reset()
+
+            let incomingEngine = IncomingWarmupRecordingEngine()
+            let incomingSession = IncomingWarmupSession(engine: incomingEngine)
+            session.warmupController.scheduleWarmup(
+                session: incomingSession,
+                debounce: .milliseconds(250)
+            )
+
+            await gate.release()
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await incomingEngine.requestCount == 1
+            }
+
+            #expect(session.turns.isEmpty)
+            #expect(await incomingEngine.requestCount == 1)
+        }
+    }
+
+    @Test
+    func sessionLoad_doesNotAppendTurnCapturedByPreviousHandshake() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("old chat turn")
+            let loaded = ChatSessionData(
+                id: UUID(),
+                title: "Loaded chat",
+                turns: [ChatTurnData(role: .user, content: "loaded turn")]
+            )
+            session.load(from: loaded)
+            await gate.release()
+            try await Task.sleep(for: .milliseconds(250))
+
+            #expect(session.sessionId == loaded.id)
+            #expect(session.turns.map(\.content) == ["loaded turn"])
+            #expect(session.isStreaming == false)
+            #expect(await engine.regularRequestCount == 0)
+        }
+    }
+
+    @Test
+    func sessionLoad_dropsQueuedDraftAndOneOffSkillFromPreviousHandshake() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("old chat turn")
+            session.pendingOneOffSkillId = UUID()
+            session.enqueueSend("old queued draft", attachments: [])
+            session.pendingOneOffSkillId = UUID()
+            #expect(session.queuedSend?.text == "old queued draft")
+            #expect(session.queuedSend?.oneOffSkillId != nil)
+            #expect(session.pendingOneOffSkillId != nil)
+
+            let loaded = ChatSessionData(
+                id: UUID(),
+                title: "Loaded chat",
+                turns: [ChatTurnData(role: .user, content: "loaded turn")]
+            )
+            session.load(from: loaded)
+
+            #expect(session.queuedSend == nil)
+            #expect(session.pendingOneOffSkillId == nil)
+
+            await gate.release()
+            try await Task.sleep(for: .milliseconds(250))
+
+            #expect(session.sessionId == loaded.id)
+            #expect(session.turns.map(\.content) == ["loaded turn"])
+            #expect(session.isSendActiveForComposer == false)
+            #expect(await engine.regularRequestCount == 0)
+        }
+    }
+
+    @Test
+    func send_ignoresReentrantSendWhilePreSendHandshakeIsSuspended() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("first")
+            session.send("second")
+
+            #expect(session.turns.filter { $0.role == .user }.map(\.content) == ["first"])
+
+            session.stop()
+            session.warmupController.reset()
+            await gate.release()
+        }
+    }
+
+    @Test
+    func sendCurrent_queuesDraftWhilePreSendHandshakeIsSuspended() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            session.chatEngineFactory = { _ in PreSendHandshakeRecordingEngine() }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("first")
+            #expect(session.isSendActiveForComposer)
+
+            session.input = "second"
+            session.sendCurrent()
+
+            #expect(session.turns.filter { $0.role == .user }.map(\.content) == ["first"])
+            #expect(session.queuedSend?.text == "second")
+            #expect(session.input.isEmpty)
+
+            session.stop()
+            #expect(session.isSendActiveForComposer == false)
+            session.warmupController.reset()
+            await gate.release()
+        }
+    }
+
+    @Test
+    func sendNowInterrupting_replacesSuspendedHandshakeWithQueuedSend() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let gate = IgnoringCancellationHandshakeGate()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
+
+            session.send("first")
+            session.enqueueSend("replacement", attachments: [])
+            session.sendNowInterrupting()
+
+            #expect(
+                session.turns.filter { $0.role == .user }.map(\.content)
+                    == ["first", "replacement"]
+            )
+
+            await gate.release()
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await engine.regularRequestCount == 1
+            }
+        }
+    }
+
+    @Test
     func send_finishesReasoningOnlyLocalStream() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
@@ -154,6 +382,82 @@ private actor ReasoningOnlyChatEngine: ChatEngineProtocol {
 
     func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
         throw NSError(domain: "ChatSessionStopTests", code: 2)
+    }
+}
+
+/// Suspends a model-selection switch and deliberately ignores task
+/// cancellation until the test releases it. This reproduces the production
+/// race where a pre-send handshake can outlive Stop/reset/session load.
+private actor IgnoringCancellationHandshakeGate {
+    private(set) var started = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        started = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor PreSendHandshakeRecordingEngine: ChatEngineProtocol {
+    private(set) var regularRequestCount = 0
+
+    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        if request.warmupPrefill != true {
+            regularRequestCount += 1
+        }
+        return AsyncThrowingStream { continuation in
+            continuation.yield("unexpected stale dispatch")
+            continuation.finish()
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionStopTests", code: 5)
+    }
+}
+
+@MainActor
+private final class IncomingWarmupSession: ChatWarmupSessionContext {
+    let selectedModel: String? = "incoming-warmup-model"
+    let selectedModelIsLocal = true
+    let isRemoteAgentTarget = false
+    let isStreaming = false
+    private let engine: IncomingWarmupRecordingEngine
+
+    init(engine: IncomingWarmupRecordingEngine) {
+        self.engine = engine
+    }
+
+    func isImageGenerationModel(_: String?) -> Bool { false }
+
+    func makeWarmupPayload() async -> ChatWarmupPayload? {
+        ChatWarmupPayload(
+            model: "incoming-warmup-model",
+            messages: [ChatMessage(role: "system", content: "incoming chat prefix")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "incoming-warmup-model|incoming-chat-prefix"
+        )
+    }
+
+    func makeWarmupEngine() -> ChatEngineProtocol { engine }
+}
+
+private actor IncomingWarmupRecordingEngine: ChatEngineProtocol {
+    private(set) var requestCount = 0
+
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        requestCount += 1
+        return AsyncThrowingStream { $0.finish() }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionStopTests", code: 6)
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -459,6 +459,54 @@ struct ChatWarmupControllerCompletedRunTests {
 @MainActor
 struct ChatWarmupControllerRuntimeResidencyTests {
 
+    @Test("reset cancels a warm-up suspended in resident-model preflight")
+    func resetCancelsSuspendedResidentPreflight() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|resident-preflight"
+        )
+
+        let gate = FirstResidentPreflightGate()
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in
+            await gate.check()
+        }
+
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        for _ in 0 ..< 100 {
+            if await gate.firstCallStarted { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(await gate.firstCallStarted)
+        let staleScheduledTask = try #require(controller.scheduledWarmupTaskForTests)
+
+        controller.reset()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        for _ in 0 ..< 100 {
+            if engine.requestCount == 1, controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        // The cancelled first preflight ignores cooperative cancellation.
+        // Releasing it must not let the outgoing chat create a second,
+        // untracked warm-up after reset.
+        await gate.releaseFirst()
+        await staleScheduledTask.value
+
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+    }
+
     @Test("external eviction clears the warm claim and cached fingerprint")
     func externalEvictionClearsWarmClaimAndFingerprint() async {
         let engine = WarmupRecordingEngine()
@@ -629,6 +677,26 @@ private final class WarmupRecordingEngine: ChatEngineProtocol, @unchecked Sendab
             choices: [],
             usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
         )
+    }
+}
+
+private actor FirstResidentPreflightGate {
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private(set) var firstCallStarted = false
+    private var callCount = 0
+
+    func check() async -> Bool {
+        callCount += 1
+        guard callCount == 1 else { return false }
+        firstCallStarted = true
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func releaseFirst() {
+        continuation?.resume(returning: false)
+        continuation = nil
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "f50853514ee00365837be3301c91850ca7ed5877"
+        let expectedRevision = "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "7545ba66bf1060694ca4516cdf18768fef4b7c47"
+        let expectedRevision = "da2872b07c33bd138f3217eb1760385b8cda259a"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
+        let expectedRevision = "7545ba66bf1060694ca4516cdf18768fef4b7c47"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -766,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "7545ba66bf1060694ca4516cdf18768fef4b7c47"
+        let expectedRuntimeHardenedRevision = "da2872b07c33bd138f3217eb1760385b8cda259a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -766,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
+        let expectedRuntimeHardenedRevision = "7545ba66bf1060694ca4516cdf18768fef4b7c47"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -766,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "f50853514ee00365837be3301c91850ca7ed5877"
+        let expectedRuntimeHardenedRevision = "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -331,6 +331,12 @@ final class ChatSession: ObservableObject {
     /// placeholder typing-indicator row so the wait shows "Loading Model..."
     /// instead of a silent gap under the user's message.
     private var awaitingPreSendHandshake = false
+    /// Composer-facing activity includes the outer warm-up handshake, before
+    /// `isStreaming` flips. This keeps Stop/queue behavior available during a
+    /// long model switch instead of presenting a second ordinary Send button.
+    var isSendActiveForComposer: Bool {
+        isStreaming || awaitingPreSendHandshake
+    }
     /// Stable placeholder assistant turn rendered (never persisted, never in
     /// `turns`) while `awaitingPreSendHandshake` is true. Stable identity so
     /// the typing-indicator block id doesn't churn across rebuilds.
@@ -471,6 +477,16 @@ final class ChatSession: ObservableObject {
     private var currentTask: Task<Void, Never>?
     private var activeRunId: UUID?
     private var activeRunContext: RunContext?
+    /// Outer task that parks a send behind an in-flight model-switch/warm-up
+    /// handshake. Retaining it is required for lifecycle cancellation: a
+    /// fire-and-forget task can otherwise resume after Stop, reset, or a
+    /// session load and dispatch the user turn captured from the old chat.
+    private var preSendHandshakeTask: Task<Void, Never>?
+    /// Monotonic chat/session generation for pre-send handshakes. Every
+    /// lifecycle invalidation bumps this value; the suspended task and
+    /// `dispatchSend` both re-check their captured epoch before touching the
+    /// transcript or starting inference.
+    private var preSendHandshakeEpoch: UInt64 = 0
     /// Set to true at the start of `stop()` so `completeRunCleanup` knows the
     /// run was cancelled by the user (or by `sendNowInterrupting`) and must
     /// not auto-flush a queued send. Reset to false at the top of `send(...)`.
@@ -872,6 +888,8 @@ final class ChatSession: ObservableObject {
 
     deinit {
         print("[ChatSession] deinit")
+        preSendHandshakeEpoch &+= 1
+        preSendHandshakeTask?.cancel()
         currentTask?.cancel()
         generativeGreetingTask?.cancel()
         if let observer = remoteModelsObserver {
@@ -1770,6 +1788,14 @@ final class ChatSession: ObservableObject {
     }
 
     func sendCurrent() {
+        // A normal UI send can arrive before SwiftUI has redrawn the composer
+        // into its queue/Stop state. Preserve that draft in the existing
+        // single-slot queue instead of clearing it and dropping it behind the
+        // retained handshake task.
+        if preSendHandshakeTask != nil {
+            enqueueSend(input, attachments: pendingAttachments)
+            return
+        }
         guard !isStreaming else { return }
         // One local generation at a time across all windows: the shared
         // inference context can't run two, and loading a second would evict and
@@ -1790,17 +1816,26 @@ final class ChatSession: ObservableObject {
     /// in-flight warm-up generation to finish so its prefilled KV prefix is
     /// stored and the real request can prefix-hit. Does NOT start new
     /// warm-up work.
-    private func prepareForSendWarmup() async {
+    private static func prepareForSendWarmup(
+        using warmupController: ChatWarmupController
+    ) async -> Bool {
         await warmupController.awaitActiveModelSwitch()
+        // Stop/reset/session-load may cancel this outer handshake while the
+        // model switch is suspended. The controller is reused by the incoming
+        // chat, so a stale task must not cancel that chat's newly scheduled
+        // warm-up after the old switch finally unwinds.
+        guard !Task.isCancelled else { return false }
         // The switch task's last step schedules a fresh warm-up; this send
         // owns the next generation, so drop that scheduled warm-up before it
         // starts (a warm-up that already reached generation is covered by
         // the await below and only pre-warms this send's own prefix).
         warmupController.cancelScheduledWarmup()
         await warmupController.awaitInFlightWarmup()
+        return !Task.isCancelled
     }
 
     func stop() {
+        invalidatePreSendHandshake()
         stopRequested = true
         let task = currentTask
         task?.cancel()
@@ -1809,6 +1844,19 @@ final class ChatSession: ObservableObject {
         } else {
             completeRunCleanup()
         }
+    }
+
+    /// Cancel a send that is still waiting on the pre-send warm-up handshake
+    /// and invalidate its captured chat identity. Cancellation alone is not a
+    /// sufficient guard because the model-switch/warm-up operation being
+    /// awaited may finish normally (or ignore cooperative cancellation).
+    private func invalidatePreSendHandshake() {
+        preSendHandshakeEpoch &+= 1
+        preSendHandshakeTask?.cancel()
+        preSendHandshakeTask = nil
+        guard awaitingPreSendHandshake else { return }
+        awaitingPreSendHandshake = false
+        rebuildVisibleBlocks()
     }
 
     // MARK: - Queued Send (Cursor-style interrupt UX)
@@ -1878,7 +1926,7 @@ final class ChatSession: ObservableObject {
     func sendNowInterrupting() {
         guard let pending = queuedSend else { return }
         queuedSend = nil
-        if isStreaming || activeRunId != nil {
+        if isStreaming || activeRunId != nil || preSendHandshakeTask != nil {
             stop()
         }
         if let skillId = pending.oneOffSkillId {
@@ -2410,6 +2458,8 @@ final class ChatSession: ObservableObject {
         showVoiceOverlay = false
         input = ""
         pendingAttachments = []
+        pendingOneOffSkillId = nil
+        queuedSend = nil
         transientSessionIdForCurrentRun = nil
         appendedUserTurnForCurrentRun = false
         awaitingPreSendHandshake = false
@@ -4049,6 +4099,13 @@ final class ChatSession: ObservableObject {
         let hasContent = !trimmed.isEmpty || !attachments.isEmpty
         let isRegeneration = !hasContent && !turns.isEmpty
         guard hasContent || isRegeneration else { return }
+        // `isStreaming` does not flip until the pre-send handshake finishes.
+        // Treat the retained handshake as an active send so a second Send
+        // cannot queue another captured turn into the same lifecycle gap.
+        guard preSendHandshakeTask == nil else {
+            restoreTurnsRollbackAfterAbortedRegeneration()
+            return
+        }
         guard activeRunId == nil, !isStreaming else {
             restoreTurnsRollbackAfterAbortedRegeneration()
             return
@@ -4095,15 +4152,28 @@ final class ChatSession: ObservableObject {
         awaitingPreSendHandshake = true
         rebuildVisibleBlocks()
 
-        Task { @MainActor in
-            await self.prepareForSendWarmup()
+        let handshakeEpoch = preSendHandshakeEpoch
+        let controller = warmupController
+        preSendHandshakeTask = Task { @MainActor [weak self] in
+            // Capture the controller rather than `self` across the await so
+            // this retained task cannot keep a torn-down ChatSession alive.
+            let warmupHandshakeCompleted = await Self.prepareForSendWarmup(using: controller)
+            guard
+                warmupHandshakeCompleted,
+                let self,
+                !Task.isCancelled,
+                self.preSendHandshakeEpoch == handshakeEpoch
+            else { return }
+
+            self.preSendHandshakeTask = nil
             self.awaitingPreSendHandshake = false
             self.dispatchSend(
                 trimmed: trimmed,
                 attachments: attachments,
                 hasContent: hasContent,
                 preAppendedUserTurn: preAppendedUserTurn,
-                preAppendIntroducedFirstTurn: preAppendIntroducedFirstTurn
+                preAppendIntroducedFirstTurn: preAppendIntroducedFirstTurn,
+                expectedPreSendHandshakeEpoch: handshakeEpoch
             )
         }
     }
@@ -4116,8 +4186,18 @@ final class ChatSession: ObservableObject {
         attachments: [Attachment],
         hasContent: Bool,
         preAppendedUserTurn: ChatTurn? = nil,
-        preAppendIntroducedFirstTurn: Bool = false
+        preAppendIntroducedFirstTurn: Bool = false,
+        expectedPreSendHandshakeEpoch: UInt64? = nil
     ) {
+        // The pre-send task already checks this after its await. Keep the same
+        // guard at the dispatch boundary so future refactors cannot restore
+        // the old behavior where a reset transcript caused the captured turn
+        // to be re-appended and launched in the new chat.
+        if let expectedPreSendHandshakeEpoch,
+            expectedPreSendHandshakeEpoch != preSendHandshakeEpoch
+        {
+            return
+        }
         guard activeRunId == nil, !isStreaming else {
             rollbackPreAppendedUserTurn(
                 preAppendedUserTurn,
@@ -6432,7 +6512,7 @@ struct ChatView: View {
                                 showVoiceOverlay: $observedSession.showVoiceOverlay,
                                 pickerItems: filteredPickerItems,
                                 activeModelOptions: $observedSession.activeModelOptions,
-                                isStreaming: observedSession.isStreaming,
+                                isStreaming: observedSession.isSendActiveForComposer,
                                 // Hide Stop ONLY while the redaction review
                                 // sheet is actually on screen (the sheet owns
                                 // its own Cancel and the streaming Task is
@@ -6454,7 +6534,7 @@ struct ChatView: View {
                                     if let manualText = manualText {
                                         observedSession.input = manualText
                                     }
-                                    if observedSession.isStreaming {
+                                    if observedSession.isSendActiveForComposer {
                                         observedSession.enqueueSend(
                                             observedSession.input,
                                             attachments: observedSession.pendingAttachments

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -498,6 +498,13 @@ final class ChatSession: ObservableObject {
     var chatEngineFactory: @MainActor (InferenceSource) -> ChatEngineProtocol = {
         ChatEngine(source: $0)
     }
+    #if DEBUG
+        /// Keeps ChatSession lifecycle tests independent of whichever local
+        /// image bundle the developer machine happens to expose through the
+        /// shared picker cache. Those tests inject a chat engine and must not
+        /// be silently diverted into a machine-local image generation path.
+        var forceChatEngineRouteForTests = false
+    #endif
     // nonisolated(unsafe) allows deinit to access these for cleanup
     nonisolated(unsafe) private var remoteModelsObserver: NSObjectProtocol?
     nonisolated(unsafe) private var modelSelectionCancellable: AnyCancellable?
@@ -1819,6 +1826,8 @@ final class ChatSession: ObservableObject {
     private static func prepareForSendWarmup(
         using warmupController: ChatWarmupController
     ) async -> Bool {
+        await warmupController.awaitRetiringWork()
+        guard !Task.isCancelled else { return false }
         await warmupController.awaitActiveModelSwitch()
         // Stop/reset/session-load may cancel this outer handshake while the
         // model switch is suspended. The controller is reused by the incoming
@@ -3924,6 +3933,9 @@ final class ChatSession: ObservableObject {
     /// True when `id` names an on-device image-generation model in the picker
     /// catalog. Drives the image-vs-LLM branch in `send`.
     func isImageGenerationModel(_ id: String?) -> Bool {
+        #if DEBUG
+            if forceChatEngineRouteForTests { return false }
+        #endif
         guard let id, !id.isEmpty else { return false }
         return ModelPickerItemCache.shared.items.contains {
             $0.id == id && $0.source.isImageGeneration

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1835,7 +1835,11 @@ final class ChatSession: ObservableObject {
     }
 
     func stop() {
+        let wasAwaitingPreSendHandshake = awaitingPreSendHandshake
         invalidatePreSendHandshake()
+        if wasAwaitingPreSendHandshake {
+            warmupController.cancelPendingWorkForUserStop()
+        }
         stopRequested = true
         let task = currentTask
         task?.cancel()

--- a/docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md
+++ b/docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md
@@ -1,7 +1,7 @@
 # Bonsai SSD-recency emergency gate — 2026-07-24
 
-Status: **VERIFIED-LIVE FOR THE DEFAULT PAGED-OFF SSD-L2 EMERGENCY LANE AT
-THE FINAL vMLX SQUASH PIN; OSAURUS CI PENDING**
+Status: **PARTIAL — SOURCE TESTS PASS AT THE NEW vMLX SQUASH PIN; THE
+REBUILT EXACT-PIN OSAURUS LIVE UI MATRIX IS PENDING**
 
 This gate covers the user report:
 
@@ -172,6 +172,46 @@ live stall trace.
 Sampled published-app tool steps did emit stream-drained and lease-released
 events, with subsequent lease waits of 33–69 ms. Therefore an ordinary tool
 step orphan is not being claimed as the eviction root.
+
+## Rejected hybrid candidate and retained Stop-work follow-up
+
+Adversarial review after the first exact-squash smoke found two narrower
+contracts that the earlier proof did not close:
+
+1. `DiskCache.fetch` refreshed KV recency as soon as a payload deserialized,
+   before `CacheCoordinator` validated the recurrent companion required by a
+   hybrid SSM/GDN restore. Missing or incomplete companion state rejected the
+   candidate, but the unusable KV payload had already been made hot.
+2. Stop cancelled the outer pre-send handshake without cancelling and
+   retaining the controller-owned model-switch/warm-up work it awaited. A
+   suspended switch could therefore resume and schedule a hidden warm-up, and
+   a cancellation-ignoring warm-up could later resurrect the green warm claim.
+
+vMLX PR #182 was squash-merged as
+`7545ba66bf1060694ca4516cdf18768fef4b7c47`. The coordinator now fetches a
+candidate without touching recency and refreshes KV, or the linked
+KV-plus-companion pair, only after required companion validation succeeds.
+
+Current source-test evidence:
+
+- exact `c6a2b4d` baseline production source plus the two new rejected-candidate
+  tests: 0/2 passed; both missing and incomplete companion rows changed the KV
+  timestamp and failed;
+- patched source: the same 2/2 passed;
+- broader `DiskCache` selection: 17/17 passed;
+- `MLXLMCommon` build: completed;
+- corrected Osaurus Stop tests on `033fc0e2` production source: 12/14 passed,
+  with exactly the hidden post-Stop warm-up and cancellation-ignoring late
+  warm-state rows failing;
+- patched Osaurus source: `ChatSessionStopTests` 14/14 passed;
+- `git diff --check`: clean in both worktrees.
+
+The Osaurus controller now invalidates the suspended switch epoch, cancels
+scheduled/switch/warm-up work, keeps active tasks tracked until they actually
+unwind, and refuses a cancelled engine completion permission to write `.warm`.
+This is source/test evidence only until the exact
+`7545ba66bf1060694ca4516cdf18768fef4b7c47` Release app completes the live
+Stop/new-chat/tool/cache matrix below.
 
 ## Post-fix isolated Release UI proof
 

--- a/docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md
+++ b/docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md
@@ -1,0 +1,304 @@
+# Bonsai SSD-recency emergency gate — 2026-07-24
+
+Status: **VERIFIED-LIVE FOR THE DEFAULT PAGED-OFF SSD-L2 EMERGENCY LANE AT
+THE FINAL vMLX SQUASH PIN; OSAURUS CI PENDING**
+
+This gate covers the user report:
+
+- `it’s intermittent but cache resets to 0`
+- `and it doesn’t go up sometimes, stays yellow`
+- `feels like the model gets hung`
+- `pressed cancel`
+- `and kv cache resets to 0`
+
+The acceptance lane is the real Osaurus macOS UI operated through Computer
+Use. RunBench, API-only runs, source inspection, and cache counters without a
+visible coherent result are diagnostic evidence only.
+
+## Scope
+
+This emergency PR may change only:
+
+1. SSD-L2 eviction recency for a validated cache hit, including a hybrid
+   KV-plus-recurrent companion group;
+2. the Osaurus vMLX pin and focused integration coverage needed to consume that
+   engine fix;
+3. narrowly related lifecycle fixes only if the same published-app trace
+   reproduces them and the rebuilt app closes them.
+
+Gemma 4 QAT, broad parser cleanup, automatic routing, hardware guidance,
+TurboQuant defaults, AppleScript behavior, and unrelated model-family work are
+not part of this emergency diff.
+
+## Current-source owner
+
+Current engine baseline: vMLX `f50853514ee00365837be3301c91850ca7ed5877`.
+
+The SSD cache advertises oldest/LRU-style quota eviction, but a successful
+read does not update durable recency:
+
+- `Libraries/MLXLMCommon/Cache/DiskCache.swift`: `fetch` validates and returns
+  the KV payload without calling its existing `_touchEntryLocked` helper.
+- `Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift`: `fetch` validates
+  and returns recurrent state without refreshing the paired safetensors and
+  metadata modification times.
+- `Libraries/MLXLMCommon/Cache/CacheCoordinator.swift`: combined quota groups a
+  KV entry with its linked recurrent companion and orders the group by the
+  older of the KV timestamp and companion modification time.
+- validated stable/system boundaries can skip their completion-time rewrite,
+  so a frequently restored prefix has no later store operation that
+  accidentally refreshes its timestamp.
+
+The required fix is a successful-restore touch of the complete durable group,
+not a Bonsai name check and not a forced prompt/sampler behavior change.
+
+The missing read-side recency update predates the current release, but it
+became directly user-visible under the combined hybrid quota introduced by
+vMLX `bfd0defcab5ba42ea923de686b5230172036f3a9` on 2026-07-19. That quota
+correctly treats linked KV and recurrent-state files as one eviction unit; its
+ordering exposed that successful reads never made either half of the unit hot.
+
+## Published 0.22.10 live correlation
+
+App:
+
+- published DMG:
+  `/private/tmp/osaurus-02210-published-baseline-20260724/Osaurus-0.22.10.dmg`
+- mounted app: `/Volumes/Osaurus/osaurus.app`
+- bundle identifier: `com.dinoki.osaurus`
+- runtime root:
+  `/private/tmp/osaurus-bonsai-02210-baseline-root-20260724`
+- selected local bundles:
+  - `dealign.ai/Bonsai-27b-1bit-JANG-CRACK`
+  - `dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`
+
+Observed through the live UI and matched runtime trace:
+
+1. Bonsai Ternary repeatedly restored the same 2,102-token stable prefix from
+   SSD with paged RAM cache absent from the effective store path.
+2. The SQLite `created_at` values for those entries remained at their original
+   creation times after later successful hits.
+3. A same-chat follow-up after manually cancelling a long answer visibly
+   resumed at `Prefill 2161/4774` and completed
+   `SAME_CHAT_AFTER_CANCEL_OK` at TTFT 8.57s / 28.2 tok/s. This disproves a
+   universal cache clear on ordinary Stop: the previously completed prefix was
+   restored, while the uncached partial assistant suffix still required real
+   prefill.
+4. During the same run, combined cache usage crossed the configured 10 GiB
+   limit. The trace recorded:
+   `before=10781123841 after=10466130665 max=10737418240 kvEvicted=1`.
+5. Because successful reads had not refreshed durable recency, quota pressure
+   could select a recently used stable prefix as an old entry. Its next use
+   then has no SSD boundary and legitimately falls back to a cold `0/N`
+   prefill, matching the intermittent user report.
+
+This is source-and-live correlation for the eviction root. It is not
+post-fix proof.
+
+## Engine patch checkpoint
+
+Merged vMLX revision:
+`c6a2b4d05bec0958146d26fd351782b2fc3e2b13` (squashed from the
+live-tested `7aa42711407d59dbd7e371a05c65396ff0f3855a` source tree).
+
+The patch:
+
+- refreshes the indexed KV row after a successful disk read without rewriting
+  its safetensors payload;
+- refreshes both recurrent-companion file timestamps without rewriting either
+  payload;
+- after an accepted hybrid restore, refreshes the linked KV and companion
+  group with one timestamp under the combined-quota lock, including when
+  recurrent state was served from in-memory L1;
+- refreshes processor-proven stable system/tool checkpoints only after the
+  architecture-specific runtime retains the fetched disk state; rollback
+  paths do not receive the new stable-checkpoint touch;
+- keeps KV and companion eviction atomic.
+
+Current source-test evidence:
+
+- the final retained-restore LRU rows: 3/3 passed;
+- all tests in `DiskCacheTests.swift` at the preceding recency checkpoint:
+  14/14 passed;
+- `MLXLMCommon` with the final solo, batch, native-MTP, and diffusion call
+  sites compiled successfully;
+- `git diff --check`: passed.
+
+These are focused source tests. The matching isolated Release Osaurus UI
+evidence is recorded below.
+
+## Separate lifecycle patch checkpoint
+
+The published-app trace also exposed a distinct chat-lifecycle race; it is not
+being conflated with SSD eviction:
+
+- the pre-send model-switch/warm-up handshake previously ran in an unretained
+  task, so Stop, reset, or session load could not reliably cancel it;
+- after the awaited switch completed, that stale task could dispatch the turn
+  captured from the previous chat;
+- while the handshake was suspended, the composer appeared idle, allowing a
+  second draft to be dropped or queued without a visible active-send state;
+- an initial candidate retained and epoch-bound the handshake, but adversarial
+  review then found that `load(from:)` also had to clear the outgoing chat's
+  queued draft and one-off skill selection.
+
+The current candidate retains and epoch-binds the handshake, invalidates it on
+Stop/reset/session load/deinit, guards the dispatch boundary, exposes the
+handshake as composer activity, preserves a reentrant draft in the existing
+single-slot queue, and clears that queue plus one-off skill state when loading
+another chat.
+
+Focused current-source evidence:
+
+- `ChatSessionStopTests`: 13/13 passed, 0 failed or skipped;
+- the suite includes a cancellation-ignoring handshake, an old-chat queued
+  draft carrying a one-off skill, a session load, and assertions that the
+  loaded transcript remains unchanged and no stale model request dispatches;
+- an additional same-controller reset row proves that releasing an old
+  cancellation-ignoring model switch cannot cancel the incoming chat's newly
+  scheduled warm-up;
+- `git diff --check`: passed.
+
+The Stop -> New Chat lifecycle race is also covered by the matching isolated
+Release Osaurus UI evidence below.
+
+Separately, cache persistence remains synchronous after the final visible model
+delta and before terminal stream metadata. Existing traces can localize a
+visible-answer spinner to that postflight region, but cannot yet distinguish
+GPU synchronization, cache snapshot, SSM rederive/write, quota enforcement, or
+advisor drain. No exact postflight stage is being claimed without a matching
+live stall trace.
+
+Sampled published-app tool steps did emit stream-drained and lease-released
+events, with subsequent lease waits of 33–69 ms. Therefore an ordinary tool
+step orphan is not being claimed as the eviction root.
+
+## Post-fix isolated Release UI proof
+
+Exact app:
+
+- source checkout: this Osaurus worktree with vMLX
+  `7aa42711407d59dbd7e371a05c65396ff0f3855a`;
+- Release app:
+  `/private/tmp/osaurus-bonsai-final-7aa-app/osaurus.app`;
+- isolated bundle identifier:
+  `com.dinoki.osaurus.bonsaissdfinal7aa20260724`;
+- isolated root:
+  `/private/tmp/osaurus-bonsai-ssd-final-7aa-root-20260724`;
+- executable SHA-256:
+  `17b9e27abfb8d74ad670e56e41851a45708b68f6ea1723a4295bc306f0aa44ba`;
+- runtime trace:
+  `/private/tmp/osaurus-bonsai-ssd-final-7aa-live-20260724.log`.
+
+Computer Use visibly saved and re-read the effective Settings -> Server ->
+Cache state before model testing:
+
+- Prefix Cache: On;
+- Enable GPU Cache: Off;
+- Disk Cache: On;
+- Disk Cache Size: 1.5 GB;
+- Codec: Engine Selected (TurboQuant was not forced on);
+- Re-derive SSM State After Generation: On.
+
+### Bonsai Ternary cancellation, new-chat, and restart
+
+Bundle:
+`/Users/eric/models/dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`.
+
+1. The initial warm-up stored a 3,007-token stable checkpoint. The first chat
+   restored boundary 3,005 with 24 tokens remaining and `ssm=96`, then visibly
+   completed `BONSAI_FINAL_A` at TTFT 1.21 s / 31.4 tok/s.
+2. A new chat warm-up restored boundary 3,007 with only 1 token remaining and
+   `ssm=96`. Its request restored boundary 3,007 with 22 tokens remaining and
+   visibly completed `BONSAI_FINAL_B` at TTFT 0.62 s / 31.6 tok/s.
+3. A long response was allowed to produce 643 visible deltas, then Stop was
+   pressed. New Chat was opened immediately and a send was issued in the
+   outgoing-handshake race window. The incoming warm-up restored 3,007 tokens
+   with 1 remaining; the request restored 3,007 with 23 remaining and visibly
+   completed `BONSAI_FINAL_CANCEL_OK` at TTFT 0.70 s / 27.8 tok/s. Stop
+   disappeared and the composer unlocked.
+4. The app was quit and relaunched from the same executable and isolated root.
+   The first post-restart warm-up restored boundary 3,007 with 1 token
+   remaining and `ssm=96`, proving disk persistence rather than process-memory
+   reuse. `BONSAI_FINAL_RESTART_OK` visibly completed at TTFT 0.69 s /
+   32.3 tok/s and the composer returned to its terminal state.
+
+### Adjacent architecture rows
+
+All rows used a clean chat with paged RAM still Off and visibly reached a
+terminal UI state.
+
+| Bundle | SSD restore | Visible result |
+| --- | --- | --- |
+| `JANGQ-AI/Ornith-1.0-9B-JANG_4M` | new-chat warm-up boundary 3,007, 1 remaining, `ssm=48`; request boundary 3,007, 22 remaining | coherent factual answer, TTFT 0.37 s / 66.8 tok/s; Stop absent and input unlocked |
+| `OsaurusAI/OsaurusAI--gemma-4-E2B-it-8bit` | rotating-SWA warm-up boundary 1,091, 4 remaining, `ssm=-1`; request boundary 1,095, 19 remaining | `GEMMA4_FINAL_A` at 0.42 s / 43.2 tok/s and new-chat `GEMMA4_FINAL_B` at 0.20 s / 82.9 tok/s |
+| `JANGQ-AI/Laguna-S-2.1-JANG_2L` | warm-up boundary 2,841, 3 remaining, `ssm=-1`; request boundary 2,844, 19 remaining | `LAGUNA_FINAL_A` at 2.43 s / 42.4 tok/s and new-chat `LAGUNA_FINAL_B` at 0.77 s / 43.2 tok/s |
+
+Every traced paged-store attempt reported
+`effectiveKVLayers=0 blocks=0 payload=false`, so none of these hits came from
+the disabled GPU-paged tier. Gemma and Laguna retained their required rotating
+companion offsets. The 1.5 GB disk quota also evicted complete KV/companion
+groups during the run without leaving a permanently yellow `Queued 0/N` or
+`Prefill 0/N` state.
+
+## Exact final-squash-pin smoke
+
+After vMLX PR #181 was squash-merged, all Osaurus dependency and pin-guard
+surfaces were changed to the resulting commit
+`c6a2b4d05bec0958146d26fd351782b2fc3e2b13`. Xcode resolved that exact
+checkout and built the Release app again.
+
+Exact final-pin app:
+
+- app:
+  `/private/tmp/osaurus-bonsai-final-c6a2b4d-oldid-app/osaurus.app`;
+- isolated bundle identifier:
+  `com.dinoki.osaurus.bonsaissdfinal7aa20260724`;
+- isolated root:
+  `/private/tmp/osaurus-bonsai-ssd-final-7aa-root-20260724`;
+- executable SHA-256 after the final ad-hoc seal:
+  `ddbb639351f058e4dc6bc0e31803b0f1ee9a2f86816653a22b532915f90daf5c`;
+- runtime trace:
+  `/private/tmp/osaurus-bonsai-final-c6a2b4d-oldid-live-20260724.log`.
+
+Computer Use visibly re-read the effective cache settings in that exact app:
+Prefix Cache On, Enable GPU Cache Off, Disk Cache On, 1.5 GB, Codec Engine
+Selected, and SSM re-derive On.
+
+The reused proof root had gained a changed agent/onboarding configuration, so
+the first final-pin warm-up correctly rejected the older stable identity and
+stored a new 3,005/3,007-token boundary instead of reusing stale state. The
+subsequent rows then proved the intended current-configuration path:
+
+1. The first request restored boundary 3,005 with 26 remaining and `ssm=96`,
+   visibly completed `FINAL_PIN_BONSAI_A` at TTFT 1.09 s / 31.2 tok/s, and
+   returned to an unlocked terminal UI.
+2. New Chat restored boundary 3,007 with 1 remaining; its request restored
+   3,007 with 25 remaining and visibly completed
+   `FINAL_PIN_BONSAI_NEW_CHAT` at TTFT 0.74 s / 31.2 tok/s. Stop disappeared.
+3. The app was quit and relaunched from the same final-pin executable and
+   root. The new process restored boundary 3,007 with 1 remaining and
+   `ssm=96`; its request restored 3,007 with 25 remaining and visibly
+   completed `FINAL_PIN_BONSAI_RESTART` at TTFT 0.73 s / 31.7 tok/s. Stop
+   disappeared and the composer unlocked.
+4. Final-pin quota rows evicted complete KV/companion pairs, including
+   `before=1735023124 after=1300546508 max=1610612736` with
+   `kvEvicted=1 companionEvicted=1`.
+5. Every final-pin paged-store trace still reported
+   `effectiveKVLayers=0 blocks=0 payload=false`.
+
+### Honest limits
+
+- This emergency gate proves the product-default paged-Off SSD-L2 path. It does
+  not prove the separate paged-RAM-on recency policy.
+- Bonsai Ternary is the reported regression reproducer used for the
+  cancellation and restart stress. The final candidate did not repeat a
+  separate Bonsai 1-bit UI row.
+- Failed-tool recovery and broad tool/parser behavior remain separate campaign
+  rows; they are not claimed by this cache/lifecycle diff.
+- Osaurus is pinned to and was rebuilt/smoke-tested against the final vMLX
+  squash commit `c6a2b4d05bec0958146d26fd351782b2fc3e2b13`; Osaurus CI is still
+  required before merge.
+
+No image files are to be added to Git history or a pull request. Local
+screenshots may be used only for operator inspection.

--- a/docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md
+++ b/docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md
@@ -1,7 +1,7 @@
 # Bonsai SSD-recency emergency gate — 2026-07-24
 
-Status: **PARTIAL — SOURCE TESTS PASS AT THE NEW vMLX SQUASH PIN; THE
-REBUILT EXACT-PIN OSAURUS LIVE UI MATRIX IS PENDING**
+Status: **PARTIAL — EXACT-PIN SOURCE TESTS AND THE SCOPED BONSAI LIVE UI
+LIFECYCLE PASS; FINAL OSAURUS PR-HEAD CI AND MERGE ARE PENDING**
 
 This gate covers the user report:
 
@@ -30,9 +30,11 @@ Gemma 4 QAT, broad parser cleanup, automatic routing, hardware guidance,
 TurboQuant defaults, AppleScript behavior, and unrelated model-family work are
 not part of this emergency diff.
 
-## Current-source owner
+## Published 0.22.10 root-cause baseline
 
-Current engine baseline: vMLX `f50853514ee00365837be3301c91850ca7ed5877`.
+Root-cause baseline: published Osaurus 0.22.10 using vMLX
+`f50853514ee00365837be3301c91850ca7ed5877`. This section preserves the
+pre-fix source trace; it is not the final candidate pin.
 
 The SSD cache advertises oldest/LRU-style quota eviction, but a successful
 read does not update durable recency:
@@ -95,7 +97,7 @@ Observed through the live UI and matched runtime trace:
 This is source-and-live correlation for the eviction root. It is not
 post-fix proof.
 
-## Engine patch checkpoint
+## Historical PR #181 engine checkpoint
 
 Merged vMLX revision:
 `c6a2b4d05bec0958146d26fd351782b2fc3e2b13` (squashed from the
@@ -115,7 +117,7 @@ The patch:
   paths do not receive the new stable-checkpoint touch;
 - keeps KV and companion eviction atomic.
 
-Current source-test evidence:
+Historical PR #181 source-test evidence:
 
 - the final retained-restore LRU rows: 3/3 passed;
 - all tests in `DiskCacheTests.swift` at the preceding recency checkpoint:
@@ -124,10 +126,10 @@ Current source-test evidence:
   sites compiled successfully;
 - `git diff --check`: passed.
 
-These are focused source tests. The matching isolated Release Osaurus UI
-evidence is recorded below.
+These are focused source tests. The matching historical PR #181 isolated
+Release Osaurus UI evidence is recorded below.
 
-## Separate lifecycle patch checkpoint
+## First lifecycle checkpoint
 
 The published-app trace also exposed a distinct chat-lifecycle race; it is not
 being conflated with SSD eviction:
@@ -148,7 +150,7 @@ handshake as composer activity, preserves a reentrant draft in the existing
 single-slot queue, and clears that queue plus one-off skill state when loading
 another chat.
 
-Focused current-source evidence:
+Focused historical candidate evidence:
 
 - `ChatSessionStopTests`: 13/13 passed, 0 failed or skipped;
 - the suite includes a cancellation-ignoring handshake, an old-chat queued
@@ -159,8 +161,9 @@ Focused current-source evidence:
   scheduled warm-up;
 - `git diff --check`: passed.
 
-The Stop -> New Chat lifecycle race is also covered by the matching isolated
-Release Osaurus UI evidence below.
+The historical isolated Release Osaurus UI evidence below exercised a
+Stop -> New Chat path, but it predates the separate reset-retirement barrier
+added to the final candidate.
 
 Separately, cache persistence remains synchronous after the final visible model
 delta and before terminal stream metadata. Existing traces can localize a
@@ -209,11 +212,189 @@ Current source-test evidence:
 The Osaurus controller now invalidates the suspended switch epoch, cancels
 scheduled/switch/warm-up work, keeps active tasks tracked until they actually
 unwind, and refuses a cancelled engine completion permission to write `.warm`.
-This is source/test evidence only until the exact
-`7545ba66bf1060694ca4516cdf18768fef4b7c47` Release app completes the live
-Stop/new-chat/tool/cache matrix below.
+This was source/test evidence for the intermediate
+`7545ba66bf1060694ca4516cdf18768fef4b7c47` candidate. It was superseded by
+the final accepted-only engine checkpoint and reset-retirement barrier below.
 
-## Post-fix isolated Release UI proof
+## Final accepted-only engine checkpoint
+
+vMLX PR #183 was squash-merged as
+`da2872b07c33bd138f3217eb1760385b8cda259a`
+(`Count only accepted hybrid cache restores`). It supersedes the intermediate
+PR #182 pin `7545ba66bf1060694ca4516cdf18768fef4b7c47`.
+
+The final source makes cache hit accounting and durable recency conditional on
+an accepted restore:
+
+- `DiskCache.fetch` accepts independent `touchRecency` and `countHit` controls.
+  Coordinator candidate reads use both as `false`; deserializing a candidate
+  alone neither refreshes its LRU position nor increments disk-hit telemetry.
+- After architecture-specific validation succeeds, `CacheCoordinator` records
+  one accepted disk hit and refreshes either the dense KV entry or the linked
+  KV-plus-recurrent group with one timestamp.
+- `SSMCompanionDiskStore.fetch` can require a complete companion and reject an
+  incomplete sidecar before tensor deserialization or file-recency changes.
+- `SSMStateCache.fetchEntry` propagates that completeness contract. An
+  incomplete reusable-state lookup does not hydrate L1, increment SSM hits, or
+  make the entry hotter; the attempted lookup remains an honest miss.
+- Both solo `Evaluate` and `BatchEngine` require complete N-1 recurrent seed
+  state before consuming a path-dependent full disk restore.
+
+This does not mean candidate probing emits no telemetry: genuine absent or
+invalid candidates can still count as misses. The corrected contract is that
+only an accepted restore counts as a hit or refreshes eviction recency.
+
+Local source evidence on `a8f88a6c1480cf144b29c0ac73f1a1987cf0b42a`,
+whose Git tree is identical to final squash `da2872b`, recorded:
+
+- deterministic rejected-candidate RED controls;
+- accepted/rejected restore controls: 3/3 passed;
+- cache-focused selection: 28/28 passed;
+- `DiskCacheTests`: 17/17 passed;
+- `MLXLMCommon` build completed;
+- `git diff --check` passed.
+
+GitHub CI must not be described as green: all four PR #183 Build and Test jobs
+were `SKIPPED`.
+
+## Separate reset retirement barrier
+
+This lifecycle root is distinct from SSD eviction and from the earlier
+post-Stop warm-state fix.
+
+The earlier controller retained cancelled switch and warm-up tasks until they
+unwound. `ChatSession.reset()`, however, cancelled those tasks and then cleared
+the controller's active task slots. If an engine ignored cooperative
+cancellation while still holding the generation lease, New Chat lost the
+reference needed to drain that old owner. An immediate follow-up could then
+race the old lease, remain queued, or observe an unload/load decision made
+while the prior generation still existed.
+
+The current candidate moves cancelled switch/warm-up work into a separate
+`retiringWork` barrier before clearing the current-chat slots. New work can be
+scheduled for the incoming chat, but every runtime-touching switch, warm-up,
+and pre-send handshake waits for the retired owner to unwind first.
+`needsPreSendHandshake` remains true during that drain.
+
+Adversarial review then found a second suspension boundary before a scheduled
+warm-up becomes `inFlightWarmup`: the resident-model preflight actor hop. A
+reset could cancel the scheduled task during that await, after which stale
+work could resume and create a new untracked generation. The final source
+re-checks cancellation and current session eligibility immediately after that
+hop, before consuming user intent or creating the in-flight generation.
+
+The deterministic regression test performs:
+
+1. a cancellation-ignoring warm-up that owns the engine;
+2. a send waiting on that warm-up;
+3. Stop followed by reset/New Chat;
+4. an immediate follow-up send;
+5. proof that no fresh request dispatches before the old gate releases;
+6. proof that exactly one fresh request dispatches afterward, only the incoming
+   user turn remains, and the composer reaches its terminal state.
+
+A separate deterministic row suspends the old scheduled warm-up inside a
+cancellation-ignoring resident-model preflight, resets and completes the
+incoming warm-up, then releases the stale preflight and proves it cannot launch
+a second generation or overwrite the incoming warm state.
+
+These are source-test evidence only. They do not replace the required
+exact-pin live Stop -> New Chat -> follow-up UI row.
+
+## Exact final-pin source checkpoint
+
+All six Osaurus dependency and pin-guard surfaces name
+`da2872b07c33bd138f3217eb1760385b8cda259a`:
+
+- app-project `Package.resolved`;
+- root-workspace `Package.resolved`;
+- `Packages/OsaurusCore/Package.resolved`;
+- `Packages/OsaurusCore/Package.swift`;
+- `ImageGenerationBridgeContractTests`;
+- `RuntimePolicySourceTests`.
+
+The Xcode derived checkout used by the focused run resolves to that exact HEAD.
+
+Artifact:
+
+`/private/tmp/osaurus-bonsai-emergency-da2872-release-derived-20260724/Logs/Test/Test-OsaurusCoreTests-2026.07.24_17-57-15--0700.xcresult`
+
+Result:
+
+- `RuntimePolicySourceTests`: 97/97;
+- `ChatSessionStopTests`: 15/15;
+- `ImageGenerationBridgeContractTests`: 2/2;
+- `ChatWarmupControllerRuntimeResidencyTests`: 3/3;
+- total: 117/117 passed, 0 failed, 0 skipped.
+
+This is a selected focused suite, not the full repository test suite.
+`git diff --check` is clean.
+
+## Exact final-pin scoped Release UI proof
+
+Exact app:
+
+- source checkout:
+  `/private/tmp/osaurus-bonsai-emergency-20260724`;
+- Release app:
+  `/private/tmp/osaurus-bonsai-emergency-da2872-release-derived-20260724/Build/Products/Release/osaurus.app`;
+- isolated bundle identifier:
+  `com.dinoki.osaurus.bonsaida287proof20260724`;
+- isolated root:
+  `/private/tmp/osaurus-bonsai-emergency-da2872-root-20260724`;
+- executable SHA-256:
+  `5035b9d0e4a8f64e628cd9a3cf746d77d6b46c074f2aff8134b664c4dc4a1f8e`;
+- resolved vMLX checkout:
+  `da2872b07c33bd138f3217eb1760385b8cda259a`;
+- runtime trace:
+  `/private/tmp/osaurus-bonsai-emergency-da2872-live-20260724.log`;
+- prefill trace:
+  `/tmp/osaurus-prefill-debug.log`.
+
+The executable was rebuilt after the last lifecycle edit, ad-hoc signed, and
+passed strict deep signature verification. Computer Use then completed fresh
+onboarding and visibly inspected Settings -> Server -> Cache. The fresh
+real-user defaults were:
+
+- Prefix Cache: On;
+- Enable GPU Cache: Off;
+- Disk Cache: On;
+- Disk Cache Size: blank, documented by the UI as the 10 GB engine default;
+- Codec: Engine Selected, with no forced TurboQuant setting;
+- Re-derive SSM State After Generation: On.
+
+Bundle:
+`/Users/eric/models/dealign.ai/Bonsai-27b-Ternary-JANG-CRACK`.
+
+The exact reported lifecycle was exercised through the chat UI:
+
+1. A baseline request visibly completed `BASELINE READY.` at TTFT 0.90 s /
+   30.5 tok/s. The trace accepted disk boundary 3,005 with 19 tokens remaining
+   and `ssm=96`.
+2. A 300-item response restored boundary 3,026 with 38 tokens remaining and
+   visibly entered decode. Stop was pressed after item 50 at 34.7 tok/s.
+   Stop disappeared and the composer unlocked.
+3. New Chat was opened immediately. Its warm-up restored boundary 3,007 with
+   1 token remaining. The immediate user request visibly showed
+   `Prefill 3007/3026`, then completed `RECOVERED AFTER STOP.` at TTFT 0.65 s /
+   29.9 tok/s. Stop disappeared and input unlocked; it never remained in
+   `Queued 0/N`, `Prefill 0/N`, or a yellow spinner.
+4. The app was quit and relaunched from the same exact executable and isolated
+   root. The new process restored boundary 3,007 with 1 token remaining during
+   warm-up and boundary 3,019 with 7 tokens remaining for the repeated user
+   request, both with `ssm=96`. `RECOVERED AFTER STOP.` visibly completed at
+   TTFT 0.54 s / 31.0 tok/s, with Stop gone and the composer unlocked.
+
+Every corresponding paged-store trace reported
+`effectiveKVLayers=0 blocks=0 payload=false`, while disk stores and accepted
+disk hits were present. The new-chat and process-restart restores therefore
+came from the enabled SSD tier, not a hidden GPU-paged payload.
+
+This exact-final-pin live gate is deliberately scoped to the reported Bonsai
+Stop -> New Chat -> restart regression. The broader family/parser/media matrix
+remains separate follow-up work and is not claimed by this emergency proof.
+
+## Historical PR #181 isolated Release UI proof
 
 Exact app:
 
@@ -281,14 +462,14 @@ companion offsets. The 1.5 GB disk quota also evicted complete KV/companion
 groups during the run without leaving a permanently yellow `Queued 0/N` or
 `Prefill 0/N` state.
 
-## Exact final-squash-pin smoke
+## Historical PR #181 squash-pin smoke
 
 After vMLX PR #181 was squash-merged, all Osaurus dependency and pin-guard
 surfaces were changed to the resulting commit
 `c6a2b4d05bec0958146d26fd351782b2fc3e2b13`. Xcode resolved that exact
 checkout and built the Release app again.
 
-Exact final-pin app:
+Historical PR #181 squash-pin app:
 
 - app:
   `/private/tmp/osaurus-bonsai-final-c6a2b4d-oldid-app/osaurus.app`;
@@ -301,7 +482,8 @@ Exact final-pin app:
 - runtime trace:
   `/private/tmp/osaurus-bonsai-final-c6a2b4d-oldid-live-20260724.log`.
 
-Computer Use visibly re-read the effective cache settings in that exact app:
+Computer Use visibly re-read the effective cache settings in that historical
+candidate app:
 Prefix Cache On, Enable GPU Cache Off, Disk Cache On, 1.5 GB, Codec Engine
 Selected, and SSM re-derive On.
 
@@ -336,9 +518,10 @@ subsequent rows then proved the intended current-configuration path:
   separate Bonsai 1-bit UI row.
 - Failed-tool recovery and broad tool/parser behavior remain separate campaign
   rows; they are not claimed by this cache/lifecycle diff.
-- Osaurus is pinned to and was rebuilt/smoke-tested against the final vMLX
-  squash commit `c6a2b4d05bec0958146d26fd351782b2fc3e2b13`; Osaurus CI is still
-  required before merge.
+- The current Osaurus candidate is pinned to vMLX
+  `da2872b07c33bd138f3217eb1760385b8cda259a`, but the historical UI evidence
+  above only covers `7aa4271`/`c6a2b4d`. Exact-`da2872b` Computer Use proof and
+  final-head Osaurus CI are still required before merge.
 
 No image files are to be added to Git history or a pull request. Local
 screenshots may be used only for operator inspection.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
+        "revision" : "7545ba66bf1060694ca4516cdf18768fef4b7c47"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7545ba66bf1060694ca4516cdf18768fef4b7c47"
+        "revision" : "da2872b07c33bd138f3217eb1760385b8cda259a"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f50853514ee00365837be3301c91850ca7ed5877"
+        "revision" : "c6a2b4d05bec0958146d26fd351782b2fc3e2b13"
       }
     },
     {


### PR DESCRIPTION
## Problem

Two independent failures could produce the reported intermittent Bonsai experience:

1. SSD-L2 restores did not refresh durable recency, so quota churn could evict a recently reused stable system/tool checkpoint. A later compatible chat then legitimately fell back to a cold `0/N` prefill.
2. Osaurus did not retain the pre-send model-switch/warm-up handshake. Stop, reset, or session load could leave a suspended task able to resume against a different chat; the composer could also appear idle and accept a second send during that gap.

## Changes

- Pin all Osaurus dependency surfaces and source guards to merged vMLX commit `c6a2b4d05bec0958146d26fd351782b2fc3e2b13` from vMLX PR #181.
- Retain and epoch-bind the pre-send handshake.
- Cancel and invalidate that handshake on Stop, reset, session load, and deinit.
- Recheck cancellation before cancelling an incoming chat's scheduled warm-up.
- Treat the handshake as composer activity so Stop/queue UI remains available.
- Preserve one reentrant draft in the existing single-slot queue.
- Clear an outgoing chat's queued draft and one-off skill when loading another session.
- Add focused lifecycle regression coverage and a text-only internal evidence record.

## Source verification

- vMLX PR #181: squash-merged at `c6a2b4d05bec0958146d26fd351782b2fc3e2b13`.
- vMLX `DiskCacheTests`: 14/14 at the recency checkpoint; final retained-restore subset 3/3.
- vMLX `MLXLMCommon` build: passed.
- Exact final Osaurus pin resolved to `c6a2b4d05bec0958146d26fd351782b2fc3e2b13`.
- Osaurus Release build at the final pin: passed.
- `ChatSessionStopTests`: 13/13.
- `ImageGenerationBridgeContractTests`: passed.
- `RuntimePolicySourceTests`: passed, including the exact vMLX pin guard.
- `git diff --check`: passed.

The broad no-forced-behavior helper still reports a pre-existing base-tree match in `Packages/OsaurusCore/Tools/CapabilityTools.swift`; this PR does not touch that file and its added-line scan contains no forced thinking, sampler override, parser repair, or template coercion.

## Exact final-pin Release UI proof

Release app:

- app: `/private/tmp/osaurus-bonsai-final-c6a2b4d-oldid-app/osaurus.app`
- bundle ID: `com.dinoki.osaurus.bonsaissdfinal7aa20260724`
- isolated root: `/private/tmp/osaurus-bonsai-ssd-final-7aa-root-20260724`
- executable SHA-256: `ddbb639351f058e4dc6bc0e31803b0f1ee9a2f86816653a22b532915f90daf5c`
- trace: `/private/tmp/osaurus-bonsai-final-c6a2b4d-oldid-live-20260724.log`

Computer Use visibly re-read:

- Prefix Cache: On
- Enable GPU Cache: Off
- Disk Cache: On
- Disk Cache Size: 1.5 GB
- Codec: Engine Selected (TurboQuant not forced)
- SSM re-derive: On

Bonsai Ternary final-pin rows:

| Row | Disk trace | Visible terminal result |
| --- | --- | --- |
| first request | boundary 3,005; 26 remaining; `ssm=96` | `FINAL_PIN_BONSAI_A`; TTFT 1.09 s; 31.2 tok/s |
| New Chat | warm-up 3,007/1; request 3,007/25; `ssm=96` | `FINAL_PIN_BONSAI_NEW_CHAT`; TTFT 0.74 s; 31.2 tok/s |
| full app restart | new-process warm-up 3,007/1; request 3,007/25; `ssm=96` | `FINAL_PIN_BONSAI_RESTART`; TTFT 0.73 s; 31.7 tok/s |

For every row, the full answer appeared, Stop disappeared, and the composer unlocked. Every paged-store trace reported `effectiveKVLayers=0 blocks=0 payload=false`, so these restores were from disk with GPU-paged cache disabled. Final-pin quota churn evicted complete KV/companion pairs, including `before=1735023124 after=1300546508 max=1610612736`, without leaving the UI stuck.

The larger pre-squash byte-equivalent Release matrix also covered:

- Bonsai Stop after 643 deltas -> immediate New Chat -> coherent terminal answer;
- full app restart SSD restore;
- Ornith 9B JANG_4M hybrid `ssm=48`;
- Gemma 4 E2B rotating-SWA;
- Laguna S 2.1 JANG_2L mixed cache.

Exact counts, TTFT, token/s, and limitations are in `docs/BONSAI_SSD_RECENCY_EMERGENCY_2026-07-24.md`.

## Scope and limits

This PR contains only:

- the merged vMLX SSD-recency pin;
- the directly reproduced Osaurus pre-send lifecycle fix;
- focused tests and text evidence.

It does not change AppleScript/Computer Use planning, broad tool parsers, reasoning behavior, generation defaults, TurboQuant defaults, paged-RAM policy, batching/delegation, media, routing, or hardware guidance. Paged-RAM-On and TurboQuant-On remain separate campaign rows. No image or media evidence is committed.

## CI

Local source and exact Release UI gates above passed. GitHub CI is pending and must pass before squash merge.
