### PR TITLE
fall back to lenient decode for nonstandard streaming chunks during tool calls

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
@@ -522,7 +522,26 @@ struct OpenAICompatibleStreamParser {
     ) throws -> RemoteProviderService.StreamEventOutcome {
         switch options.decodeMode {
         case .strict:
-            let chunk = try state.decoder.decode(ChatCompletionChunk.self, from: jsonData)
+            let chunk: ChatCompletionChunk
+            do {
+                chunk = try state.decoder.decode(ChatCompletionChunk.self, from: jsonData)
+            } catch {
+                // Mostly-compatible providers (DeepSeek among them) emit
+                // occasional frames that miss a strict-envelope field
+                // (`object`, `id`, `created`, `choices[].index`). Those frames
+                // can carry tool-argument deltas, so dropping them corrupts
+                // the accumulated call and failing on them kills the turn.
+                // Re-read well-formed JSON with the lenient schema; only
+                // genuinely corrupt payloads (real truncation) propagate the
+                // decode error.
+                guard
+                    let lenient = try? state.decoder.decode(
+                        LenientChatCompletionChunk.self,
+                        from: jsonData
+                    )
+                else { throw error }
+                return processLenientChunk(lenient, options: options, state: &state, yield: yield)
+            }
             // OpenAI emits usage on a dedicated final chunk (empty `choices`)
             // when `stream_options.include_usage` was set; on every other chunk
             // `usage` is null. Capture whatever is present — surfaced at the
@@ -538,25 +557,34 @@ struct OpenAICompatibleStreamParser {
             )
         case .lenient:
             let chunk = try state.decoder.decode(LenientChatCompletionChunk.self, from: jsonData)
-            state.captureProviderUsage(chunk.usage)
-            let choice = chunk.choices?.first
-            if let message = choice?.message {
-                return processMessageCompletion(
-                    message,
-                    finishReason: choice?.finish_reason,
-                    deferToolCallDispatchUntilUsage: options.deferToolCallDispatchUntilUsage,
-                    state: &state,
-                    yield: yield
-                )
-            }
-            return processChoice(
-                delta: choice?.delta,
+            return processLenientChunk(chunk, options: options, state: &state, yield: yield)
+        }
+    }
+
+    private static func processLenientChunk(
+        _ chunk: LenientChatCompletionChunk,
+        options: Options,
+        state: inout RemoteProviderService.StreamingState,
+        yield: (String) -> Void
+    ) -> RemoteProviderService.StreamEventOutcome {
+        state.captureProviderUsage(chunk.usage)
+        let choice = chunk.choices?.first
+        if let message = choice?.message {
+            return processMessageCompletion(
+                message,
                 finishReason: choice?.finish_reason,
                 deferToolCallDispatchUntilUsage: options.deferToolCallDispatchUntilUsage,
                 state: &state,
                 yield: yield
             )
         }
+        return processChoice(
+            delta: choice?.delta,
+            finishReason: choice?.finish_reason,
+            deferToolCallDispatchUntilUsage: options.deferToolCallDispatchUntilUsage,
+            state: &state,
+            yield: yield
+        )
     }
 
     private static func processMessageCompletion(

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1704,9 +1704,13 @@ public actor RemoteProviderService: ToolCapableService {
                 )
                 return .continue
             }
+            // Console-only payload prefix: without it an "invalid streaming
+            // event" report gives no way to identify the offending frame shape.
+            let payloadPrefix = String(decoding: jsonData.prefix(200), as: UTF8.self)
             print(
                 "[Osaurus] Failed to parse provider SSE event while receiving tool arguments: "
-                    + "\(error.localizedDescription) (\(jsonData.count) bytes)"
+                    + "\(error.localizedDescription) (\(jsonData.count) bytes) "
+                    + "payloadPrefix=\(payloadPrefix)"
             )
             return .finishWithError(
                 RemoteProviderServiceError.streamingError(

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -567,17 +567,47 @@ struct OpenAICompatibleStreamParserTests {
             yield: { _ in }
         )
 
+        let truncated = #"{"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"fu"#
         let outcome = RemoteProviderService.handleStreamEvent(
-            jsonData: Data(#"{"unexpected":"frame"}"#.utf8),
+            jsonData: Data(truncated.utf8),
             providerType: .openaiLegacy,
             state: &state,
             yield: { _ in }
         )
         guard case .finishWithError(let error) = outcome else {
-            Issue.record("Expected unparseable chunk mid-arguments to fail, got \(outcome)")
+            Issue.record("Expected truncated chunk mid-arguments to fail, got \(outcome)")
             return
         }
         #expect(error.localizedDescription.contains("while receiving tool arguments"))
+    }
+
+    @Test func parser_strictFallsBackToLenientForNonstandardEnvelopeMidToolArguments() throws {
+        var state = RemoteProviderService.StreamingState(stopSequences: [], trackContent: false)
+        var yielded: [String] = []
+        let toolStart =
+            #"{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"fetch_url","arguments":"{\"url\":"}}]}}]}"#
+        _ = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(toolStart.utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+
+        // Missing `object`, `created`, and `model` fails the strict envelope
+        // but must still contribute its argument delta via the lenient schema.
+        let nonstandard =
+            #"{"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"https://cnn.com\"}"}}]}}]}"#
+        let outcome = try OpenAICompatibleStreamParser.handleEvent(
+            jsonData: Data(nonstandard.utf8),
+            options: .strict,
+            state: &state,
+            yield: { yielded.append($0) }
+        )
+        guard case .continue = outcome else {
+            Issue.record("Expected nonstandard envelope to continue, got \(outcome)")
+            return
+        }
+        #expect(state.accumulatedToolCalls[0]?.args == #"{"url":"https://cnn.com"}"#)
     }
 
     private func dispatchEvents(


### PR DESCRIPTION
## Summary

addresses #2197

- the 0.22.10 fix skipped nonstandard DeepSeek chunks outside tool calls but kept the fatal path when one arrived mid tool-argument streaming, so tool-using turns still failed
- when strict chunk decode fails, re-read well-formed JSON with the lenient schema so argument deltas on nonstandard envelopes are preserved instead of dropped or fatal
- genuinely corrupt payloads (real truncation) still abort mid-arguments, keeping the #2108 protections intact
- log a payload prefix on that fatal path so future reports identify the offending frame shape
- update the mid-argument failure test to use truncated JSON and  add a test proving a nonstandard envelope contributes its argument delta

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
