### PR TITLE
fix(i18n): two render sites that bypass localization

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -595,18 +595,20 @@ struct MLXModel: Identifiable, Codable {
         return .tooLarge
     }
 
-    /// Compact "MMM yyyy" form of `releasedAt`, e.g. "Apr 2026". Locale
-    /// is pinned to `en_US_POSIX` so the format stays stable; the
-    /// localized prefix ("Released …") lives at the call site.
+    /// Compact month-and-year form of `releasedAt`, e.g. "Apr 2026" in English
+    /// and "2026年4月" in Chinese. The localized prefix ("Released …") lives at
+    /// the call site, so this half has to follow the same locale or the two
+    /// halves disagree.
     var formattedReleaseMonth: String? {
         guard let date = releasedAt else { return nil }
         return MLXModel.releaseMonthFormatter.string(from: date)
     }
 
+    /// Localized template so month name, order and separators follow the locale.
+    /// Mirrors `NativeMessageCellView.timestampFormatter`.
     private static let releaseMonthFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "MMM yyyy"
+        f.setLocalizedDateFormatFromTemplate("MMMyyyy")
         return f
     }()
 }

--- a/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TranscriptionModeSettingsTab.swift
@@ -524,10 +524,13 @@ struct TranscriptionModeSettingsTab: View {
 
                         Spacer()
 
-                        Text(
-                            transcriptionStopMode == .manual || pauseDuration == 0
-                                ? "Disabled" : String(format: "%.1fs", pauseDuration)
-                        )
+                        Group {
+                            if transcriptionStopMode == .manual || pauseDuration == 0 {
+                                Text("Disabled", bundle: .module)
+                            } else {
+                                Text(verbatim: String(format: "%.1fs", pauseDuration))
+                            }
+                        }
                         .font(.system(size: 13, weight: .medium, design: .monospaced))
                         .foregroundColor(theme.accentColor)
                     }


### PR DESCRIPTION

Both show English inside otherwise localized UI.

Voice → Speech to Text, the pause-detection readout:

    Text("Pause Detection", bundle: .module)      // localized
    Text(mode == .manual ? "Disabled" : "1.5s")   // not

The second call resolves to `Text(_ content: S) where S: StringProtocol`,
the verbatim overload, so `Disabled` renders literally in every locale even
though the catalog already carries a translation for it. Split into a Group
so the localized branch can use `bundle: .module` and the number stays
`Text(verbatim:)`.

Models catalog, the release month: `releaseMonthFormatter` pinned its locale
to `en_US_POSIX` with a hardcoded "MMM yyyy". The prefix around it is
localized, so a Chinese user reads 发布于 Jul 2026 and a German user
Veröffentlicht Jul 2026. Switched to `setLocalizedDateFormatFromTemplate`,
matching `NativeMessageCellView.timestampFormatter`, which already does this.
The comment claimed the pin kept "the format stable" — the template keeps the
field set stable while letting month name, order and separators follow the
locale, which is what stability should mean here.

Verified by building and launching with -AppleLanguages '(zh-Hans)'.


## Test plan

- [x] `bash scripts/i18n/check.sh` passes on a clean checkout of this branch
- [x] built and launched with `-AppleLanguages '(zh-Hans)'`, reading both sites
- [x] `git diff --stat origin/main` → 2 files, `14 insertions / 9 deletions`;
      no catalog key added or removed, no `state` field touched
