### PR TITLE
Fix stale settings warmup and add SSD cache regression eval

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d2f6f98265fabe2f017a9eb4af237b962154228a"
+        "revision" : "5aa5f160725187d327449628709d472add127541"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -493,7 +493,13 @@ final class ChatWindowState: ObservableObject {
         cachedSystemPrompt = AgentManager.shared.effectiveSystemPrompt(for: agentId)
         cachedActiveAgent = agents.first { $0.id == agentId } ?? .default
         cachedAgentDisplayName = Self.displayName(for: cachedActiveAgent)
-        session.invalidateTokenCache()
+        // `.appConfigurationChanged` also feeds ChatSession's prompt-shape
+        // detector. Keep its old preview bytes until that detector compares
+        // them with the newly persisted Default-agent configuration. Clearing
+        // the preview here allowed the intervening SwiftUI redraw to cache
+        // the new bytes first, hiding the change and leaving a stale green
+        // warm-prefix claim for the next send.
+        session.invalidateTokenCache(preservingPromptShapeBaseline: true)
     }
 
     func refreshAll() async {
@@ -628,7 +634,11 @@ final class ChatWindowState: ObservableObject {
         if !newActive.isBuiltIn {
             cachedSystemPrompt = newActive.systemPrompt
         }
-        session.invalidateTokenCache()
+        // The matching `.agentUpdated` / prompt-shape signal must compare the
+        // old preview against this newly published agent. Preserve that
+        // baseline across the immediate window-state refresh; otherwise a
+        // view redraw can consume the new shape before the detector runs.
+        session.invalidateTokenCache(preservingPromptShapeBaseline: true)
 
         if newActive.themeId != oldActive.themeId {
             refreshTheme()

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "daa9f42c6190a9220e7596b93afb04d84866bf25efb7709ba51e38d6d20980bd",
+  "originHash" : "cd73e257cd410e0669de89f8a5f9ddc331e108e562e102a30ecfdb44cde0c32d",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d2f6f98265fabe2f017a9eb4af237b962154228a"
+        "revision" : "5aa5f160725187d327449628709d472add127541"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -98,9 +98,13 @@ let package = Package(
         // prefill crosses it for standalone rotating/SWA cache topologies.
         // This preserves the existing fail-closed post-hoc rederive guard
         // while allowing a later compatible turn to restore the longer seed.
+        // vmlx-swift#191 preserves canonical scalar content for Gemma 4
+        // text-only system/developer turns. Real bundle templates otherwise
+        // omit prompt-affecting settings text and can accept an incompatible
+        // SSD checkpoint because distinct revisions tokenize identically.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d2f6f98265fabe2f017a9eb4af237b962154228a"
+            revision: "5aa5f160725187d327449628709d472add127541"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -220,7 +220,6 @@ extension ChatSession: ChatWarmupSessionContext {
     }
 
     func invalidateWarmupAfterContextShapeChange() {
-        warmupController.invalidateWarmState()
-        warmupController.scheduleWarmup(session: self)
+        warmupController.handleContextShapeChange(session: self)
     }
 }

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -88,6 +88,13 @@ final class ChatWarmupController: ObservableObject {
     private var scheduleTask: Task<Void, Never>?
     private var inFlightWarmup: Task<Void, Never>?
     private var inFlightWarmupID: UUID?
+    /// A prompt-shape change is different from an idle speculative warm-up:
+    /// the next real send is known to need these exact rendered bytes. Track
+    /// that rewarm separately so `send()` can keep cancelling ordinary
+    /// scheduled work without cancelling the only warm-up for a freshly
+    /// changed system prompt.
+    private var requiredContextWarmup: Task<Void, Never>?
+    private var requiredContextWarmupID: UUID?
     /// The model of the most recent user-driven selection change. A warm-up
     /// for this model may displace a resident model; all other (speculative)
     /// warm-ups may only fill an empty slot — see `performWarmup`.
@@ -126,6 +133,7 @@ final class ChatWarmupController: ObservableObject {
         scheduleTask?.cancel()
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
+        requiredContextWarmup?.cancel()
         retiringWork?.cancel()
     }
 
@@ -142,6 +150,7 @@ final class ChatWarmupController: ObservableObject {
         scheduleTask?.cancel()
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
+        requiredContextWarmup?.cancel()
 
         let previousRetiringWork = retiringWork
         let retiringSwitch = activeModelSwitch
@@ -164,6 +173,8 @@ final class ChatWarmupController: ObservableObject {
         activeModelSwitchID = nil
         inFlightWarmup = nil
         inFlightWarmupID = nil
+        requiredContextWarmup = nil
+        requiredContextWarmupID = nil
         userIntentWarmupModel = nil
         warmedFingerprint = nil
         state = .cold
@@ -174,6 +185,43 @@ final class ChatWarmupController: ObservableObject {
     func invalidateWarmState() {
         warmedFingerprint = nil
         if state == .warm { state = .cold }
+    }
+
+    /// Rewarm a newly composed prompt shape and make that work part of the
+    /// pre-send handshake. Unlike an idle `scheduleWarmup`, this task is not
+    /// cancelled by `send()` before dispatch: doing so made a settings edit
+    /// reliably fall back to a visible full cold prefill whenever the user
+    /// returned to chat inside the normal debounce window.
+    func handleContextShapeChange(session: ChatWarmupSessionContext) {
+        guard !isShutDown else { return }
+
+        invalidateWarmState()
+        cancelScheduledWarmup()
+
+        let previousRequiredWarmup = requiredContextWarmup
+        previousRequiredWarmup?.cancel()
+
+        let id = UUID()
+        requiredContextWarmupID = id
+        requiredContextWarmup = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if self.requiredContextWarmupID == id {
+                    self.requiredContextWarmup = nil
+                    self.requiredContextWarmupID = nil
+                }
+            }
+
+            // A prior prompt edit may already have reached generation. Let
+            // that cancellation unwind before composing the latest payload;
+            // `performWarmup` will then compare the current full-prompt
+            // fingerprint and issue a second warm-up only when necessary.
+            await previousRequiredWarmup?.value
+            guard !Task.isCancelled else { return }
+            await self.activeModelSwitch?.value
+            guard !Task.isCancelled else { return }
+            await self.performWarmup(session: session)
+        }
     }
 
     /// A load from another surface (HTTP, plugin, subagent, another window)
@@ -381,7 +429,10 @@ final class ChatWarmupController: ObservableObject {
     /// When false, sends can dispatch synchronously — preserving the
     /// "user turn is appended synchronously inside send()" contract.
     var needsPreSendHandshake: Bool {
-        retiringWork != nil || activeModelSwitch != nil || inFlightWarmup != nil
+        retiringWork != nil
+            || activeModelSwitch != nil
+            || inFlightWarmup != nil
+            || requiredContextWarmup != nil
     }
 
     /// Drop a scheduled-but-not-started warm-up so it can't fire mid-run.
@@ -399,7 +450,10 @@ final class ChatWarmupController: ObservableObject {
     /// resumes after Stop.
     func cancelPendingWorkForUserStop() {
         let hadPendingWork =
-            scheduleTask != nil || activeModelSwitch != nil || inFlightWarmup != nil
+            scheduleTask != nil
+            || activeModelSwitch != nil
+            || inFlightWarmup != nil
+            || requiredContextWarmup != nil
         guard hadPendingWork else { return }
 
         switchEpoch &+= 1
@@ -407,6 +461,7 @@ final class ChatWarmupController: ObservableObject {
         scheduleTask = nil
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
+        requiredContextWarmup?.cancel()
         userIntentWarmupModel = nil
         warmedFingerprint = nil
         state = .cold
@@ -418,6 +473,11 @@ final class ChatWarmupController: ObservableObject {
     /// makes the real request prefix-hit — the effective "resume".
     func awaitInFlightWarmup() async {
         await inFlightWarmup?.value
+    }
+
+    /// Wait for a prompt-shape rewarm that the next send depends on.
+    func awaitRequiredContextWarmup() async {
+        await requiredContextWarmup?.value
     }
 
     // MARK: - Private

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -103,6 +103,7 @@ struct ChatSessionQueuedSendTests {
     func naturalCompletion_autoFlushesQueuedSend() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 60) }
 
             session.send("first")
@@ -129,6 +130,7 @@ struct ChatSessionQueuedSendTests {
     func stop_doesNotAutoFlushAndLeavesQueueIntact() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("first")
@@ -155,6 +157,7 @@ struct ChatSessionQueuedSendTests {
     func sendNowInterrupting_stopsAndDispatchesAsNewUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("first")
@@ -194,6 +197,7 @@ struct ChatSessionQueuedSendTests {
     func send_attachmentOnlyTurnPersistsBeforeAssistantCompletes() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
             let attachment = Attachment.document(
                 filename: "assessment.txt",
@@ -221,6 +225,7 @@ struct ChatSessionQueuedSendTests {
     func send_plainTextPersistsBeforeAssistantCompletes() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("persist while streaming")
@@ -241,6 +246,7 @@ struct ChatSessionQueuedSendTests {
     func privacyCancelRemovesPersistedTransientUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
 
             session.send("review will cancel")
@@ -260,6 +266,7 @@ struct ChatSessionQueuedSendTests {
     func privacyCancelRemovesPersistedTurnFromPremintedEmptySession() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             let premintedId = UUID()
             session.sessionId = premintedId
             session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
@@ -288,6 +295,7 @@ struct ChatSessionQueuedSendTests {
             ChatSessionsManager.shared.save(existing)
 
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.load(from: existing)
             session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
 
@@ -308,6 +316,7 @@ struct ChatSessionQueuedSendTests {
     func privacyCancelLeavesQueuedSendPending() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in DelayedCancellingBeforeDeltaChatEngine(delayMs: 120) }
 
             session.send("review will cancel")
@@ -338,6 +347,7 @@ struct ChatSessionQueuedSendTests {
     func stopBeforeFirstDeltaKeepsPersistedUserTurn() async throws {
         try await ChatHistoryTestStorage.run {
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: 500) }
 
             session.send("keep this after stop")
@@ -369,6 +379,7 @@ struct ChatSessionQueuedSendTests {
             ChatSessionsManager.shared.save(existing)
 
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.load(from: existing)
             session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
             let assistantId = try #require(session.turns.last?.id)
@@ -400,6 +411,7 @@ struct ChatSessionQueuedSendTests {
             ChatSessionsManager.shared.save(existing)
 
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.load(from: existing)
             session.chatEngineFactory = { _ in CancellingBeforeDeltaChatEngine() }
             let userId = try #require(session.turns.first?.id)
@@ -431,6 +443,7 @@ struct ChatSessionQueuedSendTests {
             ChatSessionsManager.shared.save(existing)
 
             let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
             session.load(from: existing)
             let assistantId = try #require(session.turns.last?.id)
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -96,6 +96,17 @@ struct ChatWarmupControllerPromptShapeTests {
 @MainActor
 struct ChatSessionImmediatePromptShapeTests {
 
+    @Test("first preview primes a baseline without creating a required rewarm")
+    func firstPreviewIsInitializationNotRevision() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.agentId = Agent.defaultId
+
+            #expect(!session.reconcilePromptShapeBeforeSendForTests())
+            #expect(!session.warmupController.needsPreSendHandshake)
+        }
+    }
+
     @Test("Settings Save then immediate Send sees the newest rendered prompt before debounce")
     func immediateSendReconcilesCurrentPrompt() async throws {
         try await ChatHistoryTestStorage.run {

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -33,6 +33,97 @@ struct ChatConfigurationWarmModelsOnLoadTests {
     }
 }
 
+@Suite("ChatWarmupController prompt-shape rewarm")
+@MainActor
+struct ChatWarmupControllerPromptShapeTests {
+
+    @Test("settings prompt change survives send cancellation and warms the newest payload")
+    func settingsPromptChangeWarmsNewestPayload() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "settings revision A")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|settings-a"
+        )
+
+        let controller = ChatWarmupController()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+
+        session.payload = ChatWarmupPayload(
+            model: "test-model",
+            messages: [ChatMessage(role: "system", content: "settings revision B")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "test-model|settings-b"
+        )
+        controller.handleContextShapeChange(session: session)
+
+        // `ChatSession.send` cancels ordinary scheduled warm-up work before
+        // its handshake. The settings rewarm is required work and must
+        // survive that exact operation.
+        controller.cancelScheduledWarmup()
+        await controller.awaitRequiredContextWarmup()
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 2)
+        let request = try #require(engine.lastRequest)
+        #expect(request.messages.first?.content == "settings revision B")
+        #expect(controller.state == .warm)
+        #expect(!controller.needsPreSendHandshake)
+    }
+
+    @Test("chat prompt-shape signal inventory includes app configuration changes")
+    func appConfigurationChangeIsPromptShapeSignal() {
+        #expect(
+            ChatSession.promptShapeNotificationNames.contains(
+                .appConfigurationChanged
+            )
+        )
+    }
+}
+
+@Suite("ChatSession immediate prompt-shape reconciliation", .serialized)
+@MainActor
+struct ChatSessionImmediatePromptShapeTests {
+
+    @Test("Settings Save then immediate Send sees the newest rendered prompt before debounce")
+    func immediateSendReconcilesCurrentPrompt() async throws {
+        try await ChatHistoryTestStorage.run {
+            var configuration = DefaultAgentConfigurationStore.load()
+            configuration.systemPrompt = "settings revision A"
+            DefaultAgentConfigurationStore.save(configuration)
+
+            let session = ChatSession()
+            session.agentId = Agent.defaultId
+
+            // Seed the same cached preview that made the live chip green.
+            _ = session.resyncBudgetEstimateForTests()
+
+            configuration.systemPrompt = "settings revision B"
+            DefaultAgentConfigurationStore.save(configuration)
+
+            // Do not flush the main queue or wait for the 80 ms Combine
+            // debounce. Production `send()` calls this exact reconciliation
+            // before checking whether it needs a warm-up handshake.
+            #expect(session.reconcilePromptShapeBeforeSendForTests())
+
+            // The delayed notification will see identical bytes and remain a
+            // no-op rather than scheduling duplicate required warm-up work.
+            #expect(!session.reconcilePromptShapeBeforeSendForTests())
+        }
+    }
+}
+
 @Suite("ChatWarmupController immediate model switch")
 @MainActor
 struct ChatWarmupControllerModelSwitchTests {

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowStateAgentSyncTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowStateAgentSyncTests.swift
@@ -183,6 +183,36 @@ struct ChatWindowStateAgentSyncTests {
         }
     }
 
+    @Test("Default prompt Save → lazy UI read cannot hide pre-send shape change")
+    func defaultPromptSave_lazyPreviewRead_preservesShapeChange() async throws {
+        try await ChatHistoryTestStorage.run {
+            let originalConfig = DefaultAgentConfigurationStore.load()
+            defer { DefaultAgentConfigurationStore.save(originalConfig) }
+
+            var revisionA = originalConfig
+            revisionA.systemPrompt = "settings revision A"
+            DefaultAgentConfigurationStore.save(revisionA)
+
+            let window = makeWindow(for: Agent.defaultId)
+            // Seed the exact preview baseline that backed the live green chip.
+            _ = window.session.estimatedContextBreakdown
+
+            var revisionB = revisionA
+            revisionB.systemPrompt = "settings revision B"
+            DefaultAgentConfigurationStore.save(revisionB)
+            await flushMainQueue()
+
+            // Reproduce the SwiftUI redraw between Settings Save and the
+            // debounced prompt-shape observer. This used to lazily cache B
+            // after `refreshAgentConfig()` erased A, so Send compared B to B
+            // and skipped the required rewarm.
+            _ = window.session.estimatedContextBreakdown
+
+            #expect(window.session.reconcilePromptShapeBeforeSendForTests())
+            #expect(!window.session.reconcilePromptShapeBeforeSendForTests())
+        }
+    }
+
     // MARK: - 3. Non-active mutations stay cheap
 
     /// Renaming a non-active agent must update the dropdown's `agents`

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "d2f6f98265fabe2f017a9eb4af237b962154228a"
+        let expectedRevision = "5aa5f160725187d327449628709d472add127541"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -766,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "d2f6f98265fabe2f017a9eb4af237b962154228a"
+        let expectedRuntimeHardenedRevision = "5aa5f160725187d327449628709d472add127541"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -776,7 +776,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, and static system-prefix SSD cache boundaries together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, and static system-prefix SSD cache boundaries together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -164,6 +164,18 @@ private struct EmptyStateContent: View, Equatable {
 
 @MainActor
 final class ChatSession: ObservableObject {
+    /// Notifications whose source data can rewrite the composed system/tool
+    /// prompt. Kept as one testable inventory so a new settings surface
+    /// cannot refresh only its display cache while leaving warm-up state on
+    /// the previous rendered bytes.
+    static let promptShapeNotificationNames: [Notification.Name] = [
+        .agentUpdated,
+        .activeAgentChanged,
+        .toolsListChanged,
+        .appConfigurationChanged,
+        .agentChannelConfigurationChanged,
+    ]
+
     @Published var turns: [ChatTurn] = []
     @Published var isStreaming: Bool = false {
         didSet {
@@ -843,14 +855,12 @@ final class ChatSession: ObservableObject {
             NotificationCenter.default.publisher(for: $0)
                 .map { _ in () }.eraseToAnyPublisher()
         }
-        let budgetSignals: [AnyPublisher<Void, Never>] = [
-            voidNotification(.agentUpdated),
-            voidNotification(.activeAgentChanged),
-            voidNotification(.toolsListChanged),
-            // Channel destination edits rewrite the channel-destinations
-            // dynamic prompt section (and can add/remove the publish tool),
-            // so a stale warm-up must be dropped and re-warmed promptly.
-            voidNotification(.agentChannelConfigurationChanged),
+        // Channel destination edits rewrite a dynamic prompt section;
+        // Default-agent and global chat settings rewrite system/tool policy.
+        // All are equality-guarded by `recomputePreviewContext`, so unrelated
+        // settings notifications remain no-ops after recomposition.
+        let budgetSignals: [AnyPublisher<Void, Never>] =
+            Self.promptShapeNotificationNames.map(voidNotification) + [
             folderState.objectWillChange
                 .map { _ in () }.eraseToAnyPublisher(),
             $selectedModel.map { _ in () }.eraseToAnyPublisher(),
@@ -1925,6 +1935,8 @@ final class ChatSession: ObservableObject {
         // starts (a warm-up that already reached generation is covered by
         // the await below and only pre-warms this send's own prefix).
         warmupController.cancelScheduledWarmup()
+        await warmupController.awaitRequiredContextWarmup()
+        guard !Task.isCancelled else { return false }
         await warmupController.awaitInFlightWarmup()
         return !Task.isCancelled
     }
@@ -2423,10 +2435,21 @@ final class ChatSession: ObservableObject {
         generativeGreetingState = .idle
     }
 
-    /// Invalidate the token cache (called when tools/skills change)
-    func invalidateTokenCache() {
+    /// Invalidate send-time token accounting (called when tools/skills or
+    /// agent configuration change).
+    ///
+    /// Prompt-shape notifications need the previous preview bytes as their
+    /// comparison baseline. When a settings observer clears that baseline,
+    /// SwiftUI can lazily compose the new preview during the intervening
+    /// redraw; the later equality detector then compares new-to-new and
+    /// leaves a stale warm-prefix claim green. Observer-driven source changes
+    /// therefore preserve the preview until `recomputePreviewContext()` has
+    /// compared it with the newly composed bytes.
+    func invalidateTokenCache(preservingPromptShapeBaseline: Bool = false) {
         cachedContext = nil
-        cachedPreviewContext = nil
+        if !preservingPromptShapeBaseline {
+            cachedPreviewContext = nil
+        }
         budgetTracker.clear()
         objectWillChange.send()
     }
@@ -2448,6 +2471,14 @@ final class ChatSession: ObservableObject {
         @discardableResult
         func resyncBudgetEstimateForTests() -> Bool {
             recomputePreviewContext()
+        }
+
+        /// Test seam for the authoritative pre-send prompt reconciliation.
+        /// Unlike the 80 ms UI-estimate debounce, this runs synchronously and
+        /// therefore covers a Settings Save -> immediate Send sequence.
+        @discardableResult
+        func reconcilePromptShapeBeforeSendForTests() -> Bool {
+            reconcilePromptShapeBeforeSend()
         }
     #endif
 
@@ -2711,11 +2742,18 @@ final class ChatSession: ObservableObject {
     /// folder / model signals that feed the pipeline, and doing the
     /// `MemoryContextAssembler` read here once per signal, multiplied across
     /// open chat windows, saturated the cooperative pool (see #1324).
-    private func refreshPreviewEstimate() {
+    @discardableResult
+    private func reconcilePromptShapeBeforeSend() -> Bool {
         if recomputePreviewContext() {
             invalidateWarmupAfterContextShapeChange()
             objectWillChange.send()
+            return true
         }
+        return false
+    }
+
+    private func refreshPreviewEstimate() {
+        reconcilePromptShapeBeforeSend()
     }
 
     /// Re-resolve every input the welcome-screen preview estimate needs —
@@ -4246,6 +4284,18 @@ final class ChatSession: ObservableObject {
             restoreTurnsRollbackAfterAbortedRegeneration()
             return
         }
+
+        // Settings notifications intentionally debounce preview work by 80 ms
+        // to coalesce UI churn. A user can still click Send inside that
+        // window. Recompose from the authoritative stores *before* deciding
+        // whether a warm-up handshake is needed; if the rendered bytes
+        // changed, this synchronously invalidates the stale green claim and
+        // creates required rewarm work that the send below must await.
+        //
+        // This is an equality-guarded source reconciliation, not a blind
+        // delay. The later debounced notification observes the same bytes and
+        // becomes a no-op.
+        reconcilePromptShapeBeforeSend()
 
         // A scheduled-but-not-started warm-up must not fire mid-run.
         warmupController.cancelScheduledWarmup()

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2744,12 +2744,23 @@ final class ChatSession: ObservableObject {
     /// open chat windows, saturated the cooperative pool (see #1324).
     @discardableResult
     private func reconcilePromptShapeBeforeSend() -> Bool {
-        if recomputePreviewContext() {
-            invalidateWarmupAfterContextShapeChange()
+        let hadPromptShapeBaseline = cachedPreviewContext != nil
+        guard recomputePreviewContext() else { return false }
+
+        // Nil -> first preview is initialization, not evidence that a warmed
+        // prompt became stale. Treating it as a required shape rewarm moves an
+        // immediate first send into an unnecessary async handshake (and delays
+        // its crash-safe persistence). A real Settings/agent/tool change has
+        // an established old preview — preserved by the source observers —
+        // and still takes the required-rewarm path below.
+        guard hadPromptShapeBaseline else {
             objectWillChange.send()
-            return true
+            return false
         }
-        return false
+
+        invalidateWarmupAfterContextShapeChange()
+        objectWillChange.send()
+        return true
     }
 
     private func refreshPreviewEstimate() {

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -178,6 +178,7 @@
       "cache_proof.identical-query-replay",
       "cache_proof.prefix-reuse-second-turn",
       "cache_proof.prefix-reuse-three-turns",
+      "cache_proof.settings-prompt-revision",
       "cache_proof.thinking-toggle-boundary"
     ],
     "CapabilityClaims" : [

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -832,6 +832,12 @@ that explicitly target those tiers.
   monotonic completed counts, restore-to-prefill continuity, and a terminal
   `complete == total` frame on every turn.
 - `requireFinalDiskCacheRestore` pins the final turn to the SSD tier.
+- `requireNoCacheRestoreOnTurns` pins incompatible prompt/config revisions to
+  zero restored tokens instead of accepting a stale checkpoint.
+- `requireDiskCacheRestoreOnTurns` and
+  `requirePartialCacheRestoreOnTurns` identify the exact turns that must
+  restore the newest compatible SSD state and still prefill their divergent
+  tail.
 - `minFinalRestoreGainTokens` compares the final two typed restore counts so a
   test can prove the runtime chose a newly stored longer valid prefix instead
   of repeatedly restoring an older shorter candidate.

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -896,6 +896,17 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         public let minStructuredCacheRestoreTurns: Int?
         /// Require the final turn's typed restore event to identify disk.
         public let requireFinalDiskCacheRestore: Bool?
+        /// One-based turns that must not report any restored prompt tokens.
+        /// Used when a prompt/config revision diverges before the first
+        /// cacheable block: accepting an older full checkpoint is stale-state
+        /// reuse, not a speedup.
+        public let requireNoCacheRestoreOnTurns: [Int]?
+        /// One-based turns that must report a nonzero typed restore from the
+        /// disk tier.
+        public let requireDiskCacheRestoreOnTurns: [Int]?
+        /// One-based turns that must restore a nonzero compatible prefix and
+        /// still prefill a nonzero divergent tail.
+        public let requirePartialCacheRestoreOnTurns: [Int]?
         /// Minimum final-turn restore gain over the immediately preceding
         /// turn. Used by the three-session longest-match case: after both a
         /// short and a longer prefix have been persisted, the final request
@@ -933,6 +944,9 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             requireDiskCacheRestore: Bool? = nil,
             minStructuredCacheRestoreTurns: Int? = nil,
             requireFinalDiskCacheRestore: Bool? = nil,
+            requireNoCacheRestoreOnTurns: [Int]? = nil,
+            requireDiskCacheRestoreOnTurns: [Int]? = nil,
+            requirePartialCacheRestoreOnTurns: [Int]? = nil,
             minFinalRestoreGainTokens: Int? = nil,
             requirePrefillProgressAccounting: Bool? = nil,
             requireNonEmptyVisibleTurns: Bool? = nil,
@@ -959,6 +973,9 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.requireDiskCacheRestore = requireDiskCacheRestore
             self.minStructuredCacheRestoreTurns = minStructuredCacheRestoreTurns
             self.requireFinalDiskCacheRestore = requireFinalDiskCacheRestore
+            self.requireNoCacheRestoreOnTurns = requireNoCacheRestoreOnTurns
+            self.requireDiskCacheRestoreOnTurns = requireDiskCacheRestoreOnTurns
+            self.requirePartialCacheRestoreOnTurns = requirePartialCacheRestoreOnTurns
             self.minFinalRestoreGainTokens = minFinalRestoreGainTokens
             self.requirePrefillProgressAccounting = requirePrefillProgressAccounting
             self.requireNonEmptyVisibleTurns = requireNonEmptyVisibleTurns

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerCacheProof.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerCacheProof.swift
@@ -264,6 +264,45 @@ extension EvalRunner {
                     + "(restore=\(restored), tier=\(tier ?? "none"))"
             )
         }
+        for turnNumber in exp.requireNoCacheRestoreOnTurns ?? [] {
+            let turn = turnMetrics.first { $0.turnNumber == turnNumber }
+            let restored = turn?.cacheRestoredTokens ?? 0
+            check(
+                turn != nil && restored == 0,
+                pass: "turn \(turnNumber) rejected incompatible cached prompt state",
+                fail: turn == nil
+                    ? "turn \(turnNumber) has no typed metrics"
+                    : "turn \(turnNumber) restored \(restored) token(s) despite an "
+                        + "incompatible prompt revision"
+            )
+        }
+        for turnNumber in exp.requireDiskCacheRestoreOnTurns ?? [] {
+            let turn = turnMetrics.first { $0.turnNumber == turnNumber }
+            let restored = turn?.cacheRestoredTokens ?? 0
+            let tier = turn?.cacheRestoreDetail?.lowercased()
+            check(
+                turn != nil && restored > 0 && tier == "disk",
+                pass: "turn \(turnNumber) restored \(restored) tokens from disk",
+                fail: turn == nil
+                    ? "turn \(turnNumber) has no typed metrics"
+                    : "turn \(turnNumber) did not restore from disk "
+                        + "(restore=\(restored), tier=\(tier ?? "none"))"
+            )
+        }
+        for turnNumber in exp.requirePartialCacheRestoreOnTurns ?? [] {
+            let turn = turnMetrics.first { $0.turnNumber == turnNumber }
+            let restored = turn?.cacheRestoredTokens ?? 0
+            let remaining = turn?.remainingPrefillTokens ?? 0
+            check(
+                turn != nil && restored > 0 && remaining > 0,
+                pass: "turn \(turnNumber) partially restored \(restored) tokens and "
+                    + "prefilled \(remaining)",
+                fail: turn == nil
+                    ? "turn \(turnNumber) has no typed metrics"
+                    : "turn \(turnNumber) lacked a partial restore "
+                        + "(restore=\(restored), remaining=\(remaining))"
+            )
+        }
         if let floor = exp.minFinalRestoreGainTokens {
             let previous = turnMetrics.dropLast().last?.cacheRestoredTokens
             let final = turnMetrics.last?.cacheRestoredTokens

--- a/Packages/OsaurusEvals/Suites/CacheProof/settings-prompt-revision.json
+++ b/Packages/OsaurusEvals/Suites/CacheProof/settings-prompt-revision.json
@@ -1,0 +1,35 @@
+{
+  "id": "cache_proof.settings-prompt-revision",
+  "domain": "cache_proof",
+  "label": "cache proof • settings prompt revision rejects stale warm-up and restores newest SSD state",
+  "query": "Reply with exactly CURRENT SETTINGS RESTORED.",
+  "notes": "Three fresh-session regression for the intermittent Prefill 0 report after changing prompt-affecting settings. Session 1 stores revision A. Session 2 changes near the start of the system prompt to revision B, so it must not claim any incompatible revision-A restore and must persist B. Session 3 repeats B and must restore the newly current prompt from disk with a nonzero remaining prefill. This scores production typed progress rather than the chip color. Run with OSAURUS_EVALS_KV_REGIME=disk-l2 and OSAURUS_EVALS_PAGED_KV=off.",
+  "fixtures": {},
+  "expect": {
+    "cacheProof": {
+      "followUpTurns": [
+        "Reply with exactly CURRENT SETTINGS RESTORED.",
+        "Reply with exactly CURRENT SETTINGS RESTORED."
+      ],
+      "systemPromptsPerSession": [
+        "REVISION-A-DO-NOT-REUSE-AFTER-SETTINGS-CHANGE. You are validating the prompt cache used by Osaurus after a user changes chat settings. The active configuration requires concise answers. Preserve cache blocks only when every rendered prompt token and runtime option remains compatible. Alpha records model identity. Beta records the chat template revision. Gamma records tool schemas. Delta records reasoning mode. Epsilon records sampler overrides. Zeta records media salts. Eta records cache topology. Theta records the configuration revision. Iota rejects stale prompt state. Kappa persists valid disk checkpoints. Lambda restores only positionally valid tokens. Mu reports restored and remaining prefill separately. Nu finishes with a coherent visible answer.",
+        "REVISION-B-CURRENT-SETTINGS-MUST-WIN. You are validating the prompt cache used by Osaurus after a user changes chat settings. The active configuration requires concise answers. Preserve cache blocks only when every rendered prompt token and runtime option remains compatible. Alpha records model identity. Beta records the chat template revision. Gamma records tool schemas. Delta records reasoning mode. Epsilon records sampler overrides. Zeta records media salts. Eta records cache topology. Theta records the configuration revision. Iota rejects stale prompt state. Kappa persists valid disk checkpoints. Lambda restores only positionally valid tokens. Mu reports restored and remaining prefill separately. Nu finishes with a coherent visible answer.",
+        "REVISION-B-CURRENT-SETTINGS-MUST-WIN. You are validating the prompt cache used by Osaurus after a user changes chat settings. The active configuration requires concise answers. Preserve cache blocks only when every rendered prompt token and runtime option remains compatible. Alpha records model identity. Beta records the chat template revision. Gamma records tool schemas. Delta records reasoning mode. Epsilon records sampler overrides. Zeta records media salts. Eta records cache topology. Theta records the configuration revision. Iota rejects stale prompt state. Kappa persists valid disk checkpoints. Lambda restores only positionally valid tokens. Mu reports restored and remaining prefill separately. Nu finishes with a coherent visible answer."
+      ],
+      "thinkingPerTurn": [false, false, false],
+      "maxTokens": 128,
+      "startNewSessionBeforeTurns": [2, 3],
+      "minDiskL2StoresDelta": 2,
+      "minCacheRestoredTokens": 64,
+      "requireNoCacheRestoreOnTurns": [2],
+      "requireDiskCacheRestoreOnTurns": [3],
+      "requirePartialCacheRestoreOnTurns": [3],
+      "requireFinalDiskCacheRestore": true,
+      "requirePrefillProgressAccounting": true,
+      "requireNonEmptyVisibleTurns": true,
+      "requireClosedReasoning": true,
+      "requireCompanionOnHybrid": true,
+      "requireDiskL2EvidenceOnHybrid": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopCacheProofCampaignTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopCacheProofCampaignTests.swift
@@ -126,6 +126,31 @@ struct AgentLoopCacheProofCampaignTests {
         #expect(expectation.requirePrefillProgressAccounting == true)
     }
 
+    @Test func settingsRevisionCaseRejectsStaleWarmupAndRestoresNewestRevision() throws {
+        let suite = try EvalSuite.load(
+            from: Self.packageRoot.appendingPathComponent("Suites/CacheProof")
+        )
+        let testCase = try #require(
+            suite.cases.first {
+                $0.id == "cache_proof.settings-prompt-revision"
+            }
+        )
+        let expectation = try #require(testCase.expect.cacheProof)
+
+        #expect(expectation.startNewSessionBeforeTurns == [2, 3])
+        #expect(expectation.systemPromptsPerSession?.count == 3)
+        #expect(expectation.systemPromptsPerSession?[0] != expectation.systemPromptsPerSession?[1])
+        #expect(expectation.systemPromptsPerSession?[1] == expectation.systemPromptsPerSession?[2])
+        #expect(expectation.requireNoCacheRestoreOnTurns == [2])
+        #expect(expectation.requireDiskCacheRestoreOnTurns == [3])
+        #expect(expectation.requirePartialCacheRestoreOnTurns == [3])
+        #expect(expectation.minCacheRestoredTokens == 64)
+        #expect(expectation.requireFinalDiskCacheRestore == true)
+        #expect(expectation.requirePrefillProgressAccounting == true)
+        #expect(expectation.requireNonEmptyVisibleTurns == true)
+        #expect(expectation.requireClosedReasoning == true)
+    }
+
     @MainActor
     @Test func repeatedCacheProofTrialsReceiveDistinctButInternallyStableNamespaces() {
         let first = EvalRunner.cacheProofTrialInputs(

--- a/docs/internal/evidence/2026-07-27-settings-warmup-prefill/README.md
+++ b/docs/internal/evidence/2026-07-27-settings-warmup-prefill/README.md
@@ -1,0 +1,272 @@
+# Settings-change warm-up / Prefill 0 regression
+
+Status: `PARTIAL` — the Gemma 4 prompt-shape defect has an owning-layer fix,
+focused tests, real OsaurusEval passes on Ornith, Gemma 4, and Bonsai, and the
+current Osaurus UI-cache fix has passed the isolated Release-app lifecycle. The
+remaining gates are current-main integration and PR CI. The
+vMLX fix is squash-merged at
+`5aa5f160725187d327449628709d472add127541`, Osaurus is pinned to that exact
+commit in every workspace/package lockfile, and the Gemma runtime row was
+repeated on the merged pin.
+
+## User-visible regression
+
+After changing prompt-affecting chat settings, the model chip could continue
+to represent an older warmed context. The next real turn then composed the
+new system prompt, diverged from the stale warm-up, and visibly restarted at
+`Prefill 0`. Reports reproduced this intermittently with Bonsai, Ornith, and
+Qwen models. A user Stop could make the stale/cold transition more obvious,
+but Stop was not the source of the prompt mismatch.
+
+## Current-source trace
+
+1. `DefaultAgentConfigurationStore.save` and `ChatConfigurationStore.save`
+   publish `.appConfigurationChanged`.
+2. `ChatWindowState` consumes that notification only to refresh its cached
+   agent/system-prompt display state.
+3. `ChatSession`'s equality-guarded prompt-shape pipeline listens for agent,
+   tool, channel, folder, and model changes, but not
+   `.appConfigurationChanged`. Therefore the composed preview is not compared
+   after a chat/default-agent setting changes, and the warm fingerprint can
+   remain stale.
+4. `ChatWarmupPayload.fingerprint` already hashes the full rendered system
+   prompt. The cache identity is correct once a fresh payload is composed; the
+   missing link is triggering that composition and rewarm.
+5. `invalidateWarmupAfterContextShapeChange` currently schedules an ordinary
+   500 ms debounced warm-up. `ChatSession.send` intentionally cancels such a
+   scheduled warm-up before dispatch and only waits for model switches or
+   already-running warm-up generations. A send inside that debounce window can
+   therefore cancel the only warm-up for the new prompt and start cold.
+6. The first Osaurus fix changed a proven prompt-shape edit into required
+   rewarm work, but the proof task is not created until the 80 ms
+   `contextEstimateCancellable` debounce fires. `send()` checks
+   `needsPreSendHandshake` synchronously. If the user saves Settings and sends
+   before that debounce expires, the controller still reports the old warm
+   state and the real send starts without reconciling the current rendered
+   prompt.
+7. The synchronous send-time reconciliation still failed in the real app
+   because `ChatWindowState.refreshAgentConfig()` cleared both the send
+   context and the old `cachedPreviewContext`. A SwiftUI redraw between
+   Settings Save and the 80 ms observer then lazily cached the new preview.
+   Both the observer and Send compared the new bytes to those same new bytes,
+   so neither could detect that the green warm claim belonged to the old
+   prompt.
+
+## Required root fix
+
+- Feed `.appConfigurationChanged` into the existing 80 ms, full-prompt
+  equality-guarded preview pipeline. Unrelated settings must remain a no-op
+  after recomposition.
+- Represent a proven prompt-shape change as a required, tracked rewarm rather
+  than ordinary speculative scheduled work. A real send may cancel unrelated
+  speculative warm-up, but must wait for this current-prompt rewarm.
+- Make `send()` synchronously reconcile the authoritative composed prompt shape
+  before it decides whether the async warm-up handshake is needed. This must
+  derive from current stores and composed bytes, not a blind delay.
+- When an agent/default-agent settings refresh invalidates display/send caches,
+  retain the prior prompt-shape preview only as the comparison baseline until
+  the equality-guarded detector consumes it. A lazy UI read must not overwrite
+  the old warmed shape before Send compares it.
+- Preserve the existing model-switch, Stop, shutdown, RAM-safety, and
+  single-resident-model rules.
+
+## Permanent regression coverage
+
+- Unit: warm revision A, mutate the session payload to revision B, trigger a
+  context-shape rewarm, immediately follow the same cancellation path used by
+  send, and require revision B to finish warming.
+- UI-state unit: seed revision A through `ChatWindowState`, save revision B,
+  flush the real configuration observer, force the intervening lazy preview
+  read performed by the UI, and require synchronous pre-send reconciliation
+  to detect B exactly once.
+- OsaurusEval CacheProof: use three fresh sessions with system prompt
+  revisions A, B, B. Turn 2 must not claim an incompatible stale full restore;
+  turn 3 must restore the newly persisted B prefix from disk with typed,
+  monotonic prefill accounting and coherent terminal output.
+- Live Release app: change a prompt-affecting setting through Settings, return
+  immediately to chat, send, inspect restored/remaining prefill counts and
+  terminal UI state, then repeat in a new chat and after app restart.
+
+No screenshot or video artifact belongs in Git history. Local visual evidence
+is retained outside the repository.
+
+## Current implementation
+
+- `ChatView` now feeds `.appConfigurationChanged` into the existing
+  equality-guarded prompt-shape pipeline.
+- `ChatWarmupController` tracks prompt-shape rewarm separately from ordinary
+  speculative warm-up. The send path may cancel speculative work, but it waits
+  for the required current-prompt rewarm before dispatch.
+- `send()` now performs exact current-store prompt recomposition before
+  cancelling speculative work or deciding whether the required handshake is
+  needed.
+- `ChatWindowState` invalidates the authoritative send context after a
+  settings/active-agent edit while retaining the old prompt preview solely as
+  the shape-comparison baseline. This closes the lazy-redraw race without a
+  timer, forced prompt, or global warm-up.
+- `cache_proof.settings-prompt-revision` permanently scores three fresh
+  sessions with prompt revisions A, B, B:
+  - turn 2 must not restore the incompatible A state;
+  - turn 3 must restore the newly stored B state from disk;
+  - typed restored/remaining prefill accounting, closed reasoning, coherent
+    output, disk stores, and hybrid companion evidence remain required.
+- The eval harness gained exact per-turn cache tier/restore expectations
+  instead of inferring correctness from aggregate counters.
+
+## Source and focused-test evidence
+
+- `ChatWarmupControllerPromptShapeTests`: 2/2 passed.
+- All focused `ChatWarmupController` suites: 20/20 passed.
+- Final standalone OsaurusEval contract gate: 15/15 passed across
+  `AgentLoopCacheProofCampaignTests` (13/13) and
+  `EvalCatalogManifestTests` (2/2) after the per-turn cache assertions and
+  permanent case were added.
+- Exact-pin OsaurusCore gate: 119/119 passed across the focused
+  `ChatWarmupController` and `RuntimePolicySourceTests` suites.
+- Final broad OsaurusCore warm-up/runtime-policy gate: 131/131 passed. This
+  includes the exact `ChatWindowState` Save -> observer -> lazy-preview ->
+  immediate-Send regression, prompt-shape signals, required rewarm,
+  model-switch, Stop, shutdown, RAM-gate, runtime-residency, completed-run, and
+  pin-policy coverage.
+- vMLX `gemma4ProcessorPreservesTextOnlySystemContent`: 1/1 passed with the
+  Xcode Swift toolchain after preparing the package Metal library.
+- All related vMLX chat-message processor tests: 17/17 passed before the
+  owning-layer fix was squash-merged.
+- `prepare-evals-env.sh` no longer aborts under `set -u` when Xcode metallib
+  candidates are absent.
+
+## Real OsaurusEval runtime evidence
+
+### Ornith 1.0 9B JANG_4M — PASS
+
+Report:
+`/private/tmp/osaurus-settings-prompt-revision-ornith9b-20260727-pass2.json`
+
+- turn 1 / revision A: no restore; 217 prompt tokens; 1,142.6 prefill tok/s;
+  364 ms TTFT.
+- turn 2 / changed revision B: no restore; 212 prompt tokens; 1,125.6 prefill
+  tok/s; 326 ms TTFT.
+- turn 3 / repeated revision B: disk restored 205/212 tokens with 7 remaining;
+  3,427.3 prefill tok/s; 217 ms TTFT.
+- Run deltas: disk L2 +1 hit / +5 stores; SSM companion +1 hit; 38.2 decode
+  tok/s; 2,654 MB peak physical footprint; nonempty visible output; reasoning
+  closed.
+
+### Gemma 4 E2B 8-bit — PASS after owning-layer fix
+
+Merged-pin report:
+`/private/tmp/osaurus-settings-prompt-revision-gemma4-merged-pin-v2-20260727.json`
+
+- turn 1 / revision A: no restore; 215 prompt tokens; 300.2 prefill tok/s;
+  867 ms TTFT.
+- turn 2 / changed revision B: no restore; 210 prompt tokens; 3,083.8 prefill
+  tok/s; 235 ms TTFT.
+- turn 3 / repeated revision B: disk restored 209/210 tokens with 1 remaining;
+  4,558.1 prefill tok/s; 220 ms TTFT.
+- Run deltas: disk L2 +1 hit / +14 stores; 45.7 decode tok/s; 6,148 MB peak
+  physical footprint; nonempty visible output; reasoning closed.
+- Both the OsaurusCore and OsaurusEvals SwiftPM checkouts resolved vMLX to
+  `5aa5f160725187d327449628709d472add127541` before this run.
+
+Before the vMLX fix, the same strict case tokenized all three prompts to only
+25 tokens and incorrectly restored 24/25 tokens after the settings change.
+The cache matched the invalid sequence it received. The defect originated in
+`Gemma4MessageGenerator`, which converted every nonempty text message,
+including a plain leading system message, into a content-parts array. Real
+Gemma 4 bundle templates read the leading system/developer content directly as
+a scalar string before their generic content-parts branch. The fix preserves
+scalar content for text-only turns and uses content-parts arrays only when
+media is present; the strict eval was not weakened.
+
+### Bonsai 27B Ternary JANG — PASS
+
+Report:
+`/private/tmp/osaurus-settings-prompt-revision-bonsai-fixed-20260727.json`
+
+- turn 1 / revision A: no restore; 215 prompt tokens; 283.3 prefill tok/s;
+  1,067 ms TTFT.
+- turn 2 / changed revision B: no restore; 210 prompt tokens; 393.4 prefill
+  tok/s; 783 ms TTFT.
+- turn 3 / repeated revision B: disk restored 203/210 tokens with 7 remaining;
+  1,300.1 prefill tok/s; 451 ms TTFT.
+- Run deltas: disk L2 +1 hit / +5 stores; SSM companion +1 hit; 18.4 decode
+  tok/s; 2,914 MB peak physical footprint; nonempty visible output; reasoning
+  closed.
+- With the eval's 1 GB disk limit, the run also logged one KV entry and its
+  companion entry being evicted, reducing the cache from 1.229 GB to
+  0.994 GB.
+
+## Isolated Release UI findings — FAIL before current UI-cache fix
+
+App:
+`/private/tmp/osaurus-settings-warmup-release-derived-20260727/Build/Products/Release/osaurus.app`
+
+- Bundle identifier:
+  `com.dinoki.osaurus.settingswarmupproof20260727`
+- Test root:
+  `/private/tmp/osaurus-settings-warmup-live-root-20260727-2`
+- Active real model:
+  `OsaurusAI--gemma-4-26B-A4B-it-qat-JANG_4M`
+- The built-in Osaurus agent warmed prompt revision A to a terminal green chip.
+  Trace: 2,442 token cold warm-up, static-prefix hash
+  `e06b309998e06fed`.
+- In Settings -> Chat, the system prompt was changed to revision B. The user
+  immediately returned to chat and sent `What is 19 plus 23?`.
+- The model honored revision B and answered `forty-two`; the final answer was
+  coherent, the Stop control disappeared, input unlocked, and the visible
+  terminal metrics were TTFT 1.55 s / 67.8 tok/s / 8 tokens.
+- Cache behavior failed: the chip still claimed warm at send time, the UI
+  visibly progressed through `Prefill 512/2557`, and the trace recorded
+  `prefill completed=0/2557` with no restore. Revision B had static-prefix hash
+  `8eaa2ab9444677de`.
+- Therefore this row is a settings-to-send ordering failure, not a slow SSD:
+  the current prompt bytes reached generation correctly, but the send began
+  before the debounced observer invalidated and rewarmed them.
+- After adding synchronous send-time reconciliation, revision C still failed
+  the same live row. The model answered `42` coherently at TTFT 1.45 s and
+  66.6 tok/s, then finalized and unlocked input, but generation started at
+  `Prefill 0/2556`. Trace hash `5e5b6ffddaf8de0c` showed no cache restore;
+  disk misses increased from 2 to 11 and stores from 2 to 7. A later idle warm
+  restored 2,556/2,563 tokens, proving disk L2 itself was usable.
+- Source tracing of that second failure found the UI-cache race described
+  above: the Settings observer erased revision B, and an intervening UI preview
+  cached revision C before either the debounced detector or Send compared
+  shapes.
+
+## Isolated Release UI evidence — PASS on current UI-cache fix
+
+Binary:
+`/private/tmp/osaurus-settings-warmup-release-derived-20260727/Build/Products/Release/osaurus.app`
+
+- Built from the current worktree at `2026-07-27 13:26:50`, using the dedicated
+  bundle identifier and test root listed above.
+- Runtime settings were read back from the isolated root: block-disk cache on,
+  prefix cache on, paged KV off, legacy disk cache off, and safe-auto memory
+  safety. This is an SSD-L2-only proof; no RAM prefix hit was credited.
+- On app start, revision C restored 2,441/2,445 prompt tokens from disk.
+- Through Settings -> Chat, the system prompt was changed to revision D and
+  the arithmetic turn was sent immediately. The required revision-D system
+  warm-up completed first. Because D intentionally diverged from C near the
+  beginning, that warm-up correctly performed a cold 2,445-token prefill
+  rather than reusing incompatible C state.
+- The real user turn then visibly began at `Prefill 2445/2556`, and trace
+  recorded `cacheRestore completed=2445/2556 detail=disk`. It answered `42`,
+  TTFT was 0.47 s, decode was 69.1 tok/s, Stop disappeared, and input unlocked.
+- A same-chat follow-up restored 2,563/2,674 tokens from disk, answered `42`
+  at TTFT 0.50 s / 71.0 tok/s, and finalized normally.
+- A fresh chat visibly entered warm-up, restored 2,444/2,445 system tokens from
+  disk, then its first user turn restored 2,445/2,556. It answered `42` at
+  TTFT 0.44 s / 69.1 tok/s and finalized normally.
+- After quitting and relaunching the exact same Release app and isolated root,
+  startup again restored 2,444/2,445 tokens from disk. Its first user turn
+  restored 2,445/2,556, answered `42` at TTFT 0.47 s / 68.5 tok/s, and
+  finalized normally.
+- Current live trace artifacts remain outside Git:
+  `/tmp/osaurus-prefill-debug-pass-revision-d-ui-20260727.log` and
+  `/tmp/osaurus-prefill-debug.log`.
+
+## Remaining proof
+
+- Integrate onto current `osaurus/main` and repeat affected tests if the
+  rebase changes relevant files.
+- Run Osaurus PR CI and only then close this row.

--- a/docs/internal/evidence/2026-07-27-settings-warmup-prefill/README.md
+++ b/docs/internal/evidence/2026-07-27-settings-warmup-prefill/README.md
@@ -2,9 +2,10 @@
 
 Status: `PARTIAL` — the Gemma 4 prompt-shape defect has an owning-layer fix,
 focused tests, real OsaurusEval passes on Ornith, Gemma 4, and Bonsai, and the
-current Osaurus UI-cache fix has passed the isolated Release-app lifecycle. The
-remaining gates are current-main integration and PR CI. The
-vMLX fix is squash-merged at
+current Osaurus UI-cache fix has passed the exact rebased isolated Release-app
+lifecycle. The branch is rebased on current `osaurus/main` at `929f8c25`; the
+remaining gate is fresh PR CI on the rebased head. The vMLX fix is
+squash-merged at
 `5aa5f160725187d327449628709d472add127541`, Osaurus is pinned to that exact
 commit in every workspace/package lockfile, and the Gemma runtime row was
 repeated on the merged pin.
@@ -128,6 +129,13 @@ is retained outside the repository.
   immediate-Send regression, prompt-shape signals, required rewarm,
   model-switch, Stop, shutdown, RAM-gate, runtime-residency, completed-run, and
   pin-policy coverage.
+- Post-rebase focused regression gate: 48/48 passed from the current workspace
+  source. It covers first-preview initialization, immediate prompt-shape
+  reconciliation, every Stop/reset/handshake row, every queued-send
+  persistence/privacy/regeneration row, and the exact merged-vMLX source
+  contract. The result bundle reports 48 tests, 0 failures, and 0 skips:
+  `/private/tmp/osaurus-settings-warmup-tests-derived-20260727/Logs/Test/`
+  `Test-OsaurusCoreTests-2026.07.27_16-05-25--0700.xcresult`.
 - vMLX `gemma4ProcessorPreservesTextOnlySystemContent`: 1/1 passed with the
   Xcode Swift toolchain after preparing the package Metal library.
 - All related vMLX chat-message processor tests: 17/17 passed before the
@@ -195,6 +203,44 @@ Report:
 - With the eval's 1 GB disk limit, the run also logged one KV entry and its
   companion entry being evicted, reducing the cache from 1.229 GB to
   0.994 GB.
+
+### Full CacheProof family matrix — one Bonsai finalization row remains red
+
+These runs used the current PR source with paged RAM cache off and typed disk
+L2 on. The JSON reports remain outside Git; PR reporting must preserve the
+exact pass/fail count rather than flattening a family to “cache works.”
+
+| Exact model | Cases | Decode tok/s mean (min-max) | Peak physical footprint | Disk L2 hits / stores |
+| --- | ---: | ---: | ---: | ---: |
+| `Ornith-1.0-9B-JANG_4M` | 11/11 pass | 31.66 (24.37-37.55) | 2,793 MB | +18 / +35 |
+| `Bonsai-27b-Ternary-JANG-CRACK` | 10/11 pass | 14.52 (12.58-18.03) | 3,232 MB | +18 / +35 |
+| `OsaurusAI--gemma-4-E2B-it-8bit` | 11/11 pass | 41.81 (29.38-45.76) | 6,422 MB | +18 / +116 |
+| `dealign.ai/Qwen3.6-27B-JANG_4M-CRACK` | 11/11 pass | 12.51 (8.64-15.96) | 16,322 MB | +18 / +35 |
+| `dealign.ai/Laguna-XS-2.1-JANG_4M-CRACK` | 11/11 pass | 33.09 (30.71-34.59) | 15,183 MB | +18 / +103 |
+
+The Bonsai failure is
+`cache_proof.cross-session-partial-disk-restore`. Its cache assertions passed:
+turn 2 restored 298/319 tokens from disk, freshly prefilling the remaining 21;
+disk L2 moved +1 hit/+3 stores; and the hybrid SSM companion moved +1 hit.
+The row failed because turn 1 consumed its 512-token budget entirely in
+reasoning, stopped for length, and produced no visible final answer.
+
+A fresh-root three-trial replay made that distinction repeatable: 0/3 trials
+passed, but every trial again restored 298/319 tokens from disk with 21
+remaining and the companion hit. Both turns length-stopped with empty visible
+output and unclosed reasoning. This is evidence of a Bonsai
+reasoning/finalization defect, not evidence of an SSD reset.
+
+The clean-main control reached the same result before this PR. A detached
+`osaurus/main` checkout at `235027b2`, using its exact pinned vMLX revision
+`d2f6f98265fabe2f017a9eb4af237b962154228a`, failed the row 0/3. The
+representative trial restored 295/316 tokens from disk with 21 remaining,
+moved disk L2 by +1 hit/+3 stores and the hybrid companion by +1 hit, then
+failed because its cold first turn stopped for length with reasoning but no
+visible answer. The report is retained outside Git at
+`/private/tmp/osaurus-main-cacheproof-bonsai-partial-repeat3-20260727.json`.
+This classifies the red Bonsai finalization row as pre-existing; the current
+settings-warmup branch neither caused it nor converts it into a cache pass.
 
 ## Isolated Release UI findings — FAIL before current UI-cache fix
 
@@ -264,9 +310,84 @@ Binary:
 - Current live trace artifacts remain outside Git:
   `/tmp/osaurus-prefill-debug-pass-revision-d-ui-20260727.log` and
   `/tmp/osaurus-prefill-debug.log`.
+- The exact corrected source was also exercised with the detected
+  `qwen3-0.6b-8bit` bundle in the same isolated Release app. With paged RAM off
+  and disk L2 on, Settings revision E was saved through the visible UI and the
+  immediate user turn restored 2,138/2,254 tokens from disk, prefilling only
+  116. The model answered `44 + 19 = 63.`, the visible terminal metrics were
+  TTFT 0.17 s / 312.2 tok/s, Stop disappeared, and input unlocked. The exact
+  trace is retained outside Git at
+  `/tmp/osaurus-prefill-debug-pass-revision-e-qwen-latest-20260727.log`.
+
+### Exact post-rebase Release lifecycle
+
+- The exact Release binary was built from Osaurus head
+  `7306a4017e51d37839f2afe2a3c0e8b96462ea18`, rebased onto
+  `osaurus/main` `929f8c25`, with vMLX pinned to
+  `5aa5f160725187d327449628709d472add127541`.
+- Binary SHA-256:
+  `6c1a9992d70598b7ba499382e424eb436e9dc0463ab9991cf1a24cfbca24bc25`.
+  The proof used bundle identifier
+  `com.dinoki.osaurus.settingswarmupproof20260727` and isolated root
+  `/private/tmp/osaurus-settings-warmup-live-root-20260727-2`.
+- With paged RAM off and block-disk L2 on, Settings -> Chat changed the system
+  prompt to revision G and the user immediately returned to chat and sent
+  `What is 58 plus 27?`. The revision-G warm-up established the new
+  2,447-token system prefix. The real user turn restored 2,447/2,558 tokens
+  from disk, prefilling only 111; prompt throughput was 9,269.6 tok/s and disk
+  L2 hits increased 0 -> 1.
+- The visible answer was `85`, TTFT was 0.44 s, decode was 68.1 tok/s, no
+  reasoning or protocol debris appeared, Stop disappeared, and input
+  unlocked.
+- The same-chat follow-up `What is 31 plus 12?` restored 2,565/2,676 tokens
+  from disk, prefilling 111; prompt throughput was 9,486.2 tok/s and disk L2
+  hits increased 2 -> 3. It answered `43` at TTFT 0.44 s / 69.1 tok/s and
+  finalized normally.
+- After quitting only the isolated proof app and relaunching the exact binary
+  against the same root, startup restored 2,446/2,447 system tokens from disk
+  with zero disk misses. The first new-chat turn visibly showed
+  `Prefill 2447/2558`, restored those same 2,447 tokens from disk, and
+  prefilling only 111 increased disk hits 1 -> 2.
+- The post-restart answer was `91` for `What is 72 plus 19?`, with TTFT
+  0.45 s / 63.4 tok/s. Stop disappeared and input unlocked.
+- The current trace remains outside Git at
+  `/tmp/osaurus-prefill-debug-rebased-revision-g-with-restart-20260727.log`.
 
 ## Remaining proof
 
-- Integrate onto current `osaurus/main` and repeat affected tests if the
-  rebase changes relevant files.
-- Run Osaurus PR CI and only then close this row.
+- PR CI run `30304013300` passed `test-evals`, `test-cli`, `test-packages`,
+  `test-statspack`, `swiftlint`, and `shellcheck`, but `test-core` failed.
+  This row therefore remains open.
+- One failure was a stale source-contract assertion:
+  `ImageGenerationBridgeContractTests` still expects vMLX revision
+  `d2f6f98265fabe2f017a9eb4af237b962154228a`, while the four actual package
+  pins and the runtime-policy source tripwire use the merged, live-proven
+  revision `5aa5f160725187d327449628709d472add127541`. The assertion now names the
+  exact merged revision and passes.
+- `reset_incomingWarmupSurvivesCancelledPreviousHandshake` timed out in the
+  cold CI run. It now passes in both workspace test-plan executions together
+  with every other Stop/reset/handshake row.
+- Two queued-send persistence tests observed a nil session ID in the same run.
+  Focused local execution reproduced those failures and additional privacy
+  rollback failures. Source tracing found a real shared cause: the first
+  preview composition has no older prompt shape to invalidate, but the new
+  required-rewarm path treated that nil-to-initial transition like a Settings
+  edit. An immediate first send was therefore moved into an unnecessary async
+  handshake instead of synchronously appending and persisting its user turn.
+  This also introduced an extra cancelled required-warmup task into the reset
+  lifecycle test. Initial preview priming must update the estimate without
+  creating required rewarm work; only a change from one established preview
+  shape to another is evidence that a warmed prefix became stale.
+- After that owning-layer correction, the original nil-session failures and
+  cancelled-handshake timeout passed. Additional local-only queue-suite rows
+  then exposed an independent test isolation defect: tests that inject a
+  `ChatEngineProtocol` double did not activate the existing
+  `forceChatEngineRouteForTests` seam. On a developer machine whose detected
+  picker currently resolves an image model first, regeneration bypassed the
+  injected cancellation double and produced `Enter a prompt to generate an
+  image.` This is not a production route change; all injected-engine rows are
+  made deterministic by selecting the existing test-only chat-engine route
+  explicitly. All queued-send rows now pass in both workspace test-plan
+  executions.
+- Push the rebased, live-proven head and require a fresh PR CI run. Close this
+  row only after every required check passes on that exact head.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d2f6f98265fabe2f017a9eb4af237b962154228a"
+        "revision" : "5aa5f160725187d327449628709d472add127541"
       }
     },
     {

--- a/scripts/evals/prepare-evals-env.sh
+++ b/scripts/evals/prepare-evals-env.sh
@@ -59,7 +59,7 @@ find_metallib_source() {
     "${HOME}"/Library/Developer/Xcode/DerivedData/osaurus-*/Build/Products/*/osaurus.app/Contents/Resources/default.metallib
   )
   local c
-  for c in "${cands[@]}"; do
+  for c in "${cands[@]-}"; do
     [[ -f "${c}" ]] && { printf '%s' "${c}"; return 0; }
   done
   return 1


### PR DESCRIPTION
## Root cause

Prompt-affecting settings saves published appConfigurationChanged, but ChatSession did not include that signal in its prompt-shape pipeline. Even after adding the signal, two ordering defects remained: send could cancel the debounced rewarm, and ChatWindowState could erase the old preview baseline before the detector compared it with the new rendered prompt. The UI could therefore keep a stale green warm claim while the next request started at Prefill 0.

This change fixes the owning app layer: it preserves the old prompt-shape baseline through the settings refresh, synchronously reconciles authoritative prompt bytes before send, and treats a proven prompt revision as required rewarm work that send awaits. It does not force sampler values, reasoning tags, output caps, or a global retry/continuation behavior.

It also pins vmlx-swift 5aa5f160725187d327449628709d472add127541, the squash-merged scalar Gemma 4 text-only system-message fix from vmlx-swift PR 191.

## Permanent regression

Adds cache_proof.settings-prompt-revision to OsaurusEval. Three fresh sessions render system revisions A, B, B. Turn 2 must reject incompatible A state; turn 3 must partially restore current B state from SSD with typed restored and remaining-prefill accounting. Paged KV is off for this proof.

## Source gates

- OsaurusCore focused warmup, settings-race, Stop, shutdown, RAM-gate, residency, and runtime-policy suites: 131 passed, 0 failed.
- OsaurusEval AgentLoopCacheProofCampaignTests plus EvalCatalogManifestTests: 15 passed, 0 failed.
- git diff --check and shell syntax check passed.

## Real runtime scores

- Ornith 1.0 9B JANG_4M: changed B 0/212 restored; repeated B restored 205/212 from disk, 7 prefilled; TTFT 217 ms; 38.2 decode tok/s; disk +1 hit/+5 stores; SSM +1 hit; peak 2,654 MB.
- Bonsai 27B Ternary JANG: changed B 0/210 restored; repeated B restored 203/210 from disk, 7 prefilled; TTFT 451 ms; 18.4 decode tok/s; disk +1 hit/+5 stores; SSM +1 hit; peak 2,914 MB. The 1 GB disk limit also evicted the oldest KV and companion entries.
- Gemma 4 E2B 8-bit on the exact merged vMLX pin: changed B 0/210 restored; repeated B restored 209/210 from disk, 1 prefilled; TTFT 220 ms; 45.7 decode tok/s; disk +1 hit/+14 stores; peak 6,148 MB.

All three produced nonempty coherent output and closed reasoning.

## Isolated Release app proof

Dedicated bundle com.dinoki.osaurus.settingswarmupproof20260727 and isolated test root, block-disk/prefix on and paged KV off:

- Settings -> Chat revision change -> immediate send: required new system warmup completed; actual turn restored 2445/2556 from disk; answer 42; TTFT 0.47 s; 69.1 tok/s; Stop disappeared and input unlocked.
- Same-chat follow-up: restored 2563/2674; TTFT 0.50 s; 71.0 tok/s; finalized.
- Fresh chat: system restored 2444/2445, first turn restored 2445/2556; TTFT 0.44 s; 69.1 tok/s; finalized.
- App quit/relaunch: startup restored 2444/2445, first turn restored 2445/2556; TTFT 0.47 s; 68.5 tok/s; finalized.

No screenshots or videos are included in Git history.