### PR TITLE
i18n(zh-Hans): unify “agent” terminology to 智能体 (majority usage)

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -11935,7 +11935,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除代理的允许域名以恢复出站访问。"
+            "value" : "已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除智能体的允许域名以恢复出站访问。"
           }
         },
         "zh-Hant" : {
@@ -17028,7 +17028,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道连接 `%1$@` 不支持 `%2$@`。"
+            "value" : "智能体频道连接 `%1$@` 不支持 `%2$@`。"
           }
         },
         "zh-Hant" : {
@@ -17062,7 +17062,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道连接 `%@` 已禁用。"
+            "value" : "智能体频道连接 `%@` 已禁用。"
           }
         },
         "zh-Hant" : {
@@ -17096,7 +17096,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道连接 `%@` 未配置。"
+            "value" : "智能体频道连接 `%@` 未配置。"
           }
         },
         "zh-Hant" : {
@@ -17130,7 +17130,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道类型 `%@` 尚不可执行。"
+            "value" : "智能体频道类型 `%@` 尚不可执行。"
           }
         },
         "zh-Hant" : {
@@ -17305,7 +17305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理正在使用中"
+            "value" : "智能体正在使用中"
           }
         },
         "zh-Hant" : {
@@ -17479,7 +17479,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理会话"
+            "value" : "智能体会话"
           }
         },
         "zh-Hant" : {
@@ -17767,7 +17767,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理会标记看起来过期的文档。维护者代理会在此提出修复建议供你批准——在你批准之前不会有任何更改。"
+            "value" : "智能体会标记看起来过期的文档。维护者智能体会在此提出修复建议供你批准——在你批准之前不会有任何更改。"
           }
         },
         "zh-Hant" : {
@@ -17801,7 +17801,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以向写入允许列表中的目标发送消息。"
+            "value" : "智能体可以向写入允许列表中的目标发送消息。"
           }
         },
         "zh-Hant" : {
@@ -19939,7 +19939,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理频道诊断和工具解析此频道定义。"
+            "value" : "允许智能体频道诊断和工具解析此频道定义。"
           }
         },
         "zh-Hant" : {
@@ -32041,7 +32041,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览器使用默认关闭，只能为自定义代理启用 — 内置的默认代理永远不会获得浏览器访问权限。"
+            "value" : "浏览器使用默认关闭，只能为自定义智能体启用 — 内置的默认智能体永远不会获得浏览器访问权限。"
           }
         },
         "zh-Hant" : {
@@ -35992,7 +35992,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以读取或搜索的频道或房间 ID。"
+            "value" : "智能体可以读取或搜索的频道或房间 ID。"
           }
         },
         "zh-Hant" : {
@@ -36026,7 +36026,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "启用写入时，代理可以写入的频道或房间 ID。"
+            "value" : "启用写入时，智能体可以写入的频道或房间 ID。"
           }
         },
         "zh-Hant" : {
@@ -36128,7 +36128,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以列出、读取和搜索的频道。"
+            "value" : "智能体可以列出、读取和搜索的频道。"
           }
         },
         "zh-Hant" : {
@@ -36233,7 +36233,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以发布的频道或线程。"
+            "value" : "智能体可以发布的频道或线程。"
           }
         },
         "zh-Hant" : {
@@ -36267,7 +36267,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以读取和搜索的频道或线程。"
+            "value" : "智能体可以读取和搜索的频道或线程。"
           }
         },
         "zh-Hant" : {
@@ -37128,7 +37128,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以发布的聊天。"
+            "value" : "智能体可以发布的聊天。"
           }
         },
         "zh-Hant" : {
@@ -39249,7 +39249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择代理可以使用哪些工具"
+            "value" : "选择智能体可以使用哪些工具"
           }
         },
         "zh-Hant" : {
@@ -40911,7 +40911,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭代理标签页"
+            "value" : "关闭智能体标签页"
           }
         },
         "zh-Hant" : {
@@ -40947,7 +40947,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭代理标签页？"
+            "value" : "关闭智能体标签页？"
           }
         },
         "zh-Hant" : {
@@ -51527,7 +51527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建工具或导入 JSON 配方。自定义工具在代理首次使用时会自动设置。"
+            "value" : "创建工具或导入 JSON 配方。自定义工具在智能体首次使用时会自动设置。"
           }
         },
         "zh-Hant" : {
@@ -53305,7 +53305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可按需查阅的精选参考资料。"
+            "value" : "智能体可按需查阅的精选参考资料。"
           }
         },
         "zh-Hant" : {
@@ -56374,7 +56374,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI 生成问候语和快速操作的默认语音。在代理的外观选项卡中按代理开启问候语，每个代理也可以覆盖此语音。"
+            "value" : "AI 生成问候语和快速操作的默认语音。在智能体的外观选项卡中按智能体开启问候语，每个智能体也可以覆盖此语音。"
           }
         },
         "zh-Hant" : {
@@ -57924,7 +57924,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理仍可恢复的已删除行。"
+            "value" : "智能体仍可恢复的已删除行。"
           }
         },
         "zh-Hant" : {
@@ -70249,7 +70249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个文档都有类别，来自其前置元数据 `type:` 或从其文件夹名称推断。代理可以按类别过滤此集合。"
+            "value" : "每个文档都有类别，来自其前置元数据 `type:` 或从其文件夹名称推断。智能体可以按类别过滤此集合。"
           }
         },
         "zh-Hant" : {
@@ -70496,7 +70496,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以使用的所有内容，按每个工具的来源分组"
+            "value" : "智能体可以使用的所有内容，按每个工具的来源分组"
           }
         },
         "zh-Hant" : {
@@ -71272,7 +71272,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "实验性功能：从每个代理自己的基础镜像写时复制克隆启动，使系统包在每个代理之间独立保留"
+            "value" : "实验性功能：从每个智能体自己的基础镜像写时复制克隆启动，使系统包按智能体独立保留"
           }
         },
         "zh-Hant" : {
@@ -76316,7 +76316,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "供代理按需搜索和阅读的文档文件夹"
+            "value" : "供智能体按需搜索和阅读的文档文件夹"
           }
         },
         "zh-Hant" : {
@@ -81122,7 +81122,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "授予一个 macOS 文件夹的访问权限，包括通过认证的远程代理运行。写入保留在文件夹内；shell 和 git 保持禁用。"
+            "value" : "授予一个 macOS 文件夹的访问权限，包括通过认证的远程智能体运行。写入保留在文件夹内；shell 和 git 保持禁用。"
           }
         },
         "zh-Hant" : {
@@ -91958,7 +91958,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将已授权的 Telegram 更新保留在本地收件箱中，以便代理可以读取和搜索它们。"
+            "value" : "将已授权的 Telegram 更新保留在本地收件箱中，以便智能体可以读取和搜索它们。"
           }
         },
         "zh-Hant" : {
@@ -94319,7 +94319,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让代理在其自己的持久会话中浏览网页"
+            "value" : "让智能体在自己的持久会话中浏览网页"
           }
         },
         "zh-Hant" : {
@@ -94389,7 +94389,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理发布到写入允许列表的 Discord 目标。频道写入也必须全局开启。"
+            "value" : "允许智能体发布到写入允许列表的 Discord 目标。频道写入也必须全局开启。"
           }
         },
         "zh-Hant" : {
@@ -94423,7 +94423,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理发布到写入允许列表的 Slack 频道。频道写入也必须全局开启。"
+            "value" : "允许智能体发布到写入允许列表的 Slack 频道。频道写入也必须全局开启。"
           }
         },
         "zh-Hant" : {
@@ -94457,7 +94457,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理发布到写入允许列表的 Telegram 聊天。频道写入也必须全局开启。"
+            "value" : "允许智能体发布到写入允许列表的 Telegram 聊天。频道写入也必须全局开启。"
           }
         },
         "zh-Hant" : {
@@ -94491,7 +94491,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理在 Discord、Slack 和 Telegram 上读取和回复"
+            "value" : "允许智能体在 Discord、Slack 和 Telegram 上读取和回复"
           }
         },
         "zh-Hant" : {
@@ -94668,7 +94668,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让派生的工作代理自行读取文件（file_read / file_search），避免批量读取占用此代理的上下文。"
+            "value" : "让派生的工作智能体自行读取文件（file_read / file_search），避免批量读取占用此智能体的上下文。"
           }
         },
         "zh-Hant" : {
@@ -94775,7 +94775,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让代理在其自己的持久浏览器会话中浏览网页 — 登录状态在聊天之间保持。读取和导航自动运行；输入和任何重要操作会暂停等待您的批准。"
+            "value" : "让智能体在自己的持久浏览器会话中浏览网页 — 登录状态在聊天之间保持。读取和导航自动运行；输入和任何重要操作会暂停等待你的批准。"
           }
         },
         "zh-Hant" : {
@@ -95134,7 +95134,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理搜索和阅读下方授权的知识集合：精选指南、模板和规范。与记忆不同，知识由你编辑，代理绝不会改写。"
+            "value" : "允许智能体搜索和阅读下方授权的知识集合：精选指南、模板和规范。与记忆不同，知识由你编辑，智能体绝不会改写。"
           }
         },
         "zh-Hant" : {
@@ -95484,7 +95484,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许此代理将文档更新起草为待审提案（它也可以提交和处理过期工单）。在你于知识板块批准提案之前，集合不会有任何变化。"
+            "value" : "允许此智能体将文档更新起草为待审提案（它也可以提交和处理过期工单）。在你于知识板块批准提案之前，集合不会有任何变化。"
           }
         },
         "zh-Hant" : {
@@ -98982,7 +98982,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地编排移交已关闭（设置 → 子代理）。尝试生成/启动模型与当前对话模型不同的本地代理或模型将被拒绝 — 仅允许运行远程目标和已加载的模型。"
+            "value" : "本地编排移交已关闭（设置 → 子智能体）。尝试生成/启动模型与当前对话模型不同的本地智能体或模型将被拒绝 — 仅允许运行远程目标和已加载的模型。"
           }
         },
         "zh-Hant" : {
@@ -115225,7 +115225,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "暂无运行记录。当代理按计划或自动运行时，每次运行都会显示在此处。"
+            "value" : "暂无运行记录。当智能体按计划或自动运行时，每次运行都会显示在此处。"
           }
         },
         "zh-Hant" : {
@@ -125471,7 +125471,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "出站仅限于配置代理允许的域名"
+            "value" : "出站仅限于配置智能体允许的域名"
           }
         },
         "zh-Hant" : {
@@ -129047,7 +129047,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个代理的环境"
+            "value" : "按智能体的环境"
           }
         },
         "zh-Hant" : {
@@ -129152,7 +129152,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个代理的根文件系统模板"
+            "value" : "每个智能体的根文件系统模板"
           }
         },
         "zh-Hant" : {
@@ -129188,7 +129188,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个代理的热重启根文件系统"
+            "value" : "每个智能体的热重启根文件系统"
           }
         },
         "zh-Hant" : {
@@ -129548,7 +129548,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "永久删除此代理存储的每个表和行。代理本身保留。"
+            "value" : "永久删除此智能体存储的每个表和行。智能体本身保留。"
           }
         },
         "zh-Hant" : {
@@ -131178,7 +131178,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择此代理可以使用哪些工具"
+            "value" : "选择此智能体可以使用哪些工具"
           }
         },
         "zh-Hant" : {
@@ -131220,7 +131220,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择此代理可以使用哪些工具。技能来自共享库，始终可用。"
+            "value" : "选择此智能体可以使用哪些工具。技能来自共享库，始终可用。"
           }
         },
         "zh-Hant" : {
@@ -133103,7 +133103,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让 Osaurus 指向一个包含指南、模板、规范的文件夹，并授权给代理，让它们可以按需查阅。支持 Markdown、纯文本、代码、PDF、Word、Excel、PowerPoint 和 CSV 文件。"
+            "value" : "让 Osaurus 指向一个包含指南、模板、规范的文件夹，并授权给智能体，让它们可以按需查阅。支持 Markdown、纯文本、代码、PDF、Word、Excel、PowerPoint 和 CSV 文件。"
           }
         },
         "zh-Hant" : {
@@ -149011,7 +149011,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 1 个代理派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 1 个智能体派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149047,7 +149047,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 1 个代理派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 1 个智能体派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149130,7 +149130,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 %lld 个代理派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 %lld 个智能体派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149166,7 +149166,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 %lld 个代理派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 %lld 个智能体派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -151893,7 +151893,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置将清除沙盒插件状态。主机上的代理工作区文件将保留。"
+            "value" : "重置将清除沙盒插件状态。主机上的智能体工作区文件将保留。"
           }
         },
         "zh-Hant" : {
@@ -155874,7 +155874,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在这台 Mac 上运行受限于沙盒工作区的代理命令。（macOS 26 或更高版本提供完整的 VM 隔离。）"
+            "value" : "在这台 Mac 上运行受限于沙盒工作区的智能体命令。（macOS 26 或更高版本提供完整的 VM 隔离。）"
           }
         },
         "zh-Hant" : {
@@ -162166,7 +162166,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "专为 AI 代理打造的搜索 — 最佳回答质量用于语境锚定。"
+            "value" : "专为 AI 智能体打造的搜索 — 最佳回答质量用于语境锚定。"
           }
         },
         "zh-Hant" : {
@@ -166290,7 +166290,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "发送已全局暂停。代理仍可读取已允许列表的频道。"
+            "value" : "发送已全局暂停。智能体仍可读取允许列表中的频道。"
           }
         },
         "zh-Hant" : {
@@ -179774,7 +179774,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换到全部并开启此代理应使用的工具。"
+            "value" : "切换到“全部”并开启此智能体应使用的工具。"
           }
         },
         "zh-Hant" : {
@@ -183116,7 +183116,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "智能体仅在您请求时运行。代理的定时API调用被拒绝。"
+            "value" : "智能体仅在你请求时运行。来自智能体的定时 API 调用会被拒绝。"
           }
         },
         "zh-Hant" : {
@@ -187120,7 +187120,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此代理声称支持加密但未包含可验证的身份，因此无法安全配对。它可能在冒充其他设备，或者对方设备可能需要更新 Osaurus。"
+            "value" : "此智能体声称支持加密，但未包含可验证的身份，因此无法安全配对。它可能在冒充其他设备，或者对方设备可能需要更新 Osaurus。"
           }
         },
         "zh-Hant" : {
@@ -187156,7 +187156,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此代理拥有其自己的隔离浏览器配置文件。在「设置」→「浏览器」中查看会话和登录状态。"
+            "value" : "此智能体拥有自己的隔离浏览器配置文件。在「设置」→「浏览器」中查看会话和登录状态。"
           }
         },
         "zh-Hant" : {
@@ -187227,7 +187227,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该代理暂无可以分享的身份。请通过网络进行配对，或点击顶部\"分享\"按钮生成中继邀请，已连接的对等端将显示在此处。"
+            "value" : "该智能体暂无可分享的身份。请通过网络进行配对，或点击顶部“分享”按钮生成中继邀请，已连接的对等端将显示在此处。"
           }
         },
         "zh-Hant" : {
@@ -187335,7 +187335,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此代理的数据库接近存储上限。"
+            "value" : "此智能体的数据库接近存储上限。"
           }
         },
         "zh-Hant" : {
@@ -188471,7 +188471,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将永久删除 %@ 的浏览数据 — cookie、登录信息及历史记录。代理将以全新的配置文件重新开始。"
+            "value" : "这将永久删除 %@ 的浏览数据 — cookie、登录信息及历史记录。该智能体将以全新的配置文件重新开始。"
           }
         },
         "zh-Hant" : {
@@ -188507,7 +188507,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将永久删除所有代理的浏览数据 — 所有 cookie、登录信息和历史记录。"
+            "value" : "这将永久删除所有智能体的浏览数据 — 所有 cookie、登录信息和历史记录。"
           }
         },
         "zh-Hant" : {
@@ -194521,7 +194521,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按代理逐一开启： 打开对应代理的\"子代理\"选项卡，启用\"计算机使用\"功能，然后选择\"共享屏幕上下文\"选项（默认已开启）。需要辅助功能权限。"
+            "value" : "按智能体逐一开启：打开对应智能体的“子智能体”选项卡，启用“计算机使用”，并使用“共享屏幕上下文”选项（默认已开启）。需要辅助功能权限。"
           }
         },
         "zh-Hant" : {
@@ -203896,7 +203896,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理存储内容一览。"
+            "value" : "智能体存储内容一览。"
           }
         },
         "zh-Hant" : {
@@ -203932,7 +203932,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理在沙盒内可以做什么。"
+            "value" : "智能体在沙盒内可以做什么。"
           }
         },
         "zh-Hant" : {
@@ -204002,7 +204002,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "描述该资料库的内容，会展示给代理"
+            "value" : "描述该资料库的内容，会展示给智能体"
           }
         },
         "zh-Hant" : {
@@ -205375,7 +205375,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "有了数据库，代理可以在对话之间保存笔记、列表和记录 — 以加密形式存储在此 Mac 上。你可以浏览和编辑它保存的所有内容。"
+            "value" : "有了数据库，智能体可以在对话之间保存笔记、列表和记录 — 以加密形式存储在此 Mac 上。你可以浏览和编辑它保存的所有内容。"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
## Summary

The catalog translates “agent” as 智能体 in ~288 active strings and as 代理 in ~70 others — the sidebar and the pane it opens currently disagree on the product's core noun. This unifies the minority to the majority (same direction as the 33 strings already fixed in #2178). Strings where 代理 correctly means proxy (e.g. HTTP User Agent) are untouched. Follow-up to #2177.

## Changes

- 70 zh-Hans string **values** in `Packages/OsaurusCore/Resources/Localizable.xcstrings` — no keys, states, or other locales touched

## How to verify without speaking Chinese

Every row below links the English source to the defect. The author is a native Simplified Chinese speaker; every change was checked against the English source string and its Swift call site.

| English source | old → new (zh-Hans) | defect |
|---|---|---|
| A domain allowlist is configured, which this sandbox can't enforce — n | 已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除代理的允许域名以恢复 → 已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除智能体的允许域名以恢 | "agents" here are AI agents; 代理 reads as network proxy — glossary says 智能体. |
| Agent Sessions | 代理会话 → 智能体会话 | AI "Agent" must be 智能体 per glossary, not 代理. |
| Agent channel connection `%@` does not support `%@`. | 代理通道连接 `%1$@` 不支持 `%2$@`。 → 智能体频道连接 `%1$@` 不支持 `%2$@`。 | "Agent channel" rendered 代理通道; glossary/majority usage is 智能体频道. |
| Agent channel connection `%@` is disabled. | 代理通道连接 `%@` 已禁用。 → 智能体频道连接 `%@` 已禁用。 | "Agent channel" rendered 代理通道; should be 智能体频道. |
| Agent channel connection `%@` is not configured. | 代理通道连接 `%@` 未配置。 → 智能体频道连接 `%@` 未配置。 | "Agent channel" rendered 代理通道; should be 智能体频道. |
| Agent channel kind `%@` is not executable yet. | 代理通道类型 `%@` 尚不可执行。 → 智能体频道类型 `%@` 尚不可执行。 | "Agent channel" rendered 代理通道; should be 智能体频道. |
| Agent in use | 代理正在使用中 → 智能体正在使用中 | AI "Agent" must be 智能体 per glossary, not 代理. |
| Agents flag documents that look out of date. A Curator agent proposes  | 代理会标记看起来过期的文档。维护者代理会在此提出修复建议供你批准——在你批准之前不会有任何 → 智能体会标记看起来过期的文档。维护者智能体会在此提出修复建议供你批准——在你批准之前不会有 | AI "agent" rendered 代理 twice; glossary requires 智能体. |
| Agents may send messages to write-allowlisted destinations. | 代理可以向写入允许列表中的目标发送消息。 → 智能体可以向写入允许列表中的目标发送消息。 | AI "Agents" must be 智能体 per glossary, not 代理. |
| Allow this channel definition to be resolved by agent channel diagnost | 允许代理频道诊断和工具解析此频道定义。 → 允许智能体频道诊断和工具解析此频道定义。 | "agent" (AI agent) should be 智能体 per glossary, not 代理. |

<details><summary>All 70 changes</summary>

| English source | old → new | defect |
|---|---|---|
| Browser Use is off by default and can only be enabled per custom agent | 浏览器使用默认关闭，只能为自定义代理启用 — 内置的默认代理永远不会获得浏览器访问权限。 → 浏览器使用默认关闭，只能为自定义智能体启用 — 内置的默认智能体永远不会获得浏览器访问权限 | "agent" (AI agent) rendered as 代理 instead of the glossary term 智能体. |
| Channel or room ids agents may read or search. | 代理可以读取或搜索的频道或房间 ID。 → 智能体可以读取或搜索的频道或房间 ID。 | "agents" rendered as 代理 instead of 智能体. |
| Channel or room ids agents may write to when writes are enabled. | 启用写入时，代理可以写入的频道或房间 ID。 → 启用写入时，智能体可以写入的频道或房间 ID。 | "agents" rendered as 代理 instead of 智能体. |
| Channels agents may list, read, and search. | 代理可以列出、读取和搜索的频道。 → 智能体可以列出、读取和搜索的频道。 | "agents" rendered as 代理 instead of 智能体, inconsistent with sibling string. |
| Channels or threads agents may post to. | 代理可以发布的频道或线程。 → 智能体可以发布的频道或线程。 | "agents" rendered as 代理 instead of 智能体. |
| Channels or threads agents may read and search. | 代理可以读取和搜索的频道或线程。 → 智能体可以读取和搜索的频道或线程。 | "agents" rendered as 代理 instead of 智能体. |
| Chats agents may post to. | 代理可以发布的聊天。 → 智能体可以发布的聊天。 | "agents" rendered as 代理 instead of 智能体. |
| Choose which tools agents can use | 选择代理可以使用哪些工具 → 选择智能体可以使用哪些工具 | agent (AI) should be 智能体 per glossary, not 代理 |
| Close Agent Tab? | 关闭代理标签页？ → 关闭智能体标签页？ | agent (AI) should be 智能体 per glossary, not 代理 |
| Close agent tab | 关闭代理标签页 → 关闭智能体标签页 | agent (AI) should be 智能体 per glossary, not 代理 |
| Create a tool or import a JSON recipe. Custom tools are set up automat | 创建工具或导入 JSON 配方。自定义工具在代理首次使用时会自动设置。 → 创建工具或导入 JSON 配方。自定义工具在智能体首次使用时会自动设置。 | agent (AI agent) should be 智能体, not 代理 |
| Curated reference material the agent can consult on demand. | 代理可按需查阅的精选参考资料。 → 智能体可按需查阅的精选参考资料。 | agent (AI agent) should be 智能体, not 代理 |
| Default voice for AI-generated greetings + quick actions. Turn greetin | AI 生成问候语和快速操作的默认语音。在代理的外观选项卡中按代理开启问候语，每个代理也可以 → AI 生成问候语和快速操作的默认语音。在智能体的外观选项卡中按智能体开启问候语，每个智能体 | All three "agent" occurrences mean AI agent; glossary requires 智能体, translation uses 代理. |
| Deleted rows the agent can still restore. | 代理仍可恢复的已删除行。 → 智能体仍可恢复的已删除行。 | "agent" here is the AI agent; glossary requires 智能体, translation uses 代理. |
| Every document has a category, from its frontmatter `type:` or inferre | 每个文档都有类别，来自其前置元数据 `type:` 或从其文件夹名称推断。代理可以按类别过 → 每个文档都有类别，来自其前置元数据 `type:` 或从其文件夹名称推断。智能体可以按类别 | Agents must be 智能体, sibling key already uses it |
| Everything agents can use, grouped by where each tool comes from | 代理可以使用的所有内容，按每个工具的来源分组 → 智能体可以使用的所有内容，按每个工具的来源分组 | agents must be 智能体, not 代理 |
| Experimental: boot from each agent's own copy-on-write clone of the ba | 实验性功能：从每个代理自己的基础镜像写时复制克隆启动，使系统包在每个代理之间独立保留 → 实验性功能：从每个智能体自己的基础镜像写时复制克隆启动，使系统包按智能体独立保留 | agent must be 智能体 (two occurrences) |
| Folders of documents your agents can search and read on demand | 供代理按需搜索和阅读的文档文件夹 → 供智能体按需搜索和阅读的文档文件夹 | agent translated as 代理 instead of glossary term 智能体 |
| Grant access to one macOS folder, including over authenticated remote  | 授予一个 macOS 文件夹的访问权限，包括通过认证的远程代理运行。写入保留在文件夹内；s → 授予一个 macOS 文件夹的访问权限，包括通过认证的远程智能体运行。写入保留在文件夹内； | 'remote agent runs' uses 代理 instead of glossary term 智能体. |
| Keep authorized Telegram updates in the local inbox so agents can read | 将已授权的 Telegram 更新保留在本地收件箱中，以便代理可以读取和搜索它们。 → 将已授权的 Telegram 更新保留在本地收件箱中，以便智能体可以读取和搜索它们。 | AI 'agents' should be 智能体, not 代理. |
| Let agents browse the web in their own persistent sessions | 让代理在其自己的持久会话中浏览网页 → 让智能体在自己的持久会话中浏览网页 | AI 'agents' should be 智能体, not 代理. |
| Let agents post to write-allowlisted Discord destinations. Channel wri | 允许代理发布到写入允许列表的 Discord 目标。频道写入也必须全局开启。 → 允许智能体发布到写入允许列表的 Discord 目标。频道写入也必须全局开启。 | AI 'agents' should be 智能体, not 代理. |
| Let agents post to write-allowlisted Slack channels. Channel writes mu | 允许代理发布到写入允许列表的 Slack 频道。频道写入也必须全局开启。 → 允许智能体发布到写入允许列表的 Slack 频道。频道写入也必须全局开启。 | AI 'agents' should be 智能体, not 代理. |
| Let agents post to write-allowlisted Telegram chats. Channel writes mu | 允许代理发布到写入允许列表的 Telegram 聊天。频道写入也必须全局开启。 → 允许智能体发布到写入允许列表的 Telegram 聊天。频道写入也必须全局开启。 | AI 'agents' should be 智能体, not 代理. |
| Let agents read and reply on Discord, Slack, and Telegram | 允许代理在 Discord、Slack 和 Telegram 上读取和回复 → 允许智能体在 Discord、Slack 和 Telegram 上读取和回复 | AI 'agents' should be 智能体, not 代理. |
| Let spawned workers read files themselves (file_read / file_search) so | 让派生的工作代理自行读取文件（file_read / file_search），避免批量读 → 让派生的工作智能体自行读取文件（file_read / file_search），避免批量 | AI 'agent/workers' should be 智能体, not 代理. |
| Let the agent browse the web in its own persistent browser session — s | 让代理在其自己的持久浏览器会话中浏览网页 — 登录状态在聊天之间保持。读取和导航自动运行； → 让智能体在自己的持久浏览器会话中浏览网页 — 登录状态在聊天之间保持。读取和导航自动运行； | AI 'agent' should be 智能体, not 代理; also uses 您. |
| Let the agent search and read the knowledge collections granted below: | 允许代理搜索和阅读下方授权的知识集合：精选指南、模板和规范。与记忆不同，知识由你编辑，代理 → 允许智能体搜索和阅读下方授权的知识集合：精选指南、模板和规范。与记忆不同，知识由你编辑，智 | AI 'agent' should be 智能体, not 代理. |
| Let this agent draft document updates as pending proposals (it can als | 允许此代理将文档更新起草为待审提案（它也可以提交和处理过期工单）。在你于知识板块批准提案之 → 允许此智能体将文档更新起草为待审提案（它也可以提交和处理过期工单）。在你于知识板块批准提案 | AI 'agent' should be 智能体, not 代理. |
| Local Orchestrator Handoff is off (Settings → Subagents). Spawning a l | 本地编排移交已关闭（设置 → 子代理）。尝试生成/启动模型与当前对话模型不同的本地代理或模 → 本地编排移交已关闭（设置 → 子智能体）。尝试生成/启动模型与当前对话模型不同的本地智能体 | Uses 代理/子代理 for AI agent/subagent; glossary requires 智能体/子智能体. |
| No runs yet. When the agent works on a schedule or automation, each ru | 暂无运行记录。当代理按计划或自动运行时，每次运行都会显示在此处。 → 暂无运行记录。当智能体按计划或自动运行时，每次运行都会显示在此处。 | AI agent should be 智能体, not 代理 |
| Outbound limited to the provisioning agent's allowed domains | 出站仅限于配置代理允许的域名 → 出站仅限于配置智能体允许的域名 | AI agent should be 智能体; 代理 reads as network proxy here. |
| Per-Agent Environments | 每个代理的环境 → 按智能体的环境 | "Agent" (AI agent) should be 智能体 per glossary, matching "Per-Agent Memory". |
| Per-agent rootfs template | 每个代理的根文件系统模板 → 每个智能体的根文件系统模板 | "agent" should be 智能体 per glossary. |
| Per-agent warm restart rootfs | 每个代理的热重启根文件系统 → 每个智能体的热重启根文件系统 | "agent" should be 智能体 per glossary. |
| Permanently delete every table and row this agent has stored. The agen | 永久删除此代理存储的每个表和行。代理本身保留。 → 永久删除此智能体存储的每个表和行。智能体本身保留。 | "agent" should be 智能体 per glossary (both occurrences). |
| Pick which tools this agent can use | 选择此代理可以使用哪些工具 → 选择此智能体可以使用哪些工具 | "agent" should be 智能体 per glossary. |
| Pick which tools this agent can use. Skills come from the shared libra | 选择此代理可以使用哪些工具。技能来自共享库，始终可用。 → 选择此智能体可以使用哪些工具。技能来自共享库，始终可用。 | "agent" should be 智能体 per glossary. |
| Point Osaurus at a folder of guides, templates, and standards and gran | 让 Osaurus 指向一个包含指南、模板、规范的文件夹，并授权给代理，让它们可以按需查阅 → 让 Osaurus 指向一个包含指南、模板、规范的文件夹，并授权给智能体，让它们可以按需查 | "agents" here means AI agents; glossary says 智能体, not 代理. |
| Repair will derive a fresh address for 1 agent and revoke %lld stale a | 修复将为 1 个代理派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密 → 修复将为 1 个智能体派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些 | agent (AI agent) should be 智能体, not 代理 |
| Repair will derive a fresh address for 1 agent and revoke 1 stale acce | 修复将为 1 个代理派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有 → 修复将为 1 个智能体派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现 | agent (AI agent) should be 智能体, not 代理 |
| Repair will derive fresh addresses for %lld agents and revoke %lld sta | 修复将为 %lld 个代理派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有 → 修复将为 %lld 个智能体派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持 | agent (AI agent) should be 智能体, not 代理 |
| Repair will derive fresh addresses for %lld agents and revoke 1 stale  | 修复将为 %lld 个代理派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥 → 修复将为 %lld 个智能体派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密 | agent (AI agent) should be 智能体, not 代理 |
| Resetting clears sandbox plugin state. Agent workspace files on the ho | 重置将清除沙盒插件状态。主机上的代理工作区文件将保留。 → 重置将清除沙盒插件状态。主机上的智能体工作区文件将保留。 | agent should be 智能体; sibling string already uses 智能体工作区 |
| Run agent commands confined to a sandbox workspace on this Mac. (macOS | 在这台 Mac 上运行受限于沙盒工作区的代理命令。（macOS 26 或更高版本提供完整的 → 在这台 Mac 上运行受限于沙盒工作区的智能体命令。（macOS 26 或更高版本提供完整 | agent should be 智能体 per glossary |
| Search built for AI agents — best answer quality for grounding. | 专为 AI 代理打造的搜索 — 最佳回答质量用于语境锚定。 → 专为 AI 智能体打造的搜索 — 最佳回答质量用于语境锚定。 | "AI agents" should be AI 智能体 per glossary, not AI 代理 |
| Sending is paused everywhere. Agents can still read allowlisted channe | 发送已全局暂停。代理仍可读取已允许列表的频道。 → 发送已全局暂停。智能体仍可读取允许列表中的频道。 | 'Agents' should be 智能体 per glossary; 已允许列表的频道 is awkward for 'allowlisted channels' |
| Switch to All and turn on the tools this agent should use. | 切换到全部并开启此代理应使用的工具。 → 切换到“全部”并开启此智能体应使用的工具。 | 'agent' (AI agent) should be 智能体, not 代理. |
| The agent only runs when you ask. Scheduled API calls from the agent a | 智能体仅在您请求时运行。代理的定时API调用被拒绝。 → 智能体仅在你请求时运行。来自智能体的定时 API 调用会被拒绝。 | same agent translated as both 智能体 and 代理 in one string; also 您 and missing CJK-Latin spaci |
| This agent advertised that it supports encryption but didn't include a | 此代理声称支持加密但未包含可验证的身份，因此无法安全配对。它可能在冒充其他设备，或者对方设 → 此智能体声称支持加密，但未包含可验证的身份，因此无法安全配对。它可能在冒充其他设备，或者对 | agent rendered as 代理 instead of 智能体 |
| This agent gets its own isolated browser profile. View sessions and si | 此代理拥有其自己的隔离浏览器配置文件。在「设置」→「浏览器」中查看会话和登录状态。 → 此智能体拥有自己的隔离浏览器配置文件。在「设置」→「浏览器」中查看会话和登录状态。 | agent rendered as 代理 instead of 智能体 |
| This agent has no shareable identity. Pair it over your network or gen | 该代理暂无可以分享的身份。请通过网络进行配对，或点击顶部"分享"按钮生成中继邀请，已连接的 → 该智能体暂无可分享的身份。请通过网络进行配对，或点击顶部“分享”按钮生成中继邀请，已连接的 | agent rendered as 代理; straight quotes around Chinese text |
| This agent's database is approaching its storage limit. | 此代理的数据库接近存储上限。 → 此智能体的数据库接近存储上限。 | agent rendered as 代理 instead of 智能体 |
| This permanently deletes %@'s browsing data — cookies, sign-ins, and h | 这将永久删除 %@ 的浏览数据 — cookie、登录信息及历史记录。代理将以全新的配置文 → 这将永久删除 %@ 的浏览数据 — cookie、登录信息及历史记录。该智能体将以全新的配 | agent rendered as 代理 instead of 智能体 |
| This permanently deletes every agent's browsing data — all cookies, si | 这将永久删除所有代理的浏览数据 — 所有 cookie、登录信息和历史记录。 → 这将永久删除所有智能体的浏览数据 — 所有 cookie、登录信息和历史记录。 | agent rendered as 代理 instead of 智能体 |
| Turn this on per agent: open the agent's Subagents tab, enable Compute | 按代理逐一开启： 打开对应代理的"子代理"选项卡，启用"计算机使用"功能，然后选择"共享屏 → 按智能体逐一开启：打开对应智能体的“子智能体”选项卡，启用“计算机使用”，并使用“共享屏幕 | AI 'agent' rendered as '代理' instead of glossary '智能体'; also straight quotes. |
| What the agent has stored, at a glance. | 代理存储内容一览。 → 智能体存储内容一览。 | AI agent should be 智能体 per glossary, not 代理. |
| What the agent may do inside the sandbox. | 代理在沙盒内可以做什么。 → 智能体在沙盒内可以做什么。 | AI agent should be 智能体 per glossary, not 代理. |
| What this corpus contains, shown to agents | 描述该资料库的内容，会展示给代理 → 描述该资料库的内容，会展示给智能体 | AI agent should be 智能体 per glossary, not 代理. |
| With a database, the agent can keep notes, lists, and records between  | 有了数据库，代理可以在对话之间保存笔记、列表和记录 — 以加密形式存储在此 Mac 上。你 → 有了数据库，智能体可以在对话之间保存笔记、列表和记录 — 以加密形式存储在此 Mac 上。 | AI agent should be 智能体 per glossary, not 代理. |

</details>

## Screenshots (app running in zh-Hans)

![before-tools-pane.png](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/before-tools-pane.png)

## Test plan

- [x] `bash scripts/i18n/check.sh` passes
- [x] catalog still parses; diff touches exactly the listed value lines
- [x] placeholder multisets re-validated mechanically against English source


