### PR TITLE
Fix tracked tool completion and prompt cache stability

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -72,13 +72,22 @@ struct AgentLoopPolicy: Sendable {
     /// because only they can land a successful `db_*` bulk call.
     var maxDataMovementSteps: Int = 0
 
+    /// Chat-only structural fallback for models that ignore the proactive
+    /// `todo` guidance. When greater than zero, the Nth ordinary action tool
+    /// is not executed until this run has produced a valid Todo. The rejected
+    /// call remains model-visible and retryable, so the model can create the
+    /// checklist and retry the exact action. Headless surfaces leave this at
+    /// zero and retain their existing semantics.
+    var todoRequiredBeforeToolCallCount: Int = 0
+
     init(
         maxIterations: Int,
         budgetWarningThreshold: Int = 3,
         stopOnToolRejection: Bool,
         dedupeNoticeEnabled: Bool,
         todoStalenessThreshold: Int = 4,
-        maxDataMovementSteps: Int = 0
+        maxDataMovementSteps: Int = 0,
+        todoRequiredBeforeToolCallCount: Int = 0
     ) {
         self.maxIterations = max(1, maxIterations)
         self.budgetWarningThreshold = budgetWarningThreshold
@@ -86,6 +95,7 @@ struct AgentLoopPolicy: Sendable {
         self.dedupeNoticeEnabled = dedupeNoticeEnabled
         self.todoStalenessThreshold = max(1, todoStalenessThreshold)
         self.maxDataMovementSteps = max(0, maxDataMovementSteps)
+        self.todoRequiredBeforeToolCallCount = max(0, todoRequiredBeforeToolCallCount)
     }
 }
 
@@ -235,6 +245,21 @@ struct AgentTodoProgressSnapshot: Equatable, Sendable {
     var pending: Int { max(0, total - done) }
 }
 
+/// Semantic checklist identity for one parsed `todo` invocation. Markdown
+/// headings, bullet choice, whitespace, and other presentation-only text are
+/// intentionally excluded: progress means that at least one parsed task or
+/// checkbox state changed. This snapshot is scoped to one `run` invocation;
+/// an identical checklist in a later user turn is still a legitimate first
+/// update and must not be rejected because of stale session state.
+struct AgentTodoSemanticSnapshot: Equatable, Sendable {
+    struct Item: Equatable, Sendable {
+        let text: String
+        let isDone: Bool
+    }
+
+    let items: [Item]
+}
+
 // MARK: - Hooks
 
 /// Surface-specific behavior, injected as async closures. All closures
@@ -270,12 +295,16 @@ struct AgentLoopHooks {
     /// reasoning tag, sampler override, EOS override, or other coercion.
     var prepareIncompleteReasoningContinuation: (() async -> Void)?
 
-    /// Preserve an ordinary assistant response from a run that successfully
-    /// created/updated a todo list while structured unchecked work remains,
-    /// then prepare a fresh output buffer for the next model step. Unlike
-    /// incomplete-reasoning recovery, the response MUST remain model-visible:
-    /// it is real work/progress emitted by the model. Only chat opts into this
-    /// boundary; headless surfaces keep their existing terminal behavior.
+    /// Preserve an ordinary assistant response visibly when a run that
+    /// successfully created/updated a todo list stops while structured work
+    /// remains, then prepare a fresh output buffer for the next model step.
+    /// The premature response MUST be excluded from the next model request:
+    /// otherwise chat persists `assistant(final), assistant(tool_call)` after
+    /// the transient continuation notice disappears. That invalid role shape
+    /// changes Qwen-family template rendering and can restore stale hybrid
+    /// state from disk. The preceding tool result remains the authoritative
+    /// continuation anchor. Only chat opts into this boundary; headless
+    /// surfaces keep their existing terminal behavior.
     var prepareTrackedTaskContinuation: (() async -> Void)?
 
     /// Called for every parsed invocation before the dedupe check, so the
@@ -1232,6 +1261,164 @@ enum AgentToolLoop {
     /// the serial path stops immediately.
     static let interceptToolNames: Set<String> = ["complete", "clarify"]
 
+    /// Agent-loop control calls are not user-task actions and therefore do
+    /// not consume the structural tracking threshold. `share_artifact` is an
+    /// action because it performs the requested delivery.
+    static let taskTrackingControlToolNames: Set<String> = ["todo", "complete", "clarify"]
+
+    static let taskTrackingRequiredReason = "task_tracking_required"
+    static let todoProgressUpdateRequiredReason = "todo_progress_update_required"
+    static let todoNoProgressReason = "todo_no_progress"
+
+    /// The premature post-tool stop has current live proof only for local
+    /// Gemma and Qwen-backbone bundles (including Ornith/Bonsai). Keep the
+    /// structural Todo precondition off for remote providers and unrelated
+    /// local families until those rows independently prove they need it.
+    static func chatTodoPreconditionThreshold(
+        hasTodoTool: Bool,
+        isLocalModel: Bool,
+        modelType: String?
+    ) -> Int {
+        guard hasTodoTool, isLocalModel else { return 0 }
+        guard let normalized = modelType?.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !normalized.isEmpty
+        else { return 0 }
+        return normalized.contains("gemma") || normalized.contains("qwen") ? 3 : 0
+    }
+
+    static func isTaskTrackingAction(toolName: String) -> Bool {
+        !taskTrackingControlToolNames.contains(toolName)
+    }
+
+    /// Honest, structured precondition failure used only by a surface that
+    /// explicitly enables Todo enforcement. The requested tool did not run;
+    /// the model can either create the required checklist and retry, or stop
+    /// using tools and give the user a complete answer from evidence already
+    /// collected.
+    static func taskTrackingRequiredResult(toolName: String, threshold: Int) -> String {
+        ToolEnvelope.failure(
+            kind: .rejected,
+            message:
+                "This tool call was not executed because this run reached \(threshold) ordinary "
+                + "tool actions without a current-run todo. Call `todo(markdown)` with the "
+                + "remaining checklist, then retry this exact tool call. If no more tools are "
+                + "needed, answer the user completely now.",
+            tool: toolName,
+            retryable: true,
+            metadata: [
+                "reason": taskTrackingRequiredReason,
+                "executed": false,
+                "required_before_tool_call": threshold,
+            ]
+        )
+    }
+
+    static func isTaskTrackingRequiredResult(_ result: String) -> Bool {
+        guard ToolEnvelope.isError(result),
+            let data = result.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return object["reason"] as? String == taskTrackingRequiredReason
+    }
+
+    /// A tracked task must not terminate from a stale checklist after new
+    /// actions have run. The model owns the semantic mapping from results to
+    /// checklist items; the runtime only requires one fresh, structured Todo
+    /// snapshot before accepting `complete`. This avoids guessing which work
+    /// succeeded while preventing a green completion banner beside a stale
+    /// `0/N` list.
+    static func todoProgressUpdateRequiredResult(toolName: String, pending: Int) -> String {
+        ToolEnvelope.failure(
+            kind: .rejected,
+            message:
+                "This completion was not accepted because \(pending) todo item"
+                + (pending == 1 ? " is" : "s are")
+                + " still unchecked and ordinary tool actions ran after the last todo update. "
+                + "Call `todo(markdown)` with the full current checklist now, checking every "
+                + "item actually finished and leaving blocked work unchecked. Then answer "
+                + "normally if no items remain, or call `complete` again with an honest blocked "
+                + "summary if unfinished work remains.",
+            tool: toolName,
+            retryable: true,
+            metadata: [
+                "reason": todoProgressUpdateRequiredReason,
+                "executed": false,
+                "pending_todo_items": pending,
+            ]
+        )
+    }
+
+    static func isTodoProgressUpdateRequiredResult(_ result: String) -> Bool {
+        guard ToolEnvelope.isError(result),
+            let data = result.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return object["reason"] as? String == todoProgressUpdateRequiredReason
+    }
+
+    /// Reject an exact semantic replay of the current run's latest successful
+    /// checklist. Rewriting the same `0/N` Todo is not task progress and, in a
+    /// live Gemma run, kept a completed answer spinning until the step cap.
+    /// The call is not executed, so the session store and UI timestamp do not
+    /// churn and the model receives an explicit choice: do work, record a real
+    /// checkbox/task change, or close honestly as blocked.
+    static func todoNoProgressResult(pending: Int) -> String {
+        ToolEnvelope.failure(
+            kind: .rejected,
+            message:
+                "This todo call was not executed because it exactly repeats the current "
+                + "checklist with no task or checkbox change. Do not submit the same todo "
+                + "again. Continue a concrete pending step, then re-send the full checklist "
+                + "with real progress checked. If the remaining work cannot continue, call "
+                + "`complete(summary)` with an honest blocked result.",
+            tool: "todo",
+            retryable: true,
+            metadata: [
+                "reason": todoNoProgressReason,
+                "executed": false,
+                "pending_todo_items": pending,
+            ]
+        )
+    }
+
+    static func isTodoNoProgressResult(_ result: String) -> Bool {
+        guard ToolEnvelope.isError(result),
+            let data = result.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return object["reason"] as? String == todoNoProgressReason
+    }
+
+    static func isRecoverableTodoContractResult(_ result: String) -> Bool {
+        isTaskTrackingRequiredResult(result)
+            || isTodoProgressUpdateRequiredResult(result)
+            || isTodoNoProgressResult(result)
+    }
+
+    static func todoProgressUpdateRequiredNotice(pending: Int) -> String {
+        "[System Notice] Your completion was rejected because \(pending) todo item"
+            + (pending == 1 ? " is" : "s are")
+            + " still unchecked and tools ran after the last checklist update. Re-send the full "
+            + "todo now with completed work checked. If work remains blocked after that update, "
+            + "call `complete` again with an honest blocked summary."
+    }
+
+    static func taskTrackingRequiredNotice(threshold: Int) -> String {
+        "[System Notice] This run reached \(threshold) ordinary tool actions without the "
+            + "required current-run todo. The rejected tool was not executed. Call "
+            + "`todo(markdown)` now and retry it, or give the user a complete final answer "
+            + "without another tool call."
+    }
+
+    static func todoNoProgressNotice(pending: Int) -> String {
+        "[System Notice] Your todo update was rejected because it exactly repeated the "
+            + "current checklist with \(pending) unchecked item\(pending == 1 ? "" : "s"). "
+            + "Do not call todo unchanged again. Continue a concrete step and then record a "
+            + "real checkbox/task change, or call `complete(summary)` with an honest blocked "
+            + "result if the remaining work cannot continue."
+    }
+
     /// Whether a batch carries a loop-ending intercept tool.
     static func containsIntercept(
         _ calls: [(invocation: ServiceToolInvocation, callId: String)]
@@ -1269,6 +1456,26 @@ enum AgentToolLoop {
         let todo = AgentTodo.parse(markdown)
         guard todo.totalCount > 0 else { return nil }
         return AgentTodoProgressSnapshot(done: todo.doneCount, total: todo.totalCount)
+    }
+
+    /// Read the parsed task texts + checkbox states from a Todo invocation.
+    /// This deliberately ignores non-checklist prose/formatting so cosmetic
+    /// rewrites cannot masquerade as progress.
+    static func todoSemanticSnapshot(
+        from invocation: ServiceToolInvocation
+    ) -> AgentTodoSemanticSnapshot? {
+        guard invocation.toolName == "todo",
+            let data = invocation.jsonArguments.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let markdown = dict["markdown"] as? String
+        else { return nil }
+        let todo = AgentTodo.parse(markdown)
+        guard !todo.items.isEmpty else { return nil }
+        return AgentTodoSemanticSnapshot(
+            items: todo.items.map {
+                AgentTodoSemanticSnapshot.Item(text: $0.text, isDone: $0.isDone)
+            }
+        )
     }
 
     // Capability schemas loaded mid-run are delivered append-only in the
@@ -1386,6 +1593,11 @@ enum AgentToolLoop {
         // transient missing lookup must not turn known unchecked work into a
         // clean final response.
         var lastSuccessfulCurrentRunTodoProgress: AgentTodoProgressSnapshot?
+        // Semantic identity of the latest Todo that actually succeeded during
+        // THIS run. Never seed this from the session store: the same checklist
+        // is valid as the first update of a later user turn, but not as
+        // repeated pseudo-progress within one agent loop.
+        var lastSuccessfulCurrentRunTodoSemanticSnapshot: AgentTodoSemanticSnapshot?
         // Last iteration that carried a `todo` call (0 = run start), for
         // the staleness check below.
         var lastTodoIteration = 0
@@ -1395,6 +1607,75 @@ enum AgentToolLoop {
         var dataMovementStepsUsed = 0
         var announcedDataMovementRelief = false
         var completedToolWork = false
+        // Counts attempted ordinary action calls in this logical run. Failed,
+        // rejected, and deduped calls still count because the threshold
+        // describes task complexity, not successful side effects. Control
+        // tools (`todo` / `complete` / `clarify`) never count.
+        var currentRunActionToolCallCount = 0
+        // Action-call count captured at the latest successful current-run Todo
+        // update. If more actions run while items remain pending, `complete`
+        // must not terminate until the model refreshes the checklist. Keeping
+        // this structural (rather than inferring progress from prose/tool
+        // names) preserves family and task neutrality.
+        var lastSuccessfulCurrentRunTodoActionToolCallCount: Int?
+
+        func taskTrackingPreconditionResult(
+            for invocation: ServiceToolInvocation,
+            batchContainsParseableTodo: Bool
+        ) -> String? {
+            guard Self.isTaskTrackingAction(toolName: invocation.toolName) else {
+                return nil
+            }
+            currentRunActionToolCallCount += 1
+            let threshold = policy.todoRequiredBeforeToolCallCount
+            guard threshold > 0,
+                !hasSuccessfulCurrentRunTodo,
+                !batchContainsParseableTodo,
+                currentRunActionToolCallCount >= threshold
+            else { return nil }
+            return Self.taskTrackingRequiredResult(
+                toolName: invocation.toolName,
+                threshold: threshold
+            )
+        }
+
+        func todoProgressUpdatePreconditionResult(
+            for invocation: ServiceToolInvocation,
+            batchContainsPrecedingParseableTodo: Bool
+        ) -> String? {
+            guard invocation.toolName == "complete",
+                hasSuccessfulCurrentRunTodo,
+                let progress = lastSuccessfulCurrentRunTodoProgress,
+                progress.pending > 0,
+                let actionCountAtTodo = lastSuccessfulCurrentRunTodoActionToolCallCount,
+                currentRunActionToolCallCount > actionCountAtTodo,
+                !batchContainsPrecedingParseableTodo
+            else { return nil }
+            return Self.todoProgressUpdateRequiredResult(
+                toolName: invocation.toolName,
+                pending: progress.pending
+            )
+        }
+
+        func todoNoProgressPreconditionResult(
+            for invocation: ServiceToolInvocation
+        ) -> String? {
+            guard let candidate = Self.todoSemanticSnapshot(from: invocation),
+                let latest = lastSuccessfulCurrentRunTodoSemanticSnapshot,
+                candidate == latest
+            else { return nil }
+            // Although this is not progress and must not churn the store, the
+            // model did re-affirm the current structured state after any
+            // intervening actions. Let a subsequent `complete` close the task
+            // honestly as blocked; otherwise a failed action with no checkbox
+            // transition would create an impossible contract (unchanged Todo
+            // rejected, but blocked completion forever demanding an update).
+            lastSuccessfulCurrentRunTodoActionToolCallCount =
+                currentRunActionToolCallCount
+            return Self.todoNoProgressResult(
+                pending: lastSuccessfulCurrentRunTodoProgress?.pending ?? 0
+            )
+        }
 
         while iteration < policy.maxIterations {
             if await hooks.isCancelled() {
@@ -1448,11 +1729,15 @@ enum AgentToolLoop {
                         return RunResult(exit: .cancelled, iterations: iteration - 1)
                     }
                     if let progress, progress.pending > 0 {
-                        // Preserve the model's real response in visible/model
-                        // history and start the next attempt in a fresh
-                        // assistant turn. This boundary also runs at the hard
-                        // cap so Chat's existing tool-free finalizer does not
-                        // concatenate its wrap-up onto progress prose.
+                        // Preserve the model's real response in the visible
+                        // transcript but exclude this abandoned terminal
+                        // attempt from model history, then start the next
+                        // attempt in a fresh assistant turn. This prevents an
+                        // adjacent assistant(final) -> assistant(tool_call)
+                        // history after the transient Todo notice disappears.
+                        // The boundary also runs at the hard cap so Chat's
+                        // existing tool-free finalizer does not concatenate its
+                        // wrap-up onto progress prose.
                         await prepareContinuation()
                         if await hooks.isCancelled() {
                             return RunResult(exit: .cancelled, iterations: iteration)
@@ -1601,6 +1886,18 @@ enum AgentToolLoop {
 
                 var outcomes: [AgentLoopToolOutcome] = []
                 outcomes.reserveCapacity(invocations.count)
+                // A valid Todo in the same model-emitted batch satisfies the
+                // precondition for its sibling actions. The actual successful
+                // outcome still arms terminal tracking below; malformed Todo
+                // arguments cannot bypass this gate.
+                let batchContainsParseableTodo = invocations.contains {
+                    Self.todoProgressSnapshot(from: $0) != nil
+                }
+                // Captures how many ordinary actions had been attempted when
+                // each Todo call appeared in model order. This is more exact
+                // than assigning the batch's final count to every Todo when a
+                // model emits Todo + action calls together.
+                var todoActionToolCallCountByCallId: [String: Int] = [:]
 
                 if let executeBatch = hooks.executeBatch {
                     // Slotting mode (HTTP semantics): dedupe pass over the
@@ -1623,9 +1920,58 @@ enum AgentToolLoop {
                     // the live state decides replay vs. execute.
                     var deferredDuplicates: [Int: (invocation: ServiceToolInvocation, callId: String)] = [:]
                     var seenSignatures: Set<CallSignature> = []
+                    var batchHasPrecedingParseableTodo = false
                     for (slot, invocation) in invocations.enumerated() {
                         let callId = Self.callId(for: invocation)
                         await hooks.willProcessCall(invocation, callId)
+                        let invocationHasParseableTodo =
+                            Self.todoProgressSnapshot(from: invocation) != nil
+                        if let trackingRequired = taskTrackingPreconditionResult(
+                            for: invocation,
+                            batchContainsParseableTodo: batchContainsParseableTodo
+                        ) {
+                            slotted[slot] = AgentLoopToolOutcome(
+                                invocation: invocation,
+                                callId: callId,
+                                result: trackingRequired,
+                                wasDeduped: false,
+                                wasError: true
+                            )
+                            continue
+                        }
+                        if let noProgress = todoNoProgressPreconditionResult(
+                            for: invocation
+                        ) {
+                            slotted[slot] = AgentLoopToolOutcome(
+                                invocation: invocation,
+                                callId: callId,
+                                result: noProgress,
+                                wasDeduped: false,
+                                wasError: true
+                            )
+                            continue
+                        }
+                        if invocationHasParseableTodo {
+                            todoActionToolCallCountByCallId[callId] =
+                                currentRunActionToolCallCount
+                        }
+                        if let progressUpdateRequired = todoProgressUpdatePreconditionResult(
+                            for: invocation,
+                            batchContainsPrecedingParseableTodo:
+                                batchHasPrecedingParseableTodo
+                        ) {
+                            slotted[slot] = AgentLoopToolOutcome(
+                                invocation: invocation,
+                                callId: callId,
+                                result: progressUpdateRequired,
+                                wasDeduped: false,
+                                wasError: true
+                            )
+                            continue
+                        }
+                        if invocationHasParseableTodo {
+                            batchHasPrecedingParseableTodo = true
+                        }
                         if let guarded = state.guardedResult(name: invocation.toolName) {
                             slotted[slot] = AgentLoopToolOutcome(
                                 invocation: invocation,
@@ -1777,6 +2123,35 @@ enum AgentToolLoop {
                         pendingStateNotice = "[System Notice] " + bias
                     }
                     outcomes = slotted.compactMap { $0 }
+                    if outcomes.contains(where: {
+                        Self.isTaskTrackingRequiredResult($0.result)
+                    }) {
+                        pendingStateNotice = Self.taskTrackingRequiredNotice(
+                            threshold: policy.todoRequiredBeforeToolCallCount
+                        )
+                    }
+                    if let pending = outcomes.compactMap({ outcome -> Int? in
+                        guard Self.isTodoProgressUpdateRequiredResult(outcome.result),
+                            let data = outcome.result.data(using: .utf8),
+                            let object = try? JSONSerialization.jsonObject(with: data)
+                                as? [String: Any]
+                        else { return nil }
+                        return object["pending_todo_items"] as? Int
+                    }).last {
+                        pendingTodoNotice = Self.todoProgressUpdateRequiredNotice(
+                            pending: pending
+                        )
+                    }
+                    if let pending = outcomes.compactMap({ outcome -> Int? in
+                        guard Self.isTodoNoProgressResult(outcome.result),
+                            let data = outcome.result.data(using: .utf8),
+                            let object = try? JSONSerialization.jsonObject(with: data)
+                                as? [String: Any]
+                        else { return nil }
+                        return object["pending_todo_items"] as? Int
+                    }).last {
+                        pendingTodoNotice = Self.todoNoProgressNotice(pending: pending)
+                    }
                     // Cancellation is honored only AFTER the executed batch
                     // is recorded — the surface history already contains
                     // these tool turns, so skipping `state.record` would
@@ -1784,18 +2159,104 @@ enum AgentToolLoop {
                     if await hooks.isCancelled() {
                         return await finishBatch(.cancelled)
                     }
-                    if policy.stopOnToolRejection, outcomes.contains(where: { $0.wasError }) {
+                    if policy.stopOnToolRejection,
+                        outcomes.contains(where: {
+                            $0.wasError && !Self.isRecoverableTodoContractResult($0.result)
+                        })
+                    {
                         return await finishBatch(.toolRejected)
                     }
                 } else {
                     // Serial mode (chat/plugin semantics): interleaved dedupe
                     // and execution, per-call policy checks.
+                    var batchHasPrecedingParseableTodo = false
                     for invocation in invocations {
                         if await hooks.isCancelled() {
                             return RunResult(exit: .cancelled, iterations: iteration)
                         }
                         let callId = Self.callId(for: invocation)
                         await hooks.willProcessCall(invocation, callId)
+                        let invocationHasParseableTodo =
+                            Self.todoProgressSnapshot(from: invocation) != nil
+
+                        if let trackingRequired = taskTrackingPreconditionResult(
+                            for: invocation,
+                            batchContainsParseableTodo: batchContainsParseableTodo
+                        ) {
+                            state.record(
+                                name: invocation.toolName,
+                                argsJSON: invocation.jsonArguments,
+                                result: trackingRequired
+                            )
+                            outcomes.append(
+                                AgentLoopToolOutcome(
+                                    invocation: invocation,
+                                    callId: callId,
+                                    result: trackingRequired,
+                                    wasDeduped: false,
+                                    wasError: true
+                                )
+                            )
+                            pendingStateNotice = Self.taskTrackingRequiredNotice(
+                                threshold: policy.todoRequiredBeforeToolCallCount
+                            )
+                            continue
+                        }
+                        if let noProgress = todoNoProgressPreconditionResult(
+                            for: invocation
+                        ) {
+                            state.record(
+                                name: invocation.toolName,
+                                argsJSON: invocation.jsonArguments,
+                                result: noProgress
+                            )
+                            outcomes.append(
+                                AgentLoopToolOutcome(
+                                    invocation: invocation,
+                                    callId: callId,
+                                    result: noProgress,
+                                    wasDeduped: false,
+                                    wasError: true
+                                )
+                            )
+                            pendingTodoNotice = Self.todoNoProgressNotice(
+                                pending: lastSuccessfulCurrentRunTodoProgress?.pending ?? 0
+                            )
+                            continue
+                        }
+                        if invocationHasParseableTodo {
+                            todoActionToolCallCountByCallId[callId] =
+                                currentRunActionToolCallCount
+                        }
+                        if let progressUpdateRequired = todoProgressUpdatePreconditionResult(
+                            for: invocation,
+                            batchContainsPrecedingParseableTodo:
+                                batchHasPrecedingParseableTodo
+                        ) {
+                            state.record(
+                                name: invocation.toolName,
+                                argsJSON: invocation.jsonArguments,
+                                result: progressUpdateRequired
+                            )
+                            outcomes.append(
+                                AgentLoopToolOutcome(
+                                    invocation: invocation,
+                                    callId: callId,
+                                    result: progressUpdateRequired,
+                                    wasDeduped: false,
+                                    wasError: true
+                                )
+                            )
+                            if let pending = lastSuccessfulCurrentRunTodoProgress?.pending {
+                                pendingTodoNotice = Self.todoProgressUpdateRequiredNotice(
+                                    pending: pending
+                                )
+                            }
+                            continue
+                        }
+                        if invocationHasParseableTodo {
+                            batchHasPrecedingParseableTodo = true
+                        }
 
                         // Bounded discovery guard: once the state machine has
                         // enough ranked sources, synthesize a structured
@@ -1887,14 +2348,18 @@ enum AgentToolLoop {
                         if await hooks.isCancelled() {
                             return RunResult(exit: .cancelled, iterations: iteration)
                         }
-                        if wasError, policy.stopOnToolRejection {
+                        if wasError, policy.stopOnToolRejection,
+                            !Self.isRecoverableTodoContractResult(execution.result)
+                        {
                             return RunResult(exit: .toolRejected, iterations: iteration)
                         }
                     }
                 }
 
                 await hooks.onBatchComplete(outcomes)
-                if !outcomes.isEmpty {
+                if outcomes.contains(where: {
+                    !Self.isRecoverableTodoContractResult($0.result)
+                }) {
                     completedToolWork = true
                 }
                 let successfulTodoOutcomes = outcomes.filter { outcome in
@@ -1914,6 +2379,13 @@ enum AgentToolLoop {
                     }).last {
                         hasSuccessfulCurrentRunTodo = true
                         lastSuccessfulCurrentRunTodoProgress = latestProgress
+                        if let latestTodoOutcome = successfulTodoOutcomes.last {
+                            lastSuccessfulCurrentRunTodoSemanticSnapshot =
+                                Self.todoSemanticSnapshot(from: latestTodoOutcome.invocation)
+                            lastSuccessfulCurrentRunTodoActionToolCallCount =
+                                todoActionToolCallCountByCallId[latestTodoOutcome.callId]
+                                ?? currentRunActionToolCallCount
+                        }
                     }
                 }
 

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -60,6 +60,7 @@ extension ChatSession: ChatWarmupSessionContext {
             toolsDisabled: chatCfg.disableTools,
             additionalToolNames: cachedSession?.loadedToolNames ?? [],
             frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
+            frozenToolSpecs: cachedSession?.initialToolSpecs,
             frozenManifest: cachedSession?.frozenManifest,
             frozenSoul: cachedSession?.frozenSoul,
             trace: nil

--- a/Packages/OsaurusCore/Services/Chat/ComposeRequest.swift
+++ b/Packages/OsaurusCore/Services/Chat/ComposeRequest.swift
@@ -27,6 +27,11 @@ struct ComposeRequest: Sendable {
     let toolsDisabled: Bool
     let additionalToolNames: LoadedTools
     let frozenAlwaysLoadedNames: LoadedTools?
+    /// Exact first-compose tool payloads. Names are still resolved through
+    /// the live permission/feature gates; surviving baseline names reuse these
+    /// canonical schemas so async registry metadata cannot rewrite a session's
+    /// tokenizer prefix between turns.
+    let frozenToolSpecs: [Tool]?
     /// Turn-1 rendered enabled-capabilities manifest echoed back on turn 2+
     /// so the static system-prompt prefix stays byte-identical across the
     /// session (mirrors `frozenAlwaysLoadedNames`). `nil` = render fresh;
@@ -48,6 +53,7 @@ struct ComposeRequest: Sendable {
         toolsDisabled: Bool = false,
         additionalToolNames: LoadedTools = [],
         frozenAlwaysLoadedNames: LoadedTools? = nil,
+        frozenToolSpecs: [Tool]? = nil,
         frozenManifest: String? = nil,
         frozenSoul: String? = nil,
         trace: TTFTTrace? = nil
@@ -61,6 +67,7 @@ struct ComposeRequest: Sendable {
         self.toolsDisabled = toolsDisabled
         self.additionalToolNames = additionalToolNames
         self.frozenAlwaysLoadedNames = frozenAlwaysLoadedNames
+        self.frozenToolSpecs = frozenToolSpecs
         self.frozenManifest = frozenManifest
         self.frozenSoul = frozenSoul
         self.trace = trace

--- a/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
+++ b/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
@@ -285,6 +285,9 @@ struct ComposedContext: Sendable {
     /// mid-session from silently appearing in turn 2. It may include a
     /// trivial-turn baseline even when `tools` is empty for that one request.
     let alwaysLoadedNames: LoadedTools
+    /// Exact tool payloads to freeze on the first compose of a session. This
+    /// can be non-empty when `tools` is empty for the greeting-only fast path.
+    let initialToolSpecs: [Tool]
     /// Hash of the static prefix + canonical tool payloads for cache evidence.
     let cacheHint: String
     /// Rendered static-only system content for prefix cache building.

--- a/Packages/OsaurusCore/Services/Chat/ResolvedToolset.swift
+++ b/Packages/OsaurusCore/Services/Chat/ResolvedToolset.swift
@@ -23,6 +23,12 @@ struct ResolvedToolset: Sendable {
     /// alphabetical). Empty when `effectiveToolsOff` is true.
     let tools: [Tool]
 
+    /// Full resolved tool surface before a greeting-only first turn suppresses
+    /// the request schema. Callers persist these exact payloads as the session
+    /// baseline so the next non-trivial turn does not rebuild them from
+    /// asynchronously changing registry state.
+    let sessionBaselineTools: [Tool]
+
     /// Rendered enabled-capabilities manifest section for this session, or
     /// `nil` when the section is gated off / empty. Frozen at session start
     /// and injected as a static prefix section, so it is query- and

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -100,6 +100,7 @@ public struct SystemPromptComposer: Sendable {
         toolsDisabled: Bool = false,
         additionalToolNames: LoadedTools = [],
         frozenAlwaysLoadedNames: LoadedTools? = nil,
+        frozenToolSpecs: [Tool]? = nil,
         frozenManifest: String? = nil,
         frozenSoul: String? = nil,
         trace: TTFTTrace? = nil
@@ -115,6 +116,7 @@ public struct SystemPromptComposer: Sendable {
                 toolsDisabled: toolsDisabled,
                 additionalToolNames: additionalToolNames,
                 frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
+                frozenToolSpecs: frozenToolSpecs,
                 frozenManifest: frozenManifest,
                 frozenSoul: frozenSoul,
                 trace: trace
@@ -158,6 +160,7 @@ public struct SystemPromptComposer: Sendable {
             messages: request.messages,
             additionalToolNames: request.additionalToolNames,
             frozenAlwaysLoadedNames: request.frozenAlwaysLoadedNames,
+            frozenToolSpecs: request.frozenToolSpecs,
             frozenManifest: request.frozenManifest,
             frozenSoul: request.frozenSoul,
             trace: trace
@@ -230,6 +233,7 @@ public struct SystemPromptComposer: Sendable {
         messages: [ChatMessage],
         additionalToolNames: LoadedTools = [],
         frozenAlwaysLoadedNames: LoadedTools? = nil,
+        frozenToolSpecs: [Tool]? = nil,
         frozenManifest: String? = nil,
         frozenSoul: String? = nil,
         trace: TTFTTrace? = nil
@@ -261,6 +265,7 @@ public struct SystemPromptComposer: Sendable {
             messages: messages,
             additionalToolNames: additionalToolNames,
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
+            frozenToolSpecs: frozenToolSpecs,
             frozenManifest: frozenManifest,
             trace: trace
         )
@@ -304,6 +309,14 @@ public struct SystemPromptComposer: Sendable {
             {
                 PrefillDebugLog.shared.log("---- ENABLED-MANIFEST (rendered)\n\(manifestText)")
             }
+            for tool in toolset.tools {
+                let signature = PromptPrefixHasher.hash(systemContent: "", tools: [tool])
+                let tokens = ToolRegistry.shared.totalEstimatedTokens(for: [tool])
+                PrefillDebugLog.shared.log(
+                    "---- TOOL-SCHEMA name=\(tool.function.name) "
+                        + "hash=\(signature) tokens≈\(tokens)"
+                )
+            }
         }
 
         emitToolDiagnostics(
@@ -324,6 +337,7 @@ public struct SystemPromptComposer: Sendable {
             toolTokens: ToolRegistry.shared.totalEstimatedTokens(for: toolset.tools),
             memorySection: memorySection,
             alwaysLoadedNames: toolset.alwaysLoadedNames,
+            initialToolSpecs: toolset.sessionBaselineTools,
             cacheHint: manifest.staticPrefixHash(tools: toolset.tools),
             staticPrefix: manifest.staticPrefixContent,
             contextDisable: toolset.contextDisable,
@@ -515,6 +529,7 @@ public struct SystemPromptComposer: Sendable {
         messages: [ChatMessage],
         additionalToolNames: LoadedTools,
         frozenAlwaysLoadedNames: LoadedTools?,
+        frozenToolSpecs: [Tool]?,
         frozenManifest: String? = nil,
         trace: TTFTTrace?
     ) async -> ResolvedToolset {
@@ -549,7 +564,8 @@ public struct SystemPromptComposer: Sendable {
             executionMode: executionMode,
             toolsDisabled: effectiveToolsOff,
             additionalToolNames: additionalToolNames,
-            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
+            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
+            frozenToolSpecs: frozenToolSpecs
         )
         trace?.mark("resolve_tools_done")
         let suppressTrivialToolSchema = shouldSuppressTrivialToolSchema(
@@ -586,6 +602,7 @@ public struct SystemPromptComposer: Sendable {
 
         return ResolvedToolset(
             tools: tools,
+            sessionBaselineTools: resolvedTools,
             enabledManifest: enabledManifest,
             alwaysLoadedNames: alwaysLoadedNames,
             contextDisable: contextDisable,
@@ -1861,6 +1878,7 @@ public struct SystemPromptComposer: Sendable {
             toolTokens: ToolRegistry.shared.totalEstimatedTokens(for: toolset.tools),
             memorySection: nil,
             alwaysLoadedNames: toolset.alwaysLoadedNames,
+            initialToolSpecs: toolset.sessionBaselineTools,
             cacheHint: manifest.staticPrefixHash(tools: toolset.tools),
             staticPrefix: manifest.staticPrefixContent,
             contextDisable: toolset.contextDisable
@@ -1921,6 +1939,7 @@ public struct SystemPromptComposer: Sendable {
         )
         return ResolvedToolset(
             tools: tools,
+            sessionBaselineTools: tools,
             enabledManifest: enabledManifest,
             alwaysLoadedNames: alwaysLoadedNames,
             contextDisable: contextDisable,
@@ -2103,7 +2122,8 @@ public struct SystemPromptComposer: Sendable {
         executionMode: ExecutionMode,
         toolsDisabled: Bool = false,
         additionalToolNames: LoadedTools = [],
-        frozenAlwaysLoadedNames: LoadedTools? = nil
+        frozenAlwaysLoadedNames: LoadedTools? = nil,
+        frozenToolSpecs: [Tool]? = nil
     ) -> [Tool] {
         let snapshot = AgentConfigSnapshot.capture(
             agentId: agentId,
@@ -2114,7 +2134,8 @@ public struct SystemPromptComposer: Sendable {
             executionMode: executionMode,
             toolsDisabled: toolsDisabled,
             additionalToolNames: additionalToolNames,
-            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
+            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
+            frozenToolSpecs: frozenToolSpecs
         )
     }
 
@@ -2124,7 +2145,8 @@ public struct SystemPromptComposer: Sendable {
         executionMode: ExecutionMode,
         toolsDisabled: Bool = false,
         additionalToolNames: LoadedTools = [],
-        frozenAlwaysLoadedNames: LoadedTools? = nil
+        frozenAlwaysLoadedNames: LoadedTools? = nil,
+        frozenToolSpecs: [Tool]? = nil
     ) -> [Tool] {
         guard !toolsDisabled else { return [] }
 
@@ -2467,6 +2489,29 @@ public struct SystemPromptComposer: Sendable {
                 || (isManual && (snapshot.manualToolNames?.contains("image") ?? false))
             let genOnly = ImageTool.generationOnlySpec()
             byName["image"] = imageLoadedExplicitly ? genOnly : compactBootstrapSpec(genOnly)
+        }
+
+        // Freeze the exact first-compose payload for every baseline tool that
+        // remains visible after the current permission/feature gates. Names
+        // alone are not sufficient: a computed schema can change while its
+        // registration and name remain identical (web_search categories are
+        // populated asynchronously after keychain/provider discovery). Such a
+        // change rewrites the tokenizer prefix and defeats disk-L2 reuse.
+        //
+        // A tool explicitly loaded this session is the intentional exception:
+        // `capabilities_load` must still be able to upgrade a compact
+        // bootstrap schema to the live full contract. Newly registered tools
+        // absent from the frozen baseline likewise remain live.
+        if let frozenToolSpecs {
+            let frozenByName = Dictionary(
+                uniqueKeysWithValues: frozenToolSpecs.map { ($0.function.name, $0) }
+            )
+            for name in Array(byName.keys)
+            where !additionalToolNames.contains(name) {
+                if let frozen = frozenByName[name] {
+                    byName[name] = frozen
+                }
+            }
         }
 
         // Eval-scoped ablation hook (nil in production): strip deferred

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -64,16 +64,16 @@ public enum SystemPromptTemplates {
         ## Agent loop
 
         - Always answer the user in plain text — that reply is what they read. It ends a direct task, or a tracked task once its todo has no unchecked items.
-        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it with the next box checked after each item. Once created, unchecked items keep this agent run open. Skip direct/single-step work.
-        - `complete(summary)` — OPTIONAL explicit closure for a `todo`: use it with a short WHAT+HOW status (not the answer) in the SAME message as your answer when work is done or honestly blocked. Not for direct questions or other tools; no vague placeholders.
+        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it with the next box checked after each item. Once created, unchecked items keep this agent run open. Skip direct/single-step work. The runtime may require it before a later action in a long tool run.
+        - `complete(summary)` — OPTIONAL early closure for honestly blocked `todo` work. A fully checked todo needs no complete call: answer the user normally and stop. Invoke complete only as a structured tool call; never type `complete(...)` into the answer.
         - `clarify(question)` — pause and ask exactly one concrete question only when guessing wrong would change the result. For minor preferences pick a sensible default and proceed.
         - `share_artifact(path | content+filename)` — the only way the user sees a generated image, chart, report, code blob, or any file. **The file MUST exist before this call.** Sandbox: save under your home dir (default cwd), not `/tmp`. For inline text/markdown, pass `content`+`filename` and skip the file write.
         """
 
     /// Compact agent-loop cheat-sheet for small-context / small local models
     /// (`prefersCompactPrompt`). Same four tools and the load-bearing rules
-    /// (always answer in plain text, OPTIONAL 3+ step todo, OPTIONAL complete
-    /// that only closes a todo alongside the answer, last-resort one-question
+    /// (always answer in plain text, OPTIONAL 3+ step todo, OPTIONAL blocked
+    /// closure that must remain a real tool call, last-resort one-question
     /// clarify with the anti-punt rule, file-exists artifact), one line each.
     ///
     /// The clarify line keeps the false-clarify discipline from the W4 eval
@@ -87,8 +87,8 @@ public enum SystemPromptTemplates {
         ## Agent loop
 
         - Answer the user in plain text; it ends direct work, or tracked work once no todo items remain unchecked.
-        - `todo(markdown)` — OPTIONAL, 3+ step work only: create first, re-send with each box checked. Once created, unchecked items keep this run open. Skip single-step work.
-        - `complete(summary)` — OPTIONAL explicit `todo` closure: short WHAT+HOW status in the SAME message as your answer when done or honestly blocked, not the answer.
+        - `todo(markdown)` — OPTIONAL, 3+ step work only: create first, re-send with each box checked. Once created, unchecked items keep this run open. Skip direct/single-step work. The runtime may require it before a later action in a long tool run.
+        - `complete(summary)` — OPTIONAL early closure for blocked `todo` work. For success, check every box, answer normally, and stop. Invoke it as a tool only; never print `complete(...)` in the answer.
         - `clarify(question)` — last resort; a fully specified task is not ambiguous, just do it. Ask ONE question only when the user asks or a required input is missing/contradictory with no sensible default.
         - `share_artifact(path | content+filename)` — the only way the user sees a file/image; it MUST exist first. Sandbox: save under home, not `/tmp`.
         """

--- a/Packages/OsaurusCore/Services/Context/SessionToolState.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolState.swift
@@ -28,6 +28,16 @@ struct SessionToolState: Sendable {
     /// `capabilities_load` path (which writes loadedToolNames).
     /// `nil` means "no snapshot yet" — the next compose will record one.
     var initialAlwaysLoadedNames: LoadedTools?
+    /// Exact canonical tool specifications exposed by the first compose of
+    /// this session. Freezing names alone is insufficient: some registered
+    /// tools derive their JSON schema from asynchronously discovered runtime
+    /// state (for example, the available web-search categories). A name can
+    /// therefore remain stable while its parameters change, invalidating the
+    /// tokenizer prefix and forcing a full prefill. Subsequent composes reuse
+    /// these payloads for tools that remain visible; an explicit
+    /// `capabilities_load` is still allowed to replace a compact bootstrap
+    /// spec with the live full contract.
+    var initialToolSpecs: [Tool]?
     /// Compact signature of the (executionMode, toolSelectionMode) that
     /// captured this state. The send path compares the live signature on
     /// every turn and invalidates on a flip, so dynamically-loaded tools
@@ -61,6 +71,7 @@ struct SessionToolState: Sendable {
     init(
         loadedToolNames: LoadedTools = [],
         initialAlwaysLoadedNames: LoadedTools? = nil,
+        initialToolSpecs: [Tool]? = nil,
         sessionFingerprint: String? = nil,
         frozenManifest: String? = nil,
         frozenSoul: String? = nil,
@@ -68,6 +79,7 @@ struct SessionToolState: Sendable {
     ) {
         self.loadedToolNames = loadedToolNames
         self.initialAlwaysLoadedNames = initialAlwaysLoadedNames
+        self.initialToolSpecs = initialToolSpecs
         self.sessionFingerprint = sessionFingerprint
         self.frozenManifest = frozenManifest
         self.frozenSoul = frozenSoul

--- a/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
@@ -129,17 +129,32 @@ actor SessionToolStateStore {
     func setInitial(
         _ sessionId: String,
         alwaysLoadedNames: LoadedTools?,
+        toolSpecs: [Tool]? = nil,
         fingerprint: String? = nil,
         manifest: String? = nil,
         soul: String? = nil
     ) {
-        guard states[sessionId] == nil else { return }
-        states[sessionId] = SessionToolState(
-            initialAlwaysLoadedNames: alwaysLoadedNames,
-            sessionFingerprint: fingerprint,
-            frozenManifest: manifest,
-            frozenSoul: soul
-        )
+        // A capabilities load or frozen-memory write can legitimately create
+        // the entry before the first compose reaches this point. Fill only
+        // missing first-compose fields instead of returning early, preserving
+        // anything already accumulated on the entry.
+        var entry = states[sessionId] ?? SessionToolState()
+        if entry.initialAlwaysLoadedNames == nil {
+            entry.initialAlwaysLoadedNames = alwaysLoadedNames
+        }
+        if entry.initialToolSpecs == nil {
+            entry.initialToolSpecs = toolSpecs
+        }
+        if entry.sessionFingerprint == nil {
+            entry.sessionFingerprint = fingerprint
+        }
+        if entry.frozenManifest == nil {
+            entry.frozenManifest = manifest
+        }
+        if entry.frozenSoul == nil {
+            entry.frozenSoul = soul
+        }
+        states[sessionId] = entry
     }
 
     /// Drop the cached state for a session if its recorded (mode, toolMode)

--- a/Packages/OsaurusCore/Services/ExternalModelLocator.swift
+++ b/Packages/OsaurusCore/Services/ExternalModelLocator.swift
@@ -181,12 +181,21 @@ enum ExternalModelLocator {
         let entries = Array(loadedLocked().values)
         lock.unlock()
         return entries.map { entry in
-            MLXModel(
+            let bundleDirectory = URL(fileURLWithPath: entry.bundlePath, isDirectory: true)
+            return MLXModel(
                 id: entry.id,
                 name: ModelMetadataParser.friendlyName(from: entry.id),
                 description: "Found in \(entry.source).",
                 downloadURL: "https://huggingface.co/\(entry.id)",
-                bundleDirectory: URL(fileURLWithPath: entry.bundlePath, isDirectory: true),
+                // The persisted external registry intentionally stores only
+                // identity/path/provenance. Rehydrate architecture from the
+                // authoritative bundle here; otherwise an external model is
+                // local and loadable but loses `model_type` in the picker.
+                // Chat-family routing and structural agent contracts would
+                // then silently differ from the same bundle installed under
+                // Osaurus's managed model directory.
+                modelType: VLMDetection.readModelType(at: bundleDirectory),
+                bundleDirectory: bundleDirectory,
                 externalSource: entry.source
             )
         }

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -978,13 +978,15 @@ final class PluginHostContext: @unchecked Sendable {
             messages: messages,
             additionalToolNames: cachedSession?.loadedToolNames ?? [],
             frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
+            frozenToolSpecs: cachedSession?.initialToolSpecs,
             frozenManifest: cachedSession?.frozenManifest,
             frozenSoul: cachedSession?.frozenSoul
         )
-        if let sid = sessionId, cachedSession == nil {
+        if let sid = sessionId {
             await SessionToolStateStore.shared.setInitial(
                 sid,
                 alwaysLoadedNames: composed.alwaysLoadedNames,
+                toolSpecs: composed.initialToolSpecs,
                 fingerprint: SessionToolState.fingerprint(executionMode: execMode, toolMode: toolMode),
                 manifest: composed.enabledManifest,
                 soul: composed.soul
@@ -1193,10 +1195,31 @@ final class PluginHostContext: @unchecked Sendable {
                     }
                     return live
                 }
+                await SessionToolStateStore.shared.setInitial(
+                    sid,
+                    alwaysLoadedNames: Set(builtInTools.map { $0.function.name }),
+                    toolSpecs: builtInTools,
+                    fingerprint: liveFp
+                )
+                let stable = await SessionToolStateStore.shared.get(sid) ?? cached
                 let extraSpecs = await MainActor.run {
-                    ToolRegistry.shared.specs(forTools: Array(cached.loadedToolNames))
+                    ToolRegistry.shared.specs(forTools: Array(stable.loadedToolNames))
                 }
-                return await applyResolvedTools(builtInTools + extraSpecs, to: inference)
+                var byName = Dictionary(
+                    uniqueKeysWithValues: (builtInTools + extraSpecs).map {
+                        ($0.function.name, $0)
+                    }
+                )
+                if let frozen = stable.initialToolSpecs {
+                    let frozenByName = Dictionary(
+                        uniqueKeysWithValues: frozen.map { ($0.function.name, $0) }
+                    )
+                    for name in Array(byName.keys)
+                    where !stable.loadedToolNames.contains(name) {
+                        if let spec = frozenByName[name] { byName[name] = spec }
+                    }
+                }
+                return await applyResolvedTools(Array(byName.values), to: inference)
             }
         }
 
@@ -1216,6 +1239,7 @@ final class PluginHostContext: @unchecked Sendable {
             await SessionToolStateStore.shared.setInitial(
                 sid,
                 alwaysLoadedNames: builtInNames,
+                toolSpecs: builtInTools,
                 fingerprint: fp
             )
         }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -168,10 +168,395 @@ private func headlessPolicy(maxIterations: Int = 30) -> AgentLoopPolicy {
     )
 }
 
+private func taskTrackingChatPolicy(
+    maxIterations: Int = 15,
+    threshold: Int = 3
+) -> AgentLoopPolicy {
+    AgentLoopPolicy(
+        maxIterations: maxIterations,
+        stopOnToolRejection: true,
+        dedupeNoticeEnabled: true,
+        todoRequiredBeforeToolCallCount: threshold
+    )
+}
+
 // MARK: - Tests
 
 @MainActor
 struct AgentToolLoopTests {
+    @Test func chatTodoPreconditionIsLimitedToProvenLocalBundleTypes() {
+        for modelType in ["gemma4_moe", "qwen3_5", "qwen3_5_moe"] {
+            #expect(
+                AgentToolLoop.chatTodoPreconditionThreshold(
+                    hasTodoTool: true,
+                    isLocalModel: true,
+                    modelType: modelType
+                ) == 3
+            )
+        }
+
+        for modelType in ["glm4_moe", "laguna_s21", "lfm2", "deepseek_v4", nil] {
+            #expect(
+                AgentToolLoop.chatTodoPreconditionThreshold(
+                    hasTodoTool: true,
+                    isLocalModel: true,
+                    modelType: modelType
+                ) == 0
+            )
+        }
+
+        #expect(
+                AgentToolLoop.chatTodoPreconditionThreshold(
+                    hasTodoTool: true,
+                    isLocalModel: false,
+                    modelType: "gemma4_moe"
+                ) == 0
+        )
+        #expect(
+            AgentToolLoop.chatTodoPreconditionThreshold(
+                hasTodoTool: false,
+                isLocalModel: true,
+                modelType: "qwen3_5_moe"
+            ) == 0
+        )
+    }
+
+    @Test func thirdChatActionRequiresCurrentRunTodoAndRemainsRecoverable() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("web_search", #"{"query":"one"}"#)]),
+            .toolCalls([inv("web_search", #"{"query":"two"}"#)]),
+            .toolCalls([inv("web_search", #"{"query":"three"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] collect sources"}"#)]),
+            .toolCalls([inv("web_search", #"{"query":"three"}"#)]),
+            .finalResponse,
+        ])
+        var executedBatches: [[String]] = []
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            executedBatches.append(calls.map { $0.invocation.toolName })
+            return calls.map { call in
+                if call.invocation.toolName == "web_search" {
+                    // Correctable tool failures still describe attempted
+                    // multi-step work and therefore count toward the gate.
+                    return AgentLoopToolExecution(
+                        result: ToolEnvelope.failure(
+                            kind: .executionError,
+                            message: "provider unavailable",
+                            tool: call.invocation.toolName,
+                            retryable: true
+                        )
+                    )
+                }
+                return AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: call.invocation.toolName, text: "ok")
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: taskTrackingChatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 6))
+        // The third search was surfaced but not executed. A valid current-run
+        // Todo then unlocked the exact retry.
+        #expect(executedBatches == [
+            ["web_search"], ["web_search"], ["todo"], ["web_search"],
+        ])
+        #expect(surface.batchOutcomes.count == 5)
+        let rejected = try #require(surface.batchOutcomes[2].first)
+        #expect(rejected.wasError)
+        #expect(AgentToolLoop.isTaskTrackingRequiredResult(rejected.result))
+        #expect(surface.builtNotices.flatMap { $0 }.contains(where: {
+            $0.contains("reached 3 ordinary tool actions")
+        }))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 1))
+    }
+
+    @Test func parseableTodoInThirdBatchUnlocksSiblingAction() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("tool_one")]),
+            .toolCalls([inv("tool_two")]),
+            .toolCalls([
+                inv("todo", #"{"markdown":"- [x] finish the task"}"#),
+                inv("tool_three"),
+            ]),
+            .finalResponse,
+        ])
+        var executedBatches: [[String]] = []
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            executedBatches.append(calls.map { $0.invocation.toolName })
+            return calls.map {
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: taskTrackingChatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(executedBatches == [
+            ["tool_one"], ["tool_two"], ["todo", "tool_three"],
+        ])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTaskTrackingRequiredResult($0.result)
+        }))
+    }
+
+    @Test func completeAfterNewActionRequiresFreshTodoUpdateThenEndsBlocked() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] report"}"#)]),
+            .toolCalls([inv("file_read", #"{"path":"report.txt"}"#)]),
+            .toolCalls([
+                inv(
+                    "complete",
+                    #"{"summary":"Read the available report, but the second required source is unavailable."}"#
+                )
+            ]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [ ] report"}"#)]),
+            .toolCalls([
+                inv(
+                    "complete",
+                    #"{"summary":"Read and verified the available report; the final report remains blocked on the missing source."}"#
+                )
+            ]),
+        ])
+        var executedBatches: [[String]] = []
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            executedBatches.append(calls.map { $0.invocation.toolName })
+            return calls.map { call in
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: call.invocation.toolName, text: "ok"),
+                    endRun: call.invocation.toolName == "complete"
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 5))
+        #expect(executedBatches == [["todo"], ["file_read"], ["todo"], ["complete"]])
+        let rejected = try #require(surface.batchOutcomes[2].first)
+        #expect(rejected.invocation.toolName == "complete")
+        #expect(rejected.wasError)
+        #expect(AgentToolLoop.isTodoProgressUpdateRequiredResult(rejected.result))
+        #expect(rejected.result.contains("2 todo items"))
+        #expect(surface.builtNotices.flatMap { $0 }.contains(where: {
+            $0.contains("completion was rejected") && $0.contains("2 todo items")
+                && $0.contains("checklist update")
+        }))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 2))
+    }
+
+    @Test func precedingTodoInSameBatchCanRefreshBeforeBlockedComplete() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] report"}"#)]),
+            .toolCalls([inv("file_read", #"{"path":"report.txt"}"#)]),
+            .toolCalls([
+                inv("todo", #"{"markdown":"- [x] inspect\n- [ ] report"}"#),
+                inv(
+                    "complete",
+                    #"{"summary":"Read and verified the available report; the final report remains blocked on the missing source."}"#
+                ),
+            ]),
+        ])
+        var executedBatches: [[String]] = []
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            executedBatches.append(calls.map { $0.invocation.toolName })
+            return calls.map { call in
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: call.invocation.toolName, text: "ok"),
+                    endRun: call.invocation.toolName == "complete"
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 3))
+        #expect(executedBatches == [["todo"], ["file_read"], ["todo", "complete"]])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoProgressUpdateRequiredResult($0.result)
+        }))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 2))
+    }
+
+    @Test func repeatedSemanticTodoIsRejectedUntilChecklistActuallyChanges() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            // Presentation changes do not turn an unchanged 0/2 checklist
+            // into progress.
+            .toolCalls([inv("todo", #"{"markdown":"Plan\n* [ ] inspect\n* [ ] answer"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [ ] answer"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
+            .finalResponse,
+        ])
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
+        // The unchanged second Todo never reaches the tool/store executor;
+        // the two real checkbox transitions do.
+        #expect(surface.executedCalls.map(\.name) == ["todo", "todo", "todo"])
+        let rejected = try #require(surface.batchOutcomes[1].first)
+        #expect(rejected.wasError)
+        #expect(AgentToolLoop.isTodoNoProgressResult(rejected.result))
+        #expect(rejected.result.contains("not executed"))
+        #expect(surface.builtNotices.flatMap { $0 }.contains(where: {
+            $0.contains("exactly repeated") && $0.contains("2 unchecked items")
+        }))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
+    }
+
+    @Test func batchExecutorAlsoSkipsRepeatedSemanticTodo() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
+            .finalResponse,
+        ])
+        var executedBatches: [[String]] = []
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            executedBatches.append(calls.map { $0.invocation.toolName })
+            return calls.map {
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(executedBatches == [["todo"], ["todo"]])
+        let rejected = try #require(surface.batchOutcomes[1].first)
+        #expect(AgentToolLoop.isTodoNoProgressResult(rejected.result))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
+    }
+
+    @Test func unchangedTodoAfterUnproductiveWorkAllowsHonestBlockedComplete() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] fetch source\n- [ ] report"}"#)]),
+            .toolCalls([inv("web_fetch", #"{"url":"https://blocked.example"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] fetch source\n- [ ] report"}"#)]),
+            .toolCalls([
+                inv(
+                    "complete",
+                    #"{"summary":"The source fetch failed and no claims could be verified, so both tracked items remain honestly blocked."}"#
+                )
+            ]),
+        ])
+        surface.toolResults["web_fetch"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(
+                tool: "web_fetch",
+                text: "The provider returned no extractable source content."
+            )
+        )
+        surface.toolResults["complete"] = AgentLoopToolExecution(
+            result: ToolEnvelope.success(tool: "complete", text: "closed blocked"),
+            endRun: true
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 4))
+        #expect(surface.executedCalls.map(\.name) == ["todo", "web_fetch", "complete"])
+        #expect(AgentToolLoop.isTodoNoProgressResult(
+            try #require(surface.batchOutcomes[2].first).result
+        ))
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoProgressUpdateRequiredResult($0.result)
+        }))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 0, total: 2))
+    }
+
+    @Test func staleSessionTodoCannotBypassThirdActionGate() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("tool_one")]),
+            .toolCalls([inv("tool_two")]),
+            .toolCalls([inv("tool_three")]),
+            .finalResponse,
+        ])
+        // Simulate a completed Todo left by an older user turn. Only a Todo
+        // successfully emitted during this logical run may unlock actions.
+        surface.pendingTodos = 0
+        surface.todoProgress = AgentTodoProgressSnapshot(done: 2, total: 2)
+        var executedBatches: [[String]] = []
+        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
+        hooks.executeBatch = { calls in
+            executedBatches.append(calls.map { $0.invocation.toolName })
+            return calls.map {
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
+                )
+            }
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: taskTrackingChatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(executedBatches == [["tool_one"], ["tool_two"]])
+        #expect(AgentToolLoop.isTaskTrackingRequiredResult(
+            try #require(surface.batchOutcomes[2].first).result
+        ))
+    }
+
+    @Test func headlessPolicyDoesNotImposeChatTodoPrecondition() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("tool_one")]),
+            .toolCalls([inv("tool_two")]),
+            .toolCalls([inv("tool_three")]),
+            .finalResponse,
+        ])
+
+        let result = try await AgentToolLoop.run(
+            policy: headlessPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
+        #expect(surface.executedCalls.map(\.name) == ["tool_one", "tool_two", "tool_three"])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTaskTrackingRequiredResult($0.result)
+        }))
+    }
+
     @Test func finalResponseOnFirstStepEndsRun() async throws {
         let surface = ScriptedLoopSurface(steps: [.finalResponse])
         let result = try await AgentToolLoop.run(
@@ -2143,6 +2528,13 @@ struct AgentLoopTrackedTodoCompletionTests {
             },
             prepareTrackedTaskContinuation: {
                 continuationPreparations += 1
+                // Chat keeps the premature assistant response visible but
+                // excludes it from the next model request. Simulate that
+                // surface contract here so the captured continuation history
+                // cannot regress to adjacent assistant messages.
+                if history.last?.role == "assistant" {
+                    history.removeLast()
+                }
             },
             executeTool: { invocation, _ in
             do {
@@ -2207,9 +2599,9 @@ struct AgentLoopTrackedTodoCompletionTests {
         #expect(stored?.totalCount == 2)
         #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
         #expect(continuationPreparations == 1)
-        #expect(continuationInput.map(\.role) == ["user", "assistant", "tool", "assistant"])
-        #expect(continuationInput.last?.content == progressText)
-        #expect(continuationInput.filter { $0.content == progressText }.count == 1)
+        #expect(continuationInput.map(\.role) == ["user", "assistant", "tool"])
+        #expect(continuationInput.last?.role == "tool")
+        #expect(continuationInput.allSatisfy { $0.content != progressText })
     }
 
     @Test func multipleTodoUpdatesInOneBatchPreserveRecordedProgress() async throws {

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -73,12 +73,13 @@ struct ChatSessionStopTests {
     }
 
     @Test
-    func trackedTodoContinuationHistoryKeepsProgressOnceAndDropsEmptyBuffer() {
+    func trackedTodoContinuationKeepsPrematureResponseVisibleButOutOfModelHistory() {
         let user = ChatTurn(role: .user, content: "research these repositories")
         let progress = ChatTurn(
             role: .assistant,
             content: "Got the Osaurus models. Now let me check the other two orgs."
         )
+        ChatSession.excludeAbandonedTrackedTaskResponse(progress)
         let emptyContinuationBuffer = ChatTurn(role: .assistant, content: "")
         let turns = [user, progress, emptyContinuationBuffer]
 
@@ -92,16 +93,11 @@ struct ChatSessionStopTests {
             }
         }
 
-        #expect(messages.map(\.role) == ["user", "assistant"])
-        #expect(messages.map(\.content) == [
-            "research these repositories",
-            "Got the Osaurus models. Now let me check the other two orgs.",
-        ])
-        #expect(
-            messages.filter {
-                $0.content == "Got the Osaurus models. Now let me check the other two orgs."
-            }.count == 1
-        )
+        #expect(progress.content == "Got the Osaurus models. Now let me check the other two orgs.")
+        #expect(progress.modelContextExcluded)
+        #expect(messages.map(\.role) == ["user"])
+        #expect(messages.map(\.content) == ["research these repositories"])
+        #expect(ChatSession.modelVisibleAssistantMessage(progress, isLastTurn: false) == nil)
     }
 
     @Test
@@ -796,9 +792,11 @@ private actor ReasoningRetryChatEngine: ChatEngineProtocol {
     private(set) var requestSnapshots: [ChatRequestSnapshot] = []
 
     func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        let messageEncoder = JSONEncoder()
+        messageEncoder.outputFormatting = [.sortedKeys]
         requestSnapshots.append(
             ChatRequestSnapshot(
-                encodedMessages: (try? JSONEncoder().encode(request.messages)) ?? Data(),
+                encodedMessages: (try? messageEncoder.encode(request.messages)) ?? Data(),
                 toolNames: request.tools?.map(\.function.name) ?? [],
                 idempotencyKey: request.idempotencyKey
             )

--- a/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
@@ -512,6 +512,7 @@ struct PromptSectionOrderingTests {
                 model: "gpt-5",
                 query: "now refactor the networking layer",
                 frozenAlwaysLoadedNames: turn1.alwaysLoadedNames,
+                frozenToolSpecs: turn1.initialToolSpecs,
                 frozenManifest: turn1.enabledManifest
             )
             #expect(steady.prompt == turn1.prompt)
@@ -529,6 +530,7 @@ struct PromptSectionOrderingTests {
                 query: "and render a chart of the results",
                 additionalToolNames: ["render_chart"],
                 frozenAlwaysLoadedNames: turn1.alwaysLoadedNames,
+                frozenToolSpecs: turn1.initialToolSpecs,
                 frozenManifest: turn1.enabledManifest
             )
             #expect(afterLoad.prompt == turn1.prompt)
@@ -612,6 +614,7 @@ struct PromptSectionOrderingTests {
                 model: "gpt-5",
                 query: "now add a route",
                 frozenAlwaysLoadedNames: turn1.alwaysLoadedNames,
+                frozenToolSpecs: turn1.initialToolSpecs,
                 frozenManifest: turn1.enabledManifest,
                 frozenSoul: turn1.soul
             )

--- a/Packages/OsaurusCore/Tests/Chat/SessionPreflightCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SessionPreflightCacheTests.swift
@@ -41,9 +41,21 @@ struct SessionPreflightCacheTests {
             fallbackAlwaysLoadedNames: nil
         )
 
+        let baselineSpecs = ToolRegistry.shared.specs(forTools: ["capabilities_load"])
+        await SessionToolStateStore.shared.setInitial(
+            sessionId,
+            alwaysLoadedNames: ["capabilities_load"],
+            toolSpecs: baselineSpecs,
+            fingerprint: "none/auto",
+            manifest: "frozen manifest"
+        )
+
         let state = await SessionToolStateStore.shared.get(sessionId)
         #expect(state?.loadedToolNames == ["miyo_search", "calendar_lookup"])
         #expect(state?.initialAlwaysLoadedNames == ["capabilities_load"])
+        #expect(state?.initialToolSpecs?.map(\.function.name) == ["capabilities_load"])
+        #expect(state?.sessionFingerprint == "none/auto")
+        #expect(state?.frozenManifest == "frozen manifest")
 
         await SessionToolStateStore.shared.invalidate(sessionId)
     }

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -183,6 +183,65 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
+    @Test("session schema freeze preserves canonical payload across async provider discovery")
+    func sessionSchemaFreeze_preservesComputedWebSearchPayload() async {
+        let originalCategories = SearchToolSchemaState.availableCategories()
+        defer { SearchToolSchemaState.update(categories: originalCategories) }
+
+        await withSandboxAgent(autonomous: false) { agentId in
+            SearchToolSchemaState.update(categories: ["web"])
+            let first = SystemPromptComposer.resolveTools(
+                agentId: agentId,
+                executionMode: .none
+            )
+            let firstWeb = first.first { $0.function.name == "web_search" }
+            #expect(firstWeb != nil)
+            guard let firstWeb else { return }
+
+            // Simulate the asynchronous keychain/provider refresh that used
+            // to mutate the same named tool after turn one.
+            SearchToolSchemaState.update(categories: ["web", "news", "images"])
+            let liveSecond = SystemPromptComposer.resolveTools(
+                agentId: agentId,
+                executionMode: .none,
+                frozenAlwaysLoadedNames: Set(first.map(\.function.name))
+            )
+            let liveWeb = liveSecond.first { $0.function.name == "web_search" }
+            #expect(liveWeb != nil)
+            guard let liveWeb else { return }
+            #expect(liveWeb.canonicalHashPayload() != firstWeb.canonicalHashPayload())
+
+            let frozenSecond = SystemPromptComposer.resolveTools(
+                agentId: agentId,
+                executionMode: .none,
+                frozenAlwaysLoadedNames: Set(first.map(\.function.name)),
+                frozenToolSpecs: first
+            )
+            let frozenWeb = frozenSecond.first { $0.function.name == "web_search" }
+            #expect(frozenWeb != nil)
+            guard let frozenWeb else { return }
+            #expect(frozenWeb.canonicalHashPayload() == firstWeb.canonicalHashPayload())
+            #expect(
+                PromptPrefixHasher.hash(systemContent: "prefix", tools: frozenSecond)
+                    == PromptPrefixHasher.hash(systemContent: "prefix", tools: first)
+            )
+
+            // Explicit loading remains an intentional schema upgrade: it may
+            // replace the compact baseline with the current full contract.
+            let explicitlyLoaded = SystemPromptComposer.resolveTools(
+                agentId: agentId,
+                executionMode: .none,
+                additionalToolNames: ["web_search"],
+                frozenAlwaysLoadedNames: Set(first.map(\.function.name)),
+                frozenToolSpecs: first
+            )
+            let loadedWeb = explicitlyLoaded.first { $0.function.name == "web_search" }
+            #expect(loadedWeb != nil)
+            guard let loadedWeb else { return }
+            #expect(loadedWeb.canonicalHashPayload() != firstWeb.canonicalHashPayload())
+        }
+    }
+
     // MARK: - Manual mode (pragmatic)
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
@@ -120,6 +120,19 @@ struct SystemPromptDefaultIdentityTests {
         #expect(block.contains("share_artifact"))
     }
 
+    @Test("shared agent-loop guidance preserves optional todo and structured complete")
+    func sharedAgentLoopGuidancePreservesFamilyScope() {
+        for block in [
+            SystemPromptTemplates.agentLoopGuidance,
+            SystemPromptTemplates.agentLoopGuidanceCompact,
+        ] {
+            #expect(block.contains("OPTIONAL"))
+            #expect(block.contains("3+"))
+            #expect(block.contains("never") && block.contains("complete(...)"))
+            #expect(!block.contains("SAME message"))
+        }
+    }
+
     /// Same sanity for the capability-discovery nudge — still names
     /// `capabilities_discover` / `capabilities_load` because that block is
     /// gated on `capabilities_discover` actually being in the tools[] array.

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -278,9 +278,16 @@ struct ExternalModelLocatorTests {
 
         let bundle = customRoot.appendingPathComponent("publisher/repo", isDirectory: true)
         writeBundle(at: bundle)
+        try? Data(#"{"model_type":"gemma4"}"#.utf8)
+            .write(to: bundle.appendingPathComponent("config.json"))
 
         ExternalModelLocator.testRootsOverride = [(root: customRoot, source: .customModelFolder)]
         ExternalModelLocator.rescan()
+
+        let report = ExternalModelLocator.lastScanReport()
+        // Exercise the app-relaunch path: the persisted registry carries no
+        // architecture field, so `models()` must rehydrate it from the bundle.
+        ExternalModelLocator.invalidateInMemory()
 
         let resolved = ExternalModelLocator.path(forId: "publisher/repo")
         #expect(resolved?.standardizedFileURL.path == bundle.standardizedFileURL.path)
@@ -288,11 +295,12 @@ struct ExternalModelLocatorTests {
         let models = ExternalModelLocator.models()
         #expect(
             models.contains {
-                $0.id == "publisher/repo" && $0.externalSource == "Custom model folder"
+                $0.id == "publisher/repo"
+                    && $0.externalSource == "Custom model folder"
+                    && $0.modelType == "gemma4"
             }
         )
 
-        let report = ExternalModelLocator.lastScanReport()
         #expect(report?.discovered.contains { $0.id == "publisher/repo" } == true)
         #expect(report?.skipped.isEmpty == true)
     }

--- a/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
@@ -17,6 +17,24 @@ import Testing
 @Suite(.serialized)
 struct AgentLoopToolsTests {
 
+    @Test("shared todo schema stays optional outside targeted family policy")
+    func sharedTodoSchemaStaysOptional() {
+        let description = TodoTool().description
+        #expect(description.contains("OPTIONAL"))
+        #expect(description.contains("runtime may require it"))
+        #expect(description.contains("direct question"))
+        #expect(!description.contains("It is REQUIRED"))
+    }
+
+    @Test("complete schema cannot invite literal protocol text")
+    func completeSchemaRequiresStructuredInvocationOnly() {
+        let description = CompleteTool().description
+        #expect(description.contains("structured tool protocol only"))
+        #expect(description.contains("never by typing `complete(...)`"))
+        #expect(description.contains("successful task does not need this tool"))
+        #expect(!description.contains("same message as"))
+    }
+
     // MARK: - Helpers
 
     private func withSession<T>(
@@ -151,7 +169,7 @@ struct AgentLoopToolsTests {
     }
 
     @Test
-    func complete_warnsOnUncheckedTodoBoxes() async throws {
+    func complete_reportsBlockedOutcomeWhenTodoIsUnchecked() async throws {
         try await withSession { _ in
             _ = try await TodoTool().execute(
                 argumentsJSON: #"{"markdown": "- [x] done step\n- [ ] left one\n- [ ] left two"}"#
@@ -161,9 +179,10 @@ struct AgentLoopToolsTests {
                     {"summary": "Finished the first step; verified by re-reading the file contents."}
                     """#
             )
-            // Soft warning, NOT a rejection — rejecting loops small models.
             #expect(ToolEnvelope.isSuccess(result))
-            #expect(result.contains("2 unchecked item"))
+            #expect(result.contains("\"outcome\":\"blocked\""))
+            #expect(result.contains("\"pending_todo_items\":2"))
+            #expect(result.contains("still pending"))
         }
     }
 
@@ -180,6 +199,8 @@ struct AgentLoopToolsTests {
             )
             #expect(ToolEnvelope.isSuccess(result))
             #expect(!result.contains("unchecked"))
+            #expect(result.contains("\"outcome\":\"completed\""))
+            #expect(result.contains("\"pending_todo_items\":0"))
         }
     }
 

--- a/Packages/OsaurusCore/Tools/AgentLoopTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentLoopTools.swift
@@ -29,13 +29,14 @@ import Foundation
 public final class TodoTool: OsaurusTool, @unchecked Sendable {
     public let name = "todo"
     public let description =
-        "Write or replace the OPTIONAL task checklist. Use it for multi-step work (3+ steps): "
-        + "create the list BEFORE starting, then re-send it with the new box checked IMMEDIATELY "
+        "Write or replace the OPTIONAL task checklist for multi-step work (3+ steps). The "
+        + "runtime may require it before a later action in a long tool run. Create the list BEFORE "
+        + "starting, then re-send it with the new box checked IMMEDIATELY "
         + "after finishing each item — do not batch updates for the end. Every item is a line "
         + "starting with `- [ ]` (pending) or `- [x]` (done); each call replaces the entire "
         + "list. Once created, unchecked items keep this agent run open until you update them or "
-        + "honestly close the tracked task with `complete`. Skip it for a direct question or "
-        + "single-step work — just answer."
+        + "honestly close blocked tracked work with `complete`. Skip it for a direct question or "
+        + "single-step work unless the runtime reports that tracking is required."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -115,8 +116,9 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
                 "Todo updated: \(stored.doneCount)/\(stored.totalCount) complete. "
                 + "Unchecked items keep this agent run open, so continue with the next pending "
                 + "item and re-send the full checklist as you check items. When everything is "
-                + "done, write your answer to the user; if work is blocked, answer honestly and "
-                + "call `complete(summary)` with what remains."
+                + "checked, answer the user normally and stop; no `complete` call is required. "
+                + "If work is blocked, use the structured `complete` tool with what remains. "
+                + "Never print tool-call syntax in the answer."
         )
     }
 }
@@ -128,14 +130,13 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
 public final class CompleteTool: OsaurusTool, @unchecked Sendable {
     public let name = "complete"
     public let description =
-        "OPTIONAL closure for a multi-step task you tracked with a `todo` list. Write your "
-        + "actual answer/result to the user as a normal message FIRST; this summary is a short "
-        + "status of WHAT you did + HOW you verified it (the command you ran, the file you "
-        + "checked, the URL you opened), NOT the answer itself. Call it in the same message as "
-        + "that final answer and not alongside other tool calls; for a direct question, just "
-        + "answer and do not call complete. Vague summaries (`done`, `looks good`, `complete`) "
-        + "are rejected. If you couldn't finish, say so honestly in the summary instead of "
-        + "pretending — that's fine; the user understands partial work."
+        "OPTIONAL early closure for a multi-step task tracked with `todo` that is honestly "
+        + "blocked or cannot be finished. A successful task does not need this tool: first mark "
+        + "every todo item checked, then answer the user normally and stop. For blocked work, "
+        + "the summary must state WHAT was done, HOW it was verified, and what remains. Invoke "
+        + "this through the structured tool protocol only, never by typing `complete(...)` into "
+        + "the answer, and never alongside another tool call. Vague summaries (`done`, `looks "
+        + "good`, `complete`) are rejected."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -178,10 +179,11 @@ public final class CompleteTool: OsaurusTool, @unchecked Sendable {
             )
         }
 
-        // Soft warning, never a rejection (rejecting here loops small
-        // models): completing with unchecked todo boxes is allowed, but
-        // the discrepancy is flagged in the envelope so it lands in the
-        // transcript the user reads.
+        // Pending items mean this is an honest blocked terminal, not success.
+        // The canonical loop separately requires a fresh Todo update after
+        // the latest action before this tool may execute. Keep the remaining
+        // items visible and return typed outcome data so headless/API callers
+        // receive the same truth as Chat's blocked completion banner.
         if let sessionId = ChatExecutionContext.currentSessionId, !sessionId.isEmpty,
             let todo = await AgentTodoStore.shared.todo(for: sessionId)
         {
@@ -189,14 +191,27 @@ public final class CompleteTool: OsaurusTool, @unchecked Sendable {
             if pending > 0 {
                 return ToolEnvelope.success(
                     tool: name,
-                    text: "Task completed.",
+                    result: [
+                        "text": "Tracked task closed with \(pending) todo item"
+                            + (pending == 1 ? "" : "s") + " still pending.",
+                        "outcome": "blocked",
+                        "pending_todo_items": pending,
+                    ],
                     warnings: [
-                        "todo list has \(pending) unchecked item\(pending == 1 ? "" : "s") — update it, or state honestly in the summary that they were not done"
+                        "the task is incomplete; the remaining todo item"
+                            + (pending == 1 ? " is" : "s are") + " still unchecked"
                     ]
                 )
             }
         }
-        return ToolEnvelope.success(tool: name, text: "Task completed.")
+        return ToolEnvelope.success(
+            tool: name,
+            result: [
+                "text": "Task completed.",
+                "outcome": "completed",
+                "pending_todo_items": 0,
+            ]
+        )
     }
 
     /// Returns nil when the summary is acceptable, or a human-readable

--- a/Packages/OsaurusCore/Views/Chat/AgentInlineBlocks.swift
+++ b/Packages/OsaurusCore/Views/Chat/AgentInlineBlocks.swift
@@ -267,20 +267,25 @@ struct InlineTodoBlock: View {
 /// dismiss it to read what's underneath.
 struct InlineCompleteBlock: View {
     let summary: String
+    let isBlocked: Bool
     var onDismiss: () -> Void
 
     @Environment(\.theme) private var theme
 
+    private var statusColor: Color {
+        isBlocked ? theme.warningColor : theme.successColor
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: Layout.bannerIconSpacing) {
-            Image(systemName: "checkmark.seal.fill")
-                .foregroundColor(theme.successColor)
+            Image(systemName: isBlocked ? "exclamationmark.triangle.fill" : "checkmark.seal.fill")
+                .foregroundColor(statusColor)
                 .padding(.top, Layout.bannerIconTopOffset)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(localized: "Done")
+                Text(localized: isBlocked ? "Blocked" : "Done")
                     .font(theme.font(size: CGFloat(theme.captionSize), weight: .semibold))
-                    .foregroundColor(theme.successColor)
+                    .foregroundColor(statusColor)
                     .textCase(.uppercase)
 
                 Text(summary)
@@ -298,8 +303,8 @@ struct InlineCompleteBlock: View {
         .padding(.vertical, Layout.bannerPaddingV)
         .background(
             FloatingGlassSurface(
-                tint: theme.successColor.opacity(0.10),
-                borderColor: theme.successColor.opacity(0.30)
+                tint: statusColor.opacity(0.10),
+                borderColor: statusColor.opacity(0.30)
             )
         )
         .padding(.horizontal, Layout.outerHorizontalMargin)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -413,6 +413,10 @@ final class ChatSession: ObservableObject {
     /// the engine intercepts `complete` and breaks the loop. The chat
     /// view renders it as a "Completed" banner inline.
     @Published var lastCompletionSummary: String?
+    /// True when the completion tool closed an honestly blocked tracked task
+    /// with unchecked Todo items. Kept separate from the summary so legacy
+    /// session persistence remains unchanged while the live banner is honest.
+    @Published var lastCompletionWasBlocked = false
 
     /// Per-task state machine the harness holds so the (small) model doesn't
     /// have to. Session-scoped here so a listing produced by one user message
@@ -1758,6 +1762,18 @@ final class ChatSession: ObservableObject {
         )
     }
 
+    /// Mark a model-authored terminal response as an abandoned protocol
+    /// attempt when structured Todo work from this run remains unchecked.
+    /// The response stays in the visible transcript, but feeding it back before
+    /// a fresh assistant tool call creates two adjacent assistant messages.
+    /// Qwen-family templates render that malformed history differently and a
+    /// hybrid disk restore can then resume unrelated state. This is the same
+    /// persistence-backed exclusion contract used for incomplete reasoning;
+    /// no model text, tags, sampling, or stop behavior is synthesized.
+    static func excludeAbandonedTrackedTaskResponse(_ turn: ChatTurn) {
+        turn.modelContextExcluded = true
+    }
+
     /// Prepend a user turn's frozen memory / screen-context prefix to its
     /// rendered message. The prefix already carries its trailing separator
     /// (`SystemPromptComposer.composeInjectedUserPrefix`), so this is a pure
@@ -2205,6 +2221,7 @@ final class ChatSession: ObservableObject {
         // Reset agent-loop UI state.
         currentTodo = nil
         lastCompletionSummary = nil
+        lastCompletionWasBlocked = false
         promptQueue.drainAll()
         let oldSid = expectedTodoSessionId
         Task { await AgentTodoStore.shared.clear(for: oldSid) }
@@ -4337,6 +4354,7 @@ final class ChatSession: ObservableObject {
         // somehow still queued, dismiss it before sending so the new
         // turn doesn't race a stale overlay resolution.
         lastCompletionSummary = nil
+        lastCompletionWasBlocked = false
         if promptQueue.current != nil {
             promptQueue.drainAll()
         }
@@ -4626,6 +4644,7 @@ final class ChatSession: ObservableObject {
                         additionalToolNames: (cachedSession?.loadedToolNames ?? [])
                             .union(skillReferencedTools),
                         frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
+                        frozenToolSpecs: cachedSession?.initialToolSpecs,
                         frozenManifest: cachedSession?.frozenManifest,
                         frozenSoul: cachedSession?.frozenSoul,
                         trace: ttftTrace
@@ -4692,10 +4711,11 @@ final class ChatSession: ObservableObject {
                     // names already accumulated this session. Stamp the live
                     // fingerprint so the invalidation rule above can detect
                     // a flip on the next turn.
-                    if let sid = sessionId, cachedSession == nil {
+                    if let sid = sessionId {
                         await SessionToolStateStore.shared.setInitial(
                             sessionStateKey(sid),
                             alwaysLoadedNames: context.alwaysLoadedNames,
+                            toolSpecs: context.initialToolSpecs,
                             fingerprint: liveFingerprint,
                             manifest: context.enabledManifest,
                             soul: context.soul
@@ -4929,6 +4949,14 @@ final class ChatSession: ObservableObject {
                         // retries with a real summary.
                         if inv.toolName == "complete" {
                             if !ToolEnvelope.isError(resultText) {
+                                if let todo = await AgentTodoStore.shared.todo(
+                                    for: todoSessionIdForRun
+                                ) {
+                                    self.lastCompletionWasBlocked =
+                                        todo.doneCount < todo.totalCount
+                                } else {
+                                    self.lastCompletionWasBlocked = false
+                                }
                                 self.lastCompletionSummary =
                                     Self.parseCompleteSummary(from: inv.jsonArguments) ?? resultText
                                 // Drain any pending prompts so a stale
@@ -5702,14 +5730,20 @@ final class ChatSession: ObservableObject {
                         prepareTrackedTaskContinuation: {
                             // The driver observed a successful current-run Todo
                             // with structured pending items at an ordinary final.
-                            // Keep that real assistant turn in both UI and model
-                            // history, then give the bounded agent loop a fresh
-                            // assistant buffer. No prose classifier, reasoning
-                            // marker, sampler, or decode setting is involved.
+                            // Keep the real response visible, but exclude that
+                            // abandoned terminal attempt from model history
+                            // before giving the bounded loop a fresh assistant
+                            // buffer. Otherwise the next persisted tool call is
+                            // adjacent to an assistant final after the transient
+                            // Todo notice disappears. No prose classifier,
+                            // reasoning marker, sampler, or decode setting is
+                            // involved.
                             debugLog(
                                 "send: current-run todo still has unchecked work at model stop; "
-                                    + "continuing within the configured tool-attempt budget"
+                                    + "excluding abandoned final and continuing within the "
+                                    + "configured tool-attempt budget"
                             )
+                            Self.excludeAbandonedTrackedTaskResponse(assistantTurn)
                             let nextAssistantTurn = ChatTurn(role: .assistant, content: "")
                             self.turns.append(nextAssistantTurn)
                             assistantTurn = nextAssistantTurn
@@ -5847,7 +5881,26 @@ final class ChatSession: ObservableObject {
                             maxIterations: maxAttempts,
                             stopOnToolRejection: true,
                             dedupeNoticeEnabled: true,
-                            maxDataMovementSteps: min(16, maxAttempts)
+                            maxDataMovementSteps: min(16, maxAttempts),
+                            // Only the locally proven Gemma/Qwen-family rows
+                            // receive the third-action Todo precondition.
+                            // Bundle model_type is authoritative, so renamed
+                            // Ornith/Bonsai bundles do not depend on display
+                            // names. Remote and unrelated local families keep
+                            // their existing behavior.
+                            todoRequiredBeforeToolCallCount:
+                                AgentToolLoop.chatTodoPreconditionThreshold(
+                                    hasTodoTool: toolSpecs.contains {
+                                        $0.function.name == "todo"
+                                    },
+                                    // Catalog lookup remains authoritative
+                                    // even while picker rows are refreshing.
+                                    // It also covers externally registered
+                                    // bundles reconstructed from the persisted
+                                    // id -> path registry.
+                                    isLocalModel: selectedModelIsLocal,
+                                    modelType: selectedPickerItem?.modelType
+                                )
                         ),
                         state: taskState,
                         hooks: loopHooks
@@ -7618,8 +7671,10 @@ struct ChatView: View {
         if let summary = session.lastCompletionSummary {
             InlineCompleteBlock(
                 summary: summary,
+                isBlocked: session.lastCompletionWasBlocked,
                 onDismiss: { [weak session] in
                     session?.lastCompletionSummary = nil
+                    session?.lastCompletionWasBlocked = false
                 }
             )
             // Asymmetric transition: appear with a soft slide+scale so
@@ -8144,6 +8199,7 @@ extension ChatView {
                 // closes the window.
                 if session.lastCompletionSummary != nil {
                     session.lastCompletionSummary = nil
+                    session.lastCompletionWasBlocked = false
                     return nil
                 }
 

--- a/docs/RUNTIME_COMPATIBILITY_CAMPAIGN_2026_07_24.md
+++ b/docs/RUNTIME_COMPATIBILITY_CAMPAIGN_2026_07_24.md
@@ -1276,3 +1276,269 @@ Chat has no new global watchdog in this diff.
 The scoped post-tool completion regression is `VERIFIED-LIVE` for the rows
 above. Arbitrary lazy-capability discovery and the broader cache/family matrix
 remain `PARTIAL` and must not be represented as closed by this emergency PR.
+
+### 2026-07-26 current-main untracked multi-tool regression
+
+Status: `OPEN` before the next fixing round.
+
+The exact merged source `cc08980260584790484ad948aa7e064e92999a20` was
+rebuilt in Release configuration as
+`com.dinoki.osaurus.gemmaqwencompletionproof20260726` with exact vMLX pin
+`d0e1f1a9ef3115b505056b679d6b01d6861f8daa`. In the isolated live app,
+`dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK` received the three-organization
+Hugging Face recommendation prompt with Thinking visibly on.
+
+The visible lifecycle contained closed reasoning and three completed
+`web_search` cards (two successful, one structured failure). The fourth model
+step then emitted 2,275 reasoning characters and 258 normal content
+characters promising to inspect the repositories, followed by authoritative
+terminal reason `stop`. The UI treated that promise as final, removed Stop,
+and unlocked input at displayed TTFT 1.63 s, 42.7 tok/s, and 716 tokens. The
+persisted turn confirms `content_len=258`, `thinking_len=2275`, and
+`terminal_stop_reason=stop`; it was neither an empty response, an output-token
+limit, an unclosed reasoning envelope, a malformed tool call, nor a dropped
+content delta.
+
+The current owning-layer contradiction is structural: the loop can continue
+ordinary progress prose only after a successful current-run Todo, while the
+agent-loop guidance tells a model to skip Todo for a “direct question.” This
+prompt is phrased as a direct question but requires multiple source-retrieval
+steps, so Gemma performed multi-tool work without arming the only structured
+completion contract. No phrase matcher, forced reasoning marker, sampler/EOS
+override, parser masking, or cache change is acceptable as a fix. The next
+round must make the multi-step tracking contract unambiguous, then re-run this
+exact prompt plus Ornith/Qwen controls in a fresh isolated Release app.
+
+### 2026-07-26 candidate structural contract
+
+Status: **SOURCE-PASS / FINAL RELEASE-UI PROOF OPEN**.
+
+A prompt-only correction was not sufficient. One fresh Release-app attempt
+completed, but an identical new-chat repeat reproduced the current-main
+failure after multiple ordinary tool actions. The candidate therefore makes
+the existing Todo state machine an explicit precondition before the third
+ordinary action, but only for local bundles whose authoritative
+`config.json:model_type` contains `gemma` or `qwen`. This includes renamed
+Qwen-backbone bundles such as Ornith and Bonsai without matching their display
+names. It excludes remote models, GLM, Laguna, LFM, DeepSeek, missing metadata,
+and every headless/API policy unless that surface explicitly opts in later.
+
+The rejected third action does not execute. It returns one structured,
+retryable `task_tracking_required` envelope telling the model to create a
+current-run Todo and retry the exact call, or to answer completely if no more
+tools are needed. Control tools do not consume the action count; stale session
+Todos and malformed Todo arguments cannot unlock it. The serial and batch
+paths share this contract, and ordinary tool rejection semantics remain
+unchanged. Focused tests cover the third-action boundary, successful retry,
+same-batch Todo, stale-Todo rejection, headless preservation, and the exact
+positive/negative bundle-type scope.
+
+The first candidate live round found a second independent instruction defect:
+the successful checked-Todo path told models to emit a normal final answer and
+also call `complete` “in the same message.” Gemma rendered literal
+`complete(summary: ...)` protocol text in visible content. The candidate now
+reserves structured `complete` for honestly blocked tracked work. A successful
+checked Todo ends with a normal answer and no `complete` call; both prompt and
+tool schema explicitly prohibit printing tool-call syntax. This is an owning
+schema correction, not a content scrubber or parser repair.
+
+The final isolated Release binary must still prove, for both Gemma and Ornith:
+closed reasoning, the third-action precondition, Todo creation and retry,
+finished tool cards, a coherent protocol-free final, Stop disappearance,
+input unlock, a completing follow-up, and compatible disk-L2 partial restore.
+No merge or `VERIFIED-LIVE` classification is allowed before those rows.
+
+### 2026-07-26 external-bundle and schema/cache live finding
+
+Status: **SOURCE FIX / REBUILT RELEASE-UI PROOF OPEN**.
+
+The first Release candidate was launched as the isolated app
+`com.dinoki.osaurus.gemmaqwenschemafreezeproof20260726` against vMLX
+`d0e1f1a9ef3115b505056b679d6b01d6861f8daa`. Through Settings, the custom
+model folder was set to `/Users/eric/models`; Server → Cache visibly showed
+prefix and disk L2 on, paged RAM off, and the engine-selected codec. The exact
+external bundle
+`/Users/eric/models/dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK` was selected
+with Thinking on.
+
+The long Hugging Face research turn completed several closed reasoning/tool
+cycles, recovered from structured search and capability-load failures, emitted
+a qualified final, removed Stop, and unlocked input. The UI reported TTFT
+2.07 s, 87.3 tok/s, and 964 generated tokens. However, the third-action Todo
+precondition did not fire. Source trace found the exact metadata loss:
+`ExternalModelLocator.models()` reconstructed persisted external entries with
+their id/path/provenance but omitted the authoritative bundle `model_type`.
+The bundle itself declares `gemma4`; the picker therefore handed the chat
+policy `nil` and selected threshold zero. The candidate now rehydrates
+`model_type` from the registered bundle's `config.json` and uses the catalog's
+local-model resolution rather than requiring a momentarily populated picker
+row. A focused test invalidates the in-memory registry before asserting the
+rehydrated `gemma4` value, exercising the app-relaunch path.
+
+This live round also distinguishes a valid cache invalidation from the
+reported persistent cold-prefill defect. Explicitly loading
+`search_and_extract` changed the callable schema from eight to nine tools;
+the token LCP with the previous request fell to 996 and the immediately
+following turn correctly missed disk because the configured prompt inventory
+had changed. After that nine-tool schema stabilized, the next visible
+follow-up restored 7,267 of 7,295 prompt tokens from disk with paged RAM still
+off, prefilling only 28. It closed its reasoning, answered “Three plus three
+is six,” removed Stop, and unlocked input at UI TTFT 0.49 s (41.3 tok/s,
+81 generated tokens). This is current-source evidence for same-session Gemma
+rotating-cache disk reuse; new chat, app restart, the patched Todo contract,
+and the Ornith hybrid row remain required before release classification.
+
+### 2026-07-26 Todo continuation history and disk-L2 A/B
+
+Status: **VERIFIED-LIVE FOR THE REPRODUCED ORNITH/GEMMA TODO CONTINUATION ROW**.
+
+The stale Release candidate
+`com.dinoki.osaurus.gemmaqwentodoproof20260726` reproduced a narrower
+continuation defect with the exact Ornith 1.0 35B MXFP8 bundle. With prefix
+and disk L2 on and paged RAM off, session
+`DCB5997B-8BCE-4135-961B-167F57BF0EA2` rejected an unchanged duplicate Todo,
+visibly reached Todo 1/1, and then emitted unrelated answer text from the
+preceding user turn. Its persisted sequence was user -> assistant Todo call ->
+tool result -> assistant duplicate Todo call -> structured
+`todo_no_progress` result -> assistant premature final -> assistant checked
+Todo call -> tool result -> stale final. The live trace contained Ornith disk
+restores with all 60 hybrid SSM companion states.
+
+The same stale binary was changed through Settings to disk L2 off while
+leaving prefix on and paged RAM off. A fresh new-chat repetition in session
+`1E7B9BDD-47A8-45BC-8748-5092D96D73E3` reached Todo 1/1 and the correct final,
+`Task complete — the duplicate todo call was rejected as expected.`, at TTFT
+3.33 s, 62.7 tok/s, and 124 generated tokens. Stop disappeared and the
+composer unlocked. Cache tracing reported misses at every tier and no disk
+stores. This A/B is diagnostic only: turning disk off is not a fix and the
+successful row still persisted an invalid adjacent-assistant history before
+the checked Todo call.
+
+Source trace found the owning contradiction in the chat surface. When
+`AgentToolLoop` rejected a premature final because a current-run Todo remained
+pending, `prepareTrackedTaskContinuation` appended a fresh assistant turn but
+left the abandoned final model-visible. After its transient notice was
+removed, Qwen/Ornith received assistant(final) -> assistant(tool call) -> tool
+history. The bundle template's `last_query_index` handling makes that history
+structurally different from the intended tool-result continuation; restoring
+hybrid state from the earlier valid boundary exposed the stale continuation.
+
+The candidate keeps the premature response visible in chat but marks that
+turn `modelContextExcluded` before appending the fresh assistant buffer. The
+preceding tool result remains the model-visible continuation anchor. This does
+not inject reasoning tags, alter EOS, change sampling, disable cache, rewrite
+model content, or apply a family-wide output guard. Tests now require the
+model-visible continuation roles to end user -> assistant(tool call) -> tool.
+
+The checkout was fast-forwarded without overlap to Osaurus main
+`c820eb1d7c6c0ff183198c236b4efb5657580196` with exact vMLX pin
+`d0e1f1a9ef3115b505056b679d6b01d6861f8daa`. The focused current-head result
+`/private/tmp/osaurus-gemma-qwen-schema-freeze-release-derived-20260726/Logs/Test/Test-OsaurusCoreTests-2026.07.26_17-41-48--0700.xcresult`
+contains 42 passes, zero failures, and zero skips. A separate serial stress
+result at
+`/private/tmp/osaurus-gemma-qwen-schema-freeze-release-derived-20260726/Logs/Test/Test-OsaurusCoreTests-2026.07.26_17-37-19--0700.xcresult`
+contains 95 successful runs of the 19 stop/session tests. The stress round
+also exposed and corrected a test-only defect: raw `JSONEncoder` bytes were
+compared without sorted keys, so semantically identical message arrays could
+fail on object-key order. Production encoding and requests were not changed.
+
+The exact current-head source was then rebuilt in Release, copied to
+`/private/tmp/osaurus-gemma-qwen-todo-history-fix-proof-20260726-1749.app`,
+ad-hoc signed under isolated bundle id
+`com.dinoki.osaurus.gemmaqwentodohistoryfixproof20260726`, and launched with a
+fresh isolated test root. Its executable SHA-256 is
+`200ace6064e0d3d930f228aec174ef6f43b6db258c77ea28bf20b6f4e070d1d7`.
+Through the real Settings UI, the external model root was set to
+`/Users/eric/models` and rescanned, prefix and disk L2 were enabled, paged RAM
+was disabled, the on-the-fly cache codec was explicitly set to `None`, and
+SSM re-derivation remained enabled. The UI confirmed that the saved runtime
+policy unloaded the resident model for reload; no TurboQuant cache mode was
+enabled.
+
+Two fresh-chat Ornith 1.0 35B MXFP8 trials then ran the exact duplicate-Todo
+contract with Thinking visibly on. Both rejected the unchanged call as
+`todo_no_progress`, reached Todo 1/1, emitted a coherent short final, removed
+Stop, unlocked the composer, and completed a subsequent arithmetic turn.
+Trial one finalized at 0.62-second TTFT and 65.3 tok/s; its follow-up finalized
+at 0.80-second TTFT and 62.1 tok/s. Trial two finalized at 0.41-second TTFT and
+64.7 tok/s; its follow-up finalized at 0.83-second TTFT and 48.7 tok/s. The
+Thinking UI opened and closed separately from content, and no protocol debris
+or inline `<think>` text appeared.
+
+The corresponding persisted sessions are
+`35ABAFFE-AA0D-4758-9327-ADCA812052EB` and
+`F477E925-B702-4E61-A534-FCAA04FB483E`. In the first, both premature assistant
+finals at sequence 5 and 6 have `model_context_excluded=1`; in the second, the
+single premature final at sequence 5 has `model_context_excluded=1`. The next
+model-visible turn in each case is the checked Todo call, followed by its tool
+result and the terminal final. The UI intentionally preserves the abandoned
+text for auditability, but it cannot contaminate a later model request.
+
+Disk L2 remained active with paged RAM disabled throughout both trials. The
+second new-chat request restored 3,226 of 3,231 prompt tokens from disk, and
+the subsequent tool continuations restored the best compatible 3,336, 3,516,
+3,501, and 3,629-token boundaries with only five tokens remaining at each
+matching boundary. Every restore included all 60 Ornith SSM companion states.
+Paged-store telemetry reported zero effective KV layers, zero blocks, and no
+RAM payload, so these were disk-backed hybrid restores rather than hidden
+paged-RAM hits.
+
+The same binary and cache policy then loaded
+`/Users/eric/models/dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK`, with Thinking
+visibly enabled, in a fresh chat. Gemma called Todo pending, received the
+structured duplicate rejection, called Todo complete, reached Todo 1/1, and
+finalized `The duplicate call was rejected.` at 0.42-second TTFT and
+80.2 tok/s. A direct follow-up finalized `Two plus two is four.` at
+0.59-second TTFT and 77.1 tok/s. Stop disappeared and input unlocked after
+both turns. Session `6F2A5AC5-6403-4A90-A164-9697D76270C9` contains the exact
+user -> assistant(tool) -> tool sequence for all three calls with no abandoned
+final. Gemma's disk restores carried the required rotating-SWA companion state:
+the new-chat path restored 1,107 prompt tokens with four remaining, followed by
+valid partial boundaries of 1,111, 1,201, 1,323, and 1,605 tokens while paged
+RAM remained empty.
+
+This verifies the reproduced malformed-history root cause and its current-head
+fix for the tested Ornith hybrid-Qwen and Gemma rotating-SWA rows. It does not
+claim family-wide compatibility for every Qwen/Gemma bundle, parser,
+quantization, modality, cache codec, or task; those broader matrix rows remain
+separately open below.
+
+## Follow-on live issue ledger after the emergency merge
+
+These are deliberately not bundled into the Gemma/Qwen completion patch. Each
+remains open until its owning source and fresh Release-app UI lifecycle are
+proved.
+
+1. **PDF content-based batch rename — OPEN.** Reproduce Ornith 9B on a copied
+   folder: inspect first pages, handle text PDFs and OCR fallback, derive exact
+   author/title names, perform reversible rename/move into the configured
+   folder only, continue after a missing `pdftotext`/OCR command, and report
+   every per-file result. Prove repeated files, name collisions, Unicode,
+   encrypted/image-only PDFs, cancellation, and a follow-up turn. Evaluate
+   same-model bounded subagent batching only after the single-file contract is
+   correct.
+2. **Todo terminal UI — OPEN.** A pinned checklist must not remain “in
+   progress” after final answer, Stop, cancellation, failure, session change,
+   or app restart. Stale Todos must not arm later turns. Prove normal success,
+   blocked closure, malformed Todo, cancellation, and chat deletion.
+3. **Computer Use / AppleScript exact-scope handoff — OPEN.** Re-run the 16B
+   rows for open-only, new blank document, replace existing text once, no
+   unsolicited save, no placeholder text, wrong-dialog recovery, malformed
+   `verb`, repeated-action detection, success recognition, and terminal UI.
+   The orchestrator must pass only the user's literal requested content and
+   current task; the worker must not inherit stale job history.
+4. **Batched delegation and residency — PARTIAL.** Existing same-model
+   `handoff:false` evidence remains current, but PDF fan-out still needs
+   bounded same-local batching, failure isolation, cancellation, RAM
+   accounting once per resident model, and cache reuse per child. Different
+   local parent/child work must unload and restore once per grouped handoff;
+   mixed local/remote jobs must honor the saved allow-list and ordered result
+   envelope. Generation defaults, Thinking, max-output limits, context budget,
+   and RAM-safety settings must propagate to every child.
+5. **Context and cache truthfulness — PARTIAL.** Continue separating model
+   maximum context, 85% conversation budget, bundle maximum output, active KV
+   retention, paged-RAM capacity, and disk-L2 quota. Prove paged RAM off plus
+   disk partial-prefix restore across new chats/reloads/restarts, then paged
+   RAM eviction followed by disk restore. UI warm/prefill counters and TTFT/
+   token-rate telemetry must agree with exact restored and remaining token
+   counts; no arbitrary suffix or unrelated block concatenation is allowed.


### PR DESCRIPTION
## Summary

Fixes the reproduced Gemma/Qwen-family tracked-tool failure where a model could emit a premature answer while Todo work remained, then continue from an invalid adjacent-assistant history and later stop, repeat stale output, or lose useful disk-prefix reuse.

This PR also freezes the exact first-compose baseline tool schemas for each session and rehydrates external bundles' authoritative `model_type`, so asynchronous schema discovery and custom-folder model reconstruction do not silently change prompt identity or family routing.

## Root cause and implementation

- A premature assistant final remained visible **and model-visible** before a later assistant tool call. Once the transient continuation notice was removed, Qwen/Ornith saw `assistant(final) -> assistant(tool_call)` instead of continuing from the preceding tool result.
- Chat now preserves that abandoned text for UI auditability but marks it `modelContextExcluded` before the next generation. The preceding tool result stays the model-visible continuation anchor.
- The Todo contract now rejects exact semantic checklist replays as retryable `todo_no_progress`, requires a fresh checklist after later actions before blocked closure, and limits the structural third-action precondition to proven local Gemma/Qwen bundle types. Headless and unrelated families retain existing behavior.
- Session prompt state now freezes baseline tool specifications, not names alone. Explicit `capabilities_load` additions remain allowed; asynchronous mutations to an already-visible baseline schema no longer rewrite the cacheable prompt.
- External custom-folder entries now re-read `model_type` from the registered bundle config, restoring correct Gemma/Qwen routing after relaunch.
- Todo completion/blocked UI and tool envelopes now reflect the actual terminal state.

No reasoning tags, EOS tokens, sampler parameters, repetition penalties, output caps, prompt coercion, cache disablement, or family-wide decode guards are injected.

## Current-base validation

- Base: `c820eb1d7c6c0ff183198c236b4efb5657580196` (current `osaurus/main` when pushed)
- vMLX pin: `d0e1f1a9ef3115b505056b679d6b01d6861f8daa`
- Focused Xcode result: 42 passed, 0 failed, 0 skipped
  - `/private/tmp/osaurus-gemma-qwen-schema-freeze-release-derived-20260726/Logs/Test/Test-OsaurusCoreTests-2026.07.26_17-41-48--0700.xcresult`
- Stop/session stress: 95/95 successful runs
  - `/private/tmp/osaurus-gemma-qwen-schema-freeze-release-derived-20260726/Logs/Test/Test-OsaurusCoreTests-2026.07.26_17-37-19--0700.xcresult`
- Release app executable SHA-256: `200ace6064e0d3d930f228aec174ef6f43b6db258c77ea28bf20b6f4e070d1d7`
- `git diff --check`: clean

## Live Release-app proof

The exact source was built in Release, ad-hoc signed under isolated bundle id `com.dinoki.osaurus.gemmaqwentodohistoryfixproof20260726`, and launched with a fresh test root. Through the real Settings UI:

- external model root `/Users/eric/models` was scanned;
- prefix cache and disk L2 were enabled;
- paged RAM cache was disabled;
- cache codec was explicitly set to `None` (TurboQuant off);
- SSM re-derivation remained enabled.

### Ornith 1.0 35B MXFP8

Two fresh-chat duplicate-Todo trials with Thinking visibly on both reached Todo 1/1, returned `todo_no_progress`, finalized coherently, removed Stop, unlocked input, and completed a follow-up turn.

- Trial 1: 0.62 s TTFT, 65.3 tok/s; follow-up 0.80 s, 62.1 tok/s
- Trial 2: 0.41 s TTFT, 64.7 tok/s; follow-up 0.83 s, 48.7 tok/s
- SQLite sessions: `35ABAFFE-AA0D-4758-9327-ADCA812052EB`, `F477E925-B702-4E61-A534-FCAA04FB483E`
- Every premature final is persisted with `model_context_excluded=1`; the checked Todo call remains model-visible after the preceding tool result.
- Cross-chat disk restore: 3,226 of 3,231 prompt tokens; subsequent matching boundaries restored with five tokens remaining and all 60 SSM states.
- Paged telemetry remained zero effective KV layers / zero blocks / no RAM payload.

### Gemma 4 26B A4B JANG_4M CRACK

The same binary and cache policy loaded `/Users/eric/models/dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK` with Thinking visibly on.

- Duplicate Todo rejected, Todo 1/1, final at 0.42 s TTFT and 80.2 tok/s
- Follow-up at 0.59 s TTFT and 77.1 tok/s
- SQLite session: `6F2A5AC5-6403-4A90-A164-9697D76270C9`
- Exact user -> assistant(tool) -> tool history for all three Todo calls; no abandoned final
- Disk restore included rotating-SWA companion state while paged RAM remained empty

## Scope boundary

This proves the reproduced tracked-task/history defect for these exact Ornith and Gemma bundles. It does not claim every Qwen/Gemma quant, parser, modality, cache codec, or task is now family-wide verified. AppleScript/Computer Use, batching/delegation, broader parser/media rows, and the remaining family matrix are documented follow-up work and are not included here.
