### PR TITLE
inject current date and timezone into the latest user turn

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2965,6 +2965,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             if let recorded = SystemPromptComposer.applyFrozenMemoryPrefixes(
                 memorySection: composed.memorySection,
                 frozen: frozen,
+                timeContext: SystemPromptTemplates.timeContext(now: Date(), timeZone: .current),
                 into: &enriched.messages
             ) {
                 await SessionToolStateStore.shared.recordUserPrefix(

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2671,7 +2671,8 @@ public struct SystemPromptComposer: Sendable {
     static func composeInjectedUserPrefix(
         memorySection: String?,
         screenContext: String?,
-        automationContext: String? = nil
+        automationContext: String? = nil,
+        timeContext: String? = nil
     ) -> String? {
         var prefix = ""
         if let memorySection {
@@ -2684,6 +2685,10 @@ public struct SystemPromptComposer: Sendable {
         }
         if let automationContext {
             let trimmed = automationContext.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { prefix = "\(trimmed)\n\n" + prefix }
+        }
+        if let timeContext {
+            let trimmed = timeContext.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty { prefix = "\(trimmed)\n\n" + prefix }
         }
         return prefix.isEmpty ? nil : prefix
@@ -2727,6 +2732,7 @@ public struct SystemPromptComposer: Sendable {
     static func applyFrozenMemoryPrefixes(
         memorySection: String?,
         frozen: [String: String],
+        timeContext: String? = nil,
         into messages: inout [ChatMessage]
     ) -> (key: String, prefix: String)? {
         guard let lastUserIdx = messages.lastIndex(where: { $0.role == "user" }) else { return nil }
@@ -2758,7 +2764,8 @@ public struct SystemPromptComposer: Sendable {
         guard messages[lastUserIdx].contentParts == nil,
             let prefix = composeInjectedUserPrefix(
                 memorySection: memorySection,
-                screenContext: nil
+                screenContext: nil,
+                timeContext: timeContext
             )
         else { return nil }
         prepend(prefix, at: lastUserIdx)

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -93,6 +93,32 @@ public enum SystemPromptTemplates {
         - `share_artifact(path | content+filename)` — the only way the user sees a file/image; it MUST exist first. Sandbox: save under home, not `/tmp`.
         """
 
+    // MARK: - Time Context
+
+    /// Per-turn current date/time block injected into the latest user
+    /// message alongside memory — never into the system prompt, which must
+    /// stay byte-stable across turns for paged KV-cache reuse (see
+    /// `injectMemoryPrefix`). Without it, small local models burn tool
+    /// turns discovering what "today" means — or worse, hallucinate a date
+    /// — before they can fill absolute date-time tool arguments like a
+    /// reminder's `dueDate` (live-confirmed 2026-07-27: Ornith-9B passed
+    /// `2025-05-15` for "today").
+    public static func timeContext(now: Date, timeZone: TimeZone) -> String {
+        let readable = DateFormatter()
+        readable.locale = Locale(identifier: "en_US_POSIX")
+        readable.timeZone = timeZone
+        readable.dateFormat = "EEEE, MMMM d, yyyy 'at' h:mm a"
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+        iso.timeZone = timeZone
+        return """
+            [Current Time]
+            \(readable.string(from: now)) — \(iso.string(from: now)) (\(timeZone.identifier))
+            Resolve relative dates ("today", "tomorrow at 8 AM") against this, and pass absolute date-times with this UTC offset in tool arguments.
+            [/Current Time]
+            """
+    }
+
     // MARK: - Grounding
 
     /// Anti-fabrication directive injected whenever tools are present

--- a/Packages/OsaurusCore/Tests/Chat/TimeContextTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TimeContextTests.swift
@@ -1,0 +1,55 @@
+//
+//  TimeContextTests.swift
+//  osaurusTests
+//
+//  Coverage for the per-turn [Current Time] block: deterministic rendering
+//  for a fixed instant/zone, and its placement at the head of the injected
+//  user prefix ahead of automation/screen/memory blocks.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Time context injection")
+struct TimeContextTests {
+
+    private let fixedInstant = Date(timeIntervalSince1970: 1_785_123_932)  // 2026-07-27 03:45:32 UTC
+
+    @Test func rendersReadableAndISOInTargetZone() throws {
+        let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
+        let block = SystemPromptTemplates.timeContext(now: fixedInstant, timeZone: zone)
+        #expect(block.hasPrefix("[Current Time]"))
+        #expect(block.hasSuffix("[/Current Time]"))
+        #expect(block.contains("Monday, July 27, 2026 at 9:15 AM"))
+        #expect(block.contains("2026-07-27T09:15:32+05:30"))
+        #expect(block.contains("Asia/Kolkata"))
+    }
+
+    @Test func prefixPlacesTimeContextFirst() throws {
+        let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
+        let time = SystemPromptTemplates.timeContext(now: fixedInstant, timeZone: zone)
+        let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: "a fact",
+            screenContext: "[Screen Context]\nDoing: In Safari\n[/Screen Context]",
+            timeContext: time
+        )
+        let rendered = try #require(prefix)
+        #expect(rendered.hasPrefix("[Current Time]"))
+        let timeRange = try #require(rendered.range(of: "[/Current Time]"))
+        let memoryRange = try #require(rendered.range(of: "[Memory]"))
+        #expect(timeRange.upperBound <= memoryRange.lowerBound)
+    }
+
+    @Test func timeContextAloneProducesPrefix() throws {
+        let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
+        let time = SystemPromptTemplates.timeContext(now: fixedInstant, timeZone: zone)
+        let prefix = SystemPromptComposer.composeInjectedUserPrefix(
+            memorySection: nil,
+            screenContext: nil,
+            timeContext: time
+        )
+        #expect(prefix?.hasPrefix("[Current Time]") == true)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4201,7 +4201,8 @@ final class ChatSession: ObservableObject {
             let prefix = SystemPromptComposer.composeInjectedUserPrefix(
                 memorySection: memorySection,
                 screenContext: screenContext,
-                automationContext: automationContext
+                automationContext: automationContext,
+                timeContext: SystemPromptTemplates.timeContext(now: Date(), timeZone: .current)
             )
         else { return }
         turn.injectedContextPrefix = prefix


### PR DESCRIPTION
## Summary

addresses #2160 

  - local models had no way to resolve relative times like "today at 8 AM" and either burned tool turns calling get_current_time or hallucinated a wrong date (observed: Ornith-9B passing 2025-05-15 for "today"), surfaced while debugging osaurus-ai/osaurus-reminders notifications (#2160)
  - adds a [Current Time] block with readable date, ISO 8601 with explicit UTC offset, and timezone identifier
  - injected into the latest user turn alongside memory and screen context, not the system prompt, so the system prompt stays byte stable and the paged KV cache keeps reusing the conversation prefix
  - frozen onto each user turn at send time like the existing injected context, so sent turns replay byte identically
  - wired into both the chat send path and the session-tracked HTTP path
  - adds TimeContextTests covering deterministic rendering for a fixed instant and prefix ordering

## Verification

  - live test: a "remind me at 9:25 AM" prompt now produces a create_reminder call with the correct absolute dueDate and offset in one shot, and the reminder notification fired at the scheduled time
  - OSAURUS_PREFILL_DEBUG trace over a multi-turn tool session: static prefix hash byte stable across all composes, every agent loop step prefix-extends the previous prompt (lcp equal to prev at each step), frozen time blocks replay identically across turns
  - the only large re-prefill observed was the pre-existing one-time tool schema growth after a mid-session capabilities_load, unrelated to this change
  - eval suites on this branch: CacheProof, ScreenContext, PromptSurface, and PrefixHash all pass
  - Memory suite shows 3 failing rows (identity-override-applies, multi-fact-synthesis, pinned-beats-conflicting-guess) that fail bit-identically on main with Ornith-9B-4bit, so they are a pre-existing model limitation, not introduced here
  - per-turn cost is roughly 60 tokens of new content on the latest user turn, no cached prefix invalidation

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
