### PR TITLE
i18n(zh-Hans): fix mistranslated labels shown in the UI (Block, Path, Duration, …)

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -851,7 +851,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[密钥]"
+            "value" : "[机密]"
           }
         },
         "zh-Hant" : {
@@ -4748,7 +4748,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 个项目将被编辑"
+            "value" : "%lld 个项目将被隐去"
           }
         },
         "zh-Hant" : {
@@ -6456,7 +6456,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 次编辑"
+            "value" : "%lld 处隐去"
           }
         },
         "zh-Hant" : {
@@ -9053,7 +9053,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "~%1$@ of %2$.0f GB"
+            "value" : "~%1$@ / %2$.0f GB"
           }
         },
         "zh-Hant" : {
@@ -10135,7 +10135,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 个项目将被编辑"
+            "value" : "1 个项目将被脱敏"
           }
         },
         "zh-Hant" : {
@@ -10407,7 +10407,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 次编辑"
+            "value" : "1 次脱敏"
           }
         },
         "zh-Hant" : {
@@ -11237,7 +11237,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "6位（q6，GGUF-head奇偶校验）"
+            "value" : "6 位（q6，与 GGUF-head 持平）"
           }
         },
         "zh-Hant" : {
@@ -12311,7 +12311,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "快速浏览"
+            "value" : "快速导览"
           }
         },
         "zh-Hant" : {
@@ -24579,7 +24579,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "观众"
+            "value" : "受众"
           }
         },
         "zh-Hant" : {
@@ -29990,7 +29990,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "块"
+            "value" : "阻止"
           }
         },
         "zh-Hant" : {
@@ -63674,7 +63674,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "期间"
+            "value" : "时长"
           }
         },
         "zh-Hant" : {
@@ -63847,7 +63847,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "例如：客户"
+            "value" : "例如：CUSTOMER"
           }
         },
         "zh-Hant" : {
@@ -65145,7 +65145,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑模型"
+            "value" : "图像编辑模型"
           }
         },
         "zh-Hant" : {
@@ -65767,7 +65767,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在编辑"
+            "value" : "编辑操作"
           }
         },
         "zh-Hant" : {
@@ -65978,7 +65978,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "身份"
+            "value" : "基本信息"
           }
         },
         "zh-Hant" : {
@@ -76638,7 +76638,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分数从0.10到1.00。"
+            "value" : "比例值范围为 0.10 到 1.00。"
           }
         },
         "zh-Hant" : {
@@ -93484,7 +93484,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近签署的支票"
+            "value" : "最近的签名校验"
           }
         },
         "zh-Hant" : {
@@ -96041,7 +96041,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "偏好"
+            "value" : "点赞"
           }
         },
         "zh-Hant" : {
@@ -96488,7 +96488,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "列表"
+            "value" : "条目"
           }
         },
         "zh-Hant" : {
@@ -99535,7 +99535,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览并自由导航；从不编辑。"
+            "value" : "自由查看和导航；绝不编辑。"
           }
         },
         "zh-Hant" : {
@@ -100897,7 +100897,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手册"
+            "value" : "手动"
           }
         },
         "zh-Hant" : {
@@ -103255,7 +103255,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存与重载"
+            "value" : "记忆与回忆"
           }
         },
         "zh-Hant" : {
@@ -103361,7 +103361,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存预算"
+            "value" : "记忆预算"
           }
         },
         "zh-Hant" : {
@@ -103466,7 +103466,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库已重新打开。"
+            "value" : "记忆数据库已重新打开。"
           }
         },
         "zh-Hant" : {
@@ -103501,7 +103501,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库已打开"
+            "value" : "记忆数据库已打开"
           }
         },
         "zh-Hant" : {
@@ -103863,7 +103863,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存存储重置。"
+            "value" : "记忆存储已重置。"
           }
         },
         "zh-Hant" : {
@@ -103899,7 +103899,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存存储重置。旧文件保存在%@。"
+            "value" : "记忆存储已重置。旧文件保留在 %@。"
           }
         },
         "zh-Hant" : {
@@ -106179,7 +106179,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型记忆"
+            "value" : "模型内存"
           }
         },
         "zh-Hant" : {
@@ -108049,7 +108049,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地的"
+            "value" : "原生"
           }
         },
         "zh-Hant" : {
@@ -108748,7 +108748,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "网络积分"
+            "value" : "净积分"
           }
         },
         "zh-Hant" : {
@@ -121715,7 +121715,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开放身份"
+            "value" : "打开身份"
           }
         },
         "zh-Hant" : {
@@ -122954,7 +122954,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开网络"
+            "value" : "打开网页"
           }
         },
         "zh-Hant" : {
@@ -128057,7 +128057,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "小路"
+            "value" : "路径"
           }
         },
         "zh-Hant" : {
@@ -134282,7 +134282,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预览受限内存上下文"
+            "value" : "预览受限记忆上下文"
           }
         },
         "zh-Hant" : {
@@ -135388,7 +135388,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "密钥"
+            "value" : "机密"
           }
         },
         "zh-Hant" : {
@@ -145231,7 +145231,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "恢复助记词"
+            "value" : "助记词"
           }
         },
         "zh-Hant" : {
@@ -145369,7 +145369,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已编辑的活动导出已复制"
+            "value" : "已脱敏的活动导出已复制"
           }
         },
         "zh-Hant" : {
@@ -146694,7 +146694,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继电器关闭"
+            "value" : "中继已关闭"
           }
         },
         "zh-Hant" : {
@@ -147858,7 +147858,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移除镜像"
+            "value" : "移除图片"
           }
         },
         "zh-Hant" : {
@@ -149790,7 +149790,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制路径"
+            "value" : "复现路径"
           }
         },
         "zh-Hant" : {
@@ -151399,7 +151399,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置内存存储？"
+            "value" : "重置记忆存储？"
           }
         },
         "zh-Hant" : {
@@ -152030,7 +152030,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已解决的计划"
+            "value" : "解析后的计划"
           }
         },
         "zh-Hant" : {
@@ -177147,7 +177147,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仍然无法打开内存 — 尝试重置。"
+            "value" : "仍然无法打开记忆 — 请尝试重置。"
           }
         },
         "zh-Hant" : {
@@ -179425,7 +179425,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "支持导出"
+            "value" : "导出支持数据"
           }
         },
         "zh-Hant" : {
@@ -181663,7 +181663,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "图片生成时应避免的术语"
+            "value" : "图片生成时应避免的词语"
           }
         },
         "zh-Hant" : {
@@ -198935,7 +198935,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "用户智能体"
+            "value" : "用户代理"
           }
         },
         "zh-Hant" : {
@@ -202005,7 +202005,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "等待被赎回"
+            "value" : "等待兑换"
           }
         },
         "zh-Hant" : {
@@ -208986,7 +208986,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zip 捆绑包"
+            "value" : "Zip 压缩包"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
## Summary

Fixes short zh-Hans labels whose translation picked the wrong sense of the English word, so the UI currently shows unrelated words. Worst example: the tool-permission policy option **Block** (deny) is translated as 块 — “a lump/chunk of material” — in the autonomy policy menu. Every fix was verified against the Swift call site. Follow-up to #2177.

## Changes

- 48 zh-Hans string **values** in `Packages/OsaurusCore/Resources/Localizable.xcstrings` — no keys, states, or other locales touched

## How to verify without speaking Chinese

Every row below links the English source to the defect. The author is a native Simplified Chinese speaker; every change was checked against the English source string and its Swift call site.

| English source | old → new (zh-Hans) | defect |
|---|---|---|
| %lld items would be redacted | %lld 个项目将被编辑 → %lld 个项目将被隐去 | "redacted" mistranslated as "edited". |
| %lld redactions | %lld 次编辑 → %lld 处隐去 | "redactions" mistranslated as "edits". |
| 1 item would be redacted | 1 个项目将被编辑 → 1 个项目将被脱敏 | "redacted" means privacy masking, not "edited"; current zh says the item will be edited. |
| 1 redaction | 1 次编辑 → 1 次脱敏 | "redaction" mistranslated as "edit"; should be masking/redaction count. |
| 6-bit (q6, GGUF-head parity) | 6位（q6，GGUF-head奇偶校验） → 6 位（q6，与 GGUF-head 持平） | "parity" here means quality parity with GGUF-head, not parity checking; current zh says "p |
| Audience | 观众 → 受众 | "Audience" here is the token/JWT aud claim, not spectators; 观众 is a wrong-sense translatio |
| Block | 块 → 阻止 | 'Block' here is the action verb (block a tool/action), not a data block; 块 is a mistransla |
| Memory & Recall | 内存与重载 → 记忆与回忆 | Feature is agent memory, not RAM; 'Recall' mistranslated as 'reload' |
| Memory DB open | 内存数据库已打开 → 记忆数据库已打开 | Memory-feature DB mistranslated as in-memory/RAM database |
| Memory database reopened. | 内存数据库已重新打开。 → 记忆数据库已重新打开。 | Same RAM-vs-memories word-sense error |

<details><summary>All 48 changes</summary>

| English source | old → new | defect |
|---|---|---|
| Memory store reset. | 内存存储重置。 → 记忆存储已重置。 | RAM-vs-memories error; missing completed aspect |
| Memory store reset. Old file kept at %@. | 内存存储重置。旧文件保存在%@。 → 记忆存储已重置。旧文件保留在 %@。 | Same RAM-vs-memories error in reset toast |
| Net credits | 网络积分 → 净积分 | 'Net' (net amount) mistranslated as 'network' |
| Open Identity | 开放身份 → 打开身份 | "Open" is the verb (open identity settings), not "make public"; 开放身份 misleads. |
| Open Web | 打开网络 → 打开网页 | Button opens the theme's web page; 网络 means "network", should be 网页. |
| Path | 小路 → 路径 | "Path" (file path) mistranslated as "小路" (a footpath/trail). |
| Preview bounded memory context | 预览受限内存上下文 → 预览受限记忆上下文 | "memory" here is agent memory (记忆), not RAM (内存); sibling key uses 记忆. |
| Relay Off | 继电器关闭 → 中继已关闭 | Relay mistranslated as electrical relay (继电器) instead of network relay (中继), inconsistent  |
| Remove Image | 移除镜像 → 移除图片 | In the theme editor, Image means picture, not container image; 镜像 is wrong. |
| Repro path | 复制路径 → 复现路径 | Repro means reproduction, not copy; current zh reads as 'copy path' |
| Still can't open memory — try Reset. | 仍然无法打开内存 — 尝试重置。 → 仍然无法打开记忆 — 请尝试重置。 | 'memory' here is the agent memory store, not RAM; 内存 means RAM. |
| User Agent | 用户智能体 → 用户代理 | In a request-details pane "User Agent" is the HTTP header, not an AI agent. |
| Waiting to be redeemed | 等待被赎回 → 等待兑换 | "redeemed" means to claim/exchange here; 赎回 is the financial buy-back sense. |
| Duration | 期间 → 时长 | "Duration" (elapsed time label) translated as 期间 ("during a period") instead of 时长. |
| Fraction from 0.10 to 1.00. | 分数从0.10到1.00。 → 比例值范围为 0.10 到 1.00。 | 'Fraction' (ratio value) mistranslated as 分数 which reads as 'score' |
| Last signed checks | 最近签署的支票 → 最近的签名校验 | 'checks' here are signed verification checks, not bank cheques. |
| Likes | 偏好 → 点赞 | 'Likes' is the HF like count, not preferences. |
| Listing | 列表 → 条目 | 'Listing' (marketplace entry) mistranslated as 'list'. |
| Memory Budget | 内存预算 → 记忆预算 | Likely memories-feature budget, not RAM budget (callsite MemoryView) |
| Model Memory | 模型记忆 → 模型内存 | Server-settings 'Model Memory' is RAM, not memories |
| Redacted activity export copied | 已编辑的活动导出已复制 → 已脱敏的活动导出已复制 | Redacted translated as 'edited' instead of 'de-sensitized', contradicting the established  |
| Reset memory store? | 重置内存存储？ → 重置记忆存储？ | 'memory' is the agent memory feature, not RAM; 内存 means RAM |
| Resolved Plan | 已解决的计划 → 解析后的计划 | 'Resolved' means computed/effective plan, not 'solved' |
| e.g. CUSTOMER | 例如：客户 → 例如：CUSTOMER | The uppercase placeholder-label example CUSTOMER should stay as a literal token, not be tr |
| manual | 手册 → 手动 | "manual" here means the manual/hand-triggered mode, not a handbook; 手册 is the wrong sense. |
| native | 本地的 → 原生 | "native" should be 原生, not 本地的 which collides with "local". |
| privacy.category.secret | 密钥 → 机密 | Privacy category "secret" means confidential value generally, not cryptographic key. |
| ~%@ of %.0f GB | ~%1$@ of %2$.0f GB → ~%1$@ / %2$.0f GB | English word 'of' left untranslated in the Chinese string. |
| A quick tour | 快速浏览 → 快速导览 | In onboarding context "tour" means a guided walkthrough; "浏览" means skim/browse, which mis |
| Edit model | 编辑模型 → 图像编辑模型 | Label for the image-edit model picker (noun compound), but 编辑模型 parses as the verb phrase  |
| Editing | 正在编辑 → 编辑操作 | Effect-class category label mistranslated as an in-progress status (正在编辑). |
| Look and navigate freely; never edit. | 浏览并自由导航；从不编辑。 → 自由查看和导航；绝不编辑。 | Misattached 'freely', term mismatch with the Looking tier label, and unnatural 从不编辑. |
| Recovery Phrase | 恢复助记词 → 助记词 | '恢复助记词' parses as a verb phrase 'recover the mnemonic'; the field label should be the noun |
| Support Export | 支持导出 → 导出支持数据 | 'Support' here is attributive (export for support purposes); 支持导出 reads as 'supports expor |
| Terms to avoid during image generation | 图片生成时应避免的术语 → 图片生成时应避免的词语 | 'terms' means words/phrases to avoid in image prompts, not terminology; 术语 is the wrong se |
| Zip Bundle | Zip 捆绑包 → Zip 压缩包 | "捆绑包" is a calque of bundle; the conventional zh term for a zip archive is 压缩包. |
| [secret] | [密钥] → [机密] | Masking token for any secret value; "密钥" is too narrow and inconsistent with the corrected |
| editor.section.identity | 身份 → 基本信息 | Comment explicitly invites a 'basic info' rendering to avoid colliding with the cryptograp |

</details>

## Screenshots (app running in zh-Hans)

![before-block-menu.png](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/before-block-menu.png)
![before-tools-pane.png](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/before-tools-pane.png)

## Test plan

- [x] `bash scripts/i18n/check.sh` passes
- [x] catalog still parses; diff touches exactly the listed value lines
- [x] placeholder multisets re-validated mechanically against English source


