### PR TITLE
Fix selected-chat idle warmup recovery

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -486,6 +486,15 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         )
     }
 
+    /// True only for the visible key chat while Osaurus is frontmost. Runtime
+    /// residency notifications use this stronger predicate instead of
+    /// `lastFocusedWindowId`, which can still refer to a hidden/background
+    /// window and must never authorize a speculative replacement warm-up.
+    func isChatWindowActive(id: UUID) -> Bool {
+        guard NSApp.isActive, let window = nsWindows[id] else { return false }
+        return window.isVisible && window.isKeyWindow
+    }
+
     /// Set a callback to be invoked when window is about to close (for session saving)
     public func setCloseCallback(for windowId: UUID, callback: @escaping () -> Void) {
         sessionCallbacks[windowId] = callback
@@ -729,6 +738,11 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     // Called by delegate when window becomes key
     fileprivate func windowDidBecomeKey(id: UUID) {
         lastFocusedWindowId = id
+        // Idle residency may have unloaded this window's selected model while
+        // the user was away. Re-arm the existing speculative warm-up when the
+        // user returns; its RAM and competing-residency gates still decide
+        // whether background loading is safe.
+        windowStates[id]?.session.notifySessionBecameActive()
         // Distinguishes "user was in a chat window" from a management tab when
         // localizing a layout-engine app hang (no first-party frame in stack).
         CrashReportingService.recordBreadcrumb(category: "navigation", message: "chat.window focused")

--- a/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
@@ -182,7 +182,7 @@ enum ChatResidencyHandoff {
 
         onPhase("unloading_chat_models", resident.joined(separator: ", "))
         for name in resident {
-            await ModelRuntime.shared.unload(name: name)
+            await ModelRuntime.shared.unload(name: name, reason: .handoff)
         }
         return ChatResidencyLease(unloadedModelNames: resident)
     }

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -201,7 +201,7 @@ extension ChatSession: ChatWarmupSessionContext {
     }
 
     func notifySessionBecameActive() {
-        warmupController.scheduleWarmup(session: self)
+        warmupController.handleSessionBecameActive(session: self)
     }
 
     func handleWarmupAfterRunCompleted(wasCancelled: Bool, hadError: Bool) {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -79,6 +79,24 @@ final class ChatWarmupController: ObservableObject {
         await ModelRuntime.shared.hasResidentModelOther(than: model)
     }
 
+    /// Typed runtime snapshots make activation and notification delivery use
+    /// the same monotonic residency timeline. Tests replace these seams to
+    /// hold the exact focus/idle-unload race without wall-clock sleeps.
+    var runtimeResidencySnapshot: @MainActor () async -> ModelRuntimeResidencySnapshot = {
+        await ModelRuntime.shared.residencySnapshot()
+    }
+    var chatActivationResidencySnapshot:
+        @MainActor (String?) async -> ModelRuntimeChatActivationResidencySnapshot = { model in
+            await ModelRuntime.shared.chatActivationResidencySnapshot(selectedModel: model)
+    }
+
+    /// Debounce suspension seam. Production uses the real clock; lifecycle
+    /// tests can hold this boundary so residency changes that occur after the
+    /// activation snapshot are exercised without timing sleeps.
+    var scheduleDebounceSleep: @MainActor (Duration) async -> Void = { duration in
+        try? await Task.sleep(for: duration)
+    }
+
     @Published private(set) var state: WarmState = .cold
 
     /// True when the UI should render the green "warm" dot.
@@ -86,6 +104,11 @@ final class ChatWarmupController: ObservableObject {
 
     private var warmedFingerprint: String?
     private var scheduleTask: Task<Void, Never>?
+    private var scheduleTaskID: UUID?
+    /// Non-nil only when `scheduleTask` was created by a window-focus
+    /// activation. A newer non-recoverable eviction may cancel that exact
+    /// speculative task without disturbing model-switch or user-intent work.
+    private var scheduledActivationID: UUID?
     private var inFlightWarmup: Task<Void, Never>?
     private var inFlightWarmupID: UUID?
     /// A prompt-shape change is different from an idle speculative warm-up:
@@ -111,6 +134,25 @@ final class ChatWarmupController: ObservableObject {
     /// scheduled, but runtime-touching paths drain it before proceeding.
     private var retiringWork: Task<Void, Never>?
     private var retiringWorkID: UUID?
+    /// Runtime-residency reconciliation launched when a chat becomes active.
+    /// This is controller-owned (rather than an untracked Task in ChatSession)
+    /// so reset, Stop, shutdown, and model selection can invalidate a
+    /// suspended residency snapshot before it schedules hidden warm-up work.
+    private var sessionActivation: Task<Void, Never>?
+    private var sessionActivationID: UUID?
+    /// One-shot identity for the *exact* idle decision that crossed into
+    /// teardown while this chat was being activated. A later idle timer,
+    /// memory-pressure eviction, handoff, explicit unload, or model switch can
+    /// never match this token and therefore can never create unload/rewarm
+    /// ping-pong merely because the window remains key.
+    private struct ActivationRecovery: Equatable {
+        let model: String
+        let idleDecisionID: UInt64
+    }
+    private var activationRecovery: ActivationRecovery?
+    /// Highest runtime residency revision consumed by this controller. This
+    /// rejects delayed and duplicate NotificationCenter delivery.
+    private var lastResidencyRevision: UInt64?
     /// Monotonic counter bumped by every switch-affecting entry point
     /// (selection change, reset). Handlers that suspend re-check it
     /// afterwards so a stale resume can't cancel or restore state installed
@@ -121,6 +163,7 @@ final class ChatWarmupController: ObservableObject {
         /// Deterministic lifecycle tests retain the outgoing scheduled task
         /// across reset so they can await its actual cancellation unwind.
         var scheduledWarmupTaskForTests: Task<Void, Never>? { scheduleTask }
+        var sessionActivationTaskForTests: Task<Void, Never>? { sessionActivation }
     #endif
 
     /// True once the owning window began teardown. `session.stop()` during
@@ -135,6 +178,7 @@ final class ChatWarmupController: ObservableObject {
         inFlightWarmup?.cancel()
         requiredContextWarmup?.cancel()
         retiringWork?.cancel()
+        sessionActivation?.cancel()
     }
 
     /// Permanently stop this controller: cancel pending and in-flight warm-up
@@ -151,6 +195,7 @@ final class ChatWarmupController: ObservableObject {
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
         requiredContextWarmup?.cancel()
+        cancelSessionActivation()
 
         let previousRetiringWork = retiringWork
         let retiringSwitch = activeModelSwitch
@@ -169,6 +214,8 @@ final class ChatWarmupController: ObservableObject {
         }
 
         scheduleTask = nil
+        scheduleTaskID = nil
+        scheduledActivationID = nil
         activeModelSwitch = nil
         activeModelSwitchID = nil
         inFlightWarmup = nil
@@ -270,6 +317,10 @@ final class ChatWarmupController: ObservableObject {
         to newModel: String?,
         performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
     ) {
+        // Invalidate an activation snapshot immediately, before the deferred
+        // switch task runs. Otherwise a slow runtime actor response can resume
+        // in this gap and schedule a warm-up for the outgoing selection.
+        cancelSessionActivation()
         Task { @MainActor in
             self.performModelSelectionChange(
                 session: session,
@@ -379,7 +430,9 @@ final class ChatWarmupController: ObservableObject {
 
     func scheduleWarmup(
         session: ChatWarmupSessionContext,
-        debounce: Duration = scheduleDebounce
+        debounce: Duration = scheduleDebounce,
+        revalidateResidencyAfterDebounce: Bool = false,
+        activationID: UUID? = nil
     ) {
         guard shouldAttemptWarmup(session: session) else {
             if !ChatConfigurationStore.load().warmModelsOnLoad {
@@ -391,13 +444,175 @@ final class ChatWarmupController: ObservableObject {
         if state == .cold { state = .warming }
 
         scheduleTask?.cancel()
+        scheduledActivationID = activationID
+        let taskID = UUID()
+        scheduleTaskID = taskID
         scheduleTask = Task { @MainActor in
+            defer {
+                if self.scheduleTaskID == taskID {
+                    self.scheduleTask = nil
+                    self.scheduleTaskID = nil
+                    self.scheduledActivationID = nil
+                }
+            }
             if debounce > .zero {
-                try? await Task.sleep(for: debounce)
+                await scheduleDebounceSleep(debounce)
+            }
+            guard !Task.isCancelled else { return }
+
+            // A focus activation takes an initial snapshot before scheduling,
+            // but an idle unload can remove the selected model during this
+            // debounce. Reconcile again at the last boundary before payload
+            // fingerprint coalescing; otherwise the stale warm fingerprint can
+            // turn the required replacement warm-up into a no-op.
+            if revalidateResidencyAfterDebounce {
+                let snapshot = await runtimeResidencySnapshot()
+                guard !Task.isCancelled else { return }
+                let selectedModel = session.selectedModel
+                if acceptResidencySnapshot(snapshot, selectedModel: selectedModel),
+                    let selectedModel,
+                    !Self.isSelectedModelResident(selectedModel, in: snapshot.names)
+                {
+                    activationRecovery = nil
+                }
             }
             guard !Task.isCancelled else { return }
             await performWarmup(session: session)
         }
+    }
+
+    /// Re-arm speculative warm-up when a chat window becomes active.
+    ///
+    /// Runtime residency is checked first because the idle-unload notification
+    /// and the AppKit focus event are delivered independently. Without this
+    /// ordering, focus can observe a stale `warmedFingerprint` and coalesce
+    /// away the exact warm-up needed after eviction.
+    func handleSessionBecameActive(
+        session: ChatWarmupSessionContext,
+        debounce: Duration = scheduleDebounce
+    ) {
+        guard !isShutDown else { return }
+        cancelSessionActivation()
+
+        let selectedModel = session.selectedModel
+        let epoch = switchEpoch
+        let id = UUID()
+        sessionActivationID = id
+        sessionActivation = Task { @MainActor [weak self, weak session] in
+            guard let self, let session else { return }
+            defer {
+                if self.sessionActivationID == id {
+                    self.sessionActivation = nil
+                    self.sessionActivationID = nil
+                }
+            }
+
+            let activation = await self.chatActivationResidencySnapshot(selectedModel)
+            guard
+                !Task.isCancelled,
+                !self.isShutDown,
+                self.sessionActivationID == id,
+                self.switchEpoch == epoch,
+                session.selectedModel == selectedModel
+            else { return }
+
+            guard self.acceptResidencySnapshot(
+                activation.residency,
+                selectedModel: selectedModel,
+                allowDuplicateRevision: true
+            ) else { return }
+
+            if let selectedModel,
+                Self.isSelectedModelResident(selectedModel, in: activation.residency.names),
+                let idleDecisionID = activation.recoverableIdleDecisionID
+            {
+                self.activationRecovery = ActivationRecovery(
+                    model: selectedModel,
+                    idleDecisionID: idleDecisionID
+                )
+            } else {
+                self.activationRecovery = nil
+            }
+            self.scheduleWarmup(
+                session: session,
+                debounce: debounce,
+                revalidateResidencyAfterDebounce: true,
+                activationID: id
+            )
+        }
+    }
+
+    /// Await the currently active focus reconciliation. Production send paths
+    /// cancel this before dispatch; this await primarily makes lifecycle tests
+    /// deterministic without sleeping through the debounce interval.
+    func awaitSessionActivation() async {
+        await sessionActivation?.value
+    }
+
+    /// Reconcile a runtime removal and recover the one activation race that
+    /// cannot be closed by a second snapshot alone.
+    ///
+    /// Recovery is allowed only when this exact selected model was armed by a
+    /// recent focus activation, that activation already coalesced to `.warm`,
+    /// and this window is still the visible key chat. The token is consumed
+    /// before scheduling, so later idle expiry cannot create a periodic
+    /// unload/rewarm loop. `performWarmup` still applies RAM and competing-
+    /// residency gates, so the retry cannot displace another surface's model.
+    func handleRuntimeResidencyChanged(
+        session: ChatWarmupSessionContext,
+        snapshot: ModelRuntimeResidencySnapshot,
+        isSessionActive: Bool,
+        debounce: Duration = .zero
+    ) {
+        let selectedModel = session.selectedModel
+        let wasWarm = state == .warm
+        guard acceptResidencySnapshot(snapshot, selectedModel: selectedModel) else { return }
+
+        guard let selectedModel,
+            !Self.isSelectedModelResident(selectedModel, in: snapshot.names)
+        else { return }
+
+        let recovery = activationRecovery
+        activationRecovery = nil
+        let matchesActivationIdleDecision = isSessionActive
+            && snapshot.reason == .idlePolicy
+            && snapshot.idleDecisionID != nil
+            && recovery?.idleDecisionID == snapshot.idleDecisionID
+            && recovery.map({ Self.isSelectedModelResident(selectedModel, in: [$0.model]) }) == true
+
+        // When focus begins from `.cold`, `scheduleWarmup` immediately moves
+        // the UI to `.warming`. If the exact idle removal lands during that
+        // debounce, the activation-owned task is already the required
+        // replacement. Preserve it instead of cancelling it and reproducing
+        // the stuck yellow/no-warmup state.
+        if matchesActivationIdleDecision,
+            state == .warming,
+            scheduledActivationID != nil
+        {
+            return
+        }
+
+        let mayRecover = wasWarm
+            && state == .cold
+            && matchesActivationIdleDecision
+
+        if !mayRecover, scheduledActivationID != nil {
+            scheduleTask?.cancel()
+            scheduleTask = nil
+            scheduleTaskID = nil
+            scheduledActivationID = nil
+            state = .cold
+        }
+
+        guard mayRecover,
+            snapshot.idleDecisionID != nil
+        else { return }
+
+        scheduleWarmup(
+            session: session,
+            debounce: debounce,
+            revalidateResidencyAfterDebounce: true
+        )
     }
 
     /// Re-warm the completed transcript only after a natural, successful
@@ -439,6 +654,9 @@ final class ChatWarmupController: ObservableObject {
     func cancelScheduledWarmup() {
         scheduleTask?.cancel()
         scheduleTask = nil
+        scheduleTaskID = nil
+        scheduledActivationID = nil
+        cancelSessionActivation()
     }
 
     /// Cancel speculative work owned by a user-stopped pre-send handshake.
@@ -454,14 +672,18 @@ final class ChatWarmupController: ObservableObject {
             || activeModelSwitch != nil
             || inFlightWarmup != nil
             || requiredContextWarmup != nil
+            || sessionActivation != nil
         guard hadPendingWork else { return }
 
         switchEpoch &+= 1
         scheduleTask?.cancel()
         scheduleTask = nil
+        scheduleTaskID = nil
+        scheduledActivationID = nil
         activeModelSwitch?.cancel()
         inFlightWarmup?.cancel()
         requiredContextWarmup?.cancel()
+        cancelSessionActivation()
         userIntentWarmupModel = nil
         warmedFingerprint = nil
         state = .cold
@@ -494,6 +716,35 @@ final class ChatWarmupController: ObservableObject {
         guard !session.isStreaming else { return false }
         guard !session.isImageGenerationModel(model) else { return false }
         if ChatWindowManager.shared.isAnyWindowStreamingLocalModel { return false }
+        return true
+    }
+
+    private func cancelSessionActivation() {
+        sessionActivationID = nil
+        sessionActivation?.cancel()
+        sessionActivation = nil
+        activationRecovery = nil
+    }
+
+    /// Apply a typed residency snapshot if it is not older than the newest
+    /// state already observed. Activation is allowed to consume an equal
+    /// revision because its atomic runtime reply may additionally carry the
+    /// exact in-flight idle-decision identity absent from the notification.
+    @discardableResult
+    private func acceptResidencySnapshot(
+        _ snapshot: ModelRuntimeResidencySnapshot,
+        selectedModel: String?,
+        allowDuplicateRevision: Bool = false
+    ) -> Bool {
+        if let lastResidencyRevision {
+            if snapshot.revision < lastResidencyRevision { return false }
+            if snapshot.revision == lastResidencyRevision, !allowDuplicateRevision { return false }
+        }
+        lastResidencyRevision = max(lastResidencyRevision ?? 0, snapshot.revision)
+        reconcileRuntimeResidency(
+            selectedModel: selectedModel,
+            residentModelNames: snapshot.names
+        )
         return true
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -22,8 +22,69 @@ private let genLog = Logger(subsystem: "com.dinoki.osaurus", category: "Generati
 
 extension Notification.Name {
     /// Posted after the set of resident local model containers changes.
-    /// The object is the complete `[String]` resident-name snapshot.
+    /// The object is a revisioned `ModelRuntimeResidencySnapshot`.
     static let modelRuntimeResidencyChanged = Notification.Name("modelRuntimeResidencyChanged")
+}
+
+/// Owning-layer cause for a model-residency change. UI lifecycle recovery must
+/// never infer intent from an empty resident-name list: only an exact
+/// `.idlePolicy` decision associated with the current activation is recoverable.
+enum ModelRuntimeResidencyChangeReason: String, Sendable, Equatable {
+    case initial
+    case load
+    case idlePolicy
+    case memoryPressure
+    case handoff
+    case modelSwitch
+    case explicit
+    case settingsClear
+    case shutdown
+}
+
+/// Immutable, ordered runtime-residency event/query result.
+struct ModelRuntimeResidencySnapshot: Sendable, Equatable {
+    let names: [String]
+    let revision: UInt64
+    let reason: ModelRuntimeResidencyChangeReason
+    let idleDecisionID: UInt64?
+}
+
+/// Atomic result used when a visible chat becomes active. The runtime cancels
+/// the currently pending idle decision before returning. If that exact
+/// decision had already crossed into unload, its identity is returned so the
+/// controller may recover only the matching removal event.
+struct ModelRuntimeChatActivationResidencySnapshot: Sendable, Equatable {
+    let residency: ModelRuntimeResidencySnapshot
+    let recoverableIdleDecisionID: UInt64?
+}
+
+/// Small value-type ledger shared by runtime publication and deterministic
+/// tests. Keeping revision/reason/decision in one mutation prevents a
+/// notification from pairing a new resident-name set with stale metadata.
+struct ModelRuntimeResidencyLedger: Sendable {
+    private(set) var revision: UInt64 = 0
+    private var lastReason: ModelRuntimeResidencyChangeReason = .initial
+    private var lastIdleDecisionID: UInt64?
+
+    func snapshot(names: [String]) -> ModelRuntimeResidencySnapshot {
+        ModelRuntimeResidencySnapshot(
+            names: names.sorted(),
+            revision: revision,
+            reason: lastReason,
+            idleDecisionID: lastIdleDecisionID
+        )
+    }
+
+    mutating func record(
+        names: [String],
+        reason: ModelRuntimeResidencyChangeReason,
+        idleDecisionID: UInt64? = nil
+    ) -> ModelRuntimeResidencySnapshot {
+        revision &+= 1
+        lastReason = reason
+        lastIdleDecisionID = idleDecisionID
+        return snapshot(names: names)
+    }
 }
 
 // Force-link both trampolines so ModelFactoryRegistry discovers them at runtime.
@@ -242,6 +303,29 @@ public actor ModelRuntime {
     private var coldLoadWaiters: [CheckedContinuation<Void, Never>] = []
     private var currentModelName: String?
     private var cachedConfig: RuntimeConfig?
+    /// Monotonic sequence for every published residency-set mutation. Direct
+    /// queries return the latest value, allowing MainActor consumers to reject
+    /// delayed/duplicate NotificationCenter delivery deterministically.
+    private var residencyLedger = ModelRuntimeResidencyLedger()
+
+    /// Runtime-owned idle-policy identities. `pending` means the residency
+    /// manager may still fire; `inFlight` means the decision already won the
+    /// actor race and entered teardown. A focus activation invalidates the
+    /// former and captures the latter atomically.
+    private var nextIdleResidencyDecisionID: UInt64 = 0
+    private var pendingIdleResidencyDecisions: [String: UInt64] = [:]
+    private var inFlightIdleResidencyDecisions: [String: UInt64] = [:]
+    /// Once an idle teardown passes its final pre-destructive decision check,
+    /// new use waits for that exact teardown to finish and then reloads. Before
+    /// this point, new use cancels the in-flight decision and the teardown
+    /// exits without touching the engine or container.
+    private struct IdleResidencyTeardown {
+        let decisionID: UInt64
+        let task: Task<Void, Never>
+    }
+    private var committedIdleResidencyDecisions: [String: UInt64] = [:]
+    private var idleResidencyTeardowns: [String: IdleResidencyTeardown] = [:]
+    private var isClearingAllResidency = false
 
     /// Result of the most recent pre-load RAM feasibility check. Surfaced via
     /// `lastRAMFeasibilitySnapshot()` so `/health` and the model picker can
@@ -298,7 +382,47 @@ public actor ModelRuntime {
     /// already in memory instead of an arbitrary installed model, which under the
     /// strict single-model policy would evict whatever the user is chatting with.
     func residentModelNames() -> [String] {
-        Array(modelCache.keys)
+        modelCache.keys.sorted()
+    }
+
+    /// Current typed snapshot without changing residency.
+    func residencySnapshot() -> ModelRuntimeResidencySnapshot {
+        currentResidencySnapshot()
+    }
+
+    /// Atomically reconcile a visible-chat activation against an idle-policy
+    /// decision. A pending decision is invalidated before the actor yields;
+    /// an already-running decision is returned by identity for one-shot UI
+    /// recovery. Conditional manager cancellation cannot erase a newer timer.
+    func chatActivationResidencySnapshot(
+        selectedModel: String?
+    ) async -> ModelRuntimeChatActivationResidencySnapshot {
+        guard let selectedModel, !selectedModel.isEmpty else {
+            return ModelRuntimeChatActivationResidencySnapshot(
+                residency: currentResidencySnapshot(),
+                recoverableIdleDecisionID: nil
+            )
+        }
+
+        let matchingName = matchingRuntimeModelName(selectedModel)
+        let cancelledDecision = matchingName.flatMap {
+            pendingIdleResidencyDecisions.removeValue(forKey: $0)
+        }
+        let recoverableDecision = matchingName.flatMap {
+            inFlightIdleResidencyDecisions[$0]
+        }
+
+        if let matchingName, let cancelledDecision {
+            await ModelResidencyManager.shared.cancel(
+                modelName: matchingName,
+                ownerDecisionID: cancelledDecision
+            )
+        }
+
+        return ModelRuntimeChatActivationResidencySnapshot(
+            residency: currentResidencySnapshot(),
+            recoverableIdleDecisionID: recoverableDecision
+        )
     }
 
     /// Warm-load an installed local model without starting generation. Used by
@@ -372,7 +496,7 @@ public actor ModelRuntime {
             genLog.info(
                 "memory pressure: unloading idle model \(name, privacy: .public)"
             )
-            await unload(name: name)
+            await unload(name: name, reason: .memoryPressure)
             unloaded.append(name)
         }
         return unloaded
@@ -407,10 +531,17 @@ public actor ModelRuntime {
         for name in modelCache.keys where !activeNames.contains(name) {
             if let source = lastUseSource[name], source != .chatUI { continue }
             guard await ModelLease.shared.count(for: name) == 0 else { continue }
+            guard let idleDecisionID = pendingIdleResidencyDecisions[name] else { continue }
             await ModelResidencyManager.shared.accelerateIdleUnload(
                 modelName: name,
                 grace: grace,
-                unload: { name in await ModelRuntime.shared.unload(name: name) },
+                ownerDecisionID: idleDecisionID,
+                unload: { name in
+                    await ModelRuntime.shared.performIdleUnloadIfCurrent(
+                        name: name,
+                        decisionID: idleDecisionID
+                    )
+                },
                 leaseCount: { name in await ModelLease.shared.count(for: name) },
                 isResident: { name in await ModelRuntime.shared.isResident(name: name) },
                 shouldStillUnload: { name in
@@ -497,7 +628,15 @@ public actor ModelRuntime {
             )
         }
 
-        await ModelResidencyManager.shared.markActive(modelName: holder.name)
+        guard await markModelActiveForResidency(holder.name) else {
+            return LiveVoiceAudioPreencodeResult(
+                status: .skippedModelNotResident,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: nil
+            )
+        }
         // Live voice runs inside the chat UI, so its residency is chat-scoped.
         lastUseSource[holder.name] = .chatUI
         await ModelLease.shared.acquire(holder.name)
@@ -781,6 +920,15 @@ public actor ModelRuntime {
         currentModelName = name
         Memory.cacheLimit = mlxCacheLimit()
 
+        // Publish the cache mutation before the native-MTP warm-up suspends
+        // this actor. An unload/model switch may win while that warm-up is
+        // running; publishing afterwards would create a newer, stale `.load`
+        // revision for a model that is no longer resident.
+        genLog.info(
+            "loadContainer: loaded \(name, privacy: .public) isVLM=\(holder.isVLM, privacy: .public)"
+        )
+        publishResidencyChange(reason: .load)
+
         // Native-MTP bundles historically ran their FIRST request in plain
         // autoregressive mode (the registry's cold-warmup rule), so the one
         // request most users judge a model by silently lost the speculative
@@ -795,11 +943,6 @@ public actor ModelRuntime {
             runtime: getConfig(),
             maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
         )
-
-        genLog.info(
-            "loadContainer: loaded \(name, privacy: .public) isVLM=\(holder.isVLM, privacy: .public)"
-        )
-        publishResidencyChange()
         return holder
     }
 
@@ -807,33 +950,70 @@ public actor ModelRuntime {
     /// model has fully released its lease. The lease is held for the entire
     /// stream lifetime (see `generateEventStream`), so this guarantees we
     /// never free buffers that an active Metal command buffer still references.
-    func unload(name: String) async {
-        await ModelResidencyManager.shared.cancel(modelName: name)
-
-        // Shut the BatchEngine first so its scheduling loop stops issuing
-        // new model forward passes; then wait for any in-flight per-request
-        // leases to drain before we touch the container.
-        await MLXBatchAdapter.Registry.shared.shutdownEngine(for: name)
-        await ModelLease.shared.waitForZero(name)
-        // Defensive: cancel the latest tracked wrapper task. The lease drain
-        // above already covers in-flight requests; this only catches the
-        // rare case where a task was cancelled mid-setup before acquiring.
-        await cancelActiveGeneration(for: name)
-
-        if let record = loadingTasks[name] {
-            await cancelAndDrainLoadingTasks([(name, record)])
+    func unload(
+        name: String,
+        reason: ModelRuntimeResidencyChangeReason = .explicit,
+        idleDecisionID: UInt64? = nil
+    ) async {
+        guard (reason == .idlePolicy) == (idleDecisionID != nil) else {
+            assertionFailure("idlePolicy unloads require one exact decision ID; other unloads require none")
+            return
         }
 
-        // Serialize the GPU teardown against every other Metal producer via the
-        // exclusive teardown gate. Acquired here — AFTER the lease/idle drains
-        // above, so we never hold the gate while waiting for in-flight requests
-        // — and released only after the final synchronize below, so "teardown
-        // gate released" provably means "this model's GPU work is idle",
-        // symmetric with the load and image lanes. Without it the next admitted
-        // producer (a model load, image job, or embedder) starts the moment this
-        // function returns and races the async buffer frees/fences the weight
-        // release enqueues — the chat→image handoff `Gather::eval_gpu` abort.
-        await MetalGate.shared.enterModelTeardown(model: name)
+        // A committed idle teardown already owns the container and Metal
+        // boundary. A second explicit/model-switch teardown waits for that
+        // exact task instead of racing duplicate engine shutdown and buffer
+        // release work against it.
+        if reason != .idlePolicy,
+            let teardown = idleResidencyTeardowns[name],
+            committedIdleResidencyDecisions[name] == teardown.decisionID
+        {
+            await teardown.task.value
+            return
+        }
+
+        if reason == .idlePolicy, let idleDecisionID {
+            await ModelResidencyManager.shared.cancel(
+                modelName: name,
+                ownerDecisionID: idleDecisionID
+            )
+        } else {
+            pendingIdleResidencyDecisions.removeValue(forKey: name)
+            inFlightIdleResidencyDecisions.removeValue(forKey: name)
+            await ModelResidencyManager.shared.cancel(modelName: name)
+        }
+
+        if reason == .idlePolicy, let idleDecisionID {
+            // Idle teardown differs from explicit teardown: until it commits,
+            // a new request wins. Do not shut down the engine or cancel any
+            // generation before the exact decision is checked at the final
+            // actor boundary. Once committed, `markModelActiveForResidency`
+            // waits for this teardown and the request cold-loads safely.
+            await ModelLease.shared.waitForZero(name)
+            guard inFlightIdleResidencyDecisions[name] == idleDecisionID else { return }
+            await MetalGate.shared.enterModelTeardown(model: name)
+            guard inFlightIdleResidencyDecisions[name] == idleDecisionID else {
+                await MetalGate.shared.exitModelTeardown(model: name)
+                return
+            }
+            committedIdleResidencyDecisions[name] = idleDecisionID
+            await MLXBatchAdapter.Registry.shared.shutdownEngine(for: name)
+            await cancelActiveGeneration(for: name)
+            if let record = loadingTasks[name] {
+                await cancelAndDrainLoadingTasks([(name, record)])
+            }
+        } else {
+            // Explicit teardown owns cancellation semantics. Shut the engine
+            // down first, drain every lease/setup task, then take the Metal
+            // teardown gate before touching the container.
+            await MLXBatchAdapter.Registry.shared.shutdownEngine(for: name)
+            await ModelLease.shared.waitForZero(name)
+            await cancelActiveGeneration(for: name)
+            if let record = loadingTasks[name] {
+                await cancelAndDrainLoadingTasks([(name, record)])
+            }
+            await MetalGate.shared.enterModelTeardown(model: name)
+        }
         modelCache[name]?.container.disableCaching()
 
         // Drain the GPU BEFORE releasing the weight arrays. The lease/idle
@@ -852,7 +1032,9 @@ public actor ModelRuntime {
         }
         lastUseSource.removeValue(forKey: name)
         if currentModelName == name { currentModelName = nil }
-        if didRemove { publishResidencyChange() }
+        if didRemove {
+            publishResidencyChange(reason: reason, idleDecisionID: idleDecisionID)
+        }
 
         Memory.cacheLimit = mlxCacheLimit()
         // Fully settle the teardown before returning so the NEXT GPU producer
@@ -891,7 +1073,7 @@ public actor ModelRuntime {
             _ = await ModelLease.shared.waitForZero(other, timeoutSeconds: 300)
         }
         genLog.info("loadContainer: strict eviction of \(other, privacy: .public)")
-        await unload(name: other)
+        await unload(name: other, reason: .modelSwitch)
     }
 
     /// Unloads any loaded model whose name is not in `activeNames`.
@@ -922,7 +1104,7 @@ public actor ModelRuntime {
         let toUnload = modelCache.keys.filter { !keep.contains($0) }
         for name in toUnload {
             print("[ModelRuntime] GC: Unloading unused model \(name)")
-            await unload(name: name)
+            await unload(name: name, reason: .modelSwitch)
         }
     }
 
@@ -935,12 +1117,22 @@ public actor ModelRuntime {
     ///   normal (settings-change / GC) path leave this `false` for the full,
     ///   correctness-first teardown.
     func clearAll(quit: Bool = false) async {
+        isClearingAllResidency = true
+        defer { isClearingAllResidency = false }
         await ModelResidencyManager.shared.cancelAll()
 
-        // Shut down every BatchEngine so they stop scheduling new forward
-        // passes and cancel ALL tracked generation wrapper tasks, then wait
-        // for every leased model to drain before we touch any container.
+        // A pre-commit idle teardown may be waiting for the active model lease
+        // to drain. Cancel generation wrappers first so that lease can release;
+        // awaiting idle teardown tasks before this point can wedge settings
+        // clear and app termination behind the very generation they must stop.
         await cancelAllGenerations()
+        let idleTeardownTasks = idleResidencyTeardowns.values.map(\.task)
+        for task in idleTeardownTasks {
+            await task.value
+        }
+
+        // With idle teardown serialization settled, wait for every leased
+        // model to drain before touching any remaining container.
         var hasStuckLease = false
         for name in modelCache.keys {
             if quit {
@@ -985,6 +1177,10 @@ public actor ModelRuntime {
             loadingTasks.removeAll()
             supersededLoadingTaskIDs.removeAll()
             lastUseSource.removeAll()
+            pendingIdleResidencyDecisions.removeAll()
+            inFlightIdleResidencyDecisions.removeAll()
+            committedIdleResidencyDecisions.removeAll()
+            idleResidencyTeardowns.removeAll()
             currentModelName = nil
             cachedConfig = nil
             return
@@ -1004,11 +1200,15 @@ public actor ModelRuntime {
             modelCache.removeAll()
         }
         lastUseSource.removeAll()
+        pendingIdleResidencyDecisions.removeAll()
+        inFlightIdleResidencyDecisions.removeAll()
+        committedIdleResidencyDecisions.removeAll()
+        idleResidencyTeardowns.removeAll()
         loadingTasks.removeAll()
         supersededLoadingTaskIDs.removeAll()
         currentModelName = nil
         cachedConfig = nil
-        publishResidencyChange()
+        publishResidencyChange(reason: quit ? .shutdown : .settingsClear)
 
         // `clearAll` empties `modelCache`, so `mlxCacheLimit()` returns 0
         // anyway — but route through the shared helper so the policy stays
@@ -1023,11 +1223,51 @@ public actor ModelRuntime {
     /// Broadcast a value snapshot rather than the actor-owned dictionary so
     /// UI observers can invalidate stale warm indicators without crossing
     /// actor isolation or polling the runtime.
-    private func publishResidencyChange() {
+    private func publishResidencyChange(
+        reason: ModelRuntimeResidencyChangeReason,
+        idleDecisionID: UInt64? = nil
+    ) {
+        let snapshot = residencyLedger.record(
+            names: Array(modelCache.keys),
+            reason: reason,
+            idleDecisionID: idleDecisionID
+        )
         NotificationCenter.default.post(
             name: .modelRuntimeResidencyChanged,
-            object: Array(modelCache.keys)
+            object: snapshot
         )
+    }
+
+    private func currentResidencySnapshot() -> ModelRuntimeResidencySnapshot {
+        residencyLedger.snapshot(names: Array(modelCache.keys))
+    }
+
+    private func matchingRuntimeModelName(_ selectedModel: String) -> String? {
+        let candidates = Set(modelCache.keys)
+            .union(pendingIdleResidencyDecisions.keys)
+            .union(inFlightIdleResidencyDecisions.keys)
+        if let exact = candidates.first(where: {
+            $0.caseInsensitiveCompare(selectedModel) == .orderedSame
+        }) {
+            return exact
+        }
+        if let installedName = ModelManager.findInstalledModel(named: selectedModel)?.name,
+            let exactInstalled = candidates.first(where: {
+                $0.caseInsensitiveCompare(installedName) == .orderedSame
+            })
+        {
+            return exactInstalled
+        }
+
+        let selectedTail = selectedModel.split(separator: "/").last.map(String.init) ?? selectedModel
+        let tailMatches = candidates.filter { candidate in
+            let candidateTail = candidate.split(separator: "/").last.map(String.init) ?? candidate
+            return candidate.caseInsensitiveCompare(selectedTail) == .orderedSame
+                || candidateTail.caseInsensitiveCompare(selectedTail) == .orderedSame
+        }
+        // A basename is only safe when it identifies one runtime owner. If
+        // multiple installed repos share it, do not cancel either idle timer.
+        return tailMatches.count == 1 ? tailMatches.first : nil
     }
 
     /// Invalidates the cached RuntimeConfig so the next request reads fresh values.
@@ -1045,17 +1285,96 @@ public actor ModelRuntime {
     }
 
     private func scheduleIdleResidency(for modelName: String) async {
+        guard !isClearingAllResidency else { return }
         let policy =
             await ServerConfigurationStore.load()?.modelIdleResidencyPolicy
             ?? ServerConfiguration.default.modelIdleResidencyPolicy
+        if case .never = policy {
+            pendingIdleResidencyDecisions.removeValue(forKey: modelName)
+            await ModelResidencyManager.shared.scheduleIdleUnload(
+                modelName: modelName,
+                policy: policy,
+                unload: { _ in },
+                leaseCount: { name in await ModelLease.shared.count(for: name) },
+                isResident: { name in await ModelRuntime.shared.isResident(name: name) }
+            )
+            return
+        }
 
+        nextIdleResidencyDecisionID &+= 1
+        let idleDecisionID = nextIdleResidencyDecisionID
+        pendingIdleResidencyDecisions[modelName] = idleDecisionID
         await ModelResidencyManager.shared.scheduleIdleUnload(
             modelName: modelName,
             policy: policy,
-            unload: { name in await ModelRuntime.shared.unload(name: name) },
+            ownerDecisionID: idleDecisionID,
+            unload: { name in
+                await ModelRuntime.shared.performIdleUnloadIfCurrent(
+                    name: name,
+                    decisionID: idleDecisionID
+                )
+            },
             leaseCount: { name in await ModelLease.shared.count(for: name) },
             isResident: { name in await ModelRuntime.shared.isResident(name: name) }
         )
+
+        // `ModelRuntime` is reentrant across the manager actor hop. If a new
+        // generation/focus/schedule replaced this decision meanwhile, remove
+        // only the stale manager entry that this call may just have installed.
+        if pendingIdleResidencyDecisions[modelName] != idleDecisionID {
+            await ModelResidencyManager.shared.cancel(
+                modelName: modelName,
+                ownerDecisionID: idleDecisionID
+            )
+        }
+    }
+
+    /// Cancel a pre-commit idle decision, or wait for an already-committed
+    /// teardown before allowing the caller to touch/load the model again.
+    /// Returns whether the old container is still resident after that gate.
+    @discardableResult
+    private func markModelActiveForResidency(_ modelName: String) async -> Bool {
+        pendingIdleResidencyDecisions.removeValue(forKey: modelName)
+        if let teardown = idleResidencyTeardowns[modelName],
+            committedIdleResidencyDecisions[modelName] == teardown.decisionID
+        {
+            await teardown.task.value
+        } else {
+            inFlightIdleResidencyDecisions.removeValue(forKey: modelName)
+        }
+        await ModelResidencyManager.shared.markActive(modelName: modelName)
+        return modelCache[modelName] != nil
+    }
+
+    fileprivate func performIdleUnloadIfCurrent(
+        name: String,
+        decisionID: UInt64
+    ) async {
+        guard pendingIdleResidencyDecisions[name] == decisionID else { return }
+        pendingIdleResidencyDecisions.removeValue(forKey: name)
+        inFlightIdleResidencyDecisions[name] = decisionID
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.unload(name: name, reason: .idlePolicy, idleDecisionID: decisionID)
+            await self.finishIdleResidencyTeardown(name: name, decisionID: decisionID)
+        }
+        idleResidencyTeardowns[name] = IdleResidencyTeardown(
+            decisionID: decisionID,
+            task: task
+        )
+        await task.value
+    }
+
+    private func finishIdleResidencyTeardown(name: String, decisionID: UInt64) {
+        if inFlightIdleResidencyDecisions[name] == decisionID {
+            inFlightIdleResidencyDecisions.removeValue(forKey: name)
+        }
+        if committedIdleResidencyDecisions[name] == decisionID {
+            committedIdleResidencyDecisions.removeValue(forKey: name)
+        }
+        if idleResidencyTeardowns[name]?.decisionID == decisionID {
+            idleResidencyTeardowns.removeValue(forKey: name)
+        }
     }
 
     /// MLX freed-buffer cache limit sized for intermediate activation reuse.
@@ -1918,7 +2237,7 @@ public actor ModelRuntime {
             genLog.info(
                 "loadContainer: flexible budget eviction of \(candidate.key, privacy: .public) before loading \(targetName, privacy: .public) residentBytes=\(self.residentWeightBytes(excluding: targetName), privacy: .public) incomingBytes=\(incomingWeightsSizeBytes, privacy: .public) limitBytes=\(limit, privacy: .public)"
             )
-            await unload(name: candidate.key)
+            await unload(name: candidate.key, reason: .modelSwitch)
         }
     }
 
@@ -3073,7 +3392,7 @@ public actor ModelRuntime {
         if Task.isCancelled { throw CancellationError() }
 
         genLog.info("generateEventStream: start model=\(modelName, privacy: .public)")
-        await ModelResidencyManager.shared.markActive(modelName: modelName)
+        await markModelActiveForResidency(modelName)
         lastUseSource[modelName] = parameters.requestSource
 
         // Scoped start/finish around ONLY a cold container load. Hot

--- a/Packages/OsaurusCore/Services/ModelRuntime/ModelResidencyManager.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ModelResidencyManager.swift
@@ -15,6 +15,7 @@ import Foundation
 public actor ModelResidencyManager {
     public struct Snapshot: Equatable, Sendable {
         public var modelName: String
+        public var ownerDecisionID: UInt64?
         public var lastUsedAt: Date
         public var unloadAt: Date?
         public var policy: ModelIdleResidencyPolicy
@@ -26,6 +27,11 @@ public actor ModelResidencyManager {
 
     private struct Entry {
         var generation: UInt64
+        /// Runtime-owned identity for the idle policy decision that installed
+        /// this timer. `nil` is reserved for non-runtime/test callers. Keeping
+        /// it alongside the manager generation lets a focus activation cancel
+        /// only the timer it observed without deleting a newer replacement.
+        var ownerDecisionID: UInt64?
         var lastUsedAt: Date
         var unloadAt: Date?
         var policy: ModelIdleResidencyPolicy
@@ -51,6 +57,7 @@ public actor ModelResidencyManager {
         existing?.task?.cancel()
         entries[modelName] = Entry(
             generation: nextGeneration,
+            ownerDecisionID: nil,
             lastUsedAt: now,
             unloadAt: nil,
             policy: existing?.policy ?? .never,
@@ -62,10 +69,12 @@ public actor ModelResidencyManager {
     public func scheduleIdleUnload(
         modelName: String,
         policy: ModelIdleResidencyPolicy,
+        ownerDecisionID: UInt64? = nil,
         now: Date = Date(),
         unload: @Sendable @escaping (String) async -> Void,
         leaseCount: @Sendable @escaping (String) async -> Int,
-        isResident: @Sendable @escaping (String) async -> Bool
+        isResident: @Sendable @escaping (String) async -> Bool,
+        shouldStillUnload: @Sendable @escaping (String) async -> Bool = { _ in true }
     ) {
         nextGeneration &+= 1
         let generation = nextGeneration
@@ -84,6 +93,7 @@ public actor ModelResidencyManager {
         case .never:
             entries[modelName] = Entry(
                 generation: generation,
+                ownerDecisionID: ownerDecisionID,
                 lastUsedAt: now,
                 unloadAt: nil,
                 policy: policy,
@@ -102,12 +112,14 @@ public actor ModelResidencyManager {
                 generation: generation,
                 unload: unload,
                 leaseCount: leaseCount,
-                isResident: isResident
+                isResident: isResident,
+                shouldStillUnload: shouldStillUnload
             )
         }
 
         entries[modelName] = Entry(
             generation: generation,
+            ownerDecisionID: ownerDecisionID,
             lastUsedAt: now,
             unloadAt: unloadAt,
             policy: policy,
@@ -138,6 +150,7 @@ public actor ModelResidencyManager {
     public func accelerateIdleUnload(
         modelName: String,
         grace: TimeInterval,
+        ownerDecisionID: UInt64? = nil,
         now: Date = Date(),
         unload: @Sendable @escaping (String) async -> Void,
         leaseCount: @Sendable @escaping (String) async -> Int,
@@ -146,7 +159,8 @@ public actor ModelResidencyManager {
     ) {
         guard let existing = entries[modelName],
             existing.task != nil,
-            let existingUnloadAt = existing.unloadAt
+            let existingUnloadAt = existing.unloadAt,
+            ownerDecisionID == nil || existing.ownerDecisionID == ownerDecisionID
         else { return }
 
         let clampedGrace = max(0, grace)
@@ -175,6 +189,7 @@ public actor ModelResidencyManager {
 
         entries[modelName] = Entry(
             generation: generation,
+            ownerDecisionID: existing.ownerDecisionID,
             lastUsedAt: existing.lastUsedAt,
             unloadAt: target,
             policy: existing.policy,
@@ -182,8 +197,12 @@ public actor ModelResidencyManager {
         )
     }
 
-    public func cancel(modelName: String) {
-        entries[modelName]?.task?.cancel()
+    /// Cancel the current entry. When an owner decision is supplied, a newer
+    /// replacement entry is deliberately left untouched.
+    public func cancel(modelName: String, ownerDecisionID: UInt64? = nil) {
+        guard let entry = entries[modelName] else { return }
+        guard ownerDecisionID == nil || entry.ownerDecisionID == ownerDecisionID else { return }
+        entry.task?.cancel()
         entries.removeValue(forKey: modelName)
     }
 
@@ -198,6 +217,7 @@ public actor ModelResidencyManager {
         entries.map { modelName, entry in
             Snapshot(
                 modelName: modelName,
+                ownerDecisionID: entry.ownerDecisionID,
                 lastUsedAt: entry.lastUsedAt,
                 unloadAt: entry.unloadAt,
                 policy: entry.policy

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -634,9 +634,14 @@ struct ChatWarmupControllerRuntimeResidencyTests {
         #expect(controller.state == .warm)
         #expect(engine.requestCount == 1)
 
-        controller.reconcileRuntimeResidency(
-            selectedModel: session.selectedModel,
-            residentModelNames: ["different-model"]
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(
+                names: ["different-model"],
+                revision: 1,
+                reason: .modelSwitch
+            ),
+            isSessionActive: false
         )
         #expect(controller.state == .cold)
 
@@ -652,6 +657,567 @@ struct ChatWarmupControllerRuntimeResidencyTests {
         // without touching the runtime.
         #expect(engine.requestCount == 2)
         #expect(controller.state == .warm)
+    }
+
+    @Test("focus-style rearm after external eviction remains speculative")
+    func focusRearmAfterExternalEvictionRemainsSpeculative() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|focus-rearm"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.chatActivationResidencySnapshot = { _ in
+            activationResidencySnapshot(
+                names: [],
+                revision: 1,
+                reason: .modelSwitch
+            )
+        }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: [], revision: 1, reason: .modelSwitch)
+        }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
+
+        // `ChatWindowManager.windowDidBecomeKey` reaches this same scheduling
+        // path through `ChatSession.notifySessionBecameActive()`. Deliberately
+        // leave the stale warm claim intact: the activation-time runtime check
+        // must clear it without relying on notification delivery ordering.
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await controller.awaitSessionActivation()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 2)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("eviction during the focus debounce cannot reuse a stale warm fingerprint")
+    func focusEvictionDuringDebounceRearmsWarmup() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|focus-debounce-eviction"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        // The activation snapshot still sees the selected model. Hold the
+        // following debounce, then make the execution-time snapshot report the
+        // idle eviction. Without the second reconciliation, fingerprint
+        // equality suppresses the required replacement request.
+        let snapshots = ResidentSnapshotSequence([
+            residencySnapshot(names: ["test-model"], revision: 1),
+            residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 41
+            ),
+        ])
+        let debounce = WarmupDebounceGate()
+        controller.chatActivationResidencySnapshot = { _ in
+            ModelRuntimeChatActivationResidencySnapshot(
+                residency: await snapshots.next(),
+                recoverableIdleDecisionID: nil
+            )
+        }
+        controller.runtimeResidencySnapshot = { await snapshots.next() }
+        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
+
+        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        await controller.awaitSessionActivation()
+        await debounce.waitUntilBlocked()
+        #expect(await snapshots.callCount() == 1)
+
+        await debounce.release()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(await snapshots.callCount() == 2)
+        #expect(engine.requestCount == 2)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("matching idle decision after focus coalescing performs exactly one replacement warmup")
+    func focusRemovalAfterCoalescingRearmsExactlyOnce() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|post-coalesce-removal"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        // Both focus snapshots report resident, so the activation request
+        // legitimately coalesces on the existing fingerprint. Only after that
+        // return does the runtime publish the completed removal. The active
+        // chat must receive one replacement warm-up instead of staying cold.
+        let snapshots = ResidentSnapshotSequence([
+            residencySnapshot(names: ["test-model"], revision: 10),
+            residencySnapshot(names: ["test-model"], revision: 10),
+            residencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+        ])
+        let debounce = WarmupDebounceGate()
+        controller.chatActivationResidencySnapshot = { _ in
+            ModelRuntimeChatActivationResidencySnapshot(
+                residency: await snapshots.next(),
+                recoverableIdleDecisionID: 71
+            )
+        }
+        controller.runtimeResidencySnapshot = { await snapshots.next() }
+        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
+
+        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        await controller.awaitSessionActivation()
+        await debounce.waitUntilBlocked()
+        await debounce.release()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(await snapshots.callCount() == 2)
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        controller.scheduleDebounceSleep = { _ in }
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+            isSessionActive: true
+        )
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(await snapshots.callCount() == 3)
+        #expect(engine.requestCount == 2)
+        #expect(controller.state == .warm)
+
+        // Duplicate and stale delivery from the same runtime timeline cannot
+        // invalidate the replacement warm claim or create another warm-up.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+            isSessionActive: true
+        )
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 9,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+            isSessionActive: true
+        )
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 2)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("matching idle removal while focus is warming preserves the activation warmup")
+    func focusRemovalWhileWarmingPreservesScheduledWarmup() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|focus-warming-removal"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        let debounce = WarmupDebounceGate()
+        controller.chatActivationResidencySnapshot = { _ in
+            activationResidencySnapshot(
+                names: ["test-model"],
+                revision: 10,
+                recoverableIdleDecisionID: 71
+            )
+        }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            )
+        }
+        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
+
+        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        await controller.awaitSessionActivation()
+        await debounce.waitUntilBlocked()
+        #expect(controller.state == .warming)
+
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+            isSessionActive: true
+        )
+        #expect(controller.state == .warming)
+
+        await debounce.release()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("mismatched idle-decision identity does not rewarm")
+    func mismatchedIdleDecisionDoesNotRewarm() async {
+        await expectArmedRecoveryToStayCold(
+            reason: .idlePolicy,
+            idleDecisionID: 72,
+            isSessionActive: true
+        )
+    }
+
+    @Test("non-idle removal reasons do not rewarm")
+    func nonIdleRemovalReasonsDoNotRewarm() async {
+        let reasons: [ModelRuntimeResidencyChangeReason] = [
+            .initial,
+            .load,
+            .memoryPressure,
+            .handoff,
+            .modelSwitch,
+            .explicit,
+            .settingsClear,
+            .shutdown,
+        ]
+        for reason in reasons {
+            await expectArmedRecoveryToStayCold(
+                reason: reason,
+                idleDecisionID: 71,
+                isSessionActive: true
+            )
+        }
+    }
+
+    @Test("matching idle decision does not rewarm an inactive session")
+    func inactiveSessionDoesNotRewarm() async {
+        await expectArmedRecoveryToStayCold(
+            reason: .idlePolicy,
+            idleDecisionID: 71,
+            isSessionActive: false
+        )
+    }
+
+    @Test("duplicate and stale residency revisions are ignored")
+    func duplicateAndStaleRevisionsAreIgnored() async {
+        let fixture = await makeArmedRecoveryFixture()
+
+        for revision: UInt64 in [10, 9] {
+            fixture.controller.handleRuntimeResidencyChanged(
+                session: fixture.session,
+                snapshot: residencySnapshot(
+                    names: [],
+                    revision: revision,
+                    reason: .idlePolicy,
+                    idleDecisionID: 71
+                ),
+                isSessionActive: true
+            )
+        }
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(fixture.engine.requestCount == 1)
+        #expect(fixture.controller.state == .warm)
+    }
+
+    @Test("focus-style rearm does not displace another resident model")
+    func focusRearmDoesNotDisplaceAnotherResidentModel() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|focus-rearm"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+
+        controller.chatActivationResidencySnapshot = { _ in
+            activationResidencySnapshot(
+                names: ["different-model"],
+                revision: 1,
+                reason: .load
+            )
+        }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: ["different-model"], revision: 1)
+        }
+        controller.hasResidentModelOther = { _ in true }
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await controller.awaitSessionActivation()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .cold)
+    }
+
+    @Test("focus-style activation preserves a valid resident warm claim")
+    func focusActivationPreservesResidentWarmClaim() async {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|focus-resident"
+        )
+
+        let controller = ChatWarmupController()
+        controller.chatActivationResidencySnapshot = { _ in
+            activationResidencySnapshot(names: ["test-model"], revision: 1)
+        }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: ["test-model"], revision: 1)
+        }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await controller.awaitSessionActivation()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(controller.state == .warm)
+        #expect(engine.requestCount == 1)
+    }
+
+    @Test("newest activation snapshot wins when an older runtime reply resumes last")
+    func newestActivationSnapshotWins() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|activation-order"
+        )
+
+        let controller = ChatWarmupController()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+        #expect(controller.state == .warm)
+        #expect(engine.requestCount == 1)
+
+        let gate = ResidentSnapshotGate()
+        controller.chatActivationResidencySnapshot = { _ in await gate.snapshot() }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: ["test-model"], revision: 2)
+        }
+
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await gate.waitForCallCount(1)
+        let staleActivation = try #require(controller.sessionActivationTaskForTests)
+
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await gate.waitForCallCount(2)
+        await gate.resume(
+            call: 2,
+            with: activationResidencySnapshot(names: ["test-model"], revision: 2)
+        )
+        await controller.awaitSessionActivation()
+        await controller.scheduledWarmupTaskForTests?.value
+
+        // The cancelled first runtime lookup deliberately ignores cooperative
+        // cancellation. Its late empty snapshot must not clear the valid warm
+        // claim or create another hidden warm-up.
+        await gate.resume(
+            call: 1,
+            with: activationResidencySnapshot(
+                names: [],
+                revision: 1,
+                reason: .modelSwitch
+            )
+        )
+        await staleActivation.value
+
+        #expect(controller.state == .warm)
+        #expect(engine.requestCount == 1)
+    }
+
+    @Test("reset invalidates a suspended activation snapshot")
+    func resetInvalidatesSuspendedActivationSnapshot() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|activation-reset"
+        )
+
+        let controller = ChatWarmupController()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+        #expect(controller.state == .warm)
+
+        let gate = ResidentSnapshotGate()
+        controller.chatActivationResidencySnapshot = { _ in await gate.snapshot() }
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await gate.waitForCallCount(1)
+        let staleActivation = try #require(controller.sessionActivationTaskForTests)
+
+        controller.reset()
+        await gate.resume(
+            call: 1,
+            with: activationResidencySnapshot(
+                names: [],
+                revision: 1,
+                reason: .modelSwitch
+            )
+        )
+        await staleActivation.value
+
+        #expect(controller.state == .cold)
+        #expect(engine.requestCount == 1)
+        #expect(controller.sessionActivationTaskForTests == nil)
+    }
+
+    @Test("user Stop invalidates a suspended activation snapshot")
+    func userStopInvalidatesSuspendedActivationSnapshot() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|activation-stop"
+        )
+
+        let controller = ChatWarmupController()
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        let gate = ResidentSnapshotGate()
+        controller.chatActivationResidencySnapshot = { _ in await gate.snapshot() }
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await gate.waitForCallCount(1)
+        let staleActivation = try #require(controller.sessionActivationTaskForTests)
+
+        controller.cancelPendingWorkForUserStop()
+        await gate.resume(
+            call: 1,
+            with: activationResidencySnapshot(
+                names: [],
+                revision: 1,
+                reason: .modelSwitch
+            )
+        )
+        await staleActivation.value
+
+        #expect(controller.state == .cold)
+        #expect(engine.requestCount == 1)
+        #expect(controller.sessionActivationTaskForTests == nil)
     }
 
     @Test("canonical and tail model identifiers preserve the warm claim")
@@ -677,13 +1243,81 @@ struct ChatWarmupControllerRuntimeResidencyTests {
         await controller.awaitInFlightWarmup()
         #expect(controller.state == .warm)
 
-        controller.reconcileRuntimeResidency(
-            selectedModel: session.selectedModel,
-            residentModelNames: ["test-model"]
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: ["test-model"], revision: 1),
+            isSessionActive: false
         )
 
         #expect(controller.state == .warm)
         #expect(engine.requestCount == 1)
+    }
+
+    private func expectArmedRecoveryToStayCold(
+        reason: ModelRuntimeResidencyChangeReason,
+        idleDecisionID: UInt64?,
+        isSessionActive: Bool
+    ) async {
+        let fixture = await makeArmedRecoveryFixture()
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 11,
+                reason: reason,
+                idleDecisionID: idleDecisionID
+            ),
+            isSessionActive: isSessionActive
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(fixture.engine.requestCount == 1, "unexpected rewarm for \(reason.rawValue)")
+        #expect(fixture.controller.state == .cold, "unexpected state for \(reason.rawValue)")
+    }
+
+    private func makeArmedRecoveryFixture() async -> (
+        controller: ChatWarmupController,
+        session: WarmupTestSession,
+        engine: WarmupRecordingEngine
+    ) {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|armed-idle-recovery"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.chatActivationResidencySnapshot = { _ in
+            activationResidencySnapshot(
+                names: ["test-model"],
+                revision: 10,
+                recoverableIdleDecisionID: 71
+            )
+        }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: ["test-model"], revision: 10)
+        }
+
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await controller.awaitSessionActivation()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+        return (controller, session, engine)
     }
 }
 
@@ -759,6 +1393,38 @@ private final class WarmupTestSession: ChatWarmupSessionContext {
     func makeWarmupEngine() -> ChatEngineProtocol { engine }
 }
 
+private func residencySnapshot(
+    names: [String],
+    revision: UInt64,
+    reason: ModelRuntimeResidencyChangeReason = .load,
+    idleDecisionID: UInt64? = nil
+) -> ModelRuntimeResidencySnapshot {
+    ModelRuntimeResidencySnapshot(
+        names: names,
+        revision: revision,
+        reason: reason,
+        idleDecisionID: idleDecisionID
+    )
+}
+
+private func activationResidencySnapshot(
+    names: [String],
+    revision: UInt64,
+    reason: ModelRuntimeResidencyChangeReason = .load,
+    idleDecisionID: UInt64? = nil,
+    recoverableIdleDecisionID: UInt64? = nil
+) -> ModelRuntimeChatActivationResidencySnapshot {
+    ModelRuntimeChatActivationResidencySnapshot(
+        residency: residencySnapshot(
+            names: names,
+            revision: revision,
+            reason: reason,
+            idleDecisionID: idleDecisionID
+        ),
+        recoverableIdleDecisionID: recoverableIdleDecisionID
+    )
+}
+
 private final class WarmupRecordingEngine: ChatEngineProtocol, @unchecked Sendable {
     var lastRequest: ChatCompletionRequest?
     var requestCount = 0
@@ -798,6 +1464,71 @@ private actor FirstResidentPreflightGate {
 
     func releaseFirst() {
         continuation?.resume(returning: false)
+        continuation = nil
+    }
+}
+
+private actor ResidentSnapshotGate {
+    private var callCount = 0
+    private var continuations: [
+        Int: CheckedContinuation<ModelRuntimeChatActivationResidencySnapshot, Never>
+    ] = [:]
+
+    func snapshot() async -> ModelRuntimeChatActivationResidencySnapshot {
+        callCount += 1
+        let call = callCount
+        return await withCheckedContinuation { continuation in
+            continuations[call] = continuation
+        }
+    }
+
+    func waitForCallCount(_ expected: Int) async {
+        while callCount < expected {
+            await Task.yield()
+        }
+    }
+
+    func resume(call: Int, with snapshot: ModelRuntimeChatActivationResidencySnapshot) {
+        continuations.removeValue(forKey: call)?.resume(returning: snapshot)
+    }
+}
+
+private actor ResidentSnapshotSequence {
+    private var snapshots: [ModelRuntimeResidencySnapshot]
+    private var calls = 0
+
+    init(_ snapshots: [ModelRuntimeResidencySnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    func next() -> ModelRuntimeResidencySnapshot {
+        calls += 1
+        precondition(!snapshots.isEmpty, "unexpected residency snapshot request")
+        return snapshots.removeFirst()
+    }
+
+    func callCount() -> Int { calls }
+}
+
+private actor WarmupDebounceGate {
+    private var blocked = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        blocked = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilBlocked() async {
+        while !blocked {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        continuation?.resume()
         continuation = nil
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/ModelResidencyManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelResidencyManagerTests.swift
@@ -104,6 +104,42 @@ struct ModelResidencyManagerTests {
         #expect(snapshots.first?.unloadAt == nil)
     }
 
+    @Test("conditional cancel cannot erase a newer owner decision")
+    func conditionalCancelPreservesNewerOwnerDecision() async {
+        let sleeper = ResidencySleepRecorder()
+        let unloads = ResidencyUnloadRecorder()
+        let manager = ModelResidencyManager(sleep: { nanoseconds in
+            await sleeper.sleep(nanoseconds)
+        })
+
+        await manager.scheduleIdleUnload(
+            modelName: "ornith",
+            policy: .afterSeconds(30),
+            ownerDecisionID: 41,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await manager.scheduleIdleUnload(
+            modelName: "ornith",
+            policy: .afterSeconds(30),
+            ownerDecisionID: 42,
+            unload: { name in await unloads.unload(name) },
+            leaseCount: { _ in 0 },
+            isResident: { _ in true }
+        )
+        await Self.allowTasksToRun()
+
+        // A focus activation that observed decision 41 must not cancel the
+        // replacement installed by a later generation release.
+        await manager.cancel(modelName: "ornith", ownerDecisionID: 41)
+        #expect(await manager.snapshots().first?.ownerDecisionID == 42)
+
+        await sleeper.finishAll()
+        await Self.allowTasksToRun()
+        #expect(await unloads.names() == ["ornith"])
+    }
+
     @Test("never policy records residency without scheduling a timer")
     func neverPolicyDoesNotScheduleTimer() async {
         let sleeper = ResidencySleepRecorder()
@@ -538,5 +574,33 @@ struct ModelResidencyManagerTests {
 
         #expect(await unloads.names().isEmpty)
         #expect(await manager.snapshots().isEmpty)
+    }
+}
+
+@Suite("Model runtime residency publication")
+struct ModelRuntimeResidencyPublicationTests {
+    @Test("ledger publishes monotonic revisions with exact reason and decision identity")
+    func ledgerPreservesReasonAndDecisionIdentity() {
+        var ledger = ModelRuntimeResidencyLedger()
+
+        let loaded = ledger.record(names: ["zaya", "ornith"], reason: .load)
+        #expect(loaded.names == ["ornith", "zaya"])
+        #expect(loaded.revision == 1)
+        #expect(loaded.reason == .load)
+        #expect(loaded.idleDecisionID == nil)
+
+        let idleRemoval = ledger.record(
+            names: ["zaya"],
+            reason: .idlePolicy,
+            idleDecisionID: 77
+        )
+        #expect(idleRemoval.revision == 2)
+        #expect(idleRemoval.reason == .idlePolicy)
+        #expect(idleRemoval.idleDecisionID == 77)
+
+        let pressureRemoval = ledger.record(names: [], reason: .memoryPressure)
+        #expect(pressureRemoval.revision == 3)
+        #expect(pressureRemoval.reason == .memoryPressure)
+        #expect(pressureRemoval.idleDecisionID == nil)
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2010,6 +2010,19 @@ struct RuntimePolicySourceTests {
             ensureShutdown.lowerBound < clearRuntime.lowerBound,
             "network/VM teardown must run before the abandonable MLX clearAll tail"
         )
+
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+        let clearAllBody = try Self.functionBody("func clearAll(quit:", in: runtime)
+        let clearCancel = try #require(
+            clearAllBody.range(of: "await cancelAllGenerations()")
+        )
+        let awaitIdleTeardown = try #require(
+            clearAllBody.range(of: "let idleTeardownTasks = idleResidencyTeardowns.values.map")
+        )
+        #expect(
+            clearCancel.lowerBound < awaitIdleTeardown.lowerBound,
+            "clearAll must cancel generations before awaiting pre-commit idle teardown tasks"
+        )
     }
 
     @Test("NIO server stop reports completion so the group isn't dropped mid-shutdown")
@@ -2730,9 +2743,8 @@ struct RuntimePolicySourceTests {
     func modelRuntimeWiresIdleResidencyAroundLeases() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         let manager = try Self.source("Services/ModelRuntime/ModelResidencyManager.swift")
-
         #expect(runtime.contains("ModelResidencyManager.shared.markActive(modelName: modelName)"))
-        #expect(runtime.contains("ModelResidencyManager.shared.markActive(modelName: holder.name)"))
+        #expect(runtime.contains("await markModelActiveForResidency(holder.name)"))
         #expect(runtime.contains("private func scheduleIdleResidency(for modelName: String) async"))
         #expect(runtime.contains("ServerConfigurationStore.load()?.modelIdleResidencyPolicy"))
         #expect(runtime.contains("ModelResidencyManager.shared.scheduleIdleUnload"))
@@ -2741,6 +2753,45 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("await ModelResidencyManager.shared.cancelAll()"))
         #expect(manager.contains("guard await leaseCount(modelName) == 0"))
         #expect(manager.contains("guard await isResident(modelName)"))
+
+        let unloadBody = try Self.functionBody("func unload(", in: runtime)
+        let idleBranch = try #require(unloadBody.range(of: "if reason == .idlePolicy, let idleDecisionID"))
+        let finalDecisionGate = try #require(
+            unloadBody.range(
+                of: "guard inFlightIdleResidencyDecisions[name] == idleDecisionID else {",
+                range: idleBranch.upperBound ..< unloadBody.endIndex
+            )
+        )
+        let commit = try #require(
+            unloadBody.range(
+                of: "committedIdleResidencyDecisions[name] = idleDecisionID",
+                range: finalDecisionGate.upperBound ..< unloadBody.endIndex
+            )
+        )
+        let idleShutdown = try #require(
+            unloadBody.range(
+                of: "await MLXBatchAdapter.Registry.shared.shutdownEngine(for: name)",
+                range: commit.upperBound ..< unloadBody.endIndex
+            )
+        )
+        #expect(finalDecisionGate.lowerBound < commit.lowerBound)
+        #expect(commit.lowerBound < idleShutdown.lowerBound)
+
+        let markActiveBody = try Self.functionBody(
+            "private func markModelActiveForResidency(",
+            in: runtime
+        )
+        let committedWait = try #require(markActiveBody.range(of: "await teardown.task.value"))
+        let cancelPrecommit = try #require(
+            markActiveBody.range(
+                of: "inFlightIdleResidencyDecisions.removeValue(forKey: modelName)"
+            )
+        )
+        let managerMark = try #require(
+            markActiveBody.range(of: "await ModelResidencyManager.shared.markActive")
+        )
+        #expect(committedWait.lowerBound < managerMark.lowerBound)
+        #expect(cancelPrecommit.lowerBound < managerMark.lowerBound)
     }
 
     @Test("RuntimeConfig snapshot does not hop to MainActor before model load")
@@ -2770,11 +2821,87 @@ struct RuntimePolicySourceTests {
         #expect(health.contains("\"idle_unload_at\""))
         #expect(health.contains("\"idle_seconds_remaining\""))
         #expect(windows.contains("modelIdleResidencyPolicy"))
+        let focusBody = try Self.functionBody(
+            "fileprivate func windowDidBecomeKey(id: UUID)",
+            in: windows
+        )
+        #expect(focusBody.contains("windowStates[id]?.session.notifySessionBecameActive()"))
+        let activationBody = try Self.functionBody(
+            "func notifySessionBecameActive()",
+            in: try Self.source("Services/Chat/ChatSessionWarmup.swift")
+        )
+        #expect(activationBody.contains("handleSessionBecameActive(session: self)"))
+        let warmup = try Self.source("Services/Chat/ChatWarmupController.swift")
+        let activationRearmBody = try Self.functionBody(
+            "func handleSessionBecameActive(",
+            in: warmup
+        )
+        #expect(activationRearmBody.contains("sessionActivation = Task"))
+        #expect(
+            activationRearmBody.contains(
+                "let activation = await self.chatActivationResidencySnapshot(selectedModel)"
+            )
+        )
+        #expect(activationRearmBody.contains("self.sessionActivationID == id"))
+        #expect(activationRearmBody.contains("self.switchEpoch == epoch"))
+        #expect(activationRearmBody.contains("activation.residency"))
+        #expect(activationRearmBody.contains("allowDuplicateRevision: true"))
+        #expect(activationRearmBody.contains("activation.recoverableIdleDecisionID"))
+        #expect(activationRearmBody.contains("activationRecovery = ActivationRecovery("))
+        #expect(
+            activationRearmBody.contains(
+                "revalidateResidencyAfterDebounce: true"
+            )
+        )
+        let removalRecoveryBody = try Self.functionBody(
+            "func handleRuntimeResidencyChanged(",
+            in: warmup
+        )
+        #expect(removalRecoveryBody.contains("snapshot: ModelRuntimeResidencySnapshot"))
+        #expect(
+            removalRecoveryBody.contains(
+                "guard acceptResidencySnapshot(snapshot, selectedModel: selectedModel) else { return }"
+            )
+        )
+        #expect(removalRecoveryBody.contains("snapshot.reason == .idlePolicy"))
+        #expect(removalRecoveryBody.contains("recovery?.idleDecisionID == snapshot.idleDecisionID"))
+        #expect(removalRecoveryBody.contains("let matchesActivationIdleDecision = isSessionActive"))
+        #expect(
+            removalRecoveryBody.contains(
+                "if matchesActivationIdleDecision,\n            state == .warming,\n            scheduledActivationID != nil"
+            )
+        )
+        #expect(
+            removalRecoveryBody.contains(
+                "revalidateResidencyAfterDebounce: true"
+            )
+        )
+        let revisionGateBody = try Self.functionBody(
+            "private func acceptResidencySnapshot(",
+            in: warmup
+        )
+        #expect(revisionGateBody.contains("snapshot.revision < lastResidencyRevision"))
+        #expect(
+            revisionGateBody.contains(
+                "snapshot.revision == lastResidencyRevision, !allowDuplicateRevision"
+            )
+        )
+        #expect(revisionGateBody.contains("lastResidencyRevision = max("))
+        let activeWindowBody = try Self.functionBody(
+            "func isChatWindowActive(id: UUID)",
+            in: windows
+        )
+        #expect(activeWindowBody.contains("NSApp.isActive"))
+        #expect(activeWindowBody.contains("window.isVisible && window.isKeyWindow"))
+        let chatView = try Self.source("Views/Chat/ChatView.swift")
+        #expect(chatView.contains("ChatWindowManager.shared.isChatWindowActive"))
+        #expect(chatView.contains("warmupController.handleRuntimeResidencyChanged("))
         // Window close must branch on the full policy: immediate GC for
         // `.immediately`, short-grace acceleration for `.afterSeconds`
         // (chat-sourced models only, with a fire-time reopen guard), and no
         // action for `.never`.
         #expect(windows.contains("case .immediately:"))
+        #expect(windows.contains("await ModelRuntime.shared.unloadModelsNotIn(active)"))
         #expect(windows.contains("case .afterSeconds:"))
         #expect(windows.contains("accelerateIdleUnloadAfterChatClose"))
         #expect(

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -683,12 +683,16 @@ final class ChatSession: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] note in
-            let residentModelNames = note.object as? [String] ?? []
+            guard let snapshot = note.object as? ModelRuntimeResidencySnapshot else { return }
             Task { @MainActor in
                 guard let self else { return }
-                self.warmupController.reconcileRuntimeResidency(
-                    selectedModel: self.selectedModel,
-                    residentModelNames: residentModelNames
+                let isSessionActive = self.windowState.map {
+                    ChatWindowManager.shared.isChatWindowActive(id: $0.windowId)
+                } ?? false
+                self.warmupController.handleRuntimeResidencyChanged(
+                    session: self,
+                    snapshot: snapshot,
+                    isSessionActive: isSessionActive
                 )
             }
         }

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SelectedChatWarmupLifecycleTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SelectedChatWarmupLifecycleTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Deterministic lifecycle gate for the live regression where an already
+/// selected chat retained a stale green warm claim after the runtime evicted
+/// its model. This belongs in the eval package as a release preflight, but is
+/// intentionally not a CacheProof JSON case: that runner owns request/session
+/// cache telemetry and has no window-focus or ChatSession activation surface.
+@Suite("Selected-chat idle-eviction warmup lifecycle")
+@MainActor
+struct SelectedChatWarmupLifecycleTests {
+    @Test("eviction while activation debounce is held performs a replacement warmup")
+    func reactivationRearmsAfterDebouncedEviction() async {
+        let engine = EvalWarmupRecordingEngine()
+        let session = EvalWarmupSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "stable shared prefix")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|debounce-eviction"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        let snapshots = EvalResidentSnapshotSequence([
+            evalResidencySnapshot(names: ["test-model"], revision: 1),
+            evalResidencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 41
+            ),
+        ])
+        let debounce = EvalWarmupDebounceGate()
+        controller.chatActivationResidencySnapshot = { _ in
+            ModelRuntimeChatActivationResidencySnapshot(
+                residency: await snapshots.next(),
+                recoverableIdleDecisionID: nil
+            )
+        }
+        controller.runtimeResidencySnapshot = { await snapshots.next() }
+        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
+
+        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        await controller.awaitSessionActivation()
+        await debounce.waitUntilBlocked()
+        #expect(await snapshots.callCount() == 1)
+
+        await debounce.release()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(await snapshots.callCount() == 2)
+        #expect(engine.requestCount == 2)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("matching idle-decision removal after activation performs one replacement warmup")
+    func reactivationRearmsAfterPostCoalesceRemoval() async {
+        let engine = EvalWarmupRecordingEngine()
+        let session = EvalWarmupSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "stable shared prefix")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|selected-chat-reactivation"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.scheduleWarmup(session: session, debounce: .zero)
+
+        for _ in 0 ..< 100 {
+            if controller.state == .warm { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
+
+        // Match ChatWindowManager.windowDidBecomeKey -> ChatSession activation.
+        // Both residency snapshots still contain the selected model, so the
+        // activation legitimately coalesces. The runtime publishes removal
+        // only afterwards — the final TOCTOU a second snapshot cannot close.
+        let snapshots = EvalResidentSnapshotSequence([
+            evalResidencySnapshot(names: ["test-model"], revision: 10),
+            evalResidencySnapshot(names: ["test-model"], revision: 10),
+            evalResidencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+        ])
+        let debounce = EvalWarmupDebounceGate()
+        controller.chatActivationResidencySnapshot = { _ in
+            ModelRuntimeChatActivationResidencySnapshot(
+                residency: await snapshots.next(),
+                recoverableIdleDecisionID: 71
+            )
+        }
+        controller.runtimeResidencySnapshot = { await snapshots.next() }
+        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
+
+        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        await controller.awaitSessionActivation()
+        await debounce.waitUntilBlocked()
+        #expect(await snapshots.callCount() == 1)
+
+        await debounce.release()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(await snapshots.callCount() == 2)
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        controller.scheduleDebounceSleep = { _ in }
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: evalResidencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+            isSessionActive: true
+        )
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(await snapshots.callCount() == 3)
+        #expect(engine.requestCount == 2)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("matching idle removal cannot cancel a yellow activation warmup")
+    func idleRemovalPreservesWarmingActivation() async {
+        let engine = EvalWarmupRecordingEngine()
+        let session = EvalWarmupSession()
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "stable shared prefix")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|warming-idle-removal"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        let debounce = EvalWarmupDebounceGate()
+        controller.chatActivationResidencySnapshot = { _ in
+            ModelRuntimeChatActivationResidencySnapshot(
+                residency: evalResidencySnapshot(names: ["test-model"], revision: 10),
+                recoverableIdleDecisionID: 71
+            )
+        }
+        controller.runtimeResidencySnapshot = {
+            evalResidencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            )
+        }
+        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
+
+        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        await controller.awaitSessionActivation()
+        await debounce.waitUntilBlocked()
+        #expect(controller.state == .warming)
+
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: evalResidencySnapshot(
+                names: [],
+                revision: 11,
+                reason: .idlePolicy,
+                idleDecisionID: 71
+            ),
+            isSessionActive: true
+        )
+        #expect(controller.state == .warming)
+
+        await debounce.release()
+        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        #expect(engine.lastRequest?.backgroundModelLoad == true)
+        #expect(controller.state == .warm)
+    }
+}
+
+private func evalResidencySnapshot(
+    names: [String],
+    revision: UInt64,
+    reason: ModelRuntimeResidencyChangeReason = .load,
+    idleDecisionID: UInt64? = nil
+) -> ModelRuntimeResidencySnapshot {
+    ModelRuntimeResidencySnapshot(
+        names: names,
+        revision: revision,
+        reason: reason,
+        idleDecisionID: idleDecisionID
+    )
+}
+
+private actor EvalResidentSnapshotSequence {
+    private var snapshots: [ModelRuntimeResidencySnapshot]
+    private var calls = 0
+
+    init(_ snapshots: [ModelRuntimeResidencySnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    func next() -> ModelRuntimeResidencySnapshot {
+        calls += 1
+        precondition(!snapshots.isEmpty, "unexpected residency snapshot request")
+        return snapshots.removeFirst()
+    }
+
+    func callCount() -> Int { calls }
+}
+
+private actor EvalWarmupDebounceGate {
+    private var blocked = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        blocked = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilBlocked() async {
+        while !blocked {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+@MainActor
+private final class EvalWarmupSession: ChatWarmupSessionContext {
+    var selectedModel: String? = "org/test-model"
+    var selectedModelIsLocal = true
+    var isRemoteAgentTarget = false
+    var isStreaming = false
+    var payload: ChatWarmupPayload?
+    var engine: ChatEngineProtocol = EvalWarmupRecordingEngine()
+
+    func isImageGenerationModel(_ id: String?) -> Bool { false }
+    func makeWarmupPayload() async -> ChatWarmupPayload? { payload }
+    func makeWarmupEngine() -> ChatEngineProtocol { engine }
+}
+
+private final class EvalWarmupRecordingEngine: ChatEngineProtocol, @unchecked Sendable {
+    var lastRequest: ChatCompletionRequest?
+    var requestCount = 0
+
+    func streamChat(
+        request: ChatCompletionRequest
+    ) async throws -> AsyncThrowingStream<String, Error> {
+        lastRequest = request
+        requestCount += 1
+        return AsyncThrowingStream { $0.finish() }
+    }
+
+    func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        lastRequest = request
+        return ChatCompletionResponse(
+            id: "eval-warmup",
+            object: "chat.completion",
+            created: 0,
+            model: request.model,
+            choices: [],
+            usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
+        )
+    }
+}


### PR DESCRIPTION
## Scope

Fix selected-chat recovery when an idle-policy teardown races window reactivation. The prior lifecycle could coalesce against a stale warm fingerprint, then publish model removal after the activation decision, leaving the selected chat yellow without a replacement warmup.

## Root-cause fix

- Add revisioned residency snapshots with explicit removal reasons and exact idle-decision IDs.
- Revalidate residency after debounce and immediately before warmup coalescing.
- Recover exactly once only from the matching idle-policy removal while preserving activation-owned warming state.
- Make idle teardown two-phase so new use cancels it before commit or waits for the committed teardown and cold-loads afterward.
- Route real chat focus activation through the warmup lifecycle and cancel only the owning idle decision.
- Add permanent OsaurusEvals coverage for idle removal before activation, during debounce, and during an in-flight warmup.

## Final verification — PASS for this PR's lifecycle gate

Exact source:

- PR commit: `b236fbaa5cb571f862d188ade19b31c984dfae4b`
- Base: `bbad6ed9165e186e2e212f5160e6594dc3345c5e`
- vMLX pin: `7300afaa764f50743b11d8f7f8ececf0100731a2`

Current results:

- Focused OsaurusCore suites: **133/133 passed**
- Selected-chat lifecycle regression: **3/3 passed**
- Full Swift OsaurusEvals package: **277/277 passed**; one optional CPU-ceiling assertion was omitted by its explicit environment gate
- Deterministic authoritative floor: **87/87 passed**
- CacheProof: **11/11 passed**
- GitHub checks: **8/8 passed**
- AgentLoop: **27/38 passed, 8 failed, 3 skipped, 0 errors**
- AgentLoopFrontier: **23/39 passed, 16 failed (58.97%)**

Real isolated Release-app proof completed the entire visible lifecycle on the selected Ornith JANG_4M chat:

`selected warm → terminal baseline → >5 minute visible unload → same-chat refocus → yellow Warming up → green prefix warm → terminal recovery → terminal follow-up`

The proof included exact disk-L2 restored/fresh-prefill counts, TTFT, decode speed, physical-footprint unload/reload behavior, Stop disappearance, and composer unlock. The non-perfect AgentLoop and Frontier rows remain explicitly attributed in the final proof comment; they are not summarized as passing.

Full proof and evidence hashes: https://github.com/osaurus-ai/osaurus/pull/2216#issuecomment-5114469686

No evidence images are committed or attached to repository history.
