### PR TITLE
fix app freeze when saving channel tokens in 
  keychain

### DIFF
--- a/Packages/OsaurusCore/Services/Discord/DiscordConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Discord/DiscordConnectionService.swift
@@ -238,6 +238,32 @@ final class DiscordConnectionService: @unchecked Sendable {
         credentialStore.hasBotToken()
     }
 
+    // MARK: - Off-main credential access
+    //
+    // SecItem calls can block for seconds under securityd contention, so UI
+    // flows await these instead of the synchronous accessors above.
+
+    func saveBotTokenOffMain(_ token: String) async throws {
+        let store = credentialStore
+        let saved = await Keychain.perform { store.saveBotToken(token) }
+        if !saved {
+            throw DiscordConnectionServiceError.configurationSaveFailed(
+                "The token was empty or Keychain storage was unavailable."
+            )
+        }
+    }
+
+    @discardableResult
+    func deleteBotTokenOffMain() async -> Bool {
+        let store = credentialStore
+        return await Keychain.perform { store.deleteBotToken() }
+    }
+
+    func hasBotTokenOffMain() async -> Bool {
+        let store = credentialStore
+        return await Keychain.perform { store.hasBotToken() }
+    }
+
     func discoverConfigurationOptions() async throws -> DiscordConnectionDiscovery {
         let token = try requireToken()
         do {

--- a/Packages/OsaurusCore/Services/Keychain/Keychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/Keychain.swift
@@ -91,6 +91,17 @@ enum Keychain {
         writeQueue.async(execute: work)
     }
 
+    /// Await a keychain operation on the serial write queue and return its
+    /// result. For callers (typically UI flows) that need the outcome of a
+    /// SecItem read or mutation without blocking the main thread on
+    /// Security-framework I/O. Ordered relative to `writeInBackground` and
+    /// `performInBackground` work.
+    static func perform<T: Sendable>(_ work: @escaping @Sendable () -> T) async -> T {
+        await withCheckedContinuation { continuation in
+            writeQueue.async { continuation.resume(returning: work()) }
+        }
+    }
+
     /// Read (`service`, `account`). Returns `nil` when the item is absent or
     /// the read would require interactive authorization.
     static func read(

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -468,6 +468,70 @@ final class SlackConnectionService: @unchecked Sendable {
         credentialStore.appToken()
     }
 
+    // MARK: - Off-main credential access
+    //
+    // SecItem calls can block for seconds under securityd contention, so UI
+    // flows await these instead of the synchronous accessors above.
+
+    struct CredentialPresence: Sendable {
+        let botToken: Bool
+        let signingSecret: Bool
+        let appToken: Bool
+    }
+
+    func credentialPresenceOffMain() async -> CredentialPresence {
+        let store = credentialStore
+        return await Keychain.perform {
+            CredentialPresence(
+                botToken: store.hasBotToken(),
+                signingSecret: store.hasSigningSecret(),
+                appToken: store.hasAppToken()
+            )
+        }
+    }
+
+    /// Save any provided secrets in one keychain hop; nil means "no change".
+    func saveCredentialsOffMain(
+        botToken: String? = nil,
+        signingSecret: String? = nil,
+        appToken: String? = nil
+    ) async throws {
+        let store = credentialStore
+        let failure: String? = await Keychain.perform {
+            if let botToken, !store.saveBotToken(botToken) {
+                return "The bot token was empty or Keychain storage was unavailable."
+            }
+            if let signingSecret, !store.saveSigningSecret(signingSecret) {
+                return "The signing secret was empty or Keychain storage was unavailable."
+            }
+            if let appToken, !store.saveAppToken(appToken) {
+                return "The app-level token was empty or Keychain storage was unavailable."
+            }
+            return nil
+        }
+        if let failure {
+            throw SlackConnectionServiceError.configurationSaveFailed(failure)
+        }
+    }
+
+    @discardableResult
+    func deleteBotTokenOffMain() async -> Bool {
+        let store = credentialStore
+        return await Keychain.perform { store.deleteBotToken() }
+    }
+
+    @discardableResult
+    func deleteSigningSecretOffMain() async -> Bool {
+        let store = credentialStore
+        return await Keychain.perform { store.deleteSigningSecret() }
+    }
+
+    @discardableResult
+    func deleteAppTokenOffMain() async -> Bool {
+        let store = credentialStore
+        return await Keychain.perform { store.deleteAppToken() }
+    }
+
     func socketModeAppToken(teamId: String) -> String? {
         credentialStore.appToken(teamId: teamId)
     }

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -461,6 +461,34 @@ final class TelegramConnectionService: @unchecked Sendable {
         credentialStore.hasBotToken()
     }
 
+    // MARK: - Off-main credential access
+    //
+    // SecItem calls can block for seconds under securityd contention, so UI
+    // flows await these instead of the synchronous accessors above.
+
+    func saveBotTokenOffMain(_ token: String) async throws {
+        clearCachedBotIdentity()
+        let store = credentialStore
+        let saved = await Keychain.perform { store.saveBotToken(token) }
+        if !saved {
+            throw TelegramConnectionServiceError.configurationSaveFailed(
+                "The token was empty or Keychain storage was unavailable."
+            )
+        }
+    }
+
+    @discardableResult
+    func deleteBotTokenOffMain() async -> Bool {
+        clearCachedBotIdentity()
+        let store = credentialStore
+        return await Keychain.perform { store.deleteBotToken() }
+    }
+
+    func hasBotTokenOffMain() async -> Bool {
+        let store = credentialStore
+        return await Keychain.perform { store.hasBotToken() }
+    }
+
     func discoverConfigurationOptions() async throws -> TelegramConnectionDiscovery {
         let token = try requireToken()
         do {

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
@@ -668,15 +668,32 @@ struct AgentChannelConnectionCenterView: View {
     /// Derive channel badges for native providers from saved-credential
     /// presence plus live receive-transport health.
     private func refreshNativeBadges() {
+        // Credential presence lives in the keychain; read it off the main
+        // thread so a slow securityd never stalls the connection list.
+        Task {
+            let discordConfigured = await DiscordConnectionService.shared.hasBotTokenOffMain()
+            let slackPresence = await SlackConnectionService.shared.credentialPresenceOffMain()
+            let telegramConfigured = await TelegramConnectionService.shared.hasBotTokenOffMain()
+            applyNativeBadges(
+                discordConfigured: discordConfigured,
+                slackConfigured: slackPresence.botToken,
+                slackReceiveExpected: slackPresence.appToken,
+                telegramConfigured: telegramConfigured
+            )
+        }
+    }
+
+    private func applyNativeBadges(
+        discordConfigured: Bool,
+        slackConfigured: Bool,
+        slackReceiveExpected: Bool,
+        telegramConfigured: Bool
+    ) {
         let discordConfig = DiscordConnectionService.shared.configuration()
-        let discordConfigured = DiscordConnectionService.shared.hasBotToken()
         let discordReceiveExpected = discordConfigured
             && !discordConfig.readableChannelIds.isEmpty
             && !discordConfig.senderAllowlist.isEmpty
-        let slackConfigured = SlackConnectionService.shared.hasBotToken()
-        let slackReceiveExpected = SlackConnectionService.shared.hasAppToken()
         let telegramConfig = TelegramConnectionService.shared.configuration()
-        let telegramConfigured = TelegramConnectionService.shared.hasBotToken()
         let telegramReceiveExpected = telegramConfig.longPollingEnabled
         let slackDispatch = SlackConnectionService.shared.configuration().inboundDispatch
 

--- a/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
@@ -704,7 +704,7 @@ struct DiscordSettingsView: View {
         inboundRequireMention = configuration.inboundDispatch.requireMention
         inboundContinueThreads = configuration.inboundDispatch.continueThreads
         inboundAutoReplyEnabled = configuration.inboundDispatch.autoReplyEnabled
-        tokenSaved = DiscordConnectionService.shared.hasBotToken()
+        Task { tokenSaved = await DiscordConnectionService.shared.hasBotTokenOffMain() }
         // Arm autosave only after the stored configuration has hydrated the
         // draft, so hydration itself is never mistaken for an edit.
         lastSavedDraft = currentDraft
@@ -715,10 +715,12 @@ struct DiscordSettingsView: View {
     }
 
     /// Persist a pasted bot token to Keychain before the configuration save.
-    private func persistPendingSecrets() -> Bool {
+    /// Awaited off the main thread so a slow securityd never beachballs the
+    /// Save/Test buttons.
+    private func persistPendingSecrets() async -> Bool {
         guard hasPendingToken else { return true }
         do {
-            try DiscordConnectionService.shared.saveBotToken(botToken)
+            try await DiscordConnectionService.shared.saveBotTokenOffMain(botToken)
             botToken = ""
             tokenSaved = true
             return true
@@ -729,9 +731,9 @@ struct DiscordSettingsView: View {
     }
 
     private func removeToken() {
-        _ = DiscordConnectionService.shared.deleteBotToken()
         botToken = ""
         tokenSaved = false
+        Task { await DiscordConnectionService.shared.deleteBotTokenOffMain() }
         showStatus(L("Discord bot token removed"), isError: false)
     }
 
@@ -802,9 +804,12 @@ struct DiscordSettingsView: View {
     /// than dismissing on a superficially successful save.
     private func saveAndDismiss() {
         autosaveTask?.cancel()
-        guard persistPendingSecrets(), saveConfiguration() else { return }
         isSaving = true
         Task {
+            guard await persistPendingSecrets(), saveConfiguration() else {
+                isSaving = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.refreshDiscordRuntime()
             guard inboundDispatchEnabled else {
                 await MainActor.run {
@@ -838,9 +843,12 @@ struct DiscordSettingsView: View {
     /// user sees in the form, not a stale save.
     private func testConnection() {
         autosaveTask?.cancel()
-        guard persistPendingSecrets(), saveConfiguration() else { return }
         isTesting = true
         Task {
+            guard await persistPendingSecrets(), saveConfiguration() else {
+                isTesting = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.refreshDiscordRuntime()
             let diagnostics = await DiscordConnectionService.shared.diagnostics()
             await MainActor.run {
@@ -859,9 +867,12 @@ struct DiscordSettingsView: View {
     }
 
     private func refreshDiscovery(showStatus announce: Bool) {
-        guard persistPendingSecrets() else { return }
         isDiscovering = true
         Task {
+            guard await persistPendingSecrets() else {
+                isDiscovering = false
+                return
+            }
             do {
                 let loaded = try await DiscordConnectionService.shared.discoverConfigurationOptions()
                 await MainActor.run {

--- a/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
@@ -955,9 +955,12 @@ struct SlackSettingsView: View {
         inboundRequireMention = configuration.inboundDispatch.requireMention
         inboundContinueThreads = configuration.inboundDispatch.continueThreads
         inboundAutoReplyEnabled = configuration.inboundDispatch.autoReplyEnabled
-        botTokenSaved = SlackConnectionService.shared.hasBotToken()
-        signingSecretSaved = SlackConnectionService.shared.hasSigningSecret()
-        appTokenSaved = SlackConnectionService.shared.hasAppToken()
+        Task {
+            let presence = await SlackConnectionService.shared.credentialPresenceOffMain()
+            botTokenSaved = presence.botToken
+            signingSecretSaved = presence.signingSecret
+            appTokenSaved = presence.appToken
+        }
         // Arm autosave only after the stored configuration has hydrated the
         // draft, so hydration itself is never mistaken for an edit.
         lastSavedDraft = currentDraft
@@ -968,9 +971,12 @@ struct SlackSettingsView: View {
     }
 
     private func refreshDiscovery(showStatus announce: Bool) {
-        guard persistPendingSecrets() else { return }
         isDiscovering = true
         Task {
+            guard await persistPendingSecrets() else {
+                isDiscovering = false
+                return
+            }
             do {
                 let loaded = try await SlackConnectionService.shared.discoverConfigurationOptions()
                 await MainActor.run {
@@ -1011,20 +1017,29 @@ struct SlackSettingsView: View {
     }
 
     /// Persist any pasted secrets to Keychain before the configuration save.
-    private func persistPendingSecrets() -> Bool {
+    /// Awaited off the main thread so a slow securityd never beachballs the
+    /// Save/Test buttons.
+    private func persistPendingSecrets() async -> Bool {
+        let pendingBot = hasPendingBotToken ? botToken : nil
+        let trimmedSigning = signingSecret.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pendingSigning = trimmedSigning.isEmpty ? nil : signingSecret
+        let trimmedApp = appToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pendingApp = trimmedApp.isEmpty ? nil : appToken
         do {
-            if hasPendingBotToken {
-                try SlackConnectionService.shared.saveBotToken(botToken)
+            try await SlackConnectionService.shared.saveCredentialsOffMain(
+                botToken: pendingBot,
+                signingSecret: pendingSigning,
+                appToken: pendingApp
+            )
+            if pendingBot != nil {
                 botToken = ""
                 botTokenSaved = true
             }
-            if !signingSecret.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                try SlackConnectionService.shared.saveSigningSecret(signingSecret)
+            if pendingSigning != nil {
                 signingSecret = ""
                 signingSecretSaved = true
             }
-            if !appToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                try SlackConnectionService.shared.saveAppToken(appToken)
+            if pendingApp != nil {
                 appToken = ""
                 appTokenSaved = true
             }
@@ -1113,26 +1128,30 @@ struct SlackSettingsView: View {
     }
 
     private func removeBotToken() {
-        _ = SlackConnectionService.shared.deleteBotToken()
         botToken = ""
         botTokenSaved = false
         discovery = nil
-        refreshReceiveRuntime()
+        Task {
+            await SlackConnectionService.shared.deleteBotTokenOffMain()
+            refreshReceiveRuntime()
+        }
         showStatus(L("Slack bot token removed"), isError: false)
     }
 
     private func removeSigningSecret() {
-        _ = SlackConnectionService.shared.deleteSigningSecret()
         signingSecret = ""
         signingSecretSaved = false
+        Task { await SlackConnectionService.shared.deleteSigningSecretOffMain() }
         showStatus(L("Slack signing secret removed"), isError: false)
     }
 
     private func removeAppToken() {
-        _ = SlackConnectionService.shared.deleteAppToken()
         appToken = ""
         appTokenSaved = false
-        refreshReceiveRuntime()
+        Task {
+            await SlackConnectionService.shared.deleteAppTokenOffMain()
+            refreshReceiveRuntime()
+        }
         showStatus(L("Slack Socket Mode app token removed"), isError: false)
     }
 
@@ -1184,9 +1203,12 @@ struct SlackSettingsView: View {
     /// than dismissing on a superficially successful save.
     private func saveAndDismiss() {
         autosaveTask?.cancel()
-        guard persistPendingSecrets(), saveConfiguration(), persistAdditionalWorkspace() else { return }
         isSaving = true
         Task {
+            guard await persistPendingSecrets(), saveConfiguration(), persistAdditionalWorkspace() else {
+                isSaving = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
             guard inboundDispatchEnabled else {
                 await MainActor.run {
@@ -1220,9 +1242,12 @@ struct SlackSettingsView: View {
     /// user sees in the form, not a stale save.
     private func testConnection() {
         autosaveTask?.cancel()
-        guard persistPendingSecrets(), saveConfiguration(), persistAdditionalWorkspace() else { return }
         isTesting = true
         Task {
+            guard await persistPendingSecrets(), saveConfiguration(), persistAdditionalWorkspace() else {
+                isTesting = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.refreshSlackRuntime()
             let discoveryResult: Result<SlackConnectionDiscovery, any Error>
             do {

--- a/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
@@ -664,7 +664,7 @@ struct TelegramSettingsView: View {
         inboundAgentId = configuration.inboundDispatch.targetAgentId
         inboundRoutes = configuration.inboundDispatch.routes
         inboundAutoReplyEnabled = configuration.inboundDispatch.autoReplyEnabled
-        tokenSaved = TelegramConnectionService.shared.hasBotToken()
+        Task { tokenSaved = await TelegramConnectionService.shared.hasBotTokenOffMain() }
         // Arm autosave only after the stored configuration has hydrated the
         // draft, so hydration itself is never mistaken for an edit.
         lastSavedDraft = currentDraft
@@ -675,10 +675,12 @@ struct TelegramSettingsView: View {
     }
 
     /// Persist a pasted bot token to Keychain before the configuration save.
-    private func persistPendingSecrets() -> Bool {
+    /// Awaited off the main thread so a slow securityd never beachballs the
+    /// Save/Test buttons.
+    private func persistPendingSecrets() async -> Bool {
         guard hasPendingToken else { return true }
         do {
-            try TelegramConnectionService.shared.saveBotToken(botToken)
+            try await TelegramConnectionService.shared.saveBotTokenOffMain(botToken)
             botToken = ""
             tokenSaved = true
             return true
@@ -689,11 +691,13 @@ struct TelegramSettingsView: View {
     }
 
     private func removeToken() {
-        _ = TelegramConnectionService.shared.deleteBotToken()
         botToken = ""
         tokenSaved = false
         webhookRegistered = false
-        refreshReceiveRuntime()
+        Task {
+            await TelegramConnectionService.shared.deleteBotTokenOffMain()
+            refreshReceiveRuntime()
+        }
         showStatus(L("Telegram bot token removed"), isError: false)
     }
 
@@ -770,9 +774,12 @@ struct TelegramSettingsView: View {
     /// rather than dismissing on a superficially successful save.
     private func saveAndDismiss() {
         autosaveTask?.cancel()
-        guard persistPendingSecrets(), saveConfiguration() else { return }
         isSaving = true
         Task {
+            guard await persistPendingSecrets(), saveConfiguration() else {
+                isSaving = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.refreshTelegramRuntime()
             let diagnostics = await TelegramConnectionService.shared.diagnostics()
             let report = AgentChannelLiveProofReadiness.telegram(diagnostics)
@@ -827,9 +834,12 @@ struct TelegramSettingsView: View {
     /// user sees in the form, not a stale save.
     private func testConnection() {
         autosaveTask?.cancel()
-        guard persistPendingSecrets(), saveConfiguration() else { return }
         isTesting = true
         Task {
+            guard await persistPendingSecrets(), saveConfiguration() else {
+                isTesting = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.refreshTelegramRuntime()
             let diagnostics = await TelegramConnectionService.shared.diagnostics()
             await MainActor.run {
@@ -944,9 +954,12 @@ struct TelegramSettingsView: View {
     /// active long-poll runtime (Telegram allows one consumer). Pause the
     /// runtime around discovery and resume it afterwards.
     private func refreshDiscovery(showStatus announce: Bool) {
-        guard persistPendingSecrets() else { return }
         isDiscovering = true
         Task {
+            guard await persistPendingSecrets() else {
+                isDiscovering = false
+                return
+            }
             await AgentChannelTransportSupervisor.shared.suspendTelegramRuntime()
             defer {
                 Task {


### PR DESCRIPTION
Users reported the app beachballing until force quit right after connecting Discord. The channel settings views were running SecItem keychain calls synchronously on the main thread, so a slow securityd stalled the whole UI. This is the same root cause as the remote provider hangs fixed in #2203, which did not cover the channel surfaces.

- add an awaitable Keychain.perform helper on the existing serial write queue so UI flows can read or mutate secrets off the main thread with ordering preserved
- move discord settings token save, presence check, delete, and discovery persist off the main thread
- same treatment for telegram settings, including the cached bot identity clear
- same treatment for slack settings, batching bot token, signing secret, and app token writes into one keychain hop
- read credential presence badges off the main thread in the connection center, which was doing six keychain reads per refresh
- save, test, and discovery buttons now show their busy spinner while the secret persists, and failure paths reset the busy state

Verified by injecting a 5 second sleep into the discord credential store to simulate a wedged securityd. The UI stayed fully responsive with the spinner running, where the previous code froze the app for the full duration. Token save, test connection, and discovery were also exercised live against a real Discord bot.
