### PR TITLE
i18n(zh-Hans): add style linter and normalize spacing/quotes/colons

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -2096,7 +2096,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@有错误的类型"
+            "value" : "%@ 有错误的类型"
           }
         },
         "zh-Hant" : {
@@ -2172,7 +2172,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@是空的"
+            "value" : "%@ 是空的"
           }
         },
         "zh-Hant" : {
@@ -2206,7 +2206,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@缺失"
+            "value" : "%@ 缺失"
           }
         },
         "zh-Hant" : {
@@ -2276,7 +2276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@不可读"
+            "value" : "%@ 不可读"
           }
         },
         "zh-Hant" : {
@@ -2310,7 +2310,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@不可写"
+            "value" : "%@ 不可写"
           }
         },
         "zh-Hant" : {
@@ -2793,7 +2793,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@仍然无法打开。尝试重置。"
+            "value" : "%@ 仍然无法打开。尝试重置。"
           }
         },
         "zh-Hant" : {
@@ -6676,7 +6676,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 个设置匹配\"%@\""
+            "value" : "%lld 个设置匹配“%@”"
           }
         },
         "zh-Hant" : {
@@ -9451,7 +9451,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自启动以来0次尝试"
+            "value" : "自启动以来 0 次尝试"
           }
         },
         "zh-Hant" : {
@@ -9486,7 +9486,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "0倾向于性能，2是安全自动，3是严格的，4是诊断/自定义。"
+            "value" : "0 倾向于性能，2 是安全自动，3 是严格的，4 是诊断/自定义。"
           }
         },
         "zh-Hant" : {
@@ -9753,7 +9753,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1天"
+            "value" : "1 天"
           }
         },
         "zh-Hant" : {
@@ -10543,7 +10543,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 个设置匹配 \"%@\""
+            "value" : "1 个设置匹配 “%@”"
           }
         },
         "zh-Hant" : {
@@ -11163,7 +11163,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "4位（q4，最快）"
+            "value" : "4 位（q4，最快）"
           }
         },
         "zh-Hant" : {
@@ -11271,7 +11271,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "7天"
+            "value" : "7 天"
           }
         },
         "zh-Hant" : {
@@ -11305,7 +11305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "8位（q8，保守）"
+            "value" : "8 位（q8，保守）"
           }
         },
         "zh-Hant" : {
@@ -11379,7 +11379,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30天"
+            "value" : "30 天"
           }
         },
         "zh-Hant" : {
@@ -12209,7 +12209,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将生成一个新的256位密钥，并将位于 ~/.osaurus 下的所有加密数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此Mac上读取。"
+            "value" : "将生成一个新的 256 位密钥，并将位于 ~/.osaurus 下的所有加密数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此 Mac 上读取。"
           }
         },
         "zh-Hant" : {
@@ -12243,7 +12243,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将生成一个新的256位密钥，并将 ~/.osaurus 下所有加密的数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此Mac上读取。我们强烈建议首先导出纯文本备份。"
+            "value" : "将生成一个新的 256 位密钥，并将 ~/.osaurus 下所有加密的数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此 Mac 上读取。我们强烈建议首先导出纯文本备份。"
           }
         },
         "zh-Hant" : {
@@ -12730,7 +12730,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一个名为“%@”的技能已存在。替换它将覆盖其SKILL.md、引用和资源。"
+            "value" : "一个名为“%@”的技能已存在。替换它将覆盖其 SKILL.md、引用和资源。"
           }
         },
         "zh-Hant" : {
@@ -14201,7 +14201,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "操作 \"%@\" 不是标准操作名称，且永远不会被调用。"
+            "value" : "操作 “%@” 不是标准操作名称，且永远不会被调用。"
           }
         },
         "zh-Hant" : {
@@ -18085,7 +18085,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI检测（设备端模型）"
+            "value" : "AI 检测（设备端模型）"
           }
         },
         "zh-Hant" : {
@@ -18154,7 +18154,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI原生网络搜索和内容提取"
+            "value" : "AI 原生网络搜索和内容提取"
           }
         },
         "zh-Hant" : {
@@ -20891,7 +20891,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已安装为%@。"
+            "value" : "已安装为 %@。"
           }
         },
         "zh-Hant" : {
@@ -22058,7 +22058,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API密钥在钥匙串中"
+            "value" : "API 密钥在钥匙串中"
           }
         },
         "zh-Hant" : {
@@ -23007,7 +23007,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用JSON"
+            "value" : "应用 JSON"
           }
         },
         "zh-Hant" : {
@@ -27212,7 +27212,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Azure部署ID已配置，即使/models不可用，连接也可以继续进行。"
+            "value" : "Azure 部署 ID 已配置，即使/models 不可用，连接也可以继续进行。"
           }
         },
         "zh-Hant" : {
@@ -27246,7 +27246,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Azure部署"
+            "value" : "Azure 部署"
           }
         },
         "zh-Hant" : {
@@ -28084,7 +28084,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在进行聊天生成时，后台蒸馏会暂停 —— 它们共享GPU/统一内存。"
+            "value" : "在进行聊天生成时，后台蒸馏会暂停 —— 它们共享 GPU/统一内存。"
           }
         },
         "zh-Hant" : {
@@ -31408,7 +31408,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览和转换Cloudinary媒体资产"
+            "value" : "浏览和转换 Cloudinary 媒体资产"
           }
         },
         "zh-Hant" : {
@@ -31582,7 +31582,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过Copilot浏览仓库、问题和拉取请求"
+            "value" : "通过 Copilot 浏览仓库、问题和拉取请求"
           }
         },
         "zh-Hant" : {
@@ -32599,7 +32599,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在沙盒容器内运行的内置沙盒执行工具和JSON定义的插件工具。"
+            "value" : "在沙盒容器内运行的内置沙盒执行工具和 JSON 定义的插件工具。"
           }
         },
         "zh-Hant" : {
@@ -36815,7 +36815,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT 拒绝了登录回调: %@"
+            "value" : "ChatGPT 拒绝了登录回调：%@"
           }
         },
         "zh-Hant" : {
@@ -36849,7 +36849,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT 登录回调失败: %@"
+            "value" : "ChatGPT 登录回调失败：%@"
           }
         },
         "zh-Hant" : {
@@ -36917,7 +36917,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要ChatGPT登录"
+            "value" : "需要 ChatGPT 登录"
           }
         },
         "zh-Hant" : {
@@ -36951,7 +36951,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT已登录"
+            "value" : "ChatGPT 已登录"
           }
         },
         "zh-Hant" : {
@@ -37026,7 +37026,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT/Codex目录"
+            "value" : "ChatGPT/Codex 目录"
           }
         },
         "zh-Hant" : {
@@ -37060,7 +37060,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT/Codex模型目录请求失败：%@"
+            "value" : "ChatGPT/Codex 模型目录请求失败：%@"
           }
         },
         "zh-Hant" : {
@@ -37094,7 +37094,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT/Codex或平台API"
+            "value" : "ChatGPT/Codex 或平台 API"
           }
         },
         "zh-Hant" : {
@@ -38215,7 +38215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择要导入的CSV、TSV、JSON或JSONL文件。"
+            "value" : "选择要导入的 CSV、TSV、JSON 或 JSONL 文件。"
           }
         },
         "zh-Hant" : {
@@ -39075,7 +39075,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择用于驱动 AI 检测的端侧模型。\"规则\"选项卡中的模式规则无需任何模型即可运行。"
+            "value" : "选择用于驱动 AI 检测的端侧模型。“规则”选项卡中的模式规则无需任何模型即可运行。"
           }
         },
         "zh-Hant" : {
@@ -39527,7 +39527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Claude模型"
+            "value" : "Claude 模型"
           }
         },
         "zh-Hant" : {
@@ -41543,7 +41543,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Codex OAuth令牌在模型发现之前存在并刷新。"
+            "value" : "Codex OAuth 令牌在模型发现之前存在并刷新。"
           }
         },
         "zh-Hant" : {
@@ -42225,7 +42225,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提交更改到git仓库"
+            "value" : "提交更改到 git 仓库"
           }
         },
         "zh-Hant" : {
@@ -43231,7 +43231,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "config.json、分词器资源和safetensors权重文件都存在。"
+            "value" : "config.json、分词器资源和 safetensors 权重文件都存在。"
           }
         },
         "zh-Hant" : {
@@ -45475,7 +45475,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接到任何其他兼容MCP的服务器"
+            "value" : "连接到任何其他兼容 MCP 的服务器"
           }
         },
         "zh-Hant" : {
@@ -45616,7 +45616,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接到远程MCP服务器以访问其他工具"
+            "value" : "连接到远程 MCP 服务器以访问其他工具"
           }
         },
         "zh-Hant" : {
@@ -48066,7 +48066,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "控制通过/models和/tags返回的模型。隐藏的模型仍可通过直接请求来使用。更改立即生效。"
+            "value" : "控制通过/models 和/tags 返回的模型。隐藏的模型仍可通过直接请求来使用。更改立即生效。"
           }
         },
         "zh-Hant" : {
@@ -48738,7 +48738,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制JSON"
+            "value" : "复制 JSON"
           }
         },
         "zh-Hant" : {
@@ -49958,7 +49958,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法从登录令牌中识别ChatGPT账户。请使用具有Codex访问权限的ChatGPT账户登录，然后重试。"
+            "value" : "无法从登录令牌中识别 ChatGPT 账户。请使用具有 Codex 访问权限的 ChatGPT 账户登录，然后重试。"
           }
         },
         "zh-Hant" : {
@@ -50033,7 +50033,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法导入技能文件\"%1$@\"：%2$@"
+            "value" : "无法导入技能文件“%1$@”：%2$@"
           }
         },
         "zh-Hant" : {
@@ -50101,7 +50101,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法检查技能归档%@"
+            "value" : "无法检查技能归档 %@"
           }
         },
         "zh-Hant" : {
@@ -50135,7 +50135,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法加载xAI OAuth配置：%@"
+            "value" : "无法加载 xAI OAuth 配置：%@"
           }
         },
         "zh-Hant" : {
@@ -50169,7 +50169,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法打开浏览器进行ChatGPT登录。请检查macOS默认浏览器设置，然后重试。"
+            "value" : "无法打开浏览器进行 ChatGPT 登录。请检查 macOS 默认浏览器设置，然后重试。"
           }
         },
         "zh-Hant" : {
@@ -50203,7 +50203,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法打开浏览器进行Grok登录。请检查macOS默认浏览器设置，然后重试。"
+            "value" : "无法打开浏览器进行 Grok 登录。请检查 macOS 默认浏览器设置，然后重试。"
           }
         },
         "zh-Hant" : {
@@ -51005,7 +51005,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "CPU负载"
+            "value" : "CPU 负载"
           }
         },
         "zh-Hant" : {
@@ -51253,7 +51253,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建新的API密钥"
+            "value" : "创建新的 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -51905,7 +51905,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建或复制一个API密钥"
+            "value" : "创建或复制一个 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -51939,7 +51939,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建或修复%@。"
+            "value" : "创建或修复 %@。"
           }
         },
         "zh-Hant" : {
@@ -53865,7 +53865,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义HTTP"
+            "value" : "自定义 HTTP"
           }
         },
         "zh-Hant" : {
@@ -55401,7 +55401,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地vMLX模型的解码吞吐量选项。更改将在下一次模型加载时生效。"
+            "value" : "本地 vMLX 模型的解码吞吐量选项。更改将在下一次模型加载时生效。"
           }
         },
         "zh-Hant" : {
@@ -56915,7 +56915,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除\"%@\"？"
+            "value" : "删除“%@”？"
           }
         },
         "zh-Hant" : {
@@ -59150,7 +59150,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DFlash推测解码"
+            "value" : "DFlash 推测解码"
           }
         },
         "zh-Hant" : {
@@ -59184,7 +59184,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DFlash推测解码不完整"
+            "value" : "DFlash 推测解码不完整"
           }
         },
         "zh-Hant" : {
@@ -59365,7 +59365,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "诊断正在使用%@。"
+            "value" : "诊断正在使用 %@。"
           }
         },
         "zh-Hant" : {
@@ -65458,7 +65458,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修改端点URL并重新测试。"
+            "value" : "修改端点 URL 并重新测试。"
           }
         },
         "zh-Hant" : {
@@ -67955,7 +67955,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用SQLCipher加密"
+            "value" : "使用 SQLCipher 加密"
           }
         },
         "zh-Hant" : {
@@ -67990,7 +67990,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加密，但此Mac上无法使用存储密钥。恢复钥匙串密钥并重试，或重置以重新开始。"
+            "value" : "加密，但此 Mac 上无法使用存储密钥。恢复钥匙串密钥并重试，或重置以重新开始。"
           }
         },
         "zh-Hant" : {
@@ -68171,7 +68171,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过Osaurus安全通道进行端到端加密"
+            "value" : "通过 Osaurus 安全通道进行端到端加密"
           }
         },
         "zh-Hant" : {
@@ -68621,7 +68621,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "输入美元金额，比如25。"
+            "value" : "输入美元金额，比如 25。"
           }
         },
         "zh-Hant" : {
@@ -69032,7 +69032,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 Enter 保存 · 按Esc取消"
+            "value" : "按 Enter 保存 · 按 Esc 取消"
           }
         },
         "zh-Hant" : {
@@ -69741,7 +69741,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "错误：此进程未被信任用于辅助功能。如果在系统设置中已启用，请尝试将Osaurus从列表中移除并重新添加。"
+            "value" : "错误：此进程未被信任用于辅助功能。如果在系统设置中已启用，请尝试将 Osaurus 从列表中移除并重新添加。"
           }
         },
         "zh-Hant" : {
@@ -70882,7 +70882,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在文件夹中执行shell命令"
+            "value" : "在文件夹中执行 shell 命令"
           }
         },
         "zh-Hant" : {
@@ -76038,7 +76038,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复或清除服务器设置中的代理URL。"
+            "value" : "修复或清除服务器设置中的代理 URL。"
           }
         },
         "zh-Hant" : {
@@ -76072,7 +76072,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复或删除%@，然后再次保存沙盒设置。"
+            "value" : "修复或删除 %@，然后再次保存沙盒设置。"
           }
         },
         "zh-Hant" : {
@@ -76112,7 +76112,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复%1$@的所有权或权限，然后重新运行预检。对于用户拥有的路径，通常chmod u+rwX \"%2$@\"就足够了。"
+            "value" : "修复 %1$@ 的所有权或权限，然后重新运行预检。对于用户拥有的路径，通常 chmod u+rwX “%2$@”就足够了。"
           }
         },
         "zh-Hant" : {
@@ -76776,7 +76776,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "释放包含%@的卷中的磁盘空间，然后重新运行预检。"
+            "value" : "释放包含 %@ 的卷中的磁盘空间，然后重新运行预检。"
           }
         },
         "zh-Hant" : {
@@ -77820,7 +77820,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gemini模型列表"
+            "value" : "Gemini 模型列表"
           }
         },
         "zh-Hant" : {
@@ -77854,7 +77854,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gemini模型"
+            "value" : "Gemini 模型"
           }
         },
         "zh-Hant" : {
@@ -78165,7 +78165,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生成一个新的API密钥"
+            "value" : "生成一个新的 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -79390,7 +79390,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅限GGUF的捆绑包"
+            "value" : "仅限 GGUF 的捆绑包"
           }
         },
         "zh-Hant" : {
@@ -79428,7 +79428,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Git提交"
+            "value" : "Git 提交"
           }
         },
         "zh-Hant" : {
@@ -80270,7 +80270,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往%@控制台"
+            "value" : "前往 %@ 控制台"
           }
         },
         "zh-Hant" : {
@@ -80409,7 +80409,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往AtlasCloud API密钥页面"
+            "value" : "前往 AtlasCloud API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80443,7 +80443,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往DeepSeek平台API密钥页面"
+            "value" : "前往 DeepSeek 平台 API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80477,7 +80477,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往MiniMax平台的API密钥页面"
+            "value" : "前往 MiniMax 平台的 API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80511,7 +80511,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往Mistral控制台API密钥页面"
+            "value" : "前往 Mistral 控制台 API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80579,7 +80579,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往Venice AI设置页面"
+            "value" : "前往 Venice AI 设置页面"
           }
         },
         "zh-Hant" : {
@@ -80984,7 +80984,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将\"%@\"授予智能体"
+            "value" : "将“%@”授予智能体"
           }
         },
         "zh-Hant" : {
@@ -81401,7 +81401,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已将\"%1$@\"授予 %2$lld 个智能体"
+            "value" : "已将“%1$@”授予 %2$lld 个智能体"
           }
         },
         "zh-Hant" : {
@@ -81435,7 +81435,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已将\"%@\"授予 1 个智能体"
+            "value" : "已将“%@”授予 1 个智能体"
           }
         },
         "zh-Hant" : {
@@ -81605,7 +81605,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Grok模型"
+            "value" : "Grok 模型"
           }
         },
         "zh-Hant" : {
@@ -83511,7 +83511,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "主机为此插件发出了 %d 条一次性警告%@。"
+            "value" : "主机为此插件发出了 %d 条一次性警告 %@。"
           }
         },
         "zh-Hant" : {
@@ -84549,7 +84549,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "HTTP路由"
+            "value" : "HTTP 路由"
           }
         },
         "zh-Hant" : {
@@ -87252,7 +87252,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已导入\"%@\"，包含 %lld 个文件"
+            "value" : "已导入“%@”，包含 %lld 个文件"
           }
         },
         "zh-Hant" : {
@@ -89831,7 +89831,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从ollama.com安装Ollama"
+            "value" : "从 ollama.com 安装 Ollama"
           }
         },
         "zh-Hant" : {
@@ -91249,7 +91249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无效的技能存档 - 未找到SKILL.md文件"
+            "value" : "无效的技能存档 - 未找到 SKILL.md 文件"
           }
         },
         "zh-Hant" : {
@@ -91283,7 +91283,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无效的URL"
+            "value" : "无效的 URL"
           }
         },
         "zh-Hant" : {
@@ -91317,7 +91317,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调查Sentry问题、跟踪和版本"
+            "value" : "调查 Sentry 问题、跟踪和版本"
           }
         },
         "zh-Hant" : {
@@ -97550,7 +97550,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已加载的模型%@"
+            "value" : "已加载的模型 %@"
           }
         },
         "zh-Hant" : {
@@ -99086,7 +99086,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地主机客户端可以无需真实密钥调用API。为局域网、中继或需要Bearer值的客户端创建访问密钥。"
+            "value" : "本地主机客户端可以无需真实密钥调用 API。为局域网、中继或需要 Bearer 值的客户端创建访问密钥。"
           }
         },
         "zh-Hant" : {
@@ -99775,7 +99775,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS版本不支持沙盒配置"
+            "value" : "macOS 版本不支持沙盒配置"
           }
         },
         "zh-Hant" : {
@@ -100446,7 +100446,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "管理Supabase Postgres、认证和存储"
+            "value" : "管理 Supabase Postgres、认证和存储"
           }
         },
         "zh-Hant" : {
@@ -101177,7 +101177,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "如果/models缺失或返回的不是OpenAI格式的schema，则使用手动ID。"
+            "value" : "如果/models 缺失或返回的不是 OpenAI 格式的 schema，则使用手动 ID。"
           }
         },
         "zh-Hant" : {
@@ -102333,7 +102333,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大显示的Toast数量"
+            "value" : "最大显示的 Toast 数量"
           }
         },
         "zh-Hant" : {
@@ -102368,7 +102368,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同时运行的最大后台任务数。空值使用默认5"
+            "value" : "同时运行的最大后台任务数。空值使用默认 5"
           }
         },
         "zh-Hant" : {
@@ -102543,7 +102543,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一次显示的最大Toast数量。空值则使用默认的5个"
+            "value" : "一次显示的最大 Toast 数量。空值则使用默认的 5 个"
           }
         },
         "zh-Hant" : {
@@ -105057,7 +105057,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MiniMax M系列模型"
+            "value" : "MiniMax M 系列模型"
           }
         },
         "zh-Hant" : {
@@ -105093,7 +105093,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最低充值金额为5.00美元"
+            "value" : "最低充值金额为 5.00 美元"
           }
         },
         "zh-Hant" : {
@@ -105307,7 +105307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "缺少API密钥"
+            "value" : "缺少 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -105341,7 +105341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "缺少ChatGPT/Codex登录令牌。再次使用ChatGPT登录，然后重试提供商。"
+            "value" : "缺少 ChatGPT/Codex 登录令牌。再次使用 ChatGPT 登录，然后重试提供商。"
           }
         },
         "zh-Hant" : {
@@ -106454,7 +106454,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型请求和余额变动，按最新排序。当此Mac有匹配的副本时，打开聊天或洞察。"
+            "value" : "模型请求和余额变动，按最新排序。当此 Mac 有匹配的副本时，打开聊天或洞察。"
           }
         },
         "zh-Hant" : {
@@ -107417,7 +107417,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "大多数客户端默认为1337（Osaurus）或11434（Ollama兼容）。"
+            "value" : "大多数客户端默认为 1337（Osaurus）或 11434（Ollama 兼容）。"
           }
         },
         "zh-Hant" : {
@@ -107525,7 +107525,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移动或删除%1$@，然后使用mkdir -p \"%2$@\"创建目录。"
+            "value" : "移动或删除 %1$@，然后使用 mkdir -p “%2$@”创建目录。"
           }
         },
         "zh-Hant" : {
@@ -107559,7 +107559,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移动或删除%@目录，然后重新运行沙盒设置。"
+            "value" : "移动或删除 %@ 目录，然后重新运行沙盒设置。"
           }
         },
         "zh-Hant" : {
@@ -107662,7 +107662,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "多语言模型。支持25种欧洲语言。推荐给大多数用户。"
+            "value" : "多语言模型。支持 25 种欧洲语言。推荐给大多数用户。"
           }
         },
         "zh-Hant" : {
@@ -107772,7 +107772,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "我的MCP服务器"
+            "value" : "我的 MCP 服务器"
           }
         },
         "zh-Hant" : {
@@ -109346,7 +109346,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新数据将使用SQLCipher进行加密。"
+            "value" : "新数据将使用 SQLCipher 进行加密。"
           }
         },
         "zh-Hant" : {
@@ -109380,7 +109380,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新数据将以明文形式存储，并受FileVault保护。"
+            "value" : "新数据将以明文形式存储，并受 FileVault 保护。"
           }
         },
         "zh-Hant" : {
@@ -110594,7 +110594,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus未添加授权头。"
+            "value" : "Osaurus 未添加授权头。"
           }
         },
         "zh-Hant" : {
@@ -111052,7 +111052,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有为该提供商保存Codex OAuth令牌。"
+            "value" : "没有为该提供商保存 Codex OAuth 令牌。"
           }
         },
         "zh-Hant" : {
@@ -112339,7 +112339,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尚未安装此共享ID的主题。"
+            "value" : "尚未安装此共享 ID 的主题。"
           }
         },
         "zh-Hant" : {
@@ -117042,7 +117042,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不是MLX模型"
+            "value" : "不是 MLX 模型"
           }
         },
         "zh-Hant" : {
@@ -117672,7 +117672,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不是MLX"
+            "value" : "不是 MLX"
           }
         },
         "zh-Hant" : {
@@ -118300,7 +118300,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不用于stdio"
+            "value" : "不用于 stdio"
           }
         },
         "zh-Hant" : {
@@ -119100,7 +119100,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要OAuth登录"
+            "value" : "需要 OAuth 登录"
           }
         },
         "zh-Hant" : {
@@ -119134,7 +119134,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OAuth令牌已保存"
+            "value" : "OAuth 令牌已保存"
           }
         },
         "zh-Hant" : {
@@ -119423,7 +119423,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭则仅绑定到127.0.0.1（仅此Mac）。开启则绑定到0.0.0.0，这样手机、iPad和其他网络设备就可以连接。"
+            "value" : "关闭则仅绑定到 127.0.0.1（仅此 Mac）。开启则绑定到 0.0.0.0，这样手机、iPad 和其他网络设备就可以连接。"
           }
         },
         "zh-Hant" : {
@@ -120016,7 +120016,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在现代Mac上，文件保险箱已经在静态时对整个磁盘进行加密。明文存储依赖于这一点，并且是最可靠的选择——它从不依赖于钥匙串密钥。"
+            "value" : "在现代 Mac 上，文件保险箱已经在静态时对整个磁盘进行加密。明文存储依赖于这一点，并且是最可靠的选择——它从不依赖于钥匙串密钥。"
           }
         },
         "zh-Hant" : {
@@ -120499,7 +120499,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一个或多个检查无法被证明；复制报告以供支持或CI证明。"
+            "value" : "一个或多个检查无法被证明；复制报告以供支持或 CI 证明。"
           }
         },
         "zh-Hant" : {
@@ -122211,7 +122211,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开沙盒设置或运行设置以写入%@。"
+            "value" : "打开沙盒设置或运行设置以写入 %@。"
           }
         },
         "zh-Hant" : {
@@ -123267,7 +123267,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OpenAI令牌请求失败：%@"
+            "value" : "OpenAI 令牌请求失败：%@"
           }
         },
         "zh-Hant" : {
@@ -124747,7 +124747,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus本地模型"
+            "value" : "Osaurus 本地模型"
           }
         },
         "zh-Hant" : {
@@ -125357,7 +125357,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus将使用默认的沙盒设置，直到保存配置文件。"
+            "value" : "Osaurus 将使用默认的沙盒设置，直到保存配置文件。"
           }
         },
         "zh-Hant" : {
@@ -126063,7 +126063,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "软件包名称（例如python3）"
+            "value" : "软件包名称（例如 python3）"
           }
         },
         "zh-Hant" : {
@@ -127115,7 +127115,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴有效的ID或链接以查看标准化的服务器详情。"
+            "value" : "粘贴有效的 ID 或链接以查看标准化的服务器详情。"
           }
         },
         "zh-Hant" : {
@@ -127183,7 +127183,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在行内提示中粘贴API令牌或编辑提供商。"
+            "value" : "在行内提示中粘贴 API 令牌或编辑提供商。"
           }
         },
         "zh-Hant" : {
@@ -128193,7 +128193,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PATH问题"
+            "value" : "PATH 问题"
           }
         },
         "zh-Hant" : {
@@ -129371,7 +129371,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每会话KV限制（词元数）"
+            "value" : "每会话 KV 限制（词元数）"
           }
         },
         "zh-Hant" : {
@@ -133462,7 +133462,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预注册的 OAuth Client ID（留空以使用DCR）"
+            "value" : "预注册的 OAuth Client ID（留空以使用 DCR）"
           }
         },
         "zh-Hant" : {
@@ -135094,7 +135094,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐私优先的AI"
+            "value" : "隐私优先的 AI"
           }
         },
         "zh-Hant" : {
@@ -140509,7 +140509,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "任何公共GitHub仓库的问答"
+            "value" : "任何公共 GitHub 仓库的问答"
           }
         },
         "zh-Hant" : {
@@ -140751,7 +140751,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查询和管理Neon Postgres数据库"
+            "value" : "查询和管理 Neon Postgres 数据库"
           }
         },
         "zh-Hant" : {
@@ -140785,7 +140785,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查询和管理PayPal付款和订单"
+            "value" : "查询和管理 PayPal 付款和订单"
           }
         },
         "zh-Hant" : {
@@ -140819,7 +140819,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查询HubSpot联系人、交易和管道"
+            "value" : "查询 HubSpot 联系人、交易和管道"
           }
         },
         "zh-Hant" : {
@@ -142254,7 +142254,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查看和管理Square的付款和订单"
+            "value" : "查看和管理 Square 的付款和订单"
           }
         },
         "zh-Hant" : {
@@ -142458,7 +142458,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "读取并更新monday.com的看板和项目"
+            "value" : "读取并更新 monday.com 的看板和项目"
           }
         },
         "zh-Hant" : {
@@ -146276,7 +146276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已注册%@工具；使用capabilities_load加载"
+            "value" : "已注册 %@ 工具；使用 capabilities_load 加载"
           }
         },
         "zh-Hant" : {
@@ -147298,7 +147298,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "远程Osaurus"
+            "value" : "远程 Osaurus"
           }
         },
         "zh-Hant" : {
@@ -147472,7 +147472,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除%@并重新运行沙盒设置，以便Osaurus可以下载新的资源。"
+            "value" : "删除 %@ 并重新运行沙盒设置，以便 Osaurus 可以下载新的资源。"
           }
         },
         "zh-Hant" : {
@@ -147506,7 +147506,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除%@并重新运行设置。"
+            "value" : "删除 %@ 并重新运行设置。"
           }
         },
         "zh-Hant" : {
@@ -147994,7 +147994,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除或移动%@，然后重新运行沙盒设置。"
+            "value" : "删除或移动 %@，然后重新运行沙盒设置。"
           }
         },
         "zh-Hant" : {
@@ -150316,7 +150316,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要 @提及"
+            "value" : "需要 @ 提及"
           }
         },
         "zh-Hant" : {
@@ -150701,7 +150701,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要%@返回一个OpenAI风格的模型列表。"
+            "value" : "需要 %@ 返回一个 OpenAI 风格的模型列表。"
           }
         },
         "zh-Hant" : {
@@ -155095,7 +155095,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由到 %@（名称 \"%@\"）"
+            "value" : "路由到 %@（名称 “%@”）"
           }
         },
         "zh-Hant" : {
@@ -156226,7 +156226,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行ID：%@"
+            "value" : "运行 ID：%@"
           }
         },
         "zh-Hant" : {
@@ -156498,7 +156498,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在macOS 26或更高版本上运行Osaurus沙盒配置。"
+            "value" : "在 macOS 26 或更高版本上运行 Osaurus 沙盒配置。"
           }
         },
         "zh-Hant" : {
@@ -156600,7 +156600,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行设置沙盒以便 Osaurus 可以创建或下载%@。"
+            "value" : "运行设置沙盒以便 Osaurus 可以创建或下载 %@。"
           }
         },
         "zh-Hant" : {
@@ -156635,7 +156635,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行Shell命令"
+            "value" : "运行 Shell 命令"
           }
         },
         "zh-Hant" : {
@@ -157470,7 +157470,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在Osaurus沙盒中运行，并在断开连接时被销毁。"
+            "value" : "在 Osaurus 沙盒中运行，并在断开连接时被销毁。"
           }
         },
         "zh-Hant" : {
@@ -161510,7 +161510,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "来自%@的屏幕上下文"
+            "value" : "来自 %@ 的屏幕上下文"
           }
         },
         "zh-Hant" : {
@@ -170777,7 +170777,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用具有Codex访问权限的ChatGPT账户登录。"
+            "value" : "使用具有 Codex 访问权限的 ChatGPT 账户登录。"
           }
         },
         "zh-Hant" : {
@@ -170811,7 +170811,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用具有Grok API访问权限的xAI账户登录。"
+            "value" : "使用具有 Grok API 访问权限的 xAI 账户登录。"
           }
         },
         "zh-Hant" : {
@@ -171363,7 +171363,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已使用Grok登录。令牌存储在Keychain中。"
+            "value" : "已使用 Grok 登录。令牌存储在 Keychain 中。"
           }
         },
         "zh-Hant" : {
@@ -176932,7 +176932,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stdio命令缺失"
+            "value" : "Stdio 命令缺失"
           }
         },
         "zh-Hant" : {
@@ -178210,7 +178210,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "存储在配置的Osaurus模型目录下。"
+            "value" : "存储在配置的 Osaurus 模型目录下。"
           }
         },
         "zh-Hant" : {
@@ -178909,7 +178909,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功: %@"
+            "value" : "成功：%@"
           }
         },
         "zh-Hant" : {
@@ -179215,7 +179215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功：连接到%@"
+            "value" : "成功：连接到 %@"
           }
         },
         "zh-Hant" : {
@@ -179740,7 +179740,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换AI模型"
+            "value" : "切换 AI 模型"
           }
         },
         "zh-Hant" : {
@@ -183854,7 +183854,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该定义至少需要一个端点（例如 \"web\"）。"
+            "value" : "该定义至少需要一个端点（例如 “web”）。"
           }
         },
         "zh-Hant" : {
@@ -184167,7 +184167,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ID \"%@\" 已被内置提供商占用。请选择其他 ID。"
+            "value" : "ID “%@” 已被内置提供商占用。请选择其他 ID。"
           }
         },
         "zh-Hant" : {
@@ -184341,7 +184341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地目录中没有所需的MLX文件。"
+            "value" : "本地目录中没有所需的 MLX 文件。"
           }
         },
         "zh-Hant" : {
@@ -185954,7 +185954,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "测试按钮启动子进程，运行initialize/listTools，并将其关闭。"
+            "value" : "测试按钮启动子进程，运行 initialize/listTools，并将其关闭。"
           }
         },
         "zh-Hant" : {
@@ -186097,7 +186097,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "权衡在于可靠性：如果钥匙串密钥丢失（如钥匙串被清除、应用程序重新签名或在未使用iCloud钥匙串的情况下迁移Mac），则无法打开加密数据。而明文数据则永远不会面临这种风险。"
+            "value" : "权衡在于可靠性：如果钥匙串密钥丢失（如钥匙串被清除、应用程序重新签名或在未使用 iCloud 钥匙串的情况下迁移 Mac），则无法打开加密数据。而明文数据则永远不会面临这种风险。"
           }
         },
         "zh-Hant" : {
@@ -187446,7 +187446,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这个捆绑包不是MLX格式，因此本地引擎(vmlx)无法加载它。Osaurus只能运行MLX格式的权重——请使用mlx_lm进行转换，或选择该模型的MLX版本。"
+            "value" : "这个捆绑包不是 MLX 格式，因此本地引擎(vmlx)无法加载它。Osaurus 只能运行 MLX 格式的权重——请使用 mlx_lm 进行转换，或选择该模型的 MLX 版本。"
           }
         },
         "zh-Hant" : {
@@ -188964,7 +188964,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将从配置文件中移除 \"%@\" 频道定义。其引用的钥匙串密钥不会被删除。"
+            "value" : "这将从配置文件中移除 “%@” 频道定义。其引用的钥匙串密钥不会被删除。"
           }
         },
         "zh-Hant" : {
@@ -189493,7 +189493,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这会遍历你历史中的每一个聊天会话，将它们的回合缓冲到pending_signals中，然后进行蒸馏。如果你有数百个会话，这可能需要一些时间——每个会话都是对你的核心模型的一次单独的LLM调用。已经蒸馏过的会话会被跳过。"
+            "value" : "这会遍历你历史中的每一个聊天会话，将它们的回合缓冲到 pending_signals 中，然后进行蒸馏。如果你有数百个会话，这可能需要一些时间——每个会话都是对你的核心模型的一次单独的 LLM 调用。已经蒸馏过的会话会被跳过。"
           }
         },
         "zh-Hant" : {
@@ -191438,7 +191438,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工具“%1$@”超过了%2$lld秒的执行预算。"
+            "value" : "工具“%1$@”超过了 %2$lld 秒的执行预算。"
           }
         },
         "zh-Hant" : {
@@ -194344,7 +194344,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭Osaurus路由器？"
+            "value" : "关闭 Osaurus 路由器？"
           }
         },
         "zh-Hant" : {
@@ -196051,7 +196051,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不受支持的Hunyuan Dense"
+            "value" : "不受支持的 Hunyuan Dense"
           }
         },
         "zh-Hant" : {
@@ -196729,7 +196729,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已更新 \"%@\""
+            "value" : "已更新 “%@”"
           }
         },
         "zh-Hant" : {
@@ -198624,7 +198624,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用OpenAI兼容的基础URL https://api.atlascloud.ai/v1"
+            "value" : "使用 OpenAI 兼容的基础 URL https://api.atlascloud.ai/v1"
           }
         },
         "zh-Hant" : {
@@ -199003,7 +199003,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用Anthropic的分页模型目录端点。"
+            "value" : "使用 Anthropic 的分页模型目录端点。"
           }
         },
         "zh-Hant" : {
@@ -199299,7 +199299,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用AI + 正则规则"
+            "value" : "使用 AI + 正则规则"
           }
         },
         "zh-Hant" : {
@@ -204320,7 +204320,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当加密开启时，清除macOS钥匙串或在没有iCloud钥匙串同步的情况下迁移到新Mac会使加密存储无法恢复。迁移前请导出明文备份。"
+            "value" : "当加密开启时，清除 macOS 钥匙串或在没有 iCloud 钥匙串同步的情况下迁移到新 Mac 会使加密存储无法恢复。迁移前请导出明文备份。"
           }
         },
         "zh-Hant" : {
@@ -206737,7 +206737,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI OAuth发现返回了不受信任的%@"
+            "value" : "xAI OAuth 发现返回了不受信任的 %@"
           }
         },
         "zh-Hant" : {
@@ -206805,7 +206805,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI 拒绝了登录回调: %@"
+            "value" : "xAI 拒绝了登录回调：%@"
           }
         },
         "zh-Hant" : {
@@ -206839,7 +206839,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI在Grok登录过程中返回了无效的令牌响应"
+            "value" : "xAI 在 Grok 登录过程中返回了无效的令牌响应"
           }
         },
         "zh-Hant" : {
@@ -206873,7 +206873,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要xAI登录"
+            "value" : "需要 xAI 登录"
           }
         },
         "zh-Hant" : {
@@ -206907,7 +206907,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI已登录"
+            "value" : "xAI 已登录"
           }
         },
         "zh-Hant" : {
@@ -206941,7 +206941,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI令牌请求失败：%@"
+            "value" : "xAI 令牌请求失败：%@"
           }
         },
         "zh-Hant" : {

--- a/scripts/i18n/lint-zh-style.py
+++ b/scripts/i18n/lint-zh-style.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Style linter for Chinese locales in Localizable.xcstrings.
+
+Rules (zh-Hans by default):
+  spacing  - insert a space between CJK and Latin/digit/placeholder runs
+  quotes   - ASCII "straight" quote pairs around text -> curly “ ” (‘ ’)
+  colon    - halfwidth colon after a CJK character -> fullwidth ：
+
+Values inside backtick spans and URLs are left untouched. Only stringUnit
+values are rewritten; state fields are never modified. The catalog is written
+back byte-exactly (indent=2, separators=(',', ' : '), no trailing newline) so
+diffs contain only the changed value lines.
+
+Usage:
+  python3 scripts/i18n/lint-zh-style.py --check            # report, exit 1 if dirty
+  python3 scripts/i18n/lint-zh-style.py --fix              # apply fixes in place
+  python3 scripts/i18n/lint-zh-style.py --fix --locale zh-Hant
+  python3 scripts/i18n/lint-zh-style.py --check --exclude-keys keys.txt
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CATALOG = Path(__file__).resolve().parents[2] / "Packages/OsaurusCore/Resources/Localizable.xcstrings"
+
+CJK = r"㐀-䶿一-鿿"
+LATIN = r"A-Za-z0-9"
+# spans we must never touch or space-pad inside
+PROTECTED = re.compile(r"`[^`]*`|https?://\S+|www\.\S+")
+PLACEHOLDER = re.compile(r"%(\d+\$)?[#0\- +']*\d*(\.\d+)?(hh|h|ll|l|q|z|t|L)?[@dDuUxXoOfeEgGaAcCsSpF]|%%")
+
+def protect(value):
+    """Replace protected spans with sentinels; return (masked, spans)."""
+    spans = []
+    def repl(m):
+        spans.append(m.group(0))
+        return f"\x00{len(spans)-1}\x00"
+    return PROTECTED.sub(repl, value), spans
+
+def unprotect(value, spans):
+    for i, s in enumerate(spans):
+        value = value.replace(f"\x00{i}\x00", s)
+    return value
+
+def fix_spacing(value):
+    # treat each placeholder as an opaque Latin-like token
+    masked = PLACEHOLDER.sub(lambda m: f"\x01{m.group(0)}\x01", value)
+    masked = re.sub(rf"([{CJK}])([\x01{LATIN}%])", r"\1 \2", masked)
+    masked = re.sub(rf"([\x01{LATIN}%@])([{CJK}])", r"\1 \2", masked)
+    return masked.replace("\x01", "")
+
+def fix_quotes(value):
+    if value.count('"') and value.count('"') % 2 == 0:
+        value = re.sub(r'"([^"]*)"', "“\\1”", value)
+    if re.search(rf"'[^']*[{CJK}][^']*'", value):
+        value = re.sub(rf"'([^']*[{CJK}][^']*)'", "‘\\1’", value)
+    return value
+
+def fix_colon(value):
+    return re.sub(rf"([{CJK}]):(?!//)\s?", "\\1：", value)
+
+def apply_rules(value, rules):
+    masked, spans = protect(value)
+    if "quotes" in rules:
+        masked = fix_quotes(masked)
+    if "colon" in rules:
+        masked = fix_colon(masked)
+    if "spacing" in rules:
+        masked = fix_spacing(masked)
+    return unprotect(masked, spans)
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="report violations, exit 1 if any")
+    mode.add_argument("--fix", action="store_true", help="rewrite the catalog in place")
+    ap.add_argument("--locale", default="zh-Hans")
+    ap.add_argument("--rules", default="spacing,quotes,colon", help="comma-separated subset of rules")
+    ap.add_argument("--exclude-keys", type=Path, help="file with one key per line (JSON-encoded or raw) to skip")
+    ap.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    args = ap.parse_args()
+
+    rules = set(args.rules.split(","))
+    excluded = set()
+    if args.exclude_keys:
+        for line in args.exclude_keys.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                excluded.add(json.loads(line))
+            except ValueError:
+                excluded.add(line)
+
+    raw = args.catalog.read_bytes()
+    catalog = json.loads(raw)
+    rendered = json.dumps(catalog, ensure_ascii=False, indent=2, separators=(",", " : ")).encode()
+    if rendered != raw:
+        sys.exit("refusing to run: catalog does not round-trip byte-exactly; check serialization recipe")
+
+    changed = []
+    for key, entry in catalog["strings"].items():
+        if key in excluded or entry.get("shouldTranslate") is False:
+            continue
+        unit = entry.get("localizations", {}).get(args.locale, {}).get("stringUnit")
+        if not unit or "value" not in unit:
+            continue
+        new = apply_rules(unit["value"], rules)
+        if new != unit["value"]:
+            changed.append((key, unit["value"], new))
+            if args.fix:
+                unit["value"] = new
+
+    for key, old, new in changed:
+        print(f"[{args.locale}] {key[:60]!r}\n  - {old}\n  + {new}")
+    print(f"\n{len(changed)} value(s) {'fixed' if args.fix else 'need fixing'}")
+
+    if args.fix and changed:
+        args.catalog.write_bytes(json.dumps(catalog, ensure_ascii=False, indent=2, separators=(",", " : ")).encode())
+    if args.check and changed:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `scripts/i18n/lint-zh-style.py` (--check/--fix) enforcing three mechanical rules for Chinese values — CJK↔Latin spacing, curly quotes around Chinese text, fullwidth colon after CJK — and applies it to the active zh-Hans catalog. ~5,700 strings already follow these conventions; this fixes the remaining minority. Backtick spans and URLs are never touched. The script can later be wired into CI and reused for zh-Hant. Follow-up to #2177.

## Changes

- 189 zh-Hans string **values** in `Packages/OsaurusCore/Resources/Localizable.xcstrings` — no keys, states, or other locales touched;
- adds `scripts/i18n/lint-zh-style.py`

## How to verify without speaking Chinese

Every row below links the English source to the defect. The author is a native Simplified Chinese speaker; every change was checked against the English source string and its Swift call site.

| English source | old → new (zh-Hans) | defect |
|---|---|---|
| %@ has the wrong type | %@有错误的类型 → %@ 有错误的类型 | Missing space between placeholder and CJK text. |
| %@ is empty | %@是空的 → %@ 是空的 | Missing space between placeholder and CJK text. |
| %@ is missing | %@缺失 → %@ 缺失 | Missing space between placeholder and CJK text. |
| %@ is not readable | %@不可读 → %@ 不可读 | Missing space between placeholder and CJK text. |
| %@ is not writable | %@不可写 → %@ 不可写 | Missing space between placeholder and CJK text. |
| %@ still can't be opened. Try Reset. | %@仍然无法打开。尝试重置。 → %@ 仍然无法打开。尝试重置。 | Missing space between placeholder and CJK text. |
| %lld settings match "%@" | %lld 个设置匹配"%@" → %lld 个设置匹配“%@” | Straight quotes used instead of curly quotes; missing spacing. |
| 0 attempts since launch | 自启动以来0次尝试 → 自启动以来 0 次尝试 | Missing spaces around the digit. |
| 0 favors performance, 2 is Safe Auto, 3 is strict, and 4 is diagnostic | 0倾向于性能，2是安全自动，3是严格的，4是诊断/自定义。 → 0 倾向于性能，2 是安全自动，3 是严格的，4 是诊断/自定义。 | Digits hug Chinese text without spaces, unlike the sibling key. |
| 1 day | 1天 → 1 天 | Missing space between digit and 天. |

<details><summary>All 189 changes</summary>

| English source | old → new | defect |
|---|---|---|
| 1 setting matches "%@" | 1 个设置匹配 "%@" → 1 个设置匹配 “%@” | Straight quotes retained around %@; should use curly quotes. |
| 30 days | 30天 → 30 天 | Missing space between digit and 天. |
| 4-bit (q4, fastest) | 4位（q4，最快） → 4 位（q4，最快） | Missing space in 4位. |
| 7 days | 7天 → 7 天 | Missing space between digit and 天. |
| 8-bit (q8, conservative) | 8位（q8，保守） → 8 位（q8，保守） | Missing space in 8位. |
| A new 256-bit key will be generated and every encrypted database + fil | 将生成一个新的256位密钥，并将位于 ~/.osaurus 下的所有加密数据库和文件重新加 → 将生成一个新的 256 位密钥，并将位于 ~/.osaurus 下的所有加密数据库和文件重 | Missing spaces in 256位 and 此Mac. |
| A new 256-bit key will be generated and every encrypted database + fil | 将生成一个新的256位密钥，并将 ~/.osaurus 下所有加密的数据库和文件重新加密。 → 将生成一个新的 256 位密钥，并将 ~/.osaurus 下所有加密的数据库和文件重新加 | Missing spaces in 256位 and 此Mac. |
| A skill named "%@" already exists. Replacing it overwrites its SKILL.m | 一个名为“%@”的技能已存在。替换它将覆盖其SKILL.md、引用和资源。 → 一个名为“%@”的技能已存在。替换它将覆盖其 SKILL.md、引用和资源。 | Missing space before SKILL.md. |
| AI detection (on-device model) | AI检测（设备端模型） → AI 检测（设备端模型） | Missing space between AI and 检测. |
| AI-native web search and content extraction | AI原生网络搜索和内容提取 → AI 原生网络搜索和内容提取 | Missing space between AI and 原生. |
| API key in Keychain | API密钥在钥匙串中 → API 密钥在钥匙串中 | Missing space between API and 密钥, inconsistent with sibling keys. |
| Action "%@" is not a standard action name and will never be called. | 操作 "%@" 不是标准操作名称，且永远不会被调用。 → 操作 “%@” 不是标准操作名称，且永远不会被调用。 | Straight quotes retained around placeholder; style calls for curly quotes. |
| Already installed as %@. | 已安装为%@。 → 已安装为 %@。 | Missing space between Chinese text and the placeholder. |
| Apply JSON | 应用JSON → 应用 JSON | Missing space between 应用 and JSON. |
| Azure deployment IDs are configured, so connect can proceed even when  | Azure部署ID已配置，即使/models不可用，连接也可以继续进行。 → Azure 部署 ID 已配置，即使/models 不可用，连接也可以继续进行。 | Missing spaces between Chinese and Latin text. |
| Azure deployments | Azure部署 → Azure 部署 | Missing space between Azure and 部署. |
| Background distillation is paused while a chat generation is streaming | 在进行聊天生成时，后台蒸馏会暂停 —— 它们共享GPU/统一内存。 → 在进行聊天生成时，后台蒸馏会暂停 —— 它们共享 GPU/统一内存。 | Missing space before GPU. |
| Browse and transform Cloudinary media assets | 浏览和转换Cloudinary媒体资产 → 浏览和转换 Cloudinary 媒体资产 | Missing spaces around Cloudinary. |
| Browse repos, issues, and pull requests via Copilot | 通过Copilot浏览仓库、问题和拉取请求 → 通过 Copilot 浏览仓库、问题和拉取请求 | Missing spaces around Copilot. |
| Built-in sandbox execution tools and JSON-defined plugin tools that ru | 在沙盒容器内运行的内置沙盒执行工具和JSON定义的插件工具。 → 在沙盒容器内运行的内置沙盒执行工具和 JSON 定义的插件工具。 | Missing spaces around "JSON". |
| CPU Load | CPU负载 → CPU 负载 | Missing space in CPU负载. |
| ChatGPT rejected the sign-in callback: %@ | ChatGPT 拒绝了登录回调: %@ → ChatGPT 拒绝了登录回调：%@ | Half-width colon after Chinese text. |
| ChatGPT sign-in callback failed: %@ | ChatGPT 登录回调失败: %@ → ChatGPT 登录回调失败：%@ | Half-width colon after Chinese text. |
| ChatGPT sign-in required | 需要ChatGPT登录 → 需要 ChatGPT 登录 | Missing spaces around "ChatGPT". |
| ChatGPT signed in | ChatGPT已登录 → ChatGPT 已登录 | Missing space after "ChatGPT". |
| ChatGPT/Codex catalog | ChatGPT/Codex目录 → ChatGPT/Codex 目录 | Missing space after "Codex". |
| ChatGPT/Codex model catalog request failed: %@ | ChatGPT/Codex模型目录请求失败：%@ → ChatGPT/Codex 模型目录请求失败：%@ | Missing space after "Codex". |
| ChatGPT/Codex or Platform API | ChatGPT/Codex或平台API → ChatGPT/Codex 或平台 API | Missing spaces around English terms. |
| Choose a CSV, TSV, JSON, or JSONL file to import. | 选择要导入的CSV、TSV、JSON或JSONL文件。 → 选择要导入的 CSV、TSV、JSON 或 JSONL 文件。 | missing spaces between Chinese and Latin acronyms |
| Choose the on-device model that powers AI detection. Pattern rules in  | 选择用于驱动 AI 检测的端侧模型。"规则"选项卡中的模式规则无需任何模型即可运行。 → 选择用于驱动 AI 检测的端侧模型。“规则”选项卡中的模式规则无需任何模型即可运行。 | straight quotes around Chinese text |
| Claude models | Claude模型 → Claude 模型 | missing space between 'Claude' and Chinese text |
| Codex OAuth tokens are present and refreshed before model discovery. | Codex OAuth令牌在模型发现之前存在并刷新。 → Codex OAuth 令牌在模型发现之前存在并刷新。 | missing space between 'OAuth' and Chinese text |
| Commit changes to git repository | 提交更改到git仓库 → 提交更改到 git 仓库 | missing spaces around 'git' |
| Connect to any other MCP-compatible server | 连接到任何其他兼容MCP的服务器 → 连接到任何其他兼容 MCP 的服务器 | Missing spaces around "MCP". |
| Connect to remote MCP servers to access additional tools | 连接到远程MCP服务器以访问其他工具 → 连接到远程 MCP 服务器以访问其他工具 | Missing spaces around "MCP". |
| Controls the models returned by /models and /tags. Hidden models can s | 控制通过/models和/tags返回的模型。隐藏的模型仍可通过直接请求来使用。更改立即生 → 控制通过/models 和/tags 返回的模型。隐藏的模型仍可通过直接请求来使用。更改立 | Missing spaces around "/models" and "/tags". |
| Copy JSON | 复制JSON → 复制 JSON | Missing space before "JSON". |
| Could not identify the ChatGPT account from the sign-in token. Sign in | 无法从登录令牌中识别ChatGPT账户。请使用具有Codex访问权限的ChatGPT账户登 → 无法从登录令牌中识别 ChatGPT 账户。请使用具有 Codex 访问权限的 ChatG | missing spaces around ChatGPT/Codex |
| Could not import skill file "%@": %@ | 无法导入技能文件"%1$@"：%2$@ → 无法导入技能文件“%1$@”：%2$@ | straight quotes in Chinese text; sibling keys use curly quotes |
| Could not inspect skill archive%@ | 无法检查技能归档%@ → 无法检查技能归档 %@ |  |
| Could not load xAI OAuth configuration: %@ | 无法加载xAI OAuth配置：%@ → 无法加载 xAI OAuth 配置：%@ | missing space before xAI |
| Could not open the browser for ChatGPT sign-in. Check the macOS defaul | 无法打开浏览器进行ChatGPT登录。请检查macOS默认浏览器设置，然后重试。 → 无法打开浏览器进行 ChatGPT 登录。请检查 macOS 默认浏览器设置，然后重试。 | missing spaces around ChatGPT/macOS |
| Could not open the browser for Grok sign-in. Check the macOS default b | 无法打开浏览器进行Grok登录。请检查macOS默认浏览器设置，然后重试。 → 无法打开浏览器进行 Grok 登录。请检查 macOS 默认浏览器设置，然后重试。 | missing spaces around Grok/macOS |
| Create a new API key | 创建新的API密钥 → 创建新的 API 密钥 | missing spaces around API |
| Create or copy an API key | 创建或复制一个API密钥 → 创建或复制一个 API 密钥 | missing spaces around API |
| Create or repair %@. | 创建或修复%@。 → 创建或修复 %@。 | missing space before placeholder, inconsistent with siblings |
| Custom HTTP | 自定义HTTP → 自定义 HTTP | missing space before HTTP |
| DFlash speculative decoding | DFlash推测解码 → DFlash 推测解码 | missing space after DFlash |
| DFlash speculative decoding incomplete | DFlash推测解码不完整 → DFlash 推测解码不完整 | missing space after DFlash |
| Decode-throughput options for local vMLX models. Changes apply on the  | 本地vMLX模型的解码吞吐量选项。更改将在下一次模型加载时生效。 → 本地 vMLX 模型的解码吞吐量选项。更改将在下一次模型加载时生效。 | Missing spaces between Chinese text and "vMLX". |
| Delete "%@"? | 删除"%@"？ → 删除“%@”？ | Straight quotes around %@; sibling key uses curly quotes. |
| Diagnostics are using %@. | 诊断正在使用%@。 → 诊断正在使用 %@。 | Missing space before %@ placeholder. |
| ERROR: Process is NOT trusted for Accessibility. If enabled in System  | 错误：此进程未被信任用于辅助功能。如果在系统设置中已启用，请尝试将Osaurus从列表中移 → 错误：此进程未被信任用于辅助功能。如果在系统设置中已启用，请尝试将 Osaurus 从列表 | Missing spaces around "Osaurus" in mixed Chinese-English text. |
| Edit the endpoint URL and test again. | 修改端点URL并重新测试。 → 修改端点 URL 并重新测试。 | Missing space between 端点 and URL. |
| Encrypted with SQLCipher | 使用SQLCipher加密 → 使用 SQLCipher 加密 | missing space around SQLCipher |
| Encrypted, but the storage key is unavailable on this Mac. Restore the | 加密，但此Mac上无法使用存储密钥。恢复钥匙串密钥并重试，或重置以重新开始。 → 加密，但此 Mac 上无法使用存储密钥。恢复钥匙串密钥并重试，或重置以重新开始。 | missing spaces around Mac |
| End-to-end encrypted via Osaurus Secure Channel | 通过Osaurus安全通道进行端到端加密 → 通过 Osaurus 安全通道进行端到端加密 | missing spaces around Osaurus |
| Enter a dollar amount, like 25. | 输入美元金额，比如25。 → 输入美元金额，比如 25。 | missing space before the number 25 |
| Enter to save · Esc to cancel | 按 Enter 保存 · 按Esc取消 → 按 Enter 保存 · 按 Esc 取消 | missing spaces around Esc, inconsistent with first half |
| Execute shell commands in the folder | 在文件夹中执行shell命令 → 在文件夹中执行 shell 命令 | missing spaces around shell |
| Fix or clear the proxy URL in Server settings. | 修复或清除服务器设置中的代理URL。 → 修复或清除服务器设置中的代理 URL。 | missing space between Chinese and 'URL' |
| Fix or remove %@, then save Sandbox settings again. | 修复或删除%@，然后再次保存沙盒设置。 → 修复或删除 %@，然后再次保存沙盒设置。 |  |
| Fix ownership or permissions for %@, then rerun preflight. For user-ow | 修复%1$@的所有权或权限，然后重新运行预检。对于用户拥有的路径，通常chmod u+rw → 修复 %1$@ 的所有权或权限，然后重新运行预检。对于用户拥有的路径，通常 chmod u | missing spaces around the chmod command |
| Free disk space on the volume that contains %@, then rerun preflight. | 释放包含%@的卷中的磁盘空间，然后重新运行预检。 → 释放包含 %@ 的卷中的磁盘空间，然后重新运行预检。 |  |
| GGUF-only bundle | 仅限GGUF的捆绑包 → 仅限 GGUF 的捆绑包 | missing spaces around 'GGUF' |
| Gemini model list | Gemini模型列表 → Gemini 模型列表 | missing space between 'Gemini' and Chinese |
| Gemini models | Gemini模型 → Gemini 模型 | missing space between 'Gemini' and Chinese |
| Generate a new API key | 生成一个新的API密钥 → 生成一个新的 API 密钥 | missing space between Chinese and 'API' |
| Git Commit | Git提交 → Git 提交 | Missing space between Latin and CJK. |
| Go to %@ console | 前往%@控制台 → 前往 %@ 控制台 | Missing spaces around placeholder likely expanding to Latin text. |
| Go to Venice AI settings page | 前往Venice AI设置页面 → 前往 Venice AI 设置页面 | Missing space between Latin and CJK. |
| Go to the AtlasCloud API keys page | 前往AtlasCloud API密钥页面 → 前往 AtlasCloud API 密钥页面 | Missing space between Latin and CJK. |
| Go to the DeepSeek Platform API keys page | 前往DeepSeek平台API密钥页面 → 前往 DeepSeek 平台 API 密钥页面 | Missing space between Latin and CJK. |
| Go to the MiniMax platform API keys page | 前往MiniMax平台的API密钥页面 → 前往 MiniMax 平台的 API 密钥页面 | Missing space between Latin and CJK. |
| Go to the Mistral console API keys page | 前往Mistral控制台API密钥页面 → 前往 Mistral 控制台 API 密钥页面 | Missing space between Latin and CJK. |
| Grant "%@" to agents | 将"%@"授予智能体 → 将“%@”授予智能体 | Straight quotes should be curly quotes in zh. |
| Granted "%@" to %lld agents | 已将"%1$@"授予 %2$lld 个智能体 → 已将“%1$@”授予 %2$lld 个智能体 | Straight quotes should be curly quotes in zh. |
| Granted "%@" to 1 agent | 已将"%@"授予 1 个智能体 → 已将“%@”授予 1 个智能体 | Straight quotes should be curly quotes in zh. |
| Grok models | Grok模型 → Grok 模型 | Missing space between Latin and CJK. |
| HTTP Routes | HTTP路由 → HTTP 路由 | Missing space between Latin and CJK. |
| Host emitted %d one-shot warning%@ for this plugin. | 主机为此插件发出了 %d 条一次性警告%@。 → 主机为此插件发出了 %d 条一次性警告 %@。 |  |
| Imported "%@" with %lld files | 已导入"%@"，包含 %lld 个文件 → 已导入“%@”，包含 %lld 个文件 | Straight quotes around %@; sibling key uses curly quotes |
| Install Ollama from ollama.com | 从ollama.com安装Ollama → 从 ollama.com 安装 Ollama | Missing spaces between Chinese and ollama.com/Ollama |
| Invalid URL | 无效的URL → 无效的 URL | Missing space between 的 and URL |
| Invalid skill archive - SKILL.md not found | 无效的技能存档 - 未找到SKILL.md文件 → 无效的技能存档 - 未找到 SKILL.md 文件 | Missing space between Chinese and 'SKILL.md'. |
| Investigate Sentry issues, traces, and releases | 调查Sentry问题、跟踪和版本 → 调查 Sentry 问题、跟踪和版本 | Missing spaces around 'Sentry'. |
| Loaded Models%@ | 已加载的模型%@ → 已加载的模型 %@ |  |
| Localhost clients can call the API without a real key. Create access k | 本地主机客户端可以无需真实密钥调用API。为局域网、中继或需要Bearer值的客户端创建访 → 本地主机客户端可以无需真实密钥调用 API。为局域网、中继或需要 Bearer 值的客户端 | Missing CJK-Latin spacing around API/Bearer. |
| Manage Supabase Postgres, auth, and storage | 管理Supabase Postgres、认证和存储 → 管理 Supabase Postgres、认证和存储 | Missing space between 管理 and Supabase. |
| Manual IDs are used if /models is missing or returns a non-OpenAI sche | 如果/models缺失或返回的不是OpenAI格式的schema，则使用手动ID。 → 如果/models 缺失或返回的不是 OpenAI 格式的 schema，则使用手动 ID | Missing CJK-Latin spacing around /models, OpenAI, schema, ID. |
| Max Visible Toasts | 最大显示的Toast数量 → 最大显示的 Toast 数量 | Missing CJK-Latin spacing around Toast. |
| Maximum background tasks running at once. Empty uses default 5 | 同时运行的最大后台任务数。空值使用默认5 → 同时运行的最大后台任务数。空值使用默认 5 | Missing space before the digit 5. |
| Maximum toasts shown at once. Empty uses default 5 | 一次显示的最大Toast数量。空值则使用默认的5个 → 一次显示的最大 Toast 数量。空值则使用默认的 5 个 | Missing spacing around Toast and the digit 5. |
| MiniMax M-series models | MiniMax M系列模型 → MiniMax M 系列模型 | Missing CJK-Latin spacing |
| Minimum top-up is $5.00 | 最低充值金额为5.00美元 → 最低充值金额为 5.00 美元 | Missing spacing around number |
| Missing API key | 缺少API密钥 → 缺少 API 密钥 | Missing CJK-Latin spacing |
| Missing ChatGPT/Codex sign-in tokens. Sign in with ChatGPT again, then | 缺少ChatGPT/Codex登录令牌。再次使用ChatGPT登录，然后重试提供商。 → 缺少 ChatGPT/Codex 登录令牌。再次使用 ChatGPT 登录，然后重试提供商 | Missing CJK-Latin spacing, inconsistent with Grok sibling |
| Model requests and balance changes, newest first. Open the chat or Ins | 模型请求和余额变动，按最新排序。当此Mac有匹配的副本时，打开聊天或洞察。 → 模型请求和余额变动，按最新排序。当此 Mac 有匹配的副本时，打开聊天或洞察。 | Missing CJK-Latin spacing |
| Most clients default to 1337 (Osaurus) or 11434 (Ollama-compatible). | 大多数客户端默认为1337（Osaurus）或11434（Ollama兼容）。 → 大多数客户端默认为 1337（Osaurus）或 11434（Ollama 兼容）。 | Missing spacing around numbers and Latin text |
| Move or remove %@, then create the directory with mkdir -p "%@". | 移动或删除%1$@，然后使用mkdir -p "%2$@"创建目录。 → 移动或删除 %1$@，然后使用 mkdir -p “%2$@”创建目录。 | Missing spacing around placeholders and command |
| Move or remove the directory at %@, then rerun sandbox setup. | 移动或删除%@目录，然后重新运行沙盒设置。 → 移动或删除 %@ 目录，然后重新运行沙盒设置。 | Missing spacing around placeholder |
| Multilingual model. Supports 25 European languages. Recommended for mo | 多语言模型。支持25种欧洲语言。推荐给大多数用户。 → 多语言模型。支持 25 种欧洲语言。推荐给大多数用户。 | Missing number spacing, inconsistent with sibling key |
| My MCP Server | 我的MCP服务器 → 我的 MCP 服务器 | Missing CJK-Latin spacing |
| New data will be encrypted with SQLCipher. | 新数据将使用SQLCipher进行加密。 → 新数据将使用 SQLCipher 进行加密。 | Missing spaces around SQLCipher. |
| New data will be stored as plaintext, protected by FileVault. | 新数据将以明文形式存储，并受FileVault保护。 → 新数据将以明文形式存储，并受 FileVault 保护。 | Missing spaces around FileVault. |
| No Authorization header is added by Osaurus. | Osaurus未添加授权头。 → Osaurus 未添加授权头。 | Missing space after Osaurus. |
| No Codex OAuth tokens are saved for this provider. | 没有为该提供商保存Codex OAuth令牌。 → 没有为该提供商保存 Codex OAuth 令牌。 | Missing CJK-Latin spacing around Codex and 令牌. |
| No installed theme has this shared ID yet. | 尚未安装此共享ID的主题。 → 尚未安装此共享 ID 的主题。 | Missing space between 共享 and ID. |
| Not MLX | 不是MLX → 不是 MLX | missing space between Chinese and MLX |
| Not an MLX model | 不是MLX模型 → 不是 MLX 模型 | missing spaces around MLX |
| Not used for stdio | 不用于stdio → 不用于 stdio | missing space before stdio |
| OAuth sign-in required | 需要OAuth登录 → 需要 OAuth 登录 | missing spaces around OAuth |
| OAuth tokens saved | OAuth令牌已保存 → OAuth 令牌已保存 | missing space after OAuth |
| Off binds to 127.0.0.1 (this Mac only). On binds to 0.0.0.0 so phones, | 关闭则仅绑定到127.0.0.1（仅此Mac）。开启则绑定到0.0.0.0，这样手机、iP → 关闭则仅绑定到 127.0.0.1（仅此 Mac）。开启则绑定到 0.0.0.0，这样手机 | multiple missing CJK-Latin spaces (127.0.0.1, Mac, iPad) |
| On modern Macs, FileVault already encrypts your whole disk at rest. Pl | 在现代Mac上，文件保险箱已经在静态时对整个磁盘进行加密。明文存储依赖于这一点，并且是最可 → 在现代 Mac 上，文件保险箱已经在静态时对整个磁盘进行加密。明文存储依赖于这一点，并且是 | missing space around Mac |
| One or more checks could not be proven; copy the report for support or | 一个或多个检查无法被证明；复制报告以供支持或CI证明。 → 一个或多个检查无法被证明；复制报告以供支持或 CI 证明。 | missing space before CI |
| Open Sandbox settings or run setup to write %@. | 打开沙盒设置或运行设置以写入%@。 → 打开沙盒设置或运行设置以写入 %@。 | Missing space before %@ placeholder. |
| OpenAI token request failed: %@ | OpenAI令牌请求失败：%@ → OpenAI 令牌请求失败：%@ | Missing space between OpenAI and Chinese text. |
| Osaurus local models | Osaurus本地模型 → Osaurus 本地模型 | Missing space between Osaurus and Chinese text. |
| Osaurus will use default sandbox settings until a config file is saved | Osaurus将使用默认的沙盒设置，直到保存配置文件。 → Osaurus 将使用默认的沙盒设置，直到保存配置文件。 | Missing space between Osaurus and Chinese text. |
| PATH issue | PATH问题 → PATH 问题 | Missing space between PATH and Chinese text. |
| Package name (e.g. python3) | 软件包名称（例如python3） → 软件包名称（例如 python3） | Missing space before python3. |
| Paste a valid ID or link to see normalized server details. | 粘贴有效的ID或链接以查看标准化的服务器详情。 → 粘贴有效的 ID 或链接以查看标准化的服务器详情。 | Missing spaces around "ID". |
| Paste an API token in the inline prompt or edit the provider. | 在行内提示中粘贴API令牌或编辑提供商。 → 在行内提示中粘贴 API 令牌或编辑提供商。 | Missing spaces around "API". |
| Per-Session KV Cap (tokens) | 每会话KV限制（词元数） → 每会话 KV 限制（词元数） | Missing spaces around "KV". |
| Pre-registered OAuth client id (leave blank for DCR) | 预注册的 OAuth Client ID（留空以使用DCR） → 预注册的 OAuth Client ID（留空以使用 DCR） | Missing space between Chinese and "DCR". |
| Privacy-first AI | 隐私优先的AI → 隐私优先的 AI | Missing space before "AI". |
| Q&A over any public GitHub repo | 任何公共GitHub仓库的问答 → 任何公共 GitHub 仓库的问答 | Missing spaces around "GitHub". |
| Query HubSpot contacts, deals, and pipelines | 查询HubSpot联系人、交易和管道 → 查询 HubSpot 联系人、交易和管道 | Missing spaces around "HubSpot". |
| Query and manage Neon Postgres databases | 查询和管理Neon Postgres数据库 → 查询和管理 Neon Postgres 数据库 | Missing spaces around "Neon Postgres". |
| Query and manage PayPal payments and orders | 查询和管理PayPal付款和订单 → 查询和管理 PayPal 付款和订单 | Missing spaces around "PayPal". |
| Read and manage Square payments and orders | 查看和管理Square的付款和订单 → 查看和管理 Square 的付款和订单 | Missing CJK-Latin spacing around 'Square'. |
| Read and update monday.com boards and items | 读取并更新monday.com的看板和项目 → 读取并更新 monday.com 的看板和项目 | Missing CJK-Latin spacing around 'monday.com'. |
| Remote Osaurus | 远程Osaurus → 远程 Osaurus | Missing CJK-Latin spacing before 'Osaurus'. |
| Remove %@ and rerun sandbox setup so Osaurus can download a fresh asse | 删除%@并重新运行沙盒设置，以便Osaurus可以下载新的资源。 → 删除 %@ 并重新运行沙盒设置，以便 Osaurus 可以下载新的资源。 | Missing CJK-Latin spacing around %@ and Osaurus. |
| Remove %@ and rerun setup. | 删除%@并重新运行设置。 → 删除 %@ 并重新运行设置。 | Missing CJK-Latin spacing around %@. |
| Remove or move %@, then rerun sandbox setup. | 删除或移动%@，然后重新运行沙盒设置。 → 删除或移动 %@，然后重新运行沙盒设置。 | Missing space between Chinese text and %@ placeholder |
| Require an @mention | 需要 @提及 → 需要 @ 提及 |  |
| Requires %@ to return an OpenAI-shaped model list. | 需要%@返回一个OpenAI风格的模型列表。 → 需要 %@ 返回一个 OpenAI 风格的模型列表。 | Missing spaces around %@ and OpenAI |
| Routed to %@ (name "%@") | 路由到 %@（名称 "%@"） → 路由到 %@（名称 “%@”） | Straight quotes in Chinese context |
| Run ID: %@ | 运行ID：%@ → 运行 ID：%@ | Missing space between Chinese and Latin text |
| Run Osaurus sandbox provisioning on macOS 26 or later. | 在macOS 26或更高版本上运行Osaurus沙盒配置。 → 在 macOS 26 或更高版本上运行 Osaurus 沙盒配置。 | Missing spaces around Latin terms |
| Run Set Up Sandbox so Osaurus can create or download %@. | 运行设置沙盒以便 Osaurus 可以创建或下载%@。 → 运行设置沙盒以便 Osaurus 可以创建或下载 %@。 | Missing space before placeholder |
| Run Shell Commands | 运行Shell命令 → 运行 Shell 命令 | Missing spaces around Shell |
| Runs inside the Osaurus sandbox and is torn down on disconnect. | 在Osaurus沙盒中运行，并在断开连接时被销毁。 → 在 Osaurus 沙盒中运行，并在断开连接时被销毁。 | Missing spaces around Osaurus |
| SUCCESS: %@ | 成功: %@ → 成功：%@ | Half-width colon after Chinese, inconsistent with sibling keys |
| SUCCESS: Connected to %@ | 成功：连接到%@ → 成功：连接到 %@ | Missing space before placeholder |
| Screen context from %@ | 来自%@的屏幕上下文 → 来自 %@ 的屏幕上下文 | No spaces around the %@ placeholder (usually an English app name) |
| Sign in with the ChatGPT account that has Codex access. | 使用具有Codex访问权限的ChatGPT账户登录。 → 使用具有 Codex 访问权限的 ChatGPT 账户登录。 | Missing spaces between Chinese and Latin words (Codex, ChatGPT). |
| Sign in with the xAI account that has Grok API access. | 使用具有Grok API访问权限的xAI账户登录。 → 使用具有 Grok API 访问权限的 xAI 账户登录。 | Missing spaces between Chinese and Latin words (Grok API, xAI). |
| Signed in with Grok. Tokens are stored in Keychain. | 已使用Grok登录。令牌存储在Keychain中。 → 已使用 Grok 登录。令牌存储在 Keychain 中。 | Missing CJK-Latin spaces; Keychain left untranslated while sibling string uses 钥匙串. |
| Stdio command missing | Stdio命令缺失 → Stdio 命令缺失 | Missing space between Latin and CJK text. |
| Stored under the configured Osaurus model directory. | 存储在配置的Osaurus模型目录下。 → 存储在配置的 Osaurus 模型目录下。 | Missing spaces around 'Osaurus'. |
| Switch the AI model | 切换AI模型 → 切换 AI 模型 | Missing spaces around 'AI'. |
| The Test button launches the subprocess, runs initialize/listTools, an | 测试按钮启动子进程，运行initialize/listTools，并将其关闭。 → 测试按钮启动子进程，运行 initialize/listTools，并将其关闭。 | Missing spaces around 'initialize/listTools'. |
| The definition needs at least one endpoint (e.g. "web"). | 该定义至少需要一个端点（例如 "web"）。 → 该定义至少需要一个端点（例如 “web”）。 |  |
| The id "%@" is taken by a bundled provider. Pick another id. | ID "%@" 已被内置提供商占用。请选择其他 ID。 → ID “%@” 已被内置提供商占用。请选择其他 ID。 |  |
| The local directory does not have the required MLX files. | 本地目录中没有所需的MLX文件。 → 本地目录中没有所需的 MLX 文件。 | missing CJK-Latin spacing around MLX |
| The trade-off is reliability: if the Keychain key is lost (Keychain wi | 权衡在于可靠性：如果钥匙串密钥丢失（如钥匙串被清除、应用程序重新签名或在未使用iCloud → 权衡在于可靠性：如果钥匙串密钥丢失（如钥匙串被清除、应用程序重新签名或在未使用 iClou | missing CJK-Latin spacing around iCloud and Mac |
| This bundle isn't in MLX format, so the local engine (vmlx) can't load | 这个捆绑包不是MLX格式，因此本地引擎(vmlx)无法加载它。Osaurus只能运行MLX → 这个捆绑包不是 MLX 格式，因此本地引擎(vmlx)无法加载它。Osaurus 只能运行 | missing CJK-Latin spacing throughout; half-width parentheses |
| This removes the "%@" channel definition from the configuration file.  | 这将从配置文件中移除 "%@" 频道定义。其引用的钥匙串密钥不会被删除。 → 这将从配置文件中移除 “%@” 频道定义。其引用的钥匙串密钥不会被删除。 |  |
| This walks every chat session in your history, buffers their turns int | 这会遍历你历史中的每一个聊天会话，将它们的回合缓冲到pending_signals中，然后 → 这会遍历你历史中的每一个聊天会话，将它们的回合缓冲到 pending_signals 中， | Missing spaces between Chinese and Latin terms (pending_signals, LLM). |
| Tool '%@' exceeded the %llds execution budget. | 工具“%1$@”超过了%2$lld秒的执行预算。 → 工具“%1$@”超过了 %2$lld 秒的执行预算。 | Missing spaces around the %2$lld placeholder. |
| Turn off Osaurus Router? | 关闭Osaurus路由器？ → 关闭 Osaurus 路由器？ | Missing spaces around 'Osaurus'. |
| Unsupported Hunyuan Dense | 不受支持的Hunyuan Dense → 不受支持的 Hunyuan Dense | Missing CJK-Latin space; inconsistent with sibling 不支持的. |
| Updated "%@" | 已更新 "%@" → 已更新 “%@” |  |
| Use the OpenAI-compatible base URL https://api.atlascloud.ai/v1 | 使用OpenAI兼容的基础URL https://api.atlascloud.ai/v1 → 使用 OpenAI 兼容的基础 URL https://api.atlascloud.ai | Missing CJK-Latin spaces around OpenAI and URL. |
| Uses Anthropic's paginated model catalog endpoint. | 使用Anthropic的分页模型目录端点。 → 使用 Anthropic 的分页模型目录端点。 | Missing CJK-Latin spaces around Anthropic. |
| Using AI + pattern rules | 使用AI + 正则规则 → 使用 AI + 正则规则 | Missing CJK-Latin space before AI. |
| When encryption is on, wiping the macOS Keychain or migrating to a new | 当加密开启时，清除macOS钥匙串或在没有iCloud钥匙串同步的情况下迁移到新Mac会使 → 当加密开启时，清除 macOS 钥匙串或在没有 iCloud 钥匙串同步的情况下迁移到新  | Missing spaces between Chinese text and macOS/iCloud/Mac. |
| config.json, tokenizer assets, and safetensors weights are present. | config.json、分词器资源和safetensors权重文件都存在。 → config.json、分词器资源和 safetensors 权重文件都存在。 | Missing CJK-Latin spacing around "safetensors". |
| macOS version does not support sandbox provisioning | macOS版本不支持沙盒配置 → macOS 版本不支持沙盒配置 | Missing CJK-Latin spacing after "macOS". |
| registered %@ tool; load with capabilities_load | 已注册%@工具；使用capabilities_load加载 → 已注册 %@ 工具；使用 capabilities_load 加载 | Missing spaces between Chinese text and placeholder/code. |
| xAI OAuth discovery returned an untrusted %@ | xAI OAuth发现返回了不受信任的%@ → xAI OAuth 发现返回了不受信任的 %@ | Missing spaces between Chinese and English/placeholder. |
| xAI rejected the sign-in callback: %@ | xAI 拒绝了登录回调: %@ → xAI 拒绝了登录回调：%@ | Half-width colon after Chinese text. |
| xAI returned an invalid token response during Grok sign-in | xAI在Grok登录过程中返回了无效的令牌响应 → xAI 在 Grok 登录过程中返回了无效的令牌响应 | Missing spaces between Chinese and English product names. |
| xAI sign-in required | 需要xAI登录 → 需要 xAI 登录 | Missing space between Chinese and 'xAI'. |
| xAI signed in | xAI已登录 → xAI 已登录 | Missing space between 'xAI' and Chinese. |
| xAI token request failed: %@ | xAI令牌请求失败：%@ → xAI 令牌请求失败：%@ | Missing space between 'xAI' and Chinese text. |

</details>

## Test plan

- [x] `bash scripts/i18n/check.sh` passes
- [x] catalog still parses; diff touches exactly the listed value lines
- [x] placeholder multisets re-validated mechanically against English source


