### PR TITLE
Wire remaining OsaurusCore network call sites into global proxy

### DIFF
--- a/Packages/OsaurusCore/Managers/OpenAICompatibleTTSClient.swift
+++ b/Packages/OsaurusCore/Managers/OpenAICompatibleTTSClient.swift
@@ -60,6 +60,13 @@ struct OpenAICompatibleTTSClient: Sendable {
     /// real headers (ffmpeg's canonical or LIST-prefixed) fit in well under 1 KB.
     private static let maxWavHeaderBytes = 8192
 
+    /// Exposed separately from `synthesizeStreaming` so tests can inspect the
+    /// session's proxy configuration directly, matching the pattern used by
+    /// the other `GlobalProxySettings`-backed call sites.
+    static func makeSession() -> URLSession {
+        GlobalProxySettings.sharedSession()
+    }
+
     /// Ceiling for buffering a compressed (MP3/FLAC) body before decoding.
     /// 32 MB of MP3 is over an hour of speech; anything bigger is not TTS.
     private static let maxCompressedBytes = 32 * 1024 * 1024
@@ -229,7 +236,7 @@ struct OpenAICompatibleTTSClient: Sendable {
         return AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+                    let (bytes, response) = try await Self.makeSession().bytes(for: request)
                     if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
                         var body = ""
                         for try await line in bytes.lines {

--- a/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartModelManager.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartModelManager.swift
@@ -114,6 +114,16 @@ public final class RampartModelManager: ObservableObject {
         state = .idle
     }
 
+    /// Exposed separately from `downloadBundle` so tests can inspect the
+    /// session's proxy configuration directly without needing access to the
+    /// private `HFRedirectAuthStripper` type -- matches the sibling
+    /// `PrivacyFilterModelDownloader.makeDownloadSession`, which this file
+    /// was inconsistent with before (this downloader built a plain
+    /// `URLSession(configuration: .default)`, bypassing the global proxy).
+    nonisolated static func makeDownloadSession(delegate: URLSessionTaskDelegate) -> URLSession {
+        GlobalProxySettings.makeSession(base: .default, delegate: delegate, delegateQueue: nil)
+    }
+
     /// Fetch each file from HuggingFace into a temp dir, then atomically
     /// move the completed set into place. Runs off the main thread.
     nonisolated private static func downloadBundle(
@@ -126,7 +136,7 @@ public final class RampartModelManager: ObservableObject {
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: staging) }
 
-        let session = URLSession(configuration: .default)
+        let session = makeDownloadSession(delegate: HFRedirectAuthStripper.shared)
         for (index, file) in files.enumerated() {
             try Task.checkCancellation()
             guard let url = resolveURL(file: file) else {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelCustomJSONRunner.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelCustomJSONRunner.swift
@@ -1359,13 +1359,16 @@ final class AgentChannelCustomJSONRunner: AgentChannelCustomJSONRunning, @unchec
         return trimmed
     }
 
-    private static func makeDefaultHTTPClient() -> URLSession {
+    /// Not `private`: exposed so tests can inspect the session's proxy
+    /// configuration directly, matching the pattern used by the other
+    /// `GlobalProxySettings`-backed call sites.
+    static func makeDefaultHTTPClient() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpShouldSetCookies = false
         configuration.httpCookieAcceptPolicy = .never
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-        return URLSession(
-            configuration: configuration,
+        return GlobalProxySettings.makeSession(
+            base: configuration,
             delegate: AgentChannelNoRedirectDelegate(),
             delegateQueue: nil
         )

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelCustomJSONRunnerGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelCustomJSONRunnerGlobalProxyTests.swift
@@ -1,0 +1,46 @@
+//
+//  AgentChannelCustomJSONRunnerGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct AgentChannelCustomJSONRunnerGlobalProxyTests {
+    @Test func defaultHTTPClientUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-agentchannel-customjson-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "http://proxy.example.com:3128"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = AgentChannelCustomJSONRunner.makeDefaultHTTPClient()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPPort)] as? Int == 3128)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}

--- a/Packages/OsaurusCore/Tests/Networking/OpenAICompatibleTTSClientGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/OpenAICompatibleTTSClientGlobalProxyTests.swift
@@ -1,0 +1,45 @@
+//
+//  OpenAICompatibleTTSClientGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct OpenAICompatibleTTSClientGlobalProxyTests {
+    @Test func defaultSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tts-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = OpenAICompatibleTTSClient.makeSession()
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}

--- a/Packages/OsaurusCore/Tests/PrivacyFilter/RampartModelManagerGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/PrivacyFilter/RampartModelManagerGlobalProxyTests.swift
@@ -1,0 +1,49 @@
+//
+//  RampartModelManagerGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct RampartModelManagerGlobalProxyTests {
+    @Test func downloadSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-rampart-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let delegate = TaskDelegate()
+            let session = RampartModelManager.makeDownloadSession(delegate: delegate)
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+        }
+    }
+}
+
+private final class TaskDelegate: NSObject, URLSessionTaskDelegate {}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Summary
Follow-up to #2168 (search/fetch). While tracing every `GlobalProxySettings` call site for #1091 I found three more real, unproxied outbound-HTTP surfaces in `OsaurusCore` — none named explicitly in the issue, but real gaps against the "all network connections" ask:

- **`OpenAICompatibleTTSClient.synthesizeStreaming()`** — called `URLSession.shared.bytes(for:)` directly for external TTS provider streaming.
- **`RampartModelManager.downloadBundle()`** — built a plain `URLSession(configuration: .default)`, bypassing the proxy entirely. This is a second NER-model downloader, inconsistent with its sibling `PrivacyFilterModelDownloader.swift`, which already had a `makeDownloadSession(delegate:)` factory wired to the proxy.
- **`AgentChannelCustomJSONRunner.makeDefaultHTTPClient()`** — built its own session for the generic/custom agent-channel HTTP integration (as opposed to the already-wired named Discord/Telegram/Slack clients).

## Changes
- `OpenAICompatibleTTSClient`: added `makeSession()` backed by `GlobalProxySettings.sharedSession()`.
- `RampartModelManager`: added `makeDownloadSession(delegate:)`, mirroring `PrivacyFilterModelDownloader`'s exact pattern (`GlobalProxySettings.makeSession(base: .default, delegate:, delegateQueue: nil)`).
- `AgentChannelCustomJSONRunner`: swapped `makeDefaultHTTPClient()`'s session construction for `GlobalProxySettings.makeSession(base:...)`, keeping the existing ephemeral cookie/cache configuration unchanged. Widened from `private` to internal access (test-only reason — it takes no parameters and fully encapsulates its own delegate).
- Added `<Subject>GlobalProxyTests.swift` for all three, following the established convention.

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` — clean
- [x] `swift test --package-path Packages/OsaurusCore --filter GlobalProxy` — 28/28 pass across 14 suites (11 pre-existing + 3 new)
- [x] `swift test --package-path Packages/OsaurusCore --filter CustomJSONAgentChannelRunnerTests` — 26/26 pass (checks the access-level widening on `makeDefaultHTTPClient` didn't regress the existing large suite for this type)
- [x] `swift test --package-path Packages/OsaurusCore --filter Rampart` — pass
- [x] `swift test --package-path Packages/OsaurusCore --filter TTS` — 29/29 pass

## Out of scope (left for a possible follow-up)
The `OsaurusCLI` package uses `URLSession.shared` throughout (`Pull`, `Bench`, `List`, `MCPCommand`, `Show`, `Status`, `Run`, `ServerControl`) even though `OsaurusCLICore` transitively depends on the already-wired `OsaurusRepository`. `Pull.swift`'s `CLIFileDownloader` (model pull via CLI) is the most notable since it's a parallel model-download path to the app's `ModelDownloadService`. Different package, different pattern (`RepositoryGlobalProxySettings`, not `GlobalProxySettings`), so keeping it separate rather than folding into this PR.