### PR TITLE
i18n(zh-Hans): one word per concept, where the rest of the catalog already agrees

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -64614,7 +64614,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在下方下载模型以进行选择。"
+            "value" : "在下方下载模型后即可选择。"
           }
         },
         "zh-Hant" : {
@@ -82732,7 +82732,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "为智能体提供专用的设备端模型，用于编写和运行 AppleScript 来自动化此 Mac——控制 Finder、Safari、邮件、备忘录和系统事件等应用。在「智能体」标签页中按智能体启用；在下方下载模型以使其可用。"
+            "value" : "为智能体提供专用的设备端模型，用于编写和运行 AppleScript 来自动化此 Mac——控制访达、Safari、邮件、备忘录和系统事件等应用。在「智能体」标签页中按智能体启用；在下方下载模型以使其可用。"
           }
         },
         "zh-Hant" : {
@@ -82875,7 +82875,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "让助手获得你正在处理内容的环境感知。开启后，Osaurus 会在每次对话开始时，快速捕捉你打开的窗口与当前聚焦的输入框，定格为一帧快照，并将其作为背景上下文传给助手。该快照仅提取屏幕文字，不含截图，并会在发送给云端模型前经隐私过滤器清洗。"
+            "value" : "让助手获得你正在处理内容的环境感知。开启后，Osaurus 会在每次对话开始时，快速捕捉你打开的窗口与当前聚焦的输入框，定格为一帧快照，并将其作为背景上下文传给助手。该快照仅提取屏幕文字，不含截图，并会在发送给云端模型前先经隐私过滤器脱敏。"
           }
         },
         "zh-Hant" : {
@@ -87215,7 +87215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "每个生成的脚本在运行前如何经过把关。"
+            "value" : "每个生成的脚本在运行前的门控方式。"
           }
         },
         "zh-Hant" : {
@@ -105424,7 +105424,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅遮罩检测到的敏感文本"
+            "value" : "仅对检测到的敏感文本脱敏"
           }
         },
         "zh-Hant" : {
@@ -134055,7 +134055,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按应用规则、应用白名单和云端视觉。"
+            "value" : "按应用划分的规则、应用允许列表和云端视觉。"
           }
         },
         "zh-Hant" : {
@@ -160060,7 +160060,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Finder 中显示"
+            "value" : "在访达中显示"
           }
         },
         "zh-Hant" : {
@@ -160094,7 +160094,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Finder 中显示此智能体的沙盒主目录。"
+            "value" : "在访达中显示此智能体的沙盒主目录。"
           }
         },
         "zh-Hant" : {
@@ -165577,7 +165577,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沙盒命令将 ~/.osaurus/container/workspace/ 视为 /workspace — 这是它们唯一可写入的目录。在 Finder 中打开即可直接浏览或编辑文件。"
+            "value" : "沙盒命令将 ~/.osaurus/container/workspace/ 视为 /workspace — 这是它们唯一可写入的目录。在访达中打开即可直接浏览或编辑文件。"
           }
         },
         "zh-Hant" : {
@@ -175288,7 +175288,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分享屏幕上下文"
+            "value" : "共享屏幕上下文"
           }
         },
         "zh-Hant" : {
@@ -176029,7 +176029,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在 Finder 中显示 agent-channels.json"
+            "value" : "在访达中显示 agent-channels.json"
           }
         },
         "zh-Hant" : {
@@ -178670,7 +178670,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "单驻留"
+            "value" : "单模型驻留"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
i18n(zh-Hans): one word per concept, where the rest of the catalog already agrees

Eight terms where a single value reaches for a word the catalog does not use
anywhere else. Each row is a count taken on main, not an impression: the
replacement is what the majority already says.

  遮罩 → 脱敏               1 vs 25   "Mask only detected sensitive text"
  清洗 → 脱敏               1 vs 25   "…scrubbed by the Privacy Filter…"
  把关 → 门控               1 vs  6   "How each generated script is gated…"
  应用白名单 → 应用允许列表  1 vs 42   "Per-app rules, app allowlist…"
  分享屏幕上下文 → 共享…     1 vs  2   "Share screen context"
  单驻留 → 单模型驻留        1 vs  2   "Single Residency"
  Finder → 访达             5 vs  3   five values, see below
  「以进行选择」→ 改写        —        "Download a model below to choose one."

On 脱敏: it is already the word for all three English verbs in this area —
redact (18 values), mask (2), scrub (3). So 遮罩 and 清洗 are not a finer
distinction, they are the two places that missed the convention. 清洗 also sat
directly after 过滤器 in the same clause, which reads as filter-then-wash.

On 访达: that is the name macOS itself ships in Chinese (InfoPlist.loctable),
three values in this catalog already use it, and one of the five English
holdouts is the sentence

    控制 Finder、Safari、邮件、备忘录和系统事件等应用

where every other app in the list is already under its Chinese name.

On 「以进行选择」: an infinitive of purpose carried over from the English.
"在下方下载模型以进行选择。" → "在下方下载模型后即可选择。"

Deliberately left alone: Top Picks → 首选推荐. It looks like a singleton next
to 精选, but the badge on each item is Top Pick → 首选, so the section header
and the badge already agree. Renaming the header would create the mismatch,
not remove one.

12 values, zh-Hans only. Every changed line is a `value`; no `state` field is
touched. After this the eight words above have zero occurrences left.

