### PR TITLE
Wire global proxy into search and fetch tool requests

### DIFF
--- a/Packages/OsaurusCore/Services/Search/SearchReadability.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchReadability.swift
@@ -51,6 +51,20 @@ enum SearchReadability {
         var extracted: Bool { status == .ok }
     }
 
+    /// Exposed separately from `extract` so tests can inspect the session's
+    /// proxy configuration directly, matching the pattern used by the other
+    /// `GlobalProxySettings`-backed call sites. The default delegate value
+    /// (rather than requiring callers to pass one) means tests don't need
+    /// access to the private redirect delegate type at all; `extract` still
+    /// passes its own instance explicitly so it can read `.blockedReason`
+    /// afterward.
+    static func makeSession(
+        configuration: URLSessionConfiguration = .ephemeral,
+        delegate: URLSessionTaskDelegate = SearchReadabilityRedirectDelegate()
+    ) -> URLSession {
+        GlobalProxySettings.makeSession(base: configuration, delegate: delegate, delegateQueue: nil)
+    }
+
     /// Fetch `url` and extract the main content. Always returns a typed status
     /// so tool payloads can explain failures without raw network errors.
     static func extract(
@@ -84,7 +98,7 @@ enum SearchReadability {
         )
 
         let delegate = SearchReadabilityRedirectDelegate()
-        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        let session = makeSession(configuration: configuration, delegate: delegate)
         defer {
             session.invalidateAndCancel()
         }

--- a/Packages/OsaurusCore/Services/Search/SearchTypes.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchTypes.swift
@@ -300,6 +300,13 @@ enum SearchHTTPClient {
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
     ]
 
+    /// Exposed separately from `request` so tests can inspect the session's
+    /// proxy configuration directly, matching the pattern used by the other
+    /// `GlobalProxySettings`-backed call sites (e.g. `GitHubSkillService`).
+    static func makeSession() -> URLSession {
+        GlobalProxySettings.sharedSession()
+    }
+
     static func request(
         url: String,
         method: String = "GET",
@@ -322,7 +329,7 @@ enum SearchHTTPClient {
         for (k, v) in combined { req.setValue(v, forHTTPHeaderField: k) }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: req)
+            let (data, response) = try await makeSession().data(for: req)
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             return (status, data)
         } catch is CancellationError {

--- a/Packages/OsaurusCore/Tests/Search/SearchHTTPClientGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/SearchHTTPClientGlobalProxyTests.swift
@@ -1,0 +1,74 @@
+//
+//  SearchHTTPClientGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SearchHTTPClientGlobalProxyTests {
+    @MainActor
+    @Test func defaultSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-search-http-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "http://proxy.example.com:8080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = SearchHTTPClient.makeSession()
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPPort)] as? Int == 8080)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8080)
+        }
+    }
+
+    @MainActor
+    @Test func noProxyConfiguredMeansNoProxyDictionary() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-search-http-noproxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            let configuration = ServerConfiguration.default
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = SearchHTTPClient.makeSession()
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect((dictionary?[proxyKey(kCFNetworkProxiesHTTPEnable)] as? Int ?? 0) == 0)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}

--- a/Packages/OsaurusCore/Tests/Search/SearchReadabilityGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/SearchReadabilityGlobalProxyTests.swift
@@ -1,0 +1,74 @@
+//
+//  SearchReadabilityGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SearchReadabilityGlobalProxyTests {
+    @MainActor
+    @Test func defaultSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-search-readability-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "socks5://proxy.example.com:1080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = SearchReadability.makeSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+        }
+    }
+
+    @MainActor
+    @Test func noProxyConfiguredMeansNoProxyDictionary() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-search-readability-noproxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            let configuration = ServerConfiguration.default
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = SearchReadability.makeSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect((dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int ?? 0) == 0)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Summary
Closes the remaining gap in #1091. PR #1214 (and follow-ups #1565, #1693) already added global HTTP/SOCKS5 proxy support and wired it into most network call sites — model downloads, provider requests, MCP transport, Discord/Telegram/Slack clients, etc. Two surfaces #1091 names explicitly were never migrated:

- **Search** — `SearchHTTPClient.request()` (`Services/Search/SearchTypes.swift`), used by every search backend, called `URLSession.shared` directly.
- **Fetch/extract** — `SearchReadability.extract()` (`Services/Search/SearchReadability.swift`), backing the `search_and_extract` tool, built its own `URLSession(configuration:delegate:delegateQueue:)` per call with no proxy configuration.

This closes both, following the existing pattern used by `GitHubSkillService`, `ThemesAPIClient`, and others.

## Changes
- `SearchHTTPClient`: added a `makeSession()` factory backed by `GlobalProxySettings.sharedSession()`, exposed separately from `request()` (which now calls it) for testability.
- `SearchReadability`: added a `makeSession(configuration:delegate:)` factory backed by `GlobalProxySettings.makeSession(base:delegate:delegateQueue:)`. Delegate has a default value so tests don't need access to the private `SearchReadabilityRedirectDelegate` type; `extract()` still passes its own instance explicitly so it can read `.blockedReason` afterward — that behavior is unchanged.
- Added `SearchHTTPClientGlobalProxyTests` and `SearchReadabilityGlobalProxyTests`, following the `<Subject>GlobalProxyTests.swift` convention already established for this feature (proxy-configured session picks up the right `connectionProxyDictionary`; unconfigured session has none).

## Test plan
- [x] `swift test --package-path Packages/OsaurusCore --filter GlobalProxy` — 29/29 tests pass across all 13 proxy suites (11 pre-existing + 2 new)
- [x] `swift test --package-path Packages/OsaurusCore --filter Search` — 279/279 pass on a clean run. (One earlier run of this same broad filter reported 3 failures elsewhere in the 279; an immediate re-run passed clean, so that looks like pre-existing flakiness unrelated to these two files — flagging for visibility, not something I chased down further since it reproduces outside the files this PR touches.)
- [x] `swift build --package-path Packages/OsaurusCore` — clean, no new warnings

## Out of scope (real gaps, left for follow-up PRs)
While tracing every proxy call site I found a few more real, unproxied outbound-HTTP surfaces that #1091 doesn't name explicitly, so I left them out of this PR to keep it reviewable:
- `Managers/OpenAICompatibleTTSClient.swift` — external TTS provider streaming
- `PrivacyFilter/Rampart/RampartModelManager.swift` — a second NER-model downloader, inconsistent with its sibling `PrivacyFilterModelDownloader.swift` which *is* wired
- `Services/AgentChannel/AgentChannelCustomJSONRunner.swift` — the generic/custom agent-channel HTTP client
- `OsaurusCLI` package — `URLSession.shared` throughout, even though `OsaurusCLICore` transitively depends on the already-wired `OsaurusRepository`

Happy to open separate PRs for these if useful.