### PR TITLE
Pin Nanbeige vMLX runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "75ee8c170b015456f29f1463e031c275116cb3ae"
+        "revision" : "7300afaa764f50743b11d8f7f8ececf0100731a2"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5aa5f160725187d327449628709d472add127541"
+        "revision" : "75ee8c170b015456f29f1463e031c275116cb3ae"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5aa5f160725187d327449628709d472add127541"
+        "revision" : "75ee8c170b015456f29f1463e031c275116cb3ae"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cd73e257cd410e0669de89f8a5f9ddc331e108e562e102a30ecfdb44cde0c32d",
+  "originHash" : "140a664177c1b248aa81b49ec9ff5b0995cff032c2ae3b07bf6c3f2b82b06685",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "75ee8c170b015456f29f1463e031c275116cb3ae"
+        "revision" : "7300afaa764f50743b11d8f7f8ececf0100731a2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -106,7 +106,7 @@ let package = Package(
         // 44 loop-layer KV slots and fail-closed runtime-contract validation.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "75ee8c170b015456f29f1463e031c275116cb3ae"
+            revision: "7300afaa764f50743b11d8f7f8ececf0100731a2"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -102,9 +102,11 @@ let package = Package(
         // text-only system/developer turns. Real bundle templates otherwise
         // omit prompt-affecting settings text and can accept an incompatible
         // SSD checkpoint because distinct revisions tokenize identically.
+        // vmlx-swift#192 adds Nanbeige 4.2's looped-transformer runtime with
+        // 44 loop-layer KV slots and fail-closed runtime-contract validation.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5aa5f160725187d327449628709d472add127541"
+            revision: "75ee8c170b015456f29f1463e031c275116cb3ae"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "5aa5f160725187d327449628709d472add127541"
+        let expectedRevision = "75ee8c170b015456f29f1463e031c275116cb3ae"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "75ee8c170b015456f29f1463e031c275116cb3ae"
+        let expectedRevision = "7300afaa764f50743b11d8f7f8ececf0100731a2"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -766,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "75ee8c170b015456f29f1463e031c275116cb3ae"
+        let expectedRuntimeHardenedRevision = "7300afaa764f50743b11d8f7f8ececf0100731a2"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -766,7 +766,7 @@ struct RuntimePolicySourceTests {
         // files -- Package.swift, Packages/OsaurusCore/Package.resolved, and both
         // xcworkspace Package.resolved files. Miss one and the app resolves a
         // revision nobody proved.
-        let expectedRuntimeHardenedRevision = "5aa5f160725187d327449628709d472add127541"
+        let expectedRuntimeHardenedRevision = "75ee8c170b015456f29f1463e031c275116cb3ae"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -776,7 +776,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, and static system-prefix SSD cache boundaries together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, and Nanbeige 4.2 looped-transformer runtime support together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "75ee8c170b015456f29f1463e031c275116cb3ae"
+        "revision" : "7300afaa764f50743b11d8f7f8ececf0100731a2"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5aa5f160725187d327449628709d472add127541"
+        "revision" : "75ee8c170b015456f29f1463e031c275116cb3ae"
       }
     },
     {


### PR DESCRIPTION
## Summary

Pins Osaurus to vmlx-swift `75ee8c170b015456f29f1463e031c275116cb3ae`, which adds Nanbeige 4.2 looped-transformer runtime support from vmlx-swift PR #192.

This keeps all four Osaurus vMLX pin surfaces aligned:

- `Packages/OsaurusCore/Package.swift`
- `Packages/OsaurusCore/Package.resolved`
- `osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- `App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`

## Source validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --no-parallel --filter RuntimePolicySourceTests`
  - 99 tests passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --no-parallel --filter ImageGenerationBridgeContractTests`
  - 2 tests passed
- `git diff --check`
  - clean

## vMLX evidence from PR #192

- `NanbeigeRuntimeTests`: 6 tests passed
- Diagnostic RunBench probes covered:
  - JANG_4M, JANG_6M, MXFP8 config/template smoke
  - 44-slot looped KV topology
  - JANG_4M thinking on/off
  - JANG_4M XML tool call parsing
  - disk L2 cache restore with paged RAM disabled

## Live proof status

This PR is a source pin only. It does not claim Osaurus release/live UI verification. Nanbeige remains `PARTIAL_OSAURUS_LIVE_UI_MISSING` until an isolated Release Osaurus build is driven through live UI chat, reasoning, tool, cache, and finalization checks.
