### PR TITLE
i18n: add 43 Settings-search strings that never entered the catalog

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -17230,6 +17230,40 @@
         }
       }
     },
+    "Agent Database" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agenten-Datenbank"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "에이전트 데이터베이스"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "База данных агентов"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智能体数据库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智能體資料庫"
+          }
+        }
+      }
+    },
     "Agent DB" : {
       "localizations" : {
         "de" : {
@@ -21891,6 +21925,40 @@
         }
       }
     },
+    "API Authentication" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "API-Authentifizierung"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "API 인증"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Аутентификация API"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 身份验证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 身分驗證"
+          }
+        }
+      }
+    },
     "API Endpoints" : {
       "localizations" : {
         "de" : {
@@ -22523,6 +22591,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外觀"
+          }
+        }
+      }
+    },
+    "Appearance & Themes" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erscheinungsbild und Themes"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모양 및 테마"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Внешний вид и темы"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外观与主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外觀與主題"
           }
         }
       }
@@ -32069,6 +32171,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瀏覽器會話"
+          }
+        }
+      }
+    },
+    "Browser Sessions" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Browser-Sitzungen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "브라우저 세션"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сеансы браузера"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览器会话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏覽器工作階段"
           }
         }
       }
@@ -47491,6 +47627,40 @@
         }
       }
     },
+    "Context & KV Policy" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kontext- und KV-Richtlinie"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "컨텍스트 및 KV 정책"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Политика контекста и KV"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上下文与 KV 策略"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上下文與 KV 策略"
+          }
+        }
+      }
+    },
     "Context Budget" : {
       "localizations" : {
         "de" : {
@@ -54086,6 +54256,40 @@
         }
       }
     },
+    "Custom HTTP Connections" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Benutzerdefinierte HTTP-Verbindungen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "사용자 지정 HTTP 연결"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Пользовательские HTTP-подключения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义 HTTP 连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂 HTTP 連線"
+          }
+        }
+      }
+    },
     "Custom HTTP JSON channel" : {
       "comment" : "Subtitle for the custom channel setup sheet.",
       "isCommentAutoGenerated" : true,
@@ -54186,6 +54390,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自訂的 JSON 通道 `%@` 已經設定，但尚未啟用自訂的 HTTP 執行。"
+          }
+        }
+      }
+    },
+    "Custom JSON Connections" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Benutzerdefinierte JSON-Verbindungen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "사용자 지정 JSON 연결"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Пользовательские JSON-подключения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义 JSON 连接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂 JSON 連線"
           }
         }
       }
@@ -54470,6 +54708,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定義沙盒根目錄已激活"
+          }
+        }
+      }
+    },
+    "Custom Search Provider" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Benutzerdefinierter Suchanbieter"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "사용자 지정 검색 제공자"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Пользовательский поставщик поиска"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义搜索提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂搜尋提供商"
           }
         }
       }
@@ -56107,6 +56379,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默認智能體"
+          }
+        }
+      }
+    },
+    "Default Agent Max Output Tokens" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Standard-Agent: maximale Ausgabe-Token"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "기본 에이전트 최대 출력 토큰"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Макс. число выходных токенов агента по умолчанию"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智能体默认最大输出 Token 数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智能體預設最大輸出 Token 數"
           }
         }
       }
@@ -59627,6 +59933,40 @@
         }
       }
     },
+    "Dictation Hotkey" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diktat-Kurzbefehl"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "받아쓰기 단축키"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Горячая клавиша диктовки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "听写快捷键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聽寫快速鍵"
+          }
+        }
+      }
+    },
     "Diffusion Models" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -60330,6 +60670,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "斷開連接"
+          }
+        }
+      }
+    },
+    "Discord" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Discord"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Discord"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Discord"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discord"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discord"
           }
         }
       }
@@ -62311,6 +62685,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載遇到問題"
+          }
+        }
+      }
+    },
+    "Download image models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bildmodelle laden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이미지 모델 다운로드"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Загрузить модели изображений"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载图片模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載圖片模型"
           }
         }
       }
@@ -67981,6 +68389,40 @@
         }
       }
     },
+    "Encrypt Local Data at Rest" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lokale Daten im Ruhezustand verschlüsseln"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "저장된 로컬 데이터 암호화"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Шифровать локальные данные при хранении"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密本地静态数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密本機靜態資料"
+          }
+        }
+      }
+    },
     "Encrypt local data at rest (SQLCipher)" : {
       "comment" : "A label describing the option to enable SQLCipher encryption for local data.",
       "isCommentAutoGenerated" : true,
@@ -73434,6 +73876,40 @@
         }
       }
     },
+    "External Model Sources" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Externe Modellquellen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "외부 모델 소스"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Внешние источники моделей"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部模型来源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部模型來源"
+          }
+        }
+      }
+    },
     "External Models" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -73787,6 +74263,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "事實覈查和平衡分析"
+          }
+        }
+      }
+    },
+    "Factory Reset" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Auf Werkseinstellungen zurücksetzen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "공장 초기화"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Сброс к заводским настройкам"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复出厂设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回復原廠設定"
           }
         }
       }
@@ -76606,6 +77116,40 @@
         }
       }
     },
+    "Folder Tool Permissions" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Berechtigungen für Ordner-Tools"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "폴더 도구 권한"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Разрешения для инструментов папок"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹工具权限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料夾工具權限"
+          }
+        }
+      }
+    },
     "Folders of documents your agents can search and read on demand" : {
       "localizations" : {
         "de" : {
@@ -79218,6 +79762,40 @@
         }
       }
     },
+    "Generation Defaults" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Standardwerte für die Generierung"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "생성 기본값"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Параметры генерации по умолчанию"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成默认值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成預設值"
+          }
+        }
+      }
+    },
     "Generation model" : {
       "comment" : "A label for a picker that lets the user select a model for generating images.",
       "isCommentAutoGenerated" : true,
@@ -80311,6 +80889,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全域代理通道寫入功能已被終止開關禁用（產生 %lld）。"
+          }
+        }
+      }
+    },
+    "Global Channel Safety" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Globale Kanalsicherheit"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전역 채널 보안"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Глобальная безопасность каналов"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局频道安全"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全域頻道安全"
+          }
+        }
+      }
+    },
+    "Global Channel Writes" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Globale Kanal-Schreibzugriffe"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전역 채널 쓰기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Глобальная запись в каналы"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局频道写入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全域頻道寫入"
           }
         }
       }
@@ -85435,6 +86081,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "身份 →"
+          }
+        }
+      }
+    },
+    "Identity & Recovery" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Identität und Wiederherstellung"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "신원 및 복구"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Личность и восстановление"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "身份与恢复"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "身分與復原"
           }
         }
       }
@@ -97503,6 +98183,40 @@
         }
       }
     },
+    "Load Policy" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ladestrategie"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "로드 정책"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Политика загрузки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加载策略"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入策略"
+          }
+        }
+      }
+    },
     "Load policy" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -106814,6 +107528,40 @@
         }
       }
     },
+    "Model Residency" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modell-Residenz"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모델 상주 방식"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Резиденция модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型驻留"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型駐留"
+          }
+        }
+      }
+    },
     "Model residency" : {
       "localizations" : {
         "de" : {
@@ -108445,6 +109193,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "原生"
+          }
+        }
+      }
+    },
+    "Native Integrations" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Native Integrationen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "네이티브 통합"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Встроенные интеграции"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原生集成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原生整合"
           }
         }
       }
@@ -129687,6 +130469,40 @@
         }
       }
     },
+    "Per-category Provider Order" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Anbieterreihenfolge je Kategorie"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "카테고리별 제공자 순서"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Порядок поставщиков по категориям"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分类提供商顺序"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分類提供商順序"
+          }
+        }
+      }
+    },
     "Per-domain network allowlists require the VM sandbox (macOS 26 or later). On this device sandbox network access is all-or-nothing — use the Sandbox Network toggle above." : {
       "localizations" : {
         "de" : {
@@ -133629,6 +134445,40 @@
         }
       }
     },
+    "Port & Network" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Port und Netzwerk"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "포트 및 네트워크"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Порт и сеть"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "端口与网络"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連接埠與網路"
+          }
+        }
+      }
+    },
     "Port, network exposure, CORS, top-P, model eviction, and idle residency now live in Server → Settings, backed by the vmlx server-runtime contract." : {
       "comment" : "A description of the changes to the Server/Local",
       "extractionState" : "stale",
@@ -133759,6 +134609,40 @@
     "Posts your agents want to send. You always see the exact message and destination before anything goes out, and every safety check runs again at send time." : {
       "comment" : "A description of the purpose of the outbox.",
       "isCommentAutoGenerated" : true
+    },
+    "Power" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Energie"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전원"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Питание"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電源"
+          }
+        }
+      }
     },
     "Power & Sleep" : {
       "extractionState" : "manual",
@@ -134209,6 +135093,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高級無廣告搜尋（付費 API）。"
+          }
+        }
+      }
+    },
+    "Premium Search" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Premium-Suche"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "프리미엄 검색"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Премиум-поиск"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高级搜索"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進階搜尋"
           }
         }
       }
@@ -135429,6 +136347,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱私與安全"
+          }
+        }
+      }
+    },
+    "Privacy Filter" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Datenschutzfilter"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "개인정보 필터"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Фильтр конфиденциальности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐私过滤器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私過濾器"
           }
         }
       }
@@ -140047,6 +140999,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提示詞框"
+          }
+        }
+      }
+    },
+    "Prompt Cache" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Prompt-Cache"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "프롬프트 캐시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Кэш промптов"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示快取"
           }
         }
       }
@@ -162835,6 +163821,40 @@
         }
       }
     },
+    "Search Credits" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Such-Guthaben"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색 크레딧"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Кредиты на поиск"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索积分"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋點數"
+          }
+        }
+      }
+    },
     "Search credits" : {
       "comment" : "A label for the number of remaining search credits.",
       "isCommentAutoGenerated" : true,
@@ -163245,6 +164265,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索插件"
+          }
+        }
+      }
+    },
+    "Search Providers" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Suchanbieter"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색 제공자"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Поставщики поиска"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索提供商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋提供商"
           }
         }
       }
@@ -175663,6 +176717,40 @@
         }
       }
     },
+    "Speech to Text" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sprache-zu-Text"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "음성 텍스트 변환"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Распознавание речи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音转文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語音轉文字"
+          }
+        }
+      }
+    },
     "Speed" : {
       "localizations" : {
         "de" : {
@@ -175833,6 +176921,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已朗讀"
+          }
+        }
+      }
+    },
+    "Spoken Voice" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sprechstimme"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "음성 종류"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Голос озвучивания"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "朗读音色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "朗讀音色"
           }
         }
       }
@@ -182157,6 +183279,40 @@
         }
       }
     },
+    "Terms & Privacy Policy" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nutzungsbedingungen und Datenschutzerklärung"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "약관 및 개인정보 처리방침"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Условия и политика конфиденциальности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条款与隐私政策"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "條款與隱私權政策"
+          }
+        }
+      }
+    },
     "Terms (one per line)" : {
       "localizations" : {
         "de" : {
@@ -182599,6 +183755,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "測試通知"
+          }
+        }
+      }
+    },
+    "Test Search" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Suche testen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색 테스트"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Тестовый поиск"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "测试搜索"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試搜尋"
           }
         }
       }
@@ -183150,6 +184340,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文本轉語音"
+          }
+        }
+      }
+    },
+    "Text to Speech" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Text-zu-Sprache"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "텍스트 음성 변환"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Синтез речи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本转语音"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字轉語音"
           }
         }
       }
@@ -191278,6 +192502,40 @@
         }
       }
     },
+    "Toast Notifications" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toast-Benachrichtigungen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "토스트 알림"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Всплывающие уведомления"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toast 通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toast 通知"
+          }
+        }
+      }
+    },
     "Toast notifications are working!" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -191344,6 +192602,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toast 位置"
+          }
+        }
+      }
+    },
+    "Toast Timeout" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toast-Anzeigedauer"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "토스트 표시 시간"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Длительность показа уведомления"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toast 显示时长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toast 顯示時長"
           }
         }
       }
@@ -193001,6 +194293,40 @@
         }
       }
     },
+    "Top P" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top P"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top P"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Top P"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top P"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top P"
+          }
+        }
+      }
+    },
     "Top P Override" : {
       "localizations" : {
         "de" : {
@@ -193717,6 +195043,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "轉寫模式"
+          }
+        }
+      }
+    },
+    "Transcription Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transkriptionsmodell"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "전사 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Модель транскрипции"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转写模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轉錄模型"
           }
         }
       }
@@ -201702,6 +203062,40 @@
         }
       }
     },
+    "Voice Activity Detection" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Spracherkennung (VAD)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "음성 활동 감지"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Детекция голосовой активности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音活动检测"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語音活動偵測"
+          }
+        }
+      }
+    },
     "Voice Detection Error: %@" : {
       "localizations" : {
         "de" : {
@@ -202009,6 +203403,40 @@
         }
       }
     },
+    "Voice Models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sprachmodelle"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "음성 모델"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Голосовые модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語音模型"
+          }
+        }
+      }
+    },
     "Voice output lives in General → Configure → Voice; the greeting text and personality are in General → Appearance → Empty State." : {
       "localizations" : {
         "de" : {
@@ -202147,6 +203575,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "語音靈敏度"
+          }
+        }
+      }
+    },
+    "Voice Temperature" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sprach-Temperatur"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "음성 온도"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Температура голоса"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语音温度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語音溫度"
           }
         }
       }


### PR DESCRIPTION
## Summary

The Settings search index renders every entry through
`Text(LocalizedStringKey(entry.title))` / `Text(LocalizedStringKey(entry.section))`
(`SettingsSearchResultsView.swift:102,106`), but **38 of its 79 titles and 6 of its
section names have no entry in `Localizable.xcstrings`**. They fall back to English in
*every* locale.

So today, in a fully localized app, searching Settings returns results titled
`Context & KV Policy`, `Prompt Cache`, `Voice Models`, `Factory Reset`, `Privacy Filter`,
`Identity & Recovery` … next to localized section labels. I hit this as a Chinese user —
Settings search is the fastest way to reach a pane, and it is the one surface that still
answers in English.

This adds the 43 missing keys (38 titles + 5 section names; `Power` is both).
No existing entry is modified: the diff is **+1462 / −0**.

## Why CI did not catch it

`check-swift-catalog-keys.py` scans for five literal markers — `L("`,
`Text(localized: "`, `Button(localized: "`, `Label(localized: "`, `localizedHelp("`.
`SettingsSearchIndex.swift` declares its strings as plain `String` values and localizes
them later at the render site, so no marker matches, the checker reports OK, and Xcode's
automatic extraction misses them for the same reason.

The same indirection hides other strings elsewhere in the app. I can send a follow-up
that teaches the checker to resolve literals passed into helpers that wrap them in
`LocalizedStringKey(...)`; this PR is data only.

## Verified in two locales

Settings → search "KV", same build, before and after:

| before | after (zh-Hans) |
|---|---|
| ![before](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/a1-before-search-en.png) | ![after zh](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/a1-after-search-zh.png) |

The same build launched with `-AppleLanguages '(de)'`, showing the fix is not
Chinese-specific — the three results are German where they used to be English:

![de after](https://raw.githubusercontent.com/YspritanHyzygy/osaurus/i18n-evidence/a1-after-search-de.png)

## A note on the non-Chinese values

`xcstrings_util.is_maintained_entry` enforces all of `de, zh-Hans, ko, ru` on any key that
declares one of them, so a Chinese-only addition cannot pass `check.sh`.

| locale | state | source |
|---|---|---|
| zh-Hans, zh-Hant | `translated` | native speaker (me) |
| de, ko, ru | `needs_review` | LLM-assisted, not verified by a native speaker |

Nothing here is marked `translated` that I cannot vouch for. Happy to drop the de/ko/ru
values if you would rather these keys ship Chinese-only and let `check.sh` change instead.

## Keys added

<details><summary>38 search titles</summary>

| English key | zh-Hans | tab / section |
|---|---|---|
| Factory Reset | 恢复出厂设置 | settings / General |
| Default Agent Max Output Tokens | 智能体默认最大输出 Token 数 | chat / Generation |
| Context & KV Policy | 上下文与 KV 策略 | server / Cache |
| Top P | Top P | chat / Generation |
| Toast Notifications | Toast 通知 | settings / Notifications |
| Toast Timeout | Toast 显示时长 | settings / Notifications |
| Folder Tool Permissions | 文件夹工具权限 | chat / Tool Permissions |
| Terms & Privacy Policy | 条款与隐私政策 | settings / Legal |
| Transcription Model | 转写模型 | voice / Speech to Text |
| Dictation Hotkey | 听写快捷键 | voice / Speech to Text |
| Voice Activity Detection | 语音活动检测 | voice / VAD Mode |
| Spoken Voice | 朗读音色 | voice / Text to Speech |
| Voice Temperature | 语音温度 | voice / Text to Speech |
| Voice Models | 语音模型 | voice / Models |
| Port & Network | 端口与网络 | server / Connection |
| API Authentication | API 身份验证 | server / Authentication |
| Generation Defaults | 生成默认值 | server / Sampling Defaults |
| Model Residency | 模型驻留 | server / Model Memory |
| Prompt Cache | 提示缓存 | server / Cache |
| Power | 电源 | server / Power |
| Browser Sessions | 浏览器会话 | browser |
| Global Channel Writes | 全局频道写入 | agentChannels / Global Channel Safety |
| Discord | Discord | agentChannels / Native Integrations |
| Custom HTTP Connections | 自定义 HTTP 连接 | agentChannels / Custom JSON Connections |
| Load Policy | 加载策略 | imageGeneration / Settings |
| Download image models | 下载图片模型 | imageGeneration / Models |
| Privacy Filter | 隐私过滤器 | privacy |
| Identity & Recovery | 身份与恢复 | identity |
| External Model Sources | 外部模型来源 | storage |
| Encrypt Local Data at Rest | 加密本地静态数据 | storage |
| Appearance & Themes | 外观与主题 | themes |
| Agent Database | 智能体数据库 | agents / Knowledge |
| Search Providers | 搜索提供商 | search |
| Premium Search | 高级搜索 | search |
| Search Credits | 搜索积分 | credits / Web search |
| Test Search | 测试搜索 | search / Try it |
| Per-category Provider Order | 分类提供商顺序 | search / Advanced |
| Custom Search Provider | 自定义搜索提供商 | search / Advanced |

</details>

<details><summary>5 section names</summary>

| English key | zh-Hans |
|---|---|
| Speech to Text | 语音转文本 |
| Text to Speech | 文本转语音 |
| Native Integrations | 原生集成 |
| Global Channel Safety | 全局频道安全 |
| Custom JSON Connections | 自定义 JSON 连接 |

</details>

`Top P` and `Discord` are deliberately identical in all five locales — they are the
established forms in each.

## Test plan

- [x] `bash scripts/i18n/check.sh` passes (6171 keys, locales de/zh-Hans/ko/ru)
- [x] diff contains additions only — `git diff --numstat` → `1462  0`
- [x] built the app and confirmed Settings search returns localized titles in **zh-Hans**
      and in **de** (screenshots above)
- [x] the 9 empty entries Xcode serialises as `{\n\n    }` are preserved byte-for-byte —
      keys were inserted textually instead of re-serialising the catalog, which is also
      why nothing else in the file moved
