### PR TITLE
Stop completed agent runs from reopening on stale todos

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/AgentTodoStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/AgentTodoStore.swift
@@ -40,6 +40,28 @@ public actor AgentTodoStore {
         return todo
     }
 
+    /// Store a checklist only when its parsed tasks or checkbox states changed.
+    ///
+    /// Models sometimes repeat the same `todo` call after a successful action.
+    /// Treating that replay as a fresh update churns the UI timestamp and can
+    /// convince the model that rewriting the checklist is forward progress.
+    /// Keep the comparison actor-isolated so concurrent calls for one session
+    /// cannot both report a change.
+    public func setTodoIfChanged(
+        markdown: String,
+        for sessionId: String
+    ) -> (todo: AgentTodo, changed: Bool) {
+        let candidate = AgentTodo.parse(markdown)
+        if let existing = todosBySession[sessionId],
+            Self.hasSameChecklist(existing, candidate)
+        {
+            return (existing, false)
+        }
+        todosBySession[sessionId] = candidate
+        Self.postChanged(sessionId: sessionId)
+        return (candidate, true)
+    }
+
     /// Drop the todo for `sessionId` (called when a chat is reset).
     public func clear(for sessionId: String) {
         guard todosBySession.removeValue(forKey: sessionId) != nil else { return }
@@ -52,5 +74,12 @@ public actor AgentTodoStore {
             object: nil,
             userInfo: ["sessionId": sessionId]
         )
+    }
+
+    private static func hasSameChecklist(_ lhs: AgentTodo, _ rhs: AgentTodo) -> Bool {
+        guard lhs.items.count == rhs.items.count else { return false }
+        return zip(lhs.items, rhs.items).allSatisfy {
+            $0.text == $1.text && $0.isDone == $1.isDone
+        }
     }
 }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1270,21 +1270,17 @@ enum AgentToolLoop {
     static let todoProgressUpdateRequiredReason = "todo_progress_update_required"
     static let todoNoProgressReason = "todo_no_progress"
 
-    /// The premature post-tool stop has current live proof only for local
-    /// Gemma and Qwen-backbone bundles (including Ornith/Bonsai). Keep the
-    /// structural Todo precondition off for remote providers and unrelated
-    /// local families until those rows independently prove they need it.
+    /// Todo is model-authored progress metadata, not an execution precondition.
+    /// Rejecting the Nth ordinary action until a checklist exists turned
+    /// recoverable discovery mistakes into mandatory Todo loops and prevented
+    /// otherwise valid tools from running. Keep the compatibility helper for
+    /// callers compiled against this policy surface, but never force tracking.
     static func chatTodoPreconditionThreshold(
-        hasTodoTool: Bool,
-        isLocalModel: Bool,
-        modelType: String?
+        hasTodoTool _: Bool,
+        isLocalModel _: Bool,
+        modelType _: String?
     ) -> Int {
-        guard hasTodoTool, isLocalModel else { return 0 }
-        guard let normalized = modelType?.lowercased()
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !normalized.isEmpty
-        else { return 0 }
-        return normalized.contains("gemma") || normalized.contains("qwen") ? 3 : 0
+        0
     }
 
     static func isTaskTrackingAction(toolName: String) -> Bool {
@@ -1593,11 +1589,6 @@ enum AgentToolLoop {
         // transient missing lookup must not turn known unchecked work into a
         // clean final response.
         var lastSuccessfulCurrentRunTodoProgress: AgentTodoProgressSnapshot?
-        // Semantic identity of the latest Todo that actually succeeded during
-        // THIS run. Never seed this from the session store: the same checklist
-        // is valid as the first update of a later user turn, but not as
-        // repeated pseudo-progress within one agent loop.
-        var lastSuccessfulCurrentRunTodoSemanticSnapshot: AgentTodoSemanticSnapshot?
         // Last iteration that carried a `todo` call (0 = run start), for
         // the staleness check below.
         var lastTodoIteration = 0
@@ -1607,74 +1598,32 @@ enum AgentToolLoop {
         var dataMovementStepsUsed = 0
         var announcedDataMovementRelief = false
         var completedToolWork = false
-        // Counts attempted ordinary action calls in this logical run. Failed,
-        // rejected, and deduped calls still count because the threshold
-        // describes task complexity, not successful side effects. Control
-        // tools (`todo` / `complete` / `clarify`) never count.
-        var currentRunActionToolCallCount = 0
-        // Action-call count captured at the latest successful current-run Todo
-        // update. If more actions run while items remain pending, `complete`
-        // must not terminate until the model refreshes the checklist. Keeping
-        // this structural (rather than inferring progress from prose/tool
-        // names) preserves family and task neutrality.
-        var lastSuccessfulCurrentRunTodoActionToolCallCount: Int?
-
         func taskTrackingPreconditionResult(
-            for invocation: ServiceToolInvocation,
-            batchContainsParseableTodo: Bool
+            for _: ServiceToolInvocation,
+            batchContainsParseableTodo _: Bool
         ) -> String? {
-            guard Self.isTaskTrackingAction(toolName: invocation.toolName) else {
-                return nil
-            }
-            currentRunActionToolCallCount += 1
-            let threshold = policy.todoRequiredBeforeToolCallCount
-            guard threshold > 0,
-                !hasSuccessfulCurrentRunTodo,
-                !batchContainsParseableTodo,
-                currentRunActionToolCallCount >= threshold
-            else { return nil }
-            return Self.taskTrackingRequiredResult(
-                toolName: invocation.toolName,
-                threshold: threshold
-            )
+            // Todo is advisory UI state, not a runtime lock.
+            nil
         }
 
         func todoProgressUpdatePreconditionResult(
-            for invocation: ServiceToolInvocation,
-            batchContainsPrecedingParseableTodo: Bool
+            for _: ServiceToolInvocation,
+            batchContainsPrecedingParseableTodo _: Bool
         ) -> String? {
-            guard invocation.toolName == "complete",
-                hasSuccessfulCurrentRunTodo,
-                let progress = lastSuccessfulCurrentRunTodoProgress,
-                progress.pending > 0,
-                let actionCountAtTodo = lastSuccessfulCurrentRunTodoActionToolCallCount,
-                currentRunActionToolCallCount > actionCountAtTodo,
-                !batchContainsPrecedingParseableTodo
-            else { return nil }
-            return Self.todoProgressUpdateRequiredResult(
-                toolName: invocation.toolName,
-                pending: progress.pending
-            )
+            // A stale checklist must remain visible and honest, but it must not
+            // veto the model's explicit completion. Models frequently finish
+            // real work without rewriting Todo; rejecting completion here
+            // causes repeated summaries and unrelated follow-up actions.
+            nil
         }
 
         func todoNoProgressPreconditionResult(
-            for invocation: ServiceToolInvocation
+            for _: ServiceToolInvocation
         ) -> String? {
-            guard let candidate = Self.todoSemanticSnapshot(from: invocation),
-                let latest = lastSuccessfulCurrentRunTodoSemanticSnapshot,
-                candidate == latest
-            else { return nil }
-            // Although this is not progress and must not churn the store, the
-            // model did re-affirm the current structured state after any
-            // intervening actions. Let a subsequent `complete` close the task
-            // honestly as blocked; otherwise a failed action with no checkbox
-            // transition would create an impossible contract (unchanged Todo
-            // rejected, but blocked completion forever demanding an update).
-            lastSuccessfulCurrentRunTodoActionToolCallCount =
-                currentRunActionToolCallCount
-            return Self.todoNoProgressResult(
-                pending: lastSuccessfulCurrentRunTodoProgress?.pending ?? 0
-            )
+            // Re-sending an unchanged checklist is harmless model behavior.
+            // Turning it into a retryable tool error made Qwen/Ornith repeat
+            // Todo forever instead of returning to the actual pending action.
+            nil
         }
 
         while iteration < policy.maxIterations {
@@ -1716,48 +1665,9 @@ enum AgentToolLoop {
             }
             switch step {
             case .finalResponse:
-                if hasSuccessfulCurrentRunTodo,
-                    let prepareContinuation = hooks.prepareTrackedTaskContinuation,
-                    let todoProgressSnapshot = hooks.todoProgressSnapshot
-                {
-                    let progress = await todoProgressSnapshot()
-                        ?? lastSuccessfulCurrentRunTodoProgress
-                    // The store lookup suspends across an actor boundary. Stop
-                    // must win if it lands during that await; never create a
-                    // fresh assistant turn after the user cancelled.
-                    if await hooks.isCancelled() {
-                        return RunResult(exit: .cancelled, iterations: iteration - 1)
-                    }
-                    if let progress, progress.pending > 0 {
-                        // Preserve the model's real response in the visible
-                        // transcript but exclude this abandoned terminal
-                        // attempt from model history, then start the next
-                        // attempt in a fresh assistant turn. This prevents an
-                        // adjacent assistant(final) -> assistant(tool_call)
-                        // history after the transient Todo notice disappears.
-                        // The boundary also runs at the hard cap so Chat's
-                        // existing tool-free finalizer does not concatenate its
-                        // wrap-up onto progress prose.
-                        await prepareContinuation()
-                        if await hooks.isCancelled() {
-                            return RunResult(exit: .cancelled, iterations: iteration)
-                        }
-                        if iteration < policy.maxIterations {
-                            pendingTodoNotice = Self.todoPendingFinalNotice(
-                                pending: progress.pending
-                            )
-                            continue
-                        }
-                        return RunResult(
-                            exit: .iterationCapReached,
-                            iterations: iteration,
-                            unfinishedTodoCount: progress.pending
-                        )
-                    }
-                }
-                // A direct answer, a stale pre-run Todo, or a completed
-                // current-run Todo remains authoritative. Explicit successful
-                // `complete` / `clarify` calls end earlier through endRun.
+                // An ordinary model final is authoritative. Todo is visible
+                // progress metadata; it must never override EOS/stop and make
+                // the driver regenerate the same answer until the step cap.
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .retryWithoutCharge:
@@ -1849,38 +1759,7 @@ enum AgentToolLoop {
                     ),
                     let emitFinalText = hooks.emitFallbackText
                 {
-                    var pendingTrackedTodoCount: Int?
-                    if hasSuccessfulCurrentRunTodo,
-                        let todoProgressSnapshot = hooks.todoProgressSnapshot
-                    {
-                        let progress = await todoProgressSnapshot()
-                            ?? lastSuccessfulCurrentRunTodoProgress
-                        if await hooks.isCancelled() {
-                            return RunResult(exit: .cancelled, iterations: iteration - 1)
-                        }
-                        if let progress, progress.pending > 0 {
-                            pendingTrackedTodoCount = progress.pending
-                        }
-                    }
-
                     await emitFinalText(summary)
-                    if let pending = pendingTrackedTodoCount,
-                        let prepareContinuation = hooks.prepareTrackedTaskContinuation
-                    {
-                        await prepareContinuation()
-                        if await hooks.isCancelled() {
-                            return RunResult(exit: .cancelled, iterations: iteration)
-                        }
-                        if iteration < policy.maxIterations {
-                            pendingTodoNotice = Self.todoPendingFinalNotice(pending: pending)
-                            continue
-                        }
-                        return RunResult(
-                            exit: .iterationCapReached,
-                            iterations: iteration,
-                            unfinishedTodoCount: pending
-                        )
-                    }
                     return RunResult(exit: .finalResponse, iterations: iteration)
                 }
 
@@ -1893,12 +1772,6 @@ enum AgentToolLoop {
                 let batchContainsParseableTodo = invocations.contains {
                     Self.todoProgressSnapshot(from: $0) != nil
                 }
-                // Captures how many ordinary actions had been attempted when
-                // each Todo call appeared in model order. This is more exact
-                // than assigning the batch's final count to every Todo when a
-                // model emits Todo + action calls together.
-                var todoActionToolCallCountByCallId: [String: Int] = [:]
-
                 if let executeBatch = hooks.executeBatch {
                     // Slotting mode (HTTP semantics): dedupe pass over the
                     // whole batch first, then one batch execution for the
@@ -1950,10 +1823,6 @@ enum AgentToolLoop {
                                 wasError: true
                             )
                             continue
-                        }
-                        if invocationHasParseableTodo {
-                            todoActionToolCallCountByCallId[callId] =
-                                currentRunActionToolCallCount
                         }
                         if let progressUpdateRequired = todoProgressUpdatePreconditionResult(
                             for: invocation,
@@ -2224,10 +2093,6 @@ enum AgentToolLoop {
                             )
                             continue
                         }
-                        if invocationHasParseableTodo {
-                            todoActionToolCallCountByCallId[callId] =
-                                currentRunActionToolCallCount
-                        }
                         if let progressUpdateRequired = todoProgressUpdatePreconditionResult(
                             for: invocation,
                             batchContainsPrecedingParseableTodo:
@@ -2379,13 +2244,6 @@ enum AgentToolLoop {
                     }).last {
                         hasSuccessfulCurrentRunTodo = true
                         lastSuccessfulCurrentRunTodoProgress = latestProgress
-                        if let latestTodoOutcome = successfulTodoOutcomes.last {
-                            lastSuccessfulCurrentRunTodoSemanticSnapshot =
-                                Self.todoSemanticSnapshot(from: latestTodoOutcome.invocation)
-                            lastSuccessfulCurrentRunTodoActionToolCallCount =
-                                todoActionToolCallCountByCallId[latestTodoOutcome.callId]
-                                ?? currentRunActionToolCallCount
-                        }
                     }
                 }
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -63,8 +63,8 @@ public enum SystemPromptTemplates {
     public static let agentLoopGuidance = """
         ## Agent loop
 
-        - Always answer the user in plain text — that reply is what they read. It ends a direct task, or a tracked task once its todo has no unchecked items.
-        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it with the next box checked after each item. Once created, unchecked items keep this agent run open. Skip direct/single-step work. The runtime may require it before a later action in a long tool run.
+        - Always answer the user in plain text once the requested work is complete. Todo is advisory progress metadata and never overrides a final response.
+        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it only after a task or checkbox actually changes. Never repeat an unchanged checklist. Unchecked items remain visible but do not keep the turn open; if the requested work is complete, answer once and stop. Skip direct/single-step work.
         - `complete(summary)` — OPTIONAL early closure for honestly blocked `todo` work. A fully checked todo needs no complete call: answer the user normally and stop. Invoke complete only as a structured tool call; never type `complete(...)` into the answer.
         - `clarify(question)` — pause and ask exactly one concrete question only when guessing wrong would change the result. For minor preferences pick a sensible default and proceed.
         - `share_artifact(path | content+filename)` — the only way the user sees a generated image, chart, report, code blob, or any file. **The file MUST exist before this call.** Sandbox: save under your home dir (default cwd), not `/tmp`. For inline text/markdown, pass `content`+`filename` and skip the file write.
@@ -86,8 +86,8 @@ public enum SystemPromptTemplates {
     public static let agentLoopGuidanceCompact = """
         ## Agent loop
 
-        - Answer the user in plain text; it ends direct work, or tracked work once no todo items remain unchecked.
-        - `todo(markdown)` — OPTIONAL, 3+ step work only: create first, re-send with each box checked. Once created, unchecked items keep this run open. Skip direct/single-step work. The runtime may require it before a later action in a long tool run.
+        - Answer the user in plain text once the requested work is complete. Todo is advisory and never overrides a final response.
+        - `todo(markdown)` — OPTIONAL for 3+ steps: create once and re-send only after an actual task or checkbox change. Never repeat it unchanged. Unchecked items stay visible but do not keep the turn open. Skip direct/single-step work.
         - `complete(summary)` — OPTIONAL early closure for blocked `todo` work. For success, check every box, answer normally, and stop. Invoke it as a tool only; never print `complete(...)` in the answer.
         - `clarify(question)` — last resort; a fully specified task is not ambiguous, just do it. Ask ONE question only when the user asks or a required input is missing/contradictory with no sensible default.
         - `share_artifact(path | content+filename)` — the only way the user sees a file/image; it MUST exist first. Sandbox: save under home, not `/tmp`.

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -439,10 +439,15 @@ public enum AgentLoopEvaluator {
             stream: Bool,
             includeTools: Bool = true
         ) -> ChatCompletionRequest {
-            ChatCompletionRequest(
+            var request = ChatCompletionRequest(
                 model: resolvedModel,
                 messages: messages,
-                temperature: 0.0,
+                // Match the real chat surface: nil means the installed
+                // bundle's generation_config/JANG defaults win. A hidden
+                // greedy override can trap tool-capable models in a
+                // deterministic action loop that users never see with their
+                // configured sampler.
+                temperature: nil,
                 max_tokens: resolvedMaxTokens,
                 stream: stream,
                 top_p: nil,
@@ -454,6 +459,8 @@ public enum AgentLoopEvaluator {
                 tool_choice: (includeTools && !toolSpecs.isEmpty) ? .auto : nil,
                 session_id: sessionId
             )
+            request.samplingParametersAreImplicit = true
+            return request
         }
 
         /// Append the assistant turn carrying this step's tool calls.

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -184,18 +184,11 @@ private func taskTrackingChatPolicy(
 
 @MainActor
 struct AgentToolLoopTests {
-    @Test func chatTodoPreconditionIsLimitedToProvenLocalBundleTypes() {
-        for modelType in ["gemma4_moe", "qwen3_5", "qwen3_5_moe"] {
-            #expect(
-                AgentToolLoop.chatTodoPreconditionThreshold(
-                    hasTodoTool: true,
-                    isLocalModel: true,
-                    modelType: modelType
-                ) == 3
-            )
-        }
-
-        for modelType in ["glm4_moe", "laguna_s21", "lfm2", "deepseek_v4", nil] {
+    @Test func chatTodoPreconditionIsDisabledForEveryModelFamily() {
+        for modelType in [
+            "gemma4_moe", "qwen3_5", "qwen3_5_moe", "glm4_moe",
+            "laguna_s21", "lfm2", "deepseek_v4", nil,
+        ] {
             #expect(
                 AgentToolLoop.chatTodoPreconditionThreshold(
                     hasTodoTool: true,
@@ -221,12 +214,10 @@ struct AgentToolLoopTests {
         )
     }
 
-    @Test func thirdChatActionRequiresCurrentRunTodoAndRemainsRecoverable() async throws {
+    @Test func ordinaryActionsNeverRequireModelAuthoredTodo() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("web_search", #"{"query":"one"}"#)]),
             .toolCalls([inv("web_search", #"{"query":"two"}"#)]),
-            .toolCalls([inv("web_search", #"{"query":"three"}"#)]),
-            .toolCalls([inv("todo", #"{"markdown":"- [x] collect sources"}"#)]),
             .toolCalls([inv("web_search", #"{"query":"three"}"#)]),
             .finalResponse,
         ])
@@ -259,20 +250,14 @@ struct AgentToolLoopTests {
             hooks: hooks
         )
 
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 6))
-        // The third search was surfaced but not executed. A valid current-run
-        // Todo then unlocked the exact retry.
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
         #expect(executedBatches == [
-            ["web_search"], ["web_search"], ["todo"], ["web_search"],
+            ["web_search"], ["web_search"], ["web_search"],
         ])
-        #expect(surface.batchOutcomes.count == 5)
-        let rejected = try #require(surface.batchOutcomes[2].first)
-        #expect(rejected.wasError)
-        #expect(AgentToolLoop.isTaskTrackingRequiredResult(rejected.result))
-        #expect(surface.builtNotices.flatMap { $0 }.contains(where: {
-            $0.contains("reached 3 ordinary tool actions")
+        #expect(surface.batchOutcomes.count == 3)
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTaskTrackingRequiredResult($0.result)
         }))
-        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 1))
     }
 
     @Test func parseableTodoInThirdBatchUnlocksSiblingAction() async throws {
@@ -311,7 +296,7 @@ struct AgentToolLoopTests {
         }))
     }
 
-    @Test func completeAfterNewActionRequiresFreshTodoUpdateThenEndsBlocked() async throws {
+    @Test func explicitCompleteRemainsAuthoritativeWithStaleTodo() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] report"}"#)]),
             .toolCalls([inv("file_read", #"{"path":"report.txt"}"#)]),
@@ -319,13 +304,6 @@ struct AgentToolLoopTests {
                 inv(
                     "complete",
                     #"{"summary":"Read the available report, but the second required source is unavailable."}"#
-                )
-            ]),
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [ ] report"}"#)]),
-            .toolCalls([
-                inv(
-                    "complete",
-                    #"{"summary":"Read and verified the available report; the final report remains blocked on the missing source."}"#
                 )
             ]),
         ])
@@ -347,18 +325,12 @@ struct AgentToolLoopTests {
             hooks: hooks
         )
 
-        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 5))
-        #expect(executedBatches == [["todo"], ["file_read"], ["todo"], ["complete"]])
-        let rejected = try #require(surface.batchOutcomes[2].first)
-        #expect(rejected.invocation.toolName == "complete")
-        #expect(rejected.wasError)
-        #expect(AgentToolLoop.isTodoProgressUpdateRequiredResult(rejected.result))
-        #expect(rejected.result.contains("2 todo items"))
-        #expect(surface.builtNotices.flatMap { $0 }.contains(where: {
-            $0.contains("completion was rejected") && $0.contains("2 todo items")
-                && $0.contains("checklist update")
+        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 3))
+        #expect(executedBatches == [["todo"], ["file_read"], ["complete"]])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoProgressUpdateRequiredResult($0.result)
         }))
-        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 2))
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 0, total: 2))
     }
 
     @Test func precedingTodoInSameBatchCanRefreshBeforeBlockedComplete() async throws {
@@ -399,7 +371,7 @@ struct AgentToolLoopTests {
         #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 2))
     }
 
-    @Test func repeatedSemanticTodoIsRejectedUntilChecklistActuallyChanges() async throws {
+    @Test func repeatedSemanticTodoRemainsModelOwnedState() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
             // Presentation changes do not turn an unchanged 0/2 checklist
@@ -417,20 +389,14 @@ struct AgentToolLoopTests {
         )
 
         #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
-        // The unchanged second Todo never reaches the tool/store executor;
-        // the two real checkbox transitions do.
-        #expect(surface.executedCalls.map(\.name) == ["todo", "todo", "todo"])
-        let rejected = try #require(surface.batchOutcomes[1].first)
-        #expect(rejected.wasError)
-        #expect(AgentToolLoop.isTodoNoProgressResult(rejected.result))
-        #expect(rejected.result.contains("not executed"))
-        #expect(surface.builtNotices.flatMap { $0 }.contains(where: {
-            $0.contains("exactly repeated") && $0.contains("2 unchecked items")
+        #expect(surface.executedCalls.map(\.name) == ["todo", "todo", "todo", "todo"])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoNoProgressResult($0.result)
         }))
         #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
     }
 
-    @Test func batchExecutorAlsoSkipsRepeatedSemanticTodo() async throws {
+    @Test func batchExecutorAlsoAllowsRepeatedSemanticTodo() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
             .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
@@ -455,9 +421,10 @@ struct AgentToolLoopTests {
         )
 
         #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
-        #expect(executedBatches == [["todo"], ["todo"]])
-        let rejected = try #require(surface.batchOutcomes[1].first)
-        #expect(AgentToolLoop.isTodoNoProgressResult(rejected.result))
+        #expect(executedBatches == [["todo"], ["todo"], ["todo"]])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoNoProgressResult($0.result)
+        }))
         #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
     }
 
@@ -491,17 +458,17 @@ struct AgentToolLoopTests {
         )
 
         #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 4))
-        #expect(surface.executedCalls.map(\.name) == ["todo", "web_fetch", "complete"])
-        #expect(AgentToolLoop.isTodoNoProgressResult(
-            try #require(surface.batchOutcomes[2].first).result
-        ))
+        #expect(surface.executedCalls.map(\.name) == ["todo", "web_fetch", "todo", "complete"])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoNoProgressResult($0.result)
+        }))
         #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
             AgentToolLoop.isTodoProgressUpdateRequiredResult($0.result)
         }))
         #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 0, total: 2))
     }
 
-    @Test func staleSessionTodoCannotBypassThirdActionGate() async throws {
+    @Test func staleSessionTodoNeverCreatesAnActionGate() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("tool_one")]),
             .toolCalls([inv("tool_two")]),
@@ -530,10 +497,10 @@ struct AgentToolLoopTests {
         )
 
         #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
-        #expect(executedBatches == [["tool_one"], ["tool_two"]])
-        #expect(AgentToolLoop.isTaskTrackingRequiredResult(
-            try #require(surface.batchOutcomes[2].first).result
-        ))
+        #expect(executedBatches == [["tool_one"], ["tool_two"], ["tool_three"]])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTaskTrackingRequiredResult($0.result)
+        }))
     }
 
     @Test func headlessPolicyDoesNotImposeChatTodoPrecondition() async throws {
@@ -2417,613 +2384,74 @@ struct AgentLoopTodoStalenessTests {
 
 // MARK: - Current-run todo terminal completion
 
+
 @MainActor
-struct AgentLoopTrackedTodoCompletionTests {
-
-    @Test func progressStopWithCurrentRunTodoContinuesOnceThenFinishes() async throws {
+struct AgentLoopAdvisoryTodoCompletionTests {
+    @Test func pendingTodoDoesNotOverrideOrdinaryFinal() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
             .finalResponse,
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
-            .finalResponse,
+            .toolCalls([inv("share_artifact", #"{"filename":"unrequested.md"}"#)]),
         ])
 
         let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-        #expect(surface.emittedFinalTexts.isEmpty)
-        #expect(surface.steps.isEmpty)
-        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
-    }
-
-    @Test func repeatedStopsWithPendingTodoReachConfiguredBudgetCap() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
-            .finalResponse,
-            .finalResponse,
-            .finalResponse,
-        ])
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 4),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(
-            result == AgentToolLoop.RunResult(
-                exit: .iterationCapReached,
-                iterations: 4,
-                unfinishedTodoCount: 2
-            )
-        )
-        #expect(surface.trackedTaskContinuationPreparations == 3)
-        #expect(surface.builtNotices.count == 4)
-        let pendingNotice = AgentToolLoop.todoPendingFinalNotice(pending: 2)
-        #expect(surface.builtNotices[2].contains(pendingNotice))
-        #expect(surface.builtNotices[3].contains(pendingNotice))
-        #expect(surface.emittedFinalTexts.isEmpty)
-    }
-
-    @Test func recordedCheckboxProgressStillRequiresRemainingWorkToClose() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [ ] answer"}"#)]),
-            .finalResponse,
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
-            .finalResponse,
-        ])
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
-    }
-
-    @Test func realTodoToolStoreSnapshotDrivesZeroProgressContinuation() async throws {
-        let sessionId = "tracked-todo-test-\(UUID().uuidString)"
-        await AgentTodoStore.shared.clear(for: sessionId)
-        let todoInvocation = inv(
-            "todo",
-            #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#
-        )
-        let completedTodoInvocation = inv(
-            "todo",
-            #"{"markdown":"- [x] inspect\n- [x] answer"}"#
-        )
-        let progressText = "Got the models. Now let me inspect the other repositories."
-        var history = [ChatMessage(role: "user", content: "research repositories")]
-        var continuationInput: [ChatMessage] = []
-        var continuationPreparations = 0
-
-        let hooks = AgentLoopHooks(
-            buildMessages: { _ in
-                if continuationPreparations == 1, continuationInput.isEmpty {
-                    continuationInput = history
-                }
-                return AgentLoopIterationInput(messages: history, overBudget: false)
-            },
-            modelStep: { _, iteration in
-                switch iteration {
-                case 1:
-                    return .toolCalls([todoInvocation])
-                case 2:
-                    history.append(ChatMessage(role: "assistant", content: progressText))
-                    return .finalResponse
-                case 3:
-                    return .toolCalls([completedTodoInvocation])
-                default:
-                    history.append(ChatMessage(role: "assistant", content: "Final answer."))
-                    return .finalResponse
-                }
-            },
-            prepareTrackedTaskContinuation: {
-                continuationPreparations += 1
-                // Chat keeps the premature assistant response visible but
-                // excludes it from the next model request. Simulate that
-                // surface contract here so the captured continuation history
-                // cannot regress to adjacent assistant messages.
-                if history.last?.role == "assistant" {
-                    history.removeLast()
-                }
-            },
-            executeTool: { invocation, _ in
-            do {
-                let result = try await ChatExecutionContext.$currentSessionId.withValue(
-                    sessionId
-                ) {
-                    try await TodoTool().execute(argumentsJSON: invocation.jsonArguments)
-                }
-                return AgentLoopToolExecution(
-                    result: result,
-                    isError: ToolEnvelope.isError(result)
-                )
-            } catch {
-                return AgentLoopToolExecution(
-                    result: ToolEnvelope.fromError(error, tool: invocation.toolName),
-                    isError: true
-                )
-            }
-            },
-            onBatchComplete: { outcomes in
-                for outcome in outcomes {
-                    history.append(
-                        ChatMessage(
-                            role: "assistant",
-                            content: nil,
-                            tool_calls: [
-                                SecretArgumentScrubber.recordedToolCall(
-                                    id: outcome.callId,
-                                    invocation: outcome.invocation
-                                )
-                            ],
-                            tool_call_id: nil
-                        )
-                    )
-                    history.append(
-                        ChatMessage(
-                            role: "tool",
-                            content: outcome.result,
-                            tool_calls: nil,
-                            tool_call_id: outcome.callId
-                        )
-                    )
-                }
-            },
-            todoProgressSnapshot: {
-                guard let todo = await AgentTodoStore.shared.todo(for: sessionId) else {
-                    return nil
-                }
-                return AgentTodoProgressSnapshot(done: todo.doneCount, total: todo.totalCount)
-            }
-        )
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: hooks
-        )
-        let stored = await AgentTodoStore.shared.todo(for: sessionId)
-        await AgentTodoStore.shared.clear(for: sessionId)
-
-        #expect(stored?.doneCount == 2)
-        #expect(stored?.totalCount == 2)
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
-        #expect(continuationPreparations == 1)
-        #expect(continuationInput.map(\.role) == ["user", "assistant", "tool"])
-        #expect(continuationInput.last?.role == "tool")
-        #expect(continuationInput.allSatisfy { $0.content != progressText })
-    }
-
-    @Test func multipleTodoUpdatesInOneBatchPreserveRecordedProgress() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([
-                inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#),
-                inv("todo", #"{"markdown":"- [x] inspect\n- [ ] answer"}"#),
-            ]),
-            .finalResponse,
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
-            .finalResponse,
-        ])
-        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
-        hooks.executeBatch = { calls in
-            calls.map {
-                AgentLoopToolExecution(
-                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
-                )
-            }
-        }
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: hooks
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 2, total: 2))
-    }
-
-    @Test func stalePendingTodoWithoutCurrentRunTodoDoesNotHijackFinal() async throws {
-        let surface = ScriptedLoopSurface(steps: [.finalResponse])
-        surface.pendingTodos = 4
-        surface.todoProgress = AgentTodoProgressSnapshot(done: 0, total: 4)
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-    }
-
-    @Test func failedTodoDoesNotArmTrackedContinuation() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"not a checklist"}"#)]),
-            .finalResponse,
-        ])
-        surface.pendingTodos = 3
-        surface.toolResults["todo"] = AgentLoopToolExecution(
-            result: ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message: "No checklist items found.",
-                tool: "todo"
-            ),
-            isError: true
-        )
-
-        let result = try await AgentToolLoop.run(
-            policy: headlessPolicy(),
+            policy: taskTrackingChatPolicy(),
             state: AgentTaskState(),
             hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
         )
 
         #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 2))
+        #expect(surface.executedCalls.map(\.name) == ["todo"])
         #expect(surface.trackedTaskContinuationPreparations == 0)
+        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 0, total: 2))
+        #expect(surface.steps.count == 1)
     }
 
-    @Test func completedTodoAllowsNormalFinal() async throws {
+    @Test func reminderSuccessStopsBeforeTodoRewriteAndRepeatedSummaries() async throws {
         let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect\n- [x] answer"}"#)]),
-            .finalResponse,
-        ])
-        surface.pendingTodos = 0
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 2))
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-    }
-
-    @Test func explicitCompleteStillEndsWithUncheckedCurrentRunTodo() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect\n- [ ] answer"}"#)]),
-            .toolCalls([inv("complete", #"{"summary":"Completed the requested research and verified the cited model list."}"#)]),
-        ])
-        surface.pendingTodos = 2
-        surface.toolResults["complete"] = AgentLoopToolExecution(
-            result: ToolEnvelope.success(tool: "complete", text: "Task completed."),
-            endRun: true
-        )
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 2))
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-    }
-
-    @Test func explicitClarifyStillEndsWithUncheckedCurrentRunTodo() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .toolCalls([inv("clarify", #"{"question":"Which repository should I inspect?"}"#)]),
-        ])
-        surface.toolResults["clarify"] = AgentLoopToolExecution(
-            result: ToolEnvelope.success(tool: "clarify", text: "Question shown."),
-            endRun: true
-        )
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .endedBySurface, iterations: 2))
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-    }
-
-    @Test(arguments: ["complete", "clarify"])
-    func failedClosureIsNotTreatedAsAuthoritative(toolName: String) async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .toolCalls([inv(toolName)]),
-            .finalResponse,
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect"}"#)]),
-            .finalResponse,
-        ])
-        surface.toolResults[toolName] = AgentLoopToolExecution(
-            result: ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message: "Invalid closure arguments.",
-                tool: toolName
-            ),
-            isError: true
-        )
-
-        let result = try await AgentToolLoop.run(
-            policy: headlessPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 5))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-    }
-
-    @Test func cancellationAfterProgressContinuationStopsBeforeNextGeneration() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .finalResponse,
-        ])
-        surface.pendingTodos = 1
-        surface.cancelOnTrackedTaskContinuation = true
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 2))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-        #expect(surface.builtNotices.count == 2)
-    }
-
-    @Test func cancellationDuringTodoSnapshotSkipsContinuation() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .finalResponse,
-        ])
-        // Invocation parsing records the successful Todo directly. The first
-        // actor-backed snapshot is therefore the final-response lookup whose
-        // suspension races with Stop.
-        surface.cancelOnTodoProgressSnapshotCall = 1
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 1))
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-        #expect(surface.builtNotices.count == 2)
-    }
-
-    @Test func pendingTodoAtIterationCapUsesTypedCapAndFreshFinalizerTurn() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .finalResponse,
-        ])
-        surface.pendingTodos = 1
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 2),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(
-            result == AgentToolLoop.RunResult(
-                exit: .iterationCapReached,
-                iterations: 2,
-                unfinishedTodoCount: 1
-            )
-        )
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-        #expect(surface.emittedFinalTexts.isEmpty)
-        #expect(
-            AgentToolLoop.unfinishedTodoCapFallback(pending: 1)
-                .contains("1 todo item still unfinished")
-        )
-    }
-
-    @Test func cancellationAfterProgressContinuationWinsAtIterationCap() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .finalResponse,
-        ])
-        surface.pendingTodos = 1
-        surface.cancelOnTrackedTaskContinuation = true
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 2),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 2))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-    }
-
-    @Test func missingTodoStoreSnapshotFallsBackToCurrentRunChecklist() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .finalResponse,
-        ])
-        surface.forceMissingTodoProgressSnapshot = true
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 2),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(
-            result == AgentToolLoop.RunResult(
-                exit: .iterationCapReached,
-                iterations: 2,
-                unfinishedTodoCount: 1
-            )
-        )
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-    }
-
-    @Test func pendingTodoWithToolOnLastIterationUsesTypedCap() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .toolCalls([inv("search_and_extract", #"{"url":"https://example.com"}"#)]),
-        ])
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 2),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(
-            result == AgentToolLoop.RunResult(
-                exit: .iterationCapReached,
-                iterations: 2,
-                unfinishedTodoCount: 1
-            )
-        )
-        // A tool batch already creates the next assistant buffer; only a
-        // progress-only final response needs the explicit continuation hook.
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-        #expect(surface.batchOutcomes.count == 2)
-        #expect(surface.emittedFinalTexts.isEmpty)
-    }
-
-    @Test func malformedDesktopRepeatCannotBypassPendingTodoAtCap() async throws {
-        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task","_message":"missing required argument: task","_expected":"required parameter"}"#
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .toolCalls([inv("applescript", #"{"task":"Open TextEdit"}"#)]),
-            .toolCalls([inv("applescript", malformed)]),
-        ])
-        surface.toolResults["applescript"] = AgentLoopToolExecution(
-            result: ToolEnvelope.success(
-                tool: "applescript",
-                result: [
-                    "kind": "applescript",
-                    "status": "succeeded",
-                    "scripts_run": 1,
-                    "summary": "Ran 1 script(s) successfully.",
-                ]
-            )
-        )
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 3),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(
-            result == AgentToolLoop.RunResult(
-                exit: .iterationCapReached,
-                iterations: 3,
-                unfinishedTodoCount: 1
-            )
-        )
-        #expect(surface.executedCalls.map(\.name) == ["todo", "applescript"])
-        #expect(surface.emittedFinalTexts == ["Ran 1 script(s) successfully."])
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-    }
-
-    @Test func cancellationAfterMalformedDesktopContinuationWinsAtCap() async throws {
-        let malformed = #"{"_error":"invalid_tool_arguments","_tool":"applescript","_field":"task","_message":"missing required argument: task","_expected":"required parameter"}"#
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .toolCalls([inv("applescript", #"{"task":"Open TextEdit"}"#)]),
-            .toolCalls([inv("applescript", malformed)]),
-        ])
-        surface.toolResults["applescript"] = AgentLoopToolExecution(
-            result: ToolEnvelope.success(
-                tool: "applescript",
-                result: ["status": "succeeded", "summary": "Ran successfully."]
-            )
-        )
-        surface.cancelOnTrackedTaskContinuation = true
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 3),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 3))
-        #expect(surface.executedCalls.map(\.name) == ["todo", "applescript"])
-        #expect(surface.emittedFinalTexts == ["Ran successfully."])
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-    }
-
-    @Test func repeatedEmptyResponsesAfterPendingTodoEndAsIncomplete() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-            .emptyResponse,
-            .emptyResponse,
-            .emptyResponse,
-        ])
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .emptyResponseExhausted, iterations: 2))
-        #expect(surface.emittedFinalTexts == [AgentToolLoop.emptyToolTaskFallback])
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-    }
-
-    @Test func cancellationDuringToolCapTodoSnapshotWins() async throws {
-        let surface = ScriptedLoopSurface(steps: [
-            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
-        ])
-        surface.cancelOnTodoProgressSnapshotCall = 1
-
-        let result = try await AgentToolLoop.run(
-            policy: chatPolicy(maxIterations: 1),
-            state: AgentTaskState(),
-            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
-        )
-
-        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 1))
-        #expect(surface.trackedTaskContinuationPreparations == 0)
-    }
-
-    @Test func batchedSuccessfulTodoWithSiblingToolArmsOneContinuation() async throws {
-        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] Create reminder"}"#)]),
             .toolCalls([
-                inv("todo", #"{"markdown":"- [ ] inspect"}"#),
-                inv("search_and_extract", #"{"url":"https://example.com"}"#),
+                inv(
+                    "create_reminder",
+                    #"{"title":"Send email to Jace","dueDate":"2026-07-27T08:10:00-07:00"}"#
+                ),
             ]),
             .finalResponse,
-            .toolCalls([inv("todo", #"{"markdown":"- [x] inspect"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [x] Create reminder\n- [ ] Verify"}"#)]),
+            .toolCalls([inv("share_artifact", #"{"filename":"reminder-confirmation.md"}"#)]),
             .finalResponse,
         ])
-        var hooks = surface.makeHooks(includeTrackedTaskContinuation: true)
-        hooks.executeBatch = { calls in
-            calls.map {
-                AgentLoopToolExecution(
-                    result: ToolEnvelope.success(tool: $0.invocation.toolName, text: "ok")
-                )
-            }
-        }
+
         let result = try await AgentToolLoop.run(
-            policy: chatPolicy(),
+            policy: taskTrackingChatPolicy(),
             state: AgentTaskState(),
-            hooks: hooks
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
         )
 
-        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 4))
-        #expect(surface.trackedTaskContinuationPreparations == 1)
-        #expect(surface.batchOutcomes.first?.map { $0.invocation.toolName } == [
-            "todo", "search_and_extract",
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 3))
+        #expect(surface.executedCalls.map(\.name) == ["todo", "create_reminder"])
+        #expect(surface.trackedTaskContinuationPreparations == 0)
+        #expect(surface.steps.count == 3)
+    }
+
+    @Test func repeatedTodoCallsAreNotTurnedIntoRetryableErrors() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .toolCalls([inv("todo", #"{"markdown":"- [ ] inspect"}"#)]),
+            .finalResponse,
         ])
-        #expect(surface.todoProgress == AgentTodoProgressSnapshot(done: 1, total: 1))
+
+        let result = try await AgentToolLoop.run(
+            policy: taskTrackingChatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeTrackedTaskContinuation: true)
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 3))
+        #expect(surface.executedCalls.map(\.name) == ["todo", "todo"])
+        #expect(!surface.batchOutcomes.flatMap { $0 }.contains(where: {
+            AgentToolLoop.isTodoNoProgressResult($0.result)
+        }))
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
@@ -129,6 +129,12 @@ struct SystemPromptDefaultIdentityTests {
             #expect(block.contains("OPTIONAL"))
             #expect(block.contains("3+"))
             #expect(block.contains("never") && block.contains("complete(...)"))
+            #expect(block.contains("advisory"))
+            #expect(block.contains("never overrides a final response"))
+            #expect(block.contains("Never repeat"))
+            #expect(!block.contains("unchecked items keep"))
+            #expect(!block.contains("runtime may require"))
+            #expect(!block.contains("once no todo items remain unchecked"))
             #expect(!block.contains("SAME message"))
         }
     }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2857,6 +2857,24 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("Agent-loop evals preserve bundle-native sampling defaults")
+    func agentLoopEvalsPreserveBundleNativeSamplingDefaults() throws {
+        let evaluator = try Self.source("Services/Context/AgentLoopEvaluator.swift")
+
+        #expect(
+            evaluator.contains("temperature: nil"),
+            "Agent-loop evals must leave temperature unspecified so the active bundle config wins."
+        )
+        #expect(
+            evaluator.contains("request.samplingParametersAreImplicit = true"),
+            "Agent-loop evals must mark omitted sampling parameters as implicit, matching real chat."
+        )
+        #expect(
+            !evaluator.contains("temperature: 0.0"),
+            "The eval harness must not silently force greedy decoding for bundles tuned for sampling."
+        )
+    }
+
     @Test("Chat UI sends accumulated history and marks implicit sampling without forcing native MTP")
     func chatUISendsAccumulatedHistoryAndMarksImplicitSamplingWithoutForcingNativeMTP() throws {
         let chatView = try Self.source("Views/Chat/ChatView.swift")

--- a/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
@@ -21,9 +21,11 @@ struct AgentLoopToolsTests {
     func sharedTodoSchemaStaysOptional() {
         let description = TodoTool().description
         #expect(description.contains("OPTIONAL"))
-        #expect(description.contains("runtime may require it"))
+        #expect(description.contains("never decides whether the turn stays open"))
+        #expect(description.contains("answer the user exactly once and stop"))
         #expect(description.contains("direct question"))
         #expect(!description.contains("It is REQUIRED"))
+        #expect(!description.contains("unchecked items keep this agent run open"))
     }
 
     @Test("complete schema cannot invite literal protocol text")
@@ -60,12 +62,57 @@ struct AgentLoopToolsTests {
             #expect(ToolEnvelope.isSuccess(result))
             #expect(result.contains("Todo updated"))
             #expect(result.contains("1/3 complete"))
+            #expect(result.contains("Todo never keeps the turn open"))
+            #expect(!result.contains("Unchecked items keep this agent run open"))
 
             let stored = await AgentTodoStore.shared.todo(for: sessionId)
             #expect(stored?.totalCount == 3)
             #expect(stored?.doneCount == 1)
             #expect(stored?.items.first?.text == "Read existing config")
             #expect(stored?.items.last?.isDone == true)
+        }
+    }
+
+    @Test
+    func todo_unchangedReplayIsSuccessfulNoOp() async throws {
+        try await withSession { sessionId in
+            _ = try await TodoTool().execute(
+                argumentsJSON: #"{"markdown": "- [ ] inspect\n- [ ] fix"}"#
+            )
+            let before = try #require(await AgentTodoStore.shared.todo(for: sessionId))
+
+            let result = try await TodoTool().execute(
+                argumentsJSON: #"""
+                    {"markdown": "# Plan\n* [ ] inspect\n* [ ] fix\n\nUnchanged prose."}
+                    """#
+            )
+
+            #expect(ToolEnvelope.isSuccess(result))
+            #expect(result.contains("Todo unchanged: 0/2 complete"))
+            #expect(result.contains("Do not call `todo` again"))
+            #expect(result.contains("answer the user once and stop"))
+            let after = try #require(await AgentTodoStore.shared.todo(for: sessionId))
+            #expect(after.updatedAt == before.updatedAt)
+            #expect(after.markdown == before.markdown)
+        }
+    }
+
+    @Test
+    func todo_checkboxTransitionStillUpdatesStore() async throws {
+        try await withSession { sessionId in
+            _ = try await TodoTool().execute(
+                argumentsJSON: #"{"markdown": "- [ ] inspect\n- [ ] fix"}"#
+            )
+            let before = try #require(await AgentTodoStore.shared.todo(for: sessionId))
+
+            let result = try await TodoTool().execute(
+                argumentsJSON: #"{"markdown": "- [x] inspect\n- [ ] fix"}"#
+            )
+
+            #expect(result.contains("Todo updated: 1/2 complete"))
+            let after = try #require(await AgentTodoStore.shared.todo(for: sessionId))
+            #expect(after.updatedAt >= before.updatedAt)
+            #expect(after.doneCount == 1)
         }
     }
 

--- a/Packages/OsaurusCore/Tools/AgentLoopTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentLoopTools.swift
@@ -30,13 +30,13 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
     public let name = "todo"
     public let description =
         "Write or replace the OPTIONAL task checklist for multi-step work (3+ steps). The "
-        + "runtime may require it before a later action in a long tool run. Create the list BEFORE "
-        + "starting, then re-send it with the new box checked IMMEDIATELY "
-        + "after finishing each item — do not batch updates for the end. Every item is a line "
+        + "checklist records progress but never decides whether the turn stays open. Create it "
+        + "before starting, then re-send it only after a task or checkbox actually changes. "
+        + "Every item is a line "
         + "starting with `- [ ]` (pending) or `- [x]` (done); each call replaces the entire "
-        + "list. Once created, unchecked items keep this agent run open until you update them or "
-        + "honestly close blocked tracked work with `complete`. Skip it for a direct question or "
-        + "single-step work unless the runtime reports that tracking is required."
+        + "list. Do not repeat an unchanged checklist. Once the requested work is complete, "
+        + "answer the user exactly once and stop even if an item was left unchecked. Skip Todo "
+        + "for a direct question or single-step task."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -109,16 +109,28 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
                 tool: name
             )
         }
-        let stored = await AgentTodoStore.shared.setTodo(markdown: trimmed, for: sessionId)
+        let update = await AgentTodoStore.shared.setTodoIfChanged(
+            markdown: trimmed,
+            for: sessionId
+        )
+        let stored = update.todo
+        if !update.changed {
+            return ToolEnvelope.success(
+                tool: name,
+                text:
+                    "Todo unchanged: \(stored.doneCount)/\(stored.totalCount) complete. "
+                    + "Do not call `todo` again until a task or checkbox changes. Execute the "
+                    + "next concrete pending action now, or answer the user once and stop if "
+                    + "the requested work is already complete."
+            )
+        }
         return ToolEnvelope.success(
             tool: name,
             text:
                 "Todo updated: \(stored.doneCount)/\(stored.totalCount) complete. "
-                + "Unchecked items keep this agent run open, so continue with the next pending "
-                + "item and re-send the full checklist as you check items. When everything is "
-                + "checked, answer the user normally and stop; no `complete` call is required. "
-                + "If work is blocked, use the structured `complete` tool with what remains. "
-                + "Never print tool-call syntax in the answer."
+                + "Continue with the next concrete pending action. Re-send the full checklist "
+                + "only after its status changes. When the requested work is complete, answer "
+                + "the user once and stop; Todo never keeps the turn open."
         )
     }
 }


### PR DESCRIPTION
## Root cause

PR #2171 made Todo an execution precondition: the third ordinary tool action could be rejected until a checklist existed, and a model final could be ignored while that checklist remained unchecked. A recoverable discovery mistake could therefore create a stale Todo, complete the requested side effect, and then regenerate summaries, Todo rewrites, or artifacts indefinitely.

## Fix

- keep Todo as advisory progress metadata instead of a run lock
- accept the model's ordinary final response as authoritative even when a checklist is still unchecked
- make semantically unchanged Todo writes successful no-ops without UI timestamp churn
- preserve bundle-native generation defaults in AgentLoop evaluator requests
- retain honest malformed-tool, cancellation, iteration-cap, and surface-completion behavior

No model-specific reasoning tags, sampler overrides, stop-token bias, parser repair, or prompt coercion were added.

## Verification

- focused `OsaurusCoreTests` suites passed after rebasing current `main`: AgentToolLoop, advisory Todo completion, AgentLoop tools, system prompt contracts, runtime policy, and chat Stop/cancellation
- exact `agent_loop.todo-discipline-multistep` eval passed on Bonsai 27B JANG, Ornith 9B JANG, and Gemma 4 26B JANG
  - Bonsai: 10 steps, 16.43 tok/s, 227.6 ms TTFT, disk L2 +9 hits
  - Ornith: 17 steps, 26.9 tok/s, 227 ms TTFT, disk L2 +16 hits
  - Gemma: 9 steps, 30.9 tok/s, 151 ms TTFT, disk L2 +8 hits
- exact rebased Release app live UI: Ornith called `todo`, left `Todo 0/1`, emitted exactly one `Four.` final, removed Stop, unlocked the composer, and produced no duplicate after an 8-second delayed recheck
- same Release app follow-up with a stale `Todo 0/1`: one coherent final, terminal `stop`, no repeated assistant turn
- `git diff --check` clean; nine Swift source/test files only; no images or binary artifacts

## Guard note

The aggregate PR-hygiene script remains blocked by pre-existing `main` guard drift (including an unchanged `CapabilityTools.swift` comment matching `parser repair`, missing local SwiftPM checkout inspection, and unrelated server/tool-choice guard expectations). The branch diff adds none of the forbidden forced-behavior patterns, and the focused source/test/live gates above pass.
