### PR TITLE
Fix Gemma and Qwen post-tool completion

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/Skill.swift
+++ b/Packages/OsaurusCore/Models/Agent/Skill.swift
@@ -126,9 +126,10 @@ public struct Skill: Codable, Identifiable, Sendable, Equatable {
 
                     ## Workflow
                     1. Use `web_search` with focused queries to find candidate sources
-                    2. Pick the most authoritative results and call `search_and_extract` with each result's direct `url` to retrieve the actual page content — never pass a known URL back into `web_search` as another query
-                    3. Cross-reference key facts across at least two independent sources
-                    4. Note publication dates; prefer recent sources for fast-moving topics
+                    2. Loading this skill does not load the extraction schema. Before retrieval, if `search_and_extract` is not already in the current tool schema, call `capabilities_load` with the exact id `tool/search_and_extract`; after that succeeds, call `search_and_extract` in this same run.
+                    3. Pick the most authoritative results and call `search_and_extract` with each result's direct `url` to retrieve the actual page content — never pass a known URL back into `web_search` as another query
+                    4. Cross-reference key facts across at least two independent sources
+                    5. Note publication dates; prefer recent sources for fast-moving topics
 
                     ## Query strategy
                     - Start specific; broaden only if results are thin

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -184,6 +184,13 @@ final class ChatTurn: ObservableObject, Identifiable {
     /// Populated only on the Responses path; nil everywhere else.
     var reasoningItemId: String? = nil
     var reasoningEncrypted: String? = nil
+    /// Keeps an abandoned protocol attempt visible in the transcript while
+    /// preventing it from re-entering model history. This is set only when an
+    /// agent/tool generation ends with incomplete reasoning and the loop
+    /// retries from the exact pre-attempt history in a fresh assistant turn.
+    /// Persisting the marker prevents a later user turn or session reload from
+    /// replaying the abandoned reasoning beside the successful retry.
+    var modelContextExcluded: Bool = false
     /// For role==.tool messages, associates this result with the originating call id
     var toolCallId: String? = nil
     /// Frozen memory / screen-context block this USER turn was originally
@@ -512,6 +519,7 @@ extension ChatTurn {
         let toolResults: [String: String]?
         let toolCallId: String?
         var injectedContextPrefix: String? = nil
+        var modelContextExcluded: Bool? = nil
     }
 
     /// Converts this turn to a persistable representation
@@ -524,7 +532,8 @@ extension ChatTurn {
             toolCalls: toolCalls,
             toolResults: toolResults.isEmpty ? nil : toolResults,
             toolCallId: toolCallId,
-            injectedContextPrefix: injectedContextPrefix
+            injectedContextPrefix: injectedContextPrefix,
+            modelContextExcluded: modelContextExcluded ? true : nil
         )
     }
 
@@ -546,6 +555,7 @@ extension ChatTurn {
         }
         turn.toolCallId = p.toolCallId
         turn.injectedContextPrefix = p.injectedContextPrefix
+        turn.modelContextExcluded = p.modelContextExcluded ?? false
 
         return turn
     }

--- a/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
@@ -44,6 +44,9 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
     /// non-Responses turn.
     public var reasoningItemId: String?
     public var reasoningEncrypted: String?
+    /// An abandoned reasoning/protocol attempt can remain visible in the
+    /// transcript without being replayed to the model. False for legacy turns.
+    public var modelContextExcluded: Bool
     /// Osaurus Router billing snapshot (cost, token counts, status) for this
     /// assistant turn. Metadata only - no prompt/response text. Nil for local
     /// models and non-router providers.
@@ -74,6 +77,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         terminalStopReason: String? = nil,
         reasoningItemId: String? = nil,
         reasoningEncrypted: String? = nil,
+        modelContextExcluded: Bool = false,
         routerBilling: RouterBillingSummary? = nil,
         injectedContextPrefix: String? = nil
     ) {
@@ -95,6 +99,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         self.terminalStopReason = terminalStopReason
         self.reasoningItemId = reasoningItemId
         self.reasoningEncrypted = reasoningEncrypted
+        self.modelContextExcluded = modelContextExcluded
         self.routerBilling = routerBilling
         self.injectedContextPrefix = injectedContextPrefix
     }
@@ -119,6 +124,8 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         terminalStopReason = try container.decodeIfPresent(String.self, forKey: .terminalStopReason)
         reasoningItemId = try container.decodeIfPresent(String.self, forKey: .reasoningItemId)
         reasoningEncrypted = try container.decodeIfPresent(String.self, forKey: .reasoningEncrypted)
+        modelContextExcluded =
+            try container.decodeIfPresent(Bool.self, forKey: .modelContextExcluded) ?? false
         routerBilling = try container.decodeIfPresent(RouterBillingSummary.self, forKey: .routerBilling)
         injectedContextPrefix = try container.decodeIfPresent(String.self, forKey: .injectedContextPrefix)
 
@@ -155,6 +162,9 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         try container.encodeIfPresent(terminalStopReason, forKey: .terminalStopReason)
         try container.encodeIfPresent(reasoningItemId, forKey: .reasoningItemId)
         try container.encodeIfPresent(reasoningEncrypted, forKey: .reasoningEncrypted)
+        if modelContextExcluded {
+            try container.encode(true, forKey: .modelContextExcluded)
+        }
         try container.encodeIfPresent(routerBilling, forKey: .routerBilling)
         try container.encodeIfPresent(injectedContextPrefix, forKey: .injectedContextPrefix)
     }
@@ -167,6 +177,7 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         case thinkingDuration
         case createdAt, completedAt, generationTokenCount, timeToFirstToken, terminalStopReason
         case reasoningItemId, reasoningEncrypted
+        case modelContextExcluded
         case routerBilling
         case injectedContextPrefix
     }
@@ -196,6 +207,7 @@ extension ChatTurnData {
         self.terminalStopReason = turn.terminalStopReason
         self.reasoningItemId = turn.reasoningItemId
         self.reasoningEncrypted = turn.reasoningEncrypted
+        self.modelContextExcluded = turn.modelContextExcluded
         self.routerBilling = turn.routerBilling
         self.injectedContextPrefix = turn.injectedContextPrefix
     }
@@ -224,6 +236,7 @@ extension ChatTurn {
         self.terminalStopReason = data.terminalStopReason
         self.reasoningItemId = data.reasoningItemId
         self.reasoningEncrypted = data.reasoningEncrypted
+        self.modelContextExcluded = data.modelContextExcluded
         self.routerBilling = data.routerBilling
         self.injectedContextPrefix = data.injectedContextPrefix
     }

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -78,6 +78,12 @@ struct ModelPickerItem: Identifiable, Hashable {
     /// Whether this is a Vision Language Model
     let isVLM: Bool
 
+    /// Canonical local-bundle architecture from config.json. Nil for remote,
+    /// Foundation, image-generation, or legacy picker entries that do not
+    /// expose bundle metadata. Prompt-family routing must prefer this over
+    /// marketing/repository names when it is available.
+    let modelType: String?
+
     /// Whether the local bundle is in MLX format and therefore loadable by the
     /// local engine. Set from `MLXModel.isMLXFormat` for local items so the
     /// picker can grey out (and refuse to select) co-mingled non-MLX bundles
@@ -132,6 +138,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         parameterCount: String? = nil,
         quantization: String? = nil,
         isVLM: Bool = false,
+        modelType: String? = nil,
         isMLXFormat: Bool = true,
         isEmbedding: Bool = false,
         description: String? = nil,
@@ -152,6 +159,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         self.parameterCount = parameterCount
         self.quantization = quantization
         self.isVLM = isVLM
+        self.modelType = modelType
         self.isMLXFormat = isMLXFormat
         self.isEmbedding = isEmbedding
         self.description = description
@@ -203,6 +211,7 @@ extension ModelPickerItem {
             parameterCount: model.parameterCount,
             quantization: model.quantization,
             isVLM: model.isVLM,
+            modelType: model.modelType,
             isMLXFormat: model.isMLXFormat,
             isEmbedding: model.isEmbedding,
             description: model.description

--- a/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
@@ -64,6 +64,11 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     /// been picked yet.
     public let model: String?
 
+    /// Canonical local-bundle `config.json.model_type` captured alongside the
+    /// selected model. This keeps family guidance architecture-derived and
+    /// session-deterministic instead of re-reading a changing scan cache.
+    public let modelType: String?
+
     /// User-selected manual tool names, or nil when not in manual mode.
     public let manualToolNames: [String]?
 
@@ -159,6 +164,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         autonomousConfig: AutonomousExecConfig?,
         toolMode: ToolSelectionMode,
         model: String?,
+        modelType: String? = nil,
         manualToolNames: [String]?,
         systemPrompt: String,
         dbEnabled: Bool,
@@ -186,6 +192,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         self.autonomousConfig = autonomousConfig
         self.toolMode = toolMode
         self.model = model
+        self.modelType = modelType
         self.manualToolNames = manualToolNames
         self.systemPrompt = systemPrompt
         self.dbEnabled = dbEnabled
@@ -221,7 +228,8 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     public static func capture(
         agentId: UUID,
         requestToolsDisabled: Bool = false,
-        modelOverride: String? = nil
+        modelOverride: String? = nil,
+        modelTypeOverride: String? = nil
     ) -> AgentConfigSnapshot {
         let mgr = AgentManager.shared
         // One resolve services every capability gate (positive polarity),
@@ -235,6 +243,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
             autonomousConfig: mgr.effectiveAutonomousExec(for: agentId),
             toolMode: mgr.effectiveToolSelectionMode(for: agentId),
             model: modelOverride ?? mgr.effectiveModel(for: agentId),
+            modelType: modelTypeOverride,
             manualToolNames: mgr.effectiveManualToolNames(for: agentId),
             systemPrompt: mgr.effectiveSystemPrompt(for: agentId),
             dbEnabled: caps.dbEnabled,

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -142,12 +142,26 @@ public final class AgentTaskState {
         "file_read", "file_search", "file_edit", "capabilities_load",
     ]
 
+    /// Read-like tools that can explicitly classify a failure as
+    /// non-retryable for the exact same arguments. `search_and_extract` uses
+    /// this for challenge/blocked/empty pages: immediately repeating the same
+    /// URL batch cannot produce page evidence and previously shifted a search
+    /// loop into an extraction loop.
+    private static let deterministicAsIsFailureTools: Set<String> = [
+        "search_and_extract",
+    ]
+
     /// Error kinds eligible for held-error replay. Both depend only on the
     /// arguments + current file state, never on transient conditions.
     private static let deterministicErrorKinds: Set<String> = [
         ToolEnvelope.Kind.invalidArgs.rawValue,
         ToolEnvelope.Kind.notFound.rawValue,
     ]
+
+    /// One execution plus one same-signature retry for a transient extraction
+    /// failure. The third request is replayed as an explicit retry-exhausted
+    /// failure instead of reaching the network again.
+    private static let maxTransientAsIsRetries = 1
 
     /// The listing nudge is REACTIVE, not proactive: it fires only once the
     /// model has produced this many listings without an intervening read —
@@ -219,6 +233,9 @@ public final class AgentTaskState {
     private var heldErrors: [CallSignature: HeldError] = [:]
     /// How many times each held error has been replayed (drives escalation).
     private var heldErrorReplays: [CallSignature: Int] = [:]
+    /// Number of retryable failures executed for a selected read-like tool.
+    /// This is per exact canonical argument signature and per user message.
+    private var transientFailureExecutions: [CallSignature: Int] = [:]
     /// Notice produced by the most recent `heldResult` hit when it replayed
     /// a held ERROR (nil for fresh-read replays — the driver's standard
     /// dedupe notice covers those). The driver stages this verbatim.
@@ -257,6 +274,7 @@ public final class AgentTaskState {
         freshReads.removeAll(keepingCapacity: true)
         heldErrors.removeAll(keepingCapacity: true)
         heldErrorReplays.removeAll(keepingCapacity: true)
+        transientFailureExecutions.removeAll(keepingCapacity: true)
         lastReplayNotice = nil
         consecutiveListingsWithoutRead = 0
         nonReadCallCounts.removeAll(keepingCapacity: true)
@@ -282,10 +300,11 @@ public final class AgentTaskState {
     ///   1. Fresh reads — a still-fresh read (same tool + canonical args,
     ///      not invalidated by an intervening write to its path).
     ///   2. Held deterministic errors — an `invalid_args`/`not_found` error
-    ///      from a deterministic folder tool, with no intervening write/exec
-    ///      that could change the outcome. Replaying it (with an escalating
-    ///      notice via `lastReplayNotice`) converts an observed N-execution
-    ///      failure spiral into one execution + cached replays.
+    ///      from a deterministic folder tool, or an explicitly non-retryable
+    ///      exact-arguments failure from a read-like tool such as
+    ///      `search_and_extract`. Replaying it (with an escalating notice via
+    ///      `lastReplayNotice`) converts an observed N-execution failure
+    ///      spiral into one execution + cached replays.
     /// Returns nil for novel calls or invalidated entries. The replay is
     /// verbatim — never a collapsed/summarized form — so it is neutral.
     public func heldResult(name: String, argsJSON: String) -> String? {
@@ -294,7 +313,10 @@ public final class AgentTaskState {
         if Self.readLikeTools.contains(name), let fresh = freshReads[sig] {
             return fresh.envelope
         }
-        if Self.deterministicErrorTools.contains(name), let held = heldErrors[sig] {
+        if Self.deterministicErrorTools.contains(name)
+            || Self.deterministicAsIsFailureTools.contains(name),
+            let held = heldErrors[sig]
+        {
             let replays = (heldErrorReplays[sig] ?? 0) + 1
             heldErrorReplays[sig] = replays
             let failures = replays + 1  // original execution + replays
@@ -356,6 +378,7 @@ public final class AgentTaskState {
             freshReads.removeAll(keepingCapacity: true)
             heldErrors.removeAll(keepingCapacity: true)
             heldErrorReplays.removeAll(keepingCapacity: true)
+            transientFailureExecutions.removeAll(keepingCapacity: true)
         }
 
         // A write/edit invalidates any fresh read of the same path so the
@@ -380,23 +403,47 @@ public final class AgentTaskState {
         }
 
         // Capture (or clear) a held deterministic error for this signature.
-        // Only `invalid_args`/`not_found` from the deterministic folder tools
-        // qualify: given an unchanged filesystem, re-executing the identical
-        // call must return the identical error, so replaying is honest.
-        if Self.deterministicErrorTools.contains(name) {
-            if ToolEnvelope.isError(result),
-                let kind = Self.errorKind(result),
-                Self.deterministicErrorKinds.contains(kind)
-            {
+        // Folder/capability tools qualify by deterministic error kind;
+        // selected read-like tools may also qualify by an explicit
+        // `retryable:false` contract. Transient extraction failures therefore
+        // execute again, while an unchanged challenge-page request is replayed
+        // rather than sent to the network indefinitely.
+        if Self.deterministicErrorTools.contains(name)
+            || Self.deterministicAsIsFailureTools.contains(name)
+        {
+            let holdsByKind = Self.errorKind(result).map(Self.deterministicErrorKinds.contains)
+                ?? false
+            let holdsAsIs = Self.deterministicAsIsFailureTools.contains(name)
+                && Self.errorRetryable(result) == false
+            if ToolEnvelope.isError(result), holdsByKind || holdsAsIs {
                 heldErrors[sig] = HeldError(
                     canonicalPath: pathArgument(argsJSON).map(Self.canonicalPath),
                     envelope: result
                 )
+                transientFailureExecutions[sig] = nil
+            } else if ToolEnvelope.isError(result),
+                Self.deterministicAsIsFailureTools.contains(name),
+                Self.errorRetryable(result) == true
+            {
+                let executions = (transientFailureExecutions[sig] ?? 0) + 1
+                transientFailureExecutions[sig] = executions
+                if executions > Self.maxTransientAsIsRetries,
+                    let exhausted = Self.retryExhaustedEnvelope(result, tool: name)
+                {
+                    heldErrors[sig] = HeldError(
+                        canonicalPath: pathArgument(argsJSON).map(Self.canonicalPath),
+                        envelope: exhausted
+                    )
+                } else {
+                    heldErrors[sig] = nil
+                    heldErrorReplays[sig] = nil
+                }
             } else {
                 // A success (or non-deterministic error) supersedes any held
                 // error for this exact call.
                 heldErrors[sig] = nil
                 heldErrorReplays[sig] = nil
+                transientFailureExecutions[sig] = nil
             }
         }
 
@@ -652,6 +699,36 @@ public final class AgentTaskState {
             let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return nil }
         return dict["kind"] as? String
+    }
+
+    /// Pull the canonical retryability bit from an error envelope.
+    private static func errorRetryable(_ envelope: String) -> Bool? {
+        guard let data = envelope.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return dict["retryable"] as? Bool
+    }
+
+    /// Convert a second identical transient extraction failure into the
+    /// stable result replayed on subsequent requests. Preserve every original
+    /// diagnostic field while making the exhausted retry contract explicit.
+    private static func retryExhaustedEnvelope(_ envelope: String, tool: String) -> String? {
+        guard let data = envelope.data(using: .utf8),
+            var dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        dict["retryable"] = false
+        dict["retry_exhausted"] = true
+        dict["message"] =
+            "The identical \(tool) retrieval failed on its initial attempt and one retry. "
+            + "Do not execute the same arguments again; change the source or report the blocker."
+        dict["next_action"] = [
+            "instruction":
+                "Choose a materially different retrievable source or report the blocker. Do not claim the failed page was inspected."
+        ]
+        return try? String(
+            data: JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+            encoding: .utf8
+        )
     }
 
     // MARK: - Path canonicalization (shared)

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -123,21 +123,47 @@ enum AgentLoopModelStep {
     /// call. Visible partial content or reasoning may be present, but the
     /// authoritative terminal reason says generation was incomplete.
     case lengthExhausted
+    /// The stream ended after emitting reasoning but no user-visible answer,
+    /// or the runtime reported that the reasoning envelope never closed.
+    /// Agent runs require a normal final answer after reasoning/tool work, so
+    /// an explicitly recovery-capable surface may perform one bounded retry;
+    /// other surfaces end with a typed incomplete result instead of presenting
+    /// the reasoning card as a completed response.
+    case incompleteReasoning
+    /// The runtime reported an unclosed reasoning envelope after already
+    /// emitting user-visible content. Streaming surfaces cannot retract that
+    /// content, so transparently replaying would concatenate two attempts.
+    /// End honestly without an automatic retry.
+    case incompleteVisibleResponse
 
     /// Classify a naturally completed model step from its rendered channels
     /// and authoritative terminal stop reason.
     ///
-    /// A reasoning-only natural `stop` remains final for model families that
-    /// intentionally answer in their reasoning channel. A reasoning-only
-    /// `length` is different: the runtime says the model hit its configured
-    /// cap, so accepting it as success abandons the task.
+    /// A reasoning-only natural `stop` is not a complete agent response. The
+    /// reasoning rail is visible diagnostic work, while the user-facing answer
+    /// belongs in content. This distinction matters after tools: a reported
+    /// 29K-character Gemma thought block had no answer, but its saved artifact
+    /// lacked terminal provenance, so this classifier relies on live stop and
+    /// envelope state rather than inferring completion from reasoning alone.
     static func classifyTerminal(
         contentIsBlank: Bool,
         thinkingIsBlank: Bool,
-        stopReason: String?
+        stopReason: String?,
+        unclosedReasoning: Bool = false,
+        requiresVisibleFinalResponse: Bool
     ) -> Self {
         if stopReason == "length" {
             return .lengthExhausted
+        }
+        if requiresVisibleFinalResponse
+            && unclosedReasoning && !contentIsBlank
+        {
+            return .incompleteVisibleResponse
+        }
+        if requiresVisibleFinalResponse
+            && (unclosedReasoning || (contentIsBlank && !thinkingIsBlank))
+        {
+            return .incompleteReasoning
         }
         if contentIsBlank, thinkingIsBlank {
             return .emptyResponse
@@ -153,6 +179,21 @@ enum AgentLoopModelStep {
             return fallback
         }
         return String(content[...lastVisible]) + "\n\n" + fallback
+    }
+}
+
+/// Whether a surface owes the user a normal visible answer after a
+/// reasoning-only model stop. Merely advertising tool schemas is not evidence
+/// that an agent/tool workflow occurred: ordinary direct chats may expose
+/// baseline tools while a reasoning-only bundle intentionally returns on its
+/// reasoning rail. Structured tool work in this logical run and remote-agent
+/// execution are the two contracts that require a visible final response.
+enum AgentLoopVisibleResponsePolicy {
+    static func requiresVisibleFinalResponse(
+        hasStructuredToolWork: Bool,
+        isRemoteAgentTarget: Bool
+    ) -> Bool {
+        hasStructuredToolWork || isRemoteAgentTarget
     }
 }
 
@@ -184,6 +225,16 @@ struct AgentLoopToolOutcome {
     let wasError: Bool
 }
 
+/// Typed, session-scoped view of the checklist the `todo` tool owns.
+/// The driver compares snapshots from successful current-run `todo` calls;
+/// it never infers progress from assistant prose or tool-result strings.
+struct AgentTodoProgressSnapshot: Equatable, Sendable {
+    let done: Int
+    let total: Int
+
+    var pending: Int { max(0, total - done) }
+}
+
 // MARK: - Hooks
 
 /// Surface-specific behavior, injected as async closures. All closures
@@ -208,6 +259,24 @@ struct AgentLoopHooks {
     /// routing) and classify the outcome. Thrown errors abort the run and
     /// propagate to the caller of `run` (chat's catch blocks live there).
     var modelStep: (_ messages: [ChatMessage], _ iteration: Int) async throws -> AgentLoopModelStep
+
+    /// Keep the just-finished incomplete attempt in the surface transcript and
+    /// prepare a fresh output buffer for one natural retry. The retry's
+    /// model-visible history must remain byte-for-byte equivalent to the
+    /// pre-attempt history: local templates disagree on how a tool-free
+    /// `reasoning_content` assistant message is serialized (some drop it,
+    /// others close and rewrite it). This boundary must not append that
+    /// incomplete attempt to the next model request or inject a prompt,
+    /// reasoning tag, sampler override, EOS override, or other coercion.
+    var prepareIncompleteReasoningContinuation: (() async -> Void)?
+
+    /// Preserve an ordinary assistant response from a run that successfully
+    /// created/updated a todo list while structured unchecked work remains,
+    /// then prepare a fresh output buffer for the next model step. Unlike
+    /// incomplete-reasoning recovery, the response MUST remain model-visible:
+    /// it is real work/progress emitted by the model. Only chat opts into this
+    /// boundary; headless surfaces keep their existing terminal behavior.
+    var prepareTrackedTaskContinuation: (() async -> Void)?
 
     /// Called for every parsed invocation before the dedupe check, so the
     /// chat surface can materialise its tool-call row (and UI timers)
@@ -244,11 +313,15 @@ struct AgentLoopHooks {
     var onBatchComplete: (_ outcomes: [AgentLoopToolOutcome]) async -> Void
 
     /// Number of UNCHECKED items on the session's todo list, or nil when
-    /// the surface has no session-scoped todo (HTTP/plugin/eval). When
-    /// set, the driver stages a one-line staleness notice after
-    /// `AgentLoopPolicy.todoStalenessThreshold` iterations pass without a
-    /// `todo` call while pending items remain. Chat-only today.
+    /// the surface has no session-scoped todo (HTTP/plugin/eval). Chat uses
+    /// this only for the periodic staleness notice.
     var pendingTodoCount: (() async -> Int)?
+
+    /// Current structured checklist counts for the run's captured session.
+    /// Chat supplies this so a successful current-run `todo` cannot be silently
+    /// abandoned while unchecked work remains. Other surfaces retain their
+    /// existing terminal behavior by leaving it nil.
+    var todoProgressSnapshot: (() async -> AgentTodoProgressSnapshot?)?
 
     /// Emit a final, user-visible assistant message when an empty turn could
     /// not be recovered (the model produced nothing across the bounded
@@ -262,6 +335,8 @@ struct AgentLoopHooks {
         isCancelled: @escaping () async -> Bool = { false },
         buildMessages: @escaping (_ notices: [String]) async -> AgentLoopIterationInput,
         modelStep: @escaping (_ messages: [ChatMessage], _ iteration: Int) async throws -> AgentLoopModelStep,
+        prepareIncompleteReasoningContinuation: (() async -> Void)? = nil,
+        prepareTrackedTaskContinuation: (() async -> Void)? = nil,
         willProcessCall: @escaping (_ invocation: ServiceToolInvocation, _ callId: String) async -> Void = { _, _ in },
         onDedupedResult:
             @escaping (_ invocation: ServiceToolInvocation, _ callId: String, _ heldResult: String) async -> Void = {
@@ -275,17 +350,21 @@ struct AgentLoopHooks {
         )? = nil,
         onBatchComplete: @escaping (_ outcomes: [AgentLoopToolOutcome]) async -> Void = { _ in },
         pendingTodoCount: (() async -> Int)? = nil,
+        todoProgressSnapshot: (() async -> AgentTodoProgressSnapshot?)? = nil,
         emitFallbackText: ((_ text: String) async -> Void)? = nil
     ) {
         self.isCancelled = isCancelled
         self.buildMessages = buildMessages
         self.modelStep = modelStep
+        self.prepareIncompleteReasoningContinuation = prepareIncompleteReasoningContinuation
+        self.prepareTrackedTaskContinuation = prepareTrackedTaskContinuation
         self.willProcessCall = willProcessCall
         self.onDedupedResult = onDedupedResult
         self.executeTool = executeTool
         self.executeBatch = executeBatch
         self.onBatchComplete = onBatchComplete
         self.pendingTodoCount = pendingTodoCount
+        self.todoProgressSnapshot = todoProgressSnapshot
         self.emitFallbackText = emitFallbackText
     }
 }
@@ -713,6 +792,9 @@ enum AgentToolLoop {
         /// The model exhausted the configured output-token budget without an
         /// executable tool call. Any visible partial text is preserved.
         case lengthExhausted
+        /// Bounded recovery could not turn reasoning-only/unclosed output into
+        /// a user-visible final answer.
+        case incompleteReasoningExhausted
     }
 
     struct RunResult: Equatable, Sendable {
@@ -720,6 +802,16 @@ enum AgentToolLoop {
         /// Iterations charged against the budget (transient retries are
         /// not charged).
         var iterations: Int
+        /// Structured unfinished-work state captured when a current-run Todo
+        /// reaches the hard iteration cap. Nil for every other exit, including
+        /// an ordinary tool-loop cap with no Todo contract.
+        var unfinishedTodoCount: Int?
+
+        init(exit: Exit, iterations: Int, unfinishedTodoCount: Int? = nil) {
+            self.exit = exit
+            self.iterations = iterations
+            self.unfinishedTodoCount = unfinishedTodoCount
+        }
     }
 
     /// The dedupe-replay notice staged when a held result short-circuits
@@ -752,6 +844,31 @@ enum AgentToolLoop {
         "The model reached the configured output-token limit before naturally completing an answer or tool call. "
         + "The agent task is incomplete; increase Max Tokens, disable Thinking for this task, "
         + "or continue from the latest tool result."
+
+    /// Only one natural continuation generation is allowed after a
+    /// reasoning-only assistant step. The surface preserves that real step in
+    /// history and starts a fresh output buffer; the driver does not fabricate
+    /// a user/system message or alter decode controls.
+    static let maxIncompleteReasoningRetries = 1
+
+    static let incompleteReasoningFallback =
+        "The model ended in reasoning without producing a user-visible final answer. "
+        + "The agent task may be incomplete; retry with Thinking disabled or continue from the latest tool result."
+
+    /// Structured state notice used when a model emits an ordinary stop while
+    /// the Todo it created this run still has unchecked work. This is not a
+    /// prose classifier: the count comes from `AgentTodoStore`, and the loop is
+    /// still bounded by the user's normal tool-attempt budget.
+    static func todoPendingFinalNotice(pending: Int) -> String {
+        "[System Notice] The todo you created this turn still has \(pending) unchecked item\(pending == 1 ? "" : "s"). Continue the task now. If you cannot finish, give the user an honest final answer and call `complete(summary)` with what remains blocked."
+    }
+
+    /// Honest chat fallback when a structured current-run Todo remains
+    /// unfinished at the hard agent-step cap. This is driven by typed Todo
+    /// state, never by classifying the model's prose.
+    static func unfinishedTodoCapFallback(pending: Int) -> String {
+        "The agent reached the configured step limit with \(pending) todo item\(pending == 1 ? "" : "s") still unfinished. The task is incomplete; continue from the latest completed step or increase Max Agent Steps in Chat settings."
+    }
 
     /// The iteration-budget warning staged when the remaining budget
     /// drops to the policy threshold.
@@ -1138,6 +1255,22 @@ enum AgentToolLoop {
         "[System Notice] Your todo list still has \(pending) unchecked item\(pending == 1 ? "" : "s") and has not been updated recently. If you finished any, re-send the full list with those boxes checked now; if the plan changed, rewrite the list."
     }
 
+    /// Read structured checklist counts from the real Todo invocation body.
+    /// This is deliberately parser-based, not a prose/result-text heuristic,
+    /// and preserves the order of multiple Todo updates in one tool batch.
+    static func todoProgressSnapshot(
+        from invocation: ServiceToolInvocation
+    ) -> AgentTodoProgressSnapshot? {
+        guard invocation.toolName == "todo",
+            let data = invocation.jsonArguments.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let markdown = dict["markdown"] as? String
+        else { return nil }
+        let todo = AgentTodo.parse(markdown)
+        guard todo.totalCount > 0 else { return nil }
+        return AgentTodoProgressSnapshot(done: todo.doneCount, total: todo.totalCount)
+    }
+
     // Capability schemas loaded mid-run are delivered append-only in the
     // `capabilities_load` tool *result* (see
     // `CapabilitiesLoadTool.loadedSchemaBlock`), never by rewriting the frozen
@@ -1202,6 +1335,19 @@ enum AgentToolLoop {
         return hasher.finalize().prefix(8).map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Stable suffix for one logical generation attempt. Transport retries
+    /// reuse the same recovery ordinal and therefore the same key; the one
+    /// deliberate reasoning recovery increments it so a billing/router
+    /// idempotency layer cannot replay attempt 1 instead of generating attempt
+    /// 2 from the otherwise-identical message body.
+    static func recoveryAwareIdempotencySuffix(
+        messages: [ChatMessage],
+        incompleteReasoningRetryOrdinal: Int
+    ) -> String {
+        "r\(max(0, incompleteReasoningRetryOrdinal))-"
+            + stepIdempotencyFingerprint(messages: messages)
+    }
+
     /// Run the canonical loop to completion. Errors thrown by
     /// `hooks.modelStep` propagate to the caller (surface-specific error
     /// handling stays at the call site).
@@ -1227,6 +1373,19 @@ enum AgentToolLoop {
         // productive turn; bounds the nudge-and-retry recovery so the loop
         // can never spin on a deterministically-empty model.
         var consecutiveEmptyTurns = 0
+        // Total (not merely consecutive) reasoning-only recovery attempts.
+        // A tool call between attempts must not re-arm another potentially
+        // huge reasoning cycle in the same logical run.
+        var incompleteReasoningRetries = 0
+        // Session Todo state persists across user turns. Arm terminal gating
+        // only after THIS run successfully executes a valid `todo`; an older
+        // stale checklist must never hijack an unrelated direct answer.
+        var hasSuccessfulCurrentRunTodo = false
+        // Keep the last parseable current-run checklist as a fail-closed
+        // fallback. The session store is authoritative when available, but a
+        // transient missing lookup must not turn known unchecked work into a
+        // clean final response.
+        var lastSuccessfulCurrentRunTodoProgress: AgentTodoProgressSnapshot?
         // Last iteration that carried a `todo` call (0 = run start), for
         // the staleness check below.
         var lastTodoIteration = 0
@@ -1265,8 +1424,55 @@ enum AgentToolLoop {
             }
 
             let step = try await hooks.modelStep(input.messages, iteration)
+            // `modelStep` may return because the user pressed Stop and the
+            // surface cancelled its upstream stream. Cancellation must win
+            // before terminal classification: otherwise a cancelled,
+            // reasoning-only turn can prepare continuation state (or emit an
+            // incomplete fallback) even though no follow-up generation should
+            // occur.
+            if await hooks.isCancelled() {
+                return RunResult(exit: .cancelled, iterations: iteration - 1)
+            }
             switch step {
             case .finalResponse:
+                if hasSuccessfulCurrentRunTodo,
+                    let prepareContinuation = hooks.prepareTrackedTaskContinuation,
+                    let todoProgressSnapshot = hooks.todoProgressSnapshot
+                {
+                    let progress = await todoProgressSnapshot()
+                        ?? lastSuccessfulCurrentRunTodoProgress
+                    // The store lookup suspends across an actor boundary. Stop
+                    // must win if it lands during that await; never create a
+                    // fresh assistant turn after the user cancelled.
+                    if await hooks.isCancelled() {
+                        return RunResult(exit: .cancelled, iterations: iteration - 1)
+                    }
+                    if let progress, progress.pending > 0 {
+                        // Preserve the model's real response in visible/model
+                        // history and start the next attempt in a fresh
+                        // assistant turn. This boundary also runs at the hard
+                        // cap so Chat's existing tool-free finalizer does not
+                        // concatenate its wrap-up onto progress prose.
+                        await prepareContinuation()
+                        if await hooks.isCancelled() {
+                            return RunResult(exit: .cancelled, iterations: iteration)
+                        }
+                        if iteration < policy.maxIterations {
+                            pendingTodoNotice = Self.todoPendingFinalNotice(
+                                pending: progress.pending
+                            )
+                            continue
+                        }
+                        return RunResult(
+                            exit: .iterationCapReached,
+                            iterations: iteration,
+                            unfinishedTodoCount: progress.pending
+                        )
+                    }
+                }
+                // A direct answer, a stale pre-run Todo, or a completed
+                // current-run Todo remains authoritative. Explicit successful
+                // `complete` / `clarify` calls end earlier through endRun.
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .retryWithoutCharge:
@@ -1307,6 +1513,37 @@ enum AgentToolLoop {
                 await hooks.emitFallbackText?(Self.lengthExhaustedFallback)
                 return RunResult(exit: .lengthExhausted, iterations: iteration)
 
+            case .incompleteReasoning:
+                if let prepareRetry = hooks.prepareIncompleteReasoningContinuation,
+                    incompleteReasoningRetries < Self.maxIncompleteReasoningRetries
+                {
+                    incompleteReasoningRetries += 1
+                    // Keep the incomplete reasoning visible to the surface,
+                    // but replay the exact pre-attempt model-visible history
+                    // from a fresh output buffer. No synthetic notice, closing
+                    // tag, prompt coercion, sampler override, or EOS override
+                    // is introduced here.
+                    await prepareRetry()
+                    // This is protocol continuation rather than agent/tool
+                    // progress, so do not charge it against the tool budget.
+                    iteration -= 1
+                    continue
+                }
+                return RunResult(
+                    exit: .incompleteReasoningExhausted,
+                    iterations: iteration
+                )
+
+            case .incompleteVisibleResponse:
+                // The surface has already emitted visible content, so a
+                // transparent replay would splice two attempts into one
+                // answer. Return the typed incomplete exit and let each
+                // surface render its native error/banner without retrying.
+                return RunResult(
+                    exit: .incompleteReasoningExhausted,
+                    iterations: iteration
+                )
+
             case .toolCalls(let invocations):
                 // A productive turn — reset the empty-turn recovery budget so
                 // a later unrelated empty turn gets its own fresh allowance.
@@ -1327,7 +1564,38 @@ enum AgentToolLoop {
                     ),
                     let emitFinalText = hooks.emitFallbackText
                 {
+                    var pendingTrackedTodoCount: Int?
+                    if hasSuccessfulCurrentRunTodo,
+                        let todoProgressSnapshot = hooks.todoProgressSnapshot
+                    {
+                        let progress = await todoProgressSnapshot()
+                            ?? lastSuccessfulCurrentRunTodoProgress
+                        if await hooks.isCancelled() {
+                            return RunResult(exit: .cancelled, iterations: iteration - 1)
+                        }
+                        if let progress, progress.pending > 0 {
+                            pendingTrackedTodoCount = progress.pending
+                        }
+                    }
+
                     await emitFinalText(summary)
+                    if let pending = pendingTrackedTodoCount,
+                        let prepareContinuation = hooks.prepareTrackedTaskContinuation
+                    {
+                        await prepareContinuation()
+                        if await hooks.isCancelled() {
+                            return RunResult(exit: .cancelled, iterations: iteration)
+                        }
+                        if iteration < policy.maxIterations {
+                            pendingTodoNotice = Self.todoPendingFinalNotice(pending: pending)
+                            continue
+                        }
+                        return RunResult(
+                            exit: .iterationCapReached,
+                            iterations: iteration,
+                            unfinishedTodoCount: pending
+                        )
+                    }
                     return RunResult(exit: .finalResponse, iterations: iteration)
                 }
 
@@ -1629,6 +1897,25 @@ enum AgentToolLoop {
                 if !outcomes.isEmpty {
                     completedToolWork = true
                 }
+                let successfulTodoOutcomes = outcomes.filter { outcome in
+                    outcome.invocation.toolName == "todo"
+                        && !outcome.wasError
+                        && ToolEnvelope.isSuccess(outcome.result)
+                }
+                let successfulTodoOutcome = !successfulTodoOutcomes.isEmpty
+                if successfulTodoOutcome {
+                    lastTodoIteration = iteration
+                    // A successful envelope is not enough by itself: arm the
+                    // terminal contract only when at least one invocation has
+                    // a real parseable checklist. This keeps malformed/empty
+                    // calls and synthetic success stubs from hijacking finals.
+                    if let latestProgress = successfulTodoOutcomes.compactMap({
+                        Self.todoProgressSnapshot(from: $0.invocation)
+                    }).last {
+                        hasSuccessfulCurrentRunTodo = true
+                        lastSuccessfulCurrentRunTodoProgress = latestProgress
+                    }
+                }
 
                 // Data-movement relief: when an iteration's tool calls
                 // are ALL successful bulk loads (db_import / bulk
@@ -1667,9 +1954,8 @@ enum AgentToolLoop {
                 // items and no `todo` call has landed for a threshold of
                 // iterations, stage a one-line nudge. Firing re-arms the
                 // window so the nudge repeats at most once per threshold.
-                if invocations.contains(where: { $0.toolName == "todo" }) {
-                    lastTodoIteration = iteration
-                } else if let pendingTodoCount = hooks.pendingTodoCount,
+                if !successfulTodoOutcome,
+                    let pendingTodoCount = hooks.pendingTodoCount,
                     iteration - lastTodoIteration >= policy.todoStalenessThreshold
                 {
                     let pending = await pendingTodoCount()
@@ -1678,6 +1964,31 @@ enum AgentToolLoop {
                         lastTodoIteration = iteration
                     }
                 }
+            }
+        }
+
+        // The loop can consume its final allowed iteration with a tool batch,
+        // not only with `.finalResponse`. If this run created a real Todo and
+        // that checklist is still pending, preserve the typed pending count so
+        // Chat cannot launch its generic tool-free finalizer and guess that the
+        // unfinished task completed. `onBatchComplete` has already created the
+        // fresh assistant buffer for the terminal fallback on the chat surface.
+        if hasSuccessfulCurrentRunTodo,
+            let todoProgressSnapshot = hooks.todoProgressSnapshot
+        {
+            let progress = await todoProgressSnapshot()
+                ?? lastSuccessfulCurrentRunTodoProgress
+            // The store lookup suspends across an actor boundary. A Stop that
+            // lands during it must still win over the cap fallback.
+            if await hooks.isCancelled() {
+                return RunResult(exit: .cancelled, iterations: iteration)
+            }
+            if let progress, progress.pending > 0 {
+                return RunResult(
+                    exit: .iterationCapReached,
+                    iterations: iteration,
+                    unfinishedTodoCount: progress.pending
+                )
             }
         }
 

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -54,6 +54,7 @@ extension ChatSession: ChatWarmupSessionContext {
             agentId: effectiveAgentId,
             executionMode: executionMode,
             model: model,
+            modelType: selectedPickerItem?.modelType,
             query: "",
             messages: priorUserMessages,
             toolsDisabled: chatCfg.disableTools,
@@ -115,26 +116,15 @@ extension ChatSession: ChatWarmupSessionContext {
         return msgs
     }
 
-    private func warmupTurnToMessage(_ turn: ChatTurn, isLastTurn: Bool) -> ChatMessage? {
+    func warmupTurnToMessage(_ turn: ChatTurn, isLastTurn: Bool) -> ChatMessage? {
         switch turn.role {
         case .assistant:
-            if isLastTurn && turn.contentIsBlank && turn.thinkingIsBlank && turn.toolCalls == nil {
-                return nil
-            }
-            if turn.contentIsBlank && turn.thinkingIsBlank && (turn.toolCalls == nil || turn.toolCalls!.isEmpty) {
-                return nil
-            }
-            let content: String? = turn.contentIsBlank ? nil : turn.content
-            let reasoning: String? = turn.thinkingIsBlank ? nil : turn.thinking
-            return ChatMessage(
-                role: "assistant",
-                content: content,
-                tool_calls: turn.toolCalls,
-                tool_call_id: nil,
-                reasoning_content: reasoning,
-                reasoning_item_id: turn.reasoningItemId,
-                reasoning_encrypted: turn.reasoningEncrypted
-            )
+            // Warm-up and the real request must serialize one identical
+            // transcript. In particular, a reasoning-only attempt abandoned
+            // by the bounded retry remains visible in the UI but carries
+            // `modelContextExcluded`; warming it would prefill poisoned
+            // history that the next real send correctly omits.
+            return Self.modelVisibleAssistantMessage(turn, isLastTurn: isLastTurn)
         case .tool:
             return ChatMessage(
                 role: "tool",

--- a/Packages/OsaurusCore/Services/Chat/ComposeRequest.swift
+++ b/Packages/OsaurusCore/Services/Chat/ComposeRequest.swift
@@ -18,6 +18,10 @@ struct ComposeRequest: Sendable {
     let agentId: UUID
     let executionMode: ExecutionMode
     let model: String?
+    /// Canonical local-bundle `config.json.model_type`, captured with the
+    /// picker selection. Nil for remote/unresolved models, which deliberately
+    /// fall back to identifier-based family routing.
+    let modelType: String?
     let query: String
     let messages: [ChatMessage]
     let toolsDisabled: Bool
@@ -38,6 +42,7 @@ struct ComposeRequest: Sendable {
         agentId: UUID,
         executionMode: ExecutionMode,
         model: String? = nil,
+        modelType: String? = nil,
         query: String = "",
         messages: [ChatMessage] = [],
         toolsDisabled: Bool = false,
@@ -50,6 +55,7 @@ struct ComposeRequest: Sendable {
         self.agentId = agentId
         self.executionMode = executionMode
         self.model = model
+        self.modelType = modelType
         self.query = query
         self.messages = messages
         self.toolsDisabled = toolsDisabled

--- a/Packages/OsaurusCore/Services/Chat/ModelFamilyGuidance.swift
+++ b/Packages/OsaurusCore/Services/Chat/ModelFamilyGuidance.swift
@@ -51,7 +51,14 @@ enum ModelFamilyGuidance {
     /// Resolve the family for a model id (e.g. "gpt-4o", "gemma-4-26b-it", "qwen3-32b-mlx").
     /// Markers checked in order of specificity — `gpt`/`codex`/`o-series`
     /// first because a finetune name might mention multiple families.
-    static func family(for modelId: String?) -> ModelFamily {
+    static func family(for modelId: String?, modelType: String? = nil) -> ModelFamily {
+        // Local bundles provide the authoritative architecture contract in
+        // config.json. Prefer it over owner/repository marketing names so a
+        // renamed Qwen derivative (or a misleading owner namespace) cannot
+        // silently receive the wrong operational guidance.
+        if let rawModelType = normalizedModelType(modelType) {
+            return family(forNormalizedModelType: rawModelType)
+        }
         guard let raw = modelId?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines),
             !raw.isEmpty
         else { return .other }
@@ -72,6 +79,16 @@ enum ModelFamilyGuidance {
         for (family, markers) in groups where markers.contains(where: raw.contains) {
             return family
         }
+        // Ornith and Bonsai bundles use a Qwen 3.5 backbone but their public
+        // repo/display ids intentionally omit the word "qwen". Route only
+        // exact alias tokens into the existing Qwen operational contract;
+        // substring matching would misclassify unrelated ids such as
+        // `notornith` or `bonsaified`. This is guidance routing only — runtime,
+        // tokenizer, parser, and cache-family detection continue to use their
+        // own bundle-derived contracts.
+        if containsToken(repositoryTail(of: raw), in: qwenBackboneAliasTokens) {
+            return .glmQwen
+        }
         // LFM2 uses the precise name matcher (rejects adjacent future
         // families like `lfm21`) rather than a bare substring so it stays
         // consistent with the rest of the runtime's family detection.
@@ -86,10 +103,39 @@ enum ModelFamilyGuidance {
     /// `/`, `.`, spaces…), so `o1-preview`, `openai/o3-mini`, and a bare
     /// `o4` match while `molmo3`, `yolo11`, and `turbo4` do not.
     private static let oSeriesTokens: Set<String> = ["o1", "o3", "o4"]
+    private static let qwenBackboneAliasTokens: Set<String> = ["ornith", "bonsai"]
+
+    private static func normalizedModelType(_ modelType: String?) -> String? {
+        guard let raw = modelType?.lowercased().trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else { return nil }
+        return raw
+    }
+
+    /// A present bundle architecture is authoritative even when it is not one
+    /// of the families with targeted guidance. Falling back to the repository
+    /// id for an unknown-but-present type would let an owner such as
+    /// `qwen-owner` misroute an unrelated Llama bundle. Only absent metadata
+    /// may use the legacy id fallback above.
+    private static func family(forNormalizedModelType raw: String) -> ModelFamily {
+        if raw.contains("qwen") || raw.contains("glm") { return .glmQwen }
+        if raw.contains("gemma") { return .googleGemma }
+        if raw.contains("deepseek") { return .deepSeek }
+        if ModelFamilyNames.isLFM2Family(raw) { return .lfm2 }
+        return .other
+    }
+
+    private static func repositoryTail(of raw: String) -> String {
+        raw.split(separator: "/").last.map(String.init) ?? raw
+    }
 
     private static func containsOSeriesToken(_ raw: String) -> Bool {
+        containsToken(raw, in: oSeriesTokens)
+    }
+
+    private static func containsToken(_ raw: String, in tokens: Set<String>) -> Bool {
         raw.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
-            .contains { oSeriesTokens.contains(String($0)) }
+            .contains { tokens.contains(String($0)) }
     }
 
     /// The guidance block for a family. Every family — including `.other` —
@@ -135,11 +181,15 @@ enum ModelFamilyGuidance {
     ///
     /// `compact` selects the small-context variant where one exists (see
     /// `compactGuidance(for:)`); callers pass `sizeClass == .small`.
-    static func guidance(forModelId modelId: String?, compact: Bool = false) -> String? {
+    static func guidance(
+        forModelId modelId: String?,
+        modelType: String? = nil,
+        compact: Bool = false
+    ) -> String? {
         guard let raw = modelId?.trimmingCharacters(in: .whitespacesAndNewlines),
             !raw.isEmpty
         else { return nil }
-        let resolved = family(for: raw)
+        let resolved = family(for: raw, modelType: modelType)
         return compact ? compactGuidance(for: resolved) : guidance(for: resolved)
     }
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -94,6 +94,7 @@ public struct SystemPromptComposer: Sendable {
         agentId: UUID,
         executionMode: ExecutionMode,
         model: String? = nil,
+        modelType: String? = nil,
         query: String = "",
         messages: [ChatMessage] = [],
         toolsDisabled: Bool = false,
@@ -108,6 +109,7 @@ public struct SystemPromptComposer: Sendable {
                 agentId: agentId,
                 executionMode: executionMode,
                 model: model,
+                modelType: modelType,
                 query: query,
                 messages: messages,
                 toolsDisabled: toolsDisabled,
@@ -139,7 +141,8 @@ public struct SystemPromptComposer: Sendable {
         let snapshot = AgentConfigSnapshot.capture(
             agentId: request.agentId,
             requestToolsDisabled: request.toolsDisabled,
-            modelOverride: request.model
+            modelOverride: request.model,
+            modelTypeOverride: request.modelType
         )
         let composer = forChat(
             snapshot: snapshot,
@@ -832,6 +835,7 @@ public struct SystemPromptComposer: Sendable {
         if !effectiveToolsOff,
             let familyGuidance = ModelFamilyGuidance.guidance(
                 forModelId: snapshot.model,
+                modelType: snapshot.modelType,
                 compact: toolset.prefersCompactPrompt
             )
         {
@@ -1795,13 +1799,15 @@ public struct SystemPromptComposer: Sendable {
     static func composePreviewContext(
         agentId: UUID,
         executionMode: ExecutionMode,
-        model: String? = nil
+        model: String? = nil,
+        modelType: String? = nil
     ) -> ComposedContext {
         // Same one-shot snapshot as the real send path so the popover
         // can never disagree with the next compose's gate decisions.
         let snapshot = AgentConfigSnapshot.capture(
             agentId: agentId,
-            modelOverride: model
+            modelOverride: model,
+            modelTypeOverride: modelType
         )
         return composePreviewContext(snapshot: snapshot, executionMode: executionMode)
     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -63,9 +63,9 @@ public enum SystemPromptTemplates {
     public static let agentLoopGuidance = """
         ## Agent loop
 
-        - Always answer the user in plain text — that reply is what they read and ends the turn.
-        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it with the next box checked after each item. Skip direct/single-step work.
-        - `complete(summary)` — OPTIONAL: close a `todo` task with a short WHAT+HOW status (not the answer) in the SAME message as your answer. Not for direct questions or other tools; no vague placeholders.
+        - Always answer the user in plain text — that reply is what they read. It ends a direct task, or a tracked task once its todo has no unchecked items.
+        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it with the next box checked after each item. Once created, unchecked items keep this agent run open. Skip direct/single-step work.
+        - `complete(summary)` — OPTIONAL explicit closure for a `todo`: use it with a short WHAT+HOW status (not the answer) in the SAME message as your answer when work is done or honestly blocked. Not for direct questions or other tools; no vague placeholders.
         - `clarify(question)` — pause and ask exactly one concrete question only when guessing wrong would change the result. For minor preferences pick a sensible default and proceed.
         - `share_artifact(path | content+filename)` — the only way the user sees a generated image, chart, report, code blob, or any file. **The file MUST exist before this call.** Sandbox: save under your home dir (default cwd), not `/tmp`. For inline text/markdown, pass `content`+`filename` and skip the file write.
         """
@@ -86,9 +86,9 @@ public enum SystemPromptTemplates {
     public static let agentLoopGuidanceCompact = """
         ## Agent loop
 
-        - Answer the user in plain text; that reply ends the turn.
-        - `todo(markdown)` — OPTIONAL, 3+ step work only: create first, re-send with each box checked. Skip single-step work.
-        - `complete(summary)` — OPTIONAL, only closes a `todo`: short WHAT+HOW status in the SAME message as your answer, not the answer.
+        - Answer the user in plain text; it ends direct work, or tracked work once no todo items remain unchecked.
+        - `todo(markdown)` — OPTIONAL, 3+ step work only: create first, re-send with each box checked. Once created, unchecked items keep this run open. Skip single-step work.
+        - `complete(summary)` — OPTIONAL explicit `todo` closure: short WHAT+HOW status in the SAME message as your answer when done or honestly blocked, not the answer.
         - `clarify(question)` — last resort; a fully specified task is not ambiguous, just do it. Ask ONE question only when the user asks or a required input is missing/contradictory with no sensible default.
         - `share_artifact(path | content+filename)` — the only way the user sees a file/image; it MUST exist first. Sandbox: save under home, not `/tmp`.
         """

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -930,6 +930,7 @@ public enum AgentLoopEvaluator {
         case .overBudget: return "overBudget"
         case .emptyResponseExhausted: return "emptyResponseExhausted"
         case .lengthExhausted: return "lengthExhausted"
+        case .incompleteReasoningExhausted: return "incompleteReasoningExhausted"
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Search/SearchReadability.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchReadability.swift
@@ -96,7 +96,16 @@ enum SearchReadability {
             }
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             guard (200 ... 299).contains(status) else {
-                return failure(status: .fetchFailed, message: "HTTP status \(status)")
+                // Retry only statuses that can plausibly recover without
+                // changing the URL. A persistent 401/403/404 is not a
+                // transport outage; labeling it `fetch_failed` previously
+                // invited the agent to request the same blocked page forever.
+                let retryableHTTPStatus = status == 408 || status == 425 || status == 429
+                    || (500 ... 599).contains(status)
+                return failure(
+                    status: retryableHTTPStatus ? .fetchFailed : .blocked,
+                    message: "HTTP status \(status)"
+                )
             }
             if response.expectedContentLength > Int64(maxHTMLBytes) {
                 return failure(status: .tooLarge, message: "response exceeds \(maxHTMLBytes) bytes")

--- a/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
@@ -177,7 +177,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// stamped newer than this is refused (forward-version fail-fast).
     /// Internal (not private) so migration-repair tests assert "reconciled
     /// to the latest" against the real constant instead of a stale literal.
-    static let latestSchemaVersion = 12
+    static let latestSchemaVersion = 13
 
     private func runMigrations() throws {
         let current = try getSchemaVersion()
@@ -205,6 +205,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         if current < 10 { try runMigrationStep(10, migrateToV10) }
         if current < 11 { try runMigrationStep(11, migrateToV11) }
         if current < 12 { try runMigrationStep(12, migrateToV12) }
+        if current < 13 { try runMigrationStep(13, migrateToV13) }
     }
 
     /// Run one migration body atomically. Called only from `runMigrations`,
@@ -431,6 +432,14 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     private func migrateToV12() throws {
         try addColumnIfMissing("turns", "terminal_stop_reason", "TEXT")
         try setSchemaVersion(12)
+    }
+
+    /// v13: mark an abandoned reasoning/protocol attempt as transcript-only.
+    /// The turn remains visible to the user, but later requests (including
+    /// after an app restart) must not replay it beside the successful retry.
+    private func migrateToV13() throws {
+        try addColumnIfMissing("turns", "model_context_excluded", "INTEGER NOT NULL DEFAULT 0")
+        try setSchemaVersion(13)
     }
 
     // MARK: - Public API: sessions
@@ -1134,6 +1143,9 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         if let stopReason = turn.terminalStopReason {
             hasher.update(data: Data(stopReason.utf8))
         }
+        if turn.modelContextExcluded {
+            hasher.update(data: Data([UInt8(1)]))
+        }
         // Billing can land after the initial empty-turn save (the summary frame
         // often trails the content), so it must be part of the hash or the
         // incremental upsert would skip writing the row.
@@ -1241,8 +1253,9 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             (id, session_id, seq, role, content, attachments,
              tool_calls, tool_call_id, tool_results, thinking, content_hash,
              created_at, completed_at, generation_token_count, time_to_first_token,
-             tool_call_durations, thinking_duration, router_billing, terminal_stop_reason)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
+             tool_call_durations, thinking_duration, router_billing, terminal_stop_reason,
+             model_context_excluded)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
         ON CONFLICT(id) DO UPDATE SET
             session_id             = excluded.session_id,
             seq                    = excluded.seq,
@@ -1261,13 +1274,15 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             tool_call_durations    = excluded.tool_call_durations,
             thinking_duration      = excluded.thinking_duration,
             router_billing         = excluded.router_billing,
-            terminal_stop_reason   = excluded.terminal_stop_reason
+            terminal_stop_reason   = excluded.terminal_stop_reason,
+            model_context_excluded = excluded.model_context_excluded
         """
 
     private static let selectTurnsSQL = """
         SELECT id, role, content, attachments, tool_calls, tool_call_id, tool_results, thinking,
                created_at, completed_at, generation_token_count, time_to_first_token,
-               tool_call_durations, thinking_duration, router_billing, terminal_stop_reason
+               tool_call_durations, thinking_duration, router_billing, terminal_stop_reason,
+               model_context_excluded
         FROM turns
         WHERE session_id = ?1
         ORDER BY seq ASC
@@ -1345,6 +1360,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             .map { String(cString: $0) }
             .flatMap(decodeJSON)
         let terminalStopReason = sqlite3_column_text(stmt, 15).map { String(cString: $0) }
+        let modelContextExcluded = sqlite3_column_int(stmt, 16) != 0
         return ChatTurnData(
             id: UUID(uuidString: idStr) ?? UUID(),
             role: role,
@@ -1361,6 +1377,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
             generationTokenCount: tokenCount,
             timeToFirstToken: timeToFirstToken,
             terminalStopReason: terminalStopReason,
+            modelContextExcluded: modelContextExcluded,
             routerBilling: routerBilling
         )
     }
@@ -1406,6 +1423,7 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         bindNullableDouble(stmt, index: 17, value: turn.thinkingDuration)
         bindText(stmt, index: 18, value: turn.routerBilling.flatMap(encodeJSON))
         bindText(stmt, index: 19, value: turn.terminalStopReason)
+        sqlite3_bind_int(stmt, 20, turn.modelContextExcluded ? 1 : 0)
     }
 
     static func bindNullableDouble(_ stmt: OpaquePointer, index: Int, value: Double?) {

--- a/Packages/OsaurusCore/Subagent/Kinds/BrowserUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/BrowserUseKind.swift
@@ -266,6 +266,11 @@ final class BrowserUseKind: SubagentKind, @unchecked Sendable {
                 message: "Browser Use reached its output-token limit before producing a result.",
                 retryable: false
             )
+        case .incompleteReasoningExhausted:
+            throw SubagentError.executionFailed(
+                message: "Browser Use ended in reasoning without producing a visible result.",
+                retryable: false
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -452,6 +452,11 @@ final class TextSubagentKind: SubagentKind, @unchecked Sendable {
                 message: "Subagent '\(targetLabel)' reached its output-token limit before producing a result.",
                 retryable: false
             )
+        case .incompleteReasoningExhausted:
+            throw SubagentError.executionFailed(
+                message: "Subagent '\(targetLabel)' ended in reasoning without producing a visible result.",
+                retryable: false
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -856,6 +856,125 @@ struct AgentTaskStateTests {
         #expect(guarded.contains("transition_required"))
     }
 
+    @Test func webSearchLoop_allChallengeExtractionDoesNotResetGuard() throws {
+        let state = AgentTaskState()
+        for n in 1 ... 4 {
+            state.record(
+                name: "web_search",
+                argsJSON: #"{"query":"Hugging Face org models \#(n)"}"#,
+                result: ToolEnvelope.success(tool: "web_search", text: "ranked snippets")
+            )
+        }
+
+        let extractionFailure = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://huggingface.co/OsaurusAI/models",
+                        "extracted": false,
+                        "extract_status": "challenge",
+                        "extract_error": "challenge_page",
+                    ],
+                ],
+            ]
+        )
+        let extractionArgs = #"{"url":"https://huggingface.co/OsaurusAI/models"}"#
+        state.record(
+            name: "search_and_extract",
+            argsJSON: extractionArgs,
+            result: extractionFailure
+        )
+
+        let guarded = try #require(state.guardedResult(name: "web_search"))
+        #expect(guarded.contains("transition_required"))
+        #expect(extractionFailure.contains("do not claim these pages were read"))
+        let replay = try #require(
+            state.heldResult(name: "search_and_extract", argsJSON: extractionArgs)
+        )
+        #expect(replay == extractionFailure)
+        #expect(state.lastReplayNotice?.contains("was NOT re-executed") == true)
+    }
+
+    @Test func webSearchLoop_transientExtractionFailureGetsOneRetryThenStops() throws {
+        let state = AgentTaskState()
+        let extractionArgs = #"{"url":"https://example.com/temporarily-slow"}"#
+        let extractionFailure = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://example.com/temporarily-slow",
+                        "extracted": false,
+                        "extract_status": "timeout",
+                    ],
+                ],
+            ]
+        )
+        state.record(
+            name: "search_and_extract",
+            argsJSON: extractionArgs,
+            result: extractionFailure
+        )
+
+        #expect(ToolEnvelope.isError(extractionFailure))
+        #expect(state.heldResult(name: "search_and_extract", argsJSON: extractionArgs) == nil)
+
+        state.record(
+            name: "search_and_extract",
+            argsJSON: extractionArgs,
+            result: extractionFailure
+        )
+        let exhausted = try #require(
+            state.heldResult(name: "search_and_extract", argsJSON: extractionArgs)
+        )
+        #expect(ToolEnvelope.isError(exhausted))
+        #expect(exhausted.contains(#""retry_exhausted":true"#))
+        #expect(exhausted.contains(#""retryable":false"#))
+        #expect(exhausted.contains("Do not execute the same arguments again"))
+    }
+
+    @Test func webSearchLoop_contentfulExtractionResetsAndMayReplay() {
+        let state = AgentTaskState()
+        for n in 1 ... 4 {
+            state.record(
+                name: "web_search",
+                argsJSON: #"{"query":"Hugging Face org models \#(n)"}"#,
+                result: ToolEnvelope.success(tool: "web_search", text: "ranked snippets")
+            )
+        }
+
+        let extractionArgs = #"{"url":"https://example.com/model-card"}"#
+        let extractionSuccess = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://example.com/model-card",
+                        "extracted": true,
+                        "extract_status": "ok",
+                        "markdown": "verified model card content",
+                    ],
+                ],
+            ]
+        )
+        state.record(
+            name: "search_and_extract",
+            argsJSON: extractionArgs,
+            result: extractionSuccess
+        )
+
+        #expect(state.nextStepBias() == nil)
+        #expect(state.guardedResult(name: "web_search") == nil)
+        #expect(
+            state.heldResult(name: "search_and_extract", argsJSON: extractionArgs)
+                == extractionSuccess
+        )
+    }
+
     @Test func webSearchLoop_metaToolDetourDoesNotResetGuard() throws {
         let state = AgentTaskState()
         for n in 1 ... 4 {

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -28,6 +28,8 @@ private final class ScriptedLoopSurface {
     /// When non-nil, hooks expose `pendingTodoCount` returning this value
     /// (the chat surface's session-todo plumb).
     var pendingTodos: Int?
+    var todoProgress: AgentTodoProgressSnapshot?
+    var forceMissingTodoProgressSnapshot = false
 
     // Recorded crossings
     var builtNotices: [[String]] = []
@@ -36,12 +38,21 @@ private final class ScriptedLoopSurface {
     var willProcessCallIds: [String] = []
     var batchOutcomes: [[AgentLoopToolOutcome]] = []
     var emittedFinalTexts: [String] = []
+    var incompleteContinuationPreparations = 0
+    var cancelOnIncompleteContinuation = false
+    var trackedTaskContinuationPreparations = 0
+    var cancelOnTrackedTaskContinuation = false
+    var todoProgressSnapshotCalls = 0
+    var cancelOnTodoProgressSnapshotCall: Int?
 
     init(steps: [AgentLoopModelStep]) {
         self.steps = steps
     }
 
-    func makeHooks(includeFallbackText: Bool = true) -> AgentLoopHooks {
+    func makeHooks(
+        includeFallbackText: Bool = true,
+        includeTrackedTaskContinuation: Bool = false
+    ) -> AgentLoopHooks {
         var hooks = AgentLoopHooks(
             isCancelled: { self.cancelled },
             buildMessages: { notices in
@@ -55,6 +66,20 @@ private final class ScriptedLoopSurface {
                 guard !self.steps.isEmpty else { return .finalResponse }
                 return self.steps.removeFirst()
             },
+            prepareIncompleteReasoningContinuation: {
+                self.incompleteContinuationPreparations += 1
+                if self.cancelOnIncompleteContinuation {
+                    self.cancelled = true
+                }
+            },
+            prepareTrackedTaskContinuation: includeTrackedTaskContinuation
+                ? {
+                    self.trackedTaskContinuationPreparations += 1
+                    if self.cancelOnTrackedTaskContinuation {
+                        self.cancelled = true
+                    }
+                }
+                : nil,
             willProcessCall: { _, callId in
                 self.willProcessCallIds.append(callId)
             },
@@ -68,8 +93,20 @@ private final class ScriptedLoopSurface {
             },
             onBatchComplete: { outcomes in
                 self.batchOutcomes.append(outcomes)
+                self.recordTodoProgress(from: outcomes)
             },
-            pendingTodoCount: pendingTodos.map { count in { count } }
+            pendingTodoCount: pendingTodos == nil ? nil : { self.pendingTodos ?? 0 },
+            todoProgressSnapshot: includeTrackedTaskContinuation
+                ? {
+                    self.todoProgressSnapshotCalls += 1
+                    if self.cancelOnTodoProgressSnapshotCall
+                        == self.todoProgressSnapshotCalls
+                    {
+                        self.cancelled = true
+                    }
+                    return self.forceMissingTodoProgressSnapshot ? nil : self.todoProgress
+                }
+                : nil
         )
         if includeFallbackText {
             hooks.emitFallbackText = { text in
@@ -77,6 +114,23 @@ private final class ScriptedLoopSurface {
             }
         }
         return hooks
+    }
+
+    private func recordTodoProgress(from outcomes: [AgentLoopToolOutcome]) {
+        for outcome in outcomes where outcome.invocation.toolName == "todo" {
+            guard !outcome.wasError, ToolEnvelope.isSuccess(outcome.result),
+                let data = outcome.invocation.jsonArguments.data(using: .utf8),
+                let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let markdown = dict["markdown"] as? String
+            else { continue }
+            let todo = AgentTodo.parse(markdown)
+            let snapshot = AgentTodoProgressSnapshot(
+                done: todo.doneCount,
+                total: todo.totalCount
+            )
+            todoProgress = snapshot
+            pendingTodos = snapshot.pending
+        }
     }
 }
 
@@ -118,7 +172,6 @@ private func headlessPolicy(maxIterations: Int = 30) -> AgentLoopPolicy {
 
 @MainActor
 struct AgentToolLoopTests {
-
     @Test func finalResponseOnFirstStepEndsRun() async throws {
         let surface = ScriptedLoopSurface(steps: [.finalResponse])
         let result = try await AgentToolLoop.run(
@@ -135,7 +188,8 @@ struct AgentToolLoopTests {
         let step = AgentLoopModelStep.classifyTerminal(
             contentIsBlank: true,
             thinkingIsBlank: false,
-            stopReason: "length"
+            stopReason: "length",
+            requiresVisibleFinalResponse: true
         )
         guard case .lengthExhausted = step else {
             Issue.record("reasoning-only stop=length must be lengthExhausted")
@@ -143,23 +197,230 @@ struct AgentToolLoopTests {
         }
     }
 
-    @Test func reasoningOnlyNaturalStopRemainsFinalResponse() {
+    @Test func reasoningOnlyNaturalStopRequiresVisibleAnswer() {
         let step = AgentLoopModelStep.classifyTerminal(
             contentIsBlank: true,
             thinkingIsBlank: false,
-            stopReason: "stop"
+            stopReason: "stop",
+            requiresVisibleFinalResponse: true
         )
-        guard case .finalResponse = step else {
-            Issue.record("reasoning-only natural stop must preserve existing final behavior")
+        guard case .incompleteReasoning = step else {
+            Issue.record("reasoning-only natural stop must not masquerade as a final answer")
             return
         }
+    }
+
+    @Test func intentionalReasoningOnlyDirectChatRemainsFinal() {
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: true,
+            thinkingIsBlank: false,
+            stopReason: "stop",
+            requiresVisibleFinalResponse: false
+        )
+        guard case .finalResponse = step else {
+            Issue.record("a no-tool reasoning-only direct chat must remain a valid final response")
+            return
+        }
+    }
+
+    @Test func intentionalUnclosedReasoningOnlyDirectChatRemainsFinal() {
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: true,
+            thinkingIsBlank: false,
+            stopReason: "stop",
+            unclosedReasoning: true,
+            requiresVisibleFinalResponse: false
+        )
+        guard case .finalResponse = step else {
+            Issue.record("a no-tool reasoning-only direct chat preserves its current product contract")
+            return
+        }
+    }
+
+    @Test func visibleResponsePolicyDoesNotConfuseAvailableSchemasWithToolWork() {
+        #expect(
+            !AgentLoopVisibleResponsePolicy.requiresVisibleFinalResponse(
+                hasStructuredToolWork: false,
+                isRemoteAgentTarget: false
+            )
+        )
+        #expect(
+            AgentLoopVisibleResponsePolicy.requiresVisibleFinalResponse(
+                hasStructuredToolWork: true,
+                isRemoteAgentTarget: false
+            )
+        )
+        #expect(
+            AgentLoopVisibleResponsePolicy.requiresVisibleFinalResponse(
+                hasStructuredToolWork: false,
+                isRemoteAgentTarget: true
+            )
+        )
+    }
+
+    @Test func unclosedReasoningWithContentEndsWithoutTransparentReplay() {
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: false,
+            thinkingIsBlank: false,
+            stopReason: "stop",
+            unclosedReasoning: true,
+            requiresVisibleFinalResponse: true
+        )
+        guard case .incompleteVisibleResponse = step else {
+            Issue.record("visible partial content must not be concatenated with a transparent replay")
+            return
+        }
+    }
+
+    @Test func recoveryIdempotencyOrdinalDistinguishesLogicalReplayOnly() {
+        let messages = [ChatMessage(role: "user", content: "Do the task.")]
+        let first = AgentToolLoop.recoveryAwareIdempotencySuffix(
+            messages: messages,
+            incompleteReasoningRetryOrdinal: 0
+        )
+        let transportRetry = AgentToolLoop.recoveryAwareIdempotencySuffix(
+            messages: messages,
+            incompleteReasoningRetryOrdinal: 0
+        )
+        let reasoningRetry = AgentToolLoop.recoveryAwareIdempotencySuffix(
+            messages: messages,
+            incompleteReasoningRetryOrdinal: 1
+        )
+
+        #expect(first == transportRetry)
+        #expect(first != reasoningRetry)
+        #expect(first.hasPrefix("r0-"))
+        #expect(reasoningRetry.hasPrefix("r1-"))
+    }
+
+    @Test func visibleIncompleteResponseEndsWithoutRetryOrGenericFallback() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .incompleteVisibleResponse,
+            .finalResponse,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(
+            result
+                == AgentToolLoop.RunResult(
+                    exit: .incompleteReasoningExhausted,
+                    iterations: 1
+                )
+        )
+        #expect(surface.steps.count == 1, "visible content makes transparent replay unsafe")
+        #expect(surface.incompleteContinuationPreparations == 0)
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func reasoningOnlyTurnGetsOneBoundedContinuation() async throws {
+        let surface = ScriptedLoopSurface(steps: [.incompleteReasoning, .finalResponse])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
+        #expect(surface.builtNotices == [[], []])
+        #expect(surface.incompleteContinuationPreparations == 1)
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func repeatedReasoningOnlyTurnEndsHonestlyWithoutLooping() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .incompleteReasoning,
+            .incompleteReasoning,
+            .finalResponse,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(
+            result
+                == AgentToolLoop.RunResult(
+                    exit: .incompleteReasoningExhausted,
+                    iterations: 1
+                )
+        )
+        #expect(surface.steps.count == 1, "the third generation must not start")
+        #expect(surface.incompleteContinuationPreparations == 1)
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func continuationBudgetIsRunWideAcrossInterleavedToolWork() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .incompleteReasoning,
+            .toolCalls([inv("file_read", #"{"path":"notes.md"}"#)]),
+            .incompleteReasoning,
+            .finalResponse,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(
+            result
+                == AgentToolLoop.RunResult(
+                    exit: .incompleteReasoningExhausted,
+                    iterations: 2
+                )
+        )
+        #expect(surface.incompleteContinuationPreparations == 1)
+        #expect(surface.executedCalls.map(\.name) == ["file_read"])
+        #expect(surface.steps.count == 1, "a second reasoning-only step must end the run")
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func cancellationWinsAfterIncompleteContinuationBoundary() async throws {
+        let surface = ScriptedLoopSurface(steps: [.incompleteReasoning, .finalResponse])
+        surface.cancelOnIncompleteContinuation = true
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 0))
+        #expect(surface.incompleteContinuationPreparations == 1)
+        #expect(surface.steps.count == 1, "cancellation must prevent the continuation generation")
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func cancellationDuringModelStepSkipsIncompleteContinuation() async throws {
+        let surface = ScriptedLoopSurface(steps: [])
+        var hooks = surface.makeHooks()
+        hooks.modelStep = { _, _ in
+            surface.cancelled = true
+            return .incompleteReasoning
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 0))
+        #expect(surface.incompleteContinuationPreparations == 0)
+        #expect(surface.emittedFinalTexts.isEmpty)
     }
 
     @Test func visibleLengthResponseIsIncompleteButPreservedForFallback() {
         let step = AgentLoopModelStep.classifyTerminal(
             contentIsBlank: false,
             thinkingIsBlank: false,
-            stopReason: "length"
+            stopReason: "length",
+            requiresVisibleFinalResponse: true
         )
         guard case .lengthExhausted = step else {
             Issue.record("authoritative stop=length must remain incomplete")
@@ -1062,6 +1323,48 @@ struct AgentToolLoopTests {
         #expect(surface.batchOutcomes[0].map(\.wasDeduped) == [false, false, true])
     }
 
+    @Test func batchExecutorBoundsIdenticalTransientExtractionRetries() async throws {
+        let args = #"{"url":"https://example.com/slow"}"#
+        let transient = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://example.com/slow",
+                        "extracted": false,
+                        "extract_status": "timeout",
+                    ],
+                ],
+            ]
+        )
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([
+                inv("search_and_extract", args),
+                inv("search_and_extract", args),
+                inv("search_and_extract", args),
+            ]),
+            .finalResponse,
+        ])
+        var executed = 0
+        var hooks = surface.makeHooks()
+        hooks.executeBatch = { calls in
+            executed += calls.count
+            return calls.map { _ in AgentLoopToolExecution(result: transient) }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: headlessPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result.exit == .finalResponse)
+        #expect(executed == 2, "initial fetch plus one retry; third call must replay")
+        #expect(surface.batchOutcomes[0].map(\.wasDeduped) == [false, false, true])
+        #expect(surface.batchOutcomes[0][2].result.contains(#""retry_exhausted":true"#))
+    }
+
     @Test func batchExecutorDuplicateSiblingReplaysHeldNotFoundError() async throws {
         // Serial parity with held-error replay: a `not_found` from
         // `file_read` is DETERMINISTIC (nothing wrote between the two
@@ -1724,6 +2027,611 @@ struct AgentLoopTodoStalenessTests {
         for notices in surface.builtNotices {
             #expect(!notices.contains(where: { $0.hasPrefix(needle) }))
         }
+    }
+}
+
+// MARK: - Current-run todo terminal completion
+
+@MainActor
+struct AgentLoopTrackedTodoCompletionTests {
+
+    @Test func progressStopWithCurrentRunTodoContinuesOnceThenFinishes() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            .finalResponse,
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
+            .finalResponse,
+        ])
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+        #expect(surface.emittedFinalTexts.isEmpty)
+        #expect(surface.steps.isEmpty)
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
+    }
+
+    @Test func repeatedStopsWithPendingTodoReachConfiguredBudgetCap() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            .finalResponse,
+            .finalResponse,
+            .finalResponse,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 4),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(
+            result == AgentToolLoop.RunResult(
+                exit: .iterationCapReached,
+                iterations: 4,
+                unfinishedTodoCount: 2
+            )
+        )
+        #expect(surface.trackedTaskContinuationPreparations == 3)
+        #expect(surface.builtNotices.count == 4)
+        let pendingNotice = AgentToolLoop.todoPendingFinalNotice(pending: 2)
+        #expect(surface.builtNotices[2].contains(pendingNotice))
+        #expect(surface.builtNotices[3].contains(pendingNotice))
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func recordedCheckboxProgressStillRequiresRemainingWorkToClose() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [ ] answer"}"#)]),
+            .finalResponse,
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
+            .finalResponse,
+        ])
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
+    }
+
+    @Test func realTodoToolStoreSnapshotDrivesZeroProgressContinuation() async throws {
+        let sessionId = "tracked-todo-test-\(UUID().uuidString)"
+        await AgentTodoStore.shared.clear(for: sessionId)
+        let todoInvocation = inv(
+            "todo",
+            #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#
+        )
+        let completedTodoInvocation = inv(
+            "todo",
+            #"{"markdown":"- [x] inspect\n- [x] answer"}"#
+        )
+        let progressText = "Got the models. Now let me inspect the other repositories."
+        var history = [ChatMessage(role: "user", content: "research repositories")]
+        var continuationInput: [ChatMessage] = []
+        var continuationPreparations = 0
+
+        let hooks = AgentLoopHooks(
+            buildMessages: { _ in
+                if continuationPreparations == 1, continuationInput.isEmpty {
+                    continuationInput = history
+                }
+                return AgentLoopIterationInput(messages: history, overBudget: false)
+            },
+            modelStep: { _, iteration in
+                switch iteration {
+                case 1:
+                    return .toolCalls([todoInvocation])
+                case 2:
+                    history.append(ChatMessage(role: "assistant", content: progressText))
+                    return .finalResponse
+                case 3:
+                    return .toolCalls([completedTodoInvocation])
+                default:
+                    history.append(ChatMessage(role: "assistant", content: "Final answer."))
+                    return .finalResponse
+                }
+            },
+            prepareTrackedTaskContinuation: {
+                continuationPreparations += 1
+            },
+            executeTool: { invocation, _ in
+            do {
+                let result = try await ChatExecutionContext.$currentSessionId.withValue(
+                    sessionId
+                ) {
+                    try await TodoTool().execute(argumentsJSON: invocation.jsonArguments)
+                }
+                return AgentLoopToolExecution(
+                    result: result,
+                    isError: ToolEnvelope.isError(result)
+                )
+            } catch {
+                return AgentLoopToolExecution(
+                    result: ToolEnvelope.fromError(error, tool: invocation.toolName),
+                    isError: true
+                )
+            }
+            },
+            onBatchComplete: { outcomes in
+                for outcome in outcomes {
+                    history.append(
+                        ChatMessage(
+                            role: "assistant",
+                            content: nil,
+                            tool_calls: [
+                                SecretArgumentScrubber.recordedToolCall(
+                                    id: outcome.callId,
+                                    invocation: outcome.invocation
+                                )
+                            ],
+                            tool_call_id: nil
+                        )
+                    )
+                    history.append(
+                        ChatMessage(
+                            role: "tool",
+                            content: outcome.result,
+                            tool_calls: nil,
+                            tool_call_id: outcome.callId
+                        )
+                    )
+                }
+            },
+            todoProgressSnapshot: {
+                guard let todo = await AgentTodoStore.shared.todo(for: sessionId) else {
+                    return nil
+                }
+                return AgentTodoProgressSnapshot(done: todo.doneCount, total: todo.totalCount)
+            }
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+        let stored = await AgentTodoStore.shared.todo(for: sessionId)
+        await AgentTodoStore.shared.clear(for: sessionId)
+
+        #expect(stored?.doneCount == 2)
+        #expect(stored?.totalCount == 2)
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(continuationPreparations == 1)
+        #expect(continuationInput.map(\.role) == ["user", "assistant", "tool", "assistant"])
+        #expect(continuationInput.last?.content == progressText)
+        #expect(continuationInput.filter { $0.content == progressText }.count == 1)
+    }
+
+    @Test func multipleTodoUpdatesInOneBatchPreserveRecordedProgress() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([
+                inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#),
+                inv("todo", #"{"markdown":"- [x] inspect\n- [ ] answer"}"#),
+            ]),
+            .finalResponse,
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
+            .finalResponse,
+        ])
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            calls.map {
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
+    }
+
+    @Test func stalePendingTodoWithoutCurrentRunTodoDoesNotHijackFinal() async throws {
+        let surface = ScriptedLoopSurface(steps: [.finalResponse])
+        surface.pendingTodos = 4
+        surface.todoProgress = AgentTodoProgressSnapshot(done: 0, total: 4)
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test func failedTodoDoesNotArmTrackedContinuation() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"not a checklist"}"#)]),
+            .finalResponse,
+        ])
+        surface.pendingTodos = 3
+        surface.toolResults["todo"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "No checklist items found.",
+                tool: "todo"
+            ),
+            isError: true
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: headlessPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 2))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test func completedTodoAllowsNormalFinal() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
+            .finalResponse,
+        ])
+        surface.pendingTodos = 0
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 2))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test func explicitCompleteStillEndsWithUncheckedCurrentRunTodo() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            .toolCalls([inv("complete", #"{"summary":"Completed the requested research and verified the cited model list."}"#)]),
+        ])
+        surface.pendingTodos = 2
+        surface.toolResults["complete"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(tool: "complete", text: "Task completed."),
+            endRun: true
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 2))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test func explicitClarifyStillEndsWithUncheckedCurrentRunTodo() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .toolCalls([inv("clarify", #"{"question":"Which repository should I inspect?"}"#)]),
+        ])
+        surface.toolResults["clarify"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(tool: "clarify", text: "Question shown."),
+            endRun: true
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 2))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test(arguments: ["complete", "clarify"])
+    func failedClosureIsNotTreatedAsAuthoritative(toolName: String) async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .toolCalls([inv(toolName)]),
+            .finalResponse,
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect"}"#)]),
+            .finalResponse,
+        ])
+        surface.toolResults[toolName] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Invalid closure arguments.",
+                tool: toolName
+            ),
+            isError: true
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: headlessPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+    }
+
+    @Test func cancellationAfterProgressContinuationStopsBeforeNextGeneration() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .finalResponse,
+        ])
+        surface.pendingTodos = 1
+        surface.cancelOnTrackedTaskContinuation = true
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 2))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+        #expect(surface.builtNotices.count == 2)
+    }
+
+    @Test func cancellationDuringTodoSnapshotSkipsContinuation() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .finalResponse,
+        ])
+        // Invocation parsing records the successful Todo directly. The first
+        // actor-backed snapshot is therefore the final-response lookup whose
+        // suspension races with Stop.
+        surface.cancelOnTodoProgressSnapshotCall = 1
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 1))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+        #expect(surface.builtNotices.count == 2)
+    }
+
+    @Test func pendingTodoAtIterationCapUsesTypedCapAndFreshFinalizerTurn() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .finalResponse,
+        ])
+        surface.pendingTodos = 1
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 2),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(
+            result == AgentToolLoop.RunResult(
+                exit: .iterationCapReached,
+                iterations: 2,
+                unfinishedTodoCount: 1
+            )
+        )
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+        #expect(surface.emittedFinalTexts.isEmpty)
+        #expect(
+            AgentToolLoop.unfinishedTodoCapFallback(pending: 1)
+                .contains("1 todo item still unfinished")
+        )
+    }
+
+    @Test func cancellationAfterProgressContinuationWinsAtIterationCap() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .finalResponse,
+        ])
+        surface.pendingTodos = 1
+        surface.cancelOnTrackedTaskContinuation = true
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 2),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 2))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+    }
+
+    @Test func missingTodoStoreSnapshotFallsBackToCurrentRunChecklist() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .finalResponse,
+        ])
+        surface.forceMissingTodoProgressSnapshot = true
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 2),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(
+            result == AgentToolLoop.RunResult(
+                exit: .iterationCapReached,
+                iterations: 2,
+                unfinishedTodoCount: 1
+            )
+        )
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+    }
+
+    @Test func pendingTodoWithToolOnLastIterationUsesTypedCap() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .toolCalls([inv("search_and_extract", #"{"url":"https://example.com"}"#)]),
+        ])
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 2),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(
+            result == AgentToolLoop.RunResult(
+                exit: .iterationCapReached,
+                iterations: 2,
+                unfinishedTodoCount: 1
+            )
+        )
+        // A tool batch already creates the next assistant buffer; only a
+        // progress-only final response needs the explicit continuation hook.
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+        #expect(surface.batchOutcomes.count == 2)
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func malformedDesktopRepeatCannotBypassPendingTodoAtCap() async throws {
+        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task","_message":"missing required argument: task","_expected":"required parameter"}"#
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .toolCalls([inv("applescript", #"{"task":"Open TextEdit"}"#)]),
+            .toolCalls([inv("applescript", malformed)]),
+        ])
+        surface.toolResults["applescript"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "applescript",
+                result: [
+                    "kind": "applescript",
+                    "status": "succeeded",
+                    "scripts_run": 1,
+                    "summary": "Ran 1 script(s) successfully.",
+                ]
+            )
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 3),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(
+            result == AgentToolLoop.RunResult(
+                exit: .iterationCapReached,
+                iterations: 3,
+                unfinishedTodoCount: 1
+            )
+        )
+        #expect(surface.executedCalls.map(\.name) == ["todo", "applescript"])
+        #expect(surface.emittedFinalTexts == ["Ran 1 script(s) successfully."])
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+    }
+
+    @Test func cancellationAfterMalformedDesktopContinuationWinsAtCap() async throws {
+        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task","_message":"missing required argument: task","_expected":"required parameter"}"#
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .toolCalls([inv("applescript", #"{"task":"Open TextEdit"}"#)]),
+            .toolCalls([inv("applescript", malformed)]),
+        ])
+        surface.toolResults["applescript"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "applescript",
+                result: ["status": "succeeded", "summary": "Ran successfully."]
+            )
+        )
+        surface.cancelOnTrackedTaskContinuation = true
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 3),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 3))
+        #expect(surface.executedCalls.map(\.name) == ["todo", "applescript"])
+        #expect(surface.emittedFinalTexts == ["Ran successfully."])
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+    }
+
+    @Test func repeatedEmptyResponsesAfterPendingTodoEndAsIncomplete() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .emptyResponse,
+            .emptyResponse,
+            .emptyResponse,
+        ])
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .emptyResponseExhausted, iterations: 2))
+        #expect(surface.emittedFinalTexts == [AgentToolLoop.emptyToolTaskFallback])
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test func cancellationDuringToolCapTodoSnapshotWins() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+        ])
+        surface.cancelOnTodoProgressSnapshotCall = 1
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(maxIterations: 1),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 1))
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+    }
+
+    @Test func batchedSuccessfulTodoWithSiblingToolArmsOneContinuation() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([
+                inv("todo", #"{"markdown":"- [ ] inspect"}"#),
+                inv("search_and_extract", #"{"url":"https://example.com"}"#),
+            ]),
+            .finalResponse,
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect"}"#)]),
+            .finalResponse,
+        ])
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            calls.map {
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
+                )
+            }
+        }
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(surface.trackedTaskContinuationPreparations == 1)
+        #expect(surface.batchOutcomes.first?.map { $0.invocation.toolName } == [
+            "todo", "search_and_extract",
+        ])
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 1))
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatHistoryDatabaseTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatHistoryDatabaseTests.swift
@@ -99,6 +99,23 @@ struct ChatHistoryDatabaseTests {
     }
 
     @Test
+    func modelContextExclusionRoundTripsAndInvalidatesContentHash() throws {
+        let db = try openInMemory()
+        let id = UUID()
+        var session = makeSession(id: id, turnCount: 2)
+        session.turns[1].modelContextExcluded = true
+        try db.saveSession(session)
+
+        #expect(db.loadSession(id: id)?.turns[1].modelContextExcluded == true)
+
+        // The incremental saver must rewrite the same turn when only the
+        // transcript-only marker changes.
+        session.turns[1].modelContextExcluded = false
+        try db.saveSession(session)
+        #expect(db.loadSession(id: id)?.turns[1].modelContextExcluded == false)
+    }
+
+    @Test
     func saveSession_replacesTurnsOnReSave() throws {
         let db = try openInMemory()
         let id = UUID()

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -8,6 +8,25 @@ import Testing
 struct ChatSessionStopTests {
     private static let asyncTimeout: Duration = .seconds(10)
 
+    private func enableDefaultAgentTools(warmModelsOnLoad: Bool) {
+        var chatConfig = ChatConfigurationStore.load()
+        chatConfig.disableTools = false
+        chatConfig.warmModelsOnLoad = warmModelsOnLoad
+        chatConfig.autoGenerateChatTitles = false
+        ChatConfigurationStore.save(chatConfig)
+
+        DefaultAgentConfigurationStore.save(
+            DefaultAgentConfiguration(
+                disableTools: false,
+                autonomousExec: nil,
+                toolSelectionMode: .manual,
+                manualToolNames: ["todo"]
+            )
+        )
+        DefaultAgentConfigurationStore.resetCacheForTests()
+        AgentManager.shared.refresh()
+    }
+
     private func beginSuspendedPreSendHandshake(
         session: ChatSession,
         gate: IgnoringCancellationHandshakeGate
@@ -51,6 +70,83 @@ struct ChatSessionStopTests {
             #expect(session.turns.count == 1)
             #expect(session.turns.last?.role == .user)
         }
+    }
+
+    @Test
+    func trackedTodoContinuationHistoryKeepsProgressOnceAndDropsEmptyBuffer() {
+        let user = ChatTurn(role: .user, content: "research these repositories")
+        let progress = ChatTurn(
+            role: .assistant,
+            content: "Got the Osaurus models. Now let me check the other two orgs."
+        )
+        let emptyContinuationBuffer = ChatTurn(role: .assistant, content: "")
+        let turns = [user, progress, emptyContinuationBuffer]
+
+        var messages = [ChatMessage(role: "user", content: user.content)]
+        for (index, turn) in turns.enumerated() where turn.role == .assistant {
+            if let message = ChatSession.modelVisibleAssistantMessage(
+                turn,
+                isLastTurn: index == turns.count - 1
+            ) {
+                messages.append(message)
+            }
+        }
+
+        #expect(messages.map(\.role) == ["user", "assistant"])
+        #expect(messages.map(\.content) == [
+            "research these repositories",
+            "Got the Osaurus models. Now let me check the other two orgs.",
+        ])
+        #expect(
+            messages.filter {
+                $0.content == "Got the Osaurus models. Now let me check the other two orgs."
+            }.count == 1
+        )
+    }
+
+    @Test
+    func incompleteReasoningRetryKeepsAbandonedTurnVisibleButOutOfToolHistory() throws {
+        let session = ChatSession()
+        let abandoned = ChatTurn(role: .assistant, content: "")
+        abandoned.appendThinking("unfinished private reasoning")
+        abandoned.modelContextExcluded = true
+
+        let retry = ChatTurn(role: .assistant, content: "")
+        retry.toolCalls = [
+            ToolCall(
+                id: "retry-call",
+                type: "function",
+                function: ToolCallFunction(
+                    name: "search_and_extract",
+                    arguments: #"{"url":"https://example.com"}"#
+                )
+            )
+        ]
+
+        #expect(
+            ChatSession.modelVisibleAssistantMessage(abandoned, isLastTurn: false) == nil
+        )
+        #expect(session.warmupTurnToMessage(abandoned, isLastTurn: false) == nil)
+        let retryMessage = try #require(
+            ChatSession.modelVisibleAssistantMessage(retry, isLastTurn: false)
+        )
+        let warmupRetryMessage = try #require(
+            session.warmupTurnToMessage(retry, isLastTurn: false)
+        )
+        #expect(retryMessage.tool_calls?.first?.id == "retry-call")
+        #expect(retryMessage.reasoning_content == nil)
+        #expect(warmupRetryMessage.role == retryMessage.role)
+        #expect(warmupRetryMessage.content == retryMessage.content)
+        #expect(warmupRetryMessage.tool_calls?.first?.id == retryMessage.tool_calls?.first?.id)
+        #expect(warmupRetryMessage.reasoning_content == retryMessage.reasoning_content)
+
+        let encoded = try JSONEncoder().encode(ChatTurnData(from: abandoned))
+        let decoded = try JSONDecoder().decode(ChatTurnData.self, from: encoded)
+        let restored = ChatTurn(from: decoded)
+        #expect(restored.modelContextExcluded)
+        #expect(
+            ChatSession.modelVisibleAssistantMessage(restored, isLastTurn: false) == nil
+        )
     }
 
     @Test
@@ -465,7 +561,8 @@ struct ChatSessionStopTests {
     func send_finishesReasoningOnlyLocalStream() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
-            session.chatEngineFactory = { _ in ReasoningOnlyChatEngine() }
+            let engine = ReasoningOnlyChatEngine()
+            session.chatEngineFactory = { _ in engine }
 
             session.send("Hello")
 
@@ -480,6 +577,112 @@ struct ChatSessionStopTests {
             #expect(assistant.contentIsBlank)
             #expect(assistant.thinking.contains("The user is straightforward greeting"))
             #expect(assistant.generationTokenCount == 0)
+            #expect(await engine.streamRequestCount == 1)
+        }
+    }
+
+    @Test
+    func send_marksPostToolEmptyExhaustionFailedAndCancelsWarmup() async throws {
+        try await ChatHistoryTestStorage.run {
+            enableDefaultAgentTools(warmModelsOnLoad: true)
+
+            let session = ChatSession()
+            session.selectedModel = "chat-session-tool-loop-test-model"
+            session.forceChatEngineRouteForTests = true
+            let engine = PostToolEmptyExhaustionChatEngine()
+            session.chatEngineFactory = { _ in engine }
+
+            session.send("Research the three repositories and finish every checklist item.")
+
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await engine.isWaitingOnFirstEmptyResponse
+            }
+
+            // Queue a real warm-up while the model step is suspended. The
+            // `.emptyResponseExhausted` lifecycle must cancel it during cleanup;
+            // otherwise it fires after the failed tool run and can own the solo
+            // generation lease behind the user's next send.
+            let warmupProbe = IncomingWarmupRecordingEngine()
+            session.warmupController.scheduleWarmup(
+                session: IncomingWarmupSession(engine: warmupProbe),
+                debounce: .milliseconds(250)
+            )
+            await engine.releaseEmptyResponses()
+
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                session.isStreaming == false
+            }
+            try await Task.sleep(for: .milliseconds(400))
+
+            #expect(await engine.regularRequestCount == 4)
+            #expect(await engine.exposedToolNames.allSatisfy { $0.contains("todo") })
+            #expect(session.lastStreamError == AgentToolLoop.emptyToolTaskFallback)
+            #expect(
+                session.turns.last(where: { $0.role == .assistant })?.content
+                    == AgentToolLoop.emptyToolTaskFallback
+            )
+            // This is the ChatSession completion/indexing marker. Failed runs
+            // must never publish one for auto-speak or downstream completion
+            // consumers, and the queued completed-transcript warm-up must not run.
+            #expect(session.lastCompletedAssistantTurnId == nil)
+            #expect(await warmupProbe.requestCount == 0)
+            #expect(session.isSendActiveForComposer == false)
+        }
+    }
+
+    @Test
+    func send_retriesReasoningOnlyAgentStepOnceInFreshExcludedTurn() async throws {
+        try await ChatHistoryTestStorage.run {
+            enableDefaultAgentTools(warmModelsOnLoad: false)
+
+            let session = ChatSession()
+            session.selectedModel = "chat-session-reasoning-retry-test-model"
+            session.forceChatEngineRouteForTests = true
+            let engine = ReasoningRetryChatEngine()
+            session.chatEngineFactory = { _ in engine }
+
+            session.send("Research the repositories with the available tools, then answer.")
+
+            // `send` starts through an async pre-send handshake. Waiting only
+            // for `isStreaming == false` can succeed before that handshake has
+            // begun, producing a zero-length snapshot array and hiding the
+            // behavior under an index crash.
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await engine.requestSnapshots.isEmpty == false
+            }
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                session.isStreaming == false && session.isSendActiveForComposer == false
+            }
+
+            let snapshots = await engine.requestSnapshots
+            let completedSnapshots = try #require(snapshots.count == 3 ? snapshots : nil)
+            #expect(completedSnapshots.allSatisfy { $0.toolNames.contains("todo") })
+            // Request 1 performs real structured tool work. Request 2 then
+            // stops with an unclosed reasoning-only turn, and request 3 is the
+            // one bounded replay. That replay receives the exact pre-attempt
+            // model-visible history; the abandoned reasoning turn remains
+            // UI-visible but is not fed back to the model.
+            #expect(completedSnapshots[1].encodedMessages == completedSnapshots[2].encodedMessages)
+            #expect(completedSnapshots[1].idempotencyKey != completedSnapshots[2].idempotencyKey)
+            #expect(completedSnapshots[1].idempotencyKey?.contains(":r0-") == true)
+            #expect(completedSnapshots[2].idempotencyKey?.contains(":r1-") == true)
+
+            let assistantTurns = session.turns.filter { $0.role == .assistant }
+            #expect(assistantTurns.count == 3)
+            let abandoned = try #require(
+                assistantTurns.first(where: { $0.modelContextExcluded })
+            )
+            let completed = try #require(assistantTurns.last)
+            #expect(abandoned.id != completed.id)
+            #expect(abandoned.contentIsBlank)
+            #expect(abandoned.thinking == "I need to inspect the repositories before answering.")
+            #expect(abandoned.modelContextExcluded)
+            #expect(completed.content == "The repository review is complete.")
+            #expect(completed.thinkingIsBlank)
+            #expect(completed.modelContextExcluded == false)
+            #expect(session.lastStreamError == nil)
+            #expect(session.lastCompletedAssistantTurnId == completed.id)
+            #expect(session.isSendActiveForComposer == false)
         }
     }
 }
@@ -522,8 +725,11 @@ private actor CancellationObservingChatEngine: ChatEngineProtocol {
 }
 
 private actor ReasoningOnlyChatEngine: ChatEngineProtocol {
+    private(set) var streamRequestCount = 0
+
     func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { continuation in
+        streamRequestCount += 1
+        return AsyncThrowingStream { continuation in
             continuation.yield(StreamingReasoningHint.encode("The user is straightforward greeting"))
             continuation.yield(StreamingStatsHint.encode(tokenCount: 0, tokensPerSecond: 0, unclosedReasoning: true))
             continuation.finish()
@@ -532,6 +738,115 @@ private actor ReasoningOnlyChatEngine: ChatEngineProtocol {
 
     func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
         throw NSError(domain: "ChatSessionStopTests", code: 2)
+    }
+}
+
+private actor PostToolEmptyExhaustionChatEngine: ChatEngineProtocol {
+    private(set) var regularRequestCount = 0
+    private(set) var exposedToolNames: [[String]] = []
+    private(set) var isWaitingOnFirstEmptyResponse = false
+    private var emptyResponseContinuation: CheckedContinuation<Void, Never>?
+
+    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        if request.warmupPrefill == true {
+            return AsyncThrowingStream { $0.finish() }
+        }
+
+        regularRequestCount += 1
+        exposedToolNames.append(request.tools?.map(\.function.name) ?? [])
+
+        if regularRequestCount == 1 {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(
+                    throwing: ServiceToolInvocation(
+                        toolName: "todo",
+                        jsonArguments:
+                            #"{"markdown":"- [ ] Inspect OsaurusAI\n- [ ] Inspect JANGQ-AI"}"#,
+                        toolCallId: "call_todo"
+                    )
+                )
+            }
+        }
+
+        if regularRequestCount == 2 {
+            isWaitingOnFirstEmptyResponse = true
+            await withCheckedContinuation { emptyResponseContinuation = $0 }
+            isWaitingOnFirstEmptyResponse = false
+        }
+        return AsyncThrowingStream { $0.finish() }
+    }
+
+    func releaseEmptyResponses() {
+        emptyResponseContinuation?.resume()
+        emptyResponseContinuation = nil
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionStopTests", code: 8)
+    }
+}
+
+private struct ChatRequestSnapshot: Sendable, Equatable {
+    let encodedMessages: Data
+    let toolNames: [String]
+    let idempotencyKey: String?
+}
+
+private actor ReasoningRetryChatEngine: ChatEngineProtocol {
+    private(set) var requestSnapshots: [ChatRequestSnapshot] = []
+
+    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        requestSnapshots.append(
+            ChatRequestSnapshot(
+                encodedMessages: (try? JSONEncoder().encode(request.messages)) ?? Data(),
+                toolNames: request.tools?.map(\.function.name) ?? [],
+                idempotencyKey: request.idempotencyKey
+            )
+        )
+        let requestNumber = requestSnapshots.count
+        if requestNumber == 1 {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(
+                    throwing: ServiceToolInvocation(
+                        toolName: "todo",
+                        jsonArguments:
+                            #"{"markdown":"- [x] Inspect the available repository metadata"}"#,
+                        toolCallId: "call_completed_todo"
+                    )
+                )
+            }
+        }
+        return AsyncThrowingStream { continuation in
+            if requestNumber == 2 {
+                continuation.yield(
+                    StreamingReasoningHint.encode(
+                        "I need to inspect the repositories before answering."
+                    )
+                )
+                continuation.yield(
+                    StreamingStatsHint.encode(
+                        tokenCount: 12,
+                        tokensPerSecond: 10,
+                        unclosedReasoning: true,
+                        stopReason: "stop"
+                    )
+                )
+            } else {
+                continuation.yield("The repository review is complete.")
+                continuation.yield(
+                    StreamingStatsHint.encode(
+                        tokenCount: 6,
+                        tokensPerSecond: 10,
+                        stopReason: "stop"
+                    )
+                )
+            }
+            continuation.finish()
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionStopTests", code: 9)
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -502,6 +502,53 @@ struct ContextBudgetPreviewTests {
         }
     }
 
+    /// Local discovery first publishes a cheap id-only row, then enriches the
+    /// same id from config.json. The metadata-only picker update must evict the
+    /// cached generic preview so the next budget/warm-up/send all use the
+    /// authoritative architecture guidance. Before this regression fix the
+    /// picker showed the refreshed item while the preview and green warm claim
+    /// remained tied to the old generic prompt.
+    @Test("same-id model_type enrichment invalidates the cached family preview")
+    func sameIdModelTypeEnrichment_invalidatesFamilyPreview() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.warmModelsOnLoad = false
+            ChatConfigurationStore.save(chatConfig)
+
+            let modelId = "local/renamed-backbone"
+            let session = ChatSession()
+            session.agentId = agentId
+            session.pickerItems = [
+                ModelPickerItem(
+                    id: modelId,
+                    displayName: "Renamed Backbone",
+                    source: .local
+                )
+            ]
+            session.selectedModel = modelId
+
+            @MainActor func familyTokens() -> Int {
+                session.estimatedContextBreakdown.context
+                    .first { $0.id == "modelFamilyGuidance" }?.tokens ?? 0
+            }
+
+            let genericTokens = familyTokens()
+            #expect(genericTokens > 0)
+
+            session.applyPickerItems([
+                ModelPickerItem(
+                    id: modelId,
+                    displayName: "Renamed Backbone",
+                    source: .local,
+                    modelType: "qwen3_5"
+                )
+            ])
+
+            #expect(session.selectedPickerItem?.modelType == "qwen3_5")
+            #expect(familyTokens() != genericTokens)
+        }
+    }
+
     // MARK: - Skills are load-on-demand only
 
     /// Regression for the 55k-token Skills bloat: skills MUST be

--- a/Packages/OsaurusCore/Tests/Chat/ModelFamilyGuidanceObedienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelFamilyGuidanceObedienceTests.swift
@@ -52,6 +52,66 @@ struct ModelFamilyGuidanceObedienceTests {
         #expect(ModelFamilyGuidance.guidance(forModelId: "deepseek-v4") == ModelFamilyGuidance.deepSeekGuidance)
     }
 
+    @Test("Ornith and Bonsai aliases receive their Qwen-backbone guidance")
+    func qwenBackboneAliasesResolveOnTokenBoundaries() {
+        for id in [
+            "OsaurusAI/Ornith-1.0-35B-MXFP8",
+            "JANGQ-AI/ornith_9b_jang-4m",
+            "dealignai/Bonsai-27b-Ternary-JANG",
+            "bonsai",
+        ] {
+            #expect(ModelFamilyGuidance.family(for: id) == .glmQwen, "\(id) should be glmQwen")
+            #expect(
+                ModelFamilyGuidance.guidance(forModelId: id)
+                    == ModelFamilyGuidance.glmQwenGuidance
+            )
+        }
+
+        // Aliases are exact tokens, not arbitrary substrings.
+        for id in ["notornith-7b", "ornithology-3b", "bonsaified-8b", "mybonsai2"] {
+            #expect(ModelFamilyGuidance.family(for: id) == .other, "\(id) should remain other")
+        }
+        #expect(ModelFamilyGuidance.family(for: "ornith/Llama-3.2-8B") == .other)
+    }
+
+    @Test("bundle architecture takes precedence over repository branding")
+    func bundleArchitectureWinsOverIdentifier() {
+        #expect(
+            ModelFamilyGuidance.family(
+                for: "misleading/gemma-ornith-mashup",
+                modelType: "qwen3_5_moe"
+            ) == .glmQwen
+        )
+        #expect(
+            ModelFamilyGuidance.family(
+                for: "qwen-owner/not-a-qwen-model",
+                modelType: "gemma4"
+            ) == .googleGemma
+        )
+        #expect(
+            ModelFamilyGuidance.guidance(
+                forModelId: "renamed/backbone-hidden",
+                modelType: "qwen3_5"
+            ) == ModelFamilyGuidance.glmQwenGuidance
+        )
+        #expect(
+            ModelFamilyGuidance.family(
+                for: "qwen-owner/Llama-3.2-8B",
+                modelType: "llama"
+            ) == .other
+        )
+        #expect(
+            ModelFamilyGuidance.family(
+                for: "misleading/gemma-coder",
+                modelType: "mistral3"
+            ) == .other
+        )
+
+        // Only genuinely absent metadata uses the repository-id fallback.
+        #expect(ModelFamilyGuidance.family(for: "qwen3-32b", modelType: nil) == .glmQwen)
+        #expect(ModelFamilyGuidance.family(for: "gemma-4-12b", modelType: "  ") == .googleGemma)
+    }
+
     @Test("Gemini resolves to its own frontier block, not Gemma's brevity clamp")
     func geminiGetsDedicatedBlock() {
         for id in ["gemini-2.5-pro", "google/gemini-flash", "models/gemini-pro"] {

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
@@ -202,6 +202,18 @@ struct ModelPickerItemChatCapabilityTests {
         #expect(!item.isLikelyChatCapable)
     }
 
+    @Test func fromMLXModel_carriesCanonicalBundleModelType() {
+        let model = MLXModel(
+            id: "JANGQ-AI/Ornith-1.0-35B-MXFP8",
+            name: "Ornith 1.0 35B MXFP8",
+            description: "fixture",
+            downloadURL: "https://example.invalid/ornith",
+            modelType: "qwen3_5_moe"
+        )
+        let item = ModelPickerItem.fromMLXModel(model)
+        #expect(item.modelType == "qwen3_5_moe")
+    }
+
     @Test func remoteEmbeddingIsNotChatCapable() {
         let item = ModelPickerItem.fromRemoteModel(
             modelId: "openai/text-embedding-3-small",

--- a/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
@@ -136,6 +136,39 @@ struct SearchDiagnosticsExtractionTests {
         #expect(extraction.message?.contains("\(SearchReadability.maxHTMLBytes)") == true)
     }
 
+    @Test func persistentHTTPFailureIsBlockedButServerFailureMayRetry() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SearchExtractionHTTPStubProtocol.self]
+        var statusCode = 403
+        SearchExtractionHTTPStubProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/plain"]
+            )
+            return (try #require(response), Data())
+        }
+        defer { SearchExtractionHTTPStubProtocol.handler = nil }
+
+        let forbidden = await SearchReadability.extract(
+            url: "https://198.51.100.1/forbidden",
+            timeout: 1,
+            configuration: configuration
+        )
+        #expect(forbidden.status == .blocked)
+        #expect(forbidden.message == "HTTP status 403")
+
+        statusCode = 503
+        let unavailable = await SearchReadability.extract(
+            url: "https://198.51.100.1/unavailable",
+            timeout: 1,
+            configuration: configuration
+        )
+        #expect(unavailable.status == .fetchFailed)
+        #expect(unavailable.message == "HTTP status 503")
+    }
+
     @Test func extractionPreservesRawCSVHeaderAndRows() async {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [SearchExtractionHTTPStubProtocol.self]

--- a/Packages/OsaurusCore/Tests/Search/WebSearchToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/WebSearchToolTests.swift
@@ -59,6 +59,162 @@ struct WebSearchToolTests {
         #expect(properties["urls"] != nil)
     }
 
+    @Test func allFailedExtractionsAreAnHonestToolFailure() throws {
+        let envelope = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://huggingface.co/OsaurusAI/models",
+                        "extracted": false,
+                        "extract_status": "challenge",
+                        "extract_error": "challenge_page",
+                    ],
+                    [
+                        "url": "https://huggingface.co/dealignai/models",
+                        "extracted": false,
+                        "extract_status": "challenge",
+                        "extract_error": "challenge_page",
+                    ],
+                    [
+                        "url": "https://huggingface.co/JANGQ-AI/models",
+                        "extracted": false,
+                        "extract_status": "challenge",
+                        "extract_error": "challenge_page",
+                    ],
+                ],
+            ]
+        )
+
+        #expect(ToolEnvelope.isError(envelope))
+        #expect(envelope.contains("No page content was retrieved"))
+        #expect(envelope.contains("do not claim these pages were read"))
+
+        let data = try #require(envelope.data(using: .utf8))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(object["retryable"] as? Bool == false)
+        #expect(object["extracted_count"] as? Int == 0)
+        #expect(object["extraction_failed_count"] as? Int == 3)
+        #expect((object["results"] as? [[String: Any]])?.count == 3)
+    }
+
+    @Test func partialExtractionSuccessPreservesCountsAndResults() throws {
+        let envelope = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "search_and_extract",
+                "provider": "test",
+                "results": [
+                    [
+                        "url": "https://example.com/one",
+                        "extracted": true,
+                        "extract_status": "ok",
+                        "markdown": "retrieved body",
+                    ],
+                    [
+                        "url": "https://example.com/two",
+                        "extracted": false,
+                        "extract_status": "timeout",
+                    ],
+                    [
+                        "url": "https://example.com/not-attempted",
+                        "extracted": false,
+                    ],
+                ],
+            ]
+        )
+
+        #expect(ToolEnvelope.isSuccess(envelope))
+        let payload = try #require(ToolEnvelope.successPayload(envelope) as? [String: Any])
+        #expect(payload["extraction_attempted_count"] as? Int == 2)
+        #expect(payload["extracted_count"] as? Int == 1)
+        #expect(payload["extraction_failed_count"] as? Int == 1)
+        #expect((payload["results"] as? [[String: Any]])?.count == 3)
+    }
+
+    @Test func allTimeoutExtractionsRemainRetryableAndPreserveMetadata() throws {
+        let envelope = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "search_and_extract",
+                "provider": "local",
+                "query": "models for coding",
+                "category": "web",
+                "search_source": "local",
+                "premium_fallback": true,
+                "next_offset": 5,
+                "results": [
+                    [
+                        "url": "https://example.com/slow",
+                        "extracted": false,
+                        "extract_status": "timeout",
+                    ],
+                ],
+            ],
+            warnings: ["test warning"]
+        )
+
+        let data = try #require(envelope.data(using: .utf8))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(object["ok"] as? Bool == false)
+        #expect(object["kind"] as? String == ToolEnvelope.Kind.timeout.rawValue)
+        #expect(object["retryable"] as? Bool == true)
+        #expect(object["query"] as? String == "models for coding")
+        #expect(object["category"] as? String == "web")
+        #expect(object["search_source"] as? String == "local")
+        #expect(object["premium_fallback"] as? Bool == true)
+        #expect(object["next_offset"] as? Int == 5)
+        #expect(object["warnings"] as? [String] == ["test warning"])
+    }
+
+    @Test func fetchFailureIsRetryableButNotMislabeledAsTimeout() throws {
+        let envelope = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://example.com/offline",
+                        "extracted": false,
+                        "extract_status": "fetch_failed",
+                    ],
+                ],
+            ]
+        )
+
+        let data = try #require(envelope.data(using: .utf8))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(object["kind"] as? String == ToolEnvelope.Kind.executionError.rawValue)
+        #expect(object["retryable"] as? Bool == true)
+    }
+
+    @Test func cancellationIsNotPresentedAsARequestToRetry() throws {
+        let envelope = SearchAndExtractTool.extractionEnvelope(
+            payload: [
+                "mode": "direct_url",
+                "provider": "direct_url",
+                "results": [
+                    [
+                        "url": "https://example.com/cancelled",
+                        "extracted": false,
+                        "extract_status": "cancelled",
+                    ],
+                ],
+            ]
+        )
+
+        let data = try #require(envelope.data(using: .utf8))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(object["retryable"] as? Bool == false)
+    }
+
     // MARK: - Dynamic category enum
 
     private func categoryEnum(of tool: WebSearchTool) -> [String]? {

--- a/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
@@ -79,14 +79,18 @@ struct ChatHistoryMigrationRepairTests {
     private static let alterV7 = ["ALTER TABLE turns ADD COLUMN thinking_duration REAL"]
     private static let alterV8 = ["ALTER TABLE turns ADD COLUMN router_billing TEXT"]
     private static let alterV12 = ["ALTER TABLE turns ADD COLUMN terminal_stop_reason TEXT"]
+    private static let alterV13 = [
+        "ALTER TABLE turns ADD COLUMN model_context_excluded INTEGER NOT NULL DEFAULT 0"
+    ]
 
-    // MARK: - Reporter-exact: v1 stuck, every column except v8 router_billing
+    // MARK: - Reporter-exact legacy state: v1 stuck before v8 router_billing
 
-    /// The exact reproduced failure state: `user_version = 1`, all columns
-    /// through v7 present, only `router_billing` missing. Opening must NOT
-    /// throw, must add `router_billing`, must reconcile the version to the latest,
-    /// must return the pre-existing turns (not nil), and a fresh save must
-    /// round-trip.
+    /// The exact reproduced failure state at the time of the report:
+    /// `user_version = 1`, all columns through v7 present, and `router_billing`
+    /// missing. Newer migrations may now add later columns too. Opening must
+    /// NOT throw, must reconcile every missing column and the version to the
+    /// latest, must return the pre-existing turns (not nil), and a fresh save
+    /// must round-trip.
     @Test
     func stuckV1MissingRouterBillingHealsAndPreservesHistory() async throws {
         try await runWithPlaintextRoot {
@@ -121,6 +125,7 @@ struct ChatHistoryMigrationRepairTests {
 
             #expect(self.diskUserVersion() == ChatHistoryDatabase.latestSchemaVersion)
             #expect(self.diskColumns(table: "turns").contains("router_billing"))
+            #expect(self.diskColumns(table: "turns").contains("model_context_excluded"))
 
             let loaded = db.loadSession(id: sid)
             #expect(loaded != nil)
@@ -128,6 +133,7 @@ struct ChatHistoryMigrationRepairTests {
             #expect(loaded?.turns.first?.role == .user)
             #expect(loaded?.turns.first?.content == "hello from before the upgrade")
             #expect(loaded?.turns.last?.role == .assistant)
+            #expect(loaded?.turns.allSatisfy { !$0.modelContextExcluded } == true)
 
             let newId = UUID()
             let newSession = ChatSessionData(
@@ -145,7 +151,7 @@ struct ChatHistoryMigrationRepairTests {
     // MARK: - v1 stuck, every turn-column migration already present
 
     /// A store whose `user_version` is stuck at 1 but already carries every
-    /// migrated turn column (including v12). Every migration ALTER must be skipped, the
+    /// migrated turn column (including v13). Every migration ALTER must be skipped, the
     /// version reconciled to the latest, and data must still load + save.
     @Test
     func stuckV1WithAllColumnsPresentOpensCleanly() async throws {
@@ -157,15 +163,15 @@ struct ChatHistoryMigrationRepairTests {
             statements.append(Self.createTurnsV1)
             statements +=
                 Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7
-                + Self.alterV8 + Self.alterV12
+                + Self.alterV8 + Self.alterV12 + Self.alterV13
             statements += [
                 """
                 INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
                 VALUES ('\(sid.uuidString)', 'All columns', 1000, 2000, 'chat', 1, 0, '')
                 """,
                 """
-                INSERT INTO turns (id, session_id, seq, role, content)
-                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'already fully columned')
+                INSERT INTO turns (id, session_id, seq, role, content, model_context_excluded)
+                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'already fully columned', 1)
                 """,
                 "PRAGMA user_version = 1",
             ]
@@ -179,6 +185,7 @@ struct ChatHistoryMigrationRepairTests {
             let loaded = db.loadSession(id: sid)
             #expect(loaded?.turns.count == 1)
             #expect(loaded?.turns.first?.content == "already fully columned")
+            #expect(loaded?.turns.first?.modelContextExcluded == true)
 
             let newId = UUID()
             try db.saveSession(

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -788,6 +788,33 @@ struct CapabilitiesLoadToolTests {
         #expect(buffered.map(\.function.name) == ["render_chart"])
     }
 
+    /// Web Researcher must teach the existing, permission-checked dynamic-load
+    /// transition instead of silently authorizing a gated tool as a skill side
+    /// effect. This keeps the visible Web setting and manual tool selection in
+    /// control while preventing the model from narrating the next step and
+    /// stopping because the extraction schema is absent.
+    @Test @MainActor
+    func webResearcherSkillLoadTeachesExplicitSearchAndExtractLoad() async throws {
+        await SkillManager.shared.refresh()
+        _ = await CapabilityLoadBuffer.shared.drain()
+
+        let tool = CapabilitiesLoadTool()
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+            try await tool.execute(
+                argumentsJSON: #"{"ids":["skill/Web Researcher"]}"#
+            )
+        }
+
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("## Skill: Web Researcher"))
+        #expect(result.contains("tool/search_and_extract"))
+        #expect(result.contains("call `search_and_extract` in this same run"))
+        #expect(!result.contains("Schema for `search_and_extract`"))
+
+        let buffered = await CapabilityLoadBuffer.shared.drain()
+        #expect(buffered.isEmpty)
+    }
+
     @Test @MainActor
     func toolLoadReportsDisabledAvailability() async throws {
         try await DynamicCatalogTestLock.shared.run {

--- a/Packages/OsaurusCore/Tools/AgentLoopTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentLoopTools.swift
@@ -33,7 +33,9 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
         + "create the list BEFORE starting, then re-send it with the new box checked IMMEDIATELY "
         + "after finishing each item — do not batch updates for the end. Every item is a line "
         + "starting with `- [ ]` (pending) or `- [x]` (done); each call replaces the entire "
-        + "list. Skip it for a direct question or single-step work — just answer."
+        + "list. Once created, unchecked items keep this agent run open until you update them or "
+        + "honestly close the tracked task with `complete`. Skip it for a direct question or "
+        + "single-step work — just answer."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -111,8 +113,10 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             text:
                 "Todo updated: \(stored.doneCount)/\(stored.totalCount) complete. "
-                + "Continue with the next pending item; when everything is done, write your "
-                + "answer to the user (you may then call `complete(summary)` to close the task)."
+                + "Unchecked items keep this agent run open, so continue with the next pending "
+                + "item and re-send the full checklist as you check items. When everything is "
+                + "done, write your answer to the user; if work is blocked, answer honestly and "
+                + "call `complete(summary)` with what remains."
         )
     }
 }

--- a/Packages/OsaurusCore/Tools/WebSearchTools.swift
+++ b/Packages/OsaurusCore/Tools/WebSearchTools.swift
@@ -431,7 +431,7 @@ final class SearchAndExtractTool: OsaurusTool, @unchecked Sendable {
             if !hostedTexts.isEmpty {
                 payload["extract_source"] = "premium"
             }
-            return ToolEnvelope.success(tool: name, result: payload)
+            return Self.extractionEnvelope(payload: payload)
         }
 
         var warnings: [String] = []
@@ -479,10 +479,75 @@ final class SearchAndExtractTool: OsaurusTool, @unchecked Sendable {
         )
         WebSearchResultFormatter.applySourceMetadata(&payload, run: run)
 
-        return ToolEnvelope.success(
-            tool: name,
-            result: payload,
+        return Self.extractionEnvelope(
+            payload: payload,
             warnings: warnings.isEmpty ? nil : warnings
+        )
+    }
+
+    /// Turn per-result extraction statuses into an honest tool-level result.
+    ///
+    /// `search_and_extract` promises retrieved page content, not another list
+    /// of discovery URLs.  A request where every attempted extraction was a
+    /// challenge/timeout/empty page therefore did not succeed.  Returning an
+    /// `ok:true` envelope for that case used to reset the agent loop's
+    /// discovery budget and let Gemma/Qwen families search, load capabilities,
+    /// and reason indefinitely from snippets while believing retrieval had
+    /// progressed.
+    ///
+    /// Partial success remains a success: the model gets every result plus
+    /// explicit counts and can use whichever sources were actually retrieved.
+    /// Total failure preserves the complete search/extraction payload as
+    /// metadata. Challenge/content-policy failures are non-retryable as-is;
+    /// transport failures remain retryable so a transient outage is not
+    /// mislabeled as a permanent source contract.
+    static func extractionEnvelope(
+        payload rawPayload: [String: Any],
+        warnings: [String]? = nil
+    ) -> String {
+        var payload = rawPayload
+        let results = payload["results"] as? [[String: Any]] ?? []
+        let attempted = results.filter { $0["extract_status"] != nil }
+        let extractedCount = results.filter { ($0["extracted"] as? Bool) == true }.count
+        let failedCount = attempted.filter { ($0["extracted"] as? Bool) != true }.count
+
+        payload["extraction_attempted_count"] = attempted.count
+        payload["extracted_count"] = extractedCount
+        payload["extraction_failed_count"] = failedCount
+
+        guard extractedCount > 0 else {
+            let statuses = attempted.compactMap { $0["extract_status"] as? String }
+            let transientStatuses: Set<String> = [
+                SearchExtractionStatus.fetchFailed.rawValue,
+                SearchExtractionStatus.timeout.rawValue,
+            ]
+            let hasTransientFailure = statuses.contains { transientStatuses.contains($0) }
+            let allTimedOut = !statuses.isEmpty
+                && statuses.allSatisfy { $0 == SearchExtractionStatus.timeout.rawValue }
+            let retryable = hasTransientFailure || attempted.isEmpty
+
+            var metadata = payload
+            metadata["next_action"] = [
+                "instruction": retryable
+                    ? "A transient retrieval failure occurred. Retry once or choose a materially different retrievable source; if retrieval still fails, report the blocker. Do not claim these pages were inspected."
+                    : "Choose a materially different retrievable source or report that page retrieval is blocked. Do not claim these pages were inspected.",
+            ]
+            if let warnings, !warnings.isEmpty { metadata["warnings"] = warnings }
+
+            return ToolEnvelope.failure(
+                kind: allTimedOut ? .timeout : .executionError,
+                message:
+                    "No page content was retrieved from any attempted source. The returned URLs/snippets are discovery results, not inspected page evidence. Change the source or retrieval method, or report that retrieval is blocked; do not claim these pages were read.",
+                tool: "search_and_extract",
+                retryable: retryable,
+                metadata: metadata
+            )
+        }
+
+        return ToolEnvelope.success(
+            tool: "search_and_extract",
+            result: payload,
+            warnings: warnings
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1155,6 +1155,12 @@ final class ChatSession: ObservableObject {
     func applyPickerItems(_ newOptions: [ModelPickerItem]) {
         let newOptionIds = newOptions.map { $0.id }
         let optionsChanged = pickerItems.map({ $0.id }) != newOptionIds
+        let previousSelectedFamily = selectedModel.map { modelId in
+            ModelFamilyGuidance.family(
+                for: modelId,
+                modelType: pickerItems.first(where: { $0.id == modelId })?.modelType
+            )
+        }
 
         isDiscoveringModels = false
 
@@ -1169,6 +1175,29 @@ final class ChatSession: ObservableObject {
             if pickerItems != newOptions {
                 pickerItems = newOptions
                 loadActiveModelOptions(for: selectedModel)
+
+                // A local scanner can enrich an already-listed bundle with
+                // its authoritative config.json `model_type` without changing
+                // the model id. Family guidance is part of the static prompt
+                // prefix, so a family change must drop the old preview/send
+                // context and warm claim. Otherwise the UI can remain green
+                // for a prefix composed under generic guidance while the next
+                // real send correctly switches to Qwen/Gemma guidance and
+                // cold-prefills. This is metadata-driven invalidation only;
+                // it does not alter model output, sampling, or template state.
+                let refreshedSelectedFamily = selectedModel.map { modelId in
+                    ModelFamilyGuidance.family(
+                        for: modelId,
+                        modelType: newOptions.first(where: { $0.id == modelId })?.modelType
+                    )
+                }
+                if previousSelectedFamily != refreshedSelectedFamily {
+                    cachedPreviewContext = nil
+                    cachedContext = nil
+                    warmupController.invalidateWarmState()
+                    warmupController.scheduleWarmup(session: self)
+                    objectWillChange.send()
+                }
             }
             return
         }
@@ -1628,7 +1657,8 @@ final class ChatSession: ObservableObject {
         return SystemPromptComposer.composePreviewContext(
             agentId: effectiveId,
             executionMode: estimatedChatExecutionMode(agentId: effectiveId),
-            model: selectedModel
+            model: selectedModel,
+            modelType: selectedPickerItem?.modelType
         )
     }
 
@@ -1690,6 +1720,42 @@ final class ChatSession: ObservableObject {
         }
 
         return ChatMessage(role: "user", content: messageText)
+    }
+
+    /// Render one assistant transcript turn into model-visible history.
+    /// A trailing empty turn is the live streaming buffer and must stay out of
+    /// the next request; a preserved progress turn immediately before it must
+    /// appear exactly once. Kept as a pure helper so continuation history is
+    /// testable without launching a model.
+    static func modelVisibleAssistantMessage(
+        _ turn: ChatTurn,
+        isLastTurn: Bool,
+        excludedFromRequest: Bool = false
+    ) -> ChatMessage? {
+        if excludedFromRequest || turn.modelContextExcluded { return nil }
+        if isLastTurn,
+            turn.contentIsBlank,
+            turn.thinkingIsBlank,
+            turn.toolCalls == nil
+        {
+            return nil
+        }
+        if turn.contentIsBlank,
+            turn.thinkingIsBlank,
+            (turn.toolCalls == nil || turn.toolCalls!.isEmpty)
+        {
+            return nil
+        }
+
+        return ChatMessage(
+            role: "assistant",
+            content: turn.contentIsBlank ? nil : turn.content,
+            tool_calls: turn.toolCalls,
+            tool_call_id: nil,
+            reasoning_content: turn.thinkingIsBlank ? nil : turn.thinking,
+            reasoning_item_id: turn.reasoningItemId,
+            reasoning_encrypted: turn.reasoningEncrypted
+        )
     }
 
     /// Prepend a user turn's frozen memory / screen-context prefix to its
@@ -3291,19 +3357,26 @@ final class ChatSession: ObservableObject {
         }
 
         let context = activeRunContext
+        let runCompletedCleanly = !stopRequested && lastStreamError == nil
         activeRunId = nil
         activeRunContext = nil
         completeRunCleanup()
 
         guard persistConversationArtifacts, let context else { return }
 
-        if let lastAssistant = turns.last(where: { $0.role == .assistant }),
+        if runCompletedCleanly,
+            let lastAssistant = turns.last(where: { $0.role == .assistant }),
             !lastAssistant.contentIsBlank || lastAssistant.hasRenderableThinking
         {
             lastCompletedAssistantTurnId = lastAssistant.id
         }
 
-        let assistantContent = turns.last(where: { $0.role == .assistant })?.content
+        // Keep an honest incomplete/failure fallback visible in the chat, but
+        // never index it as a completed assistant answer or feed it into
+        // long-term memory. The next clean turn can establish completion.
+        let assistantContent = runCompletedCleanly
+            ? turns.last(where: { $0.role == .assistant })?.content
+            : nil
 
         let agentUUID = UUID(uuidString: context.memoryAgentId) ?? Agent.defaultId
         let memoryOff = AgentManager.shared.effectiveMemoryDisabled(for: agentUUID)
@@ -3439,6 +3512,14 @@ final class ChatSession: ObservableObject {
         selectedModel: String?
     ) async throws -> (invocations: [ServiceToolInvocation], finalTurn: ChatTurn) {
         var currentTurn = assistantTurn
+        // A continuation or transient retry may reuse this stream processor
+        // after the prior assistant step set terminal metadata. Each model
+        // generation owns fresh terminal state; carrying `stop` or an
+        // unclosed-reasoning flag forward can falsely reclassify a valid
+        // continuation as incomplete.
+        currentTurn.terminalStopReason = nil
+        currentTurn.unclosedReasoning = false
+        currentTurn.completedAt = nil
         // On every exit — clean end, cancel, tool-invocation throw, or a
         // mid-stream error — drop a tool-call-progress placeholder if it never
         // resolved to a committed tool name, so the "Preparing tool call" card
@@ -4305,6 +4386,11 @@ final class ChatSession: ObservableObject {
             }
         }
 
+        // One stable identity for every Todo tool execution and TodoStore read
+        // in this logical run. A reset/new-chat action must not make an
+        // in-flight call write one session while terminal checks read another.
+        let todoSessionIdForRun = expectedTodoSessionId
+
         let memoryAgentId = (agentId ?? Agent.defaultId).uuidString
         let memoryConversationId = (sessionId ?? UUID()).uuidString
 
@@ -4533,6 +4619,7 @@ final class ChatSession: ObservableObject {
                         agentId: effectiveAgentId,
                         executionMode: executionMode,
                         model: selectedModel,
+                        modelType: selectedPickerItem?.modelType,
                         query: trimmed,
                         messages: priorUserMessages,
                         toolsDisabled: chatCfg.disableTools,
@@ -4677,35 +4764,28 @@ final class ChatSession: ObservableObject {
                         )
                     }()
 
+                    // Incomplete reasoning attempts remain visible in the
+                    // transcript but must not be fed back into the retry.
+                    // Bundle templates do not share a continuation contract:
+                    // Gemma drops tool-free reasoning history while Ornith
+                    // closes and rewrites it. Excluding only these captured
+                    // attempt ids makes the bounded retry an exact replay of
+                    // the pre-attempt model-visible history.
+                    var incompleteReasoningRetryOrdinal = 0
+                    // Set only after this logical run emits a parsed tool call.
+                    // Tool schemas being available is not itself agent work and
+                    // must not force an intentional reasoning-only direct answer
+                    // through the post-tool recovery path.
+                    var hasStructuredToolWorkThisRun = false
+
                     /// Convert a single turn to a ChatMessage (returns nil if should be skipped)
                     @MainActor
                     func turnToMessage(_ t: ChatTurn, isLastTurn: Bool) -> ChatMessage? {
                         switch t.role {
                         case .assistant:
-                            // Skip the last assistant turn if it's empty (it's the streaming placeholder)
-                            if isLastTurn && t.contentIsBlank && t.thinkingIsBlank && t.toolCalls == nil {
-                                return nil
-                            }
-
-                            if t.contentIsBlank && t.thinkingIsBlank && (t.toolCalls == nil || t.toolCalls!.isEmpty) {
-                                return nil
-                            }
-
-                            let content: String? = t.contentIsBlank ? nil : t.content
-                            // DeepSeek's thinking mode requires echoing the
-                            // previous `reasoning_content` on follow-ups
-                            // (issue #959). `RemoteProviderService` strips it
-                            // again for providers that don't need it.
-                            let reasoning: String? = t.thinkingIsBlank ? nil : t.thinking
-
-                            return ChatMessage(
-                                role: "assistant",
-                                content: content,
-                                tool_calls: t.toolCalls,
-                                tool_call_id: nil,
-                                reasoning_content: reasoning,
-                                reasoning_item_id: t.reasoningItemId,
-                                reasoning_encrypted: t.reasoningEncrypted
+                            return Self.modelVisibleAssistantMessage(
+                                t,
+                                isLastTurn: isLastTurn
                             )
                         case .tool:
                             return ChatMessage(
@@ -5051,15 +5131,13 @@ final class ChatSession: ObservableObject {
                             // state in their stores. Falls back to a stable
                             // string when no session has been created yet so
                             // brand-new chats still get a todo store entry.
-                            let sessionIdForTools =
-                                self.sessionId?.uuidString ?? "chatwindow-\(ObjectIdentifier(self).hashValue)"
                             // `currentAgentId` is already pinned by the
                             // outer turn-level binding; we only need to
                             // layer per-tool-call session/turn/call ids.
                             let resultText = try await ChatExecutionContext.$toolExecutionScope
                                 .withValue(toolScope) {
                                     try await ChatExecutionContext.$currentSessionId.withValue(
-                                        sessionIdForTools
+                                        todoSessionIdForRun
                                     ) {
                                         try await ChatExecutionContext.$currentAssistantTurnId
                                             .withValue(assistantTurn.id) {
@@ -5125,6 +5203,33 @@ final class ChatSession: ObservableObject {
                                 return []
                             }
                             return [execution]
+                        }
+
+                        // Todo replaces one session-scoped checklist wholesale.
+                        // Concurrent Todo calls would make the final store value
+                        // depend on completion order instead of model order.
+                        // Keep the batch framing, but execute every call in the
+                        // batch serially when it contains Todo; onBatchComplete
+                        // still persists all result turns in slot order.
+                        if calls.contains(where: { $0.invocation.toolName == "todo" }),
+                            !AgentToolLoop.containsIntercept(calls)
+                        {
+                            var serialExecutions: [AgentLoopToolExecution] = []
+                            for call in calls {
+                                guard self.isRunActive(runId) else { break }
+                                let execution = await executeSingleToolCall(
+                                    call.invocation,
+                                    callId: call.callId
+                                )
+                                if execution.result.isEmpty,
+                                    !execution.isError,
+                                    !self.isRunActive(runId)
+                                {
+                                    break
+                                }
+                                serialExecutions.append(execution)
+                            }
+                            return serialExecutions
                         }
 
                         // Serial fallback when the batch carries a loop-ending
@@ -5211,14 +5316,14 @@ final class ChatSession: ObservableObject {
                             print(
                                 "[Osaurus][Tool] Executing batch of \(approved.count) in parallel: \(approved.map { $0.invocation.toolName }.joined(separator: ", "))"
                             )
-                            let sessionIdForTools =
-                                self.sessionId?.uuidString ?? "chatwindow-\(ObjectIdentifier(self).hashValue)"
                             let turnIdForTools = assistantTurn.id
                             let results = await AgentToolLoop.runBatchInParallel(
                                 approved.map { ($0.invocation, $0.callId) }
                             ) { inv, callId in
                                 try await ChatExecutionContext.$toolExecutionScope.withValue(toolScope) {
-                                    try await ChatExecutionContext.$currentSessionId.withValue(sessionIdForTools) {
+                                    try await ChatExecutionContext.$currentSessionId.withValue(
+                                        todoSessionIdForRun
+                                    ) {
                                         try await ChatExecutionContext.$currentAssistantTurnId.withValue(turnIdForTools)
                                         {
                                             try await ChatExecutionContext.$currentToolCallId.withValue(callId) {
@@ -5486,7 +5591,11 @@ final class ChatSession: ObservableObject {
                             // retryWithoutCharge re-POSTs still dedupe.
                             req.idempotencyKey =
                                 "\(runId.uuidString):\(attempt):"
-                                + AgentToolLoop.stepIdempotencyFingerprint(messages: msgs)
+                                + AgentToolLoop.recoveryAwareIdempotencySuffix(
+                                    messages: msgs,
+                                    incompleteReasoningRetryOrdinal:
+                                        incompleteReasoningRetryOrdinal
+                                )
                             debugLog(
                                 "send: attempt=\(attempt) model=\(req.model) tools=\(req.tools?.count ?? 0) sessionId=\(req.session_id ?? "nil")"
                             )
@@ -5518,7 +5627,6 @@ final class ChatSession: ObservableObject {
                                     selectedModel: self.selectedModel
                                 )
                                 assistantTurn = finalTurn
-
                                 // Stream finished naturally without a tool call — reset
                                 // the transient-retry budget so a future, unrelated
                                 // failure later in the conversation gets a fresh
@@ -5528,9 +5636,19 @@ final class ChatSession: ObservableObject {
                                     return AgentLoopModelStep.classifyTerminal(
                                         contentIsBlank: assistantTurn.contentIsBlank,
                                         thinkingIsBlank: assistantTurn.thinkingIsBlank,
-                                        stopReason: assistantTurn.terminalStopReason
+                                        stopReason: assistantTurn.terminalStopReason,
+                                        unclosedReasoning: assistantTurn.unclosedReasoning,
+                                        requiresVisibleFinalResponse:
+                                            AgentLoopVisibleResponsePolicy
+                                            .requiresVisibleFinalResponse(
+                                                hasStructuredToolWork:
+                                                    hasStructuredToolWorkThisRun,
+                                                isRemoteAgentTarget:
+                                                    self.isRemoteAgentTarget
+                                            )
                                     )
                                 }
+                                hasStructuredToolWorkThisRun = true
                                 return .toolCalls(invocations)
                             } catch let error as RemoteProviderServiceError {
                                 // Transient provider-side stream errors — most commonly
@@ -5558,6 +5676,44 @@ final class ChatSession: ObservableObject {
                                 }
                                 throw error
                             }
+                        },
+                        prepareIncompleteReasoningContinuation: {
+                            // Keep the model's real reasoning-only attempt in
+                            // the UI transcript but permanently exclude that
+                            // abandoned protocol attempt from model history.
+                            // Stream the one natural retry into a fresh turn so
+                            // a retry tool call and its result remain a valid,
+                            // uncontaminated assistant/tool pair. No prompt,
+                            // tags, or decode controls are injected here.
+                            debugLog(
+                                "send: reasoning-only agent step ended without visible answer; "
+                                    + "retrying exact pre-attempt history "
+                                    + "stop=\(assistantTurn.terminalStopReason ?? "nil") "
+                                    + "unclosed=\(assistantTurn.unclosedReasoning) "
+                                    + "reasoningChars=\(assistantTurn.thinkingLength)"
+                            )
+                            assistantTurn.modelContextExcluded = true
+                            let retryTurn = ChatTurn(role: .assistant, content: "")
+                            self.turns.append(retryTurn)
+                            assistantTurn = retryTurn
+                            incompleteReasoningRetryOrdinal += 1
+                            self.rebuildVisibleBlocks()
+                        },
+                        prepareTrackedTaskContinuation: {
+                            // The driver observed a successful current-run Todo
+                            // with structured pending items at an ordinary final.
+                            // Keep that real assistant turn in both UI and model
+                            // history, then give the bounded agent loop a fresh
+                            // assistant buffer. No prose classifier, reasoning
+                            // marker, sampler, or decode setting is involved.
+                            debugLog(
+                                "send: current-run todo still has unchecked work at model stop; "
+                                    + "continuing within the configured tool-attempt budget"
+                            )
+                            let nextAssistantTurn = ChatTurn(role: .assistant, content: "")
+                            self.turns.append(nextAssistantTurn)
+                            assistantTurn = nextAssistantTurn
+                            self.rebuildVisibleBlocks()
                         },
                         willProcessCall: { inv, callId in
                             // Recorded history uses the secret-safe view;
@@ -5648,10 +5804,20 @@ final class ChatSession: ObservableObject {
                         pendingTodoCount: {
                             // Feeds the driver's staleness nudge — todo is
                             // session-scoped, so only chat provides this.
-                            let key = self.expectedTodoSessionId
-                            guard let todo = await AgentTodoStore.shared.todo(for: key)
+                            guard let todo = await AgentTodoStore.shared.todo(
+                                for: todoSessionIdForRun
+                            )
                             else { return 0 }
                             return todo.totalCount - todo.doneCount
+                        },
+                        todoProgressSnapshot: {
+                            guard let todo = await AgentTodoStore.shared.todo(
+                                for: todoSessionIdForRun
+                            ) else { return nil }
+                            return AgentTodoProgressSnapshot(
+                                done: todo.doneCount,
+                                total: todo.totalCount
+                            )
                         },
                         emitFallbackText: { text in
                             // Empty-turn recovery exhausted: render a visible
@@ -5718,8 +5884,43 @@ final class ChatSession: ObservableObject {
                         lastStreamError = AgentToolLoop.lengthExhaustedFallback
                     }
 
+                    if runResult.exit == .emptyResponseExhausted {
+                        // The driver already emitted a visible, honest message
+                        // after repeated empty post-tool completions. Do not
+                        // warm or index that incomplete tool run as success.
+                        lastStreamError = AgentToolLoop.emptyToolTaskFallback
+                    }
+
+                    if runResult.exit == .incompleteReasoningExhausted {
+                        // The typed exit owns no cross-surface text. Append the
+                        // honest chat-native fallback here after the one
+                        // bounded retry failed (or visible partial content made
+                        // replay unsafe), then keep cleanup from warming or
+                        // announcing this as a completed task.
+                        assistantTurn.content =
+                            AgentLoopModelStep.contentWithLengthFallback(
+                                assistantTurn.content,
+                                fallback: AgentToolLoop.incompleteReasoningFallback
+                            )
+                        rebuildVisibleBlocks()
+                        lastStreamError = AgentToolLoop.incompleteReasoningFallback
+                    }
+
                     if runResult.exit == .iterationCapReached && isRunActive(runId) {
-                        do {
+                        if let pending = runResult.unfinishedTodoCount, pending > 0 {
+                            // A current-run Todo hit the hard step cap. Do not
+                            // launch the generic tool-free wrap-up stream: it
+                            // can only guess at unfinished work, and treating
+                            // it as clean would warm/index a partial task. The
+                            // driver provides the typed pending count instead.
+                            let message = AgentToolLoop.unfinishedTodoCapFallback(
+                                pending: pending
+                            )
+                            assistantTurn.content = message
+                            lastStreamError = message
+                            rebuildVisibleBlocks()
+                        } else {
+                            do {
                             var finalReq = ChatCompletionRequest(
                                 model: selectedModel ?? "default",
                                 // Same watermark-trimmed view of history the
@@ -5780,8 +5981,15 @@ final class ChatSession: ObservableObject {
                                 if !delta.isEmpty { processor.receiveDelta(delta) }
                             }
                             await processor.finalize()
-                        } catch {
-                            debugLog("send: final wrap-up call failed: \(error.localizedDescription)")
+                            } catch {
+                                let message =
+                                    "The agent reached the configured step limit, and its final wrap-up failed: "
+                                    + error.localizedDescription
+                                debugLog("send: final wrap-up call failed: \(error.localizedDescription)")
+                                assistantTurn.content = message
+                                lastStreamError = message
+                                rebuildVisibleBlocks()
+                            }
                         }
                     }
                 } catch is CancellationError {

--- a/docs/RUNTIME_COMPATIBILITY_CAMPAIGN_2026_07_24.md
+++ b/docs/RUNTIME_COMPATIBILITY_CAMPAIGN_2026_07_24.md
@@ -1189,3 +1189,90 @@ Laguna S/XS JANG_2L/4M/6M, MiniMax M2.7 JANG/JANGTQ, ZAYA JANGTQ, HY-3 MTP,
 Step 3.7 JANG, Nemotron Audex variants, Ornith JANG/MXFP8, Qwen AgentWorld,
 Qwen 3.6 MXFP8/JANG, Bonsai JANG, and Gemma 4 MXFP8/JANG dense/MoE bundles.
 No result is inferred from a sibling quant or architecture.
+
+## 2026-07-26 Gemma/Qwen post-tool completion emergency round
+
+This round used Osaurus base `afa32e5c84191aea90b70fa44afa72ad64feee1f`,
+candidate `e9173ee99412944a4c47e98b7c38bff6d4eed392`, and exact vMLX pin
+`d0e1f1a9ef3115b505056b679d6b01d6861f8daa`. The Release app was ad-hoc
+signed as `com.dinoki.osaurus.gemmaqwencompletionproof20260726` and launched
+under isolated test root
+`/private/tmp/osaurus-gemma-qwen-completion-proof-root-20260726-025205`.
+The app executable SHA-256 was
+`4c6397039e507a26545280ffd93e9ddf55e20c2fa297eca3332301124b736225`.
+
+Source attribution found three separate owning contracts rather than one
+global parser failure:
+
+- model-family guidance previously routed from the display name, so Ornith
+  missed Qwen 3.5 guidance even though its bundle declares
+  `model_type=qwen3_5_moe`; the candidate carries bundle `modelType` through
+  picker, warmup, compose, and system-prompt construction;
+- a total page-extraction failure previously escaped as a thrown tool error;
+  the candidate returns a structured, model-visible failure envelope while
+  keeping partial extraction successful and classifying permanent 4xx errors
+  as non-retryable;
+- a successful, parseable Todo created during the current run now owns pending
+  work. If it still has unchecked items after visible progress prose, the loop
+  continues in a fresh assistant turn. Stale, failed, or malformed Todo calls
+  cannot arm continuation. A reasoning-only terminal after real tool work gets
+  one exact-history retry in an excluded assistant turn.
+
+The candidate does not inject thinking tags, bias EOS, clamp sampling, match
+progress prose heuristically, mask parser errors, or change cache/TurboQuant
+policy. A normal visible final remains final unless the current run itself
+created a valid Todo that still reports pending work.
+
+Focused workspace tests produced 225 passes, zero failures, and zero skips in
+`/private/tmp/osaurus-gemma-qwen-loop-clean-tests-derived-20260726/Logs/Test/Test-OsaurusCoreTests-2026.07.26_02-38-09--0700.xcresult`.
+Those tests are source/mock evidence only; the rows below are the Release-app
+acceptance evidence.
+
+### Live Release UI rows
+
+- Gemma 4 26B A4B JANG_4M, Thinking on: blocked Hugging Face retrieval
+  continued through closed reasoning and search cards to a qualified final at
+  TTFT 1.44 s, 69.3 tok/s, and 2,325 tokens. A no-tool attribution follow-up
+  finalized at TTFT 5.19 s, 50.7 tok/s, and 1,367 tokens. Stop disappeared and
+  input unlocked after both turns.
+- Ornith 1.0 35B MXFP8, Thinking off: the full three-organization research
+  prompt completed its current-run Todo, settled failed search cards, emitted
+  a final, and unlocked at TTFT 0.67 s, 58.0 tok/s, and 983 tokens. Its
+  follow-up finalized at TTFT 1.35 s, 65.3 tok/s, and 2,403 tokens with no
+  reasoning card or inline `<think>` content.
+- Ornith 1.0 35B MXFP8, Thinking on: multiple structured extraction failures
+  stayed model-visible; the model eventually closed its Todo and emitted a
+  qualified final at TTFT 3.89 s, 43.3 tok/s, and 411 tokens. A no-tool
+  one-sentence follow-up closed its reasoning card and finalized at TTFT
+  12.92 s, 51.3 tok/s, and 86 tokens. Stop disappeared and input unlocked.
+- Bonsai 27B Ternary JANG, Thinking on: a real `search_and_extract` challenge
+  produced a failed visible tool card and a qualified final at TTFT 0.80 s,
+  44.0 tok/s, and 204 tokens. The no-tool follow-up truthfully stated that the
+  page was not extracted, finalized at TTFT 16.97 s, 23.3 tok/s, and 72
+  tokens, and unlocked the composer.
+- Qwen AgentWorld 35B A3B MXFP8, Thinking on: the normal initially visible
+  `web_search` path completed reasoning -> tool -> reasoning -> final at TTFT
+  1.09 s, 52.7 tok/s, and 1,339 tokens. Its no-tool follow-up finalized at TTFT
+  6.63 s, 53.3 tok/s, and 377 tokens. Both turns ended with Stop absent and
+  input unlocked.
+
+Cache traces are observations, not a cache-algorithm acceptance claim for this
+PR. The live rows used disk restores at stable boundaries with hybrid companion
+state, but some new-chat/follow-up prompts missed all tiers when their stable
+boundary changed. No cache implementation or setting was changed here.
+
+### Honest remaining boundary
+
+A synthetic Qwen AgentWorld prompt that demanded `search_and_extract` before
+that lazy capability was loaded did not reach a tool call. With Thinking on it
+emitted 8,451 reasoning deltas over 212.94 seconds, repeatedly reconsidering
+tool discovery, until manual Stop. The reasoning remained in the reasoning UI
+and cancellation unlocked the composer, so this was not an inline-channel or
+terminal-cleanup failure. It remains a `PARTIAL` model/tool-discovery row and
+is not claimed fixed by this post-tool completion change. A producer or tool
+await that literally never returns also remains outside this candidate because
+Chat has no new global watchdog in this diff.
+
+The scoped post-tool completion regression is `VERIFIED-LIVE` for the rows
+above. Arbitrary lazy-capability discovery and the broader cache/family matrix
+remain `PARTIAL` and must not be represented as closed by this emergency PR.


### PR DESCRIPTION
## Summary

Fixes the reproduced Gemma/Qwen-family agent runs that terminated on progress prose or reasoning-only output after tool work instead of reaching a final answer.

The root causes were separate contracts:

- model-family guidance was routed from display names, so Ornith missed Qwen 3.5 guidance despite bundle `model_type=qwen3_5_moe`;
- total page-extraction failure escaped as a thrown tool error instead of a model-visible structured result;
- progress output had no typed ownership signal tying it to unfinished current-run work;
- reasoning-only terminal output after real tool work had no exact-history recovery boundary.

This is deliberately narrower than a prose heuristic or global retry. Only a successful, parseable Todo created in the current run can keep visible progress alive, and reasoning-only recovery is bounded to one exact-history retry in a fresh excluded assistant turn.

This supersedes and extends the narrow continuation intent of #2155 while avoiding session-stale Todo state and same-turn output concatenation.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [x] Docs

- carry authoritative bundle `modelType` through picker, warmup, request composition, and family guidance;
- return total extraction failure as a structured model-visible failure while preserving partial success and bounded retry classification;
- track successfully parsed current-run Todo state and continue only while that typed state remains pending;
- retry one reasoning-only terminal after real tool work from exact pre-attempt history;
- exclude the abandoned reasoning turn from request history, warmup, and persistence replay;
- preserve the visible Thinking setting through tool and continuation turns.

No forced thinking tags, forced EOS/open/close tokens, sampler clamps, prose matching, parser masking, cache-policy changes, or TurboQuant changes are included.

## Test Plan

Source/mock regression suite:

- 225 tests passed, 0 failed, 0 skipped.
- Retained local xcresult: `Test-OsaurusCoreTests-2026.07.26_02-38-09--0700.xcresult`.
- Release app build succeeded and passed ad-hoc `codesign --verify --deep --strict`.
- Exact vMLX pin: `d0e1f1a9ef3115b505056b679d6b01d6861f8daa`.

Fresh isolated Release app:

- bundle id: `com.dinoki.osaurus.gemmaqwencompletionproof20260726`;
- isolated test root: `/private/tmp/osaurus-gemma-qwen-completion-proof-root-20260726-025205`;
- executable SHA-256: `4c6397039e507a26545280ffd93e9ddf55e20c2fa297eca3332301124b736225`.

Live UI rows completed through final Stop disappearance, composer unlock, and a follow-up:

- Gemma 4 26B A4B JANG_4M, Thinking on: blocked retrieval -> qualified final (TTFT 1.44s, 69.3 tok/s), follow-up final (5.19s, 50.7 tok/s).
- Ornith 1.0 35B MXFP8, Thinking off: multi-tool/Todo research -> final (0.67s, 58.0 tok/s), follow-up final (1.35s, 65.3 tok/s).
- Ornith 1.0 35B MXFP8, Thinking on: extraction failures -> completed Todo/final (3.89s, 43.3 tok/s), no-tool follow-up (12.92s, 51.3 tok/s).
- Bonsai 27B Ternary JANG, Thinking on: failed `search_and_extract` card -> qualified final (0.80s, 44.0 tok/s), no-tool follow-up (16.97s, 23.3 tok/s).
- Qwen AgentWorld 35B A3B MXFP8, Thinking on: `web_search` -> final (1.09s, 52.7 tok/s), no-tool follow-up (6.63s, 53.3 tok/s).

The committed runtime campaign document records exact token counts and the remaining boundary. In particular, asking Qwen AgentWorld to invoke an unloaded lazy capability caused a long model reasoning loop and remains PARTIAL; this PR does not hide it with a watchdog or forced closer.

## Screenshots

None committed. This changes runtime completion behavior, not UI layout, and keeps local visual proof out of repository history.

## Checklist

- [x] I have read `docs/CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
