### PR TITLE
i18n(zh-Hans): fix translations whose meaning drifted from the English source

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -2827,7 +2827,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ 使用直连网络"
+            "value" : "%@ 使用直连网络。"
           }
         },
         "zh-Hant" : {
@@ -3373,7 +3373,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剩余 %dm %ds"
+            "value" : "剩余 %d 分 %d 秒"
           }
         },
         "zh-Hant" : {
@@ -3407,7 +3407,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剩余 %ds"
+            "value" : "剩余 %d 秒"
           }
         },
         "zh-Hant" : {
@@ -5564,7 +5564,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%2$lld 个中 %1$lld 个已分类"
+            "value" : "已分类 %1$lld / %2$lld 个"
           }
         },
         "zh-Hant" : {
@@ -8837,7 +8837,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "+ Enter 保存"
+            "value" : "+ 按 Enter 保存"
           }
         },
         "zh-Hant" : {
@@ -9855,7 +9855,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 个文档没有类别"
+            "value" : "1 个文档未设置分类"
           }
         },
         "zh-Hant" : {
@@ -19484,7 +19484,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许屏蔽敏感信息后的截图发送到云端模型。"
+            "value" : "允许屏蔽敏感信息后的截图发送到云端模型"
           }
         },
         "zh-Hant" : {
@@ -27314,7 +27314,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Azure 通常需要手动部署 ID，因为 /models 可能不可用。"
+            "value" : "Azure 通常需要手动填写部署 ID，因为 /models 可能不可用。"
           }
         },
         "zh-Hant" : {
@@ -32076,7 +32076,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览器使用默认关闭，仅自定义智能体可使用。打开自定义智能体的「子智能体」标签页，开启浏览器使用 — 可选择专用浏览模型。在新建的浏览器设置标签页中查看或重置每个智能体的会话。"
+            "value" : "浏览器使用默认关闭，仅自定义智能体可使用。打开自定义智能体的“子智能体”标签页，开启浏览器使用 — 可选择专用浏览模型。在新增的“浏览器”设置标签页中查看或重置每个智能体的会话。"
           }
         },
         "zh-Hant" : {
@@ -32812,7 +32812,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无需密钥的内置来源。当没有提供商响应时始终可用作备选。"
+            "value" : "无需密钥的内置源。当没有提供商响应时始终可用作备选。"
           }
         },
         "zh-Hant" : {
@@ -33122,7 +33122,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捆绑不完整"
+            "value" : "捆绑包不完整"
           }
         },
         "zh-Hant" : {
@@ -37930,7 +37930,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检查运行时兼容性..."
+            "value" : "正在检查运行时兼容性…"
           }
         },
         "zh-Hant" : {
@@ -40841,7 +40841,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "克隆基础环境"
+            "value" : "正在克隆基础环境"
           }
         },
         "zh-Hant" : {
@@ -49890,7 +49890,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法创建安全登录验证。"
+            "value" : "无法创建安全登录验证"
           }
         },
         "zh-Hant" : {
@@ -58419,7 +58419,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "描述图片..."
+            "value" : "描述图片…"
           }
         },
         "zh-Hant" : {
@@ -59220,7 +59220,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "诊断…"
+            "value" : "正在诊断…"
           }
         },
         "zh-Hant" : {
@@ -67846,7 +67846,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已加密 %lld 个存储。"
+            "value" : "已对 %lld 个存储启用静态加密。"
           }
         },
         "zh-Hant" : {
@@ -67880,7 +67880,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已加密 1 个存储。"
+            "value" : "已对 1 个存储启用静态加密。"
           }
         },
         "zh-Hant" : {
@@ -70673,7 +70673,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此智能体能做的一切 — 翻转一项能力，观察启动上下文的响应。"
+            "value" : "此智能体能做的一切 — 切换一项能力，观察启动上下文的响应。"
           }
         },
         "zh-Hant" : {
@@ -71307,7 +71307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "实验性功能：当服务器驱逐策略设为「灵活（多模型）」且内存预测显示两个模型都能容纳时，将辅助模型与聊天模型并行加载，而非先卸载再重新加载——在大内存 Mac 上跳过换入换出的往返开销。内存紧张或采用严格策略时，始终回退至常规交接流程。"
+            "value" : "实验性功能：当服务器驱逐策略设为“灵活（多模型）”且内存预测显示两个模型都能容纳时，将辅助模型与聊天模型并行加载，而非先卸载再重新加载——在大内存 Mac 上跳过换入换出的往返开销。内存紧张或采用严格策略时，始终回退至常规交接流程。"
           }
         },
         "zh-Hant" : {
@@ -72865,7 +72865,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过中继隧道将此智能体公开到公共互联网，以便外部服务能够访问它。"
+            "value" : "通过中继隧道将此智能体暴露到公网，以便外部服务能够访问它。"
           }
         },
         "zh-Hant" : {
@@ -73367,7 +73367,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提取积分"
+            "value" : "网页提取额度"
           }
         },
         "zh-Hant" : {
@@ -86115,7 +86115,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅图像"
+            "value" : "仅图片"
           }
         },
         "zh-Hant" : {
@@ -94883,7 +94883,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许智能体使用本地模型，通过 image 工具生成和编辑图像。"
+            "value" : "允许智能体使用本地模型，通过 `image` 工具生成和编辑图像。"
           }
         },
         "zh-Hant" : {
@@ -97802,7 +97802,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加载文件..."
+            "value" : "正在加载文件…"
           }
         },
         "zh-Hant" : {
@@ -98008,7 +98008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加载模型卡片..."
+            "value" : "正在加载模型卡片…"
           }
         },
         "zh-Hant" : {
@@ -98489,7 +98489,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地捆绑包已就绪。"
+            "value" : "本地捆绑包已就绪"
           }
         },
         "zh-Hant" : {
@@ -98707,7 +98707,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地移交与生成任务的内存安全设置，属于系统设置，可在“设置 → 子智能体”中配置。"
+            "value" : "本地交接与生成任务的内存安全属于系统设置，可在“设置 → 子智能体”中配置。"
           }
         },
         "zh-Hant" : {
@@ -102508,7 +102508,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大响应词元数"
+            "value" : "最大响应 Token 数"
           }
         },
         "zh-Hant" : {
@@ -104912,7 +104912,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最小值"
+            "value" : "最小"
           }
         },
         "zh-Hant" : {
@@ -110420,7 +110420,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "还没有智能体 - 请在“智能体”标签页创建一个"
+            "value" : "还没有智能体 — 请在“智能体”标签页创建一个"
           }
         },
         "zh-Hant" : {
@@ -112270,7 +112270,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有安装的插件拥有此捕获功能。"
+            "value" : "没有任何已安装的插件拥有此捕获能力。"
           }
         },
         "zh-Hant" : {
@@ -117322,7 +117322,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此智能体未启用"
+            "value" : "未对此智能体启用"
           }
         },
         "zh-Hant" : {
@@ -126751,7 +126751,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "传入 onClearChat 处理器以启用 /clear"
+            "value" : "传入 onClearChat 处理程序以启用 /clear"
           }
         },
         "zh-Hant" : {
@@ -127499,7 +127499,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴文本进行测试..."
+            "value" : "粘贴文本进行测试…"
           }
         },
         "zh-Hant" : {
@@ -129766,7 +129766,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "权限策略被拒绝"
+            "value" : "权限策略为拒绝"
           }
         },
         "zh-Hant" : {
@@ -142009,7 +142009,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "读"
+            "value" : "读取"
           }
         },
         "zh-Hant" : {
@@ -147438,7 +147438,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从你的自定义工具中移除\"%@\"？智能体将无法再使用其工具。"
+            "value" : "从你的自定义工具中移除“%@”？智能体将无法再使用其工具。"
           }
         },
         "zh-Hant" : {
@@ -147892,7 +147892,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除模型"
+            "value" : "移除模型"
           }
         },
         "zh-Hant" : {
@@ -150527,7 +150527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录需要"
+            "value" : "转录所需"
           }
         },
         "zh-Hant" : {
@@ -150667,7 +150667,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要输入到其他应用程序中"
+            "value" : "向其他应用程序输入文字所需"
           }
         },
         "zh-Hant" : {
@@ -151791,7 +151791,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已重置为默认主题"
+            "value" : "重置为默认主题"
           }
         },
         "zh-Hant" : {
@@ -153491,7 +153491,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新加载插件？"
+            "value" : "重试加载插件？"
           }
         },
         "zh-Hant" : {
@@ -154413,7 +154413,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "撤销"
+            "value" : "已撤销"
           }
         },
         "zh-Hant" : {
@@ -154596,7 +154596,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "回滚到默认主题"
+            "value" : "已回滚到默认主题"
           }
         },
         "zh-Hant" : {
@@ -155163,7 +155163,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器"
+            "value" : "路由"
           }
         },
         "zh-Hant" : {
@@ -155197,7 +155197,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器账户"
+            "value" : "路由账户"
           }
         },
         "zh-Hant" : {
@@ -155305,7 +155305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "托管模型请求计费后，路由器使用情况将显示在此处。"
+            "value" : "托管模型请求计费后，路由使用情况将显示在此处。"
           }
         },
         "zh-Hant" : {
@@ -155562,7 +155562,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "智能体（或你）删除的行会显示在此处，准备恢复。"
+            "value" : "智能体（或你）删除的行会显示在此处，随时可以恢复。"
           }
         },
         "zh-Hant" : {
@@ -155804,7 +155804,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行本地签名检查以查看已编辑的请求形态。"
+            "value" : "运行本地签名检查以查看脱敏后的请求形态。"
           }
         },
         "zh-Hant" : {
@@ -156118,7 +156118,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行诊断以测试保存的连接与其端点。"
+            "value" : "下方的“运行诊断”会针对其端点测试已保存的连接。"
           }
         },
         "zh-Hant" : {
@@ -157332,7 +157332,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行"
+            "value" : "运行记录"
           }
         },
         "zh-Hant" : {
@@ -158369,7 +158369,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沙盒已启用 - 容器未运行"
+            "value" : "沙盒已启用 — 容器未运行"
           }
         },
         "zh-Hant" : {
@@ -158403,7 +158403,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沙盒处于活动状态 - 点击可禁用。右键打开设置。"
+            "value" : "沙盒处于活动状态 — 点击可禁用。右键打开设置。"
           }
         },
         "zh-Hant" : {
@@ -160184,7 +160184,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今日已保存；请求管道将在后续步骤中开始强制执行这些设置。"
+            "value" : "目前这些设置仅会被保存；请求管道将在后续更新中开始强制执行。"
           }
         },
         "zh-Hant" : {
@@ -160671,7 +160671,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "扫描…"
+            "value" : "正在扫描…"
           }
         },
         "zh-Hant" : {
@@ -160841,7 +160841,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将此智能体安排为按周期重复运行——非常适合每日简报或自动签到。"
+            "value" : "将此智能体安排为按周期重复运行——非常适合每日简报或自动定期汇报。"
           }
         },
         "zh-Hant" : {
@@ -163720,7 +163720,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动关闭前几秒。空值使用默认5秒"
+            "value" : "自动关闭前的秒数。留空则使用默认 5 秒"
           }
         },
         "zh-Hant" : {
@@ -163790,7 +163790,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "密钥 \"%@\" 没有钥匙串 ID（期望 name=keychain-id）。"
+            "value" : "密钥“%@”没有钥匙串 ID（应为 name=keychain-id）。"
           }
         },
         "zh-Hant" : {
@@ -165440,7 +165440,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自我计划"
+            "value" : "自调度"
           }
         },
         "zh-Hant" : {
@@ -165476,7 +165476,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在自我计划"
+            "value" : "自调度"
           }
         },
         "zh-Hant" : {
@@ -166008,7 +166008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "向机器人发送消息（或将其添加到群组并在那里发布），然后加载待处理的聊天和发送者。"
+            "value" : "向机器人发送消息（或将其添加到群组并在群里发言），然后加载待处理的聊天和发送者。"
           }
         },
         "zh-Hant" : {
@@ -168294,7 +168294,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分享匿名使用数据以帮助改进 Osaurus"
+            "value" : "共享匿名使用数据以帮助改进 Osaurus"
           }
         },
         "zh-Hant" : {
@@ -169393,7 +169393,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示更少"
+            "value" : "收起"
           }
         },
         "zh-Hant" : {
@@ -169495,7 +169495,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示更少"
+            "value" : "收起"
           }
         },
         "zh-Hant" : {
@@ -169894,7 +169894,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示 %lld-%lld 共 %lld 已加载"
+            "value" : "显示已加载 %3$lld 行中的第 %1$lld-%2$lld 行"
           }
         },
         "zh-Hant" : {
@@ -170168,7 +170168,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 huggingface.co 登录（或免费注册）。"
+            "value" : "在 huggingface.co 登录（或免费注册）"
           }
         },
         "zh-Hant" : {
@@ -173924,7 +173924,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "部分缓冲轮次达到重试上限并已进入死信队列。请查看近期活动了解失败原因，然后在修复模型/配置问题后回填或重新填充。"
+            "value" : "部分缓冲轮次达到重试上限并已进入死信队列。请查看近期活动了解失败原因，然后在修复模型/配置问题后回填或重新导入。"
           }
         },
         "zh-Hant" : {
@@ -175144,7 +175144,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "块扩散模型（DiffusionGemma）的速度/质量预算。设为 16 时速度约为模型默认值的 2 倍，且保持画面连贯；低于 12 时质量下降。对常规模型无效。"
+            "value" : "块扩散模型（DiffusionGemma）的速度/质量预算。设为 16 时速度约为模型默认值的 2 倍，且输出保持连贯；低于 12 时质量下降。对常规模型无效。"
           }
         },
         "zh-Hant" : {
@@ -175713,7 +175713,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 完成本地 AI 设置时，您现在就可以开始聊天。"
+            "value" : "Osaurus 正在完成本地 AI 设置，你现在就可以开始聊天。"
           }
         },
         "zh-Hant" : {
@@ -176445,7 +176445,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在启动宿主 API 桥接"
+            "value" : "正在启动主机 API 桥接"
           }
         },
         "zh-Hant" : {
@@ -179045,7 +179045,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功：已授权（找到 %lld 个联系人）"
+            "value" : "成功：已授权（找到 %lld+ 个联系人）"
           }
         },
         "zh-Hant" : {
@@ -179249,7 +179249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功：该进程已通过辅助功能验证。"
+            "value" : "成功：该进程已被授予辅助功能权限。"
           }
         },
         "zh-Hant" : {
@@ -182628,7 +182628,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文字转语音"
+            "value" : "文本转语音"
           }
         },
         "zh-Hant" : {
@@ -184029,7 +184029,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该文件不是一个可读的数据库（可能已损坏或密钥不匹配）。请重置以重新创建它；原始文件已被隔离。"
+            "value" : "该文件不是可读的数据库（可能已损坏或密钥不匹配）。请重置以重新创建它；原始文件会被隔离。"
           }
         },
         "zh-Hant" : {
@@ -184307,7 +184307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该链接将停止工作。任何尝试使用它的人将被拒绝访问。"
+            "value" : "该链接将失效。任何尝试使用它的人都将被拒绝访问。"
           }
         },
         "zh-Hant" : {
@@ -186133,7 +186133,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法读取的数据库已被移动到 ~/.osaurus/quarantine/ 目录（不会被删除），并创建了一个全新的空内存存储，以便记忆和搜索功能再次正常工作。旧文件中的提炼事实和情节保留在隔离区——如果您可能需要恢复密钥，请先导出纯文本备份。"
+            "value" : "无法读取的数据库会被移至 ~/.osaurus/quarantine/（绝不会被删除），并创建一个全新的空记忆存储，以便记忆和搜索恢复正常。旧文件中的提炼事实和情景会保留在隔离区——如果你可能找回密钥，请先导出纯文本备份。"
           }
         },
         "zh-Hant" : {
@@ -188119,7 +188119,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此项为可选配置。即使不设置分类，智能体仍可搜索和读取这些文档。\n\n若要让智能体按分类筛选，可将文档移入对应文件夹（文件夹名即为分类），或在文档的前置元数据中添加 `type:` 字段。"
+            "value" : "此项为可选配置。即使不设置分类，智能体仍可搜索和读取这些文档。\n\n若要让智能体按分类筛选，可将文档移入对应文件夹（文件夹名即为分类），或在文档的前置元数据中添加 `type:` 字段。\n\n"
           }
         },
         "zh-Hant" : {
@@ -189705,7 +189705,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将移除「%@」并从钥匙串中删除其 API 密钥。"
+            "value" : "这将移除“%@”并从钥匙串中删除其 API 密钥。"
           }
         },
         "zh-Hant" : {
@@ -190127,7 +190127,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "紧凑适配"
+            "value" : "空间紧张"
           }
         },
         "zh-Hant" : {
@@ -190615,7 +190615,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通知消息已生效！"
+            "value" : "Toast 通知正常工作！"
           }
         },
         "zh-Hant" : {
@@ -192852,7 +192852,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录已失效。"
+            "value" : "已忘记该转录回合。"
           }
         },
         "zh-Hant" : {
@@ -194625,7 +194625,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已到记忆轮次上限，但蒸馏正在跳过。"
+            "value" : "回合已进入记忆，但蒸馏被跳过。"
           }
         },
         "zh-Hant" : {
@@ -196085,7 +196085,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不支持的本地模型类型：hunyuan_v1_dense。Osaurus 需要 vmlx Hunyuan Dense 支持才能在此模型上本地运行。"
+            "value" : "不支持的本地模型类型：hunyuan_v1_dense。Osaurus 需要 vmlx Hunyuan Dense 支持后，此模型才能在本地运行。"
           }
         },
         "zh-Hant" : {
@@ -196409,7 +196409,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每天最多48次运行 · 每5分钟一次 · 无安静时段。"
+            "value" : "每天最多 48 次运行 · 最快每 5 分钟一次 · 无安静时段。"
           }
         },
         "zh-Hant" : {
@@ -200362,7 +200362,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "洞察视图"
+            "value" : "在洞察中查看"
           }
         },
         "zh-Hant" : {
@@ -201064,7 +201064,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "语音检测：已禁用 - 点击启用"
+            "value" : "语音检测：已禁用 — 点击启用"
           }
         },
         "zh-Hant" : {
@@ -201098,7 +201098,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "语音检测：正在聆听 - 点击禁用"
+            "value" : "语音检测：正在聆听 — 点击禁用"
           }
         },
         "zh-Hant" : {
@@ -201200,7 +201200,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "语音检测：就绪 - 点击禁用"
+            "value" : "语音检测：就绪 — 点击禁用"
           }
         },
         "zh-Hant" : {
@@ -202533,7 +202533,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预热 — 填充上下文…"
+            "value" : "预热 — 预填充上下文…"
           }
         },
         "zh-Hant" : {
@@ -202705,7 +202705,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "监控文件夹"
+            "value" : "受监视的文件夹"
           }
         },
         "zh-Hant" : {
@@ -204773,7 +204773,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus监听客户端请求的地方。更改后需要重启服务器。"
+            "value" : "Osaurus 监听客户端请求的位置。更改会重启服务器。"
           }
         },
         "zh-Hant" : {
@@ -206460,7 +206460,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将~/.osaurus下的每个数据库、附件和配置的明文副本写入您选择的文件夹。建议在重新安装 macOS 或移动 Mac 之前使用。"
+            "value" : "将 ~/.osaurus 下每个数据库、附件和配置的明文副本写入你选择的文件夹。建议在重新安装 macOS 或更换 Mac 前进行。"
           }
         },
         "zh-Hant" : {
@@ -207505,7 +207505,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您被收取了%@。"
+            "value" : "本次已扣费 %@。"
           }
         },
         "zh-Hant" : {
@@ -208310,7 +208310,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的数据库未被Osaurus加密。macOS FileVault在静止状态下保护它们。"
+            "value" : "你的数据库未由 Osaurus 加密。macOS FileVault 会在静态存储时保护它们。"
           }
         },
         "zh-Hant" : {
@@ -208592,7 +208592,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的私有模型下载已暂停"
+            "value" : "你的私有模型已暂停"
           }
         },
         "zh-Hant" : {
@@ -208910,7 +208910,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "用于Osaurus路由服务的钱包 - 添加积分并跟踪每个请求和充值。"
+            "value" : "你的 Osaurus 路由服务钱包 — 添加积分，并跟踪每笔请求与充值。"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
## Summary

Fixes zh-Hans strings that read fine but say something different from the English source (e.g. “10pm” translated as 凌晨/“early morning”, a completed “reset” status reading like a command, “channel selected as Read” translated as read/unread status). Follow-up to #2177.

## Changes

- 97 zh-Hans string **values** in `Packages/OsaurusCore/Resources/Localizable.xcstrings` — no keys, states, or other locales touched

## How to verify without speaking Chinese

Every row below links the English source to the defect. The author is a native Simplified Chinese speaker; every change was checked against the English source string and its Swift call site.

| English source | old → new (zh-Hans) | defect |
|---|---|---|
| Required to type into other applications | 需要输入到其他应用程序中 → 向其他应用程序输入文字所需 | Reversed meaning: zh reads as an instruction to type, not a permission rationale |
| Reset to default theme | 已重置为默认主题 → 重置为默认主题 | zh adds 已 (already done), turning an action label into a completed-state message |
| Revoked | 撤销 → 已撤销 | Status label reads as imperative verb; needs 已撤销 to distinguish from Revoke |
| Rolled back to the default theme | 回滚到默认主题 → 已回滚到默认主题 | Completed-action toast missing 已, reads as imperative |
| Router | 路由器 → 路由 | Model-routing feature translated as hardware router |
| Router Account | 路由器账户 → 路由账户 | Router (model routing service) mistranslated as hardware router |
| Router usage appears here after a hosted model request is billed. | 托管模型请求计费后，路由器使用情况将显示在此处。 → 托管模型请求计费后，路由使用情况将显示在此处。 | Same Router-as-hardware mistranslation |
| Run Diagnostics below tests the saved connection against its endpoint. | 运行诊断以测试保存的连接与其端点。 → 下方的“运行诊断”会针对其端点测试已保存的连接。 | Descriptive sentence turned imperative; 'against its endpoint' misread as coordinate objec |
| Run a local signing check to inspect the redacted request shape. | 运行本地签名检查以查看已编辑的请求形态。 → 运行本地签名检查以查看脱敏后的请求形态。 | redacted mistranslated as edited, losing privacy meaning |
| SUCCESS: Authorized (Found %lld+ contacts) | 成功：已授权（找到 %lld 个联系人） → 成功：已授权（找到 %lld+ 个联系人） | Dropped the '+' after %lld, changing at-least count to exact count |

<details><summary>All 97 changes</summary>

| English source | old → new | defect |
|---|---|---|
| Schedule this agent to run on a recurring cadence — perfect for daily  | 将此智能体安排为按周期重复运行——非常适合每日简报或自动签到。 → 将此智能体安排为按周期重复运行——非常适合每日简报或自动定期汇报。 | "check-ins" means periodic status reports, not attendance sign-in (签到) |
| Seconds before auto-dismiss. Empty uses default 5s | 自动关闭前几秒。空值使用默认5秒 → 自动关闭前的秒数。留空则使用默认 5 秒 | "Seconds before auto-dismiss" is a field description meaning "number of seconds"; 「自动关闭前几秒 |
| Self-scheduled | 自我计划 → 自调度 | Inconsistent with sibling key using 自调度; 计划 drifts from 'scheduled' |
| Self-scheduling | 正在自我计划 → 自调度 | Toggle title mistranslated as progressive state '正在自我计划'; should be feature name 自调度 |
| Showing %lld-%lld of %lld loaded | 显示 %lld-%lld 共 %lld 已加载 → 显示已加载 %3$lld 行中的第 %1$lld-%2$lld 行 | '共 %lld 已加载' dangling at end is ungrammatical and ambiguous |
| Sign in (or sign up free) at huggingface.co | 在 huggingface.co 登录（或免费注册）。 → 在 huggingface.co 登录（或免费注册） | Trailing full stop absent in en and in the parallel github.com key |
| Some buffered turns hit the retry cap and were dead-lettered. Check Re | 部分缓冲轮次达到重试上限并已进入死信队列。请查看近期活动了解失败原因，然后在修复模型/配置 → 部分缓冲轮次达到重试上限并已进入死信队列。请查看近期活动了解失败原因，然后在修复模型/配置 | "re-ingest" mistranslated as "重新填充" (refill), losing the data-ingestion meaning. |
| Speed/quality budget for block-diffusion models (DiffusionGemma). 16 ≈ | 块扩散模型（DiffusionGemma）的速度/质量预算。设为 16 时速度约为模型默认 → 块扩散模型（DiffusionGemma）的速度/质量预算。设为 16 时速度约为模型默认 | "stays coherent" refers to text output; zh added "画面" (visual/picture), wrong for a text d |
| Start chatting now while Osaurus finishes setting up local AI. | Osaurus 完成本地 AI 设置时，您现在就可以开始聊天。 → Osaurus 正在完成本地 AI 设置，你现在就可以开始聊天。 | zh reads as "when setup completes" but en means "while setup is still in progress"; also u |
| The unreadable database is moved to ~/.osaurus/quarantine/ (never dele | 无法读取的数据库已被移动到 ~/.osaurus/quarantine/ 目录（不会被删除 → 无法读取的数据库会被移至 ~/.osaurus/quarantine/（绝不会被删除），并 | future/behavior description rendered in past tense as if already done; episodes rendered w |
| Tight Fit | 紧凑适配 → 空间紧张 | 'Tight Fit' (model barely fits in memory) rendered as UI-layout-sounding '紧凑适配', inconsist |
| Transcript turn forgotten. | 转录已失效。 → 已忘记该转录回合。 | 'forgotten' (removed via Forget) mistranslated as 'expired/invalid'. |
| Turns reached memory, but distillation is skipping. | 已到记忆轮次上限，但蒸馏正在跳过。 → 回合已进入记忆，但蒸馏被跳过。 | Invents a 'limit reached' meaning absent from the English. |
| Unsupported local model type: hunyuan_v1_dense. Osaurus needs vmlx Hun | 不支持的本地模型类型：hunyuan_v1_dense。Osaurus 需要 vmlx H → 不支持的本地模型类型：hunyuan_v1_dense。Osaurus 需要 vmlx H | Rendered as "run locally on this model" instead of "this model can run locally". |
| Up to 48 runs/day · as often as every 5 min · no quiet hours. | 每天最多48次运行 · 每5分钟一次 · 无安静时段。 → 每天最多 48 次运行 · 最快每 5 分钟一次 · 无安静时段。 | "as often as every 5 min" (upper bound) rendered as a fixed "every 5 min". |
| View in Insights | 洞察视图 → 在洞察中查看 | Action "View in Insights" rendered as the noun phrase "Insights view". |
| Where Osaurus listens for client requests. Changes restart the server. | Osaurus监听客户端请求的地方。更改后需要重启服务器。 → Osaurus 监听客户端请求的位置。更改会重启服务器。 | EN states changes restart the server automatically; ZH implies the user must restart it ma |
| Writes a plaintext copy of every database, attachment, and config unde | 将~/.osaurus下的每个数据库、附件和配置的明文副本写入您选择的文件夹。建议在重新安 → 将 ~/.osaurus 下每个数据库、附件和配置的明文副本写入你选择的文件夹。建议在重新 | "moving Macs" means migrating to a new Mac, not physically moving one; also spacing and 您. |
| You were charged %@. | 您被收取了%@。 → 本次已扣费 %@。 | Awkward calque passive; also uses "您" and lacks spacing around placeholder. |
| Your private model is paused | 您的私有模型下载已暂停 → 你的私有模型已暂停 | Adds "download" not present in source, narrowing the meaning; uses 您. |
| not enabled for this agent | 此智能体未启用 → 未对此智能体启用 | Reads as "this agent is not enabled" instead of "not enabled for this agent" — subject fli |
| permission policy is deny | 权限策略被拒绝 → 权限策略为拒绝 | Translation says the policy "was denied" instead of "the policy is set to deny". |
| %@ use direct networking. | %@ 使用直连网络 → %@ 使用直连网络。 | Trailing period dropped, inconsistent with the sibling proxy-endpoint string which keeps i |
| %dm %ds left | 剩余 %dm %ds → 剩余 %d 分 %d 秒 | Keeps English unit suffixes m/s while the sibling key translates them to 分/秒. |
| %ds left | 剩余 %ds → 剩余 %d 秒 | Keeps English s suffix while sibling "%llds remaining" translates it to 秒. |
| %lld of %lld categorized | %2$lld 个中 %1$lld 个已分类 → 已分类 %1$lld / %2$lld 个 | Awkward inverted phrasing, inconsistent with the batch-wide "X / Y" pattern for count-of-t |
| + Enter to save | + Enter 保存 → + 按 Enter 保存 | Sibling keys use the "+ 按 Enter …" pattern; this one drops "按", breaking consistency withi |
| 1 document has no category | 1 个文档没有类别 → 1 个文档未设置分类 | Within the same KnowledgeView, "category" is rendered as 分类 in two sibling strings but 类别  |
| Allow masked screenshots to reach a cloud model | 允许屏蔽敏感信息后的截图发送到云端模型。 → 允许屏蔽敏感信息后的截图发送到云端模型 | English is a period-less toggle label but zh adds a full stop, inconsistent with sibling t |
| Azure often requires manual deployment IDs because /models may be unav | Azure 通常需要手动部署 ID，因为 /models 可能不可用。 → Azure 通常需要手动填写部署 ID，因为 /models 可能不可用。 | "手动部署 ID" is parsed as 'manually deploy the ID'; needs 填写 to disambiguate that the IDs are |
| Browser Use is off by default and only custom agents can use it. Open  | 浏览器使用默认关闭，仅自定义智能体可使用。打开自定义智能体的「子智能体」标签页，开启浏览器 → 浏览器使用默认关闭，仅自定义智能体可使用。打开自定义智能体的“子智能体”标签页，开启浏览器 | Corner brackets vs curly quotes inconsistency; 新建的 misreads "new" (newly added in this rel |
| Built-in sources that need no key. Always available as backup when no  | 无需密钥的内置来源。当没有提供商响应时始终可用作备选。 → 无需密钥的内置源。当没有提供商响应时始终可用作备选。 | 内置来源 vs 内置源 for the same concept on the same settings screen. |
| Bundle incomplete | 捆绑不完整 → 捆绑包不完整 | Sibling diagnostic string in ModelCompatibilityDiagnostics.swift; must align with 捆绑包完整 /  |
| Checking runtime compatibility… | 检查运行时兼容性... → 正在检查运行时兼容性… | missing progressive marker used by sibling status strings, and ASCII '...' instead of the  |
| Cloning base environment | 克隆基础环境 → 正在克隆基础环境 | progress status rendered without the progressive marker, reading like a command; siblings  |
| Could not create a secure login challenge | 无法创建安全登录验证。 → 无法创建安全登录验证 | Trailing full stop added where the English has none; sibling error titles have no period. |
| Describe the image... | 描述图片... → 描述图片… | Uses ASCII three dots while every other ellipsis in the batch uses the proper … character. |
| Diagnosing... | 诊断… → 正在诊断… | Progress label loses the progressive marker; sibling -ing strings all use 正在. |
| Encrypted %lld stores at rest. | 已加密 %lld 个存储。 → 已对 %lld 个存储启用静态加密。 | The at-rest qualifier is dropped though siblings consistently render it as 静态. |
| Encrypted 1 store at rest. | 已加密 1 个存储。 → 已对 1 个存储启用静态加密。 | Singular variant drops the at-rest qualifier as well. |
| Everything this agent can do — flip an ability and watch the startup c | 此智能体能做的一切 — 翻转一项能力，观察启动上下文的响应。 → 此智能体能做的一切 — 切换一项能力，观察启动上下文的响应。 | agent must be 智能体; flip should be 切换 not 翻转 |
| Experimental: when the server eviction policy is Flexible (Multi Model | 实验性功能：当服务器驱逐策略设为「灵活（多模型）」且内存预测显示两个模型都能容纳时，将辅助 → 实验性功能：当服务器驱逐策略设为“灵活（多模型）”且内存预测显示两个模型都能容纳时，将辅助 | Corner brackets used for the policy name while the rest of the batch uses curly quotes. |
| Expose this agent to the public internet via a relay tunnel so externa | 通过中继隧道将此智能体公开到公共互联网，以便外部服务能够访问它。 → 通过中继隧道将此智能体暴露到公网，以便外部服务能够访问它。 | Expose rendered as 公开 here but 暴露 elsewhere in the same feature family. |
| Extract credits | 提取积分 → 网页提取额度 | '提取积分' parses as the action 'withdraw points' instead of 'credits for the extract feature' |
| Image Only | 仅图像 → 仅图片 | 图像 conflicts with the dominant 图片 rendering of Image/Images/Image Generation in the same f |
| Let the agent generate and edit images with a local model using the `i | 允许智能体使用本地模型，通过 image 工具生成和编辑图像。 → 允许智能体使用本地模型，通过 `image` 工具生成和编辑图像。 | Backticks around `image` dropped in zh; inconsistent with `tool_choice` row which keeps th |
| Loading files… | 加载文件... → 正在加载文件… | Half-width dots instead of ellipsis and missing the 正在 pattern used by all sibling Loading |
| Loading model card… | 加载模型卡片... → 正在加载模型卡片… | Same ellipsis/prefix inconsistency as Loading files…. |
| Local bundle ready | 本地捆绑包已就绪。 → 本地捆绑包已就绪 | Trailing period added to a status label that has none in English or in sibling labels. |
| Local handoff and RAM-safety for spawn jobs are system settings in Set | 本地移交与生成任务的内存安全设置，属于系统设置，可在“设置 → 子智能体”中配置。 → 本地交接与生成任务的内存安全属于系统设置，可在“设置 → 子智能体”中配置。 | Footnote says 移交 but the section it points to is titled 交接; the reference must match the s |
| Maximum response tokens | 最大响应词元数 → 最大响应 Token 数 | Token rendered three ways (Token/令牌/词元) across sibling Max-Token settings strings. |
| No agents yet — create one in the Agents tab | 还没有智能体 - 请在“智能体”标签页创建一个 → 还没有智能体 — 请在“智能体”标签页创建一个 | ASCII hyphen used where the batch consistently renders the em dash as “ — ”. |
| No installed plugin owns this capture capability. | 没有安装的插件拥有此捕获功能。 → 没有任何已安装的插件拥有此捕获能力。 | “没有安装的插件” can be parsed as “plugins that are not installed”, inverting the meaning; capabi |
| Pass an onClearChat handler to enable /clear | 传入 onClearChat 处理器以启用 /clear → 传入 onClearChat 处理程序以启用 /clear | "handler" rendered as 处理器 (processor) here but 处理程序 in the sibling string; inconsistent te |
| Paste text to test… | 粘贴文本进行测试... → 粘贴文本进行测试… | Trailing ellipsis rendered as ASCII "..." while the source uses the ellipsis character "…" |
| Read | 读 → 读取 | Standalone label '读' is inconsistent with the sibling copy that uses 读取/写入 for the Read/Wr |
| Remove "%@" from your custom tools? Agents will no longer be able to u | 从你的自定义工具中移除"%@"？智能体将无法再使用其工具。 → 从你的自定义工具中移除“%@”？智能体将无法再使用其工具。 | AI 'Agents' should be 智能体; straight quotes should be curly. |
| Remove Model | 删除模型 → 移除模型 | Remove is consistently 移除 elsewhere; 删除 conflates Remove with Delete on a destructive cont |
| Required for transcription | 转录需要 → 转录所需 | Reads truncated on its own; sibling strings in the same settings tab use the ……所需 pattern |
| Retry plugin load? | 重新加载插件？ → 重试加载插件？ | Loses the retry-after-failure meaning and breaks pairing with the 仍然重试 button |
| Rows the agent (or you) deleted would appear here, ready to restore. | 智能体（或你）删除的行会显示在此处，准备恢复。 → 智能体（或你）删除的行会显示在此处，随时可以恢复。 | agent should be 智能体 per glossary and file-internal consistency |
| Runs | 运行 → 运行记录 | Noun label for run history collides with the verb button Run→运行. |
| SUCCESS: Process is trusted for Accessibility. | 成功：该进程已通过辅助功能验证。 → 成功：该进程已被授予辅助功能权限。 | trusted for Accessibility means granted Accessibility trust, not passed a verification. |
| Sandbox enabled — container not running | 沙盒已启用 - 容器未运行 → 沙盒已启用 — 容器未运行 | Em dash degraded to hyphen-minus, inconsistent with sibling strings. |
| Sandbox is active — click to disable. Right-click for settings. | 沙盒处于活动状态 - 点击可禁用。右键打开设置。 → 沙盒处于活动状态 — 点击可禁用。右键打开设置。 | Same hyphen-for-em-dash degradation as sibling string. |
| Saved today; the request pipeline will start enforcing these in a foll | 今日已保存；请求管道将在后续步骤中开始强制执行这些设置。 → 目前这些设置仅会被保存；请求管道将在后续更新中开始强制执行。 | "Saved today" means "for now these are only saved"; 今日已保存 reads as a dated timestamp, and  |
| Scanning… | 扫描… → 正在扫描… | Progressive-state label dropped 正在, inconsistent with sibling 正在扫描已安装的模型… and the 正在… patt |
| Secret "%@" has no keychain id (expected name=keychain-id). | 密钥 "%@" 没有钥匙串 ID（期望 name=keychain-id）。 → 密钥“%@”没有钥匙串 ID（应为 name=keychain-id）。 | Straight ASCII quotes kept in zh where the library uses curly quotes; 期望 is stiff for "exp |
| Send the bot a message (or add it to a group and post there), then loa | 向机器人发送消息（或将其添加到群组并在那里发布），然后加载待处理的聊天和发送者。 → 向机器人发送消息（或将其添加到群组并在群里发言），然后加载待处理的聊天和发送者。 | '发布' misreads 'post there' (send a message in the group) as formal publishing |
| Share anonymous usage data to help improve Osaurus | 分享匿名使用数据以帮助改进 Osaurus → 共享匿名使用数据以帮助改进 Osaurus | Sibling toggle keys use 共享; this onboarding row uses 分享 for the same setting |
| Show fewer | 显示更少 → 收起 | Same collapse action as 'Show Less'=收起; 显示更少 inconsistent and stiff |
| Show less | 显示更少 → 收起 | Sibling key 'Show Less' uses 收起; 显示更少 is a stiff literal rendering |
| Starting host API bridge | 正在启动宿主 API 桥接 → 正在启动主机 API 桥接 | "host bridge" is rendered as 主机桥 elsewhere in this batch but 宿主…桥接 here; same component, i |
| Text-to-Speech | 文字转语音 → 文本转语音 | Same feature translated inconsistently (文字转语音 vs 文本转语音) within the batch. |
| The file isn't a readable database (corruption or a key mismatch). Res | 该文件不是一个可读的数据库（可能已损坏或密钥不匹配）。请重置以重新创建它；原始文件已被隔离 → 该文件不是可读的数据库（可能已损坏或密钥不匹配）。请重置以重新创建它；原始文件会被隔离。 | "is quarantined" (what Reset will do) rendered as already-done 已被隔离. |
| The link will stop working. Anyone trying to use it will be turned awa | 该链接将停止工作。任何尝试使用它的人将被拒绝访问。 → 该链接将失效。任何尝试使用它的人都将被拒绝访问。 | Anglicism 停止工作 for a link; sibling key uses the idiomatic 失效. |
| This is optional. Agents can still search and read these documents.<br | 此项为可选配置。即使不设置分类，智能体仍可搜索和读取这些文档。<br><br>若要让智能体 → 此项为可选配置。即使不设置分类，智能体仍可搜索和读取这些文档。<br><br>若要让智能体 | Trailing "\n\n" present in the source key was dropped in the translation. |
| This will remove '%@' and delete its API key from Keychain. | 这将移除「%@」并从钥匙串中删除其 API 密钥。 → 这将移除“%@”并从钥匙串中删除其 API 密钥。 | Corner brackets 「」 are nonstandard for zh-Hans and inconsistent with sibling strings using |
| Toast notifications are working! | 通知消息已生效！ → Toast 通知正常工作！ | Drops 'Toast' (sibling keeps it) and 'are working' drifts to 'has taken effect'. |
| Voice Detection: Disabled — Click to enable | 语音检测：已禁用 - 点击启用 → 语音检测：已禁用 — 点击启用 | EN em dash downgraded to a spaced hyphen, inconsistent with other strings in the batch tha |
| Voice Detection: Listening — Click to disable | 语音检测：正在聆听 - 点击禁用 → 语音检测：正在聆听 — 点击禁用 | Same em-dash-to-hyphen downgrade as the sibling voice-detection strings. |
| Voice Detection: Ready — Click to disable | 语音检测：就绪 - 点击禁用 → 语音检测：就绪 — 点击禁用 | Same em-dash-to-hyphen downgrade as the sibling voice-detection strings. |
| Warming up — prefilling context… | 预热 — 填充上下文… → 预热 — 预填充上下文… | "prefilling" rendered as plain 填充, dropping the pre- sense and diverging from sibling stri |
| Watched Folder | 监控文件夹 → 受监视的文件夹 | 监控 vs 监视 terminology split within the same Watchers feature; also reads as verb-object ins |
| Your databases are not encrypted by Osaurus. macOS FileVault protects  | 您的数据库未被Osaurus加密。macOS FileVault在静止状态下保护它们。 → 你的数据库未由 Osaurus 加密。macOS FileVault 会在静态存储时保护它 | Missing CJK-Latin spacing around product names; inconsistent "at rest" terminology; uses 您 |
| Your wallet for Osaurus-routed services - add credits and track every  | 用于Osaurus路由服务的钱包 - 添加积分并跟踪每个请求和充值。 → 你的 Osaurus 路由服务钱包 — 添加积分，并跟踪每笔请求与充值。 | Missing CJK-Latin spacing around "Osaurus"; awkward hyphen carried over. |
| min | 最小值 → 最小 | Paired min/max labels on the same row rendered inconsistently (最小值 vs 最大). |

</details>

## Test plan

- [x] `bash scripts/i18n/check.sh` passes
- [x] catalog still parses; diff touches exactly the listed value lines
- [x] placeholder multisets re-validated mechanically against English source


