### PR TITLE
Fix plugin layout at compact widths

### DIFF
--- a/Packages/OsaurusCore/Views/Plugin/ClaudePluginCard.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudePluginCard.swift
@@ -122,11 +122,13 @@ struct ClaudePluginCard: View {
                 .font(.system(size: 8.5, weight: .semibold))
             Text("Imported", bundle: .module)
                 .font(.system(size: 9.5, weight: .semibold))
+                .lineLimit(1)
         }
         .foregroundColor(theme.accentColor)
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
         .background(Capsule().fill(theme.accentColor.opacity(0.14)))
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     @ViewBuilder

--- a/Packages/OsaurusCore/Views/Plugin/PluginsView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/PluginsView.swift
@@ -581,13 +581,7 @@ struct PluginsView: View {
                             ToolPermissionBanner(count: pluginsWithMissingPermissionsCount, subject: .plugins)
                         }
 
-                        LazyVGrid(
-                            columns: [
-                                GridItem(.flexible(minimum: 300), spacing: 20),
-                                GridItem(.flexible(minimum: 300), spacing: 20),
-                            ],
-                            spacing: 20
-                        ) {
+                        LazyVGrid(columns: responsiveGrid, spacing: 20) {
                             ForEach(Array(installedPlugins.enumerated()), id: \.element.id) { index, plugin in
                                 PluginCard(
                                     plugin: plugin,
@@ -648,10 +642,11 @@ struct PluginsView: View {
 
     // MARK: - Browse Tab
 
-    private var twoColumnGrid: [GridItem] {
+    /// Keep cards readable in the management window's compact layout, while
+    /// still using multiple columns when the window has enough room.
+    private var responsiveGrid: [GridItem] {
         [
-            GridItem(.flexible(minimum: 300), spacing: 20),
-            GridItem(.flexible(minimum: 300), spacing: 20),
+            GridItem(.adaptive(minimum: 340), spacing: 20, alignment: .top)
         ]
     }
 
@@ -716,7 +711,7 @@ struct PluginsView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 GitHubTokenCard()
-                LazyVGrid(columns: twoColumnGrid, spacing: 20) {
+                LazyVGrid(columns: responsiveGrid, spacing: 20) {
                     ForEach(Array(filteredPlugins.enumerated()), id: \.element.id) { index, plugin in
                     PluginCard(
                         plugin: plugin,
@@ -777,7 +772,7 @@ struct PluginsView: View {
         } else {
             // Installed plugins are excluded upstream (they live in the
             // Installed tab), so this grid is purely available discovery.
-            LazyVGrid(columns: twoColumnGrid, spacing: 20) {
+            LazyVGrid(columns: responsiveGrid, spacing: 20) {
                 ForEach(Array(filteredMarketplaceEntries.enumerated()), id: \.element.name) {
                     index,
                     entry in
@@ -794,7 +789,7 @@ struct PluginsView: View {
     }
 
     private var marketplaceLoadingGrid: some View {
-        LazyVGrid(columns: twoColumnGrid, spacing: 20) {
+        LazyVGrid(columns: responsiveGrid, spacing: 20) {
             ForEach(0 ..< 6, id: \.self) { _ in
                 MarketplaceSkeletonCard()
             }


### PR DESCRIPTION
## Summary
- switch plugin catalogs to an adaptive grid that uses one column in compact management windows
- prevent the imported plugin badge from collapsing into vertically wrapped text
- preserve multi-column layouts when enough width is available

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore`
- [ ] Visually verify the Plugins page at minimum and expanded window widths