### PR TITLE
fix: don't install CLI symlink into Homebrew's managed bin directory

### DIFF
--- a/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
@@ -932,18 +932,15 @@ extension ConfigurationView {
             return
         }
 
-        // Candidate target directories
-        let brewBin = URL(fileURLWithPath: "/opt/homebrew/bin", isDirectory: true)
+        // Candidate target directories. /opt/homebrew/bin is intentionally
+        // NOT a candidate: it's a directory Homebrew owns and manages, and
+        // Osaurus isn't distributed via a Homebrew formula — its presence
+        // on a user's machine for unrelated packages isn't a reason for
+        // this app to write into it. See osaurus-ai/osaurus#2137.
         let usrLocalBin = URL(fileURLWithPath: "/usr/local/bin", isDirectory: true)
         let userLocalBin = fm.homeDirectoryForCurrentUser
             .appendingPathComponent(".local", isDirectory: true)
             .appendingPathComponent("bin", isDirectory: true)
-
-        if tryInstall(cliURL: cliURL, into: brewBin) {
-            cliInstallSuccess = true
-            cliInstallMessage = "Installed to \(brewBin.appendingPathComponent("osaurus").path)"
-            return
-        }
 
         if tryInstall(cliURL: cliURL, into: usrLocalBin) {
             cliInstallSuccess = true

--- a/scripts/release/install_cli_symlink.sh
+++ b/scripts/release/install_cli_symlink.sh
@@ -11,7 +11,9 @@ set -euo pipefail
 #
 # Notes:
 # - When no path is provided, common install locations are checked.
-# - On Apple Silicon, Homebrew typically lives at /opt/homebrew; we auto-detect it.
+# - Default target is /usr/local/bin, falling back to ~/.local/bin. Homebrew's
+#   prefix is never used automatically (see resolve_target_bin_dir below) —
+#   use --prefix to target it explicitly if that's what you want.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -78,19 +80,16 @@ resolve_cli_from_dev() {
 }
 
 resolve_target_bin_dir() {
-  # Priority: explicit --prefix, Homebrew prefix/bin, /usr/local/bin, ~/.local/bin
+  # Priority: explicit --prefix, /usr/local/bin, ~/.local/bin.
+  #
+  # Homebrew's prefix is intentionally NOT used as a default: it's a
+  # directory Homebrew owns and manages, and Osaurus isn't distributed via
+  # a Homebrew formula — brew being present on a user's machine for
+  # unrelated packages isn't a reason for this app to write into it.
+  # See osaurus-ai/osaurus#2137.
   if [[ -n "$PREFIX_OVERRIDE" ]]; then
     echo "$PREFIX_OVERRIDE/bin"
     return 0
-  fi
-
-  if command -v brew >/dev/null 2>&1; then
-    local brew_prefix
-    brew_prefix="$(brew --prefix 2>/dev/null || true)"
-    if [[ -n "$brew_prefix" ]]; then
-      echo "$brew_prefix/bin"
-      return 0
-    fi
   fi
 
   if [[ -d "/usr/local/bin" ]]; then


### PR DESCRIPTION
## Summary
Fixes #2137. Both the Settings → Command Line Tool → Install CLI action (`ConfigurationView.installCLI`) and the standalone `scripts/release/install_cli_symlink.sh` tried `/opt/homebrew/bin` first, ahead of `/usr/local/bin` and `~/.local/bin`.

`/opt/homebrew/bin` is Homebrew's own managed directory. Osaurus isn't distributed via a Homebrew formula, so `brew` merely being installed on a user's machine for unrelated packages isn't a reason for a different app to write into a directory it doesn't own — this is exactly the "agentic software touching files it shouldn't" concern the issue raises.

## Changes
- `ConfigurationView.installCLI()`: removed the `/opt/homebrew/bin` candidate entirely. Falls through to `/usr/local/bin`, then `~/.local/bin` (existing writability check + "Add to PATH" messaging unchanged).
- `install_cli_symlink.sh`'s `resolve_target_bin_dir()`: removed the `brew --prefix` auto-detection branch. Same fallback order otherwise. `--prefix` remains available for anyone who explicitly wants Homebrew's prefix.

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` — clean build, no warnings/errors on the changed file
- [x] `bash -n scripts/release/install_cli_symlink.sh` — syntax OK
- [ ] Manual verification of the Settings → Install CLI flow on a machine with Homebrew installed (would appreciate a maintainer or CI check here, since I don't have a build of the full signed .app to click through in this environment)