### PR TITLE
i18n(zh-Hans): quality pass — 859 fixes across eight defect classes + style linter

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -746,7 +746,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "（未组装内存上下文 — 内存可能为空或已禁用）"
+            "value" : "（未组装记忆上下文 — 记忆可能为空或已禁用）"
           }
         },
         "zh-Hant" : {
@@ -851,7 +851,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[密钥]"
+            "value" : "[机密]"
           }
         },
         "zh-Hant" : {
@@ -1413,7 +1413,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%.1f 词元/秒"
+            "value" : "%.1f Token/秒"
           }
         },
         "zh-Hant" : {
@@ -2096,7 +2096,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@有错误的类型"
+            "value" : "%@ 有错误的类型"
           }
         },
         "zh-Hant" : {
@@ -2172,7 +2172,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@是空的"
+            "value" : "%@ 是空的"
           }
         },
         "zh-Hant" : {
@@ -2206,7 +2206,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@缺失"
+            "value" : "%@ 缺失"
           }
         },
         "zh-Hant" : {
@@ -2242,7 +2242,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@被移至~/.osaurus/quarantine/（不会被删除），并重新创建空，以便该功能再次工作。旧文件中的数据处于隔离状态——如果您可能恢复密钥，请保留纯文本备份。"
+            "value" : "%@ 会被移至 ~/.osaurus/quarantine/（绝不会删除），并重新创建为空文件，以便该功能恢复正常。旧文件中的数据仍保留在隔离区 — 如果你以后可能需要恢复密钥，请保留一份纯文本备份。"
           }
         },
         "zh-Hant" : {
@@ -2276,7 +2276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@不可读"
+            "value" : "%@ 不可读"
           }
         },
         "zh-Hant" : {
@@ -2310,7 +2310,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@不可写"
+            "value" : "%@ 不可写"
           }
         },
         "zh-Hant" : {
@@ -2575,7 +2575,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@重新打开。"
+            "value" : "%@ 已重新打开。"
           }
         },
         "zh-Hant" : {
@@ -2611,7 +2611,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@重置。"
+            "value" : "%@ 已重置。"
           }
         },
         "zh-Hant" : {
@@ -2653,7 +2653,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@重置。旧文件保留在%2$@。"
+            "value" : "%1$@ 已重置。旧文件保留在 %2$@。"
           }
         },
         "zh-Hant" : {
@@ -2722,7 +2722,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器余额 %@。点击打开钱包。"
+            "value" : "路由余额 %@。点击打开钱包。"
           }
         },
         "zh-Hant" : {
@@ -2793,7 +2793,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@仍然无法打开。尝试重置。"
+            "value" : "%@ 仍然无法打开。尝试重置。"
           }
         },
         "zh-Hant" : {
@@ -2827,7 +2827,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ 使用直连网络"
+            "value" : "%@ 使用直连网络。"
           }
         },
         "zh-Hant" : {
@@ -3373,7 +3373,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剩余 %dm %ds"
+            "value" : "剩余 %d 分 %d 秒"
           }
         },
         "zh-Hant" : {
@@ -3407,7 +3407,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剩余 %ds"
+            "value" : "剩余 %d 秒"
           }
         },
         "zh-Hant" : {
@@ -3659,7 +3659,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许 %1%lld 个 · %2$lld 人"
+            "value" : "允许 %1$lld 个 · %2$lld 人"
           }
         },
         "zh-Hant" : {
@@ -3796,7 +3796,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld缓冲区等待蒸馏。"
+            "value" : "%lld 个已缓冲的轮次正在等待蒸馏。"
           }
         },
         "zh-Hant" : {
@@ -3940,7 +3940,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 聊天"
+            "value" : "%1$lld 个聊天"
           }
         },
         "zh-Hant" : {
@@ -4137,7 +4137,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 个自定义标头%2$@"
+            "value" : "%1$lld 个自定义标头"
           }
         },
         "zh-Hant" : {
@@ -4315,7 +4315,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 已下载 • %2$@"
+            "value" : "已下载 %1$lld 个 • %2$@"
           }
         },
         "zh-Hant" : {
@@ -4349,7 +4349,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 之前的步骤"
+            "value" : "之前的 %lld 个步骤"
           }
         },
         "zh-Hant" : {
@@ -4636,7 +4636,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 张图片，%2$@ 跟踪 %3$@，%4$lld 解码，%5$lld 解码失败"
+            "value" : "%1$lld 张图片，已跟踪 %2$@ / 共 %3$@，%4$lld 个解码中，%5$lld 个解码失败"
           }
         },
         "zh-Hant" : {
@@ -4748,7 +4748,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 个项目将被编辑"
+            "value" : "%lld 个项目将被隐去"
           }
         },
         "zh-Hant" : {
@@ -5166,7 +5166,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 模型 • %2$@"
+            "value" : "%1$lld 个模型 • %2$@"
           }
         },
         "zh-Hant" : {
@@ -5564,7 +5564,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%2$lld 个中 %1$lld 个已分类"
+            "value" : "已分类 %1$lld / %2$lld 个"
           }
         },
         "zh-Hant" : {
@@ -5680,7 +5680,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "第 %1$lld 个主题，共 %2$lld 个"
+            "value" : "%1$lld / %2$lld 个主题"
           }
         },
         "zh-Hant" : {
@@ -6349,7 +6349,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 已排队 · %2$@"
+            "value" : "已排队 %1$lld 个 · %2$@"
           }
         },
         "zh-Hant" : {
@@ -6385,7 +6385,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 个最近"
+            "value" : "最近 %lld 个"
           }
         },
         "zh-Hant" : {
@@ -6456,7 +6456,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 次编辑"
+            "value" : "%lld 处隐去"
           }
         },
         "zh-Hant" : {
@@ -6676,7 +6676,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 个设置匹配\"%@\""
+            "value" : "%lld 个设置匹配“%@”"
           }
         },
         "zh-Hant" : {
@@ -6785,7 +6785,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 个技能%2$@"
+            "value" : "%1$lld 个技能"
           }
         },
         "zh-Hant" : {
@@ -7165,7 +7165,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 个词元"
+            "value" : "%lld 个 Token"
           }
         },
         "zh-Hant" : {
@@ -7603,7 +7603,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过 %lld 发现了 %@ 个工具。"
+            "value" : "通过 %2$@ 发现了 %1$lld 个工具。"
           }
         },
         "zh-Hant" : {
@@ -7852,7 +7852,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 次写入%2$@"
+            "value" : "%1$lld 次写入"
           }
         },
         "zh-Hant" : {
@@ -8000,7 +8000,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld/%lld 已连接 - %lld 注意力 - %@"
+            "value" : "%lld/%lld 已连接 - %lld 个需注意 - %@"
           }
         },
         "zh-Hant" : {
@@ -8120,7 +8120,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld/%lld 已连接，%lld 注意力，%@，%@"
+            "value" : "%lld/%lld 已连接，%lld 个需注意，%@，%@"
           }
         },
         "zh-Hant" : {
@@ -8837,7 +8837,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "+ Enter 保存"
+            "value" : "+ 按 Enter 保存"
           }
         },
         "zh-Hant" : {
@@ -8871,7 +8871,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "+%lld 更多"
+            "value" : "+另外 %lld 个"
           }
         },
         "zh-Hant" : {
@@ -9053,7 +9053,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "~%1$@ of %2$.0f GB"
+            "value" : "~%1$@ / %2$.0f GB"
           }
         },
         "zh-Hant" : {
@@ -9159,7 +9159,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "约 %lld 个词元"
+            "value" : "约 %lld 个 Token"
           }
         },
         "zh-Hant" : {
@@ -9451,7 +9451,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自启动以来0次尝试"
+            "value" : "自启动以来 0 次尝试"
           }
         },
         "zh-Hant" : {
@@ -9486,7 +9486,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "0倾向于性能，2是安全自动，3是严格的，4是诊断/自定义。"
+            "value" : "0 倾向于性能，2 是安全自动，3 是严格的，4 是诊断/自定义。"
           }
         },
         "zh-Hant" : {
@@ -9554,7 +9554,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "0 已排队 · %@"
+            "value" : "已排队 0 个 · %@"
           }
         },
         "zh-Hant" : {
@@ -9753,7 +9753,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1天"
+            "value" : "1 天"
           }
         },
         "zh-Hant" : {
@@ -9855,7 +9855,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 个文档没有类别"
+            "value" : "1 个文档未设置分类"
           }
         },
         "zh-Hant" : {
@@ -10135,7 +10135,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 个项目将被编辑"
+            "value" : "1 个项目将被脱敏"
           }
         },
         "zh-Hant" : {
@@ -10407,7 +10407,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 次编辑"
+            "value" : "1 次脱敏"
           }
         },
         "zh-Hant" : {
@@ -10543,7 +10543,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 个设置匹配 \"%@\""
+            "value" : "1 个设置匹配 “%@”"
           }
         },
         "zh-Hant" : {
@@ -10815,7 +10815,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1 词元"
+            "value" : "1 个 Token"
           }
         },
         "zh-Hant" : {
@@ -11163,7 +11163,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "4位（q4，最快）"
+            "value" : "4 位（q4，最快）"
           }
         },
         "zh-Hant" : {
@@ -11237,7 +11237,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "6位（q6，GGUF-head奇偶校验）"
+            "value" : "6 位（q6，与 GGUF-head 持平）"
           }
         },
         "zh-Hant" : {
@@ -11271,7 +11271,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "7天"
+            "value" : "7 天"
           }
         },
         "zh-Hant" : {
@@ -11305,7 +11305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "8位（q8，保守）"
+            "value" : "8 位（q8，保守）"
           }
         },
         "zh-Hant" : {
@@ -11379,7 +11379,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30天"
+            "value" : "30 天"
           }
         },
         "zh-Hant" : {
@@ -11730,7 +11730,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更大的起始上下文意味着更长的模型预热和更慢的首个 token。"
+            "value" : "更大的起始上下文意味着更长的模型预热和更慢的首个 Token。"
           }
         },
         "zh-Hant" : {
@@ -11935,7 +11935,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除代理的允许域名以恢复出站访问。"
+            "value" : "已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除智能体的允许域名以恢复出站访问。"
           }
         },
         "zh-Hant" : {
@@ -12209,7 +12209,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将生成一个新的256位密钥，并将位于 ~/.osaurus 下的所有加密数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此Mac上读取。"
+            "value" : "将生成一个新的 256 位密钥，并将位于 ~/.osaurus 下的所有加密数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此 Mac 上读取。"
           }
         },
         "zh-Hant" : {
@@ -12243,7 +12243,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将生成一个新的256位密钥，并将 ~/.osaurus 下所有加密的数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此Mac上读取。我们强烈建议首先导出纯文本备份。"
+            "value" : "将生成一个新的 256 位密钥，并将 ~/.osaurus 下所有加密的数据库和文件重新加密。旧密钥将被销毁——在旧密钥下制作的备份将无法在此 Mac 上读取。我们强烈建议首先导出纯文本备份。"
           }
         },
         "zh-Hant" : {
@@ -12311,7 +12311,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "快速浏览"
+            "value" : "快速导览"
           }
         },
         "zh-Hant" : {
@@ -12452,7 +12452,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "为此提供程序配置了常规或秘密的凭证标头。"
+            "value" : "为此提供商配置了常规或保密的凭证标头。"
           }
         },
         "zh-Hant" : {
@@ -12730,7 +12730,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一个名为“%@”的技能已存在。替换它将覆盖其SKILL.md、引用和资源。"
+            "value" : "一个名为“%@”的技能已存在。替换它将覆盖其 SKILL.md、引用和资源。"
           }
         },
         "zh-Hant" : {
@@ -12798,7 +12798,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一个 stdio MCP 提供程序需要一条命令才能启动。"
+            "value" : "一个 stdio MCP 提供商需要一条命令才能启动。"
           }
         },
         "zh-Hant" : {
@@ -14165,7 +14165,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "行动"
+            "value" : "操作"
           }
         },
         "zh-Hant" : {
@@ -14201,7 +14201,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "操作 \"%@\" 不是标准操作名称，且永远不会被调用。"
+            "value" : "操作 “%@” 不是标准操作名称，且永远不会被调用。"
           }
         },
         "zh-Hant" : {
@@ -14411,7 +14411,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "会更改或发送内容的操作会暂停等待您的批准，具体取决于下方的自主性级别。"
+            "value" : "会更改或发送内容的操作会暂停等待你的批准，具体取决于下方的自主性级别。"
           }
         },
         "zh-Hant" : {
@@ -15873,7 +15873,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加反应"
+            "value" : "添加表情回应"
           }
         },
         "zh-Hant" : {
@@ -16015,7 +16015,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加上方术语以生成正则规则。"
+            "value" : "在上方添加词条以生成匹配规则。"
           }
         },
         "zh-Hant" : {
@@ -16221,7 +16221,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已添加%@"
+            "value" : "添加于 %@"
           }
         },
         "zh-Hant" : {
@@ -16535,7 +16535,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "高级 — 定义您自己的 HTTP JSON 频道"
+            "value" : "高级 — 定义你自己的 HTTP JSON 频道"
           }
         },
         "zh-Hant" : {
@@ -16811,7 +16811,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每次聊天后，智能体会将对话提炼成简短的摘要。情节会在此累积，以便智能体回忆起过去的会话。"
+            "value" : "每次聊天后，智能体会将对话提炼成简短的摘要。情景会在此累积，以便智能体回忆起过去的会话。"
           }
         },
         "zh-Hant" : {
@@ -17028,7 +17028,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道连接 `%1$@` 不支持 `%2$@`。"
+            "value" : "智能体频道连接 `%1$@` 不支持 `%2$@`。"
           }
         },
         "zh-Hant" : {
@@ -17062,7 +17062,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道连接 `%@` 已禁用。"
+            "value" : "智能体频道连接 `%@` 已禁用。"
           }
         },
         "zh-Hant" : {
@@ -17096,7 +17096,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道连接 `%@` 未配置。"
+            "value" : "智能体频道连接 `%@` 未配置。"
           }
         },
         "zh-Hant" : {
@@ -17130,7 +17130,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理通道类型 `%@` 尚不可执行。"
+            "value" : "智能体频道类型 `%@` 尚不可执行。"
           }
         },
         "zh-Hant" : {
@@ -17305,7 +17305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理正在使用中"
+            "value" : "智能体正在使用中"
           }
         },
         "zh-Hant" : {
@@ -17479,7 +17479,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理会话"
+            "value" : "智能体会话"
           }
         },
         "zh-Hant" : {
@@ -17548,7 +17548,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "智能体工作空间根"
+            "value" : "智能体工作区根"
           }
         },
         "zh-Hant" : {
@@ -17767,7 +17767,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理会标记看起来过期的文档。维护者代理会在此提出修复建议供你批准——在你批准之前不会有任何更改。"
+            "value" : "智能体会标记看起来过期的文档。维护者智能体会在此提出修复建议供你批准——在你批准之前不会有任何更改。"
           }
         },
         "zh-Hant" : {
@@ -17801,7 +17801,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以向写入允许列表中的目标发送消息。"
+            "value" : "智能体可以向写入允许列表中的目标发送消息。"
           }
         },
         "zh-Hant" : {
@@ -17836,7 +17836,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "智能体提议，由您批准"
+            "value" : "智能体提议，由你批准"
           }
         },
         "zh-Hant" : {
@@ -18085,7 +18085,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI检测（设备端模型）"
+            "value" : "AI 检测（设备端模型）"
           }
         },
         "zh-Hant" : {
@@ -18154,7 +18154,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI原生网络搜索和内容提取"
+            "value" : "AI 原生网络搜索和内容提取"
           }
         },
         "zh-Hant" : {
@@ -18431,7 +18431,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "所有缓冲的对话轮次均已提炼（或清除）。当数据片段持续增长时，表明管道运行正常。"
+            "value" : "所有缓冲的对话轮次均已提炼（或清除）。当情景持续增长时，表明管道运行正常。"
           }
         },
         "zh-Hant" : {
@@ -19484,7 +19484,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许屏蔽敏感信息后的截图发送到云端模型。"
+            "value" : "允许屏蔽敏感信息后的截图发送到云端模型"
           }
         },
         "zh-Hant" : {
@@ -19939,7 +19939,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理频道诊断和工具解析此频道定义。"
+            "value" : "允许智能体频道诊断和工具解析此频道定义。"
           }
         },
         "zh-Hant" : {
@@ -20855,7 +20855,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已有服务商？连接它"
+            "value" : "已有提供商？连接它"
           }
         },
         "zh-Hant" : {
@@ -20891,7 +20891,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已安装为%@。"
+            "value" : "已安装为 %@。"
           }
         },
         "zh-Hant" : {
@@ -22058,7 +22058,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API密钥在钥匙串中"
+            "value" : "API 密钥在钥匙串中"
           }
         },
         "zh-Hant" : {
@@ -22269,7 +22269,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用白名单"
+            "value" : "应用允许列表"
           }
         },
         "zh-Hant" : {
@@ -22341,7 +22341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用名称（例如邮件）"
+            "value" : "应用名称（例如“邮件”）"
           }
         },
         "zh-Hant" : {
@@ -22513,7 +22513,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple 硅芯片是必需的"
+            "value" : "需要 Apple Silicon"
           }
         },
         "zh-Hant" : {
@@ -22656,7 +22656,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AppleScript 在此 Mac 上运行。当智能体首次控制某个应用时，macOS 会要求你允许 Osaurus 的自动化权限。请在「设置 → 电脑使用 → 模型」中下载 AppleScript 模型。"
+            "value" : "AppleScript 在此 Mac 上运行。当智能体首次控制某个应用时，macOS 会要求你允许 Osaurus 的自动化权限。请在「设置 → 电脑操作 → 模型」中下载 AppleScript 模型。"
           }
         },
         "zh-Hant" : {
@@ -23007,7 +23007,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用JSON"
+            "value" : "应用 JSON"
           }
         },
         "zh-Hant" : {
@@ -23463,7 +23463,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您确定要清除所有请求日志吗？此操作无法撤销。"
+            "value" : "你确定要清除所有请求日志吗？此操作无法撤销。"
           }
         },
         "zh-Hant" : {
@@ -23497,7 +23497,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您确定要删除“%@”吗？此操作无法撤销。"
+            "value" : "你确定要删除“%@”吗？此操作无法撤销。"
           }
         },
         "zh-Hant" : {
@@ -23531,7 +23531,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您确定要删除“%@”吗？此操作无法撤销。为此智能体配置的任何沙盒资源也将被移除。"
+            "value" : "你确定要删除“%@”吗？此操作无法撤销。为此智能体配置的任何沙盒资源也将被移除。"
           }
         },
         "zh-Hant" : {
@@ -23804,7 +23804,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "除阅读外，在每个动作前都要询问。"
+            "value" : "除读取外，在每个动作前都要询问。"
           }
         },
         "zh-Hant" : {
@@ -23907,7 +23907,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "先提问"
+            "value" : "先询问"
           }
         },
         "zh-Hant" : {
@@ -24579,7 +24579,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "观众"
+            "value" : "受众"
           }
         },
         "zh-Hant" : {
@@ -24820,7 +24820,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要授权"
+            "value" : "需要身份验证"
           }
         },
         "zh-Hant" : {
@@ -26138,7 +26138,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动回复需要 Discord 发送和可写频道。"
+            "value" : "自动回复需要启用 Discord 发送功能和可写频道。"
           }
         },
         "zh-Hant" : {
@@ -27212,7 +27212,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Azure部署ID已配置，即使/models不可用，连接也可以继续进行。"
+            "value" : "Azure 部署 ID 已配置，即使/models 不可用，连接也可以继续进行。"
           }
         },
         "zh-Hant" : {
@@ -27246,7 +27246,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Azure部署"
+            "value" : "Azure 部署"
           }
         },
         "zh-Hant" : {
@@ -27314,7 +27314,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Azure 通常需要手动部署 ID，因为 /models 可能不可用。"
+            "value" : "Azure 通常需要手动填写部署 ID，因为 /models 可能不可用。"
           }
         },
         "zh-Hant" : {
@@ -27873,7 +27873,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "回填完成：已缓冲 %@（%@），%lld 个已跳过。蒸馏完成。"
+            "value" : "回填完成：已缓冲 %1$@（%2$@），已跳过 %3$lld 个。蒸馏完成。"
           }
         },
         "zh-Hant" : {
@@ -27948,7 +27948,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "补全历史"
+            "value" : "回填历史"
           }
         },
         "zh-Hant" : {
@@ -28084,7 +28084,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在进行聊天生成时，后台蒸馏会暂停 —— 它们共享GPU/统一内存。"
+            "value" : "在进行聊天生成时，后台蒸馏会暂停 —— 它们共享 GPU/统一内存。"
           }
         },
         "zh-Hant" : {
@@ -28779,7 +28779,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在向客户端发送 SSE 数据块之前，先按此数量批量累积 token。"
+            "value" : "在向客户端发送 SSE 数据块之前，先按此数量批量累积 Token。"
           }
         },
         "zh-Hant" : {
@@ -28813,7 +28813,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "批量引擎最大批处理大小。设为 1 可保持编译快速路径启用；大于 1 则启用连续批处理。"
+            "value" : "BatchEngine 最大批处理大小。设为 1 可保持编译快速路径启用；大于 1 则启用连续批处理。"
           }
         },
         "zh-Hant" : {
@@ -28847,7 +28847,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "凭证配置完成"
+            "value" : "已配置 Bearer 凭证"
           }
         },
         "zh-Hant" : {
@@ -29052,7 +29052,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基准证明在运行时阻塞问题解决之前是没有意义的。"
+            "value" : "在运行时阻塞问题解决之前，基准验证没有意义。"
           }
         },
         "zh-Hant" : {
@@ -29198,7 +29198,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更大的模型更智能，但需要更多内存——您的 Mac 有 %1$lld GB 内存和 %2$@ 可用存储空间。"
+            "value" : "更大的模型更智能，但需要更多内存——你的 Mac 有 %1$lld GB 内存和 %2$@ 可用存储空间。"
           }
         },
         "zh-Hant" : {
@@ -29234,7 +29234,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更大的模型更智能，但需要更多内存——您的 Mac 有 %lld GB 内存。"
+            "value" : "更大的模型更智能，但需要更多内存——你的 Mac 有 %lld GB 内存。"
           }
         },
         "zh-Hant" : {
@@ -29613,7 +29613,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空白 = 引擎默认值"
+            "value" : "留空 = 引擎默认值"
           }
         },
         "zh-Hant" : {
@@ -29784,7 +29784,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空白=默认模式"
+            "value" : "留空 = 模式默认值"
           }
         },
         "zh-Hant" : {
@@ -29853,7 +29853,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空白 = 模型默认值（48）"
+            "value" : "留空 = 模型默认值（48）"
           }
         },
         "zh-Hant" : {
@@ -29888,7 +29888,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空白 = 默认模型；0 = 禁用"
+            "value" : "留空 = 模型默认值；0 = 禁用"
           }
         },
         "zh-Hant" : {
@@ -29990,7 +29990,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "块"
+            "value" : "阻止"
           }
         },
         "zh-Hant" : {
@@ -30024,7 +30024,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "块大小（token 数）"
+            "value" : "块大小（Token 数）"
           }
         },
         "zh-Hant" : {
@@ -30195,7 +30195,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正文 SHA-256"
+            "value" : "请求体 SHA-256"
           }
         },
         "zh-Hant" : {
@@ -30612,7 +30612,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "机器人访问已允许列表的聊天和群组"
+            "value" : "机器人可访问允许列表中的聊天和群组"
           }
         },
         "zh-Hant" : {
@@ -30646,7 +30646,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "机器人访问已允许列表的服务器和频道"
+            "value" : "机器人可访问允许列表中的服务器和频道"
           }
         },
         "zh-Hant" : {
@@ -30680,7 +30680,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "机器人访问已允许列表的工作区频道"
+            "value" : "机器人可访问允许列表中的工作区频道"
           }
         },
         "zh-Hant" : {
@@ -31408,7 +31408,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览和转换Cloudinary媒体资产"
+            "value" : "浏览和转换 Cloudinary 媒体资产"
           }
         },
         "zh-Hant" : {
@@ -31582,7 +31582,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过Copilot浏览仓库、问题和拉取请求"
+            "value" : "通过 Copilot 浏览仓库、问题和拉取请求"
           }
         },
         "zh-Hant" : {
@@ -32041,7 +32041,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览器使用默认关闭，只能为自定义代理启用 — 内置的默认代理永远不会获得浏览器访问权限。"
+            "value" : "浏览器使用默认关闭，只能为自定义智能体启用 — 内置的默认智能体永远不会获得浏览器访问权限。"
           }
         },
         "zh-Hant" : {
@@ -32076,7 +32076,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览器使用默认关闭，仅自定义智能体可使用。打开自定义智能体的「子智能体」标签页，开启浏览器使用 — 可选择专用浏览模型。在新建的浏览器设置标签页中查看或重置每个智能体的会话。"
+            "value" : "浏览器使用默认关闭，仅自定义智能体可使用。打开自定义智能体的“子智能体”标签页，开启浏览器使用 — 可选择专用浏览模型。在新增的“浏览器”设置标签页中查看或重置每个智能体的会话。"
           }
         },
         "zh-Hant" : {
@@ -32219,7 +32219,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已缓冲 %1$lld 轮%2$@ · 已跳过 %3$lld 个会话%4$@"
+            "value" : "已缓冲 %1$lld 轮 · 已跳过 %3$lld 个会话"
           }
         },
         "zh-Hant" : {
@@ -32599,7 +32599,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在沙盒容器内运行的内置沙盒执行工具和JSON定义的插件工具。"
+            "value" : "在沙盒容器内运行的内置沙盒执行工具和 JSON 定义的插件工具。"
           }
         },
         "zh-Hant" : {
@@ -32812,7 +32812,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无需密钥的内置来源。当没有提供商响应时始终可用作备选。"
+            "value" : "无需密钥的内置源。当没有提供商响应时始终可用作备选。"
           }
         },
         "zh-Hant" : {
@@ -33088,7 +33088,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捆绑完成"
+            "value" : "捆绑包完整"
           }
         },
         "zh-Hant" : {
@@ -33122,7 +33122,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捆绑不完整"
+            "value" : "捆绑包不完整"
           }
         },
         "zh-Hant" : {
@@ -33258,7 +33258,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捆绑就绪"
+            "value" : "捆绑包就绪"
           }
         },
         "zh-Hant" : {
@@ -33294,7 +33294,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "包包括智能体的配置和加密数据库，由你选择的密码保护。"
+            "value" : "捆绑包包含智能体的配置及其加密数据库，由你选择的密码保护。"
           }
         },
         "zh-Hant" : {
@@ -34453,7 +34453,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "限制此智能体的行动范围，即使您的全局策略允许更多权限。"
+            "value" : "限制此智能体的行动范围，即使你的全局策略允许更多权限。"
           }
         },
         "zh-Hant" : {
@@ -35079,7 +35079,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "目录：~%1$lld，完整：~%2$lld 个词元"
+            "value" : "目录：~%1$lld，完整：~%2$lld 个 Token"
           }
         },
         "zh-Hant" : {
@@ -35219,7 +35219,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "类别从文件夹名称推断。添加 `type:` 行到文件的前置元数据以覆盖。"
+            "value" : "类别根据文件夹名称推断。在文件的前置元数据中添加 `type:` 行即可覆盖。"
           }
         },
         "zh-Hant" : {
@@ -35682,7 +35682,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更改自动保存，接收轮询在连接和访问完成后开始。第一次轮询仅激活光标 — 不会回放旧消息。在可读频道中发送一条提及机器人的新消息，然后在此处观察每个阶段出现。"
+            "value" : "更改自动保存，接收轮询在连接和访问完成后开始。第一次轮询仅激活游标 — 不会回放旧消息。在可读频道中发送一条提及机器人的新消息，然后在此处观察每个阶段出现。"
           }
         },
         "zh-Hant" : {
@@ -35716,7 +35716,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更改自动保存，接收在连接和访问完成后开始。从可读聊天中向机器人发送任何来自授权发送者的消息，然后在此处观察每个阶段出现。"
+            "value" : "更改会自动保存，连接和访问完成后即开始接收。以授权发送者身份，在可读聊天中向机器人发送任意消息，然后在此处观察每个阶段出现。"
           }
         },
         "zh-Hant" : {
@@ -35752,7 +35752,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更改自动保存，Socket Mode 接收在连接和访问完成后开始。从授权发送者在允许列表频道中发送下面的测试消息，然后在此处观察每个阶段出现。"
+            "value" : "更改会自动保存，连接和访问完成后 Socket Mode 即开始接收。以授权发送者身份，在允许列表内的频道中发送下面的测试消息，然后在此处观察每个阶段出现。"
           }
         },
         "zh-Hant" : {
@@ -35992,7 +35992,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以读取或搜索的频道或房间 ID。"
+            "value" : "智能体可以读取或搜索的频道或房间 ID。"
           }
         },
         "zh-Hant" : {
@@ -36026,7 +36026,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "启用写入时，代理可以写入的频道或房间 ID。"
+            "value" : "启用写入时，智能体可以写入的频道或房间 ID。"
           }
         },
         "zh-Hant" : {
@@ -36128,7 +36128,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以列出、读取和搜索的频道。"
+            "value" : "智能体可以列出、读取和搜索的频道。"
           }
         },
         "zh-Hant" : {
@@ -36233,7 +36233,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以发布的频道或线程。"
+            "value" : "智能体可以发布的频道或线程。"
           }
         },
         "zh-Hant" : {
@@ -36267,7 +36267,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以读取和搜索的频道或线程。"
+            "value" : "智能体可以读取和搜索的频道或线程。"
           }
         },
         "zh-Hant" : {
@@ -36815,7 +36815,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT 拒绝了登录回调: %@"
+            "value" : "ChatGPT 拒绝了登录回调：%@"
           }
         },
         "zh-Hant" : {
@@ -36849,7 +36849,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT 登录回调失败: %@"
+            "value" : "ChatGPT 登录回调失败：%@"
           }
         },
         "zh-Hant" : {
@@ -36917,7 +36917,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要ChatGPT登录"
+            "value" : "需要 ChatGPT 登录"
           }
         },
         "zh-Hant" : {
@@ -36951,7 +36951,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT已登录"
+            "value" : "ChatGPT 已登录"
           }
         },
         "zh-Hant" : {
@@ -37026,7 +37026,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT/Codex目录"
+            "value" : "ChatGPT/Codex 目录"
           }
         },
         "zh-Hant" : {
@@ -37060,7 +37060,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT/Codex模型目录请求失败：%@"
+            "value" : "ChatGPT/Codex 模型目录请求失败：%@"
           }
         },
         "zh-Hant" : {
@@ -37094,7 +37094,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ChatGPT/Codex或平台API"
+            "value" : "ChatGPT/Codex 或平台 API"
           }
         },
         "zh-Hant" : {
@@ -37128,7 +37128,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以发布的聊天。"
+            "value" : "智能体可以发布的聊天。"
           }
         },
         "zh-Hant" : {
@@ -37407,7 +37407,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下方的检查配置验证此草稿；保存以运行实时诊断。"
+            "value" : "下方的“检查配置”会验证此草稿；保存后即可运行实时诊断。"
           }
         },
         "zh-Hant" : {
@@ -37930,7 +37930,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检查运行时兼容性..."
+            "value" : "正在检查运行时兼容性…"
           }
         },
         "zh-Hant" : {
@@ -37998,7 +37998,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在用真实搜索验证您的密钥…"
+            "value" : "正在用真实搜索验证你的密钥…"
           }
         },
         "zh-Hant" : {
@@ -38141,7 +38141,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检查每个步骤——您可以随时停止它。"
+            "value" : "检查每个步骤——你可以随时停止它。"
           }
         },
         "zh-Hant" : {
@@ -38215,7 +38215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择要导入的CSV、TSV、JSON或JSONL文件。"
+            "value" : "选择要导入的 CSV、TSV、JSON 或 JSONL 文件。"
           }
         },
         "zh-Hant" : {
@@ -38751,7 +38751,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择智能体可以自主执行多少操作。按应用规则和每个智能体自身的上限只能使此变得更严格——绝不会降低安全性。"
+            "value" : "选择智能体可以自主执行多少操作。各应用的规则和每个智能体自身的上限只会让限制更严格——绝不会降低安全性。"
           }
         },
         "zh-Hant" : {
@@ -38786,7 +38786,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择添加多少。您将在浏览器中完成支付。"
+            "value" : "选择添加多少。你将在浏览器中完成支付。"
           }
         },
         "zh-Hant" : {
@@ -39075,7 +39075,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择用于驱动 AI 检测的端侧模型。\"规则\"选项卡中的模式规则无需任何模型即可运行。"
+            "value" : "选择用于驱动 AI 检测的端侧模型。“规则”选项卡中的模式规则无需任何模型即可运行。"
           }
         },
         "zh-Hant" : {
@@ -39249,7 +39249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择代理可以使用哪些工具"
+            "value" : "选择智能体可以使用哪些工具"
           }
         },
         "zh-Hant" : {
@@ -39285,7 +39285,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择您的机器人，然后禁用 — 否则机器人无法看到群组消息。"
+            "value" : "选择你的机器人，然后禁用 — 否则机器人无法看到群组消息。"
           }
         },
         "zh-Hant" : {
@@ -39319,7 +39319,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择您的模型"
+            "value" : "选择你的模型"
           }
         },
         "zh-Hant" : {
@@ -39527,7 +39527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Claude模型"
+            "value" : "Claude 模型"
           }
         },
         "zh-Hant" : {
@@ -40596,7 +40596,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "点击以将其设为密钥值"
+            "value" : "点击以将其设为保密值"
           }
         },
         "zh-Hant" : {
@@ -40666,7 +40666,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "点击、键入和滚动来执行您的请求。"
+            "value" : "点击、键入和滚动来执行你的请求。"
           }
         },
         "zh-Hant" : {
@@ -40701,7 +40701,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Client 密钥"
+            "value" : "客户端密钥"
           }
         },
         "zh-Hant" : {
@@ -40841,7 +40841,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "克隆基础环境"
+            "value" : "正在克隆基础环境"
           }
         },
         "zh-Hant" : {
@@ -40911,7 +40911,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭代理标签页"
+            "value" : "关闭智能体标签页"
           }
         },
         "zh-Hant" : {
@@ -40947,7 +40947,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭代理标签页？"
+            "value" : "关闭智能体标签页？"
           }
         },
         "zh-Hant" : {
@@ -41441,7 +41441,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编码器"
+            "value" : "编解码器"
           }
         },
         "zh-Hant" : {
@@ -41543,7 +41543,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Codex OAuth令牌在模型发现之前存在并刷新。"
+            "value" : "Codex OAuth 令牌在模型发现之前存在并刷新。"
           }
         },
         "zh-Hant" : {
@@ -41970,7 +41970,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以逗号分隔（例如 api.github.com、*.example.com）。设置后，沙盒流量将通过仅允许这些域名的主机代理。在下次沙盒启动时生效。"
+            "value" : "以逗号分隔（例如 api.github.com, *.example.com）。设置后，沙盒流量将通过仅允许这些域名的主机代理。在下次沙盒启动时生效。"
           }
         },
         "zh-Hant" : {
@@ -42012,7 +42012,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "逗号分隔，例如：research、web、citations"
+            "value" : "逗号分隔，例如：research, web, citations"
           }
         },
         "zh-Hant" : {
@@ -42225,7 +42225,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提交更改到git仓库"
+            "value" : "提交更改到 git 仓库"
           }
         },
         "zh-Hant" : {
@@ -42362,7 +42362,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "压缩（保存）"
+            "value" : "已压缩（已保存）"
           }
         },
         "zh-Hant" : {
@@ -42955,7 +42955,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "电脑操作默认关闭。您可以按智能体启用——只有自定义智能体才能使用它（默认智能体不可以）。"
+            "value" : "电脑操作默认关闭。你可以按智能体启用——只有自定义智能体才能使用它（默认智能体不可以）。"
           }
         },
         "zh-Hant" : {
@@ -43231,7 +43231,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "config.json、分词器资源和safetensors权重文件都存在。"
+            "value" : "config.json、分词器资源和 safetensors 权重文件都存在。"
           }
         },
         "zh-Hant" : {
@@ -44288,7 +44288,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "确认没有为机器人注册 webhook（在连接部分使用检查 Webhook）。"
+            "value" : "确认没有为机器人注册 webhook（可在“连接”部分使用“检查 Webhook”）。"
           }
         },
         "zh-Hant" : {
@@ -44500,7 +44500,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "确认消息是由授权发送者在选定为已读的频道中发送的。"
+            "value" : "确认消息是由授权发送者在选定为可读的频道中发送的。"
           }
         },
         "zh-Hant" : {
@@ -44850,7 +44850,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接服务商"
+            "value" : "连接提供商"
           }
         },
         "zh-Hant" : {
@@ -44986,7 +44986,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接服务以给你的智能体更多工具。"
+            "value" : "连接服务，为你的智能体提供更多工具。"
           }
         },
         "zh-Hant" : {
@@ -45475,7 +45475,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接到任何其他兼容MCP的服务器"
+            "value" : "连接到任何其他兼容 MCP 的服务器"
           }
         },
         "zh-Hant" : {
@@ -45616,7 +45616,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接到远程MCP服务器以访问其他工具"
+            "value" : "连接到远程 MCP 服务器以访问其他工具"
           }
         },
         "zh-Hant" : {
@@ -45652,7 +45652,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接您的第一个频道"
+            "value" : "连接你的第一个频道"
           }
         },
         "zh-Hant" : {
@@ -46333,7 +46333,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将您的智能体连接到共享网络。"
+            "value" : "将你的智能体连接到共享网络。"
           }
         },
         "zh-Hant" : {
@@ -46367,7 +46367,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在连接..."
+            "value" : "连接中…"
           }
         },
         "zh-Hant" : {
@@ -46789,7 +46789,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "后果性的"
+            "value" : "有后果"
           }
         },
         "zh-Hant" : {
@@ -46899,7 +46899,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "合并间隔"
+            "value" : "整合间隔"
           }
         },
         "zh-Hant" : {
@@ -47356,7 +47356,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上下文预算：%@ tokens"
+            "value" : "上下文预算：%@ Token"
           }
         },
         "zh-Hant" : {
@@ -47564,7 +47564,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "远程模型的上下文长度"
+            "value" : "远程模型的上下文窗口"
           }
         },
         "zh-Hant" : {
@@ -47717,7 +47717,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继续参与的讨论串"
+            "value" : "继续参与讨论串"
           }
         },
         "zh-Hant" : {
@@ -48030,7 +48030,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "控制本地vMLX模型使用的加载时内存策略。更改适用于下一个模型负载。"
+            "value" : "控制本地 vMLX 模型使用的加载时内存策略。更改将在下次加载模型时生效。"
           }
         },
         "zh-Hant" : {
@@ -48066,7 +48066,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "控制通过/models和/tags返回的模型。隐藏的模型仍可通过直接请求来使用。更改立即生效。"
+            "value" : "控制通过/models 和/tags 返回的模型。隐藏的模型仍可通过直接请求来使用。更改立即生效。"
           }
         },
         "zh-Hant" : {
@@ -48134,7 +48134,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "对话历史、置顶事实和会话摘要。"
+            "value" : "对话历史、置顶事实和情景摘要。"
           }
         },
         "zh-Hant" : {
@@ -48668,7 +48668,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制诊断信息，并将这份已编辑的请求/响应证据一并附在报告中。"
+            "value" : "复制诊断信息，并将这份已脱敏的请求/响应证据一并附在报告中。"
           }
         },
         "zh-Hant" : {
@@ -48738,7 +48738,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制JSON"
+            "value" : "复制 JSON"
           }
         },
         "zh-Hant" : {
@@ -49082,7 +49082,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制回复"
+            "value" : "复制响应"
           }
         },
         "zh-Hant" : {
@@ -49116,7 +49116,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制回复"
+            "value" : "复制响应"
           }
         },
         "zh-Hant" : {
@@ -49224,7 +49224,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制探测结果并检查提供者日志。"
+            "value" : "复制探测结果并检查提供商日志。"
           }
         },
         "zh-Hant" : {
@@ -49890,7 +49890,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法创建安全登录验证。"
+            "value" : "无法创建安全登录验证"
           }
         },
         "zh-Hant" : {
@@ -49958,7 +49958,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法从登录令牌中识别ChatGPT账户。请使用具有Codex访问权限的ChatGPT账户登录，然后重试。"
+            "value" : "无法从登录令牌中识别 ChatGPT 账户。请使用具有 Codex 访问权限的 ChatGPT 账户登录，然后重试。"
           }
         },
         "zh-Hant" : {
@@ -50033,7 +50033,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法导入技能文件\"%1$@\"：%2$@"
+            "value" : "无法导入技能文件“%1$@”：%2$@"
           }
         },
         "zh-Hant" : {
@@ -50101,7 +50101,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法检查技能归档%@"
+            "value" : "无法检查技能归档 %@"
           }
         },
         "zh-Hant" : {
@@ -50135,7 +50135,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法加载xAI OAuth配置：%@"
+            "value" : "无法加载 xAI OAuth 配置：%@"
           }
         },
         "zh-Hant" : {
@@ -50169,7 +50169,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法打开浏览器进行ChatGPT登录。请检查macOS默认浏览器设置，然后重试。"
+            "value" : "无法打开浏览器进行 ChatGPT 登录。请检查 macOS 默认浏览器设置，然后重试。"
           }
         },
         "zh-Hant" : {
@@ -50203,7 +50203,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法打开浏览器进行Grok登录。请检查macOS默认浏览器设置，然后重试。"
+            "value" : "无法打开浏览器进行 Grok 登录。请检查 macOS 默认浏览器设置，然后重试。"
           }
         },
         "zh-Hant" : {
@@ -50279,7 +50279,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法在localhost:1455上启动ChatGPT登录回调服务器。使用该端口关闭任何其他正在进行的登录或应用程序，然后重试。细节：%@"
+            "value" : "无法在 localhost:1455 上启动 ChatGPT 登录回调服务器。请关闭其他正在进行的登录或占用该端口的应用程序，然后重试。详细信息：%@"
           }
         },
         "zh-Hant" : {
@@ -50319,7 +50319,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法在127.0.0.1:%1$u上启动Grok登录回调服务器。使用该端口关闭任何其他正在进行的登录或应用程序，然后重试。详细信息：%2$@"
+            "value" : "无法在 127.0.0.1:%1$u 上启动 Grok 登录回调服务器。请关闭其他正在进行的登录或占用该端口的应用程序，然后重试。详细信息：%2$@"
           }
         },
         "zh-Hant" : {
@@ -50759,7 +50759,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法在 Hugging Face 上访问此模型。该存储库可能是私有的、受限的、已删除或暂时无法访问。在“目录”标签页中添加 Hugging Face 令牌有助于访问受限存储库并缓解速率限制。"
+            "value" : "无法在 Hugging Face 上访问此模型。该仓库可能是私有的、受限的、已删除或暂时无法访问。在“目录”标签页中添加 Hugging Face 令牌有助于访问受限仓库并缓解速率限制。"
           }
         },
         "zh-Hant" : {
@@ -51005,7 +51005,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "CPU负载"
+            "value" : "CPU 负载"
           }
         },
         "zh-Hant" : {
@@ -51253,7 +51253,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建新的API密钥"
+            "value" : "创建新的 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -51287,7 +51287,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建一个新的密钥"
+            "value" : "创建一个新的 Secret key"
           }
         },
         "zh-Hant" : {
@@ -51527,7 +51527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建工具或导入 JSON 配方。自定义工具在代理首次使用时会自动设置。"
+            "value" : "创建工具或导入 JSON 配方。自定义工具在智能体首次使用时会自动设置。"
           }
         },
         "zh-Hant" : {
@@ -51905,7 +51905,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建或复制一个API密钥"
+            "value" : "创建或复制一个 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -51939,7 +51939,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建或修复%@。"
+            "value" : "创建或修复 %@。"
           }
         },
         "zh-Hant" : {
@@ -52217,7 +52217,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建目录使用 mkdir -p \"%@\" 或运行设置沙盒让 Osaurus 创建它。"
+            "value" : "使用 mkdir -p \"%@\" 创建该目录，或运行“设置沙盒”让 Osaurus 创建它。"
           }
         },
         "zh-Hant" : {
@@ -52534,7 +52534,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建您的第一个主题"
+            "value" : "创建你的第一个主题"
           }
         },
         "zh-Hant" : {
@@ -53100,7 +53100,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "信用"
+            "value" : "积分"
           }
         },
         "zh-Hant" : {
@@ -53237,7 +53237,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "积分让Osaurus代表您进行交易 - 目前用于云模型访问，未来将支持更多路由服务。"
+            "value" : "积分让Osaurus代表你进行交易 - 目前用于云模型访问，未来将支持更多路由服务。"
           }
         },
         "zh-Hant" : {
@@ -53305,7 +53305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可按需查阅的精选参考资料。"
+            "value" : "智能体可按需查阅的精选参考资料。"
           }
         },
         "zh-Hant" : {
@@ -53339,7 +53339,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内容维护"
+            "value" : "内容策展"
           }
         },
         "zh-Hant" : {
@@ -53625,7 +53625,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义频道仅限出站，直到您授权传入发送者。从此处未列出的发送者发布到传入收件箱 API 的任何内容都会被拒绝。"
+            "value" : "自定义频道仅限出站，直到你授权传入发送者。从此处未列出的发送者发布到传入收件箱 API 的任何内容都会被拒绝。"
           }
         },
         "zh-Hant" : {
@@ -53865,7 +53865,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义HTTP"
+            "value" : "自定义 HTTP"
           }
         },
         "zh-Hant" : {
@@ -53969,7 +53969,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义 JSON 通道 `%@` 已配置，但尚未启用自定义 HTTP 执行。"
+            "value" : "自定义 JSON 频道 `%@` 已配置，但尚未启用自定义 HTTP 执行。"
           }
         },
         "zh-Hant" : {
@@ -54038,7 +54038,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自定义物理内存分数"
+            "value" : "自定义物理内存占比"
           }
         },
         "zh-Hant" : {
@@ -55229,7 +55229,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剧集在被清理前保留的天数。设为 0 则永久保留。"
+            "value" : "情景在被清理前保留的天数。设为 0 则永久保留。"
           }
         },
         "zh-Hant" : {
@@ -55401,7 +55401,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地vMLX模型的解码吞吐量选项。更改将在下一次模型加载时生效。"
+            "value" : "本地 vMLX 模型的解码吞吐量选项。更改将在下一次模型加载时生效。"
           }
         },
         "zh-Hant" : {
@@ -55541,7 +55541,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "解密 `~/.osaurus` 目录下的所有文件，并将明文副本写入您选择的目标位置。建议在重新安装 macOS 或迁移 Mac 之前执行此操作。"
+            "value" : "解密 `~/.osaurus` 目录下的所有文件，并将明文副本写入你选择的目标位置。建议在重新安装 macOS 或迁移 Mac 之前执行此操作。"
           }
         },
         "zh-Hant" : {
@@ -56166,7 +56166,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "频道/线程读取的默认最近消息数。限制在 1-100 之间。"
+            "value" : "频道/子区读取的默认最近消息数。限制在 1-100 之间。"
           }
         },
         "zh-Hant" : {
@@ -56374,7 +56374,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AI 生成问候语和快速操作的默认语音。在代理的外观选项卡中按代理开启问候语，每个代理也可以覆盖此语音。"
+            "value" : "AI 生成问候语和快速操作的默认语音。在智能体的外观选项卡中按智能体开启问候语，每个智能体也可以覆盖此语音。"
           }
         },
         "zh-Hant" : {
@@ -56915,7 +56915,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除\"%@\"？"
+            "value" : "删除“%@”？"
           }
         },
         "zh-Hant" : {
@@ -57491,7 +57491,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除供应商？"
+            "value" : "删除提供商？"
           }
         },
         "zh-Hant" : {
@@ -57924,7 +57924,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理仍可恢复的已删除行。"
+            "value" : "智能体仍可恢复的已删除行。"
           }
         },
         "zh-Hant" : {
@@ -58100,7 +58100,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "去噪步骤"
+            "value" : "去噪步数"
           }
         },
         "zh-Hant" : {
@@ -58419,7 +58419,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "描述图片..."
+            "value" : "描述图片…"
           }
         },
         "zh-Hant" : {
@@ -58524,7 +58524,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用自定义颜色、字体和背景为您的聊天设计独特的外观。"
+            "value" : "使用自定义颜色、字体和背景为你的聊天设计独特的外观。"
           }
         },
         "zh-Hant" : {
@@ -59150,7 +59150,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DFlash推测解码"
+            "value" : "DFlash 推测解码"
           }
         },
         "zh-Hant" : {
@@ -59184,7 +59184,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DFlash推测解码不完整"
+            "value" : "DFlash 推测解码不完整"
           }
         },
         "zh-Hant" : {
@@ -59220,7 +59220,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "诊断…"
+            "value" : "正在诊断…"
           }
         },
         "zh-Hant" : {
@@ -59365,7 +59365,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "诊断正在使用%@。"
+            "value" : "诊断正在使用 %@。"
           }
         },
         "zh-Hant" : {
@@ -59436,7 +59436,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "直接"
+            "value" : "直连"
           }
         },
         "zh-Hant" : {
@@ -60068,7 +60068,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "断开连接"
+            "value" : "已断开连接"
           }
         },
         "zh-Hant" : {
@@ -61011,7 +61011,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分发到智能体已关闭。在频道设置中启用并选择一个智能体。"
+            "value" : "分派到智能体已关闭。请在频道设置中启用并选择一个智能体。"
           }
         },
         "zh-Hant" : {
@@ -61289,7 +61289,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "蒸馏在写入片段之前失败。"
+            "value" : "蒸馏在写入情景之前失败。"
           }
         },
         "zh-Hant" : {
@@ -61357,7 +61357,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "蒸馏已运行但未产生可用片段。"
+            "value" : "蒸馏已运行但未产生可用情景。"
           }
         },
         "zh-Hant" : {
@@ -61460,7 +61460,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您希望 Osaurus 在此聊天中自动朗读每条回复吗？"
+            "value" : "你希望 Osaurus 在此聊天中自动朗读每条回复吗？"
           }
         },
         "zh-Hant" : {
@@ -62186,7 +62186,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "先下载或导入，然后使用令牌运行生成证明。"
+            "value" : "先下载或导入，然后运行生成验证并测量 token/s 速率。"
           }
         },
         "zh-Hant" : {
@@ -62612,7 +62612,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在下载 %lld 个模型%@ – 点击查看"
+            "value" : "正在下载 %1$lld 个模型 – 点击查看"
           }
         },
         "zh-Hant" : {
@@ -62920,7 +62920,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "起草并发送文本"
+            "value" : "起草并发送短信"
           }
         },
         "zh-Hant" : {
@@ -63062,7 +63062,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "草稿信息"
+            "value" : "起草消息"
           }
         },
         "zh-Hant" : {
@@ -63130,7 +63130,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用快速辅助模型生成草案 token，并由主模型在单步中校验。模型支持时按请求启用。"
+            "value" : "使用快速辅助模型生成草案 Token，并由主模型在单步中校验。模型支持时按请求启用。"
           }
         },
         "zh-Hant" : {
@@ -63351,7 +63351,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "丢弃概率低于（顶部 token 概率 × P）的 token。"
+            "value" : "丢弃概率低于（顶部 Token 概率 × P）的 Token。"
           }
         },
         "zh-Hant" : {
@@ -63674,7 +63674,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "期间"
+            "value" : "时长"
           }
         },
         "zh-Hant" : {
@@ -63743,7 +63743,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "例如：-y @scope/server --root '包含空格的 /path'"
+            "value" : "例如：-y @scope/server --root '/path with spaces'"
           }
         },
         "zh-Hant" : {
@@ -63847,7 +63847,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "例如：客户"
+            "value" : "例如：CUSTOMER"
           }
         },
         "zh-Hant" : {
@@ -64364,7 +64364,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个智能体只能看到您在其“能力”标签页中勾选的知识库，其余内容对它完全不可见。编辑文件夹中的文件，索引会实时更新，无需重启。"
+            "value" : "每个智能体只能看到你在其“能力”标签页中勾选的知识库，其余内容对它完全不可见。编辑文件夹中的文件，索引会实时更新，无需重启。"
           }
         },
         "zh-Hant" : {
@@ -64471,7 +64471,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每行均按字面内容进行匹配——无需正则表达式。特殊字符将自动为您转义。"
+            "value" : "每行均按字面内容进行匹配——无需正则表达式。特殊字符将自动为你转义。"
           }
         },
         "zh-Hant" : {
@@ -65145,7 +65145,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑模型"
+            "value" : "图像编辑模型"
           }
         },
         "zh-Hant" : {
@@ -65458,7 +65458,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修改端点URL并重新测试。"
+            "value" : "修改端点 URL 并重新测试。"
           }
         },
         "zh-Hant" : {
@@ -65492,7 +65492,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑提供者并输入可执行文件。"
+            "value" : "编辑提供商并输入可执行文件。"
           }
         },
         "zh-Hant" : {
@@ -65526,7 +65526,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑该提供程序并保存 API 密钥或秘密的授权标头。"
+            "value" : "编辑该提供商并保存 API 密钥或机密 Authorization 标头。"
           }
         },
         "zh-Hant" : {
@@ -65767,7 +65767,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在编辑"
+            "value" : "编辑操作"
           }
         },
         "zh-Hant" : {
@@ -65978,7 +65978,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "身份"
+            "value" : "基本信息"
           }
         },
         "zh-Hant" : {
@@ -66012,7 +66012,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "编辑运行；仅发送、删除和类似操作可先执行。"
+            "value" : "编辑操作会直接运行；仅发送、删除等类似操作会先询问。"
           }
         },
         "zh-Hant" : {
@@ -66227,7 +66227,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空 — 任何应用中都允许使用计算机。"
+            "value" : "留空 — 任何应用中都允许使用计算机。"
           }
         },
         "zh-Hant" : {
@@ -66365,7 +66365,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "清空扫描HF_HUB_CACHE、HF_HOME/hub和~/.cache/huggingface/hub。"
+            "value" : "留空时将扫描 HF_HUB_CACHE、HF_HOME/hub 和 ~/.cache/huggingface/hub。"
           }
         },
         "zh-Hant" : {
@@ -67283,7 +67283,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在测试或选择其模型之前，请先启用该提供程序。"
+            "value" : "在测试或选择其模型之前，请先启用该提供商。"
           }
         },
         "zh-Hant" : {
@@ -67846,7 +67846,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已加密 %lld 个存储。"
+            "value" : "已对 %lld 个存储启用静态加密。"
           }
         },
         "zh-Hant" : {
@@ -67880,7 +67880,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已加密 1 个存储。"
+            "value" : "已对 1 个存储启用静态加密。"
           }
         },
         "zh-Hant" : {
@@ -67955,7 +67955,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用SQLCipher加密"
+            "value" : "使用 SQLCipher 加密"
           }
         },
         "zh-Hant" : {
@@ -67990,7 +67990,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加密，但此Mac上无法使用存储密钥。恢复钥匙串密钥并重试，或重置以重新开始。"
+            "value" : "加密，但此 Mac 上无法使用存储密钥。恢复钥匙串密钥并重试，或重置以重新开始。"
           }
         },
         "zh-Hant" : {
@@ -68171,7 +68171,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过Osaurus安全通道进行端到端加密"
+            "value" : "通过 Osaurus 安全通道进行端到端加密"
           }
         },
         "zh-Hant" : {
@@ -68621,7 +68621,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "输入美元金额，比如25。"
+            "value" : "输入美元金额，比如 25。"
           }
         },
         "zh-Hant" : {
@@ -69032,7 +69032,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 Enter 保存 · 按Esc取消"
+            "value" : "按 Enter 保存 · 按 Esc 取消"
           }
         },
         "zh-Hant" : {
@@ -69206,7 +69206,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剧集已禁用。"
+            "value" : "情景已禁用。"
           }
         },
         "zh-Hant" : {
@@ -69240,7 +69240,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "剧集已遗忘。"
+            "value" : "情景已遗忘。"
           }
         },
         "zh-Hant" : {
@@ -69276,7 +69276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "情节保留"
+            "value" : "情景保留"
           }
         },
         "zh-Hant" : {
@@ -69310,7 +69310,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未找到该集。"
+            "value" : "未找到该情景。"
           }
         },
         "zh-Hant" : {
@@ -69352,7 +69352,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "片段：%@。%@，%@"
+            "value" : "情景：%@。%@，%@"
           }
         },
         "zh-Hant" : {
@@ -69433,7 +69433,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "情节"
+            "value" : "情景"
           }
         },
         "zh-Hant" : {
@@ -69741,7 +69741,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "错误：此进程未被信任用于辅助功能。如果在系统设置中已启用，请尝试将Osaurus从列表中移除并重新添加。"
+            "value" : "错误：此进程未被信任用于辅助功能。如果在系统设置中已启用，请尝试将 Osaurus 从列表中移除并重新添加。"
           }
         },
         "zh-Hant" : {
@@ -70249,7 +70249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个文档都有类别，来自其前置元数据 `type:` 或从其文件夹名称推断。代理可以按类别过滤此集合。"
+            "value" : "每个文档都有类别，来自其前置元数据 `type:` 或从其文件夹名称推断。智能体可以按类别过滤此集合。"
           }
         },
         "zh-Hant" : {
@@ -70319,7 +70319,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这里的每个模型都在您的 Mac 上私密运行。不确定？保留我们根据您的 Mac 配置挑选的模型即可——您可以随时切换。"
+            "value" : "这里的每个模型都在你的 Mac 上私密运行。不确定？保留我们根据你的 Mac 配置挑选的模型即可——你可以随时切换。"
           }
         },
         "zh-Hant" : {
@@ -70496,7 +70496,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理可以使用的所有内容，按每个工具的来源分组"
+            "value" : "智能体可以使用的所有内容，按每个工具的来源分组"
           }
         },
         "zh-Hant" : {
@@ -70673,7 +70673,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此智能体能做的一切 — 翻转一项能力，观察启动上下文的响应。"
+            "value" : "此智能体能做的一切 — 切换一项能力，观察启动上下文的响应。"
           }
         },
         "zh-Hant" : {
@@ -70882,7 +70882,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在文件夹中执行shell命令"
+            "value" : "在文件夹中执行 shell 命令"
           }
         },
         "zh-Hant" : {
@@ -71272,7 +71272,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "实验性功能：从每个代理自己的基础镜像写时复制克隆启动，使系统包在每个代理之间独立保留"
+            "value" : "实验性功能：从每个智能体自己的基础镜像写时复制克隆启动，使系统包按智能体独立保留"
           }
         },
         "zh-Hant" : {
@@ -71307,7 +71307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "实验性功能：当服务器驱逐策略设为「灵活（多模型）」且内存预测显示两个模型都能容纳时，将辅助模型与聊天模型并行加载，而非先卸载再重新加载——在大内存 Mac 上跳过换入换出的往返开销。内存紧张或采用严格策略时，始终回退至常规交接流程。"
+            "value" : "实验性功能：当服务器驱逐策略设为“灵活（多模型）”且内存预测显示两个模型都能容纳时，将辅助模型与聊天模型并行加载，而非先卸载再重新加载——在大内存 Mac 上跳过换入换出的往返开销。内存紧张或采用严格策略时，始终回退至常规交接流程。"
           }
         },
         "zh-Hant" : {
@@ -71443,7 +71443,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "于 %@ 过期"
+            "value" : "将于 %@ 过期"
           }
         },
         "zh-Hant" : {
@@ -71477,7 +71477,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "解释"
+            "value" : "解释 "
           }
         },
         "zh-Hant" : {
@@ -72194,7 +72194,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "导出报告方可安全处理的暴露报告"
+            "value" : "导出可安全提供给报告方的暴露报告"
           }
         },
         "zh-Hant" : {
@@ -72695,7 +72695,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将路由器支持捆绑包导出到%@。"
+            "value" : "已将路由器支持捆绑包导出到 %@。"
           }
         },
         "zh-Hant" : {
@@ -72831,7 +72831,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全部显示"
+            "value" : "全部暴露"
           }
         },
         "zh-Hant" : {
@@ -72865,7 +72865,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过中继隧道将此智能体公开到公共互联网，以便外部服务能够访问它。"
+            "value" : "通过中继隧道将此智能体暴露到公网，以便外部服务能够访问它。"
           }
         },
         "zh-Hant" : {
@@ -73367,7 +73367,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提取积分"
+            "value" : "网页提取额度"
           }
         },
         "zh-Hant" : {
@@ -74603,7 +74603,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "获取已签名的路由器 /models 端点并隐藏过时的价格。"
+            "value" : "获取路由服务已签名的 /models 端点，并隐藏过时的价格。"
           }
         },
         "zh-Hant" : {
@@ -75303,7 +75303,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文件保险箱已关闭——明文存储在静态时不会加密。在“系统设置”→“隐私和安全”中保持SQLCipher打开或打开文件保险箱。"
+            "value" : "文件保险箱已关闭——明文存储在静态时不会加密。请保持 SQLCipher 开启，或在“系统设置”→“隐私与安全性”中打开文件保险箱。"
           }
         },
         "zh-Hant" : {
@@ -75338,7 +75338,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文件保险箱已打开——您的磁盘在静态时已加密，因此明文存储受到保护，是最可靠的选择。"
+            "value" : "文件保险箱已打开——你的磁盘在静态时已加密，因此明文存储受到保护，是最可靠的选择。"
           }
         },
         "zh-Hant" : {
@@ -76038,7 +76038,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复或清除服务器设置中的代理URL。"
+            "value" : "修复或清除服务器设置中的代理 URL。"
           }
         },
         "zh-Hant" : {
@@ -76072,7 +76072,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复或删除%@，然后再次保存沙盒设置。"
+            "value" : "修复或删除 %@，然后再次保存沙盒设置。"
           }
         },
         "zh-Hant" : {
@@ -76112,7 +76112,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复%1$@的所有权或权限，然后重新运行预检。对于用户拥有的路径，通常chmod u+rwX \"%2$@\"就足够了。"
+            "value" : "修复 %1$@ 的所有权或权限，然后重新运行预检。对于用户拥有的路径，通常 chmod u+rwX “%2$@”就足够了。"
           }
         },
         "zh-Hant" : {
@@ -76316,7 +76316,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "供代理按需搜索和阅读的文档文件夹"
+            "value" : "供智能体按需搜索和阅读的文档文件夹"
           }
         },
         "zh-Hant" : {
@@ -76638,7 +76638,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分数从0.10到1.00。"
+            "value" : "比例值范围为 0.10 到 1.00。"
           }
         },
         "zh-Hant" : {
@@ -76742,7 +76742,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "磁盘空间无法验证"
+            "value" : "可用磁盘空间无法验证"
           }
         },
         "zh-Hant" : {
@@ -76776,7 +76776,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "释放包含%@的卷中的磁盘空间，然后重新运行预检。"
+            "value" : "释放包含 %@ 的卷中的磁盘空间，然后重新运行预检。"
           }
         },
         "zh-Hant" : {
@@ -77715,7 +77715,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将每标记的解码图与 MLX 编译融合（在 Gemma 4 QAT 上测量提升 +25%）。在重启 Osaurus 后生效——MLX 在进程首次加载模型时会修复其编译状态，因此在会话中途切换此选项无法实时开启或关闭（设置会被保存并在下次启动时应用）。实验性功能：默认关闭，直到历史模型切换损坏问题（PR #1173）得到根本原因分析。如果在开启此功能时模型切换出现问题，请关闭并重启。"
+            "value" : "将每 Token 的解码图与 MLX 编译融合（在 Gemma 4 QAT 上实测 +25%）。重启 Osaurus 后生效——MLX 会在进程首次加载模型时固定其编译状态，因此会话中途切换此开关无法实时开启或关闭（设置会保存并在下次启动时应用）。实验性功能：在历史遗留的模型切换损坏问题（PR #1173）查明根因之前默认保持关闭。如果开启后模型切换出现异常，请关闭并重启。"
           }
         },
         "zh-Hant" : {
@@ -77820,7 +77820,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gemini模型列表"
+            "value" : "Gemini 模型列表"
           }
         },
         "zh-Hant" : {
@@ -77854,7 +77854,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gemini模型"
+            "value" : "Gemini 模型"
           }
         },
         "zh-Hant" : {
@@ -77990,7 +77990,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每次打开空白聊天时，都会用您的核心模型生成新的 AI 问候语和快捷操作。关闭后则使用您的自定义问候语。首次生成在 Foundation 等小模型上可能感觉较慢。"
+            "value" : "每次打开空白聊天时，都会用你的核心模型生成新的 AI 问候语和快捷操作。关闭后则使用你的自定义问候语。首次生成在 Foundation 等小模型上可能感觉较慢。"
           }
         },
         "zh-Hant" : {
@@ -78096,7 +78096,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生成一个新的256位密钥，并重新加密所有文件。旧密钥将被销毁。"
+            "value" : "生成一个新的 256 位密钥，并重新加密所有制品。旧密钥将被销毁。"
           }
         },
         "zh-Hant" : {
@@ -78165,7 +78165,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生成一个新的API密钥"
+            "value" : "生成一个新的 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -78342,7 +78342,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用设备上的模型生成和编辑图像 • %lld 在设备上"
+            "value" : "使用设备端模型生成和编辑图像 • 设备端 %lld 个"
           }
         },
         "zh-Hant" : {
@@ -78999,7 +78999,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生成问候"
+            "value" : "生成式问候"
           }
         },
         "zh-Hant" : {
@@ -79390,7 +79390,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅限GGUF的捆绑包"
+            "value" : "仅限 GGUF 的捆绑包"
           }
         },
         "zh-Hant" : {
@@ -79428,7 +79428,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Git提交"
+            "value" : "Git 提交"
           }
         },
         "zh-Hant" : {
@@ -79670,7 +79670,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当您提问时，给智能体一个它可以调用的工具来朗读回复。如需始终朗读，请在语音部分使用“自动朗读回复”。"
+            "value" : "给智能体一个它可以调用的工具，在你要求时朗读回复。如需始终朗读，请在“语音”部分使用“自动朗读回复”。"
           }
         },
         "zh-Hant" : {
@@ -79991,7 +79991,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全局代理通道写入功能已被写入终止开关禁用（生成 %lld）。"
+            "value" : "全局智能体通道的写入已被写入终止开关禁用（第 %lld 代）。"
           }
         },
         "zh-Hant" : {
@@ -80202,7 +80202,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gmail、日历、驱动器、文档（需要自托管）"
+            "value" : "Gmail、日历、云端硬盘、文档（需要自托管）"
           }
         },
         "zh-Hant" : {
@@ -80270,7 +80270,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往%@控制台"
+            "value" : "前往 %@ 控制台"
           }
         },
         "zh-Hant" : {
@@ -80375,7 +80375,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往表"
+            "value" : "前往数据表"
           }
         },
         "zh-Hant" : {
@@ -80409,7 +80409,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往AtlasCloud API密钥页面"
+            "value" : "前往 AtlasCloud API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80443,7 +80443,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往DeepSeek平台API密钥页面"
+            "value" : "前往 DeepSeek 平台 API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80477,7 +80477,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往MiniMax平台的API密钥页面"
+            "value" : "前往 MiniMax 平台的 API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80511,7 +80511,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往Mistral控制台API密钥页面"
+            "value" : "前往 Mistral 控制台 API 密钥页面"
           }
         },
         "zh-Hant" : {
@@ -80579,7 +80579,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前往Venice AI设置页面"
+            "value" : "前往 Venice AI 设置页面"
           }
         },
         "zh-Hant" : {
@@ -80984,7 +80984,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将\"%@\"授予智能体"
+            "value" : "将“%@”授予智能体"
           }
         },
         "zh-Hant" : {
@@ -81122,7 +81122,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "授予一个 macOS 文件夹的访问权限，包括通过认证的远程代理运行。写入保留在文件夹内；shell 和 git 保持禁用。"
+            "value" : "授予一个 macOS 文件夹的访问权限，包括通过认证的远程智能体运行。写入保留在文件夹内；shell 和 git 保持禁用。"
           }
         },
         "zh-Hant" : {
@@ -81401,7 +81401,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已将\"%1$@\"授予 %2$lld 个智能体"
+            "value" : "已将“%1$@”授予 %2$lld 个智能体"
           }
         },
         "zh-Hant" : {
@@ -81435,7 +81435,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已将\"%@\"授予 1 个智能体"
+            "value" : "已将“%@”授予 1 个智能体"
           }
         },
         "zh-Hant" : {
@@ -81605,7 +81605,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Grok模型"
+            "value" : "Grok 模型"
           }
         },
         "zh-Hant" : {
@@ -82440,7 +82440,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "嘿！经过 10 个月的公开建设，今天我们在 Product Hunt 上正式发布了。\n\nOsaurus 因为像你这样的人的反馈而变得更好。如果它对你有帮助，来打个招呼并支持这次发布吧。这对我们意义重大。\n\n感谢你早期的支持。"
+            "value" : "嘿！经过 10 个月的公开开发，今天我们在 Product Hunt 上正式发布了。\n\nOsaurus 因为像你这样的人的反馈而变得更好。如果它对你有帮助，来打个招呼并支持这次发布吧。这对我们意义重大。\n\n感谢你早期的支持。"
           }
         },
         "zh-Hant" : {
@@ -82545,7 +82545,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "默认隐藏。启用您希望 API 列出的远程模型。"
+            "value" : "默认隐藏。启用你希望 API 列出的远程模型。"
           }
         },
         "zh-Hant" : {
@@ -82613,7 +82613,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐藏在%@模式下"
+            "value" : "在 %@ 模式下隐藏"
           }
         },
         "zh-Hant" : {
@@ -83155,7 +83155,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最高优先级"
+            "value" : "从高到低"
           }
         },
         "zh-Hant" : {
@@ -83261,7 +83261,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "历史、事实和片段"
+            "value" : "历史、事实与情景"
           }
         },
         "zh-Hant" : {
@@ -83511,7 +83511,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "主机为此插件发出了 %d 条一次性警告%@。"
+            "value" : "主机为此插件发出了 %d 条一次性警告 %@。"
           }
         },
         "zh-Hant" : {
@@ -83753,7 +83753,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "衰减 / 去重 / 强制运行之间的小时间隔"
+            "value" : "衰减 / 去重 / 淘汰运行之间的小时间隔"
           }
         },
         "zh-Hant" : {
@@ -83925,7 +83925,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个生成的脚本在运行前如何被门控。"
+            "value" : "每个生成的脚本在运行前如何经过把关。"
           }
         },
         "zh-Hant" : {
@@ -83995,7 +83995,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每一步预填充的提示 token 数量。"
+            "value" : "每一步预填充的提示 Token 数量。"
           }
         },
         "zh-Hant" : {
@@ -84063,7 +84063,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "主模型校验前，草案模型先提议的 token 数量。"
+            "value" : "主模型校验前，草案模型先提议的 Token 数量。"
           }
         },
         "zh-Hant" : {
@@ -84549,7 +84549,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "HTTP路由"
+            "value" : "HTTP 路由"
           }
         },
         "zh-Hant" : {
@@ -84655,7 +84655,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此频道的 HTTPS 来源智能体工具调用。"
+            "value" : "智能体工具为此频道调用的 HTTPS 来源。"
           }
         },
         "zh-Hant" : {
@@ -84765,7 +84765,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hugging Face 返回了 %@。对于受限或私有存储库，请在“目录”标签页中添加 Hugging Face 访问令牌；否则请稍后再试。"
+            "value" : "Hugging Face 返回了 %@。对于受限或私有仓库，请在“目录”标签页中添加 Hugging Face 访问令牌；否则请稍后再试。"
           }
         },
         "zh-Hant" : {
@@ -85423,7 +85423,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "如果您正在迁移Mac或擦除macOS，请先导出纯文本备份。否则无需采取任何操作——加密会自动运行。"
+            "value" : "如果你正在迁移Mac或擦除macOS，请先导出纯文本备份。否则无需采取任何操作——加密会自动运行。"
           }
         },
         "zh-Hant" : {
@@ -85525,7 +85525,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "忽略来自机器人账户的 Telegram 更新，除非您明确信任机器人发送者。"
+            "value" : "忽略来自机器人账户的 Telegram 更新，除非你明确信任机器人发送者。"
           }
         },
         "zh-Hant" : {
@@ -85593,7 +85593,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "忽略"
+            "value" : "已忽略"
           }
         },
         "zh-Hant" : {
@@ -85805,7 +85805,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "图像生成和编辑模型位于「图像」设置中。"
+            "value" : "图片生成和编辑模型位于“图片”设置中。"
           }
         },
         "zh-Hant" : {
@@ -86115,7 +86115,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅图像"
+            "value" : "仅图片"
           }
         },
         "zh-Hant" : {
@@ -86436,7 +86436,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "导入 %1$lld 个技能%2$@"
+            "value" : "导入 %1$lld 个技能"
           }
         },
         "zh-Hant" : {
@@ -87252,7 +87252,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已导入\"%@\"，包含 %lld 个文件"
+            "value" : "已导入“%@”，包含 %lld 个文件"
           }
         },
         "zh-Hant" : {
@@ -87716,7 +87716,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在您的 Slack 应用中，打开“安装应用”，将其安装到工作区，然后复制机器人用户 OAuth 令牌。"
+            "value" : "在你的 Slack 应用中，打开“安装应用”，将其安装到工作区，然后复制机器人用户 OAuth 令牌。"
           }
         },
         "zh-Hant" : {
@@ -88285,7 +88285,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "推断"
+            "value" : "推理"
           }
         },
         "zh-Hant" : {
@@ -88697,7 +88697,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "输入词元"
+            "value" : "输入 Token"
           }
         },
         "zh-Hant" : {
@@ -89497,7 +89497,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "安装 %1$lld 个插件%2$@"
+            "value" : "安装 %1$lld 个插件"
           }
         },
         "zh-Hant" : {
@@ -89831,7 +89831,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从ollama.com安装Ollama"
+            "value" : "从 ollama.com 安装 Ollama"
           }
         },
         "zh-Hant" : {
@@ -90722,7 +90722,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "指令"
+            "value" : "Instruct"
           }
         },
         "zh-Hant" : {
@@ -91215,7 +91215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "来自提供商的无效回复"
+            "value" : "提供商返回的响应无效"
           }
         },
         "zh-Hant" : {
@@ -91249,7 +91249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无效的技能存档 - 未找到SKILL.md文件"
+            "value" : "无效的技能存档 - 未找到 SKILL.md 文件"
           }
         },
         "zh-Hant" : {
@@ -91283,7 +91283,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无效的URL"
+            "value" : "无效的 URL"
           }
         },
         "zh-Hant" : {
@@ -91317,7 +91317,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调查Sentry问题、跟踪和版本"
+            "value" : "调查 Sentry 问题、跟踪和版本"
           }
         },
         "zh-Hant" : {
@@ -91465,7 +91465,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "邀请机器人到您的服务器"
+            "value" : "邀请机器人到你的服务器"
           }
         },
         "zh-Hant" : {
@@ -91958,7 +91958,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将已授权的 Telegram 更新保留在本地收件箱中，以便代理可以读取和搜索它们。"
+            "value" : "将已授权的 Telegram 更新保留在本地收件箱中，以便智能体可以读取和搜索它们。"
           }
         },
         "zh-Hant" : {
@@ -92135,7 +92135,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继续"
+            "value" : "保持开启"
           }
         },
         "zh-Hant" : {
@@ -92703,7 +92703,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要Key"
+            "value" : "需要密钥"
           }
         },
         "zh-Hant" : {
@@ -92774,7 +92774,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "钥匙串钥匙：未找到"
+            "value" : "钥匙串密钥：未找到"
           }
         },
         "zh-Hant" : {
@@ -92810,7 +92810,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "钥匙串钥匙：存在"
+            "value" : "钥匙串密钥：存在"
           }
         },
         "zh-Hant" : {
@@ -93233,7 +93233,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近 %@"
+            "value" : "上次：%@"
           }
         },
         "zh-Hant" : {
@@ -93448,7 +93448,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上次搜索通过 %@ %@ 成功 — %lld 个结果%@。"
+            "value" : "上次搜索于 %2$@ 通过 %1$@ 成功 — %3$lld 个结果。"
           }
         },
         "zh-Hant" : {
@@ -93484,7 +93484,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近签署的支票"
+            "value" : "最近的签名校验"
           }
         },
         "zh-Hant" : {
@@ -93629,7 +93629,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最新蒸馏未产生可用片段。"
+            "value" : "最新蒸馏未产生可用情景。"
           }
         },
         "zh-Hant" : {
@@ -94319,7 +94319,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让代理在其自己的持久会话中浏览网页"
+            "value" : "让智能体在自己的持久会话中浏览网页"
           }
         },
         "zh-Hant" : {
@@ -94355,7 +94355,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体代您操作 macOS 应用"
+            "value" : "让智能体代你操作 macOS 应用"
           }
         },
         "zh-Hant" : {
@@ -94389,7 +94389,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理发布到写入允许列表的 Discord 目标。频道写入也必须全局开启。"
+            "value" : "允许智能体发布到写入允许列表的 Discord 目标。频道写入也必须全局开启。"
           }
         },
         "zh-Hant" : {
@@ -94423,7 +94423,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理发布到写入允许列表的 Slack 频道。频道写入也必须全局开启。"
+            "value" : "允许智能体发布到写入允许列表的 Slack 频道。频道写入也必须全局开启。"
           }
         },
         "zh-Hant" : {
@@ -94457,7 +94457,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理发布到写入允许列表的 Telegram 聊天。频道写入也必须全局开启。"
+            "value" : "允许智能体发布到写入允许列表的 Telegram 聊天。频道写入也必须全局开启。"
           }
         },
         "zh-Hant" : {
@@ -94491,7 +94491,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理在 Discord、Slack 和 Telegram 上读取和回复"
+            "value" : "允许智能体在 Discord、Slack 和 Telegram 上读取和回复"
           }
         },
         "zh-Hant" : {
@@ -94527,7 +94527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体在您团队已经交谈的地方阅读和回复。"
+            "value" : "让智能体在你团队已经交谈的地方阅读和回复。"
           }
         },
         "zh-Hant" : {
@@ -94563,7 +94563,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体在您团队已经交谈的地方阅读和回复。每个引导设置都以传入消息的实时验证结束。"
+            "value" : "让智能体在你团队已经交谈的地方阅读和回复。每个引导设置都以传入消息的实时验证结束。"
           }
         },
         "zh-Hant" : {
@@ -94668,7 +94668,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让派生的工作代理自行读取文件（file_read / file_search），避免批量读取占用此代理的上下文。"
+            "value" : "让派生的工作智能体自行读取文件（file_read / file_search），避免批量读取占用此智能体的上下文。"
           }
         },
         "zh-Hant" : {
@@ -94775,7 +94775,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让代理在其自己的持久浏览器会话中浏览网页 — 登录状态在聊天之间保持。读取和导航自动运行；输入和任何重要操作会暂停等待您的批准。"
+            "value" : "让智能体在自己的持久浏览器会话中浏览网页 — 登录状态在聊天之间保持。读取和导航自动运行；输入和任何重要操作会暂停等待你的批准。"
           }
         },
         "zh-Hant" : {
@@ -94811,7 +94811,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许智能体为您控制 macOS 应用 — 点击、输入与读取屏幕内容。读取与导航操作自动执行；编辑及其它有后果的操作将暂停并等待您批准。"
+            "value" : "允许智能体为你控制 macOS 应用 — 点击、输入与读取屏幕内容。读取与导航操作自动执行；编辑及其它有后果的操作将暂停并等待你批准。"
           }
         },
         "zh-Hant" : {
@@ -94883,7 +94883,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许智能体使用本地模型，通过 image 工具生成和编辑图像。"
+            "value" : "允许智能体使用本地模型，通过 `image` 工具生成和编辑图像。"
           }
         },
         "zh-Hant" : {
@@ -94956,7 +94956,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体在您选择的文件夹中读取和写入文件。"
+            "value" : "让智能体在你选择的文件夹中读取和写入文件。"
           }
         },
         "zh-Hant" : {
@@ -94992,7 +94992,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体以分离的方式运行长期进程（服务器、监视器）并管理它们。默认关闭以保持工具界面简洁。"
+            "value" : "让智能体以分离的方式运行长期进程（服务器、监视器）并管理它们。默认关闭，以保持工具集精简。"
           }
         },
         "zh-Hant" : {
@@ -95134,7 +95134,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许代理搜索和阅读下方授权的知识集合：精选指南、模板和规范。与记忆不同，知识由你编辑，代理绝不会改写。"
+            "value" : "允许智能体搜索和阅读下方授权的知识集合：精选指南、模板和规范。与记忆不同，知识由你编辑，智能体绝不会改写。"
           }
         },
         "zh-Hant" : {
@@ -95450,7 +95450,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许此智能体委托工作 — 控制您的 Mac、将任务移交给其他智能体，或生成图像。"
+            "value" : "允许此智能体委托工作 — 控制你的 Mac、将任务移交给其他智能体，或生成图像。"
           }
         },
         "zh-Hant" : {
@@ -95484,7 +95484,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许此代理将文档更新起草为待审提案（它也可以提交和处理过期工单）。在你于知识板块批准提案之前，集合不会有任何变化。"
+            "value" : "允许此智能体将文档更新起草为待审提案（它也可以提交和处理过期工单）。在你于知识板块批准提案之前，集合不会有任何变化。"
           }
         },
         "zh-Hant" : {
@@ -95626,7 +95626,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让智能体读取屏幕元素，并为您点击、输入和滚动。"
+            "value" : "让智能体读取屏幕元素，并为你点击、输入和滚动。"
           }
         },
         "zh-Hant" : {
@@ -95694,7 +95694,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让Osaurus代表您进行交易 - 云模型、提供商负载均衡以及未来的路由服务；请求会消耗积分。保持开启有助于支持 Osaurus 的开发 - 感谢。"
+            "value" : "让Osaurus代表你进行交易 - 云模型、提供商负载均衡以及未来的路由服务；请求会消耗积分。保持开启有助于支持 Osaurus 的开发 - 感谢。"
           }
         },
         "zh-Hant" : {
@@ -96041,7 +96041,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "偏好"
+            "value" : "点赞"
           }
         },
         "zh-Hant" : {
@@ -96247,7 +96247,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "房间列表"
+            "value" : "列出房间"
           }
         },
         "zh-Hant" : {
@@ -96281,7 +96281,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空间列表"
+            "value" : "列出空间"
           }
         },
         "zh-Hant" : {
@@ -96488,7 +96488,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "列表"
+            "value" : "条目"
           }
         },
         "zh-Hant" : {
@@ -97550,7 +97550,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已加载的模型%@"
+            "value" : "已加载的模型 %@"
           }
         },
         "zh-Hant" : {
@@ -97802,7 +97802,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加载文件..."
+            "value" : "正在加载文件…"
           }
         },
         "zh-Hant" : {
@@ -98008,7 +98008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加载模型卡片..."
+            "value" : "正在加载模型卡片…"
           }
         },
         "zh-Hant" : {
@@ -98489,7 +98489,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地捆绑包已就绪。"
+            "value" : "本地捆绑包已就绪"
           }
         },
         "zh-Hant" : {
@@ -98707,7 +98707,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地移交与生成任务的内存安全设置，属于系统设置，可在“设置 → 子智能体”中配置。"
+            "value" : "本地交接与生成任务的内存安全属于系统设置，可在“设置 → 子智能体”中配置。"
           }
         },
         "zh-Hant" : {
@@ -98982,7 +98982,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地编排移交已关闭（设置 → 子代理）。尝试生成/启动模型与当前对话模型不同的本地代理或模型将被拒绝 — 仅允许运行远程目标和已加载的模型。"
+            "value" : "本地编排移交已关闭（设置 → 子智能体）。尝试生成/启动模型与当前对话模型不同的本地智能体或模型将被拒绝 — 仅允许运行远程目标和已加载的模型。"
           }
         },
         "zh-Hant" : {
@@ -99086,7 +99086,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地主机客户端可以无需真实密钥调用API。为局域网、中继或需要Bearer值的客户端创建访问密钥。"
+            "value" : "本地主机客户端可以无需真实密钥调用 API。为局域网、中继或需要 Bearer 值的客户端创建访问密钥。"
           }
         },
         "zh-Hant" : {
@@ -99535,7 +99535,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览并自由导航；从不编辑。"
+            "value" : "自由查看和导航；绝不编辑。"
           }
         },
         "zh-Hant" : {
@@ -99570,7 +99570,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "看"
+            "value" : "查看"
           }
         },
         "zh-Hant" : {
@@ -99707,7 +99707,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "数值越低，输出越专注；数值越高，越具创造性。设为 0 则始终选取概率最高的单个 token。"
+            "value" : "数值越低，输出越专注；数值越高，越具创造性。设为 0 则始终选取概率最高的单个 Token。"
           }
         },
         "zh-Hant" : {
@@ -99775,7 +99775,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS版本不支持沙盒配置"
+            "value" : "macOS 版本不支持沙盒配置"
           }
         },
         "zh-Hant" : {
@@ -99809,7 +99809,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打造得宛如你专属"
+            "value" : "为你量身打造"
           }
         },
         "zh-Hant" : {
@@ -99884,7 +99884,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "创建和完成您的提醒事项。"
+            "value" : "创建和完成你的提醒事项。"
           }
         },
         "zh-Hant" : {
@@ -100446,7 +100446,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "管理Supabase Postgres、认证和存储"
+            "value" : "管理 Supabase Postgres、认证和存储"
           }
         },
         "zh-Hant" : {
@@ -100618,7 +100618,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "管理您的 Cloudflare 账户、Workers 和 DNS"
+            "value" : "管理你的 Cloudflare 账户、Workers 和 DNS"
           }
         },
         "zh-Hant" : {
@@ -100897,7 +100897,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手册"
+            "value" : "手动"
           }
         },
         "zh-Hant" : {
@@ -101035,7 +101035,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未被发现返回的服务器的手动回退。"
+            "value" : "为自动发现未能返回的服务器提供的手动回退。"
           }
         },
         "zh-Hant" : {
@@ -101071,7 +101071,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手动 ID 字段位于高级选项下，用于发现无法看到的条目。"
+            "value" : "对于自动发现看不到的条目，可使用高级选项下的手动 ID 字段。"
           }
         },
         "zh-Hant" : {
@@ -101107,7 +101107,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手动 ID 是未被发现返回的聊天或发送者的回退。"
+            "value" : "手动 ID 是一种回退方式，用于自动发现未能返回的聊天或发送者。"
           }
         },
         "zh-Hant" : {
@@ -101143,7 +101143,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手动 ID 是受限 Slack 范围或未被发现返回的条目的回退。"
+            "value" : "手动 ID 是一种回退方式，适用于 Slack 权限范围受限或自动发现未能返回的条目。"
           }
         },
         "zh-Hant" : {
@@ -101177,7 +101177,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "如果/models缺失或返回的不是OpenAI格式的schema，则使用手动ID。"
+            "value" : "如果/models 缺失或返回的不是 OpenAI 格式的 schema，则使用手动 ID。"
           }
         },
         "zh-Hant" : {
@@ -101211,7 +101211,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "手动模式永远不会自动蒸馏。请使用“待蒸馏”或设置为会话结束。"
+            "value" : "手动模式绝不会自动蒸馏。请使用“蒸馏待处理项”，或设置为会话结束。"
           }
         },
         "zh-Hant" : {
@@ -101421,7 +101421,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将频道标记为已读，人员标记为允许 — 无需复制数字 ID。"
+            "value" : "将频道标记为“可读”，将人员标记为“允许” — 无需复制数字 ID。"
           }
         },
         "zh-Hant" : {
@@ -101457,7 +101457,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将聊天标记为已读以便智能体可以看到，将人员标记为允许以便其消息被处理。手动 ID 字段位于高级选项下。"
+            "value" : "将聊天标记为“可读”以便智能体可以看到，将人员标记为“允许”以便处理其消息。手动 ID 字段位于高级选项下。"
           }
         },
         "zh-Hant" : {
@@ -101600,7 +101600,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "遮蔽功能在设备上运行，使用 OCR + 隐私过滤器（您配置的规则加上设备上的姓名/地址/日期/密钥识别模型）。检测并不完美 — 可能会遗漏 OCR 无法读取或模型无法识别的文本 — 因此「仅遮蔽敏感文本」在隐私和模型获取更多上下文之间做了权衡。截图还需要屏幕录制权限；没有该权限智能体只能使用辅助功能文本。"
+            "value" : "遮蔽功能在设备上运行，使用 OCR + 隐私过滤器（你配置的规则加上设备上的姓名/地址/日期/密钥识别模型）。检测并不完美 — 可能会遗漏 OCR 无法读取或模型无法识别的文本 — 因此「仅遮蔽敏感文本」在隐私和模型获取更多上下文之间做了权衡。截图还需要屏幕录制权限；没有该权限智能体只能使用辅助功能文本。"
           }
         },
         "zh-Hant" : {
@@ -102019,7 +102019,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个子智能体的最大输出令牌数"
+            "value" : "每个子智能体的最大输出 Token 数"
           }
         },
         "zh-Hant" : {
@@ -102333,7 +102333,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大显示的Toast数量"
+            "value" : "最大显示的 Toast 数量"
           }
         },
         "zh-Hant" : {
@@ -102368,7 +102368,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同时运行的最大后台任务数。空值使用默认5"
+            "value" : "同时运行的最大后台任务数。空值使用默认 5"
           }
         },
         "zh-Hant" : {
@@ -102403,7 +102403,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此记忆模式下每个聊天槽的最大缓存词元数。"
+            "value" : "此记忆模式下每个聊天槽的最大缓存 Token 数。"
           }
         },
         "zh-Hant" : {
@@ -102508,7 +102508,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大响应词元数"
+            "value" : "最大响应 Token 数"
           }
         },
         "zh-Hant" : {
@@ -102543,7 +102543,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一次显示的最大Toast数量。空值则使用默认的5个"
+            "value" : "一次显示的最大 Toast 数量。空值则使用默认的 5 个"
           }
         },
         "zh-Hant" : {
@@ -102929,7 +102929,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MCP Server Hub 诊断"
+            "value" : "MCP 服务器中心诊断"
           }
         },
         "zh-Hant" : {
@@ -103255,7 +103255,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存与重载"
+            "value" : "记忆与回忆"
           }
         },
         "zh-Hant" : {
@@ -103361,7 +103361,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存预算"
+            "value" : "记忆预算"
           }
         },
         "zh-Hant" : {
@@ -103466,7 +103466,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库已重新打开。"
+            "value" : "记忆数据库已重新打开。"
           }
         },
         "zh-Hant" : {
@@ -103501,7 +103501,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库已打开"
+            "value" : "记忆数据库已打开"
           }
         },
         "zh-Hant" : {
@@ -103535,7 +103535,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全局禁用记忆。"
+            "value" : "记忆已全局禁用。"
           }
         },
         "zh-Hant" : {
@@ -103827,7 +103827,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重复失败后内存信号已进入死信队列。"
+            "value" : "记忆信号在多次失败后已进入死信队列。"
           }
         },
         "zh-Hant" : {
@@ -103863,7 +103863,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存存储重置。"
+            "value" : "记忆存储已重置。"
           }
         },
         "zh-Hant" : {
@@ -103899,7 +103899,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存存储重置。旧文件保存在%@。"
+            "value" : "记忆存储已重置。旧文件保留在 %@。"
           }
         },
         "zh-Hant" : {
@@ -104008,7 +104008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MemoryService.bufferTurn 自应用启动后尚未被调用。聊天结束流程未到达该方法——可能是上游的某个网关（每个智能体的 disableMemory、hasContent=false 或非默认聊天路径）导致的。"
+            "value" : "MemoryService.bufferTurn 自应用启动后尚未被调用。聊天收尾流程未到达该方法——可能是上游的某个门控条件（各智能体的 disableMemory、hasContent=false 或非默认聊天路径）导致的。"
           }
         },
         "zh-Hant" : {
@@ -104912,7 +104912,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最小值"
+            "value" : "最小"
           }
         },
         "zh-Hant" : {
@@ -105057,7 +105057,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MiniMax M系列模型"
+            "value" : "MiniMax M 系列模型"
           }
         },
         "zh-Hant" : {
@@ -105093,7 +105093,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最低充值金额为5.00美元"
+            "value" : "最低充值金额为 5.00 美元"
           }
         },
         "zh-Hant" : {
@@ -105307,7 +105307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "缺少API密钥"
+            "value" : "缺少 API 密钥"
           }
         },
         "zh-Hant" : {
@@ -105341,7 +105341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "缺少ChatGPT/Codex登录令牌。再次使用ChatGPT登录，然后重试提供商。"
+            "value" : "缺少 ChatGPT/Codex 登录令牌。再次使用 ChatGPT 登录，然后重试提供商。"
           }
         },
         "zh-Hant" : {
@@ -105547,7 +105547,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐藏模式"
+            "value" : "模式已隐藏"
           }
         },
         "zh-Hant" : {
@@ -105901,7 +105901,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型下载将使用您账户更高的速率限制和受限存储库访问权限。"
+            "value" : "模型下载会使用你账户更高的速率限制和受限仓库访问权限。"
           }
         },
         "zh-Hant" : {
@@ -106179,7 +106179,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型记忆"
+            "value" : "模型内存"
           }
         },
         "zh-Hant" : {
@@ -106454,7 +106454,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型请求和余额变动，按最新排序。当此Mac有匹配的副本时，打开聊天或洞察。"
+            "value" : "模型请求和余额变动，按最新排序。当此 Mac 有匹配的副本时，打开聊天或洞察。"
           }
         },
         "zh-Hant" : {
@@ -106592,7 +106592,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型总数"
+            "value" : "模型用量合计"
           }
         },
         "zh-Hant" : {
@@ -106797,7 +106797,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保存后重新加载模型"
+            "value" : "保存后将重新加载模型"
           }
         },
         "zh-Hant" : {
@@ -107348,7 +107348,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滚动时自动加载更多行 — 现在获取下一批。"
+            "value" : "滚动时会自动加载更多行——点按此按钮可立即获取下一批。"
           }
         },
         "zh-Hant" : {
@@ -107417,7 +107417,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "大多数客户端默认为1337（Osaurus）或11434（Ollama兼容）。"
+            "value" : "大多数客户端默认为 1337（Osaurus）或 11434（Ollama 兼容）。"
           }
         },
         "zh-Hant" : {
@@ -107525,7 +107525,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移动或删除%1$@，然后使用mkdir -p \"%2$@\"创建目录。"
+            "value" : "移动或删除 %1$@，然后使用 mkdir -p “%2$@”创建目录。"
           }
         },
         "zh-Hant" : {
@@ -107559,7 +107559,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移动或删除%@目录，然后重新运行沙盒设置。"
+            "value" : "移动或删除 %@ 目录，然后重新运行沙盒设置。"
           }
         },
         "zh-Hant" : {
@@ -107662,7 +107662,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "多语言模型。支持25种欧洲语言。推荐给大多数用户。"
+            "value" : "多语言模型。支持 25 种欧洲语言。推荐给大多数用户。"
           }
         },
         "zh-Hant" : {
@@ -107772,7 +107772,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "我的MCP服务器"
+            "value" : "我的 MCP 服务器"
           }
         },
         "zh-Hant" : {
@@ -108049,7 +108049,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地的"
+            "value" : "原生"
           }
         },
         "zh-Hant" : {
@@ -108748,7 +108748,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "网络积分"
+            "value" : "净积分"
           }
         },
         "zh-Hant" : {
@@ -108850,7 +108850,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "网络和中继呼叫者在您创建访问密钥之前是受限的。"
+            "value" : "网络和中继呼叫者在你创建访问密钥之前是受限的。"
           }
         },
         "zh-Hant" : {
@@ -108884,7 +108884,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "网络和转接呼叫者必须出示访问密钥。网络暴露开启时，本地环回绕过被禁用。"
+            "value" : "网络和中继调用方必须出示访问密钥。开启网络暴露时，本地环回绕过将被禁用。"
           }
         },
         "zh-Hant" : {
@@ -109346,7 +109346,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新数据将使用SQLCipher进行加密。"
+            "value" : "新数据将使用 SQLCipher 进行加密。"
           }
         },
         "zh-Hant" : {
@@ -109380,7 +109380,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "新数据将以明文形式存储，并受FileVault保护。"
+            "value" : "新数据将以明文形式存储，并受 FileVault 保护。"
           }
         },
         "zh-Hant" : {
@@ -110006,7 +110006,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无账户或设备标识"
+            "value" : "无账户或设备画像"
           }
         },
         "zh-Hant" : {
@@ -110352,7 +110352,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "暂无可授予的智能体。请先创建智能体，然后在其“特性”部分中为其启用知识。"
+            "value" : "暂无可授予的智能体。请先创建智能体，然后在其“功能”部分中为其启用知识。"
           }
         },
         "zh-Hant" : {
@@ -110420,7 +110420,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "还没有智能体 - 请在“智能体”标签页创建一个"
+            "value" : "还没有智能体 — 请在“智能体”标签页创建一个"
           }
         },
         "zh-Hant" : {
@@ -110594,7 +110594,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus未添加授权头。"
+            "value" : "Osaurus 未添加授权头。"
           }
         },
         "zh-Hant" : {
@@ -110735,7 +110735,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有缓冲的对话轮次，也没有片段——请检查每个智能体的记忆。"
+            "value" : "没有缓冲的对话轮次，也没有情景——请检查每个智能体的记忆。"
           }
         },
         "zh-Hant" : {
@@ -111052,7 +111052,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有为该提供商保存Codex OAuth令牌。"
+            "value" : "没有为该提供商保存 Codex OAuth 令牌。"
           }
         },
         "zh-Hant" : {
@@ -111814,7 +111814,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "还没有情节"
+            "value" : "还没有情景"
           }
         },
         "zh-Hant" : {
@@ -112270,7 +112270,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有安装的插件拥有此捕获功能。"
+            "value" : "没有任何已安装的插件拥有此捕获能力。"
           }
         },
         "zh-Hant" : {
@@ -112339,7 +112339,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尚未安装此共享ID的主题。"
+            "value" : "尚未安装此共享 ID 的主题。"
           }
         },
         "zh-Hant" : {
@@ -112614,7 +112614,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此特定包尚未记录实时工具调用验证。"
+            "value" : "此特定捆绑包尚未记录实时工具调用证明。"
           }
         },
         "zh-Hant" : {
@@ -112648,7 +112648,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这里尚未记录本地基准测试证明。通过的行需要可见的输出、词元/秒、RAM 状态、取消操作以及缓存证据。"
+            "value" : "这里尚未记录本地基准测试证明。通过的行需要可见的输出、Token/秒、RAM 状态、取消操作以及缓存证据。"
           }
         },
         "zh-Hant" : {
@@ -112992,7 +112992,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有匹配 — 不会有任何内容被删除。"
+            "value" : "没有匹配 — 不会有任何内容被脱敏。"
           }
         },
         "zh-Hant" : {
@@ -113383,7 +113383,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有导入 MCP 提供者；%lld 已声明。"
+            "value" : "未导入任何 MCP 提供商；已声明 %lld 个。"
           }
         },
         "zh-Hant" : {
@@ -114003,7 +114003,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有为此提供者保存OAuth令牌。"
+            "value" : "没有为此提供商保存 OAuth 令牌。"
           }
         },
         "zh-Hant" : {
@@ -114073,7 +114073,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有未完成文件更改"
+            "value" : "没有待处理的文件更改"
           }
         },
         "zh-Hant" : {
@@ -114458,7 +114458,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无提示"
+            "value" : "无提示词"
           }
         },
         "zh-Hant" : {
@@ -114526,7 +114526,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有可重新排序的供应商。"
+            "value" : "没有可重新排序的提供商。"
           }
         },
         "zh-Hant" : {
@@ -114597,7 +114597,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尚未收到决定"
+            "value" : "暂无接收决策"
           }
         },
         "zh-Hant" : {
@@ -114667,7 +114667,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未连接远程提供商。连接后，Osaurus 路由器和您自己的提供商模型将显示在这里。"
+            "value" : "未连接远程提供商。连接后，Osaurus 路由器和你自己的提供商模型将显示在这里。"
           }
         },
         "zh-Hant" : {
@@ -114770,7 +114770,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有捕获该行的请求"
+            "value" : "未捕获此行的请求"
           }
         },
         "zh-Hant" : {
@@ -114909,7 +114909,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有捕获响应体"
+            "value" : "未捕获响应正文"
           }
         },
         "zh-Hant" : {
@@ -115155,7 +115155,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "暂无规则——每个应用都使用您的默认设置。"
+            "value" : "暂无规则——每个应用都使用你的默认设置。"
           }
         },
         "zh-Hant" : {
@@ -115225,7 +115225,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "暂无运行记录。当代理按计划或自动运行时，每次运行都会显示在此处。"
+            "value" : "暂无运行记录。当智能体按计划或自动运行时，每次运行都会显示在此处。"
           }
         },
         "zh-Hant" : {
@@ -115330,7 +115330,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未导入日程；%lld 已声明。"
+            "value" : "未导入任何计划；已声明 %lld 个。"
           }
         },
         "zh-Hant" : {
@@ -115570,7 +115570,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尚无签名检查"
+            "value" : "暂无已签名的检查"
           }
         },
         "zh-Hant" : {
@@ -115638,7 +115638,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未导入技能；%lld 已声明。"
+            "value" : "未导入任何技能；已声明 %lld 个。"
           }
         },
         "zh-Hant" : {
@@ -115812,7 +115812,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未导入斜杠命令；%lld 已声明。"
+            "value" : "未导入任何斜杠命令；已声明 %lld 个。"
           }
         },
         "zh-Hant" : {
@@ -116800,7 +116800,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有为此提供者保存 xAI OAuth 令牌。"
+            "value" : "没有为此提供商保存 xAI OAuth 令牌。"
           }
         },
         "zh-Hant" : {
@@ -117042,7 +117042,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不是MLX模型"
+            "value" : "不是 MLX 模型"
           }
         },
         "zh-Hant" : {
@@ -117322,7 +117322,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此智能体未启用"
+            "value" : "未对此智能体启用"
           }
         },
         "zh-Hant" : {
@@ -117466,7 +117466,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "冷启动配置所需空闲磁盘空间不足"
+            "value" : "冷预配所需的可用磁盘空间不足"
           }
         },
         "zh-Hant" : {
@@ -117672,7 +117672,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不是MLX"
+            "value" : "不是 MLX"
           }
         },
         "zh-Hant" : {
@@ -117815,7 +117815,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未配置"
+            "value" : "未预配"
           }
         },
         "zh-Hant" : {
@@ -118300,7 +118300,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不用于stdio"
+            "value" : "不用于 stdio"
           }
         },
         "zh-Hant" : {
@@ -119100,7 +119100,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要OAuth登录"
+            "value" : "需要 OAuth 登录"
           }
         },
         "zh-Hant" : {
@@ -119134,7 +119134,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OAuth令牌已保存"
+            "value" : "OAuth 令牌已保存"
           }
         },
         "zh-Hant" : {
@@ -119179,7 +119179,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "占模型约 %1$@ token 窗口的 %2$@"
+            "value" : "占模型约 %1$@ Token 窗口的 %2$@"
           }
         },
         "zh-Hant" : {
@@ -119423,7 +119423,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭则仅绑定到127.0.0.1（仅此Mac）。开启则绑定到0.0.0.0，这样手机、iPad和其他网络设备就可以连接。"
+            "value" : "关闭则仅绑定到 127.0.0.1（仅此 Mac）。开启则绑定到 0.0.0.0，这样手机、iPad 和其他网络设备就可以连接。"
           }
         },
         "zh-Hant" : {
@@ -119492,7 +119492,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "默认关闭。需要辅助功能。每次对话开始时都冻结了。"
+            "value" : "默认关闭。需要辅助功能。该设置在每次对话开始时冻结。"
           }
         },
         "zh-Hant" : {
@@ -119946,7 +119946,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设备上"
+            "value" : "设备端"
           }
         },
         "zh-Hant" : {
@@ -120016,7 +120016,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在现代Mac上，文件保险箱已经在静态时对整个磁盘进行加密。明文存储依赖于这一点，并且是最可靠的选择——它从不依赖于钥匙串密钥。"
+            "value" : "在现代 Mac 上，文件保险箱已经在静态时对整个磁盘进行加密。明文存储依赖于这一点，并且是最可靠的选择——它从不依赖于钥匙串密钥。"
           }
         },
         "zh-Hant" : {
@@ -120499,7 +120499,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一个或多个检查无法被证明；复制报告以供支持或CI证明。"
+            "value" : "一个或多个检查无法被证明；复制报告以供支持或 CI 证明。"
           }
         },
         "zh-Hant" : {
@@ -120603,7 +120603,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅接受的 token 进入基础缓存"
+            "value" : "仅已接受的 Token 进入基础缓存"
           }
         },
         "zh-Hant" : {
@@ -120674,7 +120674,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每步仅考虑概率最高的 K 个 token。"
+            "value" : "每步仅考虑概率最高的 K 个 Token。"
           }
         },
         "zh-Hant" : {
@@ -120849,7 +120849,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只有选定的人员才能触发入站处理。空的发送者列表会保持 Slack 接收禁用。"
+            "value" : "只有选定的人员才能触发入站处理。发送者列表为空时，Slack 接收将保持禁用。"
           }
         },
         "zh-Hant" : {
@@ -121715,7 +121715,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开放身份"
+            "value" : "打开身份"
           }
         },
         "zh-Hant" : {
@@ -122211,7 +122211,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开沙盒设置或运行设置以写入%@。"
+            "value" : "打开沙盒设置或运行设置以写入 %@。"
           }
         },
         "zh-Hant" : {
@@ -122849,7 +122849,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在浏览器中打开此 URL 并选择您的服务器。"
+            "value" : "在浏览器中打开此 URL 并选择你的服务器。"
           }
         },
         "zh-Hant" : {
@@ -122954,7 +122954,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开网络"
+            "value" : "打开网页"
           }
         },
         "zh-Hant" : {
@@ -123022,7 +123022,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Azure AI Foundry 中打开您的 Azure OpenAI 资源"
+            "value" : "在 Azure AI Foundry 中打开你的 Azure OpenAI 资源"
           }
         },
         "zh-Hant" : {
@@ -123058,7 +123058,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开您的 Slack 应用设置"
+            "value" : "打开你的 Slack 应用设置"
           }
         },
         "zh-Hant" : {
@@ -123233,7 +123233,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OpenAI 返回了一个无法阅读的 Codex 模型目录：%@"
+            "value" : "OpenAI 返回了无法解析的 Codex 模型目录：%@"
           }
         },
         "zh-Hant" : {
@@ -123267,7 +123267,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OpenAI令牌请求失败：%@"
+            "value" : "OpenAI 令牌请求失败：%@"
           }
         },
         "zh-Hant" : {
@@ -124253,7 +124253,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在模型捆绑是本地的之前，Osaurus无法证明运行时行为。"
+            "value" : "在模型捆绑包下载到本地之前，Osaurus 无法验证其运行时行为。"
           }
         },
         "zh-Hant" : {
@@ -124394,7 +124394,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 暂时无法连接模型。请重试连接、在这台 Mac 上运行私有模型，或使用你自己的服务商。"
+            "value" : "Osaurus 暂时无法连接模型。请重试连接、在这台 Mac 上运行私有模型，或使用你自己的提供商。"
           }
         },
         "zh-Hant" : {
@@ -124747,7 +124747,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus本地模型"
+            "value" : "Osaurus 本地模型"
           }
         },
         "zh-Hant" : {
@@ -125072,7 +125072,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 路由器已关闭"
+            "value" : "Osaurus 路由已关闭"
           }
         },
         "zh-Hant" : {
@@ -125185,7 +125185,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 支持兼容 MLX 的 Hugging Face 仓库，包括在具备所需文件时的 MLX、MXFP、JANG、JANGTQ 和 TurboQuant 工件。"
+            "value" : "Osaurus 支持兼容 MLX 的 Hugging Face 仓库，在所需文件齐全时也包括 MLX、MXFP、JANG、JANGTQ 和 TurboQuant 工件。"
           }
         },
         "zh-Hant" : {
@@ -125219,7 +125219,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus将在行切换关闭时不会自动连接此MCP提供商。"
+            "value" : "行开关关闭时，Osaurus 不会自动连接此 MCP 提供商。"
           }
         },
         "zh-Hant" : {
@@ -125253,7 +125253,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus将在行切换关闭时不会自动连接此提供者。"
+            "value" : "行开关关闭时，Osaurus 不会自动连接此提供商。"
           }
         },
         "zh-Hant" : {
@@ -125289,7 +125289,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 将使用存储在 macOS Keychain 中的密钥，用 SQLCipher 重新加密您的数据库和附件。如果该密钥丢失（例如清除 Keychain、重新签名应用程序或在不使用 iCloud Keychain 的情况下迁移 Mac），则加密数据将无法恢复。如果您依赖这些数据，请保留明文备份。"
+            "value" : "Osaurus 将使用存储在 macOS Keychain 中的密钥，用 SQLCipher 重新加密你的数据库和附件。如果该密钥丢失（例如清除 Keychain、重新签名应用程序或在不使用 iCloud Keychain 的情况下迁移 Mac），则加密数据将无法恢复。如果你依赖这些数据，请保留明文备份。"
           }
         },
         "zh-Hant" : {
@@ -125323,7 +125323,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus将完全在本地免费运行。通过Osaurus路由的云模型将被隐藏，任何使用Osaurus的聊天都将切换到本地模型。你可以随时重新打开它。感谢您对Osaurus的支持。"
+            "value" : "Osaurus 将完全本地免费运行。通过 Osaurus 路由的云模型将被隐藏，正在使用这类模型的聊天将切换到本地模型。你可以随时重新开启。感谢你对 Osaurus 的支持。"
           }
         },
         "zh-Hant" : {
@@ -125357,7 +125357,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus将使用默认的沙盒设置，直到保存配置文件。"
+            "value" : "Osaurus 将使用默认的沙盒设置，直到保存配置文件。"
           }
         },
         "zh-Hant" : {
@@ -125471,7 +125471,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "出站仅限于配置代理允许的域名"
+            "value" : "出站仅限于配置智能体允许的域名"
           }
         },
         "zh-Hant" : {
@@ -125679,7 +125679,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "输出词元"
+            "value" : "输出 Token"
           }
         },
         "zh-Hant" : {
@@ -126029,7 +126029,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让传入的 token 以稳定的速率逐字出现，这样无论哪个远程提供商，流式输出都像打字机一样连贯。禁用此功能后，token 会在到达时立即渲染 — 这对于您希望立即完成的非常快速的远程提供者很有用。"
+            "value" : "让传入的 Token 以稳定的速率逐字出现，使所有提供商的流式输出都像打字机一样连贯。禁用后，Token 会在到达时立即渲染 — 适用于速度极快、你更希望立即看到完整回复的远程提供商。"
           }
         },
         "zh-Hant" : {
@@ -126063,7 +126063,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "软件包名称（例如python3）"
+            "value" : "软件包名称（例如 python3）"
           }
         },
         "zh-Hant" : {
@@ -126751,7 +126751,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "传入 onClearChat 处理器以启用 /clear"
+            "value" : "传入 onClearChat 处理程序以启用 /clear"
           }
         },
         "zh-Hant" : {
@@ -127115,7 +127115,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴有效的ID或链接以查看标准化的服务器详情。"
+            "value" : "粘贴有效的 ID 或链接以查看标准化的服务器详情。"
           }
         },
         "zh-Hant" : {
@@ -127183,7 +127183,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在行内提示中粘贴API令牌或编辑提供商。"
+            "value" : "在行内提示中粘贴 API 令牌或编辑提供商。"
           }
         },
         "zh-Hant" : {
@@ -127427,7 +127427,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将其粘贴在下方。它会保存在您的 macOS 钥匙串中。"
+            "value" : "将其粘贴在下方。它会保存在你的 macOS 钥匙串中。"
           }
         },
         "zh-Hant" : {
@@ -127499,7 +127499,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴文本进行测试..."
+            "value" : "粘贴文本进行测试…"
           }
         },
         "zh-Hant" : {
@@ -127607,7 +127607,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在上方粘贴机器人令牌并按访问部分的“从 Discord 加载”，然后邀请链接会出现在此处。（您也可以在开发者门户中使用 OAuth2 → URL 生成器，选择 bot 范围。）"
+            "value" : "在上方粘贴机器人令牌并按访问部分的“从 Discord 加载”，然后邀请链接会出现在此处。（你也可以在开发者门户中使用 OAuth2 → URL 生成器，选择 bot 范围。）"
           }
         },
         "zh-Hant" : {
@@ -127921,7 +127921,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴您的 API 密钥 — 将通过真实搜索进行验证"
+            "value" : "粘贴你的 API 密钥 — 将通过真实搜索进行验证"
           }
         },
         "zh-Hant" : {
@@ -127955,7 +127955,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴您的机器人令牌"
+            "value" : "粘贴你的机器人令牌"
           }
         },
         "zh-Hant" : {
@@ -127989,7 +127989,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "粘贴您的签名密钥"
+            "value" : "粘贴你的签名密钥"
           }
         },
         "zh-Hant" : {
@@ -128057,7 +128057,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "小路"
+            "value" : "路径"
           }
         },
         "zh-Hant" : {
@@ -128193,7 +128193,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PATH问题"
+            "value" : "PATH 问题"
           }
         },
         "zh-Hant" : {
@@ -128907,7 +128907,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "待邀请 · %@…"
+            "value" : "待处理邀请 · %@…"
           }
         },
         "zh-Hant" : {
@@ -129047,7 +129047,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个代理的环境"
+            "value" : "按智能体的环境"
           }
         },
         "zh-Hant" : {
@@ -129152,7 +129152,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个代理的根文件系统模板"
+            "value" : "每个智能体的根文件系统模板"
           }
         },
         "zh-Hant" : {
@@ -129188,7 +129188,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个代理的热重启根文件系统"
+            "value" : "每个智能体的热重启根文件系统"
           }
         },
         "zh-Hant" : {
@@ -129371,7 +129371,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每会话KV限制（词元数）"
+            "value" : "每会话KV限制（Token 数）"
           }
         },
         "zh-Hant" : {
@@ -129477,7 +129477,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "感知功能默认在本机运行。如果智能体使用云端模型，您可以允许其发送截图以处理屏幕文字不足的极少数情况——但前提是敏感文字已在本地完成屏蔽。"
+            "value" : "感知功能默认在本机运行。如果智能体使用云端模型，你可以允许其发送截图以处理屏幕文字不足的极少数情况——但前提是敏感文字已在本地完成屏蔽。"
           }
         },
         "zh-Hant" : {
@@ -129548,7 +129548,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "永久删除此代理存储的每个表和行。代理本身保留。"
+            "value" : "永久删除此智能体存储的每个表和行。智能体本身保留。"
           }
         },
         "zh-Hant" : {
@@ -129582,7 +129582,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "永久删除身份、固定事实、情节和对话历史。"
+            "value" : "永久删除身份、固定事实、情景和对话历史。"
           }
         },
         "zh-Hant" : {
@@ -129766,7 +129766,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "权限策略被拒绝"
+            "value" : "权限策略为拒绝"
           }
         },
         "zh-Hant" : {
@@ -129974,7 +129974,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在支持的视频模型上允许携带视频的请求。"
+            "value" : "在支持的模型上允许携带视频的请求。"
           }
         },
         "zh-Hant" : {
@@ -130008,7 +130008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 SSD 上持久化内容寻址的提示检查点。与分页 RAM 缓存关闭时配合工作，重启后恢复最长匹配前缀；关闭以禁用磁盘复用。"
+            "value" : "在 SSD 上持久化内容寻址的提示检查点。即使分页 RAM 缓存关闭也能工作，重启后恢复最长匹配前缀；关闭以禁用磁盘复用。"
           }
         },
         "zh-Hant" : {
@@ -130042,7 +130042,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今日已持久化；这些字段的运行时使用者尚未实现。"
+            "value" : "目前仅做持久化；这些字段的运行时使用者尚未实现。"
           }
         },
         "zh-Hant" : {
@@ -130144,7 +130144,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "个人组织者"
+            "value" : "个人事务助理"
           }
         },
         "zh-Hant" : {
@@ -130822,7 +130822,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从概率总和达到 P 的最小 token 集合中进行选取。"
+            "value" : "从概率总和达到 P 的最小 Token 集合中进行选取。"
           }
         },
         "zh-Hant" : {
@@ -131178,7 +131178,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择此代理可以使用哪些工具"
+            "value" : "选择此智能体可以使用哪些工具"
           }
         },
         "zh-Hant" : {
@@ -131220,7 +131220,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择此代理可以使用哪些工具。技能来自共享库，始终可用。"
+            "value" : "选择此智能体可以使用哪些工具。技能来自共享库，始终可用。"
           }
         },
         "zh-Hant" : {
@@ -131256,7 +131256,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "为您的 Mac 精选"
+            "value" : "为你的 Mac 精选"
           }
         },
         "zh-Hant" : {
@@ -131613,7 +131613,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已固定事实被遗忘。"
+            "value" : "已遗忘固定事实。"
           }
         },
         "zh-Hant" : {
@@ -132185,7 +132185,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "计划批处理控制"
+            "value" : "计划中的批处理控制"
           }
         },
         "zh-Hant" : {
@@ -132254,7 +132254,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "计划控制"
+            "value" : "计划中的控制"
           }
         },
         "zh-Hant" : {
@@ -133103,7 +133103,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让 Osaurus 指向一个包含指南、模板、规范的文件夹，并授权给代理，让它们可以按需查阅。支持 Markdown、纯文本、代码、PDF、Word、Excel、PowerPoint 和 CSV 文件。"
+            "value" : "让 Osaurus 指向一个包含指南、模板、规范的文件夹，并授权给智能体，让它们可以按需查阅。支持 Markdown、纯文本、代码、PDF、Word、Excel、PowerPoint 和 CSV 文件。"
           }
         },
         "zh-Hant" : {
@@ -133138,7 +133138,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将 Osaurus 指向包含团队指南、标准、规范和表格等参考资料的文件夹，您的智能体即可按需搜索和阅读。Markdown、纯文本、代码、PDF、Word、Excel、PowerPoint 和 CSV 文件都会被索引，完全在您的 Mac 上进行。"
+            "value" : "将 Osaurus 指向包含团队指南、标准、规范和表格等参考资料的文件夹，你的智能体即可按需搜索和阅读。Markdown、纯文本、代码、PDF、Word、Excel、PowerPoint 和 CSV 文件都会被索引，完全在你的 Mac 上进行。"
           }
         },
         "zh-Hant" : {
@@ -133281,7 +133281,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当写入门允许时，将清理后的智能体响应发布回 Discord。"
+            "value" : "当写入门控允许时，将清理后的智能体响应发布回 Discord。"
           }
         },
         "zh-Hant" : {
@@ -133317,7 +133317,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在同一讨论串中发布所选智能体的清理响应。Slack 和全局写入以及写入允许列表仍然适用。"
+            "value" : "在同一讨论串中发布所选智能体清理后的响应。Slack 与全局写入设置以及写入允许列表仍然适用。"
           }
         },
         "zh-Hant" : {
@@ -133462,7 +133462,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预注册的 OAuth Client ID（留空以使用DCR）"
+            "value" : "预注册的 OAuth Client ID（留空以使用 DCR）"
           }
         },
         "zh-Hant" : {
@@ -133908,7 +133908,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "高级搜索通过 Osaurus 运行 `web_search` 工具 — 零设置即可获得更好的结果。搜索积分优先覆盖请求；之后，请求从此钱包计费。积分用完后，搜索自动切换到内置源。"
+            "value" : "高级搜索通过 Osaurus 运行 `web_search` 工具 — 零设置即可获得更好的结果。请求费用优先由搜索积分抵扣；积分用完后，请求将从此钱包计费。若积分耗尽，搜索会自动继续使用内置源。"
           }
         },
         "zh-Hant" : {
@@ -134282,7 +134282,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预览受限内存上下文"
+            "value" : "预览受限记忆上下文"
           }
         },
         "zh-Hant" : {
@@ -135094,7 +135094,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐私优先的AI"
+            "value" : "隐私优先的 AI"
           }
         },
         "zh-Hant" : {
@@ -135388,7 +135388,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "密钥"
+            "value" : "机密"
           }
         },
         "zh-Hant" : {
@@ -140509,7 +140509,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "任何公共GitHub仓库的问答"
+            "value" : "任何公共 GitHub 仓库的问答"
           }
         },
         "zh-Hant" : {
@@ -140683,7 +140683,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "量化一个在否则量化的捆绑包内未量化的绑定输出头（例如，Gemma 4 QAT的fp16 262k词汇头，E2B上每个解码标记约1GB读取）。q6与llama.cpp的GGUF Q6_K输出头的精度类别相匹配。从不改变捆绑包中预先量化的头，也不应用于全精度捆绑包。"
+            "value" : "对在整体已量化的模型包中仍以未量化形式提供的绑定输出头进行量化（例如 Gemma 4 QAT 的 fp16 262k 词表输出头，在 E2B 上每个解码 Token 约需读取 1 GB）。q6 与 llama.cpp 的 GGUF Q6_K 输出头精度等级相当。不会改动模型包中已预量化的输出头，也不会应用于全精度模型包。"
           }
         },
         "zh-Hant" : {
@@ -140751,7 +140751,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查询和管理Neon Postgres数据库"
+            "value" : "查询和管理 Neon Postgres 数据库"
           }
         },
         "zh-Hant" : {
@@ -140785,7 +140785,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查询和管理PayPal付款和订单"
+            "value" : "查询和管理 PayPal 付款和订单"
           }
         },
         "zh-Hant" : {
@@ -140819,7 +140819,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查询HubSpot联系人、交易和管道"
+            "value" : "查询 HubSpot 联系人、交易和管道"
           }
         },
         "zh-Hant" : {
@@ -142009,7 +142009,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "读"
+            "value" : "读取"
           }
         },
         "zh-Hant" : {
@@ -142186,7 +142186,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读和编辑 Webflow 网站和 CMS 项目"
+            "value" : "读取和编辑 Webflow 网站和 CMS 条目"
           }
         },
         "zh-Hant" : {
@@ -142254,7 +142254,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查看和管理Square的付款和订单"
+            "value" : "查看和管理 Square 的付款和订单"
           }
         },
         "zh-Hant" : {
@@ -142288,7 +142288,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读和管理Stripe客户、费用和订阅"
+            "value" : "读取和管理 Stripe 的客户、收费和订阅"
           }
         },
         "zh-Hant" : {
@@ -142322,7 +142322,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在已允许列表的聊天中读取和回复"
+            "value" : "在允许列表内的聊天中读取和回复"
           }
         },
         "zh-Hant" : {
@@ -142356,7 +142356,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在已允许列表的服务器中读取和回复"
+            "value" : "在允许列表内的服务器中读取和回复"
           }
         },
         "zh-Hant" : {
@@ -142390,7 +142390,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在已允许列表的工作区频道中读取和回复"
+            "value" : "在允许列表内的工作区频道中读取和回复"
           }
         },
         "zh-Hant" : {
@@ -142458,7 +142458,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "读取并更新monday.com的看板和项目"
+            "value" : "读取并更新 monday.com 的看板和项目"
           }
         },
         "zh-Hant" : {
@@ -142564,7 +142564,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "播放完成后自动大声朗读每条回复。仅限点播使用，请使用“朗读工具”功能。"
+            "value" : "流式输出完成后自动朗读每条回复。如只需按需朗读，请改用“朗读工具”功能。"
           }
         },
         "zh-Hant" : {
@@ -143085,7 +143085,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在屏幕上阅读和查找东西"
+            "value" : "读取和查找屏幕上的内容"
           }
         },
         "zh-Hant" : {
@@ -143120,7 +143120,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读和常规导航自动运行，遵循您的计算机使用自主级别 — 但输入操作会暂停等待您批准，而提交、购买、发送或清除数据始终会先询问。登录操作在您直接输入的窗口中进行，智能体永远不会看到您的密码。您可以随时从信息流中停止运行。"
+            "value" : "阅读和常规导航自动运行，遵循你的计算机使用自主级别 — 但输入操作会暂停等待你批准，而提交、购买、发送或清除数据始终会先询问。登录操作在你直接输入的窗口中进行，智能体永远不会看到你的密码。你可以随时从信息流中停止运行。"
           }
         },
         "zh-Hant" : {
@@ -143156,7 +143156,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读页面和常规导航自动运行，遵循您的计算机使用自主级别。"
+            "value" : "阅读页面和常规导航自动运行，遵循你的计算机使用自主级别。"
           }
         },
         "zh-Hant" : {
@@ -143262,7 +143262,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自述"
+            "value" : "README"
           }
         },
         "zh-Hant" : {
@@ -143296,7 +143296,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "阅读和导航运行；编辑和危险操作先询问。"
+            "value" : "读取和导航自动运行；编辑和危险操作会先询问。"
           }
         },
         "zh-Hant" : {
@@ -143549,7 +143549,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "准备使用"
+            "value" : "可以使用"
           }
         },
         "zh-Hant" : {
@@ -143723,7 +143723,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "推理努力"
+            "value" : "推理强度"
           }
         },
         "zh-Hant" : {
@@ -144317,7 +144317,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近的蒸馏尝试都失败了。检查近期活动以了解错误详情。"
+            "value" : "最近的蒸馏尝试都失败了。检查“最近活动”以了解错误详情。"
           }
         },
         "zh-Hant" : {
@@ -144678,7 +144678,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "服务器空闲时回收 GPU 和磁盘资源。今日已持久化；主机生命周期桥接器将在后续版本中推出。"
+            "value" : "服务器空闲时回收 GPU 和磁盘资源。目前设置已持久化；主机生命周期桥接器将在后续版本中推出。"
           }
         },
         "zh-Hant" : {
@@ -145231,7 +145231,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "恢复助记词"
+            "value" : "助记词"
           }
         },
         "zh-Hant" : {
@@ -145369,7 +145369,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已编辑的活动导出已复制"
+            "value" : "已脱敏的活动导出已复制"
           }
         },
         "zh-Hant" : {
@@ -146276,7 +146276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已注册%@工具；使用capabilities_load加载"
+            "value" : "已注册 %@ 工具；使用 capabilities_load 加载"
           }
         },
         "zh-Hant" : {
@@ -146694,7 +146694,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继电器关闭"
+            "value" : "中继已关闭"
           }
         },
         "zh-Hant" : {
@@ -146948,7 +146948,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请记住，设置后的第一次轮询仅激活光标；保存后发送新消息。"
+            "value" : "请记住，设置后的第一次轮询仅使游标就绪；保存后请发送一条新消息。"
           }
         },
         "zh-Hant" : {
@@ -147298,7 +147298,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "远程Osaurus"
+            "value" : "远程 Osaurus"
           }
         },
         "zh-Hant" : {
@@ -147438,7 +147438,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从你的自定义工具中移除\"%@\"？智能体将无法再使用其工具。"
+            "value" : "从你的自定义工具中移除“%@”？智能体将无法再使用其工具。"
           }
         },
         "zh-Hant" : {
@@ -147472,7 +147472,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除%@并重新运行沙盒设置，以便Osaurus可以下载新的资源。"
+            "value" : "删除 %@ 并重新运行沙盒设置，以便 Osaurus 可以下载新的资源。"
           }
         },
         "zh-Hant" : {
@@ -147506,7 +147506,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除%@并重新运行设置。"
+            "value" : "删除 %@ 并重新运行设置。"
           }
         },
         "zh-Hant" : {
@@ -147756,7 +147756,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从白名单中移除"
+            "value" : "从允许列表中移除"
           }
         },
         "zh-Hant" : {
@@ -147858,7 +147858,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "移除镜像"
+            "value" : "移除图片"
           }
         },
         "zh-Hant" : {
@@ -147892,7 +147892,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除模型"
+            "value" : "移除模型"
           }
         },
         "zh-Hant" : {
@@ -147926,7 +147926,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除模型？"
+            "value" : "移除模型？"
           }
         },
         "zh-Hant" : {
@@ -147994,7 +147994,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除或移动%@，然后重新运行沙盒设置。"
+            "value" : "删除或移动 %@，然后重新运行沙盒设置。"
           }
         },
         "zh-Hant" : {
@@ -148416,7 +148416,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从列表中删除此条目。"
+            "value" : "从列表中移除此条目。"
           }
         },
         "zh-Hant" : {
@@ -148833,7 +148833,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新排序供应商"
+            "value" : "重新排序提供商"
           }
         },
         "zh-Hant" : {
@@ -148867,7 +148867,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新排序供应商"
+            "value" : "重新排序提供商"
           }
         },
         "zh-Hant" : {
@@ -149011,7 +149011,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 1 个代理派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 1 个智能体派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149047,7 +149047,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 1 个代理派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 1 个智能体派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149130,7 +149130,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 %lld 个代理派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 %lld 个智能体派生新地址，并撤销当前主密钥下的 %lld 个过期访问密钥。持有这些密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149166,7 +149166,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修复将为 %lld 个代理派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
+            "value" : "修复将为 %lld 个智能体派生新地址，并撤销当前主密钥下的 1 个过期访问密钥。持有该密钥的现有配对和客户端将停止工作，直到重新颁发。"
           }
         },
         "zh-Hant" : {
@@ -149583,7 +149583,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用所选智能体的清理响应回复传入的 Telegram 消息。Telegram 和全局写入以及写入允许列表仍然适用。"
+            "value" : "使用所选智能体经过清理的响应回复传入的 Telegram 消息。Telegram 和全局写入以及写入允许列表仍然适用。"
           }
         },
         "zh-Hant" : {
@@ -149756,7 +149756,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "存储库不可用"
+            "value" : "仓库不可用"
           }
         },
         "zh-Hant" : {
@@ -149790,7 +149790,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "复制路径"
+            "value" : "复现路径"
           }
         },
         "zh-Hant" : {
@@ -149858,7 +149858,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请求正文不是聊天完成"
+            "value" : "请求体不是聊天补全请求"
           }
         },
         "zh-Hant" : {
@@ -150210,7 +150210,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请求仅运行在功能中定义的操作，并且在发送前始终确认。"
+            "value" : "请求仅针对“功能”中定义的操作运行，并且在发送前始终会先确认。"
           }
         },
         "zh-Hant" : {
@@ -150316,7 +150316,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要 @提及"
+            "value" : "需要 @ 提及"
           }
         },
         "zh-Hant" : {
@@ -150527,7 +150527,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录需要"
+            "value" : "转录所需"
           }
         },
         "zh-Hant" : {
@@ -150561,7 +150561,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要语音输入"
+            "value" : "语音输入所需"
           }
         },
         "zh-Hant" : {
@@ -150633,7 +150633,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "接收消息所需。在您的 Slack 应用中，打开“基本信息” → “应用级令牌”，生成具有 connections:write 范围的令牌，然后粘贴到此处。这为 Socket Mode 提供动力 — 不涉及 webhook。"
+            "value" : "接收消息所需。在你的 Slack 应用中，打开“基本信息” → “应用级令牌”，生成具有 connections:write 范围的令牌，然后粘贴到此处。这为 Socket Mode 提供动力 — 不涉及 webhook。"
           }
         },
         "zh-Hant" : {
@@ -150667,7 +150667,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要输入到其他应用程序中"
+            "value" : "向其他应用程序输入文字所需"
           }
         },
         "zh-Hant" : {
@@ -150701,7 +150701,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要%@返回一个OpenAI风格的模型列表。"
+            "value" : "需要 %@ 返回一个 OpenAI 风格的模型列表。"
           }
         },
         "zh-Hant" : {
@@ -151399,7 +151399,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置内存存储？"
+            "value" : "重置记忆存储？"
           }
         },
         "zh-Hant" : {
@@ -151791,7 +151791,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已重置为默认主题"
+            "value" : "重置为默认主题"
           }
         },
         "zh-Hant" : {
@@ -151893,7 +151893,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置将清除沙盒插件状态。主机上的代理工作区文件将保留。"
+            "value" : "重置将清除沙盒插件状态。主机上的智能体工作区文件将保留。"
           }
         },
         "zh-Hant" : {
@@ -152030,7 +152030,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已解决的计划"
+            "value" : "解析后的计划"
           }
         },
         "zh-Hant" : {
@@ -152241,7 +152241,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "支持流式输出的响应端点"
+            "value" : "支持流式输出的 Responses 端点"
           }
         },
         "zh-Hant" : {
@@ -153491,7 +153491,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新加载插件？"
+            "value" : "重试加载插件？"
           }
         },
         "zh-Hant" : {
@@ -153701,7 +153701,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通过在聊天输入框中输入 / 调用的可重复使用提示词快捷指令"
+            "value" : "在聊天输入框中输入 / 即可调用的可复用提示词快捷指令"
           }
         },
         "zh-Hant" : {
@@ -153807,7 +153807,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "跨请求重用缓存的提示前缀，以缩短首 token 生成时间 (TTFT)。关闭时，GPU 和磁盘重用也将被禁用。"
+            "value" : "跨请求重用缓存的提示前缀，以缩短首个 Token 生成时间（TTFT）。关闭时，GPU 和磁盘重用也将被禁用。"
           }
         },
         "zh-Hant" : {
@@ -153946,7 +153946,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在访达中显示此智能体的沙盒主目录。"
+            "value" : "在 Finder 中显示此智能体的沙盒主目录。"
           }
         },
         "zh-Hant" : {
@@ -154413,7 +154413,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "撤销"
+            "value" : "已撤销"
           }
         },
         "zh-Hant" : {
@@ -154596,7 +154596,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "回滚到默认主题"
+            "value" : "已回滚到默认主题"
           }
         },
         "zh-Hant" : {
@@ -154632,7 +154632,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "传入消息可能来自的房间 ID。空值允许任何允许列表发送者的房间。"
+            "value" : "传入消息可能来自的房间 ID。留空表示允许列表中任何发送者所在的房间均可。"
           }
         },
         "zh-Hant" : {
@@ -155095,7 +155095,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由到 %@（名称 \"%@\"）"
+            "value" : "路由到 %@（名称 “%@”）"
           }
         },
         "zh-Hant" : {
@@ -155163,7 +155163,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器"
+            "value" : "路由"
           }
         },
         "zh-Hant" : {
@@ -155197,7 +155197,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器账户"
+            "value" : "路由账户"
           }
         },
         "zh-Hant" : {
@@ -155305,7 +155305,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "托管模型请求计费后，路由器使用情况将显示在此处。"
+            "value" : "托管模型请求计费后，路由使用情况将显示在此处。"
           }
         },
         "zh-Hant" : {
@@ -155562,7 +155562,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "智能体（或你）删除的行会显示在此处，准备恢复。"
+            "value" : "智能体（或你）删除的行会显示在此处，随时可以恢复。"
           }
         },
         "zh-Hant" : {
@@ -155804,7 +155804,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行本地签名检查以查看已编辑的请求形态。"
+            "value" : "运行本地签名检查以查看脱敏后的请求形态。"
           }
         },
         "zh-Hant" : {
@@ -155874,7 +155874,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在这台 Mac 上运行受限于沙盒工作区的代理命令。（macOS 26 或更高版本提供完整的 VM 隔离。）"
+            "value" : "在这台 Mac 上运行受限于沙盒工作区的智能体命令。（macOS 26 或更高版本提供完整的 VM 隔离。）"
           }
         },
         "zh-Hant" : {
@@ -156118,7 +156118,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行诊断以测试保存的连接与其端点。"
+            "value" : "下方的“运行诊断”会针对其端点测试已保存的连接。"
           }
         },
         "zh-Hant" : {
@@ -156226,7 +156226,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行ID：%@"
+            "value" : "运行 ID：%@"
           }
         },
         "zh-Hant" : {
@@ -156498,7 +156498,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在macOS 26或更高版本上运行Osaurus沙盒配置。"
+            "value" : "在 macOS 26 或更高版本上运行 Osaurus 沙盒配置。"
           }
         },
         "zh-Hant" : {
@@ -156566,7 +156566,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Apple 硅芯片 Mac 上运行沙盒配置。"
+            "value" : "在搭载 Apple 芯片的 Mac 上运行沙盒配置。"
           }
         },
         "zh-Hant" : {
@@ -156600,7 +156600,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行设置沙盒以便 Osaurus 可以创建或下载%@。"
+            "value" : "运行设置沙盒以便 Osaurus 可以创建或下载 %@。"
           }
         },
         "zh-Hant" : {
@@ -156635,7 +156635,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行Shell命令"
+            "value" : "运行 Shell 命令"
           }
         },
         "zh-Hant" : {
@@ -156811,7 +156811,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在私有频道会话中运行已验证的、允许列表中的 Slack 消息。外部表面工具限制仍然适用。"
+            "value" : "在私有频道会话中运行已验证且在允许列表中的 Slack 消息。面向外部的工具限制仍然适用。"
           }
         },
         "zh-Hant" : {
@@ -156847,7 +156847,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在私有频道会话中运行已验证的、允许列表中的 Telegram 消息。外部表面工具限制仍然适用。"
+            "value" : "在私有频道会话中运行已验证且在允许列表中的 Telegram 消息。面向外部的工具限制仍然适用。"
           }
         },
         "zh-Hant" : {
@@ -157086,7 +157086,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行控制其他应用的 AppleScript 需要 macOS 自动化权限。当智能体首次控制某个应用时，macOS 会要求你允许 Osaurus 对其进行控制。你可以现在预先授予系统事件权限。"
+            "value" : "运行控制其他应用的 AppleScript 需要 macOS 自动化权限。当智能体首次控制某个应用时，macOS 会要求你允许 Osaurus 对其进行控制。你可以现在预先授予 System Events 权限。"
           }
         },
         "zh-Hant" : {
@@ -157332,7 +157332,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "运行"
+            "value" : "运行记录"
           }
         },
         "zh-Hant" : {
@@ -157470,7 +157470,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在Osaurus沙盒中运行，并在断开连接时被销毁。"
+            "value" : "在 Osaurus 沙盒中运行，并在断开连接时被销毁。"
           }
         },
         "zh-Hant" : {
@@ -158369,7 +158369,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沙盒已启用 - 容器未运行"
+            "value" : "沙盒已启用 — 容器未运行"
           }
         },
         "zh-Hant" : {
@@ -158403,7 +158403,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沙盒处于活动状态 - 点击可禁用。右键打开设置。"
+            "value" : "沙盒处于活动状态 — 点击可禁用。右键打开设置。"
           }
         },
         "zh-Hant" : {
@@ -159275,7 +159275,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沙盒 MCP 服务器需要 macOS 26 或更高版本，在这台 Mac 上将无法启动。选择“主机”来运行此提供方 — 注意它将在没有沙盒保护的情况下运行。"
+            "value" : "沙盒 MCP 服务器需要 macOS 26 或更高版本，在这台 Mac 上将无法启动。选择“主机”来运行此提供商 — 注意它将在没有沙盒保护的情况下运行。"
           }
         },
         "zh-Hant" : {
@@ -160184,7 +160184,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今日已保存；请求管道将在后续步骤中开始强制执行这些设置。"
+            "value" : "目前这些设置仅会被保存；请求管道将在后续更新中开始强制执行。"
           }
         },
         "zh-Hant" : {
@@ -160671,7 +160671,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "扫描…"
+            "value" : "正在扫描…"
           }
         },
         "zh-Hant" : {
@@ -160739,7 +160739,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调度信息"
+            "value" : "计划信息"
           }
         },
         "zh-Hant" : {
@@ -160841,7 +160841,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将此智能体安排为按周期重复运行——非常适合每日简报或自动签到。"
+            "value" : "将此智能体安排为按周期重复运行——非常适合每日简报或自动定期汇报。"
           }
         },
         "zh-Hant" : {
@@ -160875,7 +160875,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已排程"
+            "value" : "已计划"
           }
         },
         "zh-Hant" : {
@@ -161051,7 +161051,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "日程"
+            "value" : "计划任务"
           }
         },
         "zh-Hant" : {
@@ -161087,7 +161087,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调度和监视器"
+            "value" : "计划任务和监视器"
           }
         },
         "zh-Hant" : {
@@ -161189,7 +161189,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "安排"
+            "value" : "计划"
           }
         },
         "zh-Hant" : {
@@ -161510,7 +161510,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "来自%@的屏幕上下文"
+            "value" : "来自 %@ 的屏幕上下文"
           }
         },
         "zh-Hant" : {
@@ -161578,7 +161578,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "屏幕录制权限需要用于截图（som/vision）捕获。"
+            "value" : "截图（som/vision）捕获需要屏幕录制权限。"
           }
         },
         "zh-Hant" : {
@@ -162132,7 +162132,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "搜索并编辑您的Canva设计"
+            "value" : "搜索并编辑你的Canva设计"
           }
         },
         "zh-Hant" : {
@@ -162166,7 +162166,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "专为 AI 代理打造的搜索 — 最佳回答质量用于语境锚定。"
+            "value" : "专为 AI 智能体打造的搜索 — 最佳回答质量用于语境锚定。"
           }
         },
         "zh-Hant" : {
@@ -163339,7 +163339,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "搜索首先通过 Osaurus — 搜索积分，然后你的钱包 — 并回退到下方的源。"
+            "value" : "搜索会优先经由 Osaurus——先用搜索积分，再用你的钱包——不足时回退到下方的搜索源。"
           }
         },
         "zh-Hant" : {
@@ -163720,7 +163720,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动关闭前几秒。空值使用默认5秒"
+            "value" : "自动关闭前的秒数。留空则使用默认 5 秒"
           }
         },
         "zh-Hant" : {
@@ -163790,7 +163790,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "密钥 \"%@\" 没有钥匙串 ID（期望 name=keychain-id）。"
+            "value" : "密钥“%@”没有钥匙串 ID（应为 name=keychain-id）。"
           }
         },
         "zh-Hant" : {
@@ -165440,7 +165440,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自我计划"
+            "value" : "自调度"
           }
         },
         "zh-Hant" : {
@@ -165476,7 +165476,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在自我计划"
+            "value" : "自调度"
           }
         },
         "zh-Hant" : {
@@ -166008,7 +166008,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "向机器人发送消息（或将其添加到群组并在那里发布），然后加载待处理的聊天和发送者。"
+            "value" : "向机器人发送消息（或将其添加到群组并在群里发言），然后加载待处理的聊天和发送者。"
           }
         },
         "zh-Hant" : {
@@ -166044,7 +166044,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "发送正在输入"
+            "value" : "发送“正在输入”状态"
           }
         },
         "zh-Hant" : {
@@ -166256,7 +166256,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "发送已暂停 — 每个频道都是只读"
+            "value" : "发送已暂停 — 所有频道均为只读"
           }
         },
         "zh-Hant" : {
@@ -166290,7 +166290,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "发送已全局暂停。代理仍可读取已允许列表的频道。"
+            "value" : "发送已全局暂停。智能体仍可读取允许列表中的频道。"
           }
         },
         "zh-Hant" : {
@@ -168294,7 +168294,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分享匿名使用数据以帮助改进 Osaurus"
+            "value" : "共享匿名使用数据以帮助改进 Osaurus"
           }
         },
         "zh-Hant" : {
@@ -168681,7 +168681,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "共享工作空间"
+            "value" : "共享工作区"
           }
         },
         "zh-Hant" : {
@@ -168749,7 +168749,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最清晰。大多数模型训练的尺寸，但最慢。"
+            "value" : "最清晰。这是大多数模型训练时采用的尺寸，但速度最慢。"
           }
         },
         "zh-Hant" : {
@@ -169110,7 +169110,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示%lld更多"
+            "value" : "再显示 %lld 项"
           }
         },
         "zh-Hant" : {
@@ -169393,7 +169393,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示更少"
+            "value" : "收起"
           }
         },
         "zh-Hant" : {
@@ -169495,7 +169495,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示更少"
+            "value" : "收起"
           }
         },
         "zh-Hant" : {
@@ -169859,7 +169859,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示 %lld-%lld 共 %lld"
+            "value" : "显示 %lld-%lld，共 %lld"
           }
         },
         "zh-Hant" : {
@@ -169894,7 +169894,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示 %lld-%lld 共 %lld 已加载"
+            "value" : "显示已加载 %3$lld 行中的第 %1$lld-%2$lld 行"
           }
         },
         "zh-Hant" : {
@@ -169962,7 +169962,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示精确的工具暴露状态、token 估算和导出"
+            "value" : "显示精确的工具暴露状态、Token 估算和导出"
           }
         },
         "zh-Hant" : {
@@ -170168,7 +170168,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 huggingface.co 登录（或免费注册）。"
+            "value" : "在 huggingface.co 登录（或免费注册）"
           }
         },
         "zh-Hant" : {
@@ -170407,7 +170407,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登录您的开发者帐户"
+            "value" : "登录你的开发者帐户"
           }
         },
         "zh-Hant" : {
@@ -170777,7 +170777,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用具有Codex访问权限的ChatGPT账户登录。"
+            "value" : "使用具有 Codex 访问权限的 ChatGPT 账户登录。"
           }
         },
         "zh-Hant" : {
@@ -170811,7 +170811,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用具有Grok API访问权限的xAI账户登录。"
+            "value" : "使用具有 Grok API 访问权限的 xAI 账户登录。"
           }
         },
         "zh-Hant" : {
@@ -171363,7 +171363,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已使用Grok登录。令牌存储在Keychain中。"
+            "value" : "已使用 Grok 登录。令牌存储在 Keychain 中。"
           }
         },
         "zh-Hant" : {
@@ -171679,7 +171679,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "静音超时"
+            "value" : "静默超时"
           }
         },
         "zh-Hant" : {
@@ -171785,7 +171785,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "简单模式会自动构建匹配规则。正则表达式模式允许您自行编写匹配规则，保存前会经过校验。"
+            "value" : "简单模式会自动构建匹配规则。正则表达式模式允许你自行编写匹配规则，保存前会经过校验。"
           }
         },
         "zh-Hant" : {
@@ -172796,7 +172796,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Slack 选项尚未加载。您可以刷新或使用高级手动 ID。"
+            "value" : "Slack 选项尚未加载。你可以刷新或使用高级手动 ID。"
           }
         },
         "zh-Hant" : {
@@ -173924,7 +173924,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "部分缓冲轮次达到重试上限并已进入死信队列。请查看近期活动了解失败原因，然后在修复模型/配置问题后回填或重新填充。"
+            "value" : "部分缓冲轮次达到重试上限并已进入死信队列。请查看近期活动了解失败原因，然后在修复模型/配置问题后回填或重新导入。"
           }
         },
         "zh-Hant" : {
@@ -174833,7 +174833,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "说话工具"
+            "value" : "朗读工具"
           }
         },
         "zh-Hant" : {
@@ -175144,7 +175144,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "块扩散模型（DiffusionGemma）的速度/质量预算。设为 16 时速度约为模型默认值的 2 倍，且保持画面连贯；低于 12 时质量下降。对常规模型无效。"
+            "value" : "块扩散模型（DiffusionGemma）的速度/质量预算。设为 16 时速度约为模型默认值的 2 倍，且输出保持连贯；低于 12 时质量下降。对常规模型无效。"
           }
         },
         "zh-Hant" : {
@@ -175284,7 +175284,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SQLCipher 添加了第二层加密：数据库和附件使用您钥匙串中的 256 位密钥进行加密。如果您共享 Mac 账户或未使用文件保险箱，这会很有用。"
+            "value" : "SQLCipher 添加了第二层加密：数据库和附件使用你钥匙串中的 256 位密钥进行加密。如果你共享 Mac 账户或未使用文件保险箱，这会很有用。"
           }
         },
         "zh-Hant" : {
@@ -175386,7 +175386,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "agent_channel 工具使用的稳定 ID。本地提供者 ID 已保留。"
+            "value" : "agent_channel 工具使用的稳定 ID。原生提供商 ID 已被保留。"
           }
         },
         "zh-Hant" : {
@@ -175713,7 +175713,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 完成本地 AI 设置时，您现在就可以开始聊天。"
+            "value" : "Osaurus 正在完成本地 AI 设置，你现在就可以开始聊天。"
           }
         },
         "zh-Hant" : {
@@ -175926,7 +175926,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "先使用免费的 Osaurus Cloud 额度——之后可随时下载模型。"
+            "value" : "先使用免费的 Osaurus Cloud 积分——之后可随时下载模型。"
           }
         },
         "zh-Hant" : {
@@ -176445,7 +176445,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在启动宿主 API 桥接"
+            "value" : "正在启动主机 API 桥接"
           }
         },
         "zh-Hant" : {
@@ -176932,7 +176932,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stdio命令缺失"
+            "value" : "Stdio 命令缺失"
           }
         },
         "zh-Hant" : {
@@ -177006,7 +177006,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stdio 提供程序会启动本地子进程，而不是通过 URLSession 发送 HTTP 流量。"
+            "value" : "Stdio 提供商会启动本地子进程，而不是通过 URLSession 发送 HTTP 流量。"
           }
         },
         "zh-Hant" : {
@@ -177147,7 +177147,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仍然无法打开内存 — 尝试重置。"
+            "value" : "仍然无法打开记忆 — 请尝试重置。"
           }
         },
         "zh-Hant" : {
@@ -177420,7 +177420,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "停止沙箱，移除%@，然后重新启动沙箱。"
+            "value" : "停止沙盒，移除 %@，然后重新启动沙盒。"
           }
         },
         "zh-Hant" : {
@@ -178210,7 +178210,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "存储在配置的Osaurus模型目录下。"
+            "value" : "存储在配置的 Osaurus 模型目录下。"
           }
         },
         "zh-Hant" : {
@@ -178909,7 +178909,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功: %@"
+            "value" : "成功：%@"
           }
         },
         "zh-Hant" : {
@@ -179045,7 +179045,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功：已授权（找到 %lld 个联系人）"
+            "value" : "成功：已授权（找到 %lld+ 个联系人）"
           }
         },
         "zh-Hant" : {
@@ -179215,7 +179215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功：连接到%@"
+            "value" : "成功：连接到 %@"
           }
         },
         "zh-Hant" : {
@@ -179249,7 +179249,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "成功：该进程已通过辅助功能验证。"
+            "value" : "成功：该进程已被授予辅助功能权限。"
           }
         },
         "zh-Hant" : {
@@ -179425,7 +179425,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "支持导出"
+            "value" : "导出支持数据"
           }
         },
         "zh-Hant" : {
@@ -179740,7 +179740,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换AI模型"
+            "value" : "切换 AI 模型"
           }
         },
         "zh-Hant" : {
@@ -179774,7 +179774,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换到全部并开启此代理应使用的工具。"
+            "value" : "切换到“全部”并开启此智能体应使用的工具。"
           }
         },
         "zh-Hant" : {
@@ -179808,7 +179808,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换到主机以使用受信任的工具或启动沙箱运行时。"
+            "value" : "切换到主机以使用受信任的工具，或启动沙盒运行时。"
           }
         },
         "zh-Hant" : {
@@ -181180,7 +181180,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Telegram 分发不支持提及限制。关闭 Telegram 的需要 @提及。"
+            "value" : "Telegram 分发不支持提及限制。请关闭 Telegram 的“需要 @提及”。"
           }
         },
         "zh-Hant" : {
@@ -181354,7 +181354,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Telegram 仍报告有已注册的 webhook。请稍候并重试。"
+            "value" : "Telegram 仍报告有已注册的 webhook。请稍候，然后再次检查。"
           }
         },
         "zh-Hant" : {
@@ -181663,7 +181663,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "图片生成时应避免的术语"
+            "value" : "图片生成时应避免的词语"
           }
         },
         "zh-Hant" : {
@@ -182628,7 +182628,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文字转语音"
+            "value" : "文本转语音"
           }
         },
         "zh-Hant" : {
@@ -182801,7 +182801,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "256位加密密钥存储在您的macOS钥匙串中。它永远不会离开这台Mac，并且不会同步到iCloud。"
+            "value" : "256位加密密钥存储在你的macOS钥匙串中。它永远不会离开这台Mac，并且不会同步到iCloud。"
           }
         },
         "zh-Hant" : {
@@ -183116,7 +183116,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "智能体仅在您请求时运行。代理的定时API调用被拒绝。"
+            "value" : "智能体仅在你请求时运行。来自智能体的定时 API 调用会被拒绝。"
           }
         },
         "zh-Hant" : {
@@ -183356,7 +183356,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浏览器现在是一个原生功能。此插件的工具和技能不再加载 — 在「设置」→「浏览器」中管理会话。您可以卸载此插件。"
+            "value" : "浏览器现在是一个原生功能。此插件的工具和技能不再加载 — 在「设置」→「浏览器」中管理会话。你可以卸载此插件。"
           }
         },
         "zh-Hant" : {
@@ -183596,7 +183596,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "配置文件是无效的 JSON 或形状不兼容。"
+            "value" : "配置文件不是有效的 JSON，或其结构不兼容。"
           }
         },
         "zh-Hant" : {
@@ -183666,7 +183666,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "容器的 /workspace 目录通过绑定挂载方式来自 ~/.osaurus/container/workspace/。在访达中打开它，可直接在主机上浏览或编辑文件。"
+            "value" : "容器的 /workspace 目录从 ~/.osaurus/container/workspace/ 绑定挂载而来。在访达中打开它，可直接在主机上浏览或编辑文件。"
           }
         },
         "zh-Hant" : {
@@ -183854,7 +183854,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该定义至少需要一个端点（例如 \"web\"）。"
+            "value" : "该定义至少需要一个端点（例如 “web”）。"
           }
         },
         "zh-Hant" : {
@@ -184029,7 +184029,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该文件不是一个可读的数据库（可能已损坏或密钥不匹配）。请重置以重新创建它；原始文件已被隔离。"
+            "value" : "该文件不是可读的数据库（可能已损坏或密钥不匹配）。请重置以重新创建它；原始文件会被隔离。"
           }
         },
         "zh-Hant" : {
@@ -184063,7 +184063,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "文件看起来可以加载，但这个特定的缓存后端包在被称为验证之前还需要一个真正的生成证明。"
+            "value" : "文件看起来可以加载，但这个基于缓存的捆绑包仍需要真实的生成证明，才能被视为已验证。"
           }
         },
         "zh-Hant" : {
@@ -184097,7 +184097,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "主机在加载期间因该插件导致崩溃后将其隔离。重试会再次运行相同的dylib针对相同的宿主构建，如果潜在的bug（通常是插件中的`osr_host_api`镜像对齐错误）未修复，它将再次崩溃。仅在插件已重新构建或重新安装后使用此功能。否则，请使用卸载来移除它。"
+            "value" : "宿主在该插件加载期间引发崩溃后将其隔离。重试会在同一宿主版本上重新运行同一个动态库（dylib），因此如果底层错误（最常见的是插件中 `osr_host_api` 镜像未对齐）未被修复，它将再次崩溃。请仅在插件已重新构建或重新安装后使用此操作。否则，请使用“卸载”将其移除。"
           }
         },
         "zh-Hant" : {
@@ -184131,7 +184131,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "宿主在该插件加载期间引发崩溃后将其隔离。重试会在同一宿主版本上重新运行同一个动态库（dylib），因此如果底层错误（最常见的是插件中 `osr_host_api` 镜像未对齐）未被修复，它将再次崩溃。请仅在您重新构建或重新安装插件后使用此操作。"
+            "value" : "宿主在该插件加载期间引发崩溃后将其隔离。重试会在同一宿主版本上重新运行同一个动态库（dylib），因此如果底层错误（最常见的是插件中 `osr_host_api` 镜像未对齐）未被修复，它将再次崩溃。请仅在你重新构建或重新安装插件后使用此操作。"
           }
         },
         "zh-Hant" : {
@@ -184167,7 +184167,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ID \"%@\" 已被内置提供商占用。请选择其他 ID。"
+            "value" : "ID “%@” 已被内置提供商占用。请选择其他 ID。"
           }
         },
         "zh-Hant" : {
@@ -184273,7 +184273,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上次搜索 %@ 未返回结果。请在下方尝试测试搜索，或连接提供商以获得更可靠的结果。"
+            "value" : "上次搜索（%@）未返回任何结果。请在下方尝试测试搜索，或连接提供商以获得更可靠的结果。"
           }
         },
         "zh-Hant" : {
@@ -184307,7 +184307,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该链接将停止工作。任何尝试使用它的人将被拒绝访问。"
+            "value" : "该链接将失效。任何尝试使用它的人都将被拒绝访问。"
           }
         },
         "zh-Hant" : {
@@ -184341,7 +184341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "本地目录中没有所需的MLX文件。"
+            "value" : "本地目录中没有所需的 MLX 文件。"
           }
         },
         "zh-Hant" : {
@@ -184377,7 +184377,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "清单已启用 Socket Mode 和消息事件订阅。您无需输入请求 URL — Osaurus 通过出站连接接收事件。"
+            "value" : "清单已启用 Socket Mode 和消息事件订阅。你无需输入请求 URL — Osaurus 通过出站连接接收事件。"
           }
         },
         "zh-Hant" : {
@@ -184445,7 +184445,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库因未知原因无法打开。"
+            "value" : "记忆数据库因未知原因未能打开。"
           }
         },
         "zh-Hant" : {
@@ -184481,7 +184481,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "内存数据库未打开。它可能仍在初始化，或者已静默失败——请尝试重试。"
+            "value" : "记忆数据库未打开。它可能仍在初始化，或者已静默失败——请尝试重试。"
           }
         },
         "zh-Hant" : {
@@ -184729,7 +184729,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "模型已运行但至少一个会话未返回可用片段。"
+            "value" : "模型已运行，但至少有一个会话未返回可用情景。"
           }
         },
         "zh-Hant" : {
@@ -184944,7 +184944,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus 智能体帮助您配置Osaurus。它不使用沙盒或工作文件夹。"
+            "value" : "Osaurus 智能体帮助你配置Osaurus。它不使用沙盒或工作文件夹。"
           }
         },
         "zh-Hant" : {
@@ -185046,7 +185046,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "插件的 `osr_host_api` 镜像结构体与主机的 v6 布局不匹配——最常见的是跳过了 v5 的 `log_structured` 槽位，导致之后的每个槽位都偏移了 8 个字节。随后插件会将 `host->free_string` 分派到错误的主机跳板，`libc free()` 在一个非 malloc 指针上中止，从而导致主机崩溃。有关固定偏移量以及记录在案的 v1..v6 演进，请参阅 `docs/plugins/HOST_API.md → Mirror Struct Audit` 和 `docs/plugins/ABI_VERSIONS.md`。"
+            "value" : "插件的 `osr_host_api` 镜像结构体与宿主的 v6 布局不匹配——最常见的是跳过了 v5 的 `log_structured` 槽位，导致之后的每个槽位都偏移了 8 个字节。随后插件会将 `host->free_string` 分派到错误的宿主跳板，`libc free()` 在一个非 malloc 指针上中止，从而导致宿主崩溃。有关固定偏移量以及记录在案的 v1..v6 演进，请参阅 `docs/plugins/HOST_API.md → Mirror Struct Audit` 和 `docs/plugins/ABI_VERSIONS.md`。"
           }
         },
         "zh-Hant" : {
@@ -185186,7 +185186,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提供者已配置，但尚未注册任何工具。"
+            "value" : "提供商已配置，但尚未注册任何工具。"
           }
         },
         "zh-Hant" : {
@@ -185290,7 +185290,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "提供商发送了 Osaurus 无法解码的信封。"
+            "value" : "提供商发送了 Osaurus 无法解码的消息信封。"
           }
         },
         "zh-Hant" : {
@@ -185469,7 +185469,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器将您的身份主密钥用作您的计费账户。在添加积分或调用Osaurus模型之前，请创建或恢复身份。"
+            "value" : "路由器将你的身份主密钥用作你的计费账户。在添加积分或调用Osaurus模型之前，请创建或恢复身份。"
           }
         },
         "zh-Hant" : {
@@ -185503,7 +185503,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple 硅芯片支持沙盒映像和容器化运行时。"
+            "value" : "Apple 芯片支持沙盒映像和 Containerization 运行时。"
           }
         },
         "zh-Hant" : {
@@ -185711,7 +185711,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设置完成标志为false，因此工具和智能体启动仍需要配置。"
+            "value" : "setupComplete 标志为 false，因此工具和智能体的启动仍需要完成配置。"
           }
         },
         "zh-Hant" : {
@@ -185815,7 +185815,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "stdio 提供者缺少一个命令。"
+            "value" : "stdio 提供商缺少命令。"
           }
         },
         "zh-Hant" : {
@@ -185851,7 +185851,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此Mac上的存储加密密钥不可用（钥匙串重置、应用程序重新签名或未使用iCloud钥匙串进行迁移）。无法使用当前密钥解密您的加密内存。"
+            "value" : "此 Mac 上的存储加密密钥不可用（钥匙串被重置、应用重新签名，或迁移时未使用 iCloud 钥匙串）。当前密钥无法解锁你加密的记忆数据。"
           }
         },
         "zh-Hant" : {
@@ -185886,7 +185886,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "存储因不明原因未能开业。重试，如果仍然存在，请重试或重置。"
+            "value" : "存储因未知原因未能打开。请重试；如果问题仍然存在，请重置。"
           }
         },
         "zh-Hant" : {
@@ -185920,7 +185920,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "任务仍在运行中。取消将终止它。"
+            "value" : "任务仍在运行。关闭将取消该任务。"
           }
         },
         "zh-Hant" : {
@@ -185954,7 +185954,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "测试按钮启动子进程，运行initialize/listTools，并将其关闭。"
+            "value" : "测试按钮启动子进程，运行 initialize/listTools，并将其关闭。"
           }
         },
         "zh-Hant" : {
@@ -186062,7 +186062,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "令牌或密钥头存储在明文提供者配置之外。"
+            "value" : "令牌或密钥标头存储在明文提供商配置之外。"
           }
         },
         "zh-Hant" : {
@@ -186097,7 +186097,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "权衡在于可靠性：如果钥匙串密钥丢失（如钥匙串被清除、应用程序重新签名或在未使用iCloud钥匙串的情况下迁移Mac），则无法打开加密数据。而明文数据则永远不会面临这种风险。"
+            "value" : "权衡在于可靠性：如果钥匙串密钥丢失（如钥匙串被清除、应用程序重新签名或在未使用 iCloud 钥匙串的情况下迁移 Mac），则无法打开加密数据。而明文数据则永远不会面临这种风险。"
           }
         },
         "zh-Hant" : {
@@ -186133,7 +186133,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法读取的数据库已被移动到 ~/.osaurus/quarantine/ 目录（不会被删除），并创建了一个全新的空内存存储，以便记忆和搜索功能再次正常工作。旧文件中的提炼事实和情节保留在隔离区——如果您可能需要恢复密钥，请先导出纯文本备份。"
+            "value" : "无法读取的数据库会被移至 ~/.osaurus/quarantine/（绝不会被删除），并创建一个全新的空记忆存储，以便记忆和搜索恢复正常。旧文件中的提炼事实和情景会保留在隔离区——如果你可能找回密钥，请先导出纯文本备份。"
           }
         },
         "zh-Hant" : {
@@ -186168,7 +186168,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工作任务仍在运行。取消将终止任务。"
+            "value" : "工作任务仍在运行。关闭将取消该任务。"
           }
         },
         "zh-Hant" : {
@@ -187120,7 +187120,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此代理声称支持加密但未包含可验证的身份，因此无法安全配对。它可能在冒充其他设备，或者对方设备可能需要更新 Osaurus。"
+            "value" : "此智能体声称支持加密，但未包含可验证的身份，因此无法安全配对。它可能在冒充其他设备，或者对方设备可能需要更新 Osaurus。"
           }
         },
         "zh-Hant" : {
@@ -187156,7 +187156,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此代理拥有其自己的隔离浏览器配置文件。在「设置」→「浏览器」中查看会话和登录状态。"
+            "value" : "此智能体拥有自己的隔离浏览器配置文件。在「设置」→「浏览器」中查看会话和登录状态。"
           }
         },
         "zh-Hant" : {
@@ -187227,7 +187227,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "该代理暂无可以分享的身份。请通过网络进行配对，或点击顶部\"分享\"按钮生成中继邀请，已连接的对等端将显示在此处。"
+            "value" : "该智能体暂无可分享的身份。请通过网络进行配对，或点击顶部“分享”按钮生成中继邀请，已连接的对等端将显示在此处。"
           }
         },
         "zh-Hant" : {
@@ -187335,7 +187335,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此代理的数据库接近存储上限。"
+            "value" : "此智能体的数据库接近存储上限。"
           }
         },
         "zh-Hant" : {
@@ -187446,7 +187446,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这个捆绑包不是MLX格式，因此本地引擎(vmlx)无法加载它。Osaurus只能运行MLX格式的权重——请使用mlx_lm进行转换，或选择该模型的MLX版本。"
+            "value" : "这个捆绑包不是 MLX 格式，因此本地引擎(vmlx)无法加载它。Osaurus 只能运行 MLX 格式的权重——请使用 mlx_lm 进行转换，或选择该模型的 MLX 版本。"
           }
         },
         "zh-Hant" : {
@@ -187764,7 +187764,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此操作将删除本地磁盘上的模型。该模型的检测功能将停止，直至您重新下载。"
+            "value" : "此操作将删除本地磁盘上的模型。该模型的检测功能将停止，直至你重新下载。"
           }
         },
         "zh-Hant" : {
@@ -188119,7 +188119,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此项为可选配置。即使不设置分类，智能体仍可搜索和读取这些文档。\n\n若要让智能体按分类筛选，可将文档移入对应文件夹（文件夹名即为分类），或在文档的前置元数据中添加 `type:` 字段。"
+            "value" : "此项为可选配置。即使不设置分类，智能体仍可搜索和读取这些文档。\n\n若要让智能体按分类筛选，可将文档移入对应文件夹（文件夹名即为分类），或在文档的前置元数据中添加 `type:` 字段。\n\n"
           }
         },
         "zh-Hant" : {
@@ -188471,7 +188471,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将永久删除 %@ 的浏览数据 — cookie、登录信息及历史记录。代理将以全新的配置文件重新开始。"
+            "value" : "这将永久删除 %@ 的浏览数据 — cookie、登录信息及历史记录。该智能体将以全新的配置文件重新开始。"
           }
         },
         "zh-Hant" : {
@@ -188507,7 +188507,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将永久删除所有代理的浏览数据 — 所有 cookie、登录信息和历史记录。"
+            "value" : "这将永久删除所有智能体的浏览数据 — 所有 cookie、登录信息和历史记录。"
           }
         },
         "zh-Hant" : {
@@ -188541,7 +188541,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将从磁盘上永久删除该插件已安装的动态库（dylib）、清单文件以及每个智能体的密钥。宿主将在每次启动时停止尝试加载该插件——这是无需手动编辑文件就能摆脱导致崩溃循环的插件的唯一方法。您稍后可以通过“工具管理器”重新安装它。"
+            "value" : "这将从磁盘上永久删除该插件已安装的动态库（dylib）、清单文件以及每个智能体的密钥。宿主将在每次启动时停止尝试加载该插件——这是无需手动编辑文件就能摆脱导致崩溃循环的插件的唯一方法。你稍后可以通过“工具管理器”重新安装它。"
           }
         },
         "zh-Hant" : {
@@ -188964,7 +188964,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将从配置文件中移除 \"%@\" 频道定义。其引用的钥匙串密钥不会被删除。"
+            "value" : "这将从配置文件中移除 “%@” 频道定义。其引用的钥匙串密钥不会被删除。"
           }
         },
         "zh-Hant" : {
@@ -189315,7 +189315,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此工具将在未来自动允许运行而不提示。您可以在工具设置中更改此设置。"
+            "value" : "此工具将在未来自动允许运行而不提示。你可以在工具设置中更改此设置。"
           }
         },
         "zh-Hant" : {
@@ -189419,7 +189419,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这与您的智能体使用的搜索完全相同 — 您在这里看到的就是它们看到的。"
+            "value" : "这与你的智能体使用的搜索完全相同 — 你在这里看到的就是它们看到的。"
           }
         },
         "zh-Hant" : {
@@ -189493,7 +189493,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这会遍历你历史中的每一个聊天会话，将它们的回合缓冲到pending_signals中，然后进行蒸馏。如果你有数百个会话，这可能需要一些时间——每个会话都是对你的核心模型的一次单独的LLM调用。已经蒸馏过的会话会被跳过。"
+            "value" : "这会遍历你历史中的每一个聊天会话，将它们的回合缓冲到 pending_signals 中，然后进行蒸馏。如果你有数百个会话，这可能需要一些时间——每个会话都是对你的核心模型的一次单独的 LLM 调用。已经蒸馏过的会话会被跳过。"
           }
         },
         "zh-Hant" : {
@@ -189669,7 +189669,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将永久删除您的身份、所有固定的事实、剧集和对话历史记录。此操作无法撤销。"
+            "value" : "这将永久删除你的身份、所有固定的事实、情景和对话历史记录。此操作无法撤销。"
           }
         },
         "zh-Hant" : {
@@ -189705,7 +189705,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将移除「%@」并从钥匙串中删除其 API 密钥。"
+            "value" : "这将移除“%@”并从钥匙串中删除其 API 密钥。"
           }
         },
         "zh-Hant" : {
@@ -189875,7 +189875,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这将完全停止并移除沙盒。您可以稍后重新设置。"
+            "value" : "这将完全停止并移除沙盒。你可以稍后重新设置。"
           }
         },
         "zh-Hant" : {
@@ -190127,7 +190127,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "紧凑适配"
+            "value" : "空间紧张"
           }
         },
         "zh-Hant" : {
@@ -190615,7 +190615,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通知消息已生效！"
+            "value" : "Toast 通知正常工作！"
           }
         },
         "zh-Hant" : {
@@ -190908,7 +190908,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "词元使用量"
+            "value" : "Token 使用量"
           }
         },
         "zh-Hant" : {
@@ -191010,7 +191010,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "词元"
+            "value" : "Token"
           }
         },
         "zh-Hant" : {
@@ -191046,7 +191046,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "词元 %lld"
+            "value" : "Token %lld"
           }
         },
         "zh-Hant" : {
@@ -191080,7 +191080,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在发现HTTP MCP之前刷新了令牌。"
+            "value" : "令牌会在 HTTP MCP 发现之前刷新。"
           }
         },
         "zh-Hant" : {
@@ -191150,7 +191150,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每轮注入的记忆上下文词元数"
+            "value" : "每轮注入的记忆上下文 Token 数"
           }
         },
         "zh-Hant" : {
@@ -191184,7 +191184,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每块令牌数"
+            "value" : "每块 Token 数"
           }
         },
         "zh-Hant" : {
@@ -191218,7 +191218,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个分页块包含的 token 数。"
+            "value" : "每个分页块包含的 Token 数。"
           }
         },
         "zh-Hant" : {
@@ -191254,7 +191254,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已用词元"
+            "value" : "已用 Token"
           }
         },
         "zh-Hant" : {
@@ -191288,7 +191288,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "太大"
+            "value" : "过大"
           }
         },
         "zh-Hant" : {
@@ -191438,7 +191438,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工具“%1$@”超过了%2$lld秒的执行预算。"
+            "value" : "工具“%1$@”超过了 %2$lld 秒的执行预算。"
           }
         },
         "zh-Hant" : {
@@ -192093,7 +192093,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工具是你的小恐龙可以使用的小本领，比如阅读网络或获取文件。现在就添加几个，随时可以从“设置”中增减它们。"
+            "value" : "工具是你的小恐龙可以使用的小本领，比如浏览网页或获取文件。现在就添加几个，随时可以从“设置”中增减它们。"
           }
         },
         "zh-Hant" : {
@@ -192128,7 +192128,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已安装插件和连接提供者的工具"
+            "value" : "来自已安装插件和已连接提供商的工具"
           }
         },
         "zh-Hant" : {
@@ -192750,7 +192750,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录的文本将显示在此处..."
+            "value" : "转写的文本将显示在此处..."
           }
         },
         "zh-Hant" : {
@@ -192852,7 +192852,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录已失效。"
+            "value" : "已忘记该转录回合。"
           }
         },
         "zh-Hant" : {
@@ -192886,7 +192886,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未找到该转录记录。"
+            "value" : "未找到该转录回合。"
           }
         },
         "zh-Hant" : {
@@ -192989,7 +192989,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "转录行为"
+            "value" : "转写行为"
           }
         },
         "zh-Hant" : {
@@ -193823,7 +193823,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "尝试其他术语，如“快捷键”或“转录”。"
+            "value" : "尝试其他术语，如“快捷键”或“转写”。"
           }
         },
         "zh-Hant" : {
@@ -194029,7 +194029,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "首词元延迟 %.0f 毫秒"
+            "value" : "首 Token 延迟 %.0f 毫秒"
           }
         },
         "zh-Hant" : {
@@ -194063,7 +194063,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "首词元延迟 %.2f 秒"
+            "value" : "首 Token 延迟 %.2f 秒"
           }
         },
         "zh-Hant" : {
@@ -194344,7 +194344,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭Osaurus路由器？"
+            "value" : "关闭 Osaurus 路由器？"
           }
         },
         "zh-Hant" : {
@@ -194521,7 +194521,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按代理逐一开启： 打开对应代理的\"子代理\"选项卡，启用\"计算机使用\"功能，然后选择\"共享屏幕上下文\"选项（默认已开启）。需要辅助功能权限。"
+            "value" : "按智能体逐一开启：打开对应智能体的“子智能体”选项卡，启用“计算机使用”，并使用“共享屏幕上下文”选项（默认已开启）。需要辅助功能权限。"
           }
         },
         "zh-Hant" : {
@@ -194625,7 +194625,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已到记忆轮次上限，但蒸馏正在跳过。"
+            "value" : "回合已进入记忆，但蒸馏被跳过。"
           }
         },
         "zh-Hant" : {
@@ -194871,7 +194871,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "输入会暂停等待您的批准；提交、购买、发送或清除数据始终会先询问。"
+            "value" : "输入会暂停等待你的批准；提交、购买、发送或清除数据始终会先询问。"
           }
         },
         "zh-Hant" : {
@@ -195583,7 +195583,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未知标签页"
+            "value" : "未知选项卡"
           }
         },
         "zh-Hant" : {
@@ -196051,7 +196051,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不受支持的Hunyuan Dense"
+            "value" : "不受支持的 Hunyuan Dense"
           }
         },
         "zh-Hant" : {
@@ -196085,7 +196085,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不支持的本地模型类型：hunyuan_v1_dense。Osaurus 需要 vmlx Hunyuan Dense 支持才能在此模型上本地运行。"
+            "value" : "不支持的本地模型类型：hunyuan_v1_dense。Osaurus 需要 vmlx Hunyuan Dense 支持后，此模型才能在本地运行。"
           }
         },
         "zh-Hant" : {
@@ -196341,7 +196341,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每天最多4次运行 · 每小时最多一次 · 凌晨10点至早上7点安静。"
+            "value" : "每天最多 4 次运行 · 每小时最多一次 · 晚上 10 点至早上 7 点为安静时段。"
           }
         },
         "zh-Hant" : {
@@ -196375,7 +196375,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每天最多6次运行 · 每小时最多一次 · 凌晨10点至早上7点安静。"
+            "value" : "每天最多 6 次运行 · 每小时最多一次 · 晚上 10 点至早上 7 点为安静时段。"
           }
         },
         "zh-Hant" : {
@@ -196409,7 +196409,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每天最多48次运行 · 每5分钟一次 · 无安静时段。"
+            "value" : "每天最多 48 次运行 · 最快每 5 分钟一次 · 无安静时段。"
           }
         },
         "zh-Hant" : {
@@ -196653,7 +196653,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用维护者更新"
+            "value" : "使用策展人更新"
           }
         },
         "zh-Hant" : {
@@ -196729,7 +196729,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已更新 \"%@\""
+            "value" : "已更新 “%@”"
           }
         },
         "zh-Hant" : {
@@ -197292,7 +197292,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此记忆模式下并发解码槽位的上限。"
+            "value" : "此内存模式下并发解码槽位的上限。"
           }
         },
         "zh-Hant" : {
@@ -197500,7 +197500,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "URL或存储库"
+            "value" : "URL 或仓库"
           }
         },
         "zh-Hant" : {
@@ -198276,7 +198276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用来自您 LM Studio 库的 safetensors 模型。"
+            "value" : "使用来自你 LM Studio 库的 safetensors 模型。"
           }
         },
         "zh-Hant" : {
@@ -198381,7 +198381,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用“测试”来启动 初始化/工具列表，并记录健康快照。"
+            "value" : "使用“测试”来启动 initialize/listTools，并记录健康快照。"
           }
         },
         "zh-Hant" : {
@@ -198415,7 +198415,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用测试运行 HTTP/SSE 初始化/工具列表 并记录健康快照。"
+            "value" : "使用“测试”运行 HTTP/SSE initialize/listTools 并记录健康快照。"
           }
         },
         "zh-Hant" : {
@@ -198624,7 +198624,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用OpenAI兼容的基础URL https://api.atlascloud.ai/v1"
+            "value" : "使用 OpenAI 兼容的基础 URL https://api.atlascloud.ai/v1"
           }
         },
         "zh-Hant" : {
@@ -198935,7 +198935,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "用户智能体"
+            "value" : "用户代理"
           }
         },
         "zh-Hant" : {
@@ -199003,7 +199003,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用Anthropic的分页模型目录端点。"
+            "value" : "使用 Anthropic 的分页模型目录端点。"
           }
         },
         "zh-Hant" : {
@@ -199299,7 +199299,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用AI + 正则规则"
+            "value" : "使用 AI + 正则规则"
           }
         },
         "zh-Hant" : {
@@ -199437,7 +199437,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅使用正则规则"
+            "value" : "仅使用模式规则"
           }
         },
         "zh-Hant" : {
@@ -200225,7 +200225,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "查看全部 %lld 个情节"
+            "value" : "查看全部 %lld 个情景"
           }
         },
         "zh-Hant" : {
@@ -200362,7 +200362,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "洞察视图"
+            "value" : "在洞察中查看"
           }
         },
         "zh-Hant" : {
@@ -201064,7 +201064,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "语音检测：已禁用 - 点击启用"
+            "value" : "语音检测：已禁用 — 点击启用"
           }
         },
         "zh-Hant" : {
@@ -201098,7 +201098,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "语音检测：正在聆听 - 点击禁用"
+            "value" : "语音检测：正在聆听 — 点击禁用"
           }
         },
         "zh-Hant" : {
@@ -201200,7 +201200,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "语音检测：就绪 - 点击禁用"
+            "value" : "语音检测：就绪 — 点击禁用"
           }
         },
         "zh-Hant" : {
@@ -202005,7 +202005,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "等待被赎回"
+            "value" : "等待兑换"
           }
         },
         "zh-Hant" : {
@@ -202388,7 +202388,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "热身 — 加载模型…"
+            "value" : "预热 — 正在加载模型…"
           }
         },
         "zh-Hant" : {
@@ -202465,7 +202465,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预热 — 上下文预填充 %1$lld%% (%2$lld/%3$lld 词元)"
+            "value" : "预热 — 上下文预填充 %1$lld%% (%2$lld/%3$lld Token)"
           }
         },
         "zh-Hant" : {
@@ -202499,7 +202499,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预热中 — 预填充上下文 %lld%%（%lld/1 token）"
+            "value" : "预热中 — 预填充上下文 %1$lld%%（%2$lld/1 Token）"
           }
         },
         "zh-Hant" : {
@@ -202533,7 +202533,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预热 — 填充上下文…"
+            "value" : "预热 — 预填充上下文…"
           }
         },
         "zh-Hant" : {
@@ -202705,7 +202705,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "监控文件夹"
+            "value" : "受监视的文件夹"
           }
         },
         "zh-Hant" : {
@@ -203367,7 +203367,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "网页搜索现在是原生功能。此插件的工具不再加载 — 在设置 → 搜索中配置提供商。您可以卸载此插件。"
+            "value" : "网页搜索现在是原生功能。此插件的工具不再加载 — 在设置 → 搜索中配置提供商。你可以卸载此插件。"
           }
         },
         "zh-Hant" : {
@@ -203896,7 +203896,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理存储内容一览。"
+            "value" : "智能体存储内容一览。"
           }
         },
         "zh-Hant" : {
@@ -203932,7 +203932,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代理在沙盒内可以做什么。"
+            "value" : "智能体在沙盒内可以做什么。"
           }
         },
         "zh-Hant" : {
@@ -204002,7 +204002,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "描述该资料库的内容，会展示给代理"
+            "value" : "描述该资料库的内容，会展示给智能体"
           }
         },
         "zh-Hant" : {
@@ -204320,7 +204320,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当加密开启时，清除macOS钥匙串或在没有iCloud钥匙串同步的情况下迁移到新Mac会使加密存储无法恢复。迁移前请导出明文备份。"
+            "value" : "当加密开启时，清除 macOS 钥匙串或在没有 iCloud 钥匙串同步的情况下迁移到新 Mac 会使加密存储无法恢复。迁移前请导出明文备份。"
           }
         },
         "zh-Hant" : {
@@ -204493,7 +204493,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当您添加积分或使用Osaurus路由器模型时，它会连同金额显示在这里。如果这台 Mac 提出了请求，您可以跳转到聊天或 Insights。"
+            "value" : "当你添加积分或使用 Osaurus Router 模型时，它会连同金额显示在这里。如果这台 Mac 发出过请求，你可以跳转到对应聊天或 Insights。"
           }
         },
         "zh-Hant" : {
@@ -204561,7 +204561,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "为智能体开启此功能后，电脑操作即可让该智能体替您操作 macOS 应用程序——它会分步骤完成目标，并在实时动态中展示每一个动作。"
+            "value" : "为智能体开启此功能后，电脑操作即可让该智能体替你操作 macOS 应用程序——它会分步骤完成目标，并在实时动态中展示每一个动作。"
           }
         },
         "zh-Hant" : {
@@ -204773,7 +204773,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osaurus监听客户端请求的地方。更改后需要重启服务器。"
+            "value" : "Osaurus 监听客户端请求的位置。更改会重启服务器。"
           }
         },
         "zh-Hant" : {
@@ -205018,7 +205018,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "谁可以调用您的API以及调用的频率。"
+            "value" : "谁可以调用你的API以及调用的频率。"
           }
         },
         "zh-Hant" : {
@@ -205375,7 +205375,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "有了数据库，代理可以在对话之间保存笔记、列表和记录 — 以加密形式存储在此 Mac 上。你可以浏览和编辑它保存的所有内容。"
+            "value" : "有了数据库，智能体可以在对话之间保存笔记、列表和记录 — 以加密形式存储在此 Mac 上。你可以浏览和编辑它保存的所有内容。"
           }
         },
         "zh-Hant" : {
@@ -205875,7 +205875,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工作空间"
+            "value" : "工作区"
           }
         },
         "zh-Hant" : {
@@ -206048,7 +206048,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工作空间挂载"
+            "value" : "工作区挂载"
           }
         },
         "zh-Hant" : {
@@ -206460,7 +206460,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将~/.osaurus下的每个数据库、附件和配置的明文副本写入您选择的文件夹。建议在重新安装 macOS 或移动 Mac 之前使用。"
+            "value" : "将 ~/.osaurus 下每个数据库、附件和配置的明文副本写入你选择的文件夹。建议在重新安装 macOS 或更换 Mac 前进行。"
           }
         },
         "zh-Hant" : {
@@ -206737,7 +206737,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI OAuth发现返回了不受信任的%@"
+            "value" : "xAI OAuth 发现返回了不受信任的 %@"
           }
         },
         "zh-Hant" : {
@@ -206805,7 +206805,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI 拒绝了登录回调: %@"
+            "value" : "xAI 拒绝了登录回调：%@"
           }
         },
         "zh-Hant" : {
@@ -206839,7 +206839,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI在Grok登录过程中返回了无效的令牌响应"
+            "value" : "xAI 在 Grok 登录过程中返回了无效的令牌响应"
           }
         },
         "zh-Hant" : {
@@ -206873,7 +206873,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要xAI登录"
+            "value" : "需要 xAI 登录"
           }
         },
         "zh-Hant" : {
@@ -206907,7 +206907,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI已登录"
+            "value" : "xAI 已登录"
           }
         },
         "zh-Hant" : {
@@ -206941,7 +206941,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "xAI令牌请求失败：%@"
+            "value" : "xAI 令牌请求失败：%@"
           }
         },
         "zh-Hant" : {
@@ -207289,7 +207289,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您可以继续使用 Osaurus Cloud 聊天。"
+            "value" : "你可以继续使用 Osaurus Cloud 聊天。"
           }
         },
         "zh-Hant" : {
@@ -207359,7 +207359,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您可以随时从聊天中的活动动态停止运行。"
+            "value" : "你可以随时从聊天中的活动动态停止运行。"
           }
         },
         "zh-Hant" : {
@@ -207469,7 +207469,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您被收取了%1$@个%2$d词元的费用。"
+            "value" : "本次已扣费 %1$@（共 %2$d 个 Token）。"
           }
         },
         "zh-Hant" : {
@@ -207505,7 +207505,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您被收取了%@。"
+            "value" : "本次已扣费 %@。"
           }
         },
         "zh-Hant" : {
@@ -207616,7 +207616,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您将添加%@"
+            "value" : "你将添加%@"
           }
         },
         "zh-Hant" : {
@@ -207721,7 +207721,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的智能体现在可以为您浏览网页 — 导航页面、阅读内容和填写表单，每一步都实时展示在信息流中。每个智能体拥有独立的持久化浏览器会话，因此 Cookie 和登录状态可在对话间延续，但绝不会与其他智能体或您常用的浏览器共享。如果您之前使用过浏览器插件，您的会话已自动迁移。"
+            "value" : "你的智能体现在可以为你浏览网页 — 导航页面、阅读内容和填写表单，每一步都实时展示在信息流中。每个智能体拥有独立的持久化浏览器会话，因此 Cookie 和登录状态可在对话间延续，但绝不会与其他智能体或你常用的浏览器共享。如果你之前使用过浏览器插件，你的会话已自动迁移。"
           }
         },
         "zh-Hant" : {
@@ -207894,7 +207894,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的余额是%@。添加积分以继续聊天。"
+            "value" : "你的余额是%@。添加积分以继续聊天。"
           }
         },
         "zh-Hant" : {
@@ -207929,7 +207929,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的余额现在是%@。重试您最后一条消息以继续。"
+            "value" : "你的余额现在是%@。重试你最后一条消息以继续。"
           }
         },
         "zh-Hant" : {
@@ -208208,7 +208208,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的数据已静态加密。无需任何操作。"
+            "value" : "你的数据已静态加密。无需任何操作。"
           }
         },
         "zh-Hant" : {
@@ -208276,7 +208276,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的数据库在 macOS 钥匙串中使用 256 位密钥进行加密。"
+            "value" : "你的数据库在 macOS 钥匙串中使用 256 位密钥进行加密。"
           }
         },
         "zh-Hant" : {
@@ -208310,7 +208310,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的数据库未被Osaurus加密。macOS FileVault在静止状态下保护它们。"
+            "value" : "你的数据库未由 Osaurus 加密。macOS FileVault 会在静态存储时保护它们。"
           }
         },
         "zh-Hant" : {
@@ -208592,7 +208592,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的私有模型下载已暂停"
+            "value" : "你的私有模型已暂停"
           }
         },
         "zh-Hant" : {
@@ -208634,7 +208634,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的私有模型需要处理"
+            "value" : "你的私有模型需要处理"
           }
         },
         "zh-Hant" : {
@@ -208704,7 +208704,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的提供商"
+            "value" : "你的提供商"
           }
         },
         "zh-Hant" : {
@@ -208910,7 +208910,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "用于Osaurus路由服务的钱包 - 添加积分并跟踪每个请求和充值。"
+            "value" : "你的 Osaurus 路由服务钱包 — 添加积分，并跟踪每笔请求与充值。"
           }
         },
         "zh-Hant" : {
@@ -208986,7 +208986,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zip 捆绑包"
+            "value" : "Zip 压缩包"
           }
         },
         "zh-Hant" : {

--- a/scripts/i18n/lint-zh-style.py
+++ b/scripts/i18n/lint-zh-style.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Style linter for Chinese locales in Localizable.xcstrings.
+
+Rules (zh-Hans by default):
+  spacing  - insert a space between CJK and Latin/digit/placeholder runs
+  quotes   - ASCII "straight" quote pairs around text -> curly “ ” (‘ ’)
+  colon    - halfwidth colon after a CJK character -> fullwidth ：
+
+Values inside backtick spans and URLs are left untouched. Only stringUnit
+values are rewritten; state fields are never modified. The catalog is written
+back byte-exactly (indent=2, separators=(',', ' : '), no trailing newline) so
+diffs contain only the changed value lines.
+
+Usage:
+  python3 scripts/i18n/lint-zh-style.py --check            # report, exit 1 if dirty
+  python3 scripts/i18n/lint-zh-style.py --fix              # apply fixes in place
+  python3 scripts/i18n/lint-zh-style.py --fix --locale zh-Hant
+  python3 scripts/i18n/lint-zh-style.py --check --exclude-keys keys.txt
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CATALOG = Path(__file__).resolve().parents[2] / "Packages/OsaurusCore/Resources/Localizable.xcstrings"
+
+CJK = r"㐀-䶿一-鿿"
+LATIN = r"A-Za-z0-9"
+# spans we must never touch or space-pad inside
+PROTECTED = re.compile(r"`[^`]*`|https?://\S+|www\.\S+")
+PLACEHOLDER = re.compile(r"%(\d+\$)?[#0\- +']*\d*(\.\d+)?(hh|h|ll|l|q|z|t|L)?[@dDuUxXoOfeEgGaAcCsSpF]|%%")
+
+def protect(value):
+    """Replace protected spans with sentinels; return (masked, spans)."""
+    spans = []
+    def repl(m):
+        spans.append(m.group(0))
+        return f"\x00{len(spans)-1}\x00"
+    return PROTECTED.sub(repl, value), spans
+
+def unprotect(value, spans):
+    for i, s in enumerate(spans):
+        value = value.replace(f"\x00{i}\x00", s)
+    return value
+
+def fix_spacing(value):
+    # treat each placeholder as an opaque Latin-like token
+    masked = PLACEHOLDER.sub(lambda m: f"\x01{m.group(0)}\x01", value)
+    masked = re.sub(rf"([{CJK}])([\x01{LATIN}%])", r"\1 \2", masked)
+    masked = re.sub(rf"([\x01{LATIN}%@])([{CJK}])", r"\1 \2", masked)
+    return masked.replace("\x01", "")
+
+def fix_quotes(value):
+    if value.count('"') and value.count('"') % 2 == 0:
+        value = re.sub(r'"([^"]*)"', "“\\1”", value)
+    if re.search(rf"'[^']*[{CJK}][^']*'", value):
+        value = re.sub(rf"'([^']*[{CJK}][^']*)'", "‘\\1’", value)
+    return value
+
+def fix_colon(value):
+    return re.sub(rf"([{CJK}]):(?!//)\s?", "\\1：", value)
+
+def apply_rules(value, rules):
+    masked, spans = protect(value)
+    if "quotes" in rules:
+        masked = fix_quotes(masked)
+    if "colon" in rules:
+        masked = fix_colon(masked)
+    if "spacing" in rules:
+        masked = fix_spacing(masked)
+    return unprotect(masked, spans)
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="report violations, exit 1 if any")
+    mode.add_argument("--fix", action="store_true", help="rewrite the catalog in place")
+    ap.add_argument("--locale", default="zh-Hans")
+    ap.add_argument("--rules", default="spacing,quotes,colon", help="comma-separated subset of rules")
+    ap.add_argument("--exclude-keys", type=Path, help="file with one key per line (JSON-encoded or raw) to skip")
+    ap.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    args = ap.parse_args()
+
+    rules = set(args.rules.split(","))
+    excluded = set()
+    if args.exclude_keys:
+        for line in args.exclude_keys.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                excluded.add(json.loads(line))
+            except ValueError:
+                excluded.add(line)
+
+    raw = args.catalog.read_bytes()
+    catalog = json.loads(raw)
+    rendered = json.dumps(catalog, ensure_ascii=False, indent=2, separators=(",", " : ")).encode()
+    if rendered != raw:
+        sys.exit("refusing to run: catalog does not round-trip byte-exactly; check serialization recipe")
+
+    changed = []
+    for key, entry in catalog["strings"].items():
+        if key in excluded or entry.get("shouldTranslate") is False:
+            continue
+        unit = entry.get("localizations", {}).get(args.locale, {}).get("stringUnit")
+        if not unit or "value" not in unit:
+            continue
+        new = apply_rules(unit["value"], rules)
+        if new != unit["value"]:
+            changed.append((key, unit["value"], new))
+            if args.fix:
+                unit["value"] = new
+
+    for key, old, new in changed:
+        print(f"[{args.locale}] {key[:60]!r}\n  - {old}\n  + {new}")
+    print(f"\n{len(changed)} value(s) {'fixed' if args.fix else 'need fixing'}")
+
+    if args.fix and changed:
+        args.catalog.write_bytes(json.dumps(catalog, ensure_ascii=False, indent=2, separators=(",", " : ")).encode())
+    if args.check and changed:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Consolidated zh-Hans quality pass, replacing #2180–#2187 per @RaajeevChandran's request (single CI run). Content is unchanged from the eight split PRs: 859 string values fixed across eight defect classes, plus a new style linter. Follow-up to #2177.

Every change was verified against the English source string and its Swift call site by a native Simplified Chinese speaker. All placeholders in new values use explicit positional form and were re-validated mechanically (translated placeholder multiset ⊆ source).

## Changes

- 859 zh-Hans string **values** in `Packages/OsaurusCore/Resources/Localizable.xcstrings` — no keys, states, or other locales touched
- adds `scripts/i18n/lint-zh-style.py` (`--check`/`--fix`: CJK↔Latin spacing, curly quotes, fullwidth colon; reusable for zh-Hant and wireable into CI)

## How to verify without speaking Chinese

Six sample rows per class below; every class links to its full table.

### Mistranslated UI labels — 48 strings

| English source | old → new | defect |
|---|---|---|
| %lld items would be redacted | %lld 个项目将被编辑 → %lld 个项目将被隐去 | "redacted" mistranslated as "edited". |
| %lld redactions | %lld 次编辑 → %lld 处隐去 | "redactions" mistranslated as "edits". |
| 1 item would be redacted | 1 个项目将被编辑 → 1 个项目将被脱敏 | "redacted" means privacy masking, not "edited"; current zh says the item will be |
| 1 redaction | 1 次编辑 → 1 次脱敏 | "redaction" mistranslated as "edit"; should be masking/redaction count. |
| 6-bit (q6, GGUF-head parity) | 6位（q6，GGUF-head奇偶校验） → 6 位（q6，与 GGUF-head 持平） | "parity" here means quality parity with GGUF-head, not parity checking; current  |
| Audience | 观众 → 受众 | "Audience" here is the token/JWT aud claim, not spectators; 观众 is a wrong-sense  |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-mistranslated-labels.md)

### Placeholder & measure-word defects — 96 strings

| English source | old → new | defect |
|---|---|---|
| %lld allowed · %lld people | 允许 %1%lld 个 · %2$lld 人 → 允许 %1$lld 个 · %2$lld 人 | Malformed positional placeholder %1%lld (should be %1$lld). |
| %lld tools discovered via %@. | 通过 %lld 发现了 %@ 个工具。 → 通过 %2$@ 发现了 %1$lld 个工具。 | Placeholders reordered without positional form, so count and source name swap at |
| %lld/%lld connected - %lld attention - %@ | %lld/%lld 已连接 - %lld 注意力 - %@ → %lld/%lld 已连接 - %lld 个需注意 - %@ | "attention" (servers needing attention) mistranslated as the noun "attention/foc |
| %lld/%lld connected, %lld attention, %@, %@ | %lld/%lld 已连接，%lld 注意力，%@，%@ → %lld/%lld 已连接，%lld 个需注意，%@，%@ | Same "attention" mistranslation as sibling key. |
| buffered %lld turn%@ · skipped %lld session%@ | 已缓冲 %1$lld 轮%2$@ · 已跳过 %3$lld 个会话%4$@ → 已缓冲 %1$lld 轮 · 已跳过 %3$lld 个会话 | English plural-suffix placeholders %2$@/%4$@ kept in zh, producing stray "s" aft |
| (No memory context assembled — memory may be empty or disabled) | （未组装内存上下文 — 内存可能为空或已禁用） → （未组装记忆上下文 — 记忆可能为空或已禁用） | "memory" (the app's memory feature) translated as RAM. |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-garbled-1-placeholders-quantifiers.md)

### Machine-translation artifacts — 97 strings

| English source | old → new | defect |
|---|---|---|
| Confirm the message was sent in a channel selected as Read, by a  | 确认消息是由授权发送者在选定为已读的频道中发送的。 → 确认消息是由授权发送者在选定为可读的频道中发送的。 | "selected as Read" (channel read permission) mistranslated as 已读 (message read s |
| Download or import first, then run a generation proof with token/ | 先下载或导入，然后使用令牌运行生成证明。 → 先下载或导入，然后运行生成验证并测量 token/s 速率。 | "token/s" (tokens-per-second rate) was misread as an auth token ("使用令牌"). |
| Edits run; only sending, deleting, and similar ask first. | 编辑运行；仅发送、删除和类似操作可先执行。 → 编辑操作会直接运行；仅发送、删除等类似操作会先询问。 | "ask first" (require confirmation) was translated as "may execute first" — meani |
| Fuses the per-token decode graph with MLX compile (+25% measured  | 将每标记的解码图与 MLX 编译融合（在 Gemma 4 QAT 上测量提升 + → 将每 Token 的解码图与 MLX 编译融合（在 Gemma 4 QAT 上实 | 'fixes its compile state' means 'pins/locks', not 'repairs'; also token→词元 per g |
| Gmail, Calendar, Drive, Docs (requires self-hosting) | Gmail、日历、驱动器、文档（需要自托管） → Gmail、日历、云端硬盘、文档（需要自托管） | 'Drive' (Google Drive) mistranslated as disk drive (驱动器); official zh name is 云端 |
| Hours between decay / dedup / eviction runs | 衰减 / 去重 / 强制运行之间的小时间隔 → 衰减 / 去重 / 淘汰运行之间的小时间隔 | 'eviction' mistranslated as 强制 ('forced'), misleading about what the setting con |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-garbled-2-machine-translation.md)

### Semantic drift — 97 strings

| English source | old → new | defect |
|---|---|---|
| not enabled for this agent | 此智能体未启用 → 未对此智能体启用 | Reads as "this agent is not enabled" instead of "not enabled for this agent" — s |
| permission policy is deny | 权限策略被拒绝 → 权限策略为拒绝 | Translation says the policy "was denied" instead of "the policy is set to deny". |
| Required to type into other applications | 需要输入到其他应用程序中 → 向其他应用程序输入文字所需 | Reversed meaning: zh reads as an instruction to type, not a permission rationale |
| Reset to default theme | 已重置为默认主题 → 重置为默认主题 | zh adds 已 (already done), turning an action label into a completed-state message |
| Revoked | 撤销 → 已撤销 | Status label reads as imperative verb; needs 已撤销 to distinguish from Revoke |
| Rolled back to the default theme | 回滚到默认主题 → 已回滚到默认主题 | Completed-action toast missing 已, reads as imperative |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-garbled-3-semantic-drift.md)

### agent → 智能体 — 70 strings

| English source | old → new | defect |
|---|---|---|
| A domain allowlist is configured, which this sandbox can't enforc | 已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除代理的允许 → 已配置域名允许列表，但此沙盒无法强制执行 — 网络将保持完全阻断。清除智能体的允 | "agents" here are AI agents; 代理 reads as network proxy — glossary says 智能体. |
| Agent channel connection `%@` does not support `%@`. | 代理通道连接 `%1$@` 不支持 `%2$@`。 → 智能体频道连接 `%1$@` 不支持 `%2$@`。 | "Agent channel" rendered 代理通道; glossary/majority usage is 智能体频道. |
| Agent channel connection `%@` is disabled. | 代理通道连接 `%@` 已禁用。 → 智能体频道连接 `%@` 已禁用。 | "Agent channel" rendered 代理通道; should be 智能体频道. |
| Agent channel connection `%@` is not configured. | 代理通道连接 `%@` 未配置。 → 智能体频道连接 `%@` 未配置。 | "Agent channel" rendered 代理通道; should be 智能体频道. |
| Agent channel kind `%@` is not executable yet. | 代理通道类型 `%@` 尚不可执行。 → 智能体频道类型 `%@` 尚不可执行。 | "Agent channel" rendered 代理通道; should be 智能体频道. |
| Agent in use | 代理正在使用中 → 智能体正在使用中 | AI "Agent" must be 智能体 per glossary, not 代理. |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-term-agent.md)

### Terminology consistency (incl. LLM token → Token) — 170 strings

| English source | old → new | defect |
|---|---|---|
| %@ router balance. Click to open the wallet. | 路由器余额 %@。点击打开钱包。 → 路由余额 %@。点击打开钱包。 | "router" (model routing service) translated as hardware network router. |
| A bigger starting context means longer model warm-up and a slower | 更大的起始上下文意味着更长的模型预热和更慢的首个 token。 → 更大的起始上下文意味着更长的模型预热和更慢的首个 Token。 | LLM-context "token" left in English; glossary requires 词元. |
| A regular or secret credential header is configured for this prov | 为此提供程序配置了常规或秘密的凭证标头。 → 为此提供商配置了常规或保密的凭证标头。 | "provider" rendered 提供程序, deviating from majority term 提供商. |
| A stdio MCP provider needs a command before it can launch. | 一个 stdio MCP 提供程序需要一条命令才能启动。 → 一个 stdio MCP 提供商需要一条命令才能启动。 | "provider" rendered 提供程序 instead of majority term 提供商. |
| Action | 行动 → 操作 | "Action" rendered as 行动, inconsistent with 操作 used everywhere else in the app. |
| After each chat, the agent distills the conversation into a short | 每次聊天后，智能体会将对话提炼成简短的摘要。情节会在此累积，以便智能体回忆起过去 → 每次聊天后，智能体会将对话提炼成简短的摘要。情景会在此累积，以便智能体回忆起过去 | "Episodes" must be 情景 per glossary, not 情节. |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-term-consistency.md)

### Style normalization + new linter — 188 strings

| English source | old → new | defect |
|---|---|---|
| %@ has the wrong type | %@有错误的类型 → %@ 有错误的类型 | Missing space between placeholder and CJK text. |
| %@ is empty | %@是空的 → %@ 是空的 | Missing space between placeholder and CJK text. |
| %@ is missing | %@缺失 → %@ 缺失 | Missing space between placeholder and CJK text. |
| %@ is not readable | %@不可读 → %@ 不可读 | Missing space between placeholder and CJK text. |
| %@ is not writable | %@不可写 → %@ 不可写 | Missing space between placeholder and CJK text. |
| %@ still can't be opened. Try Reset. | %@仍然无法打开。尝试重置。 → %@ 仍然无法打开。尝试重置。 | Missing space between placeholder and CJK text. |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-style-lint.md)

### Pronoun 您 → 你 — 93 strings

| English source | old → new | defect |
|---|---|---|
| Actions that change or send something pause for your approval, ba | 会更改或发送内容的操作会暂停等待您的批准，具体取决于下方的自主性级别。 → 会更改或发送内容的操作会暂停等待你的批准，具体取决于下方的自主性级别。 | Uses honorific 您 instead of the project-standard 你. |
| Advanced — define your own HTTP JSON channel | 高级 — 定义您自己的 HTTP JSON 频道 → 高级 — 定义你自己的 HTTP JSON 频道 | Uses honorific 您 instead of the project-standard 你. |
| Agents propose, you approve | 智能体提议，由您批准 → 智能体提议，由你批准 | Uses honorific 您 instead of the project-standard 你. |
| Are you sure you want to clear all request logs? This action cann | 您确定要清除所有请求日志吗？此操作无法撤销。 → 你确定要清除所有请求日志吗？此操作无法撤销。 | Uses 您 instead of the standard 你. |
| Are you sure you want to delete "%@"? This action cannot be undon | 您确定要删除“%@”吗？此操作无法撤销。 → 你确定要删除“%@”吗？此操作无法撤销。 | Uses 您 instead of the standard 你. |
| Are you sure you want to delete "%@"? This action cannot be undon | 您确定要删除“%@”吗？此操作无法撤销。为此智能体配置的任何沙盒资源也将被移除。 → 你确定要删除“%@”吗？此操作无法撤销。为此智能体配置的任何沙盒资源也将被移除。 | Uses 您 instead of the standard 你. |
[full table](https://github.com/YspritanHyzygy/osaurus/blob/i18n-evidence/tables/zh-hans-tone-ni.md)

## Screenshots (app running in zh-Hans, v0.22.10)

The tool-permission policy menu currently offers "自动运行 / 运行前询问 / 块" — the deny option **Block** is translated as 块, "a lump/chunk":

![block-menu](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/before-block-menu.png)

Memory settings: "Memory Budget" translated as RAM (内存预算) directly above copy that correctly says 记忆; "Episode Retention" is 情节保留 while its own description says 剧集; untranslated "Skipped" in the stats row:

![memory](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/before-memory-settings.png)

## Test plan

- [x] `bash scripts/i18n/check.sh` passes
- [x] catalog parses; diff touches exactly 859 value lines + one new script
- [x] placeholder multisets re-validated mechanically against English sources
- [x] `lint-zh-style.py --check` clean on the result
