### PR TITLE
Improve chat message selection, deletion, and export

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift
@@ -12,6 +12,33 @@ import UniformTypeIdentifiers
 
 @MainActor
 enum ChatSessionExportCoordinator {
+    static func exportMarkdown(
+        turn: ChatTurnData,
+        from session: ChatSessionData,
+        scope _: ThemedAlertScope
+    ) {
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = "\(suggestedFilename(for: session, format: .markdown).dropLast(3))-message.md"
+        panel.allowedContentTypes = [contentType(for: .markdown)]
+        panel.title = L("Export Message as Markdown")
+
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            do {
+                try ChatSessionExporter.writeMarkdown(turn: turn, from: session, to: url)
+                ToastManager.shared.action(
+                    L("Export complete"),
+                    message: url.lastPathComponent,
+                    action: .revealInFinder(url),
+                    buttonTitle: L("Reveal in Finder")
+                )
+            } catch {
+                presentError(error)
+            }
+        }
+    }
+
     static func run(
         metadataSession: ChatSessionData,
         format: ChatSessionSidebar.ExportFormat,

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift
@@ -98,6 +98,20 @@ public enum ChatSessionExporter {
         }
     }
 
+    /// Writes one chat turn using the same Markdown schema as a full-session
+    /// export. The surrounding session metadata is retained, while unrelated
+    /// conversation turns are intentionally omitted.
+    public static func writeMarkdown(
+        turn: ChatTurnData,
+        from session: ChatSessionData,
+        options: ChatExportOptions = ChatExportOptions(),
+        to url: URL
+    ) throws {
+        var singleTurnSession = session
+        singleTurnSession.turns = [turn]
+        try writeMarkdown(session: singleTurnSession, options: options, to: url)
+    }
+
     // MARK: - PDF
 
     /// `NSPrintOperation` save-to-file gives page-broken output instead of

--- a/Packages/OsaurusCore/Models/Chat/ChatTurnDeletionPolicy.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurnDeletionPolicy.swift
@@ -1,0 +1,55 @@
+//
+//  ChatTurnDeletionPolicy.swift
+//  osaurus
+//
+//  Keeps persisted provider histories valid when a user removes a chat turn.
+//
+
+import Foundation
+
+/// Resolves the smallest safe deletion set for a chat turn.
+///
+/// A user turn owns its following response chain until the next user turn.
+/// An assistant turn that issued tool calls owns the matching `.tool` result
+/// turns, identified by the provider call id. Removing either side alone
+/// creates a history most providers reject on the next request.
+enum ChatTurnDeletionPolicy {
+    static func removingTurn(id: UUID, from turns: [ChatTurn]) -> [ChatTurn] {
+        guard let index = turns.firstIndex(where: { $0.id == id }) else { return turns }
+
+        switch turns[index].role {
+        case .user:
+            let nextUserIndex = turns[(index + 1)...].firstIndex { $0.role == .user } ?? turns.endIndex
+            return Array(turns[..<index]) + Array(turns[nextUserIndex...])
+
+        case .assistant:
+            let callIDs = Set(turns[index].toolCalls?.map(\.id) ?? [])
+            guard !callIDs.isEmpty else {
+                var remaining = turns
+                remaining.remove(at: index)
+                return remaining
+            }
+
+            // Tool results belong to the current exchange only. Do not remove a
+            // later result that reuses an id in malformed/legacy history.
+            let nextUserIndex = turns[(index + 1)...].firstIndex { $0.role == .user } ?? turns.endIndex
+            return turns.enumerated().compactMap { offset, turn in
+                if offset == index { return nil }
+                if offset > index,
+                    offset < nextUserIndex,
+                    turn.role == .tool,
+                    let callID = turn.toolCallId,
+                    callIDs.contains(callID)
+                {
+                    return nil
+                }
+                return turn
+            }
+
+        case .tool, .system:
+            var remaining = turns
+            remaining.remove(at: index)
+            return remaining
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnDeletionPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnDeletionPolicyTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ChatTurnDeletionPolicyTests {
+    @Test
+    func deletingUserRemovesOnlyItsExchange() {
+        let firstUser = ChatTurn(role: .user, content: "first")
+        let firstAnswer = ChatTurn(role: .assistant, content: "answer")
+        let secondUser = ChatTurn(role: .user, content: "second")
+        let secondAnswer = ChatTurn(role: .assistant, content: "later answer")
+
+        let remaining = ChatTurnDeletionPolicy.removingTurn(
+            id: firstUser.id,
+            from: [firstUser, firstAnswer, secondUser, secondAnswer]
+        )
+
+        #expect(remaining.map(\.id) == [secondUser.id, secondAnswer.id])
+    }
+
+    @Test
+    func deletingToolCallingAssistantAlsoRemovesOnlyMatchingToolResults() {
+        let user = ChatTurn(role: .user, content: "use tools")
+        let toolCall = ToolCall(
+            id: "call_read",
+            type: "function",
+            function: ToolCallFunction(name: "read_file", arguments: "{}")
+        )
+        let assistant = ChatTurn(role: .assistant, content: "")
+        assistant.toolCalls = [toolCall]
+
+        let matchingResult = ChatTurn(role: .tool, content: "file contents")
+        matchingResult.toolCallId = "call_read"
+        let unrelatedResult = ChatTurn(role: .tool, content: "keep this")
+        unrelatedResult.toolCallId = "call_other"
+        let finalAnswer = ChatTurn(role: .assistant, content: "done")
+        let nextUser = ChatTurn(role: .user, content: "next")
+
+        let remaining = ChatTurnDeletionPolicy.removingTurn(
+            id: assistant.id,
+            from: [user, assistant, matchingResult, unrelatedResult, finalAnswer, nextUser]
+        )
+
+        #expect(remaining.map(\.id) == [user.id, unrelatedResult.id, finalAnswer.id, nextUser.id])
+    }
+
+    @Test
+    func deletingPlainAssistantLeavesLaterHistoryUntouched() {
+        let user = ChatTurn(role: .user, content: "question")
+        let answer = ChatTurn(role: .assistant, content: "answer")
+        let laterUser = ChatTurn(role: .user, content: "follow-up")
+
+        let remaining = ChatTurnDeletionPolicy.removingTurn(
+            id: answer.id,
+            from: [user, answer, laterUser]
+        )
+
+        #expect(remaining.map(\.id) == [user.id, laterUser.id])
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2803,13 +2803,31 @@ final class ChatSession: ObservableObject {
         send("")  // Empty send to trigger regeneration with existing history
     }
 
-    /// Delete a turn and all subsequent turns
+    /// Delete one turn while preserving all unrelated later conversation.
+    ///
+    /// A user turn removes its response/tool chain through the next user turn.
+    /// An assistant tool-call turn also removes the matching tool-result turns
+    /// so the next provider request never contains orphaned tool results.
     func deleteTurn(id: UUID) {
-        guard let index = turns.firstIndex(where: { $0.id == id }) else { return }
-        turns = Array(turns.prefix(index))
+        let remaining = ChatTurnDeletionPolicy.removingTurn(id: id, from: turns)
+        guard remaining.count != turns.count else { return }
+        turns = remaining
         isDirty = true
         rebuildVisibleBlocks()
-        save()
+        if turns.isEmpty, let id = sessionId {
+            // `save()` deliberately skips empty sessions. Remove the persisted
+            // row instead, so a deleted final message cannot reappear after a
+            // relaunch. The next send creates a fresh session as normal.
+            ChatSessionsManager.shared.delete(id: id)
+            sessionId = nil
+            title = "New Chat"
+            createdAt = Date()
+            updatedAt = createdAt
+            isDirty = false
+            onSessionChanged?()
+        } else {
+            save()
+        }
     }
 
     /// Regenerate an assistant response (removes it and regenerates)
@@ -7584,6 +7602,7 @@ struct ChatView: View {
                 onRegenerate: regenerateTurn,
                 onEdit: beginEditingTurn,
                 onDelete: deleteTurn,
+                onExport: exportTurnAsMarkdown,
                 onSpeak: speakTurnContent,
                 editingTurnId: editingTurnId,
                 editText: $editText,
@@ -7808,6 +7827,7 @@ private struct IsolatedThreadView: View {
     let onRegenerate: ((UUID) -> Void)?
     let onEdit: ((UUID) -> Void)?
     let onDelete: ((UUID) -> Void)?
+    let onExport: ((UUID) -> Void)?
     let onSpeak: ((UUID) -> Void)?
     let editingTurnId: UUID?
     let editText: Binding<String>?
@@ -7853,6 +7873,7 @@ private struct IsolatedThreadView: View {
             onRegenerate: onRegenerate,
             onEdit: onEdit,
             onDelete: onDelete,
+            onExport: onExport,
             onSpeak: onSpeak,
             editingTurnId: editingTurnId,
             editText: editText,
@@ -8013,6 +8034,15 @@ extension ChatView {
     private func deleteTurn(turnId: UUID) {
         if session.isStreaming { session.stop() }
         session.deleteTurn(id: turnId)
+    }
+
+    private func exportTurnAsMarkdown(turnId: UUID) {
+        guard let turn = session.turns.first(where: { $0.id == turnId }) else { return }
+        ChatSessionExportCoordinator.exportMarkdown(
+            turn: ChatTurnData(from: turn),
+            from: session.toSessionData(),
+            scope: .chat(windowState.windowId)
+        )
     }
 
     // MARK: - Inline Editing

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -98,6 +98,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
     let onRegenerate: ((UUID) -> Void)?
     let onEdit: ((UUID) -> Void)?
     let onDelete: ((UUID) -> Void)?
+    let onExport: ((UUID) -> Void)?
     let onSpeak: ((UUID) -> Void)?
 
     // Inline editing state
@@ -276,6 +277,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onRegenerate: onRegenerate,
             onEdit: onEdit,
             onDelete: onDelete,
+            onExport: onExport,
             onSpeak: onSpeak,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
@@ -327,6 +329,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onRegenerate: onRegenerate,
             onEdit: onEdit,
             onDelete: onDelete,
+            onExport: onExport,
             onSpeak: onSpeak,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,

--- a/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
@@ -32,6 +32,7 @@ struct MessageThreadView: View {
     var onRegenerate: ((UUID) -> Void)? = nil
     var onEdit: ((UUID) -> Void)? = nil
     var onDelete: ((UUID) -> Void)? = nil
+    var onExport: ((UUID) -> Void)? = nil
     var onSpeak: ((UUID) -> Void)? = nil
 
     // Inline editing state (optional)
@@ -110,6 +111,7 @@ struct MessageThreadView: View {
             onRegenerate: onRegenerate,
             onEdit: onEdit,
             onDelete: onDelete,
+            onExport: onExport,
             onSpeak: onSpeak,
             editingTurnId: editingTurnId,
             editText: editText,

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -647,6 +647,7 @@ final class NativeAssistantActionsView: NSView {
     private var responseTimestamp: Date = Date()
     private var onCopy: ((UUID) -> Void)?
     private var onRegenerate: ((UUID) -> Void)?
+    private var onDelete: ((UUID) -> Void)?
     private var onExport: ((UUID) -> Void)?
     var onSpeak: ((UUID) -> Void)?
 
@@ -798,6 +799,7 @@ final class NativeAssistantActionsView: NSView {
         hideSecondaryActions: Bool,
         onCopy: ((UUID) -> Void)?,
         onRegenerate: ((UUID) -> Void)?,
+        onDelete: ((UUID) -> Void)?,
         onExport: ((UUID) -> Void)?,
         onSpeak: ((UUID) -> Void)?
     ) {
@@ -806,6 +808,7 @@ final class NativeAssistantActionsView: NSView {
         self.hideSecondaryActions = hideSecondaryActions
         self.onCopy = onCopy
         self.onRegenerate = onRegenerate
+        self.onDelete = onDelete
         self.onExport = onExport
         self.onSpeak = onSpeak
         self.currentTheme = theme
@@ -870,6 +873,24 @@ final class NativeAssistantActionsView: NSView {
         }
         menu.addItem(export)
 
+        let delete = NSMenuItem(
+            title: L("Delete"),
+            action: #selector(deleteFromMenu),
+            keyEquivalent: ""
+        )
+        delete.target = self
+        delete.isEnabled = onDelete != nil
+        if let theme = currentTheme {
+            let pointSize = CGFloat(theme.captionSize)
+            let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
+            delete.image = SymbolImageCache.image(
+                "trash",
+                accessibilityDescription: nil
+            )?.withSymbolConfiguration(cfg)
+        }
+        menu.addItem(delete)
+        menu.addItem(.separator())
+
         let inspect = NSMenuItem(
             title: L("Inspect response"),
             action: #selector(inspectFromMenu),
@@ -900,6 +921,10 @@ final class NativeAssistantActionsView: NSView {
 
     @objc private func exportFromMenu() {
         onExport?(turnId)
+    }
+
+    @objc private func deleteFromMenu() {
+        onDelete?(turnId)
     }
 
     /// Opens the Settings → Insights tab, focused on the request/response log
@@ -2651,6 +2676,7 @@ final class NativeMessageCellView: NSTableCellView {
             hideSecondaryActions: imageOnly,
             onCopy: context.onCopy,
             onRegenerate: context.onRegenerate,
+            onDelete: context.onDelete,
             onExport: context.onExport,
             onSpeak: context.onSpeak
         )

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -37,6 +37,7 @@ struct CellRenderingContext {
     var onRegenerate: ((UUID) -> Void)? = nil
     var onEdit: ((UUID) -> Void)? = nil
     var onDelete: ((UUID) -> Void)? = nil
+    var onExport: ((UUID) -> Void)? = nil
     var onSpeak: ((UUID) -> Void)? = nil
     /// attachment or shared-artifact id string → full screen preview from ChatView
     var onUserImagePreview: ((String) -> Void)? = nil
@@ -639,13 +640,14 @@ final class NativeAssistantActionsView: NSView {
     private let copyButton: HeaderCircleActionControl
     private let regenerateButton: HeaderCircleActionControl
     let speakButton: HeaderCircleActionControl
-    /// Overflow "…" menu holding the response timestamp and the Inspect action.
+    /// Overflow "…" menu holding the response timestamp, export, and Inspect actions.
     let overflowButton: HeaderCircleActionControl
 
     private var turnId: UUID = UUID()
     private var responseTimestamp: Date = Date()
     private var onCopy: ((UUID) -> Void)?
     private var onRegenerate: ((UUID) -> Void)?
+    private var onExport: ((UUID) -> Void)?
     var onSpeak: ((UUID) -> Void)?
 
     /// Formats the response timestamp for the overflow menu header, e.g.
@@ -796,6 +798,7 @@ final class NativeAssistantActionsView: NSView {
         hideSecondaryActions: Bool,
         onCopy: ((UUID) -> Void)?,
         onRegenerate: ((UUID) -> Void)?,
+        onExport: ((UUID) -> Void)?,
         onSpeak: ((UUID) -> Void)?
     ) {
         self.turnId = turnId
@@ -803,6 +806,7 @@ final class NativeAssistantActionsView: NSView {
         self.hideSecondaryActions = hideSecondaryActions
         self.onCopy = onCopy
         self.onRegenerate = onRegenerate
+        self.onExport = onExport
         self.onSpeak = onSpeak
         self.currentTheme = theme
 
@@ -835,7 +839,7 @@ final class NativeAssistantActionsView: NSView {
     }
 
     /// Drops a ChatGPT-style overflow menu under the "…" button: a disabled
-    /// header showing when the response arrived, then the Inspect action.
+    /// header showing when the response arrived, then export and Inspect actions.
     private func presentOverflowMenu() {
         let menu = NSMenu()
         menu.autoenablesItems = false
@@ -848,6 +852,23 @@ final class NativeAssistantActionsView: NSView {
         header.isEnabled = false
         menu.addItem(header)
         menu.addItem(.separator())
+
+        let export = NSMenuItem(
+            title: L("Export as Markdown"),
+            action: #selector(exportFromMenu),
+            keyEquivalent: ""
+        )
+        export.target = self
+        export.isEnabled = onExport != nil
+        if let theme = currentTheme {
+            let pointSize = CGFloat(theme.captionSize)
+            let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
+            export.image = SymbolImageCache.image(
+                "square.and.arrow.down",
+                accessibilityDescription: nil
+            )?.withSymbolConfiguration(cfg)
+        }
+        menu.addItem(export)
 
         let inspect = NSMenuItem(
             title: L("Inspect response"),
@@ -875,6 +896,10 @@ final class NativeAssistantActionsView: NSView {
 
     @objc private func inspectFromMenu() {
         openInsights()
+    }
+
+    @objc private func exportFromMenu() {
+        onExport?(turnId)
     }
 
     /// Opens the Settings → Insights tab, focused on the request/response log
@@ -2626,6 +2651,7 @@ final class NativeMessageCellView: NSTableCellView {
             hideSecondaryActions: imageOnly,
             onCopy: context.onCopy,
             onRegenerate: context.onRegenerate,
+            onExport: context.onExport,
             onSpeak: context.onSpeak
         )
     }

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -1154,6 +1154,31 @@ final class SelectableNSTextView: NSTextView {
         super.mouseDown(with: event)
     }
 
+    /// Keep the standard text-selection workflow available inside the native
+    /// message table. `NSTableView` can otherwise claim the contextual click
+    /// before this embedded text view becomes first responder, leaving users
+    /// with no right-click Copy action for selected response text.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        if window?.firstResponder !== self {
+            window?.makeFirstResponder(self)
+        }
+
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let copy = NSMenuItem(title: L("Copy"), action: #selector(copy(_:)), keyEquivalent: "")
+        copy.target = self
+        copy.isEnabled = selectedRange().length > 0
+        menu.addItem(copy)
+
+        let selectAll = NSMenuItem(title: L("Select All"), action: #selector(selectAll(_:)), keyEquivalent: "")
+        selectAll.target = self
+        selectAll.isEnabled = (textStorage?.length ?? 0) > 0
+        menu.addItem(selectAll)
+
+        return menu
+    }
+
     private func handleArtifactLink(_ url: URL) {
         let filename = url.host ?? url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !filename.isEmpty else { return }


### PR DESCRIPTION
## Summary
- add a native Copy / Select All context menu for selected message text
- delete a single exchange without discarding unrelated later history; retain valid tool-call/result pairs
- export an individual assistant message as Markdown from the overflow menu

Closes #2129

## Validation
- `xcodebuild` unsigned Release build succeeded using the resolved local source-package cache
- added `ChatTurnDeletionPolicyTests`; the SwiftPM test run could not start compilation because upstream nested Git submodules failed to fetch over HTTP/2/443 on this network