### PR TITLE
i18n(zh): fix malformed format specifier in channel member count

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -3659,13 +3659,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许 %1%lld 个 · %2$lld 人"
+            "value" : "允许 %1$lld 个 · %2$lld 人"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允許 %1%lld 個 · %2$lld 人"
+            "value" : "允許 %1$lld 個 · %2$lld 人"
           }
         }
       }


### PR DESCRIPTION
## What

`%lld allowed · %lld people` is localized as `允许 %1%lld 个 · %2$lld 人` in both
`zh-Hans` and `zh-Hant`. The first specifier reads `%1%lld`, not `%1$lld`.

## Effect

The allowed-count argument is never consumed, and the literal text `%lld` is
rendered in its place:

```
en          3 allowed · 47 people
zh today    允许 1%lld 个 · 47 人
zh fixed    允许 3 个 · 47 人
```

Reproduced with:

```swift
import Foundation
print(String(format: "允许 %1%lld 个 · %2$lld 人", 3, 47))
// 允许 1%lld 个 · 47 人
```

## Where it shows

`DiscordSettingsView.swift:627` and `SlackSettingsView.swift:859`, both via
`Text("\(allowedCount) allowed · \(members.count) people", bundle: .module)`, so
the count is wrong in both channel settings panes.

## Scope

Two value lines, one per locale. No keys, no `state` fields, no other locale
touched. The catalog is written back with Xcode-exact formatting, so the diff is
exactly those two lines. `bash scripts/i18n/check.sh` passes with the same
pre-existing stale-key warnings `main` already emits.

## Note on overlap

#2174 also touches the `zh-Hant` side of this same string — it converts 允许 → 允許
and 个 → 個 as part of a character-form pass, and leaves the specifier alone.
Whichever of the two lands first, I will rebase the other; it is a one-line
resolution either way. Happy to drop the `zh-Hant` line from this PR instead if
you would rather keep the two fully disjoint.
