### PR TITLE
Harden keychain reliability on relaunch; add identity restore from recovery phrase

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -377,8 +377,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
                 await MasterKey.seedExistsCacheOffMainActor()
             }
             if !keychainDisabledTestMode {
-                await MCPProviderManager.shared.connectEnabledProviders()
-                await RemoteProviderManager.shared.connectEnabledProviders()
+                // MCP and remote-provider startup connects run concurrently:
+                // one slow or unreachable MCP server must not delay every
+                // model provider (each connect has its own timeout and
+                // bounded transient retry inside its manager).
+                async let mcpConnects: Void = MCPProviderManager.shared.connectEnabledProviders()
+                async let remoteConnects: Void =
+                    RemoteProviderManager.shared.connectEnabledProviders()
+                _ = await (mcpConnects, remoteConnects)
                 // Touch the search-provider manager so its one-time migration
                 // of osaurus.search plugin keys runs at launch, not lazily on
                 // the first web_search call / Settings visit.
@@ -1404,6 +1410,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // Same for the sandbox and agent-delegation stores.
         SandboxConfigurationStore.flushPendingWrites()
         SubagentConfigurationStore.flushPendingWrites()
+
+        // Provider/tool configuration files (remote.json, mcp.json, …) persist
+        // through ConfigDiskWriter's background queue, and credentials persist
+        // through the Keychain serial write queue. Drain both, bounded, so a
+        // provider added or edited right before quit survives relaunch —
+        // otherwise `_exit` below drops the pending write and the provider
+        // comes back disabled or credential-less.
+        ConfigDiskWriter.flushPendingWrites()
+        Keychain.flushPendingWrites()
 
         // Aptabase batches analytics in an in-memory queue and normally drains
         // it from its own `willTerminate` observer — but that flush is async and

--- a/Packages/OsaurusCore/Identity/MasterMnemonicStore.swift
+++ b/Packages/OsaurusCore/Identity/MasterMnemonicStore.swift
@@ -32,6 +32,9 @@ public struct MasterMnemonicStore: Sendable {
         guard words.count == 24 else {
             throw OsaurusIdentityError.mnemonicInvalidWordCount
         }
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            throw OsaurusIdentityError.keychainWriteFailed
+        }
         let phrase = words.joined(separator: " ")
         guard let data = phrase.data(using: .utf8) else {
             throw OsaurusIdentityError.keychainWriteFailed
@@ -75,6 +78,7 @@ public struct MasterMnemonicStore: Sendable {
     /// the lazy backfill path for legacy installs that pre-date this
     /// store.
     public static func exists() -> Bool {
+        if KeychainQueryHelpers.disablesKeychainForProcess { return false }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -92,6 +96,9 @@ public struct MasterMnemonicStore: Sendable {
     /// phrase is the seed in a different encoding, so it carries the same
     /// access gate.
     public static func load(context: LAContext) throws -> [String] {
+        if KeychainQueryHelpers.disablesKeychainForProcess {
+            throw OsaurusIdentityError.keychainReadFailed
+        }
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -129,6 +136,7 @@ public struct MasterMnemonicStore: Sendable {
     /// "Reset Identity" tears down the mnemonic alongside the master.
     @discardableResult
     public static func delete() -> Bool {
+        if KeychainQueryHelpers.disablesKeychainForProcess { return true }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,

--- a/Packages/OsaurusCore/Identity/OsaurusIdentity.swift
+++ b/Packages/OsaurusCore/Identity/OsaurusIdentity.swift
@@ -86,6 +86,93 @@ public struct OsaurusIdentity: Sendable {
         MasterKey.existsCached()
     }
 
+    // MARK: - Restore
+
+    /// Outcome of `restore(words:)` for the UI: the restored master address
+    /// plus a summary of the derived-state reconciliation.
+    public struct RestoreResult: Sendable {
+        public let osaurusId: OsaurusID
+        public let rederivedAgentCount: Int
+        public let revokedAccessKeyCount: Int
+        /// Human-readable, per-item reconciliation failures ("name: reason").
+        /// The master itself installed successfully even when non-empty.
+        public let failures: [String]
+    }
+
+    /// Restore an identity from its 24-word BIP39 recovery phrase.
+    ///
+    /// Decodes and checksum-validates the phrase, installs the decoded
+    /// 32-byte master into iCloud Keychain (replacing any existing master),
+    /// re-stores the phrase, and reconciles persisted derivatives:
+    ///
+    /// - When the phrase is the *previous* master (drift recovery), every
+    ///   stored agent address matches again and reconciliation is a no-op.
+    /// - When the phrase is a *different* identity (fresh restore over an
+    ///   auto-generated key, explicit replace), mismatched agents are
+    ///   re-minted at fresh indices off the restored master and access keys
+    ///   signed by the old master are revoked — the same actions as the
+    ///   drift banner's Repair.
+    ///
+    /// Posts `.osaurusIdentityChanged` so identity-gated services (the
+    /// managed Osaurus Router, model picker) reconnect under the restored
+    /// identity without a manual refresh.
+    @MainActor
+    public static func restore(words: [String]) throws -> RestoreResult {
+        var seed = try MasterKeyMnemonic.key(fromMnemonic: words)
+        defer { seed.zeroOut() }
+
+        let osaurusId = try MasterKey.install(seed: seed, allowReplace: true)
+        // Keep the stored phrase in sync with the newly-installed master so
+        // "View recovery phrase" reads the store instead of lazily
+        // re-deriving from the seed.
+        try? MasterMnemonicStore.store(words)
+
+        APIKeyManager.shared.reload()
+        let drift = IdentityHealthCheck.diagnose(
+            masterKey: seed,
+            agents: AgentManager.shared.agents,
+            accessKeys: APIKeyManager.shared.listKeys()
+        )
+
+        var failures: [String] = []
+        var rederivedAgentCount = 0
+        for agent in drift.mismatchedAgents {
+            do {
+                // Forget the stale derivation, then re-assign at a fresh
+                // index off the restored master.
+                var cleared = agent
+                cleared.agentIndex = nil
+                cleared.agentAddress = nil
+                AgentManager.shared.update(cleared)
+                if let refreshed = AgentManager.shared.agent(for: agent.id) {
+                    try AgentManager.shared.assignAddress(to: refreshed)
+                    rederivedAgentCount += 1
+                }
+            } catch {
+                failures.append("\(agent.name): \(error.localizedDescription)")
+            }
+        }
+
+        var revokedAccessKeyCount = 0
+        for key in drift.staleAccessKeys where !key.revoked {
+            do {
+                try AccessKeyLifecycleService.shared.revokeAndRemove(id: key.id)
+                revokedAccessKeyCount += 1
+            } catch {
+                failures.append("\(key.label): \(error.localizedDescription)")
+            }
+        }
+
+        NotificationCenter.default.post(name: .osaurusIdentityChanged, object: nil)
+
+        return RestoreResult(
+            osaurusId: osaurusId,
+            rederivedAgentCount: rederivedAgentCount,
+            revokedAccessKeyCount: revokedAccessKeyCount,
+            failures: failures
+        )
+    }
+
     // MARK: - Wipe
 
     /// Full identity wipe used by the "Reset Identity" flow. Deletes the master

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -5,8 +5,10 @@
 //  Manages remote MCP provider connections and tool execution.
 //
 
+import AppKit
 import Foundation
 import MCP
+import Network
 
 /// Notification posted when provider connection status changes
 extension Foundation.Notification.Name {
@@ -49,6 +51,9 @@ public final class MCPProviderManager: ObservableObject {
         for provider in configuration.providers {
             providerStates[provider.id] = MCPProviderState(providerId: provider.id)
         }
+
+        registerRecoveryObservers()
+        startNetworkRecoveryMonitor()
     }
 
     // MARK: - Provider Management
@@ -56,27 +61,58 @@ public final class MCPProviderManager: ObservableObject {
     /// Add a new provider
     public func addProvider(_ provider: MCPProvider, token: String?) {
         configuration.add(provider)
-        MCPProviderConfigurationStore.save(configuration)
         // KPI: a user-configured MCP tool provider. Only the transport kind
         // is captured — never the command, URL, or args.
         FeatureTelemetry.mcpProviderAdded(transport: provider.transport.rawValue)
 
-        // Save token to Keychain if provided
-        if let token = token, !token.isEmpty {
-            MCPProviderKeychain.saveToken(token, for: provider.id)
-        }
-
         // Initialize state
         providerStates[provider.id] = MCPProviderState(providerId: provider.id)
 
-        // Auto-connect if enabled
-        if provider.enabled {
-            Task {
-                try? await connect(providerId: provider.id)
+        // Save the token off the main thread (SecItemAdd/SecItemUpdate can
+        // block for seconds under securityd contention). The on-disk provider
+        // record is persisted only after the keychain write lands, so an
+        // interrupted add can never leave an enabled provider on disk without
+        // its token, and auto-connect reads the fresh credential.
+        let providerId = provider.id
+        let shouldConnect = provider.enabled
+        Keychain.performInBackground {
+            var credentialsDurable = true
+            if let token = token, !token.isEmpty {
+                credentialsDurable = MCPProviderKeychain.saveToken(token, for: providerId)
+            }
+            Task { @MainActor in
+                MCPProviderManager.shared.finishCredentialStaging(
+                    providerId: providerId,
+                    credentialsDurable: credentialsDurable,
+                    connect: shouldConnect
+                )
             }
         }
 
         notifyStatusChanged()
+    }
+
+    /// Completion hop for `addProvider`/`updateProvider` credential staging:
+    /// persists the provider record after its secrets are durable, surfaces a
+    /// failed keychain write on the provider state (the in-memory session
+    /// still works; relaunch durability is what failed), and kicks the
+    /// requested connect.
+    private func finishCredentialStaging(
+        providerId: UUID,
+        credentialsDurable: Bool,
+        connect shouldConnect: Bool
+    ) {
+        if !credentialsDurable, !KeychainQueryHelpers.disablesKeychainForProcess {
+            providerStates[providerId]?.lastError =
+                "Could not save credentials to the Keychain — they may not survive relaunch."
+            notifyStatusChanged()
+        }
+        MCPProviderConfigurationStore.save(configuration)
+        if shouldConnect {
+            Task {
+                try? await connect(providerId: providerId)
+            }
+        }
     }
 
     /// Update an existing provider
@@ -90,27 +126,37 @@ public final class MCPProviderManager: ObservableObject {
 
         let previous = configuration.provider(id: provider.id)
         configuration.update(provider)
-        MCPProviderConfigurationStore.save(configuration)
 
-        // Update token if provided (empty string means clear token)
-        if let token = token {
-            if token.isEmpty {
-                MCPProviderKeychain.deleteToken(for: provider.id)
-            } else {
-                MCPProviderKeychain.saveToken(token, for: provider.id)
+        // Update credentials off the main thread; persist the updated record
+        // only after the keychain mutations land, and reconnect after both so
+        // connect() reads the fresh token.
+        let providerId = provider.id
+        let shouldReconnect = wasConnected && provider.enabled
+        let dropsOAuth = previous?.authType == .oauth && provider.authType != .oauth
+        Keychain.performInBackground {
+            var credentialsDurable = true
+            // Update token if provided (empty string means clear token)
+            if let token = token {
+                if token.isEmpty {
+                    MCPProviderKeychain.deleteToken(for: providerId)
+                } else {
+                    credentialsDurable = MCPProviderKeychain.saveToken(token, for: providerId)
+                }
             }
-        }
 
-        // If the user switched away from OAuth, drop any cached tokens for this provider.
-        if previous?.authType == .oauth && provider.authType != .oauth {
-            MCPProviderKeychain.deleteOAuthTokens(for: provider.id)
-            MCPProviderKeychain.deleteOAuthClientSecret(for: provider.id)
-        }
+            // If the user switched away from OAuth, drop any cached tokens
+            // for this provider.
+            if dropsOAuth {
+                MCPProviderKeychain.deleteOAuthTokens(for: providerId)
+                MCPProviderKeychain.deleteOAuthClientSecret(for: providerId)
+            }
 
-        // Reconnect if was connected and still enabled
-        if wasConnected && provider.enabled {
-            Task {
-                try? await connect(providerId: provider.id)
+            Task { @MainActor in
+                MCPProviderManager.shared.finishCredentialStaging(
+                    providerId: providerId,
+                    credentialsDurable: credentialsDurable,
+                    connect: shouldReconnect
+                )
             }
         }
 
@@ -241,6 +287,7 @@ public final class MCPProviderManager: ObservableObject {
                 updatedState.lastError = nil
                 updatedState.requiresAuth = false
                 updatedState.resourceMetadataURL = nil
+                updatedState.lastFailureWasTransient = false
                 providerStates[providerId] = updatedState
                 print(
                     "[Osaurus] MCP Provider '\(provider.name)': Connected with \(updatedState.discoveredToolCount) tools"
@@ -295,6 +342,11 @@ public final class MCPProviderManager: ObservableObject {
             state.isConnected = false
             state.discoveredToolCount = 0
             state.discoveredToolNames = []
+            // An auth challenge is terminal (requires sign-in); everything
+            // else is classified so the launch/network/wake/activation
+            // recovery paths know whether a retry can help.
+            state.lastFailureWasTransient =
+                authFailure == nil && Self.isTransientConnectError(error)
             providerStates[providerId] = state
 
             // Unregister any tools that were registered before the failure
@@ -371,15 +423,232 @@ public final class MCPProviderManager: ObservableObject {
         try await connect(providerId: providerId)
     }
 
-    /// Connect to all enabled providers on app launch
+    /// Connect providers at app launch.
+    ///
+    /// Honors the per-provider "Auto-connect" setting: only providers the
+    /// user left enabled AND auto-connect connect at launch — an enabled
+    /// provider with auto-connect off stays dormant until connected
+    /// explicitly, matching `RemoteProviderManager`.
+    ///
+    /// Connects run concurrently: each provider already has its own
+    /// discovery timeout, and one slow or unreachable MCP server must not
+    /// delay every other provider (or, upstream, the remote model
+    /// providers). Transient failures get bounded retry; the network / wake /
+    /// activation recovery sweeps handle anything that outlives the budget.
     public func connectEnabledProviders() async {
-        for provider in configuration.enabledProviders {
-            do {
-                try await connect(providerId: provider.id)
-            } catch {
-                print("[Osaurus] Failed to auto-connect to '\(provider.name)': \(error)")
+        await withTaskGroup(of: Void.self) { group in
+            for provider in configuration.autoConnectProviders {
+                let providerId = provider.id
+                let providerName = provider.name
+                group.addTask {
+                    await self.connectProviderWithTransientRetry(
+                        providerId: providerId, providerName: providerName)
+                }
             }
         }
+    }
+
+    /// Total attempts (including the first) for a launch-time connect.
+    static let connectMaxAttempts = 3
+    /// Base delay for exponential backoff between connect retries.
+    static let connectRetryBaseDelay: TimeInterval = 1.0
+
+    /// Test seam: replaces the real backoff sleep so retry tests don't wait
+    /// on wall-clock time.
+    var testRetrySleepOverride: (@MainActor (TimeInterval) async -> Void)?
+
+    /// Test seam: when set, used in place of the real `connect(providerId:)`
+    /// by the launch/recovery paths so orchestration tests don't open
+    /// network connections.
+    var testConnectOverride: (@MainActor (UUID) async throws -> Void)?
+
+    /// Connect one provider with bounded retry on *transient* failures
+    /// (offline at launch, DNS not up yet, handshake timeout). Terminal
+    /// failures — auth challenges, bad config, protocol mismatch — stop
+    /// immediately because a retry cannot fix them.
+    private func connectProviderWithTransientRetry(
+        providerId: UUID,
+        providerName: String,
+        maxAttempts: Int = MCPProviderManager.connectMaxAttempts
+    ) async {
+        let attempts = max(1, maxAttempts)
+        for attempt in 1 ... attempts {
+            do {
+                if let testConnectOverride {
+                    try await testConnectOverride(providerId)
+                } else {
+                    try await connect(providerId: providerId)
+                }
+                return
+            } catch {
+                let transient =
+                    Self.isTransientConnectError(error)
+                    && providerStates[providerId]?.requiresAuth != true
+                guard transient, attempt < attempts else {
+                    print("[Osaurus] Failed to auto-connect to '\(providerName)': \(error)")
+                    return
+                }
+                let delay = Self.connectRetryBaseDelay * pow(2.0, Double(attempt - 1))
+                if let testRetrySleepOverride {
+                    await testRetrySleepOverride(delay)
+                } else {
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                }
+                // Another path (manual connect, OAuth sign-in) may have
+                // connected while we waited — don't pile on a duplicate.
+                if providerStates[providerId]?.isConnected == true { return }
+            }
+        }
+    }
+
+    /// Whether a connect error is worth retrying. Transient = network loss /
+    /// timeout / DNS / TLS and the handshake/discovery timeout. Terminal =
+    /// auth challenges, spawn failures, protocol errors, plus anything
+    /// unrecognized (a tight retry loop must not hammer those).
+    static func isTransientConnectError(_ error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .timedOut, .networkConnectionLost,
+                .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+                .secureConnectionFailed, .resourceUnavailable, .badServerResponse:
+                return true
+            default:
+                return false
+            }
+        }
+        if let providerError = error as? MCPProviderError, case .timeout = providerError {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Transient-failure recovery
+    //
+    // Mirrors `RemoteProviderManager`'s recovery machinery: providers whose
+    // last connect failed transiently are reconnected on the network
+    // recovery edge (and first satisfied baseline), on wake from sleep, and
+    // on app re-activation — without the user toggling anything.
+
+    nonisolated(unsafe) private var networkPathMonitor: NWPathMonitor?
+    /// Last observed satisfied-ness; reconnect sweeps fire on the
+    /// unsatisfied → satisfied edge and on the very first satisfied
+    /// observation (providers can fail transiently before the monitor
+    /// produces its baseline at launch).
+    private var lastNetworkPathWasSatisfied: Bool?  // swiftlint:disable:this discouraged_optional_boolean
+    private var networkRecoveryTask: Task<Void, Never>?
+
+    /// Test seam: shrink the recovery settle delay so sweep tests don't wait
+    /// on wall-clock time.
+    var testNetworkRecoverySettleDelayOverride: TimeInterval?
+
+    private func registerRecoveryObservers() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.reconnectTransientlyFailedProviders()
+            }
+        }
+        // Wake is a recovery opportunity: connects that failed as the machine
+        // slept (or right before) are transient by nature. NSWorkspace posts
+        // wake through its own notification center, not `.default`.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleTransientRecoverySweep()
+            }
+        }
+    }
+
+    private func startNetworkRecoveryMonitor() {
+        let monitor = NWPathMonitor()
+        networkPathMonitor = monitor
+        monitor.pathUpdateHandler = { [weak self] path in
+            let satisfied = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                self?.handleNetworkPathUpdate(satisfied: satisfied)
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "ai.osaurus.mcp.pathmonitor"))
+    }
+
+    /// Internal (not private) so tests can drive connectivity edges without
+    /// a real `NWPath`.
+    func handleNetworkPathUpdate(satisfied: Bool) {
+        defer { lastNetworkPathWasSatisfied = satisfied }
+        guard satisfied, lastNetworkPathWasSatisfied != true else { return }
+        scheduleTransientRecoverySweep()
+    }
+
+    /// Schedule a debounced sweep reconnecting transiently-failed providers.
+    func scheduleTransientRecoverySweep() {
+        networkRecoveryTask?.cancel()
+        let settleDelay = testNetworkRecoverySettleDelayOverride ?? 2.0
+        networkRecoveryTask = Task { [weak self] in
+            // Give routing/DNS a moment to settle after the path flips; an
+            // immediate connect after wake often fails on stale DNS.
+            try? await Task.sleep(nanoseconds: UInt64(settleDelay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await self?.reconnectTransientlyFailedProviders()
+        }
+    }
+
+    /// Reconnect every enabled auto-connect provider whose last failure was
+    /// transient and which isn't connected, mid-connect, or waiting on a
+    /// sign-in. Each `connect` re-evaluates state so concurrent triggers
+    /// stay idempotent.
+    func reconnectTransientlyFailedProviders() async {
+        for provider in configuration.autoConnectProviders {
+            guard !Task.isCancelled else { return }
+            let state = providerStates[provider.id]
+            guard state?.isConnected != true, state?.isConnecting != true,
+                state?.lastFailureWasTransient == true, state?.requiresAuth != true
+            else { continue }
+            if let testConnectOverride {
+                try? await testConnectOverride(provider.id)
+            } else {
+                try? await connect(providerId: provider.id)
+            }
+        }
+    }
+
+    /// Await the in-flight recovery sweep, if any. Test-only.
+    func _testAwaitNetworkRecoverySweep() async {
+        await networkRecoveryTask?.value
+    }
+
+    // MARK: - Test Helpers
+
+    /// Add providers to the in-memory configuration without touching disk,
+    /// Keychain, or the network. Test-only.
+    func _testInstallProviders(_ providers: [MCPProvider]) {
+        for provider in providers {
+            configuration.add(provider)
+            if providerStates[provider.id] == nil {
+                providerStates[provider.id] = MCPProviderState(providerId: provider.id)
+            }
+        }
+    }
+
+    /// Mutate a test-installed provider's runtime state. Test-only.
+    func _testSetState(_ state: MCPProviderState, for id: UUID) {
+        providerStates[id] = state
+    }
+
+    /// Tear down test providers and reset seams/recovery state so each test
+    /// starts clean. Test-only.
+    func _testRemoveProviders(ids: [UUID]) {
+        configuration.providers.removeAll { ids.contains($0.id) }
+        for id in ids {
+            providerStates.removeValue(forKey: id)
+        }
+        networkRecoveryTask?.cancel()
+        networkRecoveryTask = nil
+        lastNetworkPathWasSatisfied = nil
+        testConnectOverride = nil
+        testRetrySleepOverride = nil
+        testNetworkRecoverySettleDelayOverride = nil
     }
 
     /// Disconnect from all providers

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -179,7 +179,6 @@ public final class RemoteProviderManager: ObservableObject {
         if isEphemeral {
             ephemeralProviderIds.insert(provider.id)
         } else {
-            saveUserProviderConfiguration()
             // KPI: a user-configured remote provider. Only the closed-enum
             // type is captured. Ephemeral Bonjour-discovered providers are
             // excluded — they aren't a deliberate configuration action.
@@ -190,26 +189,62 @@ public final class RemoteProviderManager: ObservableObject {
         providerStates[provider.id] = RemoteProviderState(providerId: provider.id)
 
         // Save credentials off the main thread — SecItemAdd/SecItemUpdate can
-        // block for seconds under securityd contention — then auto-connect
-        // once the write has landed so connect() reads the fresh key.
+        // block for seconds under securityd contention. The on-disk provider
+        // record is persisted only after the keychain writes land, so an
+        // interrupted add can never leave an enabled provider on disk without
+        // its credentials, and auto-connect reads the fresh key.
         let providerId = provider.id
         let shouldConnect = provider.enabled
+        let persistsToDisk = !isEphemeral
         Keychain.performInBackground {
+            var credentialsDurable = true
             if let apiKey = apiKey, !apiKey.isEmpty {
-                RemoteProviderKeychain.saveAPIKey(apiKey, for: providerId)
+                credentialsDurable =
+                    RemoteProviderKeychain.saveAPIKey(apiKey, for: providerId) && credentialsDurable
             }
             if let oauthTokens {
-                RemoteProviderKeychain.saveOAuthTokens(oauthTokens, for: providerId)
+                credentialsDurable =
+                    RemoteProviderKeychain.saveOAuthTokens(oauthTokens, for: providerId)
+                    && credentialsDurable
                 RemoteProviderKeychain.deleteAPIKey(for: providerId)
             }
-            if shouldConnect {
-                Task { @MainActor in
-                    try? await RemoteProviderManager.shared.connect(providerId: providerId)
-                }
+            Task { @MainActor in
+                RemoteProviderManager.shared.finishCredentialStaging(
+                    providerId: providerId,
+                    credentialsDurable: credentialsDurable,
+                    persistsToDisk: persistsToDisk,
+                    connect: shouldConnect
+                )
             }
         }
 
         notifyStatusChanged()
+    }
+
+    /// Completion hop for `addProvider`/`updateProvider` credential staging:
+    /// persists the provider record after its secrets are durable, surfaces a
+    /// failed keychain write on the provider state (the in-memory session
+    /// still works; relaunch durability is what failed), and kicks the
+    /// requested connect.
+    private func finishCredentialStaging(
+        providerId: UUID,
+        credentialsDurable: Bool,
+        persistsToDisk: Bool,
+        connect shouldConnect: Bool
+    ) {
+        if !credentialsDurable, !KeychainQueryHelpers.disablesKeychainForProcess {
+            providerStates[providerId]?.lastError =
+                "Could not save credentials to the Keychain — they may not survive relaunch."
+            notifyStatusChanged()
+        }
+        if persistsToDisk {
+            saveUserProviderConfiguration()
+        }
+        if shouldConnect {
+            Task { @MainActor in
+                try? await RemoteProviderManager.shared.connect(providerId: providerId)
+            }
+        }
     }
 
     /// Update an existing provider
@@ -226,31 +261,39 @@ public final class RemoteProviderManager: ObservableObject {
         }
 
         configuration.update(provider)
-        saveUserProviderConfiguration()
 
         // Update credentials off the main thread (nil apiKey means no change,
         // empty string means clear). SecItemUpdate can block for seconds under
         // securityd contention — a recurring app-hang source on the save
-        // button. Reconnect only after the write lands so connect() reads the
-        // fresh key.
+        // button. The updated on-disk record is persisted only after the
+        // keychain writes land, and reconnect waits for them so connect()
+        // reads the fresh key.
         let providerId = provider.id
         let shouldReconnect = wasConnected && provider.enabled
         Keychain.performInBackground {
+            var credentialsDurable = true
             if let apiKey = apiKey {
                 if apiKey.isEmpty {
                     RemoteProviderKeychain.deleteAPIKey(for: providerId)
                 } else {
-                    RemoteProviderKeychain.saveAPIKey(apiKey, for: providerId)
+                    credentialsDurable =
+                        RemoteProviderKeychain.saveAPIKey(apiKey, for: providerId)
+                        && credentialsDurable
                 }
             }
             if let oauthTokens {
-                RemoteProviderKeychain.saveOAuthTokens(oauthTokens, for: providerId)
+                credentialsDurable =
+                    RemoteProviderKeychain.saveOAuthTokens(oauthTokens, for: providerId)
+                    && credentialsDurable
                 RemoteProviderKeychain.deleteAPIKey(for: providerId)
             }
-            if shouldReconnect {
-                Task { @MainActor in
-                    try? await RemoteProviderManager.shared.connect(providerId: providerId)
-                }
+            Task { @MainActor in
+                RemoteProviderManager.shared.finishCredentialStaging(
+                    providerId: providerId,
+                    credentialsDurable: credentialsDurable,
+                    persistsToDisk: true,
+                    connect: shouldReconnect
+                )
             }
         }
 
@@ -325,12 +368,20 @@ public final class RemoteProviderManager: ObservableObject {
             if provider.authType == .openAICodexOAuth {
                 if let tokens = await provider.getOAuthTokensOffMainActor(), tokens.isExpired {
                     let refreshed = try await OpenAICodexOAuthService.refresh(tokens)
-                    await RemoteProviderKeychain.saveOAuthTokensOffMainActor(refreshed, for: provider.id)
+                    if !(await RemoteProviderKeychain.saveOAuthTokensOffMainActor(
+                        refreshed, for: provider.id)),
+                        !KeychainQueryHelpers.disablesKeychainForProcess {
+                        NSLog("RemoteProviderManager: failed to persist refreshed OAuth tokens")
+                    }
                 }
             } else if provider.authType == .xaiOAuth {
                 if let tokens = await provider.getOAuthTokensOffMainActor(), tokens.isExpired {
                     let refreshed = try await XAIOAuthService.refresh(tokens)
-                    await RemoteProviderKeychain.saveOAuthTokensOffMainActor(refreshed, for: provider.id)
+                    if !(await RemoteProviderKeychain.saveOAuthTokensOffMainActor(
+                        refreshed, for: provider.id)),
+                        !KeychainQueryHelpers.disablesKeychainForProcess {
+                        NSLog("RemoteProviderManager: failed to persist refreshed OAuth tokens")
+                    }
                 }
             }
 
@@ -490,12 +541,38 @@ public final class RemoteProviderManager: ObservableObject {
                 let providerId = provider.id
                 let providerName = provider.name
                 group.addTask {
-                    do {
-                        try await self.connect(providerId: providerId)
-                    } catch {
-                        print("[Osaurus] Failed to auto-connect to '\(providerName)': \(error)")
-                    }
+                    await self.connectProviderWithTransientRetry(
+                        providerId: providerId, providerName: providerName)
                 }
+            }
+        }
+    }
+
+    /// Launch connect for a user-configured provider with bounded retry on
+    /// *transient* failures (offline at launch, DNS not up yet, server 5xx),
+    /// mirroring the managed router's behavior. Terminal failures (auth, bad
+    /// config) stop immediately — a retry cannot fix them, and the network /
+    /// wake / activation recovery sweeps handle anything transient that
+    /// outlives the retry budget.
+    private func connectProviderWithTransientRetry(
+        providerId: UUID,
+        providerName: String,
+        maxAttempts: Int = RemoteProviderManager.osaurusRouterConnectMaxAttempts
+    ) async {
+        let attempts = max(1, maxAttempts)
+        for attempt in 1 ... attempts {
+            do {
+                try await connect(providerId: providerId)
+                return
+            } catch {
+                guard Self.isTransientConnectError(error), attempt < attempts else {
+                    print("[Osaurus] Failed to auto-connect to '\(providerName)': \(error)")
+                    return
+                }
+                await routerRetryBackoff(forAttempt: attempt, after: error)
+                // Another path (picker, activation, network recovery) may have
+                // connected while we waited — don't pile on a duplicate.
+                if providerStates[providerId]?.isConnected == true { return }
             }
         }
     }
@@ -732,11 +809,21 @@ public final class RemoteProviderManager: ObservableObject {
         notifyModelsChanged()
     }
 
-    /// Observe identity creation/wipe and app re-activation so the managed
-    /// Osaurus Router (re)connects without waiting for a user-driven refresh.
+    /// Observe identity creation/wipe, app re-activation, and wake-from-sleep
+    /// so providers (re)connect without waiting for a user-driven refresh.
     private func registerIdentityAndActivationObservers() {
         observeOnMain(.osaurusIdentityChanged) { await $0.handleIdentityChanged() }
         observeOnMain(NSApplication.didBecomeActiveNotification) { await $0.handleAppDidBecomeActive() }
+        // Wake is a recovery opportunity: connects that failed as the machine
+        // slept (or right before) are transient by nature. NSWorkspace posts
+        // wake through its own notification center, not `.default`.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleTransientRecoverySweep()
+            }
+        }
     }
 
     /// Add a main-queue notification observer that hops onto the MainActor and
@@ -772,8 +859,11 @@ public final class RemoteProviderManager: ObservableObject {
     /// connected, so a launch that failed while offline recovers on the next
     /// activation. The `isConnected` short-circuit avoids re-running
     /// `ensureManagedOsaurusRouterProviderIfNeeded` (and its `@Published`
-    /// configuration churn) on every activation.
+    /// configuration churn) on every activation. Activation is also a recovery
+    /// opportunity for user-configured providers whose last failure was
+    /// transient (the sweep is a no-op when nothing failed transiently).
     func handleAppDidBecomeActive() async {
+        await reconnectTransientlyFailedProviders()
         guard identityExists() else { return }
         guard providerStates[Self.osaurusRouterProviderId]?.isConnected != true else { return }
         await connectOsaurusRouterIfPossible()
@@ -816,18 +906,38 @@ public final class RemoteProviderManager: ObservableObject {
             // network drops and reappear the moment it returns.
             notifyModelsChanged()
         }
-        // Only the recovery edge matters for reconnects: we must have
-        // previously seen the network down, and now see it up.
-        guard satisfied, lastNetworkPathWasSatisfied == false else { return }
+        // Reconnects fire on the recovery edge (down → up) and on the very
+        // first satisfied observation. The first baseline matters at launch:
+        // providers that failed transiently moments before the monitor
+        // produced its baseline would otherwise stay down until the *next*
+        // full outage/recovery cycle. The sweep only touches providers whose
+        // last failure was transient, so a healthy launch is a no-op.
+        guard satisfied, lastNetworkPathWasSatisfied != true else { return }
         // Debounce flapping paths — replace any in-flight sweep.
+        scheduleTransientRecoverySweep()
+    }
+
+    /// Schedule a debounced sweep reconnecting transiently-failed providers.
+    /// Shared by the network-path recovery edge and the wake observer.
+    func scheduleTransientRecoverySweep() {
         networkRecoveryTask?.cancel()
+        let settleDelay = testNetworkRecoverySettleDelayOverride ?? 2.0
         networkRecoveryTask = Task { [weak self] in
             // Give routing/DNS a moment to settle after the path flips; an
             // immediate connect after wake often fails on stale DNS.
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            try? await Task.sleep(nanoseconds: UInt64(settleDelay * 1_000_000_000))
             guard !Task.isCancelled else { return }
             await self?.reconnectTransientlyFailedProviders()
         }
+    }
+
+    /// Test seam: shrink the recovery settle delay so sweep tests don't wait
+    /// on wall-clock time.
+    var testNetworkRecoverySettleDelayOverride: TimeInterval?
+
+    /// Await the in-flight recovery sweep, if any. Test-only.
+    func _testAwaitNetworkRecoverySweep() async {
+        await networkRecoveryTask?.value
     }
 
     /// Reconnect every auto-connect provider whose last failure was transient
@@ -1442,6 +1552,7 @@ public final class RemoteProviderManager: ObservableObject {
         testConnectionTransportOverride = nil
         testIdentityExistsOverride = nil
         testRetrySleepOverride = nil
+        testNetworkRecoverySettleDelayOverride = nil
     }
 }
 

--- a/Packages/OsaurusCore/Managers/SearchProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/SearchProviderManager.swift
@@ -156,14 +156,23 @@ public final class SearchProviderManager: ObservableObject {
 
     // MARK: - Secrets
 
-    public func saveSecret(_ value: String, field: String, for definitionId: String) {
+    /// Save (or clear, when blank) a secret field. Returns false when the
+    /// keychain write failed, so callers can surface that the credential may
+    /// not survive relaunch.
+    @discardableResult
+    public func saveSecret(_ value: String, field: String, for definitionId: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let durable: Bool
         if trimmed.isEmpty {
-            SearchProviderKeychain.deleteSecret(field: field, for: definitionId)
+            durable = SearchProviderKeychain.deleteSecret(field: field, for: definitionId)
         } else {
-            SearchProviderKeychain.saveSecret(trimmed, field: field, for: definitionId)
+            durable = SearchProviderKeychain.saveSecret(trimmed, field: field, for: definitionId)
+            if !durable, !KeychainQueryHelpers.disablesKeychainForProcess {
+                NSLog("SearchProviderManager: failed to save secret to Keychain")
+            }
         }
         refreshConfiguredProviderIds()
+        return durable
     }
 
     public func hasSecret(field: String, for definitionId: String) -> Bool {

--- a/Packages/OsaurusCore/Models/Configuration/MCPProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MCPProviderConfiguration.swift
@@ -319,6 +319,14 @@ public struct MCPProviderState: Sendable {
     /// Optional `resource_metadata` URL parsed out of `WWW-Authenticate`. When present
     /// the OAuth service can skip path-scoped `.well-known` discovery.
     public var resourceMetadataURL: URL?
+    /// True when the most recent connect attempt failed for a *transient*
+    /// reason (offline, timeout, DNS/TLS, server 5xx) rather than a terminal
+    /// one (auth, bad config). Drives launch/network/wake/activation
+    /// auto-reconnect so a provider that failed while the machine was offline
+    /// comes back on its own, without hammering providers whose tokens or
+    /// endpoints are actually wrong. Mirrors
+    /// `RemoteProviderState.lastFailureWasTransient`.
+    public var lastFailureWasTransient: Bool
 
     public init(providerId: UUID) {
         self.providerId = providerId
@@ -333,6 +341,7 @@ public struct MCPProviderState: Sendable {
         self.lastStderrTail = nil
         self.requiresAuth = false
         self.resourceMetadataURL = nil
+        self.lastFailureWasTransient = false
     }
 }
 

--- a/Packages/OsaurusCore/Services/GitHubAuth.swift
+++ b/Packages/OsaurusCore/Services/GitHubAuth.swift
@@ -27,10 +27,13 @@ enum GitHubAuth {
     static var token: String? {
         cachedToken.withLock { (state: inout String??) -> String? in
             if case .some(let loaded) = state { return loaded }
-            let raw = Keychain.read(service: keychainService, account: keychainAccount)
-                .flatMap { String(data: $0, encoding: .utf8) }
+            let outcome = Keychain.readItem(service: keychainService, account: keychainAccount)
+            let raw = outcome.data.flatMap { String(data: $0, encoding: .utf8) }
             let value = normalize(raw)
-            state = .some(value)
+            // Only latch definitive outcomes (found / not-found). A locked or
+            // transiently failing keychain must not be cached as "no token"
+            // for the rest of the process lifetime.
+            if outcome.isDefinitive { state = .some(value) }
             return value
         }
     }

--- a/Packages/OsaurusCore/Services/HuggingFaceAuth.swift
+++ b/Packages/OsaurusCore/Services/HuggingFaceAuth.swift
@@ -37,15 +37,21 @@ enum HuggingFaceAuth {
         // the catalog card reads on the main thread at view-init. That is the
         // deadlock behind the Catalog-tab hang: the main thread blocks on the
         // lock held by a background keychain read.
-        let raw = Keychain.read(service: keychainService, account: keychainAccount)
+        let outcome = Keychain.readItem(service: keychainService, account: keychainAccount)
+        let raw = outcome.data
             .flatMap { String(data: $0, encoding: .utf8) }?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let value = (raw?.isEmpty == false) ? raw : nil
 
         // Publish once; a racing reader that resolved the same value first
         // wins (the keychain read is idempotent, so a double read is benign).
-        cachedToken.withLock { state in
-            if case .none = state { state = .some(value) }
+        // Only definitive outcomes (found / not-found) are cached: a locked
+        // or transiently failing keychain must not latch "no token" for the
+        // rest of the process lifetime.
+        if outcome.isDefinitive {
+            cachedToken.withLock { state in
+                if case .none = state { state = .some(value) }
+            }
         }
         return value
     }

--- a/Packages/OsaurusCore/Services/Keychain/AgentSecretsKeychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/AgentSecretsKeychain.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import Security
 
 /// Keychain wrapper for agent-scoped secret storage.
 /// Account format: `"{agentId}.{key}"` — no plugin scoping.
@@ -269,11 +270,15 @@ public enum AgentSecretsKeychain {
         // the UI when reached from `secretIDs` during chat-preview composition
         // on the main thread. Account names change only through this type's own
         // writes, so memoize the enumeration and invalidate it on every
-        // mutation.
-        let accounts = Keychain.allAccounts(service: service)
-        accountsCacheLock.lock()
-        cachedAccounts = accounts
-        accountsCacheLock.unlock()
+        // mutation. Only a definitive enumeration is cached: a locked or
+        // transiently failing keychain must not latch an empty account list.
+        let outcome = Keychain.fetchAllItems(service: service, returnData: false)
+        let accounts = outcome.items.compactMap { $0[kSecAttrAccount as String] as? String }
+        if outcome.isDefinitive {
+            accountsCacheLock.lock()
+            cachedAccounts = accounts
+            accountsCacheLock.unlock()
+        }
         return accounts
     }
 }

--- a/Packages/OsaurusCore/Services/Keychain/Keychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/Keychain.swift
@@ -8,27 +8,166 @@
 
 import Foundation
 import Security
+import os.log
+
+// MARK: - Typed outcomes
+
+/// Typed result of a Keychain read.
+///
+/// The distinction between `notFound` and `unavailable`/`accessDenied` is
+/// load-bearing: a locked keychain or a denied ACL must never be reported to
+/// the user as "credential missing", and must never be cached as absence.
+enum KeychainReadOutcome: Equatable, Sendable {
+    /// The item exists and its payload was returned.
+    case found(Data)
+    /// The item definitively does not exist (`errSecItemNotFound`).
+    case notFound
+    /// The item may exist but cannot be read right now (locked keychain,
+    /// interaction required, securityd unavailable). Retry later.
+    case unavailable(OSStatus)
+    /// The keychain refused access to the item for this process (ACL denial,
+    /// authorization failure). Manual repair is likely required.
+    case accessDenied(OSStatus)
+    /// Any other Security-framework failure.
+    case failure(OSStatus)
+    /// Keychain access is disabled for this process (test/live-proof mode).
+    case disabled
+
+    /// Payload when found, `nil` otherwise (legacy-compatible view).
+    var data: Data? {
+        if case .found(let data) = self { return data }
+        return nil
+    }
+
+    /// True when the outcome is authoritative about existence (found,
+    /// not-found, or disabled) and therefore safe to cache. Transient
+    /// failures return false so callers do not latch a "missing" result.
+    var isDefinitive: Bool {
+        switch self {
+        case .found, .notFound, .disabled: return true
+        case .unavailable, .accessDenied, .failure: return false
+        }
+    }
+}
+
+/// Typed result of a Keychain mutation (write or delete).
+enum KeychainMutationOutcome: Equatable, Sendable {
+    case success
+    /// The keychain cannot accept the mutation right now (locked,
+    /// interaction required, securityd unavailable). Retry later.
+    case unavailable(OSStatus)
+    /// The keychain refused the mutation for this process.
+    case accessDenied(OSStatus)
+    case failure(OSStatus)
+    /// Keychain access is disabled for this process (test/live-proof mode).
+    case disabled
+
+    var isSuccess: Bool { self == .success }
+}
+
+/// Enumeration result carrying both the items and whether the listing is
+/// authoritative (so callers don't cache an empty list produced by a
+/// transient failure).
+struct KeychainEnumerationOutcome {
+    let items: [[String: Any]]
+    let status: OSStatus
+
+    /// True when the listing reflects the real keychain contents
+    /// (`errSecSuccess`/`errSecItemNotFound`) or the process-level disable
+    /// gate; false for transient/denied/failed enumerations.
+    let isDefinitive: Bool
+}
+
+// MARK: - Injectable backend
+
+/// The raw SecItem surface, injectable so unit tests can exercise every
+/// `OSStatus` path deterministically without a real keychain.
+protocol KeychainBackend {
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, result: AnyObject?)
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus
+    func add(attributes: [String: Any]) -> OSStatus
+    func delete(query: [String: Any]) -> OSStatus
+}
+
+/// Production backend: direct SecItem calls against the legacy login keychain.
+private struct SecItemKeychainBackend: KeychainBackend {
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, result: AnyObject?) {
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        return (status, result)
+    }
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    }
+
+    func add(attributes: [String: Any]) -> OSStatus {
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+// MARK: - Keychain
 
 /// Generic-password CRUD used by every secret store in the app.
 ///
 /// Reads run with `kSecUseAuthenticationUISkip` plus a non-interactive
 /// `LAContext` so a query that the item's ACL would otherwise gate fails
-/// silently (returns `nil`) instead of raising the "wants to use your
-/// confidential information" password prompt. Because release builds keep a
-/// stable Developer ID Designated Requirement (same cert + bundle id), the
-/// keychain treats update N+1 as the same app as update N, so legitimately
-/// owned items read back without any prompt across updates.
+/// silently (returns a typed non-found outcome) instead of raising the
+/// "wants to use your confidential information" password prompt. Because
+/// release builds keep a stable Developer ID Designated Requirement (same
+/// cert + bundle id), the keychain treats update N+1 as the same app as
+/// update N, so legitimately owned items read back without any prompt across
+/// updates.
 ///
-/// Callers apply their own `KeychainQueryHelpers.disablesKeychainForProcess`
-/// short-circuit before calling these methods.
+/// The `KeychainQueryHelpers.disablesKeychainForProcess` gate is enforced
+/// centrally here for every operation, so no consumer can accidentally reach
+/// the user's login keychain in test/live-proof mode. Wrapper stores keep
+/// their own guards as well (they are pinned by the live-proof source
+/// assertions), but the central gate covers direct callers too.
 enum Keychain {
-    /// Serial queue for fire-and-forget writes. `SecItemAdd`/`SecItemUpdate`
-    /// are synchronous and can block for seconds under iCloud-keychain or
+    private static let log = Logger(subsystem: "com.dinoki.osaurus", category: "Keychain")
+
+    /// Serial queue for all mutations. `SecItemAdd`/`SecItemUpdate` are
+    /// synchronous and can block for seconds under iCloud-keychain or
     /// first-unlock contention; running them here keeps that I/O off the main
-    /// thread (a recurring app-hang source). Serial so concurrent writes to the
-    /// same item don't race.
-    private static let writeQueue = DispatchQueue(
-        label: "com.dinoki.osaurus.keychain.write", qos: .utility)
+    /// thread (a recurring app-hang source). Serial so concurrent writes to
+    /// the same item don't race, and so `flushPendingWrites` has a single
+    /// queue to drain at quit.
+    private static let writeQueue: DispatchQueue = {
+        let queue = DispatchQueue(label: "com.dinoki.osaurus.keychain.write", qos: .utility)
+        queue.setSpecific(key: writeQueueKey, value: ())
+        return queue
+    }()
+
+    /// Marks code already running on `writeQueue` so synchronous mutations
+    /// invoked from inside a `performInBackground` batch don't deadlock on a
+    /// nested `sync` to the same serial queue.
+    private static let writeQueueKey = DispatchSpecificKey<Void>()
+
+    private static let backendLock = NSLock()
+    nonisolated(unsafe) private static var testBackendOverride: KeychainBackend?
+    private static let productionBackend = SecItemKeychainBackend()
+
+    /// Install (or clear with `nil`) a fake backend for tests. While an
+    /// override is installed the process-level disable gate is bypassed so
+    /// fake-backend tests can run under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`
+    /// without ever touching the real keychain.
+    static func _setBackendForTesting(_ backend: KeychainBackend?) {
+        backendLock.lock()
+        defer { backendLock.unlock() }
+        testBackendOverride = backend
+    }
+
+    private static func currentBackend() -> (backend: KeychainBackend, bypassesDisableGate: Bool) {
+        backendLock.lock()
+        defer { backendLock.unlock() }
+        if let override = testBackendOverride { return (override, true) }
+        return (productionBackend, false)
+    }
 
     private static func baseQuery(service: String, account: String) -> [String: Any] {
         [
@@ -38,11 +177,201 @@ enum Keychain {
         ]
     }
 
-    private static func isResolved(_ status: OSStatus) -> Bool {
-        status == errSecSuccess || status == errSecItemNotFound
+    // MARK: - Status classification
+
+    /// Statuses that mean "the keychain can't answer right now" — retryable.
+    private static func isUnavailableStatus(_ status: OSStatus) -> Bool {
+        switch status {
+        case errSecInteractionNotAllowed,  // locked keychain / ACL wants UI we suppressed
+            errSecNotAvailable,  // no keychain available (early boot, securityd down)
+            errSecInteractionRequired:
+            return true
+        default:
+            return false
+        }
     }
 
-    // MARK: - CRUD
+    /// Statuses that mean "this process was refused access" — likely
+    /// permanent for the current signing identity.
+    private static func isAccessDeniedStatus(_ status: OSStatus) -> Bool {
+        status == errSecAuthFailed || status == errSecUserCanceled
+    }
+
+    private static func readOutcome(for status: OSStatus, result: AnyObject?) -> KeychainReadOutcome {
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data else { return .failure(errSecDecode) }
+            return .found(data)
+        case errSecItemNotFound:
+            return .notFound
+        case _ where isUnavailableStatus(status):
+            return .unavailable(status)
+        case _ where isAccessDeniedStatus(status):
+            return .accessDenied(status)
+        default:
+            return .failure(status)
+        }
+    }
+
+    private static func mutationOutcome(for status: OSStatus) -> KeychainMutationOutcome {
+        switch status {
+        case errSecSuccess:
+            return .success
+        case _ where isUnavailableStatus(status):
+            return .unavailable(status)
+        case _ where isAccessDeniedStatus(status):
+            return .accessDenied(status)
+        default:
+            return .failure(status)
+        }
+    }
+
+    /// Privacy-safe failure log: service + operation + status only. Never the
+    /// account name (it can embed provider/plugin identifiers) or the value.
+    private static func logFailure(_ operation: String, service: String, status: OSStatus) {
+        log.error(
+            "Keychain \(operation, privacy: .public) failed for service \(service, privacy: .public): OSStatus \(status, privacy: .public)"
+        )
+    }
+
+    // MARK: - Mutation serialization
+
+    /// Run `work` on the serial write queue, reentrancy-safe: if the caller
+    /// is already on the queue (e.g. inside a `performInBackground` batch)
+    /// the work runs inline instead of deadlocking on a nested `sync`.
+    private static func onWriteQueueSync<T>(_ work: () -> T) -> T {
+        if DispatchQueue.getSpecific(key: writeQueueKey) != nil {
+            return work()
+        }
+        return writeQueue.sync(execute: work)
+    }
+
+    /// Block until every mutation enqueued so far has completed, bounded by
+    /// `timeout`. Called from `applicationWillTerminate` so a credential
+    /// saved right before quit isn't dropped when `_exit` skips the queue.
+    static func flushPendingWrites(timeout: TimeInterval = 3.0) {
+        let done = DispatchSemaphore(value: 0)
+        writeQueue.async { done.signal() }
+        if done.wait(timeout: .now() + timeout) == .timedOut {
+            log.error("Keychain flushPendingWrites timed out after \(timeout, privacy: .public)s")
+        }
+    }
+
+    // MARK: - Typed CRUD
+
+    /// Upsert `data` for (`service`, `account`) with a typed outcome.
+    ///
+    /// Adds only after `errSecItemNotFound`: any other update failure is the
+    /// real error and is surfaced directly instead of being hidden behind a
+    /// guaranteed-duplicate `SecItemAdd` result.
+    static func writeItem(
+        service: String,
+        account: String,
+        data: Data,
+        accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> KeychainMutationOutcome {
+        let (backend, bypassesGate) = currentBackend()
+        if !bypassesGate, KeychainQueryHelpers.disablesKeychainForProcess { return .disabled }
+        return onWriteQueueSync {
+            let base = baseQuery(service: service, account: account)
+            // Accessibility is a creation-time attribute; the legacy keychain
+            // ignores it on update and some paths reject it, so only the add
+            // carries it.
+            let updateStatus = backend.update(
+                query: base,
+                attributes: [kSecValueData as String: data]
+            )
+            if updateStatus == errSecSuccess { return .success }
+            if updateStatus == errSecItemNotFound {
+                var add = base
+                add[kSecValueData as String] = data
+                add[kSecAttrAccessible as String] = accessible
+                let addStatus = backend.add(attributes: add)
+                if addStatus == errSecSuccess { return .success }
+                logFailure("add", service: service, status: addStatus)
+                return mutationOutcome(for: addStatus)
+            }
+            logFailure("update", service: service, status: updateStatus)
+            return mutationOutcome(for: updateStatus)
+        }
+    }
+
+    /// Read (`service`, `account`) with a typed outcome distinguishing
+    /// absence from transient unavailability and access denial.
+    static func readItem(service: String, account: String) -> KeychainReadOutcome {
+        let (backend, bypassesGate) = currentBackend()
+        if !bypassesGate, KeychainQueryHelpers.disablesKeychainForProcess { return .disabled }
+        var query = baseQuery(service: service, account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query.merge(
+            [
+                kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
+                kSecUseAuthenticationContext as String: KeychainQueryHelpers.nonInteractiveContext(),
+            ]
+        ) { _, new in new }
+
+        let (status, result) = backend.copyMatching(query)
+        let outcome = readOutcome(for: status, result: result)
+        if case .found = outcome { return outcome }
+        if case .notFound = outcome { return outcome }
+        logFailure("read", service: service, status: status)
+        return outcome
+    }
+
+    /// Delete (`service`, `account`) with a typed outcome. A missing item
+    /// counts as success (the desired end state holds).
+    static func deleteItem(service: String, account: String) -> KeychainMutationOutcome {
+        let (backend, bypassesGate) = currentBackend()
+        if !bypassesGate, KeychainQueryHelpers.disablesKeychainForProcess { return .disabled }
+        return onWriteQueueSync {
+            let status = backend.delete(query: baseQuery(service: service, account: account))
+            if status == errSecSuccess || status == errSecItemNotFound { return .success }
+            logFailure("delete", service: service, status: status)
+            return mutationOutcome(for: status)
+        }
+    }
+
+    /// Every attribute dictionary stored under `service`, de-duplicated on
+    /// account name, with an authoritative flag for cache decisions.
+    static func fetchAllItems(service: String, returnData: Bool) -> KeychainEnumerationOutcome {
+        let (backend, bypassesGate) = currentBackend()
+        if !bypassesGate, KeychainQueryHelpers.disablesKeychainForProcess {
+            return KeychainEnumerationOutcome(items: [], status: errSecSuccess, isDefinitive: true)
+        }
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
+            kSecUseAuthenticationContext as String: KeychainQueryHelpers.nonInteractiveContext(),
+        ]
+        if returnData { query[kSecReturnData as String] = true }
+
+        let (status, result) = backend.copyMatching(query)
+        if status == errSecItemNotFound {
+            return KeychainEnumerationOutcome(items: [], status: status, isDefinitive: true)
+        }
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            logFailure("enumerate", service: service, status: status)
+            return KeychainEnumerationOutcome(items: [], status: status, isDefinitive: false)
+        }
+
+        var merged: [String: [String: Any]] = [:]
+        for item in items {
+            guard let account = item[kSecAttrAccount as String] as? String else { continue }
+            merged[account] = item
+        }
+        return KeychainEnumerationOutcome(
+            items: Array(merged.values), status: status, isDefinitive: true)
+    }
+
+    // MARK: - Legacy-compatible CRUD
+    //
+    // Bool/Data views over the typed outcomes, kept so existing call sites
+    // stay source-compatible. New code that needs to distinguish absence from
+    // unavailability should use the `*Item(s)` variants above.
 
     /// Upsert `data` for (`service`, `account`).
     @discardableResult
@@ -52,18 +381,7 @@ enum Keychain {
         data: Data,
         accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
     ) -> Bool {
-        let base = baseQuery(service: service, account: account)
-        let attributes: [String: Any] = [
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: accessible,
-        ]
-
-        if SecItemUpdate(base as CFDictionary, attributes as CFDictionary) == errSecSuccess {
-            return true
-        }
-        var add = base
-        add.merge(attributes) { _, new in new }
-        return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+        writeItem(service: service, account: account, data: data, accessible: accessible).isSuccess
     }
 
     /// Fire-and-forget variant of `write` that runs the blocking SecItem call
@@ -71,7 +389,7 @@ enum Keychain {
     /// memory and the write result isn't needed synchronously, so the caller
     /// never blocks the main thread on Security-framework I/O. `data` is
     /// captured at call time, so callers can encode their snapshot first and
-    /// return immediately.
+    /// return immediately. Drained by `flushPendingWrites` at quit.
     static func writeInBackground(
         service: String,
         account: String,
@@ -79,7 +397,7 @@ enum Keychain {
         accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
     ) {
         writeQueue.async {
-            _ = write(service: service, account: account, data: data, accessible: accessible)
+            _ = writeItem(service: service, account: account, data: data, accessible: accessible)
         }
     }
 
@@ -104,54 +422,23 @@ enum Keychain {
 
     /// Read (`service`, `account`). Returns `nil` when the item is absent or
     /// the read would require interactive authorization.
-    static func read(
-        service: String,
-        account: String,
-        accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-    ) -> Data? {
-        var query = baseQuery(service: service, account: account)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-        query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
-        query[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
-
-        var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-            let data = result as? Data
-        else { return nil }
-        return data
+    static func read(service: String, account: String) -> Data? {
+        readItem(service: service, account: account).data
     }
 
-    /// Delete (`service`, `account`).
+    /// Delete (`service`, `account`). In disabled test/live-proof mode the
+    /// delete is a no-op that reports success, matching the wrapper contract.
     @discardableResult
     static func delete(service: String, account: String) -> Bool {
-        isResolved(SecItemDelete(baseQuery(service: service, account: account) as CFDictionary))
+        let outcome = deleteItem(service: service, account: account)
+        if outcome == .disabled { return true }
+        return outcome.isSuccess
     }
 
     /// Every attribute dictionary stored under `service`, de-duplicated on
     /// account name.
     static func fetchAll(service: String, returnData: Bool) -> [[String: Any]] {
-        var query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
-            kSecUseAuthenticationContext as String: KeychainQueryHelpers.nonInteractiveContext(),
-        ]
-        if returnData { query[kSecReturnData as String] = true }
-
-        var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-            let items = result as? [[String: Any]]
-        else { return [] }
-
-        var merged: [String: [String: Any]] = [:]
-        for item in items {
-            guard let account = item[kSecAttrAccount as String] as? String else { continue }
-            merged[account] = item
-        }
-        return Array(merged.values)
+        fetchAllItems(service: service, returnData: returnData).items
     }
 
     /// Account names stored under `service`.

--- a/Packages/OsaurusCore/Services/Keychain/KeychainQueryHelpers.swift
+++ b/Packages/OsaurusCore/Services/Keychain/KeychainQueryHelpers.swift
@@ -26,6 +26,9 @@ enum KeychainQueryHelpers {
         return env["XCTestConfigurationFilePath"] != nil
             || env["XCTestBundlePath"] != nil
             || ProcessInfo.processInfo.processName == "xctest"
+            // `swift test` (SwiftPM + swift-testing) runs suites inside this
+            // helper without any of the XCTest markers above.
+            || ProcessInfo.processInfo.processName == "swiftpm-testing-helper"
             || Bundle.main.bundlePath.hasSuffix(".xctest")
     }
 

--- a/Packages/OsaurusCore/Services/Keychain/OsaurusKeychainServices.swift
+++ b/Packages/OsaurusCore/Services/Keychain/OsaurusKeychainServices.swift
@@ -1,0 +1,66 @@
+//
+//  OsaurusKeychainServices.swift
+//  osaurus
+//
+//  Central registry of every Keychain service Osaurus writes to.
+//
+
+import Foundation
+
+/// Every generic-password service name the app stores secrets under.
+///
+/// Factory reset (`OnboardingService`) wipes exactly this list; keeping it
+/// next to the wrappers (instead of a hard-coded copy in the reset flow)
+/// means a new secret store added with its own service string is one line
+/// away from being covered by reset. If you add a keychain-backed store,
+/// register its service here.
+public enum OsaurusKeychainServices {
+    /// Master identity seed + recovery mnemonic (`MasterKey`,
+    /// `MasterMnemonicStore`).
+    public static let account = "com.osaurus.account"
+    /// SQLCipher storage key (`StorageKeyManager`).
+    public static let storage = "com.osaurus.storage"
+    /// API access keys (`APIKeyManager`).
+    public static let accessKeys = "com.osaurus.access-keys"
+    /// Hybrid address allowlist (`WhitelistStore`; the service string keeps
+    /// the legacy name).
+    public static let addressAllowlist = "com.osaurus.whitelist"
+    /// Access-key revocations (`RevocationStore`).
+    public static let revocations = "com.osaurus.revocations"
+    /// Agent-scoped secrets (`AgentSecretsKeychain`).
+    public static let agentSecrets = "ai.osaurus.agent-secrets"
+    /// Plugin/tool secrets (`ToolSecretsKeychain`).
+    public static let toolSecrets = "ai.osaurus.tools"
+    /// MCP provider tokens and secrets (`MCPProviderKeychain`).
+    public static let mcpProviders = "ai.osaurus.mcp"
+    /// Remote model provider credentials (`RemoteProviderKeychain`).
+    public static let remoteProviders = "ai.osaurus.remote"
+    /// Search provider API keys (`SearchProviderKeychain`).
+    public static let searchProviders = "ai.osaurus.search"
+    /// Channel credentials (`ChannelCredentialVault`).
+    public static let channels = "ai.osaurus.channels"
+    /// Remote TTS API key (`TTSConfiguration`).
+    public static let ttsRemote = "ai.osaurus.tts.remote"
+    /// GitHub API token (`GitHubAuth`).
+    public static let github = "com.dinoki.osaurus.github"
+    /// Hugging Face access token (`HuggingFaceAuth`).
+    public static let huggingFace = "com.dinoki.osaurus.huggingface"
+
+    /// Everything factory reset must wipe.
+    public static let all: [String] = [
+        account,
+        storage,
+        accessKeys,
+        addressAllowlist,
+        revocations,
+        agentSecrets,
+        toolSecrets,
+        mcpProviders,
+        remoteProviders,
+        searchProviders,
+        channels,
+        ttsRemote,
+        github,
+        huggingFace,
+    ]
+}

--- a/Packages/OsaurusCore/Services/Keychain/SecretAvailability.swift
+++ b/Packages/OsaurusCore/Services/Keychain/SecretAvailability.swift
@@ -1,0 +1,39 @@
+//
+//  SecretAvailability.swift
+//  osaurus
+//
+//  Caller-facing availability of a stored secret, derived from the typed
+//  Keychain outcomes.
+//
+
+import Foundation
+
+/// Availability of a credential in the Keychain, for presence checks and
+/// diagnostics. Unlike a plain `Bool`, this distinguishes "definitively not
+/// stored" from "stored but unreadable right now" and "stored but corrupt",
+/// so a locked keychain or a decode bug is never reported to the user as a
+/// missing credential.
+public enum SecretAvailability: Equatable, Sendable {
+    /// The secret exists and decodes correctly.
+    case present
+    /// The secret definitively does not exist.
+    case absent
+    /// The keychain could not answer (locked, interaction required, denied,
+    /// or another transient failure). Do not cache this as absence; retry.
+    case unavailable
+    /// Stored bytes exist but failed to decode into the expected shape.
+    case corrupt
+
+    /// Presence for UI badges: `unavailable` keeps the previous known value
+    /// (or optimistically assumes present when there is none) so a transient
+    /// keychain failure never flashes a false "missing credential" warning.
+    /// `corrupt` counts as present — the item exists; deleting/re-entering it
+    /// is a different affordance than "add a key".
+    public func presenceForUI(previous: Bool?) -> Bool {  // swiftlint:disable:this discouraged_optional_boolean
+        switch self {
+        case .present, .corrupt: return true
+        case .absent: return false
+        case .unavailable: return previous ?? true
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
@@ -32,11 +32,49 @@ public enum ToolSecretsKeychain {
     public static func getSecret(id: String, for pluginId: String, agentId: UUID) -> String? {
         let account = agentAccount(agentId: agentId, pluginId: pluginId, key: id)
         if KeychainQueryHelpers.usesInMemoryKeychainStoreForTests {
-            return testStoreLock.withLock { testStore[account] }
+            if let value = testStoreLock.withLock({ testStore[account] }) { return value }
+            return migrateLegacySecretIfPresent(id: id, pluginId: pluginId, agentId: agentId)
         }
         if KeychainQueryHelpers.disablesKeychainForProcess { return nil }
-        return Keychain.read(service: service, account: account)
-            .flatMap { String(data: $0, encoding: .utf8) }
+        if let data = Keychain.read(service: service, account: account),
+            let value = String(data: data, encoding: .utf8) {
+            return value
+        }
+        return migrateLegacySecretIfPresent(id: id, pluginId: pluginId, agentId: agentId)
+    }
+
+    /// Read-through migration for pre-agent-scoping secrets stored as
+    /// `"{pluginId}.{key}"`. Uninstall has cleanup code for that format but
+    /// nothing ever *read* it after the agent-scoping migration, so a user
+    /// upgrading from an old build silently lost those credentials. Only the
+    /// default-agent namespace falls back (per-agent reads already fall back
+    /// to `Agent.defaultId` via `resolvedSecret`, so every resolution path
+    /// benefits). On a hit the value is copied to the canonical account, and
+    /// the legacy item is deleted only after the canonical copy reads back —
+    /// an interrupted migration can never lose the secret.
+    private static func migrateLegacySecretIfPresent(
+        id: String, pluginId: String, agentId: UUID
+    ) -> String? {
+        guard agentId == Agent.defaultId else { return nil }
+        let legacyAccount = "\(pluginId).\(id)"
+        let canonicalAccount = agentAccount(agentId: agentId, pluginId: pluginId, key: id)
+
+        if KeychainQueryHelpers.usesInMemoryKeychainStoreForTests {
+            return testStoreLock.withLock {
+                guard let value = testStore[legacyAccount] else { return nil }
+                testStore[canonicalAccount] = value
+                testStore.removeValue(forKey: legacyAccount)
+                return value
+            }
+        }
+        guard case .found(let data) = Keychain.readItem(service: service, account: legacyAccount),
+            let value = String(data: data, encoding: .utf8)
+        else { return nil }
+        if Keychain.write(service: service, account: canonicalAccount, data: data),
+            Keychain.read(service: service, account: canonicalAccount) == data {
+            Keychain.delete(service: service, account: legacyAccount)
+        }
+        return value
     }
 
     public static func hasSecret(id: String, for pluginId: String, agentId: UUID) -> Bool {
@@ -46,12 +84,23 @@ public enum ToolSecretsKeychain {
     @discardableResult
     public static func deleteSecret(id: String, for pluginId: String, agentId: UUID) -> Bool {
         let account = agentAccount(agentId: agentId, pluginId: pluginId, key: id)
+        // Deleting from the default-agent namespace also removes any
+        // pre-migration `"{pluginId}.{key}"` twin — otherwise the legacy
+        // read-through fallback would resurrect a secret the user deleted.
+        let legacyAccount = agentId == Agent.defaultId ? "\(pluginId).\(id)" : nil
         if KeychainQueryHelpers.usesInMemoryKeychainStoreForTests {
-            testStoreLock.withLock { _ = testStore.removeValue(forKey: account) }
+            testStoreLock.withLock {
+                _ = testStore.removeValue(forKey: account)
+                if let legacyAccount { _ = testStore.removeValue(forKey: legacyAccount) }
+            }
             return true
         }
         if KeychainQueryHelpers.disablesKeychainForProcess { return true }
-        return Keychain.delete(service: service, account: account)
+        let deleted = Keychain.delete(service: service, account: account)
+        if let legacyAccount {
+            Keychain.delete(service: service, account: legacyAccount)
+        }
+        return deleted
     }
 
     public static func deleteAllSecrets(for pluginId: String, agentId: UUID) {
@@ -203,6 +252,20 @@ public enum ToolSecretsKeychain {
         }
         if KeychainQueryHelpers.disablesKeychainForProcess { return [] }
         return Keychain.fetchAll(service: service, returnData: !attributesOnly)
+    }
+
+    // MARK: - Test seams
+
+    /// Seed a raw account (e.g. a pre-agent-scoping `"{pluginId}.{key}"`
+    /// entry) into the in-memory test store. Test-only: production code has
+    /// no API that writes the legacy format anymore.
+    static func _testSeedRawAccount(_ account: String, value: String) {
+        testStoreLock.withLock { testStore[account] = value }
+    }
+
+    /// Raw account lookup in the in-memory test store. Test-only.
+    static func _testRawAccountValue(_ account: String) -> String? {
+        testStoreLock.withLock { testStore[account] }
     }
 
     private static func deleteAllMatchingPrefix(_ prefix: String) {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
@@ -67,6 +67,15 @@ public enum MCPProviderKeychain {
         getToken(for: providerId) != nil
     }
 
+    /// Typed availability of the static bearer token, distinguishing a
+    /// definitively missing token from a keychain that can't answer right now.
+    public static func tokenAvailability(for providerId: UUID) -> SecretAvailability {
+        if KeychainQueryHelpers.disablesKeychainForProcess { return .absent }
+        return availability(account: tokenAccount(for: providerId)) {
+            String(data: $0, encoding: .utf8) != nil
+        }
+    }
+
     // MARK: - OAuth tokens
 
     @discardableResult
@@ -76,8 +85,25 @@ public enum MCPProviderKeychain {
     }
 
     public static func getOAuthTokens(for providerId: UUID) -> MCPOAuthTokens? {
-        getData(account: oauthAccount(for: providerId))
-            .flatMap { try? JSONDecoder().decode(MCPOAuthTokens.self, from: $0) }
+        guard let data = getData(account: oauthAccount(for: providerId)) else { return nil }
+        do {
+            return try JSONDecoder().decode(MCPOAuthTokens.self, from: data)
+        } catch {
+            // Corrupt stored blob, not absence: surface via availability and
+            // logs so the caller can offer a re-sign-in instead of silently
+            // treating the provider as signed out.
+            NSLog("MCPProviderKeychain: stored OAuth token blob failed to decode")
+            return nil
+        }
+    }
+
+    /// Typed availability of the OAuth token blob, distinguishing corrupt
+    /// stored data and a transiently unavailable keychain from absence.
+    public static func oauthTokensAvailability(for providerId: UUID) -> SecretAvailability {
+        if KeychainQueryHelpers.disablesKeychainForProcess { return .absent }
+        return availability(account: oauthAccount(for: providerId)) {
+            (try? JSONDecoder().decode(MCPOAuthTokens.self, from: $0)) != nil
+        }
     }
 
     @discardableResult
@@ -189,6 +215,21 @@ public enum MCPProviderKeychain {
     // MARK: - Generic CRUD
     //
     // All items route through the shared `Keychain` helper.
+
+    /// Map the typed read outcome for `account` into a `SecretAvailability`,
+    /// using `decodes` to detect a corrupt payload.
+    private static func availability(
+        account: String, decodes: (Data) -> Bool
+    ) -> SecretAvailability {
+        switch Keychain.readItem(service: service, account: account) {
+        case .found(let data):
+            return decodes(data) ? .present : .corrupt
+        case .notFound, .disabled:
+            return .absent
+        case .unavailable, .accessDenied, .failure:
+            return .unavailable
+        }
+    }
 
     @discardableResult
     private static func setData(_ data: Data, account: String) -> Bool {

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
@@ -260,8 +260,12 @@ public enum MCPOAuthService {
             serverMetadataCachedAt: Date(),
             loopbackPort: provider.oauth?.loopbackPort
         )
-        if persist {
-            MCPProviderKeychain.saveOAuthTokens(tokens, for: provider.id)
+        if persist, !MCPProviderKeychain.saveOAuthTokens(tokens, for: provider.id),
+            !KeychainQueryHelpers.disablesKeychainForProcess {
+            // The in-memory tokens still serve this session; what failed is
+            // relaunch durability. Surface it instead of silently signing the
+            // user out on next launch.
+            NSLog("MCPOAuthService: failed to persist OAuth tokens to Keychain after sign-in")
         }
         return MCPOAuthSignInResult(config: config, tokens: tokens)
     }
@@ -331,8 +335,11 @@ public enum MCPOAuthService {
             expiresAt: raw.expiresAt,
             scope: raw.scope ?? tokens.scope
         )
-        if persist {
-            MCPProviderKeychain.saveOAuthTokens(refreshed, for: provider.id)
+        if persist, !MCPProviderKeychain.saveOAuthTokens(refreshed, for: provider.id),
+            !KeychainQueryHelpers.disablesKeychainForProcess {
+            // The refreshed tokens still serve this request; what failed is
+            // relaunch durability (and rotated refresh tokens may be lost).
+            NSLog("MCPOAuthService: failed to persist refreshed OAuth tokens to Keychain")
         }
         return refreshed
     }

--- a/Packages/OsaurusCore/Services/OnboardingService.swift
+++ b/Packages/OsaurusCore/Services/OnboardingService.swift
@@ -286,26 +286,11 @@ public final class OnboardingService: ObservableObject {
         return lines.joined(separator: "\n\n")
     }
 
-    /// Clear all known Osaurus Keychain services
+    /// Clear all known Osaurus Keychain services. The list lives in
+    /// `OsaurusKeychainServices` next to the wrappers so a newly added
+    /// secret store can't be silently missed by factory reset.
     private func wipeKeychain() {
-        let services = [
-            // MasterKey
-            "com.osaurus.account",
-
-            // AgentSecretsKeychain
-            "ai.osaurus.agent-secrets",
-
-            // ToolSecretsKeychain
-            "ai.osaurus.tools",
-
-            // MCPProviderKeychain
-            "ai.osaurus.mcp",
-
-            // RemoteProviderKeychain
-            "ai.osaurus.remote",
-        ]
-
-        for service in services {
+        for service in OsaurusKeychainServices.all {
             let query: [String: Any] = [
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: service,

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderKeychain.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderKeychain.swift
@@ -67,6 +67,15 @@ public enum RemoteProviderKeychain {
         return getAPIKey(for: providerId) != nil
     }
 
+    /// Typed availability of the API key, distinguishing a definitively
+    /// missing key from a keychain that can't answer right now.
+    public static func apiKeyAvailability(for providerId: UUID) -> SecretAvailability {
+        if KeychainQueryHelpers.disablesKeychainForProcess { return .absent }
+        return availability(account: apiKeyAccount(for: providerId)) {
+            String(data: $0, encoding: .utf8) != nil
+        }
+    }
+
     // MARK: - OAuth Token Management
 
     @discardableResult
@@ -87,8 +96,25 @@ public enum RemoteProviderKeychain {
 
     public static func getOAuthTokens(for providerId: UUID) -> RemoteProviderOAuthTokens? {
         if KeychainQueryHelpers.disablesKeychainForProcess { return nil }
-        return getData(account: oauthAccount(for: providerId))
-            .flatMap { try? JSONDecoder().decode(RemoteProviderOAuthTokens.self, from: $0) }
+        guard let data = getData(account: oauthAccount(for: providerId)) else { return nil }
+        do {
+            return try JSONDecoder().decode(RemoteProviderOAuthTokens.self, from: data)
+        } catch {
+            // Corrupt stored blob, not absence: surface via availability and
+            // logs so the caller can offer a re-sign-in instead of silently
+            // treating the account as signed out.
+            NSLog("RemoteProviderKeychain: stored OAuth token blob failed to decode")
+            return nil
+        }
+    }
+
+    /// Typed availability of the OAuth token blob, distinguishing corrupt
+    /// stored data and a transiently unavailable keychain from absence.
+    public static func oauthTokensAvailability(for providerId: UUID) -> SecretAvailability {
+        if KeychainQueryHelpers.disablesKeychainForProcess { return .absent }
+        return availability(account: oauthAccount(for: providerId)) {
+            (try? JSONDecoder().decode(RemoteProviderOAuthTokens.self, from: $0)) != nil
+        }
     }
 
     @discardableResult
@@ -154,6 +180,21 @@ public enum RemoteProviderKeychain {
     // MARK: - Generic CRUD
     //
     // All items route through the shared `Keychain` helper.
+
+    /// Map the typed read outcome for `account` into a `SecretAvailability`,
+    /// using `decodes` to detect a corrupt payload.
+    private static func availability(
+        account: String, decodes: (Data) -> Bool
+    ) -> SecretAvailability {
+        switch Keychain.readItem(service: service, account: account) {
+        case .found(let data):
+            return decodes(data) ? .present : .corrupt
+        case .notFound, .disabled:
+            return .absent
+        case .unavailable, .accessDenied, .failure:
+            return .unavailable
+        }
+    }
 
     @discardableResult
     private static func setData(_ data: Data, account: String) -> Bool {

--- a/Packages/OsaurusCore/Tests/Identity/IdentityRestoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Identity/IdentityRestoreTests.swift
@@ -1,0 +1,200 @@
+//
+//  IdentityRestoreTests.swift
+//  OsaurusCoreTests
+//
+//  Validation and safety-gate tests for the mnemonic restore flow:
+//  `OsaurusIdentity.restore(words:)` (the shared engine behind drift repair,
+//  fresh restore, and replace-existing) and the pure helpers backing
+//  `RecoverFromMnemonicSheet`. Live-Keychain effects (master install, agent
+//  re-derivation) can't run under OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS, so
+//  these tests pin the decode/validation/gating behavior and prove the
+//  engine fails loudly — no partial state, no identity-changed signal —
+//  when the install can't happen.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Restore engine
+
+@Suite("OsaurusIdentity.restore")
+@MainActor
+struct OsaurusIdentityRestoreTests {
+
+    /// Observe `.osaurusIdentityChanged` for the duration of `body`.
+    private func identityChangedCount(during body: () -> Void) -> Int {
+        final class Counter { var value = 0 }
+        let counter = Counter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .osaurusIdentityChanged,
+            object: nil,
+            queue: nil
+        ) { _ in counter.value += 1 }
+        defer { NotificationCenter.default.removeObserver(observer) }
+        body()
+        return counter.value
+    }
+
+    @Test("invalid word count is rejected before any state changes")
+    func invalidWordCountRejected() {
+        let posts = identityChangedCount {
+            #expect(throws: OsaurusIdentityError.self) {
+                _ = try OsaurusIdentity.restore(words: Array(repeating: "abandon", count: 12))
+            }
+        }
+        #expect(posts == 0)
+    }
+
+    @Test("unknown word is rejected before any state changes")
+    func unknownWordRejected() throws {
+        var words = try MasterKeyMnemonic.mnemonic(forKey: TestKeys.alicePrivateKey)
+        words[7] = "notavalidword"
+        let posts = identityChangedCount {
+            #expect(throws: OsaurusIdentityError.self) {
+                _ = try OsaurusIdentity.restore(words: words)
+            }
+        }
+        #expect(posts == 0)
+    }
+
+    @Test("keychain-disabled install failure surfaces as an error, not a fake success")
+    func disabledKeychainFailsLoudly() throws {
+        // Under OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS the install must throw —
+        // a silent no-op would tell the user their identity was restored
+        // when nothing was persisted. No identity-changed signal either.
+        try #require(KeychainQueryHelpers.disablesKeychainForProcess)
+        let words = try MasterKeyMnemonic.mnemonic(forKey: TestKeys.alicePrivateKey)
+        let posts = identityChangedCount {
+            #expect(throws: OsaurusIdentityError.self) {
+                _ = try OsaurusIdentity.restore(words: words)
+            }
+        }
+        #expect(posts == 0)
+    }
+}
+
+// MARK: - Sheet validation helpers
+
+@Suite("RecoverFromMnemonicSheet validation")
+struct RecoverFromMnemonicSheetLogicTests {
+
+    private func aliceWords() throws -> [String] {
+        try MasterKeyMnemonic.mnemonic(forKey: TestKeys.alicePrivateKey)
+    }
+
+    // MARK: canRestore gating
+
+    @Test("incomplete phrases never enable Restore")
+    func incompletePhraseDisablesRestore() throws {
+        let partial = Array(try aliceWords().prefix(23))
+        #expect(
+            !RecoverFromMnemonicSheet.canRestore(
+                words: partial, mode: .freshRestore, acknowledgedReplace: true))
+        #expect(
+            !RecoverFromMnemonicSheet.canRestore(
+                words: [], mode: .freshRestore, acknowledgedReplace: true))
+    }
+
+    @Test("24 words enable Restore for drift repair and fresh restore")
+    func completePhraseEnablesRestore() throws {
+        let words = try aliceWords()
+        let drift = IdentityDrift(mismatchedAgents: [], staleAccessKeys: [])
+        #expect(
+            RecoverFromMnemonicSheet.canRestore(
+                words: words, mode: .driftRepair(drift), acknowledgedReplace: false))
+        #expect(
+            RecoverFromMnemonicSheet.canRestore(
+                words: words, mode: .freshRestore, acknowledgedReplace: false))
+    }
+
+    @Test("replace-existing additionally requires the acknowledgment")
+    func replaceExistingRequiresAcknowledgment() throws {
+        let words = try aliceWords()
+        let mode = RecoverFromMnemonicMode.replaceExisting(current: TestKeys.bobAddress)
+        #expect(
+            !RecoverFromMnemonicSheet.canRestore(
+                words: words, mode: mode, acknowledgedReplace: false))
+        #expect(
+            RecoverFromMnemonicSheet.canRestore(
+                words: words, mode: mode, acknowledgedReplace: true))
+    }
+
+    // MARK: Candidate address preview
+
+    @Test("a valid phrase previews the address it would restore")
+    func candidateAddressForValidPhrase() throws {
+        let words = try aliceWords()
+        #expect(RecoverFromMnemonicSheet.candidateAddress(for: words) == TestKeys.aliceAddress)
+    }
+
+    @Test("incomplete or checksum-failing phrases preview no address")
+    func candidateAddressRejectsInvalidPhrases() throws {
+        var words = try aliceWords()
+        #expect(RecoverFromMnemonicSheet.candidateAddress(for: Array(words.prefix(23))) == nil)
+
+        // Swap in a different valid word: still 24 wordlist words, but the
+        // checksum no longer matches the entropy.
+        words[0] = words[0] == "ability" ? "able" : "ability"
+        #expect(RecoverFromMnemonicSheet.candidateAddress(for: words) == nil)
+    }
+
+    // MARK: Drift-repair previous-master guard
+
+    private func agentDerived(from masterKey: Data, index: UInt32) throws -> Agent {
+        var agent = Agent(
+            id: UUID(),
+            name: "agent-\(index)",
+            description: "",
+            systemPrompt: "",
+            isBuiltIn: false,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        agent.agentIndex = index
+        agent.agentAddress = try AgentKey.deriveAddress(masterKey: masterKey, index: index)
+        return agent
+    }
+
+    @Test("the previous master's phrase passes the drift guard")
+    func previousMasterPassesGuard() throws {
+        // Agents on disk were derived from Alice; the candidate seed is Alice.
+        let drift = IdentityDrift(
+            mismatchedAgents: [try agentDerived(from: TestKeys.alicePrivateKey, index: 3)],
+            staleAccessKeys: []
+        )
+        let message = RecoverFromMnemonicSheet.previousSeedMismatchMessage(
+            drift: drift,
+            seed: TestKeys.alicePrivateKey,
+            candidate: TestKeys.aliceAddress
+        )
+        #expect(message == nil)
+    }
+
+    @Test("an unrelated valid phrase is flagged for explicit override")
+    func unrelatedMasterIsFlagged() throws {
+        // Agents on disk were derived from Alice; the candidate seed is Bob —
+        // a valid mnemonic, but not the previous master.
+        let stranded = try agentDerived(from: TestKeys.alicePrivateKey, index: 3)
+        let drift = IdentityDrift(mismatchedAgents: [stranded], staleAccessKeys: [])
+        let message = RecoverFromMnemonicSheet.previousSeedMismatchMessage(
+            drift: drift,
+            seed: TestKeys.bobPrivateKey,
+            candidate: TestKeys.bobAddress
+        )
+        #expect(message != nil)
+        #expect(message?.contains(TestKeys.bobAddress) == true)
+    }
+
+    @Test("no mismatched agents means nothing to verify against")
+    func emptyDriftPassesGuard() {
+        let drift = IdentityDrift(mismatchedAgents: [], staleAccessKeys: [])
+        let message = RecoverFromMnemonicSheet.previousSeedMismatchMessage(
+            drift: drift,
+            seed: TestKeys.bobPrivateKey,
+            candidate: TestKeys.bobAddress
+        )
+        #expect(message == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Identity/IdentityRestoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Identity/IdentityRestoreTests.swift
@@ -59,12 +59,17 @@ struct OsaurusIdentityRestoreTests {
         #expect(posts == 0)
     }
 
-    @Test("keychain-disabled install failure surfaces as an error, not a fake success")
+    // Only meaningful when the keychain is disabled for the process; the CI
+    // xcodebuild lane runs against a real keychain, where restore succeeding
+    // is the correct behavior — so skip instead of asserting the environment.
+    @Test(
+        "keychain-disabled install failure surfaces as an error, not a fake success",
+        .enabled(if: KeychainQueryHelpers.disablesKeychainForProcess)
+    )
     func disabledKeychainFailsLoudly() throws {
         // Under OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS the install must throw —
         // a silent no-op would tell the user their identity was restored
         // when nothing was persisted. No identity-changed signal either.
-        try #require(KeychainQueryHelpers.disablesKeychainForProcess)
         let words = try MasterKeyMnemonic.mnemonic(forKey: TestKeys.alicePrivateKey)
         let posts = identityChangedCount {
             #expect(throws: OsaurusIdentityError.self) {

--- a/Packages/OsaurusCore/Tests/Identity/MasterKeyMnemonicTests.swift
+++ b/Packages/OsaurusCore/Tests/Identity/MasterKeyMnemonicTests.swift
@@ -29,6 +29,16 @@ struct MasterKeyMnemonicTests {
     }
 
     @Test
+    func roundTripRestoresSameOsaurusId() throws {
+        // The restore promise: the phrase exported on one Mac derives the
+        // identical master address when pasted on another.
+        let mnemonic = try MasterKeyMnemonic.mnemonic(forKey: TestKeys.alicePrivateKey)
+        var recovered = try MasterKeyMnemonic.key(fromMnemonic: mnemonic)
+        defer { recovered.zeroOut() }
+        #expect(try deriveOsaurusId(from: recovered) == TestKeys.aliceAddress)
+    }
+
+    @Test
     func roundTripRandom() throws {
         // Generate 10 random 32-byte keys and confirm round-trip integrity for
         // each. Catches encoding/decoding bit-packing bugs that wouldn't show

--- a/Packages/OsaurusCore/Tests/Provider/MCPProviderStartupRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/MCPProviderStartupRecoveryTests.swift
@@ -1,0 +1,296 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Records the provider IDs a connect path attempted, thread-safely.
+private final class ConnectRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var attemptsById: [UUID: Int] = [:]
+
+    func record(_ id: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        attemptsById[id, default: 0] += 1
+    }
+
+    func attempts(for id: UUID) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return attemptsById[id] ?? 0
+    }
+
+    var attemptedIds: Set<UUID> {
+        lock.lock()
+        defer { lock.unlock() }
+        return Set(attemptsById.keys)
+    }
+}
+
+/// Completes `arrive()` only once `expected` callers are waiting inside it
+/// simultaneously — proof of concurrency, deadlock under serial execution.
+private actor Rendezvous {
+    private let expected: Int
+    private var arrived = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(expected: Int) {
+        self.expected = expected
+    }
+
+    func arrive() async {
+        arrived += 1
+        if arrived >= expected {
+            for waiter in waiters { waiter.resume() }
+            waiters.removeAll()
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+/// Launch/recovery orchestration for MCP providers. Serialized: the manager
+/// is a process-wide singleton.
+@Suite("MCP provider startup and recovery", .serialized)
+@MainActor
+struct MCPProviderStartupRecoveryTests {
+
+    private func makeProvider(name: String, enabled: Bool = true, autoConnect: Bool = true)
+        -> MCPProvider
+    {
+        MCPProvider(
+            name: name,
+            url: "https://\(name).example.invalid/mcp",
+            enabled: enabled,
+            autoConnect: autoConnect
+        )
+    }
+
+    @Test("launch connect honors enabled && autoConnect")
+    func launchHonorsAutoConnect() async {
+        let manager = MCPProviderManager.shared
+        let connecting = makeProvider(name: "auto-on")
+        let dormant = makeProvider(name: "auto-off", autoConnect: false)
+        let disabled = makeProvider(name: "disabled", enabled: false)
+        manager._testInstallProviders([connecting, dormant, disabled])
+        defer { manager._testRemoveProviders(ids: [connecting.id, dormant.id, disabled.id]) }
+
+        let recorder = ConnectRecorder()
+        manager.testConnectOverride = { id in recorder.record(id) }
+
+        await manager.connectEnabledProviders()
+
+        // Every *other* auto-connect provider in the shared config may also be
+        // attempted; what matters is ours: auto-connect connects, the
+        // enabled-but-dormant and disabled ones stay untouched.
+        #expect(recorder.attempts(for: connecting.id) == 1)
+        #expect(recorder.attempts(for: dormant.id) == 0)
+        #expect(recorder.attempts(for: disabled.id) == 0)
+    }
+
+    @Test("launch connects run concurrently, not serially")
+    func launchConnectsAreConcurrent() async {
+        let manager = MCPProviderManager.shared
+        let first = makeProvider(name: "concurrent-a")
+        let second = makeProvider(name: "concurrent-b")
+        manager._testInstallProviders([first, second])
+        defer { manager._testRemoveProviders(ids: [first.id, second.id]) }
+
+        // Both connects must be in-flight at the same time for either to
+        // finish. A serial launch loop would deadlock here, so guard with a
+        // timeout that fails the test instead of hanging the suite.
+        let rendezvous = Rendezvous(expected: 2)
+        let ourIds: Set<UUID> = [first.id, second.id]
+        manager.testConnectOverride = { id in
+            guard ourIds.contains(id) else { return }
+            await rendezvous.arrive()
+        }
+
+        // Hoisted out of the group: the region-based isolation checker cannot
+        // handle a `@MainActor` child task capturing the manager directly.
+        let connectTask = Task { @MainActor in
+            await manager.connectEnabledProviders()
+        }
+        let completed = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await connectTask.value
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        if !completed { connectTask.cancel() }
+        #expect(completed, "connectEnabledProviders must run providers concurrently")
+    }
+
+    @Test("transient launch failures get bounded retry")
+    func transientFailureRetries() async {
+        let manager = MCPProviderManager.shared
+        let provider = makeProvider(name: "flaky")
+        manager._testInstallProviders([provider])
+        defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+        let recorder = ConnectRecorder()
+        manager.testRetrySleepOverride = { _ in }
+        manager.testConnectOverride = { id in
+            recorder.record(id)
+            if recorder.attempts(for: id) < 3 {
+                throw URLError(.notConnectedToInternet)
+            }
+        }
+
+        await manager.connectEnabledProviders()
+
+        #expect(recorder.attempts(for: provider.id) == 3)
+    }
+
+    @Test("terminal launch failures are not retried")
+    func terminalFailureDoesNotRetry() async {
+        let manager = MCPProviderManager.shared
+        let provider = makeProvider(name: "terminal")
+        manager._testInstallProviders([provider])
+        defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+        let recorder = ConnectRecorder()
+        manager.testRetrySleepOverride = { _ in }
+        manager.testConnectOverride = { id in
+            recorder.record(id)
+            throw MCPProviderError.invalidURL
+        }
+
+        await manager.connectEnabledProviders()
+
+        #expect(recorder.attempts(for: provider.id) == 1)
+    }
+
+    @Test("first satisfied network observation recovers transiently-failed providers")
+    func firstSatisfiedObservationRecovers() async {
+        let manager = MCPProviderManager.shared
+        // The manager's real NWPathMonitor may already have consumed the
+        // launch baseline; reset connectivity bookkeeping so this test owns
+        // the "first observation".
+        manager._testRemoveProviders(ids: [])
+        let failed = makeProvider(name: "transient-failed")
+        let healthy = makeProvider(name: "healthy")
+        manager._testInstallProviders([failed, healthy])
+        defer { manager._testRemoveProviders(ids: [failed.id, healthy.id]) }
+
+        var failedState = MCPProviderState(providerId: failed.id)
+        failedState.lastFailureWasTransient = true
+        manager._testSetState(failedState, for: failed.id)
+
+        var healthyState = MCPProviderState(providerId: healthy.id)
+        healthyState.isConnected = true
+        manager._testSetState(healthyState, for: healthy.id)
+
+        let recorder = ConnectRecorder()
+        manager.testConnectOverride = { id in recorder.record(id) }
+        manager.testNetworkRecoverySettleDelayOverride = 0
+
+        // The very first path observation (launch baseline) must count as a
+        // recovery opportunity — not just a down→up edge.
+        manager.handleNetworkPathUpdate(satisfied: true)
+        await manager._testAwaitNetworkRecoverySweep()
+
+        #expect(recorder.attempts(for: failed.id) == 1)
+        #expect(recorder.attempts(for: healthy.id) == 0)
+    }
+
+    @Test("recovery sweep skips terminal failures and providers awaiting sign-in")
+    func recoverySweepSkipsTerminalAndAuth() async {
+        let manager = MCPProviderManager.shared
+        let terminal = makeProvider(name: "terminal-failed")
+        let needsAuth = makeProvider(name: "needs-auth")
+        manager._testInstallProviders([terminal, needsAuth])
+        defer { manager._testRemoveProviders(ids: [terminal.id, needsAuth.id]) }
+
+        var terminalState = MCPProviderState(providerId: terminal.id)
+        terminalState.lastFailureWasTransient = false
+        manager._testSetState(terminalState, for: terminal.id)
+
+        var authState = MCPProviderState(providerId: needsAuth.id)
+        authState.lastFailureWasTransient = true
+        authState.requiresAuth = true
+        manager._testSetState(authState, for: needsAuth.id)
+
+        let recorder = ConnectRecorder()
+        manager.testConnectOverride = { id in recorder.record(id) }
+
+        await manager.reconnectTransientlyFailedProviders()
+
+        #expect(recorder.attempts(for: terminal.id) == 0)
+        #expect(recorder.attempts(for: needsAuth.id) == 0)
+    }
+
+    @Test("repeated satisfied observations do not re-trigger recovery")
+    func repeatedSatisfiedObservationsDoNotRetrigger() async {
+        let manager = MCPProviderManager.shared
+        manager._testRemoveProviders(ids: [])
+        let failed = makeProvider(name: "once-only")
+        manager._testInstallProviders([failed])
+        defer { manager._testRemoveProviders(ids: [failed.id]) }
+
+        var state = MCPProviderState(providerId: failed.id)
+        state.lastFailureWasTransient = true
+        manager._testSetState(state, for: failed.id)
+
+        let recorder = ConnectRecorder()
+        manager.testConnectOverride = { id in
+            recorder.record(id)
+            // Stay disconnected so a second sweep would re-attempt.
+            throw URLError(.notConnectedToInternet)
+        }
+        manager.testNetworkRecoverySettleDelayOverride = 0
+
+        manager.handleNetworkPathUpdate(satisfied: true)
+        await manager._testAwaitNetworkRecoverySweep()
+        #expect(recorder.attempts(for: failed.id) == 1)
+
+        // Satisfied → satisfied is not an edge; no new sweep.
+        manager.handleNetworkPathUpdate(satisfied: true)
+        await manager._testAwaitNetworkRecoverySweep()
+        #expect(recorder.attempts(for: failed.id) == 1)
+
+        // A real outage/recovery cycle sweeps again.
+        manager.handleNetworkPathUpdate(satisfied: false)
+        manager.handleNetworkPathUpdate(satisfied: true)
+        await manager._testAwaitNetworkRecoverySweep()
+        #expect(recorder.attempts(for: failed.id) == 2)
+    }
+
+    @Test("transient error classification")
+    func transientErrorClassification() {
+        #expect(MCPProviderManager.isTransientConnectError(URLError(.notConnectedToInternet)))
+        #expect(MCPProviderManager.isTransientConnectError(URLError(.timedOut)))
+        #expect(MCPProviderManager.isTransientConnectError(URLError(.dnsLookupFailed)))
+        #expect(MCPProviderManager.isTransientConnectError(MCPProviderError.timeout))
+        #expect(!MCPProviderManager.isTransientConnectError(URLError(.userAuthenticationRequired)))
+        #expect(!MCPProviderManager.isTransientConnectError(MCPProviderError.invalidURL))
+        #expect(!MCPProviderManager.isTransientConnectError(MCPProviderError.providerNotFound))
+    }
+
+    @Test("enabled/auto-connect intent survives an encode/decode relaunch")
+    func persistedIntentSurvivesRelaunch() throws {
+        let auto = makeProvider(name: "persist-auto")
+        let manualOnly = makeProvider(name: "persist-manual", autoConnect: false)
+        let off = makeProvider(name: "persist-off", enabled: false)
+        let configuration = MCPProviderConfiguration(providers: [auto, manualOnly, off])
+
+        let data = try JSONEncoder().encode(configuration)
+        let reloaded = try JSONDecoder().decode(MCPProviderConfiguration.self, from: data)
+
+        #expect(reloaded.provider(id: auto.id)?.enabled == true)
+        #expect(reloaded.provider(id: auto.id)?.autoConnect == true)
+        #expect(reloaded.provider(id: manualOnly.id)?.enabled == true)
+        #expect(reloaded.provider(id: manualOnly.id)?.autoConnect == false)
+        #expect(reloaded.provider(id: off.id)?.enabled == false)
+        #expect(reloaded.autoConnectProviders.map(\.id) == [auto.id])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderStartupRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderStartupRecoveryTests.swift
@@ -1,0 +1,105 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// MainActor-isolated mutable counter usable from `@Sendable` override blocks.
+@MainActor
+private final class Counter {
+    var value = 0
+    func increment() { value += 1 }
+}
+
+/// Launch/recovery behavior for user-configured remote providers: the first
+/// satisfied network observation, wake, and app activation are recovery
+/// opportunities for transiently-failed auto-connect providers, and no
+/// recovery path requires toggling a provider off and on.
+@Suite(.serialized)
+@MainActor
+struct RemoteProviderStartupRecoveryTests {
+
+    private func installTransientlyFailedProvider(
+        _ manager: RemoteProviderManager, name: String
+    ) -> RemoteProvider {
+        let provider = RemoteProvider(name: name, host: "\(name).example.invalid")
+        manager._testInstallConnectedProvider(provider, discoveredModels: [])
+        var state = RemoteProviderState(providerId: provider.id)
+        state.isConnected = false
+        state.lastFailureWasTransient = true
+        manager._testSetState(state, for: provider.id)
+        return provider
+    }
+
+    @Test func firstSatisfiedNetworkObservation_recoversTransientlyFailedProvider() async throws {
+        await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            // The manager's real NWPathMonitor may already have consumed the
+            // launch baseline; reset connectivity bookkeeping so this test
+            // owns the "first observation".
+            manager._testRemoveProviders(ids: [])
+            let provider = installTransientlyFailedProvider(manager, name: "recovery-baseline")
+            defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+            manager.testFetchModelsOverride = { _ in ["recovered/model"] }
+            manager.testNetworkRecoverySettleDelayOverride = 0
+
+            // First path observation at launch — not a down→up edge — must
+            // still sweep providers that failed transiently moments earlier.
+            manager.handleNetworkPathUpdate(satisfied: true)
+            await manager._testAwaitNetworkRecoverySweep()
+
+            let state = manager.providerStates[provider.id]
+            #expect(state?.isConnected == true)
+            #expect(state?.discoveredModels == ["recovered/model"])
+        }
+    }
+
+    @Test func appActivation_recoversTransientlyFailedProvider() async throws {
+        await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            manager._testRemoveProviders(ids: [])
+            let provider = installTransientlyFailedProvider(manager, name: "recovery-activate")
+            defer { manager._testRemoveProviders(ids: [provider.id]) }
+
+            // No identity → the router leg of activation is a no-op; only the
+            // transient sweep should act.
+            manager.testIdentityExistsOverride = false
+            manager.testFetchModelsOverride = { _ in ["activated/model"] }
+
+            await manager.handleAppDidBecomeActive()
+
+            #expect(manager.providerStates[provider.id]?.isConnected == true)
+        }
+    }
+
+    @Test func recoverySweep_skipsTerminalFailuresAndConnectedProviders() async throws {
+        await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            manager._testRemoveProviders(ids: [])
+
+            let terminal = RemoteProvider(name: "terminal", host: "terminal.example.invalid")
+            manager._testInstallConnectedProvider(terminal, discoveredModels: [])
+            var terminalState = RemoteProviderState(providerId: terminal.id)
+            terminalState.isConnected = false
+            terminalState.lastFailureWasTransient = false
+            manager._testSetState(terminalState, for: terminal.id)
+
+            let connected = RemoteProvider(name: "healthy", host: "healthy.example.invalid")
+            manager._testInstallConnectedProvider(connected, discoveredModels: ["m"])
+            defer { manager._testRemoveProviders(ids: [terminal.id, connected.id]) }
+
+            let counter = Counter()
+            manager.testFetchModelsOverride = { _ in
+                counter.increment()
+                return ["should-not-fetch"]
+            }
+
+            await manager.reconnectTransientlyFailedProviders()
+
+            #expect(counter.value == 0)
+            #expect(manager.providerStates[terminal.id]?.isConnected == false)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ConfigDiskWriterFlushTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ConfigDiskWriterFlushTests.swift
@@ -1,0 +1,83 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Quit-time durability for the async config writer: `applicationWillTerminate`
+/// ends with `_exit(0)`, which skips pending background writes unless
+/// `flushPendingWrites` drains the queue first.
+@Suite("ConfigDiskWriter flush")
+struct ConfigDiskWriterFlushTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("config-disk-writer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test("flush lands every asynchronous write enqueued before it")
+    func flushDrainsPendingWrites() throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var urls: [URL] = []
+        for index in 0..<20 {
+            let url = directory.appendingPathComponent("config-\(index).json")
+            urls.append(url)
+            ConfigDiskWriter.write(Data("{\"index\":\(index)}".utf8), to: url, synchronous: false)
+        }
+
+        ConfigDiskWriter.flushPendingWrites()
+
+        for (index, url) in urls.enumerated() {
+            let data = try Data(contentsOf: url)
+            #expect(String(data: data, encoding: .utf8) == "{\"index\":\(index)}")
+        }
+    }
+
+    @Test("last write wins for repeated writes to the same file")
+    func lastWriteWins() throws {
+        let directory = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("remote.json")
+
+        for revision in 0..<50 {
+            ConfigDiskWriter.write(Data("rev-\(revision)".utf8), to: url, synchronous: false)
+        }
+        ConfigDiskWriter.flushPendingWrites()
+
+        let data = try Data(contentsOf: url)
+        #expect(String(data: data, encoding: .utf8) == "rev-49")
+    }
+
+    @Test("flush reports errors to the caller instead of dropping them")
+    func writeErrorsReachOnError() {
+        let missingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString)", isDirectory: true)
+        let url = missingDirectory.appendingPathComponent("config.json")
+
+        final class ErrorBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _error: Error?
+            var error: Error? {
+                get { lock.withLock { _error } }
+                set { lock.withLock { _error = newValue } }
+            }
+        }
+        let box = ErrorBox()
+        ConfigDiskWriter.write(Data("x".utf8), to: url, synchronous: false) { box.error = $0 }
+        ConfigDiskWriter.flushPendingWrites()
+
+        #expect(box.error != nil)
+    }
+
+    @Test("flush with an idle queue returns promptly")
+    func idleFlushIsCheap() {
+        let start = Date()
+        ConfigDiskWriter.flushPendingWrites(timeout: 1.0)
+        #expect(Date().timeIntervalSince(start) < 1.0)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/KeychainTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainTests.swift
@@ -1,63 +1,385 @@
 // Copyright © 2026 osaurus.
 
 import Foundation
+import Security
 import Testing
 
 @testable import OsaurusCore
 
-@Suite("Keychain round-trip")
-struct KeychainTests {
-    private static func packageRoot() -> URL {
-        let here = URL(fileURLWithPath: #filePath)
-        var cursor = here.deletingLastPathComponent()  // Service/
-        cursor.deleteLastPathComponent()  // Tests/
-        return cursor.deletingLastPathComponent()  // OsaurusCore/
+/// Deterministic in-memory SecItem backend that records every operation, so
+/// each `OSStatus` path in the shared `Keychain` helper can be exercised
+/// without touching a real keychain.
+private final class FakeKeychainBackend: KeychainBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private var store: [String: Data] = [:]
+
+    /// Forced statuses; when nil, the in-memory store behaves like a healthy
+    /// keychain.
+    var updateStatus: OSStatus?
+    var addStatus: OSStatus?
+    var copyStatus: OSStatus?
+    var deleteStatus: OSStatus?
+
+    private var recordedOperations: [String] = []
+    var operations: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedOperations
     }
 
-    private static func source(_ relativePath: String) throws -> String {
-        let url = packageRoot().appendingPathComponent(relativePath)
-        return try String(contentsOf: url, encoding: .utf8)
+    private func itemKey(_ query: [String: Any]) -> String {
+        let service = query[kSecAttrService as String] as? String ?? ""
+        let account = query[kSecAttrAccount as String] as? String ?? ""
+        return "\(service)\u{0}\(account)"
     }
 
-    /// Returns the body of `static func write(...)` up to the next `static func`.
-    private static func writeFunctionBody(in source: String) throws -> String {
-        let start = try #require(source.range(of: "static func write("))
-        let rest = source[start.lowerBound...]
-        let nextFunc = try #require(rest.range(of: "static func read("))
-        return String(source[start.lowerBound ..< nextFunc.lowerBound])
+    func value(service: String, account: String) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return store["\(service)\u{0}\(account)"]
     }
 
-    // `write` upserts (SecItemUpdate then SecItemAdd) and must never delete:
-    // a stray delete in the write path would wipe the value it just stored.
-    @Test("write never deletes (so it cannot wipe the item it just wrote)")
-    func writeDoesNotDelete() throws {
-        let source = try Self.source("Services/Keychain/Keychain.swift")
-        let body = try Self.writeFunctionBody(in: source)
-        let code =
-            body
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .map { line -> Substring in
-                guard let comment = line.range(of: "//") else { return line }
-                return line[line.startIndex ..< comment.lowerBound]
+    func seed(service: String, account: String, data: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        store["\(service)\u{0}\(account)"] = data
+    }
+
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, result: AnyObject?) {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedOperations.append("copy")
+        if let forced = copyStatus { return (forced, nil) }
+
+        let matchAll =
+            (query[kSecMatchLimit as String] as? String) == (kSecMatchLimitAll as String)
+        if matchAll {
+            let service = query[kSecAttrService as String] as? String ?? ""
+            let prefix = "\(service)\u{0}"
+            let items: [[String: Any]] = store.compactMap { key, data in
+                guard key.hasPrefix(prefix) else { return nil }
+                var item: [String: Any] = [
+                    kSecAttrAccount as String: String(key.dropFirst(prefix.count))
+                ]
+                if (query[kSecReturnData as String] as? Bool) == true {
+                    item[kSecValueData as String] = data
+                }
+                return item
             }
-            .joined(separator: "\n")
-        #expect(!code.contains("SecItemDelete"))
-    }
-
-    // A value written through the helper must read back unchanged. When no
-    // keychain backend is writable — e.g. a barren CI runner — `write` returns
-    // false and the round-trip assertion is skipped rather than failing.
-    @Test("a written value survives and reads back")
-    func valueSurvivesWrite() {
-        let service = "ai.osaurus.test.keychain"
-        let account = "roundtrip-\(UUID().uuidString)"
-        let secret = Data("s3cr3t-\(UUID().uuidString)".utf8)
-        defer { Keychain.delete(service: service, account: account) }
-
-        guard Keychain.write(service: service, account: account, data: secret) else {
-            return  // No writable keychain backend in this environment.
+            if items.isEmpty { return (errSecItemNotFound, nil) }
+            return (errSecSuccess, items as AnyObject)
         }
 
-        #expect(Keychain.read(service: service, account: account) == secret)
+        guard let data = store[itemKey(query)] else { return (errSecItemNotFound, nil) }
+        return (errSecSuccess, data as AnyObject)
+    }
+
+    func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedOperations.append("update")
+        if let forced = updateStatus { return forced }
+        let key = itemKey(query)
+        guard store[key] != nil else { return errSecItemNotFound }
+        if let data = attributes[kSecValueData as String] as? Data { store[key] = data }
+        return errSecSuccess
+    }
+
+    func add(attributes: [String: Any]) -> OSStatus {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedOperations.append("add")
+        if let forced = addStatus { return forced }
+        let key = itemKey(attributes)
+        guard store[key] == nil else { return errSecDuplicateItem }
+        store[key] = attributes[kSecValueData as String] as? Data
+        return errSecSuccess
+    }
+
+    func delete(query: [String: Any]) -> OSStatus {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedOperations.append("delete")
+        if let forced = deleteStatus { return forced }
+        guard store.removeValue(forKey: itemKey(query)) != nil else { return errSecItemNotFound }
+        return errSecSuccess
+    }
+}
+
+/// The backend override is process-global, so these tests must not interleave.
+@Suite("Keychain typed outcomes", .serialized)
+struct KeychainTests {
+    private static let service = "ai.osaurus.test.keychain"
+
+    private func withFakeBackend<T>(
+        _ backend: FakeKeychainBackend, _ body: () throws -> T
+    ) rethrows -> T {
+        Keychain._setBackendForTesting(backend)
+        defer { Keychain._setBackendForTesting(nil) }
+        return try body()
+    }
+
+    // MARK: - Write
+
+    @Test("write updates an existing item without adding or deleting")
+    func writeUpdatesExistingItem() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("old".utf8))
+        withFakeBackend(backend) {
+            let outcome = Keychain.writeItem(
+                service: Self.service, account: "a", data: Data("new".utf8))
+            #expect(outcome == .success)
+        }
+        #expect(backend.value(service: Self.service, account: "a") == Data("new".utf8))
+        #expect(backend.operations == ["update"])
+    }
+
+    @Test("write adds only after errSecItemNotFound")
+    func writeAddsOnlyAfterNotFound() {
+        let backend = FakeKeychainBackend()
+        withFakeBackend(backend) {
+            let outcome = Keychain.writeItem(
+                service: Self.service, account: "a", data: Data("v".utf8))
+            #expect(outcome == .success)
+        }
+        #expect(backend.value(service: Self.service, account: "a") == Data("v".utf8))
+        #expect(backend.operations == ["update", "add"])
+    }
+
+    @Test("a non-not-found update failure is surfaced, not hidden behind an add")
+    func writeSurfacesUpdateFailureWithoutAdding() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("old".utf8))
+        backend.updateStatus = errSecAuthFailed
+        withFakeBackend(backend) {
+            let outcome = Keychain.writeItem(
+                service: Self.service, account: "a", data: Data("new".utf8))
+            #expect(outcome == .accessDenied(errSecAuthFailed))
+        }
+        // The add path must not run: it would report errSecDuplicateItem and
+        // mask the real error. The stored value must survive untouched.
+        #expect(backend.operations == ["update"])
+        #expect(backend.value(service: Self.service, account: "a") == Data("old".utf8))
+    }
+
+    @Test("write maps unavailable and generic statuses to typed outcomes")
+    func writeMapsStatuses() {
+        let cases: [(OSStatus, KeychainMutationOutcome)] = [
+            (errSecInteractionNotAllowed, .unavailable(errSecInteractionNotAllowed)),
+            (errSecNotAvailable, .unavailable(errSecNotAvailable)),
+            (errSecAuthFailed, .accessDenied(errSecAuthFailed)),
+            (errSecParam, .failure(errSecParam)),
+        ]
+        for (status, expected) in cases {
+            let backend = FakeKeychainBackend()
+            backend.seed(service: Self.service, account: "a", data: Data("old".utf8))
+            backend.updateStatus = status
+            withFakeBackend(backend) {
+                let outcome = Keychain.writeItem(
+                    service: Self.service, account: "a", data: Data("new".utf8))
+                #expect(outcome == expected, "status \(status)")
+            }
+        }
+    }
+
+    @Test("write never deletes (so it cannot wipe the item it just wrote)")
+    func writeNeverDeletes() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("old".utf8))
+        withFakeBackend(backend) {
+            _ = Keychain.writeItem(service: Self.service, account: "a", data: Data("v1".utf8))
+            _ = Keychain.writeItem(service: Self.service, account: "b", data: Data("v2".utf8))
+        }
+        #expect(!backend.operations.contains("delete"))
+    }
+
+    @Test("legacy Bool write reflects the typed outcome")
+    func legacyWriteReflectsOutcome() {
+        let ok = FakeKeychainBackend()
+        withFakeBackend(ok) {
+            #expect(Keychain.write(service: Self.service, account: "a", data: Data("v".utf8)))
+        }
+        let broken = FakeKeychainBackend()
+        broken.updateStatus = errSecItemNotFound
+        broken.addStatus = errSecNotAvailable
+        withFakeBackend(broken) {
+            #expect(!Keychain.write(service: Self.service, account: "a", data: Data("v".utf8)))
+        }
+    }
+
+    // MARK: - Read
+
+    @Test("read distinguishes found, not-found, unavailable, denied, and failure")
+    func readMapsStatuses() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "present", data: Data("v".utf8))
+        withFakeBackend(backend) {
+            #expect(
+                Keychain.readItem(service: Self.service, account: "present")
+                    == .found(Data("v".utf8)))
+            #expect(Keychain.readItem(service: Self.service, account: "absent") == .notFound)
+        }
+
+        let statuses: [(OSStatus, KeychainReadOutcome)] = [
+            (errSecInteractionNotAllowed, .unavailable(errSecInteractionNotAllowed)),
+            (errSecNotAvailable, .unavailable(errSecNotAvailable)),
+            (errSecAuthFailed, .accessDenied(errSecAuthFailed)),
+            (errSecUserCanceled, .accessDenied(errSecUserCanceled)),
+            (errSecParam, .failure(errSecParam)),
+        ]
+        for (status, expected) in statuses {
+            let failing = FakeKeychainBackend()
+            failing.copyStatus = status
+            withFakeBackend(failing) {
+                let outcome = Keychain.readItem(service: Self.service, account: "a")
+                #expect(outcome == expected, "status \(status)")
+                #expect(!outcome.isDefinitive, "status \(status) must not be cacheable")
+            }
+        }
+    }
+
+    @Test("only found/not-found read outcomes are definitive")
+    func readDefinitiveness() {
+        #expect(KeychainReadOutcome.found(Data()).isDefinitive)
+        #expect(KeychainReadOutcome.notFound.isDefinitive)
+        #expect(KeychainReadOutcome.disabled.isDefinitive)
+        #expect(!KeychainReadOutcome.unavailable(errSecInteractionNotAllowed).isDefinitive)
+        #expect(!KeychainReadOutcome.accessDenied(errSecAuthFailed).isDefinitive)
+        #expect(!KeychainReadOutcome.failure(errSecParam).isDefinitive)
+    }
+
+    @Test("legacy read returns data only when found")
+    func legacyReadReturnsDataOnlyWhenFound() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("v".utf8))
+        withFakeBackend(backend) {
+            #expect(Keychain.read(service: Self.service, account: "a") == Data("v".utf8))
+            #expect(Keychain.read(service: Self.service, account: "missing") == nil)
+        }
+        let locked = FakeKeychainBackend()
+        locked.copyStatus = errSecInteractionNotAllowed
+        withFakeBackend(locked) {
+            #expect(Keychain.read(service: Self.service, account: "a") == nil)
+        }
+    }
+
+    // MARK: - Delete
+
+    @Test("delete treats a missing item as success and surfaces real failures")
+    func deleteOutcomes() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("v".utf8))
+        withFakeBackend(backend) {
+            #expect(Keychain.deleteItem(service: Self.service, account: "a") == .success)
+            #expect(Keychain.deleteItem(service: Self.service, account: "a") == .success)
+        }
+
+        let failing = FakeKeychainBackend()
+        failing.deleteStatus = errSecInteractionNotAllowed
+        withFakeBackend(failing) {
+            #expect(
+                Keychain.deleteItem(service: Self.service, account: "a")
+                    == .unavailable(errSecInteractionNotAllowed))
+        }
+    }
+
+    // MARK: - Enumeration
+
+    @Test("enumeration is definitive on success and empty service")
+    func enumerationDefinitive() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("1".utf8))
+        backend.seed(service: Self.service, account: "b", data: Data("2".utf8))
+        withFakeBackend(backend) {
+            let outcome = Keychain.fetchAllItems(service: Self.service, returnData: false)
+            #expect(outcome.isDefinitive)
+            #expect(
+                Set(Keychain.allAccounts(service: Self.service)) == ["a", "b"])
+            let empty = Keychain.fetchAllItems(service: "ai.osaurus.test.empty", returnData: false)
+            #expect(empty.isDefinitive)
+            #expect(empty.items.isEmpty)
+        }
+    }
+
+    @Test("a transient enumeration failure is not definitive (never cache it)")
+    func enumerationTransientFailureNotDefinitive() {
+        let backend = FakeKeychainBackend()
+        backend.copyStatus = errSecInteractionNotAllowed
+        withFakeBackend(backend) {
+            let outcome = Keychain.fetchAllItems(service: Self.service, returnData: false)
+            #expect(!outcome.isDefinitive)
+            #expect(outcome.items.isEmpty)
+        }
+    }
+
+    // MARK: - Queue draining
+
+    @Test("flushPendingWrites drains background writes")
+    func flushDrainsBackgroundWrites() {
+        let backend = FakeKeychainBackend()
+        withFakeBackend(backend) {
+            Keychain.writeInBackground(
+                service: Self.service, account: "bg", data: Data("queued".utf8))
+            Keychain.flushPendingWrites()
+        }
+        #expect(backend.value(service: Self.service, account: "bg") == Data("queued".utf8))
+    }
+
+    @Test("mutations inside performInBackground batches do not deadlock")
+    func performInBackgroundReentrancy() {
+        let backend = FakeKeychainBackend()
+        withFakeBackend(backend) {
+            Keychain.performInBackground {
+                _ = Keychain.writeItem(
+                    service: Self.service, account: "nested", data: Data("v".utf8))
+                _ = Keychain.deleteItem(service: Self.service, account: "other")
+            }
+            Keychain.flushPendingWrites()
+        }
+        #expect(backend.value(service: Self.service, account: "nested") == Data("v".utf8))
+    }
+
+    @Test("synchronous writes are ordered relative to queued background work")
+    func syncWritesAreOrderedWithQueue() {
+        let backend = FakeKeychainBackend()
+        withFakeBackend(backend) {
+            Keychain.writeInBackground(
+                service: Self.service, account: "ordered", data: Data("first".utf8))
+            // The synchronous write joins the same serial queue, so it must
+            // observe (and overwrite) the queued value, never lose to it.
+            _ = Keychain.writeItem(
+                service: Self.service, account: "ordered", data: Data("second".utf8))
+        }
+        #expect(backend.value(service: Self.service, account: "ordered") == Data("second".utf8))
+    }
+
+    // MARK: - Disabled mode
+
+    @Test("disabled mode short-circuits every operation without backend calls")
+    func disabledModeShortCircuits() {
+        // Only meaningful when the process-level disable gate is active (the
+        // documented test environment sets OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1).
+        guard KeychainQueryHelpers.disablesKeychainForProcess else { return }
+        // No backend override installed: the gate must win before SecItem.
+        #expect(Keychain.readItem(service: Self.service, account: "a") == .disabled)
+        #expect(Keychain.read(service: Self.service, account: "a") == nil)
+        #expect(
+            Keychain.writeItem(service: Self.service, account: "a", data: Data("v".utf8))
+                == .disabled)
+        #expect(!Keychain.write(service: Self.service, account: "a", data: Data("v".utf8)))
+        #expect(Keychain.deleteItem(service: Self.service, account: "a") == .disabled)
+        #expect(Keychain.delete(service: Self.service, account: "a"))
+        let enumeration = Keychain.fetchAllItems(service: Self.service, returnData: false)
+        #expect(enumeration.isDefinitive)
+        #expect(enumeration.items.isEmpty)
+    }
+
+    @Test("a test backend override bypasses the disable gate")
+    func overrideBypassesDisableGate() {
+        let backend = FakeKeychainBackend()
+        withFakeBackend(backend) {
+            #expect(Keychain.write(service: Self.service, account: "a", data: Data("v".utf8)))
+            #expect(Keychain.read(service: Self.service, account: "a") == Data("v".utf8))
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2200,11 +2200,26 @@ struct RuntimePolicySourceTests {
         #expect(appDelegate.contains("OSAURUS_KEYCHAIN_FREE_SHOW_UI"))
         #expect(appDelegate.contains("Keychain disabled by OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1"))
         #expect(appDelegate.contains("if keychainDisabledTestMode {"))
-        #expect(
-            appDelegate.contains(
-                "if !keychainDisabledTestMode {\n                await MCPProviderManager.shared.connectEnabledProviders()"
+        // The provider connects stay behind the keychain-disabled gate and
+        // run concurrently (one slow MCP server must not delay every model
+        // provider).
+        let mcpConnect = try #require(
+            appDelegate.range(
+                of: "async let mcpConnects: Void = MCPProviderManager.shared.connectEnabledProviders()"
             )
         )
+        let remoteConnect = try #require(
+            appDelegate.range(
+                of: "async let remoteConnects: Void =\n                    RemoteProviderManager.shared.connectEnabledProviders()"
+            )
+        )
+        let connectGate = try #require(
+            appDelegate.range(
+                of: "if !keychainDisabledTestMode {\n                // MCP and remote-provider startup connects run concurrently:"
+            )
+        )
+        #expect(connectGate.lowerBound < mcpConnect.lowerBound)
+        #expect(mcpConnect.lowerBound < remoteConnect.lowerBound)
         #expect(
             appDelegate.contains(
                 "if !keychainDisabledTestMode && !LaunchGuard.shouldSkip(.sandbox) {\n            SandboxToolRegistrar.shared.start()"

--- a/Packages/OsaurusCore/Tests/Service/ToolSecretsLegacyMigrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ToolSecretsLegacyMigrationTests.swift
@@ -1,0 +1,91 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Read-through migration of pre-agent-scoping plugin secrets stored as
+/// `"{pluginId}.{key}"`. Users upgrading from builds before agent scoping
+/// silently lost those credentials because nothing read the old accounts;
+/// `getSecret` must now fall back, copy the value to the canonical
+/// `"{agentId}.{pluginId}.{key}"` account, and never resurrect deleted keys.
+@Suite("Tool secret legacy migration")
+struct ToolSecretsLegacyMigrationTests {
+
+    private let pluginId = "legacy.plugin.\(UUID().uuidString)"
+    private let key = "api_key"
+
+    private var legacyAccount: String { "\(pluginId).\(key)" }
+    private var canonicalAccount: String {
+        "\(Agent.defaultId.uuidString).\(pluginId).\(key)"
+    }
+
+    @Test("default-agent read falls back to the legacy account and migrates it")
+    func defaultAgentReadMigrates() {
+        defer { ToolSecretsKeychain.deleteSecret(id: key, for: pluginId, agentId: Agent.defaultId) }
+        ToolSecretsKeychain._testSeedRawAccount(legacyAccount, value: "sk-legacy")
+
+        let value = ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: Agent.defaultId)
+
+        #expect(value == "sk-legacy")
+        #expect(ToolSecretsKeychain._testRawAccountValue(canonicalAccount) == "sk-legacy")
+        #expect(ToolSecretsKeychain._testRawAccountValue(legacyAccount) == nil)
+
+        // Subsequent reads hit the canonical account directly.
+        #expect(
+            ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: Agent.defaultId)
+                == "sk-legacy")
+    }
+
+    @Test("canonical value wins over a stale legacy twin")
+    func canonicalValueWins() {
+        defer { ToolSecretsKeychain.deleteSecret(id: key, for: pluginId, agentId: Agent.defaultId) }
+        ToolSecretsKeychain._testSeedRawAccount(legacyAccount, value: "sk-stale")
+        ToolSecretsKeychain.saveSecret("sk-current", id: key, for: pluginId, agentId: Agent.defaultId)
+
+        let value = ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: Agent.defaultId)
+
+        #expect(value == "sk-current")
+        // The stale legacy twin is untouched by a canonical hit…
+        #expect(ToolSecretsKeychain._testRawAccountValue(legacyAccount) == "sk-stale")
+
+        // …but deleting the canonical secret removes both, so the fallback
+        // can never resurrect a deleted key.
+        ToolSecretsKeychain.deleteSecret(id: key, for: pluginId, agentId: Agent.defaultId)
+        #expect(ToolSecretsKeychain._testRawAccountValue(legacyAccount) == nil)
+        #expect(ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: Agent.defaultId) == nil)
+    }
+
+    @Test("non-default agents do not read the legacy namespace directly")
+    func nonDefaultAgentDoesNotMigrate() {
+        let otherAgent = UUID()
+        defer {
+            ToolSecretsKeychain.deleteSecret(id: key, for: pluginId, agentId: Agent.defaultId)
+            ToolSecretsKeychain.deleteSecret(id: key, for: pluginId, agentId: otherAgent)
+        }
+        ToolSecretsKeychain._testSeedRawAccount(legacyAccount, value: "sk-legacy")
+
+        // Direct per-agent read: no legacy fallback for non-default agents.
+        #expect(ToolSecretsKeychain.getSecret(id: key, for: pluginId, agentId: otherAgent) == nil)
+        #expect(ToolSecretsKeychain._testRawAccountValue(legacyAccount) == "sk-legacy")
+
+        // The resolution policy still surfaces it: per-agent reads fall back
+        // to Agent.defaultId, which triggers the migration.
+        let resolved = ToolSecretsKeychain.resolvedSecret(
+            id: key, for: pluginId, agentId: otherAgent)
+        #expect(resolved == "sk-legacy")
+        #expect(ToolSecretsKeychain._testRawAccountValue(canonicalAccount) == "sk-legacy")
+        #expect(ToolSecretsKeychain._testRawAccountValue(legacyAccount) == nil)
+    }
+
+    @Test("hasSecret and required-secret checks see legacy values")
+    func presenceChecksSeeLegacyValues() {
+        defer { ToolSecretsKeychain.deleteSecret(id: key, for: pluginId, agentId: Agent.defaultId) }
+        ToolSecretsKeychain._testSeedRawAccount(legacyAccount, value: "sk-legacy")
+
+        #expect(ToolSecretsKeychain.hasSecret(id: key, for: pluginId, agentId: Agent.defaultId))
+        #expect(
+            ToolSecretsKeychain.hasResolvedSecret(id: key, for: pluginId, agentId: Agent.defaultId))
+    }
+}

--- a/Packages/OsaurusCore/Utils/ConfigDiskWriter.swift
+++ b/Packages/OsaurusCore/Utils/ConfigDiskWriter.swift
@@ -43,4 +43,14 @@ enum ConfigDiskWriter {
             }
         }
     }
+
+    /// Block until every write enqueued so far has landed, bounded by
+    /// `timeout`. Called from `applicationWillTerminate` so a configuration
+    /// change made right before quit (e.g. enabling a provider) isn't dropped
+    /// when `_exit` skips the pending async write.
+    static func flushPendingWrites(timeout: TimeInterval = 3.0) {
+        let done = DispatchSemaphore(value: 0)
+        queue.async { done.signal() }
+        _ = done.wait(timeout: .now() + timeout)
+    }
 }

--- a/Packages/OsaurusCore/Views/Identity/IdentityView.swift
+++ b/Packages/OsaurusCore/Views/Identity/IdentityView.swift
@@ -22,7 +22,9 @@ struct IdentityView: View {
     @State private var phase: IdentityPhase = .checking
     @State private var drift: IdentityDrift?
 
-    @State private var showRecoverSheet = false
+    /// Non-nil presents `RecoverFromMnemonicSheet` in the given mode
+    /// (drift repair, fresh restore, or replace-existing).
+    @State private var restoreSheetMode: RecoverFromMnemonicMode?
     @State private var showRepairConfirm = false
     @State private var showResetConfirm = false
     @State private var showRecoveryPhraseSheet = false
@@ -61,11 +63,16 @@ struct IdentityView: View {
                 hasAppeared = true
             }
         }
-        .sheet(isPresented: $showRecoverSheet) {
+        .sheet(
+            isPresented: Binding(
+                get: { restoreSheetMode != nil },
+                set: { if !$0 { restoreSheetMode = nil } }
+            )
+        ) {
             RecoverFromMnemonicSheet(
-                drift: drift ?? IdentityDrift(mismatchedAgents: [], staleAccessKeys: []),
+                mode: restoreSheetMode ?? .freshRestore,
                 onRecovered: handleRecovered,
-                onCancel: { showRecoverSheet = false }
+                onCancel: { restoreSheetMode = nil }
             )
             .environment(\.theme, theme)
         }
@@ -111,7 +118,11 @@ struct IdentityView: View {
             ProgressView()
                 .frame(maxWidth: .infinity, minHeight: 200)
         case .noIdentity:
-            IdentitySetupCard(onCreated: handleIdentityCreated)
+            IdentitySetupCard(
+                onCreated: handleIdentityCreated,
+                onRestore: { restoreSheetMode = .freshRestore },
+                onCheckAgain: checkIdentityStatus
+            )
         case .ready(let osaurusId, let deviceId):
             readyContent(osaurusId: osaurusId, deviceId: deviceId)
         }
@@ -122,7 +133,7 @@ struct IdentityView: View {
         if let drift, drift.hasDrift {
             IdentityDriftBanner(
                 drift: drift,
-                onRecover: { showRecoverSheet = true },
+                onRecover: { restoreSheetMode = .driftRepair(drift) },
                 onRepair: { showRepairConfirm = true },
                 onReset: { showResetConfirm = true }
             )
@@ -143,7 +154,10 @@ struct IdentityView: View {
             onChange: { runRefresh() }
         )
         DeviceSection(deviceId: deviceId)
-        DangerZoneSection(onReset: { showResetConfirm = true })
+        DangerZoneSection(
+            onRestore: { restoreSheetMode = .replaceExisting(current: osaurusId) },
+            onReset: { showResetConfirm = true }
+        )
     }
 
     // MARK: - Header
@@ -273,12 +287,22 @@ struct IdentityView: View {
 
     // MARK: - Recover
 
-    private func handleRecovered() {
-        showRecoverSheet = false
-        lastActionResult = ActionResult(
-            message: "Master key restored from recovery phrase.",
-            isError: false
-        )
+    private func handleRecovered(_ result: OsaurusIdentity.RestoreResult) {
+        restoreSheetMode = nil
+
+        var parts = ["Identity \(result.osaurusId) restored from recovery phrase."]
+        if result.rederivedAgentCount > 0 {
+            parts.append("Re-derived addresses for \(result.rederivedAgentCount) agent(s).")
+        }
+        if result.revokedAccessKeyCount > 0 {
+            parts.append("Revoked \(result.revokedAccessKeyCount) stale access key(s).")
+        }
+        var message = parts.joined(separator: " ")
+        if !result.failures.isEmpty {
+            message += "\nCompleted with errors:\n" + result.failures.joined(separator: "\n")
+        }
+
+        lastActionResult = ActionResult(message: message, isError: !result.failures.isEmpty)
         runRefresh()
         restartServerIfRunning()
     }
@@ -543,36 +567,69 @@ private struct IdentityDriftBanner: View {
 
 private struct DangerZoneSection: View {
     @Environment(\.theme) private var theme
+    let onRestore: () -> Void
     let onReset: () -> Void
 
     var body: some View {
         IdentitySection(title: L("DANGER ZONE"), icon: "exclamationmark.triangle.fill") {
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Reset Identity", bundle: .module)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(theme.primaryText)
-                    Text(
-                        "Wipes your signature, every agent address, and every access key, including the backup in your iCloud Keychain. Onboarding will start over.",
-                        bundle: .module
-                    )
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.secondaryText)
-                    .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer()
-                Button(action: onReset) {
-                    Text("Reset…", bundle: .module)
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(theme.errorColor)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 7)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.errorColor.opacity(0.10))
+            VStack(spacing: 14) {
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Restore from recovery phrase", bundle: .module)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                        Text(
+                            "Replaces the identity on this Mac with one restored from a 24-word phrase. Agents get new addresses and existing access keys are revoked.",
+                            bundle: .module
                         )
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Button(action: onRestore) {
+                        Text("Restore…", bundle: .module)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.warningColor)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(theme.warningColor.opacity(0.10))
+                            )
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
-                .buttonStyle(PlainButtonStyle())
+
+                Divider()
+
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Reset Identity", bundle: .module)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                        Text(
+                            "Wipes your signature, every agent address, and every access key, including the backup in your iCloud Keychain. Onboarding will start over.",
+                            bundle: .module
+                        )
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Button(action: onReset) {
+                        Text("Reset…", bundle: .module)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.errorColor)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(theme.errorColor.opacity(0.10))
+                            )
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
             }
         }
     }
@@ -595,6 +652,11 @@ private struct IdentitySetupCard: View {
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
     let onCreated: (IdentityInfo) -> Void
+    /// Open the fresh-restore mnemonic sheet.
+    let onRestore: () -> Void
+    /// Re-probe Keychain — an identity synced from another Mac via iCloud
+    /// Keychain may have arrived since this card was rendered.
+    let onCheckAgain: () -> Void
 
     @State private var isCreating = false
     @State private var errorMessage: String?
@@ -657,6 +719,47 @@ private struct IdentitySetupCard: View {
             }
             .buttonStyle(PlainButtonStyle())
             .disabled(isCreating)
+
+            Button(action: onRestore) {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.counterclockwise.circle")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text("Restore from recovery phrase", bundle: .module)
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .foregroundColor(theme.primaryText)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 9)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.tertiaryBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .disabled(isCreating)
+
+            VStack(spacing: 4) {
+                Text(
+                    "Already using Osaurus on another Mac? With iCloud Keychain enabled on both, your identity restores here automatically — it can take a few minutes to sync.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 420)
+
+                Button(action: onCheckAgain) {
+                    Text("Check again", bundle: .module)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.accentColor)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
 
             Spacer().frame(height: 40)
         }

--- a/Packages/OsaurusCore/Views/Identity/RecoverFromMnemonicSheet.swift
+++ b/Packages/OsaurusCore/Views/Identity/RecoverFromMnemonicSheet.swift
@@ -2,22 +2,41 @@
 //  RecoverFromMnemonicSheet.swift
 //  osaurus
 //
-//  Modal recovery flow for the broken-master state. The user pastes the
-//  24-word BIP39 phrase saved during onboarding; we validate the checksum,
-//  confirm the resulting master derives the agent addresses we already have
-//  on disk (so we know it's the *previous* master, not an unrelated valid
-//  mnemonic), and re-install the master into Keychain. Drift goes away
-//  because every persisted derivative now matches again.
+//  Modal mnemonic-restore flow. The user pastes the 24-word BIP39 phrase
+//  saved during onboarding; we validate the checksum and install the decoded
+//  master into Keychain via `OsaurusIdentity.restore`, which also reconciles
+//  agent addresses and access keys derived from a previous master.
+//
+//  Three entry modes share this sheet:
+//  - driftRepair: the broken-master state. Confirms the phrase reproduces the
+//    agent addresses already on disk (so we know it's the *previous* master,
+//    not an unrelated valid mnemonic) before installing.
+//  - freshRestore: no identity on this Mac (Settings → Identity setup card).
+//  - replaceExisting: overwrite a healthy identity. Shows the current vs.
+//    candidate address and requires an explicit acknowledgment because
+//    agent addresses are re-minted and existing access keys revoked.
 //
 
 import AppKit
 import SwiftUI
 
+/// Which flow presented the sheet — controls copy, safety checks, and
+/// confirmation requirements.
+enum RecoverFromMnemonicMode {
+    /// Identity drift banner: restore the previous master so persisted
+    /// derivatives match again.
+    case driftRepair(IdentityDrift)
+    /// No identity on disk: restore an identity from another Mac.
+    case freshRestore
+    /// Healthy identity present: replace it with a different one.
+    case replaceExisting(current: OsaurusID)
+}
+
 struct RecoverFromMnemonicSheet: View {
     @Environment(\.theme) private var theme
 
-    let drift: IdentityDrift
-    let onRecovered: () -> Void
+    let mode: RecoverFromMnemonicMode
+    let onRecovered: (OsaurusIdentity.RestoreResult) -> Void
     let onCancel: () -> Void
 
     @State private var phraseText: String = ""
@@ -25,6 +44,7 @@ struct RecoverFromMnemonicSheet: View {
     @State private var statusIsError: Bool = true
     @State private var isRestoring: Bool = false
     @State private var requiresExplicitOverride: Bool = false
+    @State private var hasAcknowledgedReplace: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -35,6 +55,10 @@ struct RecoverFromMnemonicSheet: View {
             phraseEditor
 
             wordCountLine
+
+            if case .replaceExisting(let current) = mode {
+                replaceDetails(current: current)
+            }
 
             if let statusMessage {
                 statusBanner(statusMessage)
@@ -51,7 +75,7 @@ struct RecoverFromMnemonicSheet: View {
 
     private var header: some View {
         HStack {
-            Text("Recover Master Key", bundle: .module)
+            titleText
                 .font(.system(size: 16, weight: .bold))
                 .foregroundColor(theme.primaryText)
             Spacer()
@@ -64,15 +88,43 @@ struct RecoverFromMnemonicSheet: View {
         }
     }
 
-    private var description: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(
+    private var titleText: Text {
+        switch mode {
+        case .driftRepair:
+            return Text("Recover Master Key", bundle: .module)
+        case .freshRestore:
+            return Text("Restore Identity", bundle: .module)
+        case .replaceExisting:
+            return Text("Replace Identity", bundle: .module)
+        }
+    }
+
+    private var descriptionText: Text {
+        switch mode {
+        case .driftRepair:
+            return Text(
                 "Paste the 24-word recovery phrase you saved during onboarding. We'll restore the original master key and your existing agents and access keys will start working again.",
                 bundle: .module
             )
-            .font(.system(size: 12))
-            .foregroundColor(theme.secondaryText)
-            .fixedSize(horizontal: false, vertical: true)
+        case .freshRestore:
+            return Text(
+                "Paste the 24-word recovery phrase from your other Mac to restore your identity here. If iCloud Keychain is enabled on both Macs, the identity usually syncs on its own — the phrase is only needed when it doesn't.",
+                bundle: .module
+            )
+        case .replaceExisting:
+            return Text(
+                "Paste the 24-word recovery phrase of the identity you want to switch to. This replaces the identity currently on this Mac.",
+                bundle: .module
+            )
+        }
+    }
+
+    private var description: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            descriptionText
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -125,6 +177,64 @@ struct RecoverFromMnemonicSheet: View {
                 )
             }
             .buttonStyle(PlainButtonStyle())
+        }
+    }
+
+    // MARK: - Replace-existing details
+
+    /// Current vs. candidate address plus the destructive-consequences
+    /// acknowledgment required before Restore enables.
+    @ViewBuilder
+    private func replaceDetails(current: OsaurusID) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                addressLine(label: Text("Current identity", bundle: .module), address: current)
+                addressLine(
+                    label: Text("Restored identity", bundle: .module),
+                    address: candidateAddress
+                )
+            }
+
+            Toggle(isOn: $hasAcknowledgedReplace) {
+                Text(
+                    "I understand: agents get new addresses, existing access keys are revoked, and the current identity's recovery phrase will no longer restore this Mac unless I saved it.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .toggleStyle(.checkbox)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.warningColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.warningColor.opacity(0.35), lineWidth: 1)
+                )
+        )
+    }
+
+    private func addressLine(label: Text, address: OsaurusID?) -> some View {
+        HStack(spacing: 8) {
+            label
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.secondaryText)
+                .frame(width: 110, alignment: .leading)
+            if let address {
+                Text(address)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            } else {
+                Text("Enter a valid phrase", bundle: .module)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+            }
+            Spacer(minLength: 0)
         }
     }
 
@@ -202,11 +312,11 @@ struct RecoverFromMnemonicSheet: View {
                 .padding(.vertical, 9)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(parsedWords.count == 24 ? theme.accentColor : theme.accentColor.opacity(0.4))
+                        .fill(canRestore ? theme.accentColor : theme.accentColor.opacity(0.4))
                 )
             }
             .buttonStyle(PlainButtonStyle())
-            .disabled(parsedWords.count != 24 || isRestoring)
+            .disabled(!canRestore || isRestoring)
         }
     }
 
@@ -214,6 +324,36 @@ struct RecoverFromMnemonicSheet: View {
 
     private var parsedWords: [String] {
         MasterKeyMnemonic.words(fromPhrase: phraseText)
+    }
+
+    private var canRestore: Bool {
+        Self.canRestore(
+            words: parsedWords, mode: mode, acknowledgedReplace: hasAcknowledgedReplace)
+    }
+
+    /// Whether the Restore button is enabled: a complete 24-word phrase, plus
+    /// the explicit acknowledgment when replacing a healthy identity.
+    /// Internal (not private) for direct testing.
+    static func canRestore(
+        words: [String], mode: RecoverFromMnemonicMode, acknowledgedReplace: Bool
+    ) -> Bool {
+        guard words.count == 24 else { return false }
+        if case .replaceExisting = mode, !acknowledgedReplace { return false }
+        return true
+    }
+
+    private var candidateAddress: OsaurusID? {
+        Self.candidateAddress(for: parsedWords)
+    }
+
+    /// Address the entered phrase would restore, or nil while the phrase is
+    /// incomplete or fails checksum validation. Used for the replace-existing
+    /// current-vs-candidate preview. Internal (not private) for direct testing.
+    static func candidateAddress(for words: [String]) -> OsaurusID? {
+        guard words.count == 24 else { return nil }
+        guard var seed = try? MasterKeyMnemonic.key(fromMnemonic: words) else { return nil }
+        defer { seed.zeroOut() }
+        return try? deriveOsaurusId(from: seed)
     }
 
     private func pasteFromClipboard() {
@@ -227,13 +367,16 @@ struct RecoverFromMnemonicSheet: View {
         isRestoring = true
 
         do {
-            var seed = try MasterKeyMnemonic.key(fromMnemonic: parsedWords)
-            defer { seed.zeroOut() }
-
-            let candidateAddress = try deriveOsaurusId(from: seed)
-
-            if !forceOverride {
-                if let mismatchCheck = matchesPreviousMaster(seed: seed, candidate: candidateAddress) {
+            // Drift repair verifies the phrase is the *previous* master before
+            // installing, so a typo'd-but-valid mnemonic can't silently mint a
+            // brand-new identity. Fresh restore has nothing to compare against
+            // and replace-existing is an intentional identity change.
+            if case .driftRepair(let drift) = mode, !forceOverride {
+                var seed = try MasterKeyMnemonic.key(fromMnemonic: parsedWords)
+                defer { seed.zeroOut() }
+                let candidateAddress = try deriveOsaurusId(from: seed)
+                if let mismatchCheck = Self.previousSeedMismatchMessage(
+                    drift: drift, seed: seed, candidate: candidateAddress) {
                     statusIsError = true
                     statusMessage = mismatchCheck
                     requiresExplicitOverride = true
@@ -242,15 +385,11 @@ struct RecoverFromMnemonicSheet: View {
                 }
             }
 
-            try MasterKey.install(seed: seed, allowReplace: true)
-            // Keep the stored phrase in sync with the newly-installed master
-            // so subsequent "View recovery phrase" reads hit the cache
-            // instead of falling into the lazy-backfill path.
-            try? MasterMnemonicStore.store(parsedWords)
+            let result = try OsaurusIdentity.restore(words: parsedWords)
             statusIsError = false
-            statusMessage = "Master key restored. Drift cleared."
+            statusMessage = successMessage(for: result)
             isRestoring = false
-            onRecovered()
+            onRecovered(result)
         } catch let err as OsaurusIdentityError {
             statusIsError = true
             statusMessage = err.errorDescription ?? "Recovery failed."
@@ -262,11 +401,23 @@ struct RecoverFromMnemonicSheet: View {
         }
     }
 
+    private func successMessage(for result: OsaurusIdentity.RestoreResult) -> String {
+        switch mode {
+        case .driftRepair:
+            return "Master key restored. Drift cleared."
+        case .freshRestore, .replaceExisting:
+            return "Identity \(result.osaurusId) restored."
+        }
+    }
+
     /// Returns nil when the candidate seed reproduces the agent addresses we
     /// have on disk (i.e. it's the previous master). Returns a user-facing
     /// error message when there is no match — the caller surfaces an explicit
-    /// "Restore Anyway" override in that case.
-    private func matchesPreviousMaster(seed: Data, candidate: OsaurusID) -> String? {
+    /// "Restore Anyway" override in that case. Internal (not private) for
+    /// direct testing.
+    static func previousSeedMismatchMessage(
+        drift: IdentityDrift, seed: Data, candidate: OsaurusID
+    ) -> String? {
         // We have agents whose stored addresses don't derive from the current
         // master; verify the candidate seed reproduces *those* stored addresses.
         let mismatched = drift.mismatchedAgents

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -187,14 +187,23 @@ struct ProvidersView: View {
 
     private func refreshCredentialPresence() {
         let providers = manager.configuration.providers
+        let previous = credentialPresence
         Task {
             var next: [UUID: MCPProviderCredentialPresence] = [:]
             for provider in providers {
                 let providerID = provider.id
+                let previousPresence = previous[providerID]
+                // Typed availability: a transiently unavailable keychain
+                // (locked, interaction required) keeps the previous known
+                // presence instead of flashing a false "missing token" warning.
                 let presence = await Task.detached(priority: .utility) {
                     MCPProviderCredentialPresence(
-                        bearerTokenPresent: MCPProviderKeychain.hasToken(for: providerID),
-                        oauthTokensPresent: MCPProviderKeychain.hasOAuthTokens(for: providerID)
+                        bearerTokenPresent: MCPProviderKeychain.tokenAvailability(for: providerID)
+                            .presenceForUI(previous: previousPresence?.bearerTokenPresent),
+                        oauthTokensPresent: MCPProviderKeychain.oauthTokensAvailability(
+                            for: providerID
+                        )
+                        .presenceForUI(previous: previousPresence?.oauthTokensPresent)
                     )
                 }.value
                 next[providerID] = presence
@@ -3136,16 +3145,22 @@ private struct ProviderEditSheet: View {
         // sensitive fields alone after the first save.
         for entry in envEntries
         where entry.isSecret && !entry.key.isEmpty && !entry.value.isEmpty {
-            _ = MCPProviderKeychain.saveEnvSecret(
+            if !MCPProviderKeychain.saveEnvSecret(
                 entry.value,
                 key: entry.key,
                 for: updatedProvider.id
-            )
+            ) {
+                NSLog("ProvidersView: failed to save secret env value to Keychain")
+            }
         }
 
         // Save secret header values to Keychain
         for header in customHeaders where header.isSecret && !header.key.isEmpty && !header.value.isEmpty {
-            MCPProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: updatedProvider.id)
+            if !MCPProviderKeychain.saveHeaderSecret(
+                header.value, key: header.key, for: updatedProvider.id
+            ) {
+                NSLog("ProvidersView: failed to save secret header to Keychain")
+            }
         }
 
         // Pass token (empty string means no change, nil means keep existing).

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -1605,7 +1605,9 @@ private struct AddProviderFlow: View {
 
     private func saveSecretHeaders(for providerId: UUID) {
         for header in customHeaders where header.isSecret && !header.key.isEmpty && !header.value.isEmpty {
-            RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: providerId)
+            if !RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: providerId) {
+                NSLog("RemoteProviderEditSheet: failed to save secret header to Keychain")
+            }
         }
     }
 
@@ -2586,7 +2588,8 @@ private struct EditProviderFlow: View {
             authType: authType,
             providerType: providerType,
             enabled: provider.enabled,
-            autoConnect: true,
+            // Editing must not overwrite the user's auto-connect choice.
+            autoConnect: provider.autoConnect,
             timeout: timeout,
             disableTimeout: disableTimeout,
             manualModelIds: parseManualModelIds(manualModelIdsText),
@@ -2594,7 +2597,9 @@ private struct EditProviderFlow: View {
         )
 
         for header in customHeaders where header.isSecret && !header.key.isEmpty && !header.value.isEmpty {
-            RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: updatedProvider.id)
+            if !RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: updatedProvider.id) {
+                NSLog("RemoteProviderEditSheet: failed to save secret header to Keychain")
+            }
         }
 
         onSave(updatedProvider, apiKey.isEmpty ? nil : apiKey, nil)

--- a/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
@@ -308,14 +308,23 @@ struct RemoteProvidersView: View {
 
     private func refreshCredentialPresence() {
         let providers = userConfiguredProviders
+        let previous = credentialPresence
         Task {
             var next: [UUID: RemoteProviderCredentialPresence] = [:]
             for provider in providers {
                 let providerID = provider.id
+                let previousPresence = previous[providerID]
+                // Typed availability: a transiently unavailable keychain
+                // (locked, interaction required) keeps the previous known
+                // presence instead of flashing a false "missing key" warning.
                 let presence = await RemoteProviderKeychain.runOffCooperativeExecutor {
                     RemoteProviderCredentialPresence(
-                        apiKeyPresent: RemoteProviderKeychain.hasAPIKey(for: providerID),
-                        oauthTokensPresent: RemoteProviderKeychain.hasOAuthTokens(for: providerID)
+                        apiKeyPresent: RemoteProviderKeychain.apiKeyAvailability(for: providerID)
+                            .presenceForUI(previous: previousPresence?.apiKeyPresent),
+                        oauthTokensPresent: RemoteProviderKeychain.oauthTokensAvailability(
+                            for: providerID
+                        )
+                        .presenceForUI(previous: previousPresence?.oauthTokensPresent)
                     )
                 }
                 next[providerID] = presence


### PR DESCRIPTION
## Summary

Fixes users having to re-enable providers and tool connections every time Osaurus quits and reopens, and adds the missing identity restore flow (previously export-only).

### Keychain / relaunch reliability
- Typed keychain read outcomes (`KeychainReadOutcome`, `SecretAvailability`) distinguish "definitively absent" from "locked / interaction required / transient failure", so a locked keychain at launch is never cached or surfaced as a missing credential (`GitHubAuth`, `HuggingFaceAuth`, `AgentSecretsKeychain`, provider credential badges).
- Provider managers write credentials to the keychain **before** persisting config, so a config row can no longer outlive its secret; failed writes are logged instead of silently dropped (`RemoteProviderManager`, `MCPProviderManager`, `SearchProviderManager`, `MCPOAuthService`).
- Keychain background writes and async config writes (`ConfigDiskWriter`) are flushed in `applicationWillTerminate`, closing the quit-time data-loss window.
- Startup connects enabled providers concurrently with bounded retry for transient errors; providers whose last connect failed transiently reconnect automatically on network recovery, wake from sleep, and app re-activation.
- Read-through migration recovers pre-agent-scoping plugin secrets (`{pluginId}.{key}` accounts) that were orphaned by the agent-scoping migration.
- `OsaurusKeychainServices` centralizes every keychain service name so factory reset wipes exactly the real set.

### Identity restore
- New `OsaurusIdentity.restore(words:)` engine: installs the master key from a 24-word phrase, stores the mnemonic, re-derives agent addresses, revokes access keys issued by the old identity, and posts `identityChanged`.
- `RecoverFromMnemonicSheet` generalized into three modes: drift repair (verifies the phrase matches the previous master before installing), fresh restore (no identity yet), and replace-existing (explicit acknowledgment showing current vs. candidate address).
- `IdentityView` gains restore entry points in the no-identity setup card (with an iCloud-sync hint and "Check again") and in the danger zone for replacing an existing identity.

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` clean
- [x] SwiftLint: no new warnings vs. baseline on touched files (3 pre-existing warnings removed)
- [x] Targeted suites pass locally: keychain typed outcomes, tool-secret legacy migration, identity restore, provider startup/recovery, ConfigDiskWriter flush
- [ ] Full suite via CI