### PR TITLE
Match assistant and user chat text sizing

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/ResponsiveChatTypographyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ResponsiveChatTypographyTests.swift
@@ -1,0 +1,33 @@
+import AppKit
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct ResponsiveChatTypographyTests {
+    @Test @MainActor func chatBodyTypographyMatchesInputSize() throws {
+        let blocks: [SelectableTextBlock] = [.paragraph("Hello")]
+        let theme = CustomizableTheme(
+            config: CustomTheme(typography: ThemeTypography(bodySize: 13)),
+            fontScale: 1
+        )
+
+        let userText = SelectableTextView.attributedString(
+            for: blocks,
+            width: 480,
+            theme: theme
+        )
+        let assistantText = SelectableTextView.attributedString(
+            for: blocks,
+            width: 1000,
+            theme: theme
+        )
+
+        let userFont = try #require(userText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        let assistantFont = try #require(
+            assistantText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        )
+        #expect(userFont.pointSize == CGFloat(theme.bodySize))
+        #expect(assistantFont.pointSize == userFont.pointSize)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -273,7 +273,7 @@ struct SelectableTextView: NSViewRepresentable {
         }
 
         // Render and append changed/new blocks
-        let scale = Typography.scale(for: baseWidth)
+        let scale = Typography.scale(for: Typography.baseWidth)
         let bodyFontSize = CGFloat(theme.bodySize) * scale
 
         for i in diffIndex ..< newBlocks.count {
@@ -320,7 +320,7 @@ struct SelectableTextView: NSViewRepresentable {
 
     func buildAttributedString(coordinator: Coordinator) -> NSMutableAttributedString {
         let result = NSMutableAttributedString()
-        let scale = Typography.scale(for: baseWidth)
+        let scale = Typography.scale(for: Typography.baseWidth)
         let bodyFontSize = CGFloat(theme.bodySize) * scale
         var lengths: [Int] = []
 

--- a/Packages/OsaurusCore/Views/Common/ResponsiveTypography.swift
+++ b/Packages/OsaurusCore/Views/Common/ResponsiveTypography.swift
@@ -9,10 +9,11 @@
 import SwiftUI
 
 enum Typography {
+    static let baseWidth: CGFloat = 640
     static func scale(for width: CGFloat) -> CGFloat {
         // Map 640→1.0, 1024→1.15, 1400→1.25
-        let clamped = max(640.0, min(1400.0, width))
-        let s = (clamped - 640.0) / (1400.0 - 640.0)
+        let clamped = max(baseWidth, min(1400.0, width))
+        let s = (clamped - baseWidth) / (1400.0 - baseWidth)
         return 1.0 + s * 0.25
     }
 


### PR DESCRIPTION
**AI disclaimer: I used GPT-5.6 Sol Extra High in Codex to help investigate this, write the code, and prepare the PR. I reviewed the changes myself, and all functionality testing was done manually.**

I noticed that assistant responses looked quite a bit larger than user messages and the text in the input bar. I'm a bit of a typography snob :) so I started digging through the code and history to see why.

It looks like this came from a few changes that made sense individually but interacted in a way that probably wasn't intended. Chat typography scales with the width it is given, assistant responses get almost the full chat width, and user messages are capped at 65% width. That meant the same theme Body size rendered differently depending on who sent the message.

This PR keeps the existing message widths, but uses the typography system's existing baseline width when rendering chat text. That makes user messages, assistant responses, and the input bar use the same configured Body size. It changes two renderer call sites and adds a focused regression test.

## Testing

I tested the functionality manually in a separate self-signed `Osaurus-dev` build. I tried custom fonts, different Body sizes, live theme changes, and relaunching the app. User text, assistant text, and input text stayed matched. I also added a focused regression test for a narrow user message and a wide assistant response.

## Screenshots

**Before:**
<img width="1422" height="1184" alt="CleanShot 2026-07-27 at 16 13 25" src="https://github.com/user-attachments/assets/2c4026d3-0cbf-47e3-8c85-852d62fc1e6c" />


**After:**

 <img width="1427" height="1175" alt="CleanShot 2026-07-27 at 16 26 59" src="https://github.com/user-attachments/assets/e499773a-42fa-48bd-9024-bf65bcab71bc" />

