### PR TITLE
i18n(zh-Hans): rewrite machine-translation artifacts into natural Chinese

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -3796,7 +3796,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld缓冲区等待蒸馏。"
+            "value" : "%lld 个已缓冲的轮次正在等待蒸馏。"
           }
         },
         "zh-Hant" : {
@@ -4636,7 +4636,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 张图片，%2$@ 跟踪 %3$@，%4$lld 解码，%5$lld 解码失败"
+            "value" : "%1$lld 张图片，已跟踪 %2$@ / 共 %3$@，%4$lld 个解码中，%5$lld 个解码失败"
           }
         },
         "zh-Hant" : {
@@ -5680,7 +5680,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "第 %1$lld 个主题，共 %2$lld 个"
+            "value" : "%1$lld / %2$lld 个主题"
           }
         },
         "zh-Hant" : {
@@ -15873,7 +15873,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加反应"
+            "value" : "添加表情回应"
           }
         },
         "zh-Hant" : {
@@ -16015,7 +16015,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加上方术语以生成正则规则。"
+            "value" : "在上方添加词条以生成匹配规则。"
           }
         },
         "zh-Hant" : {
@@ -16221,7 +16221,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已添加%@"
+            "value" : "添加于 %@"
           }
         },
         "zh-Hant" : {
@@ -23804,7 +23804,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "除阅读外，在每个动作前都要询问。"
+            "value" : "除读取外，在每个动作前都要询问。"
           }
         },
         "zh-Hant" : {
@@ -23907,7 +23907,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "先提问"
+            "value" : "先询问"
           }
         },
         "zh-Hant" : {
@@ -28847,7 +28847,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "凭证配置完成"
+            "value" : "已配置 Bearer 凭证"
           }
         },
         "zh-Hant" : {
@@ -29784,7 +29784,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空白=默认模式"
+            "value" : "留空 = 模式默认值"
           }
         },
         "zh-Hant" : {
@@ -29888,7 +29888,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空白 = 默认模型；0 = 禁用"
+            "value" : "留空 = 模型默认值；0 = 禁用"
           }
         },
         "zh-Hant" : {
@@ -33088,7 +33088,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捆绑完成"
+            "value" : "捆绑包完整"
           }
         },
         "zh-Hant" : {
@@ -33258,7 +33258,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捆绑就绪"
+            "value" : "捆绑包就绪"
           }
         },
         "zh-Hant" : {
@@ -33294,7 +33294,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "包包括智能体的配置和加密数据库，由你选择的密码保护。"
+            "value" : "捆绑包包含智能体的配置及其加密数据库，由你选择的密码保护。"
           }
         },
         "zh-Hant" : {
@@ -41970,7 +41970,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以逗号分隔（例如 api.github.com、*.example.com）。设置后，沙盒流量将通过仅允许这些域名的主机代理。在下次沙盒启动时生效。"
+            "value" : "以逗号分隔（例如 api.github.com, *.example.com）。设置后，沙盒流量将通过仅允许这些域名的主机代理。在下次沙盒启动时生效。"
           }
         },
         "zh-Hant" : {
@@ -42012,7 +42012,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "逗号分隔，例如：research、web、citations"
+            "value" : "逗号分隔，例如：research, web, citations"
           }
         },
         "zh-Hant" : {
@@ -42362,7 +42362,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "压缩（保存）"
+            "value" : "已压缩（已保存）"
           }
         },
         "zh-Hant" : {
@@ -44500,7 +44500,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "确认消息是由授权发送者在选定为已读的频道中发送的。"
+            "value" : "确认消息是由授权发送者在选定为可读的频道中发送的。"
           }
         },
         "zh-Hant" : {
@@ -44986,7 +44986,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接服务以给你的智能体更多工具。"
+            "value" : "连接服务，为你的智能体提供更多工具。"
           }
         },
         "zh-Hant" : {
@@ -47717,7 +47717,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继续参与的讨论串"
+            "value" : "继续参与讨论串"
           }
         },
         "zh-Hant" : {
@@ -48030,7 +48030,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "控制本地vMLX模型使用的加载时内存策略。更改适用于下一个模型负载。"
+            "value" : "控制本地 vMLX 模型使用的加载时内存策略。更改将在下次加载模型时生效。"
           }
         },
         "zh-Hant" : {
@@ -48668,7 +48668,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制诊断信息，并将这份已编辑的请求/响应证据一并附在报告中。"
+            "value" : "复制诊断信息，并将这份已脱敏的请求/响应证据一并附在报告中。"
           }
         },
         "zh-Hant" : {
@@ -49082,7 +49082,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制回复"
+            "value" : "复制响应"
           }
         },
         "zh-Hant" : {
@@ -50279,7 +50279,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法在localhost:1455上启动ChatGPT登录回调服务器。使用该端口关闭任何其他正在进行的登录或应用程序，然后重试。细节：%@"
+            "value" : "无法在 localhost:1455 上启动 ChatGPT 登录回调服务器。请关闭其他正在进行的登录或占用该端口的应用程序，然后重试。详细信息：%@"
           }
         },
         "zh-Hant" : {
@@ -50319,7 +50319,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法在127.0.0.1:%1$u上启动Grok登录回调服务器。使用该端口关闭任何其他正在进行的登录或应用程序，然后重试。详细信息：%2$@"
+            "value" : "无法在 127.0.0.1:%1$u 上启动 Grok 登录回调服务器。请关闭其他正在进行的登录或占用该端口的应用程序，然后重试。详细信息：%2$@"
           }
         },
         "zh-Hant" : {
@@ -53339,7 +53339,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内容维护"
+            "value" : "内容策展"
           }
         },
         "zh-Hant" : {
@@ -54038,7 +54038,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义物理内存分数"
+            "value" : "自定义物理内存占比"
           }
         },
         "zh-Hant" : {
@@ -60068,7 +60068,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "断开连接"
+            "value" : "已断开连接"
           }
         },
         "zh-Hant" : {
@@ -62186,7 +62186,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "先下载或导入，然后使用令牌运行生成证明。"
+            "value" : "先下载或导入，然后运行生成验证并测量 token/s 速率。"
           }
         },
         "zh-Hant" : {
@@ -62920,7 +62920,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "起草并发送文本"
+            "value" : "起草并发送短信"
           }
         },
         "zh-Hant" : {
@@ -63743,7 +63743,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "例如：-y @scope/server --root '包含空格的 /path'"
+            "value" : "例如：-y @scope/server --root '/path with spaces'"
           }
         },
         "zh-Hant" : {
@@ -66012,7 +66012,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑运行；仅发送、删除和类似操作可先执行。"
+            "value" : "编辑操作会直接运行；仅发送、删除等类似操作会先询问。"
           }
         },
         "zh-Hant" : {
@@ -71443,7 +71443,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "于 %@ 过期"
+            "value" : "将于 %@ 过期"
           }
         },
         "zh-Hant" : {
@@ -72695,7 +72695,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将路由器支持捆绑包导出到%@。"
+            "value" : "已将路由器支持捆绑包导出到 %@。"
           }
         },
         "zh-Hant" : {
@@ -72831,7 +72831,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全部显示"
+            "value" : "全部暴露"
           }
         },
         "zh-Hant" : {
@@ -75303,7 +75303,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文件保险箱已关闭——明文存储在静态时不会加密。在“系统设置”→“隐私和安全”中保持SQLCipher打开或打开文件保险箱。"
+            "value" : "文件保险箱已关闭——明文存储在静态时不会加密。请保持 SQLCipher 开启，或在“系统设置”→“隐私与安全性”中打开文件保险箱。"
           }
         },
         "zh-Hant" : {
@@ -76742,7 +76742,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "磁盘空间无法验证"
+            "value" : "可用磁盘空间无法验证"
           }
         },
         "zh-Hant" : {
@@ -77715,7 +77715,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将每标记的解码图与 MLX 编译融合（在 Gemma 4 QAT 上测量提升 +25%）。在重启 Osaurus 后生效——MLX 在进程首次加载模型时会修复其编译状态，因此在会话中途切换此选项无法实时开启或关闭（设置会被保存并在下次启动时应用）。实验性功能：默认关闭，直到历史模型切换损坏问题（PR #1173）得到根本原因分析。如果在开启此功能时模型切换出现问题，请关闭并重启。"
+            "value" : "将每词元的解码图与 MLX 编译融合（在 Gemma 4 QAT 上实测 +25%）。重启 Osaurus 后生效——MLX 会在进程首次加载模型时固定其编译状态，因此会话中途切换此开关无法实时开启或关闭（设置会保存并在下次启动时应用）。实验性功能：在历史遗留的模型切换损坏问题（PR #1173）查明根因之前默认保持关闭。如果开启后模型切换出现异常，请关闭并重启。"
           }
         },
         "zh-Hant" : {
@@ -79670,7 +79670,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当您提问时，给智能体一个它可以调用的工具来朗读回复。如需始终朗读，请在语音部分使用“自动朗读回复”。"
+            "value" : "给智能体一个它可以调用的工具，在你要求时朗读回复。如需始终朗读，请在“语音”部分使用“自动朗读回复”。"
           }
         },
         "zh-Hant" : {
@@ -79991,7 +79991,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全局代理通道写入功能已被写入终止开关禁用（生成 %lld）。"
+            "value" : "全局智能体通道的写入已被写入终止开关禁用（第 %lld 代）。"
           }
         },
         "zh-Hant" : {
@@ -80202,7 +80202,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gmail、日历、驱动器、文档（需要自托管）"
+            "value" : "Gmail、日历、云端硬盘、文档（需要自托管）"
           }
         },
         "zh-Hant" : {
@@ -82440,7 +82440,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "嘿！经过 10 个月的公开建设，今天我们在 Product Hunt 上正式发布了。\n\nOsaurus 因为像你这样的人的反馈而变得更好。如果它对你有帮助，来打个招呼并支持这次发布吧。这对我们意义重大。\n\n感谢你早期的支持。"
+            "value" : "嘿！经过 10 个月的公开开发，今天我们在 Product Hunt 上正式发布了。\n\nOsaurus 因为像你这样的人的反馈而变得更好。如果它对你有帮助，来打个招呼并支持这次发布吧。这对我们意义重大。\n\n感谢你早期的支持。"
           }
         },
         "zh-Hant" : {
@@ -83155,7 +83155,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最高优先级"
+            "value" : "从高到低"
           }
         },
         "zh-Hant" : {
@@ -83753,7 +83753,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "衰减 / 去重 / 强制运行之间的小时间隔"
+            "value" : "衰减 / 去重 / 淘汰运行之间的小时间隔"
           }
         },
         "zh-Hant" : {
@@ -85593,7 +85593,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "忽略"
+            "value" : "已忽略"
           }
         },
         "zh-Hant" : {
@@ -90722,7 +90722,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "指令"
+            "value" : "Instruct"
           }
         },
         "zh-Hant" : {
@@ -92135,7 +92135,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继续"
+            "value" : "保持开启"
           }
         },
         "zh-Hant" : {
@@ -93233,7 +93233,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近 %@"
+            "value" : "上次：%@"
           }
         },
         "zh-Hant" : {
@@ -94992,7 +94992,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体以分离的方式运行长期进程（服务器、监视器）并管理它们。默认关闭以保持工具界面简洁。"
+            "value" : "让智能体以分离的方式运行长期进程（服务器、监视器）并管理它们。默认关闭，以保持工具集精简。"
           }
         },
         "zh-Hant" : {
@@ -96247,7 +96247,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "房间列表"
+            "value" : "列出房间"
           }
         },
         "zh-Hant" : {
@@ -96281,7 +96281,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空间列表"
+            "value" : "列出空间"
           }
         },
         "zh-Hant" : {
@@ -101071,7 +101071,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手动 ID 字段位于高级选项下，用于发现无法看到的条目。"
+            "value" : "对于自动发现看不到的条目，可使用高级选项下的手动 ID 字段。"
           }
         },
         "zh-Hant" : {
@@ -101211,7 +101211,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手动模式永远不会自动蒸馏。请使用“待蒸馏”或设置为会话结束。"
+            "value" : "手动模式绝不会自动蒸馏。请使用“蒸馏待处理项”，或设置为会话结束。"
           }
         },
         "zh-Hant" : {
@@ -101421,7 +101421,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将频道标记为已读，人员标记为允许 — 无需复制数字 ID。"
+            "value" : "将频道标记为“可读”，将人员标记为“允许” — 无需复制数字 ID。"
           }
         },
         "zh-Hant" : {
@@ -101457,7 +101457,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将聊天标记为已读以便智能体可以看到，将人员标记为允许以便其消息被处理。手动 ID 字段位于高级选项下。"
+            "value" : "将聊天标记为“可读”以便智能体可以看到，将人员标记为“允许”以便处理其消息。手动 ID 字段位于高级选项下。"
           }
         },
         "zh-Hant" : {
@@ -103535,7 +103535,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全局禁用记忆。"
+            "value" : "记忆已全局禁用。"
           }
         },
         "zh-Hant" : {
@@ -103827,7 +103827,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重复失败后内存信号已进入死信队列。"
+            "value" : "记忆信号在多次失败后已进入死信队列。"
           }
         },
         "zh-Hant" : {
@@ -104008,7 +104008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MemoryService.bufferTurn 自应用启动后尚未被调用。聊天结束流程未到达该方法——可能是上游的某个网关（每个智能体的 disableMemory、hasContent=false 或非默认聊天路径）导致的。"
+            "value" : "MemoryService.bufferTurn 自应用启动后尚未被调用。聊天收尾流程未到达该方法——可能是上游的某个门控条件（各智能体的 disableMemory、hasContent=false 或非默认聊天路径）导致的。"
           }
         },
         "zh-Hant" : {
@@ -105547,7 +105547,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐藏模式"
+            "value" : "模式已隐藏"
           }
         },
         "zh-Hant" : {
@@ -106592,7 +106592,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型总数"
+            "value" : "模型用量合计"
           }
         },
         "zh-Hant" : {
@@ -106797,7 +106797,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保存后重新加载模型"
+            "value" : "保存后将重新加载模型"
           }
         },
         "zh-Hant" : {
@@ -107348,7 +107348,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滚动时自动加载更多行 — 现在获取下一批。"
+            "value" : "滚动时会自动加载更多行——点按此按钮可立即获取下一批。"
           }
         },
         "zh-Hant" : {
@@ -108884,7 +108884,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "网络和转接呼叫者必须出示访问密钥。网络暴露开启时，本地环回绕过被禁用。"
+            "value" : "网络和中继调用方必须出示访问密钥。开启网络暴露时，本地环回绕过将被禁用。"
           }
         },
         "zh-Hant" : {
@@ -110006,7 +110006,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无账户或设备标识"
+            "value" : "无账户或设备画像"
           }
         },
         "zh-Hant" : {
@@ -112992,7 +112992,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有匹配 — 不会有任何内容被删除。"
+            "value" : "没有匹配 — 不会有任何内容被脱敏。"
           }
         },
         "zh-Hant" : {
@@ -114073,7 +114073,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有未完成文件更改"
+            "value" : "没有待处理的文件更改"
           }
         },
         "zh-Hant" : {
@@ -114597,7 +114597,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尚未收到决定"
+            "value" : "暂无接收决策"
           }
         },
         "zh-Hant" : {
@@ -115570,7 +115570,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尚无签名检查"
+            "value" : "暂无已签名的检查"
           }
         },
         "zh-Hant" : {
@@ -123233,7 +123233,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OpenAI 返回了一个无法阅读的 Codex 模型目录：%@"
+            "value" : "OpenAI 返回了无法解析的 Codex 模型目录：%@"
           }
         },
         "zh-Hant" : {
@@ -125323,7 +125323,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus将完全在本地免费运行。通过Osaurus路由的云模型将被隐藏，任何使用Osaurus的聊天都将切换到本地模型。你可以随时重新打开它。感谢您对Osaurus的支持。"
+            "value" : "Osaurus 将完全本地免费运行。通过 Osaurus 路由的云模型将被隐藏，正在使用这类模型的聊天将切换到本地模型。你可以随时重新开启。感谢你对 Osaurus 的支持。"
           }
         },
         "zh-Hant" : {
@@ -128907,7 +128907,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "待邀请 · %@…"
+            "value" : "待处理邀请 · %@…"
           }
         },
         "zh-Hant" : {
@@ -129974,7 +129974,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在支持的视频模型上允许携带视频的请求。"
+            "value" : "在支持的模型上允许携带视频的请求。"
           }
         },
         "zh-Hant" : {
@@ -130042,7 +130042,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今日已持久化；这些字段的运行时使用者尚未实现。"
+            "value" : "目前仅做持久化；这些字段的运行时使用者尚未实现。"
           }
         },
         "zh-Hant" : {
@@ -130144,7 +130144,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "个人组织者"
+            "value" : "个人事务助理"
           }
         },
         "zh-Hant" : {
@@ -132185,7 +132185,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "计划批处理控制"
+            "value" : "计划中的批处理控制"
           }
         },
         "zh-Hant" : {
@@ -132254,7 +132254,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "计划控制"
+            "value" : "计划中的控制"
           }
         },
         "zh-Hant" : {
@@ -133908,7 +133908,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "高级搜索通过 Osaurus 运行 `web_search` 工具 — 零设置即可获得更好的结果。搜索积分优先覆盖请求；之后，请求从此钱包计费。积分用完后，搜索自动切换到内置源。"
+            "value" : "高级搜索通过 Osaurus 运行 `web_search` 工具 — 零设置即可获得更好的结果。请求费用优先由搜索积分抵扣；积分用完后，请求将从此钱包计费。若积分耗尽，搜索会自动继续使用内置源。"
           }
         },
         "zh-Hant" : {
@@ -142186,7 +142186,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读和编辑 Webflow 网站和 CMS 项目"
+            "value" : "读取和编辑 Webflow 网站和 CMS 条目"
           }
         },
         "zh-Hant" : {
@@ -142288,7 +142288,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读和管理Stripe客户、费用和订阅"
+            "value" : "读取和管理 Stripe 的客户、收费和订阅"
           }
         },
         "zh-Hant" : {
@@ -142564,7 +142564,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "播放完成后自动大声朗读每条回复。仅限点播使用，请使用“朗读工具”功能。"
+            "value" : "流式输出完成后自动朗读每条回复。如只需按需朗读，请改用“朗读工具”功能。"
           }
         },
         "zh-Hant" : {
@@ -143549,7 +143549,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "准备使用"
+            "value" : "可以使用"
           }
         },
         "zh-Hant" : {
@@ -144678,7 +144678,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "服务器空闲时回收 GPU 和磁盘资源。今日已持久化；主机生命周期桥接器将在后续版本中推出。"
+            "value" : "服务器空闲时回收 GPU 和磁盘资源。目前设置已持久化；主机生命周期桥接器将在后续版本中推出。"
           }
         },
         "zh-Hant" : {
@@ -146948,7 +146948,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请记住，设置后的第一次轮询仅激活光标；保存后发送新消息。"
+            "value" : "请记住，设置后的第一次轮询仅使游标就绪；保存后请发送一条新消息。"
           }
         },
         "zh-Hant" : {
@@ -150561,7 +150561,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要语音输入"
+            "value" : "语音输入所需"
           }
         },
         "zh-Hant" : {
@@ -181180,7 +181180,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Telegram 分发不支持提及限制。关闭 Telegram 的需要 @提及。"
+            "value" : "Telegram 分发不支持提及限制。请关闭 Telegram 的“需要 @提及”。"
           }
         },
         "zh-Hant" : {
@@ -181354,7 +181354,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Telegram 仍报告有已注册的 webhook。请稍候并重试。"
+            "value" : "Telegram 仍报告有已注册的 webhook。请稍候，然后再次检查。"
           }
         },
         "zh-Hant" : {
@@ -183596,7 +183596,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "配置文件是无效的 JSON 或形状不兼容。"
+            "value" : "配置文件不是有效的 JSON，或其结构不兼容。"
           }
         },
         "zh-Hant" : {
@@ -184445,7 +184445,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库因未知原因无法打开。"
+            "value" : "记忆数据库因未知原因未能打开。"
           }
         },
         "zh-Hant" : {
@@ -184481,7 +184481,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库未打开。它可能仍在初始化，或者已静默失败——请尝试重试。"
+            "value" : "记忆数据库未打开。它可能仍在初始化，或者已静默失败——请尝试重试。"
           }
         },
         "zh-Hant" : {
@@ -185290,7 +185290,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提供商发送了 Osaurus 无法解码的信封。"
+            "value" : "提供商发送了 Osaurus 无法解码的消息信封。"
           }
         },
         "zh-Hant" : {
@@ -185851,7 +185851,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此Mac上的存储加密密钥不可用（钥匙串重置、应用程序重新签名或未使用iCloud钥匙串进行迁移）。无法使用当前密钥解密您的加密内存。"
+            "value" : "此 Mac 上的存储加密密钥不可用（钥匙串被重置、应用重新签名，或迁移时未使用 iCloud 钥匙串）。当前密钥无法解锁你加密的记忆数据。"
           }
         },
         "zh-Hant" : {
@@ -185920,7 +185920,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "任务仍在运行中。取消将终止它。"
+            "value" : "任务仍在运行。关闭将取消该任务。"
           }
         },
         "zh-Hant" : {
@@ -186168,7 +186168,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工作任务仍在运行。取消将终止任务。"
+            "value" : "工作任务仍在运行。关闭将取消该任务。"
           }
         },
         "zh-Hant" : {
@@ -196341,7 +196341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每天最多4次运行 · 每小时最多一次 · 凌晨10点至早上7点安静。"
+            "value" : "每天最多 4 次运行 · 每小时最多一次 · 晚上 10 点至早上 7 点为安静时段。"
           }
         },
         "zh-Hant" : {
@@ -196375,7 +196375,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每天最多6次运行 · 每小时最多一次 · 凌晨10点至早上7点安静。"
+            "value" : "每天最多 6 次运行 · 每小时最多一次 · 晚上 10 点至早上 7 点为安静时段。"
           }
         },
         "zh-Hant" : {
@@ -197292,7 +197292,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此记忆模式下并发解码槽位的上限。"
+            "value" : "此内存模式下并发解码槽位的上限。"
           }
         },
         "zh-Hant" : {
@@ -208208,7 +208208,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的数据已静态加密。无需任何操作。"
+            "value" : "你的数据已静态加密。无需任何操作。"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
## Summary

Rewrites zh-Hans strings that are word-for-word machine translations a native speaker cannot parse (e.g. “otherwise-quantized bundle” rendered as 在否则量化的捆绑包内). Meaning is taken from the English source and the call site. Follow-up to #2177.

## Changes

- 97 zh-Hans string **values** in `Packages/OsaurusCore/Resources/Localizable.xcstrings` — no keys, states, or other locales touched

## How to verify without speaking Chinese

Every row below links the English source to the defect. The author is a native Simplified Chinese speaker; every change was checked against the English source string and its Swift call site.

| English source | old → new (zh-Hans) | defect |
|---|---|---|
| Confirm the message was sent in a channel selected as Read, by a perso | 确认消息是由授权发送者在选定为已读的频道中发送的。 → 确认消息是由授权发送者在选定为可读的频道中发送的。 | "selected as Read" (channel read permission) mistranslated as 已读 (message read status). |
| Download or import first, then run a generation proof with token/s. | 先下载或导入，然后使用令牌运行生成证明。 → 先下载或导入，然后运行生成验证并测量 token/s 速率。 | "token/s" (tokens-per-second rate) was misread as an auth token ("使用令牌"). |
| Edits run; only sending, deleting, and similar ask first. | 编辑运行；仅发送、删除和类似操作可先执行。 → 编辑操作会直接运行；仅发送、删除等类似操作会先询问。 | "ask first" (require confirmation) was translated as "may execute first" — meaning inverte |
| Fuses the per-token decode graph with MLX compile (+25% measured on Ge | 将每标记的解码图与 MLX 编译融合（在 Gemma 4 QAT 上测量提升 +25%）。 → 将每词元的解码图与 MLX 编译融合（在 Gemma 4 QAT 上实测 +25%）。重启 | 'fixes its compile state' means 'pins/locks', not 'repairs'; also token→词元 per glossary |
| Gmail, Calendar, Drive, Docs (requires self-hosting) | Gmail、日历、驱动器、文档（需要自托管） → Gmail、日历、云端硬盘、文档（需要自托管） | 'Drive' (Google Drive) mistranslated as disk drive (驱动器); official zh name is 云端硬盘. |
| Hours between decay / dedup / eviction runs | 衰减 / 去重 / 强制运行之间的小时间隔 → 衰减 / 去重 / 淘汰运行之间的小时间隔 | 'eviction' mistranslated as 强制 ('forced'), misleading about what the setting controls. |
| Mark channels as Read and people as Allow — no copying numeric IDs. | 将频道标记为已读，人员标记为允许 — 无需复制数字 ID。 → 将频道标记为“可读”，将人员标记为“允许” — 无需复制数字 ID。 | "Read" here is a read-permission toggle, not read/unread status; "已读" misleads. |
| Mark chats as Read so agents can see them, and mark people as Allow so | 将聊天标记为已读以便智能体可以看到，将人员标记为允许以便其消息被处理。手动 ID 字段位于 → 将聊天标记为“可读”以便智能体可以看到，将人员标记为“允许”以便处理其消息。手动 ID 字 | Same Read-permission vs read-status confusion; "已读" misleads. |
| Memory signals dead-lettered after repeated failures. | 重复失败后内存信号已进入死信队列。 → 记忆信号在多次失败后已进入死信队列。 | Memory-feature signals mistranslated as RAM signals |
| Up to 4 runs/day · at most once an hour · quiet 10pm–7am. | 每天最多4次运行 · 每小时最多一次 · 凌晨10点至早上7点安静。 → 每天最多 4 次运行 · 每小时最多一次 · 晚上 10 点至早上 7 点为安静时段。 | "10pm" mistranslated as 凌晨10点 (would read as ~10am); should be 晚上10点. |

<details><summary>All 97 changes</summary>

| English source | old → new | defect |
|---|---|---|
| Up to 6 runs/day · at most once an hour · quiet 10pm–7am. | 每天最多6次运行 · 每小时最多一次 · 凌晨10点至早上7点安静。 → 每天最多 6 次运行 · 每小时最多一次 · 晚上 10 点至早上 7 点为安静时段。 | "10pm" mistranslated as 凌晨10点; should be 晚上10点. |
| Upper bound for concurrent decode slots under this memory mode. | 此记忆模式下并发解码槽位的上限。 → 此内存模式下并发解码槽位的上限。 | "memory mode" here is RAM/memory-safety mode (内存), not agent memory (记忆). |
| %lld buffered turns waiting on distillation. | %lld缓冲区等待蒸馏。 → %lld 个已缓冲的轮次正在等待蒸馏。 | "buffered turns" rendered as "buffers"; also missing measure word. |
| %lld images, %@ tracked of %@, %lld decoding, %lld failed decodes | %1$lld 张图片，%2$@ 跟踪 %3$@，%4$lld 解码，%5$lld 解码失败 → %1$lld 张图片，已跟踪 %2$@ / 共 %3$@，%4$lld 个解码中，%5$l | "X tracked of Y" rendered as "X tracks Y". |
| %lld of %lld themes | 第 %1$lld 个主题，共 %2$lld 个 → %1$lld / %2$lld 个主题 | Count-of-total translated as ordinal "the Nth theme". |
| Add terms above to generate a pattern. | 添加上方术语以生成正则规则。 → 在上方添加词条以生成匹配规则。 | "terms" (words to match) mistranslated as 术语 (technical terminology). |
| Added %@ | 已添加%@ → 添加于 %@ | "Added %@" (date argument) mistranslated as "already added X"; should read "added on <date |
| Ask before every action except reading. | 除阅读外，在每个动作前都要询问。 → 除读取外，在每个动作前都要询问。 | "reading" means read-only actions in the autonomy policy, not human reading; 阅读 shifts the |
| Ask first | 先提问 → 先询问 | "Ask first" means asking the user for permission; 先提问 reads as posing a question. |
| Bearer credential configured | 凭证配置完成 → 已配置 Bearer 凭证 | Dropped 'Bearer' qualifier in a diagnostics message where the credential type matters. |
| Blank = mode default | 空白=默认模式 → 留空 = 模式默认值 | 'mode default' means the mode's default value; 默认模式 reverses it to 'default mode'. |
| Blank = model default; 0 = disabled | 空白 = 默认模型；0 = 禁用 → 留空 = 模型默认值；0 = 禁用 | 'model default' means the model's default value; 默认模型 means 'the default model'. |
| Bundle complete | 捆绑完成 → 捆绑包完整 | "complete" (= intact, paired with "Bundle incomplete") rendered as 完成 (finished). |
| Compacted (saved) | 压缩（保存） → 已压缩（已保存） | past-participle status rendered as an imperative-looking action label |
| Continue Participating Threads | 继续参与的讨论串 → 继续参与讨论串 | Toggle label rendered as a noun phrase ("threads that are participated in") instead of the |
| Controls the load-time memory policy used by local vMLX models. Change | 控制本地vMLX模型使用的加载时内存策略。更改适用于下一个模型负载。 → 控制本地 vMLX 模型使用的加载时内存策略。更改将在下次加载模型时生效。 | "next model load" mistranslated as 模型负载 (workload); sentence is garbled. |
| Could not start the ChatGPT sign-in callback server on localhost:1455. | 无法在localhost:1455上启动ChatGPT登录回调服务器。使用该端口关闭任何其 → 无法在 localhost:1455 上启动 ChatGPT 登录回调服务器。请关闭其他正 | "using that port" modifies the app to close, not the closing action; mistranslated as inst |
| Could not start the Grok sign-in callback server on 127.0.0.1:%u. Clos | 无法在127.0.0.1:%1$u上启动Grok登录回调服务器。使用该端口关闭任何其他正在 → 无法在 127.0.0.1:%1$u 上启动 Grok 登录回调服务器。请关闭其他正在进行 | same modifier misattachment: "app using that port" rendered as "use that port to close" |
| Custom Physical Memory Fraction | 自定义物理内存分数 → 自定义物理内存占比 | Fraction means proportion of RAM; 分数 reads as "score" in UI context |
| Disconnected | 断开连接 → 已断开连接 | "Disconnected" is a status label but the translation reads as the action "Disconnect", ide |
| Draft and send texts | 起草并发送文本 → 起草并发送短信 | "texts" here means text messages, not generic "text". |
| Exported router support bundle to %@. | 将路由器支持捆绑包导出到%@。 → 已将路由器支持捆绑包导出到 %@。 | past-tense success message rendered as an instruction; missing 已 |
| Expose all | 全部显示 → 全部暴露 | Expose means exposing models via API, not merely displaying them |
| FileVault is off — plaintext storage would not be encrypted at rest. K | 文件保险箱已关闭——明文存储在静态时不会加密。在“系统设置”→“隐私和安全”中保持SQLC → 文件保险箱已关闭——明文存储在静态时不会加密。请保持 SQLCipher 开启，或在“系统 | zh misplaces 'Keep SQLCipher on' inside System Settings; en offers two separate options |
| Free disk space could not be proven | 磁盘空间无法验证 → 可用磁盘空间无法验证 | drops 'Free' — it's the free/available space that could not be proven |
| Give the agent a tool it can call to read a reply aloud when you ask.  | 当您提问时，给智能体一个它可以调用的工具来朗读回复。如需始终朗读，请在语音部分使用“自动朗 → 给智能体一个它可以调用的工具，在你要求时朗读回复。如需始终朗读，请在“语音”部分使用“自动 | 'when you ask' (on request) drifted to 'when you ask a question'; also uses 您. |
| Global Agent Channel writes are disabled by the write kill switch (gen | 全局代理通道写入功能已被写入终止开关禁用（生成 %lld）。 → 全局智能体通道的写入已被写入终止开关禁用（第 %lld 代）。 | 'generation' (counter) mistranslated as 生成 (generate); agent should be 智能体. |
| Highest first | 最高优先级 → 从高到低 | Sort option 'Highest first' drifted to 'highest priority'. |
| Ignored | 忽略 → 已忽略 | Status label 'Ignored' translated as imperative 忽略; should be 已忽略 like sibling key |
| Keep On | 继续 → 保持开启 | 'Keep On' means keep the toggle enabled, not 'continue'. |
| Last %@ | 最近 %@ → 上次：%@ | '最近 + relative date' reads ungrammatically; should be 上次. |
| List rooms | 房间列表 → 列出房间 | Verb phrase 'List rooms' rendered as noun 'room list'. |
| List spaces | 空间列表 → 列出空间 | Verb phrase 'List spaces' rendered as noun 'space list'. |
| Manual ID fields are under Advanced for entries discovery cannot see. | 手动 ID 字段位于高级选项下，用于发现无法看到的条目。 → 对于自动发现看不到的条目，可使用高级选项下的手动 ID 字段。 | "用于发现无法看到的条目" reads as "used to discover invisible entries", flipping the meaning of disco |
| Memory disabled globally. | 全局禁用记忆。 → 记忆已全局禁用。 | Status statement reads as an imperative in Chinese |
| MemoryService.bufferTurn has not been invoked since the app started. T | MemoryService.bufferTurn 自应用启动后尚未被调用。聊天结束流程未到 → MemoryService.bufferTurn 自应用启动后尚未被调用。聊天收尾流程未到 | 'gate' (guard condition) mistranslated as network gateway |
| Mode hidden | 隐藏模式 → 模式已隐藏 | Status 'mode is hidden' rendered as noun phrase 'hidden mode' |
| Model totals | 模型总数 → 模型用量合计 | 'totals' means per-model usage totals, not model count |
| Network and relay callers must present an access key. Local loopback b | 网络和转接呼叫者必须出示访问密钥。网络暴露开启时，本地环回绕过被禁用。 → 网络和中继调用方必须出示访问密钥。开启网络暴露时，本地环回绕过将被禁用。 | 'relay' mistranslated as call-forwarding; inconsistent with sibling string |
| No matches — nothing would be redacted. | 没有匹配 — 不会有任何内容被删除。 → 没有匹配 — 不会有任何内容被脱敏。 | "redacted" means masked/sanitized, not deleted; 删除 misstates the operation. |
| No outstanding file changes | 没有未完成文件更改 → 没有待处理的文件更改 | "outstanding" means pending, not unfinished; 未完成 shifts the meaning. |
| No receive decisions yet | 尚未收到决定 → 暂无接收决策 | "receive decisions" means decisions about receiving messages, not "decisions received" |
| Osaurus will run fully local and free. Cloud models routed through Osa | Osaurus将完全在本地免费运行。通过Osaurus路由的云模型将被隐藏，任何使用Osa → Osaurus 将完全本地免费运行。通过 Osaurus 路由的云模型将被隐藏，正在使用这 | "any chat using one" refers to a routed cloud model, not to Osaurus itself; referent shift |
| Pending invite · %@… | 待邀请 · %@… → 待处理邀请 · %@… | "Pending invite" rendered as "waiting to be invited", reversing the meaning. |
| Persisted today; runtime consumers for these fields are not yet implem | 今日已持久化；这些字段的运行时使用者尚未实现。 → 目前仅做持久化；这些字段的运行时使用者尚未实现。 | "Persisted today" means "currently only persisted", not "persisted on this day". |
| Personal Organizer | 个人组织者 → 个人事务助理 | "Personal Organizer" literally rendered; 组织者 means event organizer in Chinese. |
| Planned Batching Controls | 计划批处理控制 → 计划中的批处理控制 | "Planned" (upcoming) misparsed; reads as "controls for scheduled batching". |
| Planned Controls | 计划控制 → 计划中的控制 | "Planned Controls" reads as "plan control" instead of "upcoming controls". |
| Read and manage Stripe customers, charges, and subscriptions | 阅读和管理Stripe客户、费用和订阅 → 读取和管理 Stripe 的客户、收费和订阅 | Stripe 'charges' means payment charges, not fees; also missing CJK-Latin spacing. |
| Read every reply aloud automatically after streaming completes. For on | 播放完成后自动大声朗读每条回复。仅限点播使用，请使用“朗读工具”功能。 → 流式输出完成后自动朗读每条回复。如只需按需朗读，请改用“朗读工具”功能。 | 'Streaming completes' rendered as 'playback completes' and the 'for on-request only, use X |
| Ready to use | 准备使用 → 可以使用 | 'Ready to use' (state) reads as 'preparing to use' (in progress) in the translation. |
| Reclaim GPU and disk when the server is idle. Persisted today; host li | 服务器空闲时回收 GPU 和磁盘资源。今日已持久化；主机生命周期桥接器将在后续版本中推出。 → 服务器空闲时回收 GPU 和磁盘资源。目前设置已持久化；主机生命周期桥接器将在后续版本中推 | 'Persisted today' means 'persisted as of now', not calendar 'today'. |
| Remember the first poll after setup only arms the cursor; send a fresh | 请记住，设置后的第一次轮询仅激活光标；保存后发送新消息。 → 请记住，设置后的第一次轮询仅使游标就绪；保存后请发送一条新消息。 | 'Cursor' here is a polling cursor (游标), not a text caret (光标); 'arms' means primes/readies |
| Required for voice input | 需要语音输入 → 语音输入所需 | Direction reversed: zh says 'voice input is needed' instead of 'needed for voice input' |
| Telegram dispatch does not support mention gating. Turn off Require an | Telegram 分发不支持提及限制。关闭 Telegram 的需要 @提及。 → Telegram 分发不支持提及限制。请关闭 Telegram 的“需要 @提及”。 | Setting name 'Require an @mention' rendered without quoting; sentence unreadable. |
| The config file is invalid JSON or has an incompatible shape. | 配置文件是无效的 JSON 或形状不兼容。 → 配置文件不是有效的 JSON，或其结构不兼容。 | "shape" (data structure) literally translated as geometric 形状 |
| The memory database failed to open for an unrecognized reason. | 内存数据库因未知原因无法打开。 → 记忆数据库因未知原因未能打开。 | memory (the Memory feature) mistranslated as 内存 (RAM) |
| The memory database isn't open. It may still be initializing, or it fa | 内存数据库未打开。它可能仍在初始化，或者已静默失败——请尝试重试。 → 记忆数据库未打开。它可能仍在初始化，或者已静默失败——请尝试重试。 | memory feature DB mistranslated as 内存 (RAM) |
| The storage encryption key is unavailable on this Mac (Keychain reset, | 此Mac上的存储加密密钥不可用（钥匙串重置、应用程序重新签名或未使用iCloud钥匙串进行 → 此 Mac 上的存储加密密钥不可用（钥匙串被重置、应用重新签名，或迁移时未使用 iClou | encrypted memory (feature data) rendered as 内存 (RAM); also spacing and 您 |
| The task is still running. Dismissing will cancel it. | 任务仍在运行中。取消将终止它。 → 任务仍在运行。关闭将取消该任务。 | "Dismissing" (closing the toast) rendered as 取消, colliding with cancel; the sentence becom |
| The work task is still running. Dismissing will cancel the task. | 工作任务仍在运行。取消将终止任务。 → 工作任务仍在运行。关闭将取消该任务。 | Same dismiss/cancel conflation as the sibling toast string. |
| Your data is encrypted at rest. No action needed. | 您的数据已静态加密。无需任何操作。 → 你的数据已静态加密。无需任何操作。 | "encrypted at rest" rendered awkwardly as "statically encrypted"; also uses 您. |
| e.g. -y @scope/server --root '/path with spaces' | 例如：-y @scope/server --root '包含空格的 /path' → 例如：-y @scope/server --root '/path with spaces | Translated the literal CLI example argument, breaking copy-paste usability. |
| Add reaction | 添加反应 → 添加表情回应 | "Add reaction" (message reaction in a chat-channel action list) translated as 添加反应, which  |
| Bundle ready | 捆绑就绪 → 捆绑包就绪 | "Bundle" is a noun (the exported bundle); 捆绑就绪 reads as the verb. Should use 捆绑包. |
| Bundles include the agent's configuration and its encrypted database,  | 包包括智能体的配置和加密数据库，由你选择的密码保护。 → 捆绑包包含智能体的配置及其加密数据库，由你选择的密码保护。 | "agent" rendered as 代理 instead of 智能体; awkward 包包括 doubling. |
| Comma-separated (e.g. api.github.com, *.example.com). When set, sandbo | 以逗号分隔（例如 api.github.com、*.example.com）。设置后，沙盒 → 以逗号分隔（例如 api.github.com, *.example.com）。设置后，沙 | the example replaces the literal commas with 顿号, contradicting the stated comma-separated  |
| Comma-separated, e.g. research, web, citations | 逗号分隔，例如：research、web、citations → 逗号分隔，例如：research, web, citations | format placeholder says comma-separated but the example uses 顿号 separators, contradicting  |
| Connect a service to give your agents more tools. | 连接服务以给你的智能体更多工具。 → 连接服务，为你的智能体提供更多工具。 | AI "agents" rendered 代理 instead of glossary term 智能体. |
| Copy diagnostics and include this redacted request/response evidence w | 复制诊断信息，并将这份已编辑的请求/响应证据一并附在报告中。 → 复制诊断信息，并将这份已脱敏的请求/响应证据一并附在报告中。 | "redacted" rendered as 已编辑 (edited) loses the sensitive-data-removed meaning. |
| Copy response | 复制回复 → 复制响应 | Paired with "Copy request JSON"; response here is an HTTP/model response, not a chat reply |
| Curation | 内容维护 → 内容策展 | curate rendered as maintenance (维护) loses the selection/curation meaning and clashes with  |
| Expires %@ | 于 %@ 过期 → 将于 %@ 过期 | Future tense lost; ambiguous next to the past-tense sibling string. |
| Hey! After 10 months of building in public, today is our official laun | 嘿！经过 10 个月的公开建设，今天我们在 Product Hunt 上正式发布了。<br → 嘿！经过 10 个月的公开开发，今天我们在 Product Hunt 上正式发布了。<br | 'building in public' (startup idiom) rendered as 公开建设 (public construction), wrong domain; |
| Instruct | 指令 → Instruct | Model-variant badge 'Instruct' translated as 指令 collides with Instructions→指令 and loses th |
| Let the agent run long-lived processes (servers, watchers) detached an | 让智能体以分离的方式运行长期进程（服务器、监视器）并管理它们。默认关闭以保持工具界面简洁。 → 让智能体以分离的方式运行长期进程（服务器、监视器）并管理它们。默认关闭，以保持工具集精简。 | 'tool surface' means the set of exposed tools, not the UI; 工具界面 misreads it as interface. |
| Manual mode never auto-distills. Use 'Distill pending' or set to sessi | 手动模式永远不会自动蒸馏。请使用“待蒸馏”或设置为会话结束。 → 手动模式绝不会自动蒸馏。请使用“蒸馏待处理项”，或设置为会话结束。 | 'Distill pending' is an action button; 待蒸馏 reads as a noun state, reversing the reference. |
| Models reload after Save | 保存后重新加载模型 → 保存后将重新加载模型 | Informational note reads as an imperative instruction in Chinese. |
| More rows load automatically as you scroll — this fetches the next bat | 滚动时自动加载更多行 — 现在获取下一批。 → 滚动时会自动加载更多行——点按此按钮可立即获取下一批。 | Second clause drops the subject 'this (button)', reading as a truncated imperative; spaced |
| No accounts or device profiles | 无账户或设备标识 → 无账户或设备画像 | profiles means device profiles/dossiers, not identifiers; 设备标识 alters the privacy claim an |
| No signed checks yet | 尚无签名检查 → 暂无已签名的检查 | '签名检查' parses as 'signature verification (activity)' rather than 'checks that are signed'; |
| OpenAI returned an unreadable Codex model catalog: %@ | OpenAI 返回了一个无法阅读的 Codex 模型目录：%@ → OpenAI 返回了无法解析的 Codex 模型目录：%@ | "Unreadable" here means unparseable by the app, not illegible to a human; 无法阅读 misleads. |
| Permit video-bearing requests on capable models. | 在支持的视频模型上允许携带视频的请求。 → 在支持的模型上允许携带视频的请求。 | "capable models" mistranslated as "supported video models"; also inconsistent with the sib |
| Premium search runs the `web_search` tool through Osaurus - better res | 高级搜索通过 Osaurus 运行 `web_search` 工具 — 零设置即可获得更好 → 高级搜索通过 Osaurus 运行 `web_search` 工具 — 零设置即可获得更好 | 'cover' (pay for) is calqued as 覆盖, which is not idiomatic in Chinese billing copy; should |
| Read and edit Webflow sites and CMS items | 阅读和编辑 Webflow 网站和 CMS 项目 → 读取和编辑 Webflow 网站和 CMS 条目 | 'CMS items' means content entries; 项目 reads as 'projects', ambiguous since 项目 maps to 'pro |
| Telegram still reports a registered webhook. Wait a moment and check a | Telegram 仍报告有已注册的 webhook。请稍候并重试。 → Telegram 仍报告有已注册的 webhook。请稍候，然后再次检查。 | 'check again' means re-check the webhook status, not retry the operation; 重试 shifts the me |
| The provider sent an envelope Osaurus could not decode. | 提供商发送了 Osaurus 无法解码的信封。 → 提供商发送了 Osaurus 无法解码的消息信封。 | Protocol "envelope" rendered bare as 信封, which reads as a physical envelope. |

</details>

## Test plan

- [x] `bash scripts/i18n/check.sh` passes
- [x] catalog still parses; diff touches exactly the listed value lines
- [x] placeholder multisets re-validated mechanically against English source


